### PR TITLE
feat: port rule react-hooks/exhaustive-deps

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -279,6 +279,35 @@ func RunLinterInProgram(program *compiler.Program, allowFiles []string, allowDir
 							Severity:    r.Severity,
 						})
 					},
+					ReportNodeWithFixesAndSuggestions: func(node *ast.Node, msg rule.RuleMessage, fixes []rule.RuleFix, suggestions []rule.RuleSuggestion) {
+						trimmedRange := utils.TrimNodeTextRange(file, node)
+						if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
+							return
+						}
+						onDiagnostic(rule.RuleDiagnostic{
+							RuleName:    r.Name,
+							Range:       trimmedRange,
+							Message:     msg,
+							FixesPtr:    &fixes,
+							Suggestions: &suggestions,
+							SourceFile:  file,
+							Severity:    r.Severity,
+						})
+					},
+					ReportRangeWithFixesAndSuggestions: func(textRange core.TextRange, msg rule.RuleMessage, fixes []rule.RuleFix, suggestions []rule.RuleSuggestion) {
+						if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
+							return
+						}
+						onDiagnostic(rule.RuleDiagnostic{
+							RuleName:    r.Name,
+							Range:       textRange,
+							Message:     msg,
+							FixesPtr:    &fixes,
+							Suggestions: &suggestions,
+							SourceFile:  file,
+							Severity:    r.Severity,
+						})
+					},
 				}
 
 				for kind, listener := range r.Run(ctx) {

--- a/internal/plugins/react_hooks/all.go
+++ b/internal/plugins/react_hooks/all.go
@@ -1,6 +1,7 @@
 package react_hooks
 
 import (
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/exhaustive_deps"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/rules_of_hooks"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -8,5 +9,6 @@ import (
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		rules_of_hooks.RulesOfHooksRule,
+		exhaustive_deps.ExhaustiveDepsRule,
 	}
 }

--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -1,0 +1,382 @@
+// Package react_hooksutil holds the AST helpers shared by every
+// rule in the `eslint-plugin-react-hooks` port.
+//
+// Both `rules-of-hooks` and `exhaustive-deps` need the same set of
+// queries — "is this a hook callee?", "is this enclosing function a
+// component?", "what's the display name of this function-like?",
+// "is this a `React.<x>` member access?", etc. Putting them here
+// keeps semantics consistent across rules and removes the second
+// (and third) copy of every predicate.
+//
+// Naming convention follows the rest of the codebase: predicates
+// start with `Is*`, getters with `Get*`. The package never imports
+// `internal/utils/` — the rules consume `internal/utils/` separately
+// and pass values through.
+package react_hooksutil
+
+import (
+	"regexp"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// hookNameTailRegex matches the suffix part of a hook identifier:
+// after the leading `use`, the next character must be uppercase Latin
+// or a digit. Mirrors upstream's `/^use[A-Z0-9]/`.
+var hookNameTailRegex = regexp.MustCompile(`^use[A-Z0-9]`)
+
+// pascalCaseRegex matches identifiers whose first character is an
+// uppercase Latin letter. Mirrors upstream's `/^[A-Z].*/` predicate.
+var pascalCaseRegex = regexp.MustCompile(`^[A-Z]`)
+
+// effectNameRegex mirrors upstream `exhaustive-deps`' `/Effect($|[^a-z])/g`
+// — used to distinguish "effect"-style hooks (lenient about over-specified
+// deps) from "memo"-style hooks (strict).
+var effectNameRegex = regexp.MustCompile(`Effect($|[^a-z])`)
+
+// IsHookName reports whether `s` follows the React hook naming
+// convention: either the bare `use` (the React `use(...)` hook) or
+// `useFoo` / `use1` (`use` followed by uppercase letter or digit).
+func IsHookName(s string) bool {
+	return s == "use" || hookNameTailRegex.MatchString(s)
+}
+
+// IsComponentNameStr reports whether `s` looks like a React component
+// name — PascalCase. Upstream's `isComponentName` is identical.
+func IsComponentNameStr(s string) bool {
+	if s == "" {
+		return false
+	}
+	return pascalCaseRegex.MatchString(s)
+}
+
+// IsEffectStyleHookName reports whether the bare hook name (no
+// `React.` prefix) parses as an effect-style hook by the
+// `Effect($|[^a-z])` rule. Used by exhaustive-deps to gate the
+// "extra over-specified deps are okay" exception that effects get
+// but memo / callback don't.
+func IsEffectStyleHookName(name string) bool {
+	return effectNameRegex.MatchString(name)
+}
+
+// StripReactNamespace returns the property identifier of a
+// `React.foo` member expression, or the original node otherwise.
+// Mirrors upstream's `getNodeWithoutReactNamespace`. Paren wrappers
+// are peeled transparently — tsgo preserves them where ESTree
+// flattens.
+func StripReactNamespace(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	n := ast.SkipParentheses(node)
+	if n.Kind == ast.KindPropertyAccessExpression {
+		pae := n.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pae.Expression)
+		prop := pae.Name()
+		if obj != nil && obj.Kind == ast.KindIdentifier &&
+			obj.AsIdentifier().Text == "React" &&
+			prop != nil && prop.Kind == ast.KindIdentifier {
+			return prop
+		}
+	}
+	return n
+}
+
+// IsReactCalleeNamed reports whether `node` is `<name>` (bare
+// identifier) or `React.<name>` (PropertyAccessExpression with object
+// `React` and property `<name>`). Mirrors upstream's
+// `isReactFunction(node, functionName)`.
+func IsReactCalleeNamed(node *ast.Node, name string) bool {
+	n := StripReactNamespace(node)
+	if n == nil || n.Kind != ast.KindIdentifier {
+		return false
+	}
+	return n.AsIdentifier().Text == name
+}
+
+// IsUseEffectEventCallee reports whether `node` is the bare
+// `useEffectEvent` or `React.useEffectEvent` callee.
+func IsUseEffectEventCallee(node *ast.Node) bool {
+	return IsReactCalleeNamed(node, "useEffectEvent")
+}
+
+// IsUseIdentifier reports whether `node` is the React `use(...)`
+// callee — either bare `use` or `React.use`.
+func IsUseIdentifier(node *ast.Node) bool {
+	return IsReactCalleeNamed(node, "use")
+}
+
+// IsHookCallee mirrors upstream's `isHook(node)`: the callee is
+// either an Identifier whose name is a hook, or a non-computed member
+// expression `Namespace.useFoo` whose object is a PascalCase
+// identifier and whose property is itself a hook name.
+func IsHookCallee(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	n := ast.SkipParentheses(node)
+	switch n.Kind {
+	case ast.KindIdentifier:
+		return IsHookName(n.AsIdentifier().Text)
+	case ast.KindPropertyAccessExpression:
+		pae := n.AsPropertyAccessExpression()
+		prop := pae.Name()
+		if prop == nil || prop.Kind != ast.KindIdentifier {
+			return false
+		}
+		if !IsHookName(prop.AsIdentifier().Text) {
+			return false
+		}
+		obj := ast.SkipParentheses(pae.Expression)
+		if obj == nil || obj.Kind != ast.KindIdentifier {
+			return false
+		}
+		return IsComponentNameStr(obj.AsIdentifier().Text)
+	}
+	return false
+}
+
+// IsFunctionLikeContainer reports whether `node` is one of the
+// function-like kinds the upstream rules treat as a "code path"
+// boundary.
+func IsFunctionLikeContainer(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
+		ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+		return true
+	}
+	return false
+}
+
+// FindEnclosingFunction walks up from `node` and returns the nearest
+// function-like ancestor, or nil when `node` is at top level.
+func FindEnclosingFunction(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	p := node.Parent
+	for p != nil {
+		if IsFunctionLikeContainer(p) {
+			return p
+		}
+		p = p.Parent
+	}
+	return nil
+}
+
+// GetFunctionBody returns the body of a function-like node — Block
+// for normal functions, the BlockOrExpression body for arrow
+// functions, or nil for abstract/declared signatures.
+func GetFunctionBody(fn *ast.Node) *ast.Node {
+	if fn == nil {
+		return nil
+	}
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		return fn.AsFunctionDeclaration().Body
+	case ast.KindFunctionExpression:
+		return fn.AsFunctionExpression().Body
+	case ast.KindArrowFunction:
+		return fn.AsArrowFunction().Body
+	case ast.KindMethodDeclaration:
+		return fn.AsMethodDeclaration().Body
+	case ast.KindGetAccessor:
+		return fn.AsGetAccessorDeclaration().Body
+	case ast.KindSetAccessor:
+		return fn.AsSetAccessorDeclaration().Body
+	case ast.KindConstructor:
+		return fn.AsConstructorDeclaration().Body
+	}
+	return nil
+}
+
+// HasAsyncModifier reports whether the function-like node carries
+// the `async` modifier.
+func HasAsyncModifier(fn *ast.Node) bool {
+	if fn == nil {
+		return false
+	}
+	return ast.HasSyntacticModifier(fn, ast.ModifierFlagsAsync)
+}
+
+// GetFunctionName mirrors upstream's `getFunctionName(node)`. Returns:
+//   - For named FunctionDeclaration / FunctionExpression: the `id` Identifier.
+//   - For MethodDeclaration / GetAccessor / SetAccessor inside an
+//     ObjectLiteralExpression: the method's own name.
+//   - For ArrowFunction / anonymous FunctionExpression: the assignment
+//     target — VariableDeclaration name, BinaryExpression LHS,
+//     PropertyAssignment name, BindingElement name, or
+//     ShorthandPropertyAssignment name.
+//   - nil otherwise.
+//
+// MethodDeclaration / GetAccessor / SetAccessor inside a class body
+// intentionally returns nil so the class-member branch can take over.
+func GetFunctionName(fn *ast.Node) *ast.Node {
+	if fn == nil {
+		return nil
+	}
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		return fn.Name()
+	case ast.KindFunctionExpression:
+		if name := fn.Name(); name != nil {
+			return name
+		}
+		// fall through to anonymous handling
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		if fn.Parent != nil && fn.Parent.Kind == ast.KindObjectLiteralExpression {
+			return fn.Name()
+		}
+		return nil
+	case ast.KindArrowFunction:
+		// fall through
+	default:
+		return nil
+	}
+	// Walk past wrapping ParenthesizedExpression layers so shapes like
+	// `const foo = (() => {})` are recognized: the function-like itself
+	// is the parens' inner expression, but the meaningful "parent kind"
+	// for name lookup is the VariableDeclaration ABOVE the parens.
+	// `child` tracks the node we're checking for `parent.X === child`
+	// equality (must be the wrapper after each peel, not the original
+	// fn).
+	child := fn
+	p := fn.Parent
+	for p != nil && p.Kind == ast.KindParenthesizedExpression {
+		child = p
+		p = p.Parent
+	}
+	if p == nil {
+		return nil
+	}
+	switch p.Kind {
+	case ast.KindVariableDeclaration:
+		vd := p.AsVariableDeclaration()
+		if vd.Initializer == child {
+			return p.Name()
+		}
+	case ast.KindBinaryExpression:
+		be := p.AsBinaryExpression()
+		if be.OperatorToken != nil && be.OperatorToken.Kind == ast.KindEqualsToken && be.Right == child {
+			return be.Left
+		}
+	case ast.KindPropertyAssignment:
+		pa := p.AsPropertyAssignment()
+		if pa.Initializer == child {
+			return p.Name()
+		}
+	case ast.KindBindingElement:
+		be := p.AsBindingElement()
+		if be.Initializer == child {
+			return p.Name()
+		}
+	case ast.KindShorthandPropertyAssignment:
+		spa := p.AsShorthandPropertyAssignment()
+		if spa.ObjectAssignmentInitializer == child {
+			return p.Name()
+		}
+	}
+	return nil
+}
+
+// IsForwardRefOrMemoCallback reports whether `fn` is the immediate
+// argument of a CallExpression whose callee is `<name>` or
+// `React.<name>`.
+func IsForwardRefOrMemoCallback(fn *ast.Node, name string) bool {
+	if fn == nil || fn.Parent == nil {
+		return false
+	}
+	p := fn.Parent
+	if p.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := ast.SkipParentheses(p.AsCallExpression().Expression)
+	return IsReactCalleeNamed(callee, name)
+}
+
+// IsClassMember reports whether `fn` is a member of a class — either
+// a MethodDeclaration / GetAccessor / SetAccessor / Constructor whose
+// direct parent is a class, or an ArrowFunction / FunctionExpression
+// that initializes a class PropertyDeclaration (class-field arrow).
+func IsClassMember(fn *ast.Node) bool {
+	if fn == nil || fn.Parent == nil {
+		return false
+	}
+	p := fn.Parent
+	switch fn.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+		return p.Kind == ast.KindClassDeclaration || p.Kind == ast.KindClassExpression
+	case ast.KindArrowFunction, ast.KindFunctionExpression:
+		if p.Kind == ast.KindPropertyDeclaration {
+			gp := p.Parent
+			if gp != nil && (gp.Kind == ast.KindClassDeclaration || gp.Kind == ast.KindClassExpression) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsComponentOrHookFn reports whether the function-like itself is a
+// React component or hook (named appropriately, or an anonymous arg
+// to forwardRef / memo). Mirrors upstream's
+// `isDirectlyInsideComponentOrHook` predicate at the function level.
+func IsComponentOrHookFn(fn *ast.Node) bool {
+	name := GetFunctionName(fn)
+	if name != nil {
+		switch name.Kind {
+		case ast.KindIdentifier:
+			text := name.AsIdentifier().Text
+			return IsComponentNameStr(text) || IsHookName(text)
+		case ast.KindPropertyAccessExpression:
+			return IsHookCallee(name)
+		}
+		return false
+	}
+	return IsForwardRefOrMemoCallback(fn, "forwardRef") || IsForwardRefOrMemoCallback(fn, "memo")
+}
+
+// IsInsideComponentOrHook walks up from `node` and returns true once
+// any ancestor function-like classifies as a component or hook.
+func IsInsideComponentOrHook(node *ast.Node) bool {
+	cur := node
+	for cur != nil {
+		if IsFunctionLikeContainer(cur) && IsComponentOrHookFn(cur) {
+			return true
+		}
+		cur = cur.Parent
+	}
+	return false
+}
+
+// AdditionalHooksFromSettings reads
+// `settings['react-hooks'].<key>` (typically `additionalHooks` for
+// exhaustive-deps, or `additionalEffectHooks` for rules-of-hooks)
+// and compiles it as a regex. Returns nil when the setting is absent
+// or the pattern fails to compile — mirroring upstream's lenient
+// behavior of silently ignoring malformed regex strings.
+func AdditionalHooksFromSettings(settings map[string]interface{}, key string) *regexp.Regexp {
+	if settings == nil {
+		return nil
+	}
+	raw, ok := settings["react-hooks"]
+	if !ok {
+		return nil
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	pattern, ok := m[key].(string)
+	if !ok || pattern == "" {
+		return nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+	return re
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
@@ -1,0 +1,1132 @@
+// Package exhaustive_deps implements the rslint port of upstream
+// `react-hooks/exhaustive-deps`.
+//
+// The upstream rule (facebook/react/packages/eslint-plugin-react-hooks)
+// leans heavily on ESLint's scope manager: every Identifier reference
+// is preresolved to a Variable, references inside a callback can be
+// enumerated by walking the callback's Scope.references, and references
+// across the entire file get a `from` Scope and `resolved` Variable.
+// rslint has no scope manager. Instead we resolve identifiers via the
+// TypeChecker (`GetSymbolAtLocation`), then look at the symbol's
+// declaration to infer scope membership. When the TypeChecker is
+// unavailable (gap files, parse errors), we fall back to a name-based
+// best-effort: scan the call's enclosing function for declarations
+// matching the identifier text, and treat anything else as external.
+//
+// The diagnostics intentionally mirror upstream's wording so consumers
+// of the JS rule can switch over without rewriting message assertions.
+// The autofix and suggestion shapes also mirror upstream — replacing
+// the deps-array text wholesale, or inserting a deps array after the
+// callback when none was provided.
+package exhaustive_deps
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var _ = fmt.Sprintf // ensure fmt referenced
+var _ core.TextRange
+
+// All hook-name / namespace / function-like queries are delegated to
+// `react_hooksutil`. This file deliberately keeps zero local copies of
+// those predicates so that any semantic change is made once and picked
+// up by every rule in the plugin.
+
+// getReactiveHookCallbackIndex returns the index of the callback argument
+// for a known reactive hook. Mirrors upstream's same-named helper.
+//   - 0 for useEffect / useLayoutEffect / useInsertionEffect / useCallback / useMemo
+//   - 1 for useImperativeHandle
+//   - 0 for additionalHooks-matching custom hooks
+//   - -1 otherwise
+func getReactiveHookCallbackIndex(callee *ast.Node, additionalHooks *regexp.Regexp) int {
+	n := react_hooksutil.StripReactNamespace(callee)
+	if n == nil || n.Kind != ast.KindIdentifier {
+		// `additionalHooks` is matched against the full path (e.g. `useFoo` or `Namespace.useFoo`);
+		// only top-level Identifier callees pass this fast path. Member expressions
+		// other than `React.<x>` skip additionalHooks entirely (matches upstream).
+		return -1
+	}
+	name := n.AsIdentifier().Text
+	switch name {
+	case "useEffect", "useLayoutEffect", "useInsertionEffect", "useCallback", "useMemo":
+		return 0
+	case "useImperativeHandle":
+		return 1
+	}
+	// `additionalHooks` only applies to bare-identifier callees, mirroring
+	// upstream's `node === calleeNode` gate. `React.useCustomEffect` is
+	// intentionally NOT treated as a reactive hook by the additionalHooks
+	// path — only the unqualified `useCustomEffect` is.
+	if additionalHooks != nil && n == callee && additionalHooks.MatchString(name) {
+		return 0
+	}
+	return -1
+}
+
+// Hook-name / namespace / function-like queries are imported from
+// `react_hooksutil` — the local helpers below are aliases so that
+// the rest of this file reads naturally without sprinkling the
+// package name everywhere.
+var (
+	stripReactNamespace     = react_hooksutil.StripReactNamespace
+	isFunctionLikeContainer = react_hooksutil.IsFunctionLikeContainer
+	findEnclosingFunction   = react_hooksutil.FindEnclosingFunction
+	hasAsyncModifier        = react_hooksutil.HasAsyncModifier
+)
+
+// effectNameRegex mirrors upstream's `/Effect($|[^a-z])/g` — see also
+// `react_hooksutil.IsEffectStyleHookName`. We keep a local handle so
+// the existing call sites can stay terse.
+var effectNameRegex = regexp.MustCompile(`Effect($|[^a-z])`)
+
+// stripAsExpression unwraps any `as X` / `<X>...` / `satisfies X` wrapper.
+func stripAsExpression(node *ast.Node) *ast.Node {
+	for node != nil {
+		switch node.Kind {
+		case ast.KindAsExpression:
+			node = node.AsAsExpression().Expression
+		case ast.KindTypeAssertionExpression:
+			node = node.AsTypeAssertion().Expression
+		case ast.KindSatisfiesExpression:
+			node = node.AsSatisfiesExpression().Expression
+		case ast.KindParenthesizedExpression:
+			node = node.AsParenthesizedExpression().Expression
+		case ast.KindNonNullExpression:
+			node = node.AsNonNullExpression().Expression
+		default:
+			return node
+		}
+	}
+	return node
+}
+
+// containsNode reports whether `descendant` is inside `ancestor` by node range.
+// Returns false when either is nil. Inclusive on both ends.
+func containsNode(ancestor, descendant *ast.Node) bool {
+	if ancestor == nil || descendant == nil {
+		return false
+	}
+	return descendant.Pos() >= ancestor.Pos() && descendant.End() <= ancestor.End()
+}
+
+// nodeText returns the trimmed source text for `node`.
+func nodeText(sf *ast.SourceFile, node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	return utils.TrimmedNodeText(sf, node)
+}
+
+// analyzePropertyChainText converts a property chain into a dotted string.
+// Returns "" + ok=false on shapes upstream's `analyzePropertyChain` would
+// reject (which becomes a "complex expression" / "literal not a valid
+// dependency" diagnostic at the call site).
+//
+// Side effect: when `optionalChains` is non-nil, the returned key is
+// recorded as either optional (when the path was first seen via `?.`) or
+// required (regular `.`). Mirrors upstream's `analyzePropertyChain` +
+// `markNode`.
+//
+// tsgo-specific: peel ParenthesizedExpression and `as` / `satisfies`
+// (mirrors upstream's outer-level `while (init.type === 'TSAsExpression'
+// || init.type === 'AsExpression')` loop in visitCallExpression). We do
+// NOT peel `NonNullExpression` (`x!`) or `TypeAssertionExpression`
+// (`<T>x`) — upstream's `analyzePropertyChain` rejects those, so the
+// rule reports them as "complex expression" rather than treating them as
+// transparent.
+func analyzePropertyChainText(node *ast.Node, optionalChains map[string]bool) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	n := ast.SkipParentheses(node)
+	for {
+		switch n.Kind {
+		case ast.KindAsExpression:
+			n = ast.SkipParentheses(n.AsAsExpression().Expression)
+			continue
+		case ast.KindSatisfiesExpression:
+			n = ast.SkipParentheses(n.AsSatisfiesExpression().Expression)
+			continue
+		}
+		break
+	}
+	switch n.Kind {
+	case ast.KindIdentifier:
+		name := n.AsIdentifier().Text
+		if optionalChains != nil {
+			optionalChains[name] = false
+		}
+		return name, true
+	case ast.KindThisKeyword:
+		// Reject `this` — upstream's `analyzePropertyChain` only handles
+		// Identifier/JSXIdentifier as the leaf; `this` forces a
+		// "complex expression" diagnostic on declared deps.
+		return "", false
+	case ast.KindPropertyAccessExpression:
+		pae := n.AsPropertyAccessExpression()
+		object, ok := analyzePropertyChainText(pae.Expression, optionalChains)
+		if !ok {
+			return "", false
+		}
+		prop := pae.Name()
+		if prop == nil || prop.Kind != ast.KindIdentifier {
+			return "", false
+		}
+		result := object + "." + prop.AsIdentifier().Text
+		if optionalChains != nil {
+			optional := pae.QuestionDotToken != nil
+			markOptionalChain(optionalChains, result, optional)
+		}
+		return result, true
+	}
+	return "", false
+}
+
+// markOptionalChain mirrors upstream's `markNode`: a path is marked optional
+// only if every observed access used `?.`; the first non-optional sighting
+// pins it to false.
+func markOptionalChain(m map[string]bool, key string, optional bool) {
+	if optional {
+		if _, ok := m[key]; !ok {
+			m[key] = true
+		}
+	} else {
+		m[key] = false
+	}
+}
+
+// getDependencyNode walks up from `node` through enclosing
+// PropertyAccessExpression chains, stopping at the deepest receiver still
+// useful as a dependency key. Mirrors upstream's `getDependency` exactly:
+//
+//   - `props` -> `props`
+//   - `props.foo` (read) -> `props.foo`
+//   - `props.foo.bar` -> `props.foo.bar`
+//   - `props.foo.current` -> `props.foo.current` (special: `.current` ends the walk)
+//   - `props.foo()` -> `props` (method call: don't recurse, return receiver)
+//   - `props.foo.bar()` -> `props.foo` (same)
+//   - `props.foo = ...` (LHS) -> `props` (the assignment makes the receiver the dep)
+func getDependencyNode(node *ast.Node) *ast.Node {
+	cur := node
+	for cur != nil && cur.Parent != nil {
+		p := cur.Parent
+		// `(x).y` — peel ParenthesizedExpression transparently (ESTree
+		// flattens this; tsgo preserves it).
+		if p.Kind == ast.KindParenthesizedExpression {
+			cur = p
+			continue
+		}
+		// NOTE: We deliberately do NOT peel `as`/`satisfies`/`!` here.
+		// Upstream's `getDependency` / `analyzePropertyChain` reject
+		// these wrappers, so a body reference of `user!.name` resolves
+		// to dep key `user` (the receiver walk stops at the NonNull
+		// wrapper because parent kind != MemberExpression).
+		if p.Kind != ast.KindPropertyAccessExpression {
+			break
+		}
+		pae := p.AsPropertyAccessExpression()
+		if pae.Expression != cur {
+			break
+		}
+		// `.current` terminates the upward walk — upstream stops here so
+		// `.current` is reported, not the parent reference.
+		propName := pae.Name()
+		if propName == nil || propName.Kind != ast.KindIdentifier {
+			break
+		}
+		if propName.AsIdentifier().Text == "current" {
+			break
+		}
+		// `.foo()` method call: upstream's condition is
+		// `!(parent.parent.type === 'CallExpression' && parent.parent.callee === parent)`.
+		// When parent IS the callee of a CallExpression, we DON'T recurse
+		// — we drop out of the loop and fall through to the else branch
+		// which returns `cur` (the current node, the receiver).
+		if p.Parent != nil && p.Parent.Kind == ast.KindCallExpression {
+			callExpr := p.Parent.AsCallExpression()
+			if callExpr.Expression == p {
+				break
+			}
+		}
+		cur = p
+	}
+	// Assignment LHS: `obj.prop = ...` and `obj['prop'] = ...` both make
+	// `obj` the dependency. Mirrors upstream's same branch — the LHS
+	// member access doesn't represent a stable read of the property,
+	// it's a write through the receiver.
+	if cur != nil && cur.Parent != nil {
+		switch cur.Kind {
+		case ast.KindPropertyAccessExpression:
+			if be, ok := getAssignmentBinaryExpr(cur.Parent); ok && be.Left == cur {
+				return cur.AsPropertyAccessExpression().Expression
+			}
+		case ast.KindElementAccessExpression:
+			if be, ok := getAssignmentBinaryExpr(cur.Parent); ok && be.Left == cur {
+				return cur.AsElementAccessExpression().Expression
+			}
+		}
+	}
+	return cur
+}
+
+// getAssignmentBinaryExpr returns the BinaryExpression iff `node` is one
+// with an assignment-shape operator. Mirrors ESTree's AssignmentExpression
+// flag in tsgo's collapsed BinaryExpression model.
+func getAssignmentBinaryExpr(node *ast.Node) (*ast.BinaryExpression, bool) {
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return nil, false
+	}
+	be := node.AsBinaryExpression()
+	if be.OperatorToken == nil {
+		return nil, false
+	}
+	switch be.OperatorToken.Kind {
+	case ast.KindEqualsToken,
+		ast.KindPlusEqualsToken, ast.KindMinusEqualsToken,
+		ast.KindAsteriskEqualsToken, ast.KindAsteriskAsteriskEqualsToken,
+		ast.KindSlashEqualsToken, ast.KindPercentEqualsToken,
+		ast.KindLessThanLessThanEqualsToken, ast.KindGreaterThanGreaterThanEqualsToken,
+		ast.KindGreaterThanGreaterThanGreaterThanEqualsToken,
+		ast.KindAmpersandEqualsToken, ast.KindBarEqualsToken,
+		ast.KindCaretEqualsToken,
+		ast.KindAmpersandAmpersandEqualsToken, ast.KindBarBarEqualsToken,
+		ast.KindQuestionQuestionEqualsToken:
+		return be, true
+	}
+	return nil, false
+}
+
+// Options holds the parsed rule options.
+type Options struct {
+	AdditionalHooks                                 *regexp.Regexp
+	EnableDangerousAutofixThisMayCauseInfiniteLoops bool
+	RequireExplicitEffectDeps                       bool
+	// AutoDepsHooks: experimental_autoDependenciesHooks. When the hook's
+	// bare name is in this list, missing deps are inferred ("auto deps")
+	// rather than being flagged. Mirrors upstream's same-named option.
+	AutoDepsHooks map[string]bool
+}
+
+// parseOptions parses the rule's options object. Both array and bare-object
+// shapes are supported via `utils.GetOptionsMap`.
+func parseOptions(options any, settings map[string]interface{}) Options {
+	opts := Options{}
+	optsMap := utils.GetOptionsMap(options)
+	// `addlSet` tracks whether the rule-level `additionalHooks` field was
+	// PRESENT in options (even as empty string). Mirrors upstream's
+	// `rawOptions.additionalHooks` truthiness check — falsy values fall
+	// back to the settings entry, so we record presence here and only
+	// fall back when the rule-level option is absent or empty.
+	addlSet := false
+	if optsMap != nil {
+		if raw, ok := optsMap["additionalHooks"].(string); ok {
+			addlSet = raw != ""
+			if raw != "" {
+				if re, err := regexp.Compile(raw); err == nil {
+					opts.AdditionalHooks = re
+				}
+			}
+		}
+		if v, ok := optsMap["enableDangerousAutofixThisMayCauseInfiniteLoops"].(bool); ok {
+			opts.EnableDangerousAutofixThisMayCauseInfiniteLoops = v
+		}
+		if v, ok := optsMap["requireExplicitEffectDeps"].(bool); ok {
+			opts.RequireExplicitEffectDeps = v
+		}
+		if raw, ok := optsMap["experimental_autoDependenciesHooks"].([]interface{}); ok {
+			opts.AutoDepsHooks = map[string]bool{}
+			for _, item := range raw {
+				if s, ok := item.(string); ok {
+					opts.AutoDepsHooks[s] = true
+				}
+			}
+		}
+	}
+	// Settings fallback for additionalHooks (matches upstream's
+	// `getAdditionalEffectHooksFromSettings`, but only when the rule-level
+	// option is absent OR empty). Delegates to react_hooksutil.
+	if !addlSet && opts.AdditionalHooks == nil {
+		opts.AdditionalHooks = react_hooksutil.AdditionalHooksFromSettings(settings, "additionalHooks")
+	}
+	return opts
+}
+
+// declaredDependency is the parsed form of an entry in the deps array.
+type declaredDependency struct {
+	Key  string
+	Node *ast.Node
+}
+
+// dependency is a used reference observed inside the callback body.
+type dependency struct {
+	IsStable bool
+	IsRef    bool   // true if it's `<x>.current` reference
+	Refs     []*depReference
+	First    *ast.Node // first observed reference identifier (for diagnostics)
+}
+
+// depReference is a single observed reference inside the callback body —
+// the identifier node and the symbol it resolved to (or nil for fallback).
+type depReference struct {
+	Identifier   *ast.Node
+	Symbol       *ast.Symbol
+	WriteExpr    *ast.Node // BinaryExpression representing assignment, when this reference is written
+	InCleanup    bool
+	DepNodeRoot  *ast.Node
+}
+
+// dependencyTreeNode mirrors upstream's `DependencyTreeNode`.
+type dependencyTreeNode struct {
+	IsUsed                 bool
+	IsSatisfiedRecursively bool
+	IsSubtreeUsed          bool
+	Children               map[string]*dependencyTreeNode
+}
+
+func newDepTreeNode() *dependencyTreeNode {
+	return &dependencyTreeNode{Children: map[string]*dependencyTreeNode{}}
+}
+
+// getOrCreateNodeByPath mirrors upstream's same-named helper.
+func getOrCreateNodeByPath(root *dependencyTreeNode, path string) *dependencyTreeNode {
+	keys := strings.Split(path, ".")
+	node := root
+	for _, key := range keys {
+		child, ok := node.Children[key]
+		if !ok {
+			child = newDepTreeNode()
+			node.Children[key] = child
+		}
+		node = child
+	}
+	return node
+}
+
+// markAllParentsByPath mirrors upstream's same-named helper.
+func markAllParentsByPath(root *dependencyTreeNode, path string, fn func(*dependencyTreeNode)) {
+	keys := strings.Split(path, ".")
+	node := root
+	for _, key := range keys {
+		child, ok := node.Children[key]
+		if !ok {
+			return
+		}
+		fn(child)
+		node = child
+	}
+}
+
+// recommendations is the result returned by collectRecommendations.
+type recommendations struct {
+	Suggested   []string
+	Unnecessary map[string]bool
+	Duplicate   map[string]bool
+	Missing     map[string]bool
+}
+
+// collectRecommendations mirrors upstream's same-named helper. It walks the
+// dependency tree to compute missing / unnecessary / duplicate sets and a
+// suggested deps array preserving the original declaration order.
+//
+// Missing-dep ordering inside the suggested array uses each dep's first-
+// reference source position (matches upstream's Map-insertion order).
+func collectRecommendations(
+	dependencies map[string]*dependency,
+	declaredDependencies []declaredDependency,
+	stableDependencies map[string]bool,
+	externalDependencies map[string]bool,
+	isEffect bool,
+) recommendations {
+	depTree := newDepTreeNode()
+	for key := range dependencies {
+		node := getOrCreateNodeByPath(depTree, key)
+		node.IsUsed = true
+		markAllParentsByPath(depTree, key, func(parent *dependencyTreeNode) {
+			parent.IsSubtreeUsed = true
+		})
+	}
+	for _, dd := range declaredDependencies {
+		node := getOrCreateNodeByPath(depTree, dd.Key)
+		node.IsSatisfiedRecursively = true
+	}
+	for key := range stableDependencies {
+		node := getOrCreateNodeByPath(depTree, key)
+		node.IsSatisfiedRecursively = true
+	}
+
+	missing := map[string]bool{}
+	satisfying := map[string]bool{}
+	var scan func(node *dependencyTreeNode, keyToPath func(string) string)
+	scan = func(node *dependencyTreeNode, keyToPath func(string) string) {
+		// Iterate children in deterministic insertion-style order. Map
+		// iteration in Go is non-deterministic, so sort keys.
+		keys := make([]string, 0, len(node.Children))
+		for k := range node.Children {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			child := node.Children[key]
+			path := keyToPath(key)
+			if child.IsSatisfiedRecursively {
+				if child.IsSubtreeUsed {
+					satisfying[path] = true
+				}
+				continue
+			}
+			if child.IsUsed {
+				missing[path] = true
+				continue
+			}
+			cur := path
+			scan(child, func(childKey string) string {
+				return cur + "." + childKey
+			})
+		}
+	}
+	scan(depTree, func(k string) string { return k })
+
+	suggested := []string{}
+	unnecessary := map[string]bool{}
+	duplicate := map[string]bool{}
+	seenSuggested := map[string]bool{}
+	for _, dd := range declaredDependencies {
+		if satisfying[dd.Key] {
+			if !seenSuggested[dd.Key] {
+				seenSuggested[dd.Key] = true
+				suggested = append(suggested, dd.Key)
+			} else {
+				duplicate[dd.Key] = true
+			}
+		} else {
+			if isEffect && !strings.HasSuffix(dd.Key, ".current") && !externalDependencies[dd.Key] {
+				if !seenSuggested[dd.Key] {
+					seenSuggested[dd.Key] = true
+					suggested = append(suggested, dd.Key)
+				}
+			} else {
+				unnecessary[dd.Key] = true
+			}
+		}
+	}
+	// Append missing in source-reference order (mirrors upstream's
+	// Map-insertion = first-reference order). Falls back to alphabetic
+	// when the dependency record carries no `First` position.
+	missingKeys := make([]string, 0, len(missing))
+	for k := range missing {
+		missingKeys = append(missingKeys, k)
+	}
+	sort.SliceStable(missingKeys, func(i, j int) bool {
+		di, dj := dependencies[missingKeys[i]], dependencies[missingKeys[j]]
+		var pi, pj int
+		if di != nil && di.First != nil {
+			pi = di.First.Pos()
+		} else {
+			pi = -1
+		}
+		if dj != nil && dj.First != nil {
+			pj = dj.First.Pos()
+		} else {
+			pj = -1
+		}
+		if pi != pj {
+			return pi < pj
+		}
+		return missingKeys[i] < missingKeys[j]
+	})
+	suggested = append(suggested, missingKeys...)
+	return recommendations{
+		Suggested:   suggested,
+		Unnecessary: unnecessary,
+		Duplicate:   duplicate,
+		Missing:     missing,
+	}
+}
+
+// joinEnglish mirrors upstream's `joinEnglish` ("a", "b", and "c").
+func joinEnglish(arr []string) string {
+	var sb strings.Builder
+	for i, s := range arr {
+		sb.WriteString(s)
+		if i == 0 && len(arr) == 2 {
+			sb.WriteString(" and ")
+		} else if i == len(arr)-2 && len(arr) > 2 {
+			sb.WriteString(", and ")
+		} else if i < len(arr)-1 {
+			sb.WriteString(", ")
+		}
+	}
+	return sb.String()
+}
+
+// formatDependency mirrors upstream's `formatDependency` — re-inserts `?.`
+// for path segments that were always observed under optional access.
+func formatDependency(path string, optionalChains map[string]bool) string {
+	parts := strings.Split(path, ".")
+	var sb strings.Builder
+	for i, part := range parts {
+		if i != 0 {
+			pathSoFar := strings.Join(parts[:i+1], ".")
+			if optionalChains[pathSoFar] {
+				sb.WriteString("?.")
+			} else {
+				sb.WriteString(".")
+			}
+		}
+		sb.WriteString(part)
+	}
+	return sb.String()
+}
+
+// getWarningMessage mirrors upstream's same-named helper.
+func getWarningMessage(deps map[string]bool, singlePrefix, label, fixVerb string, optionalChains map[string]bool) string {
+	if len(deps) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(deps))
+	for k := range deps {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	formatted := make([]string, len(keys))
+	for i, k := range keys {
+		formatted[i] = "'" + formatDependency(k, optionalChains) + "'"
+	}
+	plural := len(keys) > 1
+	prefix := ""
+	if !plural {
+		prefix = singlePrefix + " "
+	}
+	noun := "dependency"
+	if plural {
+		noun = "dependencies"
+	}
+	pronoun := "it"
+	if plural {
+		pronoun = "them"
+	}
+	return prefix + label + " " + noun + ": " + joinEnglish(formatted) +
+		". Either " + fixVerb + " " + pronoun + " or remove the dependency array."
+}
+
+// getCalleeText mirrors upstream's `context.getSourceCode().getText(reactiveHook)`.
+//
+// tsgo-specific: peel ParenthesizedExpression so messages render
+// `useEffect` rather than `(useEffect)` — ESTree never exposes the paren
+// wrapper, and upstream's diagnostics use the unwrapped text.
+func getCalleeText(sf *ast.SourceFile, callee *ast.Node) string {
+	if callee != nil {
+		callee = ast.SkipParentheses(callee)
+	}
+	return nodeText(sf, callee)
+}
+
+// areDeclaredDepsAlphabetized mirrors upstream's same-named helper.
+func areDeclaredDepsAlphabetized(declared []declaredDependency) bool {
+	if len(declared) == 0 {
+		return true
+	}
+	keys := make([]string, len(declared))
+	for i, d := range declared {
+		keys[i] = d.Key
+	}
+	sorted := append([]string(nil), keys...)
+	sort.Strings(sorted)
+	return strings.Join(keys, ",") == strings.Join(sorted, ",")
+}
+
+// hasUndefinedIdentifier reports whether `node` is a literal `undefined`
+// identifier — used to recognize `useEffect(fn, undefined)` as "no deps".
+func hasUndefinedIdentifier(node *ast.Node) bool {
+	n := stripAsExpression(node)
+	return n != nil && n.Kind == ast.KindIdentifier && n.AsIdentifier().Text == "undefined"
+}
+
+// isReferenceIdentifier reports whether the given Identifier appears in a
+// value-reference position (as opposed to a property name, label, declaration
+// name, etc).
+func isReferenceIdentifier(id *ast.Node) bool {
+	p := id.Parent
+	if p == nil {
+		return false
+	}
+	switch p.Kind {
+	case ast.KindPropertyAccessExpression:
+		return p.AsPropertyAccessExpression().Expression == id
+	case ast.KindElementAccessExpression:
+		return p.AsElementAccessExpression().Expression == id ||
+			p.AsElementAccessExpression().ArgumentExpression == id
+	case ast.KindPropertyAssignment:
+		return p.AsPropertyAssignment().Initializer == id
+	case ast.KindShorthandPropertyAssignment:
+		return p.Name() == id
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		return false
+	case ast.KindJsxAttribute:
+		return false
+	case ast.KindVariableDeclaration:
+		return p.AsVariableDeclaration().Name() != id
+	case ast.KindBindingElement:
+		return p.AsBindingElement().Name() != id
+	case ast.KindParameter:
+		return p.AsParameterDeclaration().Name() != id
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+		ast.KindClassDeclaration, ast.KindClassExpression:
+		return p.Name() != id
+	case ast.KindLabeledStatement:
+		return p.AsLabeledStatement().Label != id
+	case ast.KindBreakStatement, ast.KindContinueStatement:
+		return false
+	case ast.KindImportSpecifier, ast.KindImportClause, ast.KindNamespaceImport,
+		ast.KindExportSpecifier:
+		return false
+	case ast.KindTypeReference, ast.KindTypeQuery:
+		return false
+	}
+	return true
+}
+
+// isInsideTypePosition reports whether `node` is inside a TypeReference /
+// TypeQuery / type-only construct. Mirrors upstream's
+// `dependencyNode.parent?.type === 'TSTypeQuery' || 'TSTypeReference'`.
+func isInsideTypePosition(node *ast.Node) bool {
+	cur := node
+	for cur != nil {
+		switch cur.Kind {
+		case ast.KindTypeReference, ast.KindTypeQuery, ast.KindTypePredicate,
+			ast.KindTypeLiteral, ast.KindTypeOperator, ast.KindIndexedAccessType,
+			ast.KindMappedType, ast.KindConditionalType, ast.KindInferType,
+			ast.KindUnionType, ast.KindIntersectionType, ast.KindTupleType,
+			ast.KindArrayType, ast.KindLiteralType, ast.KindFunctionType,
+			ast.KindConstructorType, ast.KindParenthesizedType:
+			return true
+		}
+		// Stop walking when leaving the expression to avoid mistakenly
+		// considering an expression inside a function body as "in a type".
+		if isFunctionLikeContainer(cur) {
+			return false
+		}
+		cur = cur.Parent
+	}
+	return false
+}
+
+// isInsideEffectCleanup reports whether `idNode` lies inside a function
+// returned from the effect callback (i.e. effect cleanup). Mirrors upstream's
+// `isInsideEffectCleanup`.
+//
+// `callback` is the effect callback function-like (ArrowFunction /
+// FunctionExpression). We walk up from `idNode` looking for an inner
+// function-like whose immediate parent is a ReturnStatement that itself
+// belongs to the effect callback.
+func isInsideEffectCleanup(idNode *ast.Node, callback *ast.Node) bool {
+	cur := idNode
+	for cur != nil {
+		if cur == callback {
+			return false
+		}
+		if isFunctionLikeContainer(cur) && cur != callback && cur.Parent != nil {
+			// `return () => {}` — parent is ReturnStatement.
+			if cur.Parent.Kind == ast.KindReturnStatement {
+				retEnclosing := findEnclosingFunction(cur.Parent)
+				if retEnclosing != nil && retEnclosing == callback {
+					return true
+				}
+			}
+		}
+		cur = cur.Parent
+	}
+	return false
+}
+
+// isStableHookValue inspects a VariableDeclaration whose initializer is a
+// known hook call (or const literal) and reports whether the binding at
+// `bindingId` is one of React's stable identities. Mirrors the union of
+// upstream's `isStableKnownHookValue` cases.
+//
+// `bindingId` is the Identifier of the specific binding being inspected
+// — for `const [a, b] = useState()`, this is either `a` or `b`.
+//
+// The second return value, `isUseEffectEvent`, signals that the binding
+// is a useEffectEvent return — used both as "stable" and as the gate for
+// emitting the "Functions returned from useEffectEvent must not be included"
+// diagnostic on a deps-array entry.
+func isStableHookValue(decl *ast.Node, bindingId *ast.Node) (stable bool, isUseEffectEvent bool) {
+	if decl == nil || decl.Kind != ast.KindVariableDeclaration {
+		return false, false
+	}
+	vd := decl.AsVariableDeclaration()
+	init := vd.Initializer
+	if init == nil {
+		return false, false
+	}
+	init = stripAsExpression(init)
+	// `const foo = 42` / `'str'` / `null` — primitive const is stable.
+	parentDeclList := decl.Parent
+	if parentDeclList != nil && parentDeclList.Kind == ast.KindVariableDeclarationList {
+		dl := parentDeclList.AsVariableDeclarationList()
+		// `const` keyword check. NodeFlagsConst / NodeFlagsLet apply to
+		// the declaration list.
+		if dl.Flags&ast.NodeFlagsConst != 0 {
+			switch init.Kind {
+			case ast.KindStringLiteral, ast.KindNumericLiteral, ast.KindNullKeyword:
+				return true, false
+			case ast.KindNoSubstitutionTemplateLiteral:
+				return true, false
+			}
+		}
+	}
+	if init.Kind != ast.KindCallExpression {
+		return false, false
+	}
+	callee := stripReactNamespace(init.AsCallExpression().Expression)
+	if callee == nil || callee.Kind != ast.KindIdentifier {
+		return false, false
+	}
+	calleeName := callee.AsIdentifier().Text
+
+	// The binding identifier site dictates which positions are stable.
+	bindingName := vd.Name()
+	switch calleeName {
+	case "useRef":
+		// Only the binding name itself is stable; destructured forms aren't.
+		if bindingName != nil && bindingName == bindingId {
+			return true, false
+		}
+	case "useEffectEvent":
+		if bindingName != nil && bindingName == bindingId {
+			return true, true
+		}
+	case "useState", "useReducer", "useActionState":
+		if bindingName != nil && bindingName.Kind == ast.KindArrayBindingPattern {
+			arr := bindingName.AsBindingPattern()
+			if arr.Elements != nil && len(arr.Elements.Nodes) == 2 {
+				first := arr.Elements.Nodes[0]
+				second := arr.Elements.Nodes[1]
+				// `setX` / `dispatch` is the stable side.
+				if isMatchingBindingElementId(second, bindingId) {
+					return true, false
+				}
+				// state itself (`x`) is dynamic.
+				_ = first
+			}
+		}
+	case "useTransition":
+		if bindingName != nil && bindingName.Kind == ast.KindArrayBindingPattern {
+			arr := bindingName.AsBindingPattern()
+			if arr.Elements != nil && len(arr.Elements.Nodes) == 2 {
+				second := arr.Elements.Nodes[1]
+				if isMatchingBindingElementId(second, bindingId) {
+					return true, false
+				}
+			}
+		}
+	}
+	return false, false
+}
+
+// isMatchingBindingElementId reports whether `binding` is a BindingElement
+// (or OmittedExpression) whose name Identifier equals `id`. Uses Pos/End
+// to compare positions instead of pointer equality, which is fragile when
+// the same Node is reachable through multiple paths.
+func isMatchingBindingElementId(binding *ast.Node, id *ast.Node) bool {
+	if binding == nil || binding.Kind == ast.KindOmittedExpression {
+		return false
+	}
+	if binding.Kind != ast.KindBindingElement {
+		return false
+	}
+	be := binding.AsBindingElement()
+	name := be.Name()
+	if name == nil || name.Kind != ast.KindIdentifier || id == nil || id.Kind != ast.KindIdentifier {
+		return false
+	}
+	if name == id {
+		return true
+	}
+	return name.Pos() == id.Pos() && name.End() == id.End() &&
+		name.AsIdentifier().Text == id.AsIdentifier().Text
+}
+
+// isElidedComma checks for `[, foo]`-style elided elements. tsgo represents
+// them as KindOmittedExpression rather than ESTree's null.
+func isElidedComma(n *ast.Node) bool {
+	return n != nil && n.Kind == ast.KindOmittedExpression
+}
+
+// constructionType returns a human-readable description for a node that
+// would yield a fresh referential identity on every render. Mirrors
+// upstream's `getConstructionExpressionType`.
+func constructionType(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	n := stripAsExpression(node)
+	switch n.Kind {
+	case ast.KindObjectLiteralExpression:
+		return "object"
+	case ast.KindArrayLiteralExpression:
+		return "array"
+	case ast.KindArrowFunction, ast.KindFunctionExpression:
+		return "function"
+	case ast.KindClassExpression:
+		return "class"
+	case ast.KindConditionalExpression:
+		ce := n.AsConditionalExpression()
+		if constructionType(ce.WhenTrue) != "" || constructionType(ce.WhenFalse) != "" {
+			return "conditional"
+		}
+		return ""
+	case ast.KindBinaryExpression:
+		be := n.AsBinaryExpression()
+		if be.OperatorToken != nil {
+			switch be.OperatorToken.Kind {
+			case ast.KindAmpersandAmpersandToken, ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+				if constructionType(be.Left) != "" || constructionType(be.Right) != "" {
+					return "logical expression"
+				}
+				return ""
+			case ast.KindEqualsToken,
+				ast.KindPlusEqualsToken, ast.KindMinusEqualsToken,
+				ast.KindAsteriskEqualsToken, ast.KindSlashEqualsToken,
+				ast.KindPercentEqualsToken,
+				ast.KindAmpersandAmpersandEqualsToken, ast.KindBarBarEqualsToken,
+				ast.KindQuestionQuestionEqualsToken:
+				if constructionType(be.Right) != "" {
+					return "assignment expression"
+				}
+				return ""
+			}
+		}
+		return ""
+	case ast.KindJsxFragment:
+		return "JSX fragment"
+	case ast.KindJsxElement, ast.KindJsxSelfClosingElement:
+		return "JSX element"
+	case ast.KindNewExpression:
+		return "object construction"
+	case ast.KindRegularExpressionLiteral:
+		return "regular expression"
+	}
+	return ""
+}
+
+// classifiedConstruction is one item from `scanForConstructions`.
+type classifiedConstruction struct {
+	Variable          *ast.Node // the declaration name Identifier
+	Decl              *ast.Node // the VariableDeclaration / FunctionDeclaration / ClassDeclaration
+	InitNode          *ast.Node // VariableDeclaration's initializer (nil for fn/class decls)
+	DepType           string
+	IsUsedOutsideHook bool
+}
+
+// scanForConstructions mirrors upstream's same-named helper.
+//
+// For each declared dependency name, find its declaration in the component
+// scope and report it as a construction iff the declaration is one of
+// `function foo() {}` / `class Foo {}` / `const foo = <something construction-shaped>`.
+func scanForConstructions(
+	declared []declaredDependency,
+	declaredDepsNode *ast.Node,
+	componentBody *ast.Node,
+	hookCallback *ast.Node,
+	tc *checker.Checker,
+	sf *ast.SourceFile,
+) []classifiedConstruction {
+	if componentBody == nil {
+		return nil
+	}
+	out := []classifiedConstruction{}
+	for _, dd := range declared {
+		// Only care about plain identifier deps (`foo`, not `foo.bar`).
+		if strings.Contains(dd.Key, ".") {
+			continue
+		}
+		if dd.Node == nil || dd.Node.Kind != ast.KindIdentifier {
+			continue
+		}
+		// Resolve dd.Node via TypeChecker; fall back to a name walk in
+		// the component body.
+		decl := resolveDeclaration(tc, dd.Node, dd.Key, componentBody)
+		if decl == nil {
+			continue
+		}
+		switch decl.Kind {
+		case ast.KindVariableDeclaration:
+			vd := decl.AsVariableDeclaration()
+			name := vd.Name()
+			if name == nil || name.Kind != ast.KindIdentifier {
+				continue
+			}
+			if vd.Initializer == nil {
+				continue
+			}
+			ct := constructionType(vd.Initializer)
+			if ct == "" {
+				continue
+			}
+			out = append(out, classifiedConstruction{
+				Variable:          name,
+				Decl:              decl,
+				InitNode:          vd.Initializer,
+				DepType:           ct,
+				IsUsedOutsideHook: isUsedOutsideHook(name, hookCallback, declaredDepsNode, componentBody),
+			})
+		case ast.KindFunctionDeclaration:
+			out = append(out, classifiedConstruction{
+				Variable:          decl.Name(),
+				Decl:              decl,
+				DepType:           "function",
+				IsUsedOutsideHook: isUsedOutsideHook(decl.Name(), hookCallback, declaredDepsNode, componentBody),
+			})
+		case ast.KindClassDeclaration:
+			out = append(out, classifiedConstruction{
+				Variable:          decl.Name(),
+				Decl:              decl,
+				DepType:           "class",
+				IsUsedOutsideHook: isUsedOutsideHook(decl.Name(), hookCallback, declaredDepsNode, componentBody),
+			})
+		}
+	}
+	return out
+}
+
+// resolveDeclaration finds the declaration corresponding to `id`. Prefers
+// TypeChecker symbol resolution; falls back to a name-based walk over
+// `body`. The fallback walk descends into ObjectBindingPattern /
+// ArrayBindingPattern so destructured bindings (including renamed
+// `{a: b}` form and nested patterns) and parameter destructure are
+// discoverable; it also recognizes BindingElement / Parameter as
+// terminal "declaration" nodes when the name matches.
+func resolveDeclaration(tc *checker.Checker, id *ast.Node, name string, body *ast.Node) *ast.Node {
+	if tc != nil {
+		sym := tc.GetSymbolAtLocation(id)
+		if sym != nil && len(sym.Declarations) > 0 {
+			return sym.Declarations[0]
+		}
+	}
+	if body == nil {
+		return nil
+	}
+	var found *ast.Node
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if found != nil {
+			return true
+		}
+		switch n.Kind {
+		case ast.KindVariableDeclaration:
+			vd := n.AsVariableDeclaration()
+			vname := vd.Name()
+			if vname != nil {
+				if vname.Kind == ast.KindIdentifier && vname.AsIdentifier().Text == name {
+					found = n
+					return true
+				}
+				// Destructure pattern — descend into the pattern looking
+				// for BindingElement whose binding name matches.
+			}
+		case ast.KindBindingElement:
+			be := n.AsBindingElement()
+			bn := be.Name()
+			if bn != nil && bn.Kind == ast.KindIdentifier && bn.AsIdentifier().Text == name {
+				found = n
+				return true
+			}
+		case ast.KindParameter:
+			pd := n.AsParameterDeclaration()
+			pn := pd.Name()
+			if pn != nil && pn.Kind == ast.KindIdentifier && pn.AsIdentifier().Text == name {
+				found = n
+				return true
+			}
+		case ast.KindFunctionDeclaration:
+			if fname := n.Name(); fname != nil && fname.Kind == ast.KindIdentifier && fname.AsIdentifier().Text == name {
+				found = n
+				return true
+			}
+		case ast.KindClassDeclaration:
+			if cname := n.Name(); cname != nil && cname.Kind == ast.KindIdentifier && cname.AsIdentifier().Text == name {
+				found = n
+				return true
+			}
+		}
+		if isFunctionLikeContainer(n) && n != body {
+			return false
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(body)
+	return found
+}
+
+// isUsedOutsideHook reports whether `name` (a declaration's Identifier) has
+// any reference outside of the hook callback that is not inside the deps
+// array. Mirrors upstream's `isUsedOutsideOfHook`.
+//
+// `scope` bounds the walk. Pass `componentFn` whenever possible — the
+// rule only cares about uses inside the surrounding component or hook;
+// fall back to `sf.AsNode()` only when no component scope is available.
+// Limiting the walk avoids the O(file_size) per-construction cost
+// flagged in PR-808 review.
+func isUsedOutsideHook(name *ast.Node, hookCallback *ast.Node, depsNode *ast.Node, scope *ast.Node) bool {
+	if name == nil || name.Kind != ast.KindIdentifier || scope == nil {
+		return false
+	}
+	target := name.AsIdentifier().Text
+	used := false
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if used {
+			return true
+		}
+		if n == hookCallback || n == depsNode {
+			// Skip the hook callback and the deps array entirely —
+			// references inside them aren't "outside the hook".
+			return false
+		}
+		if n.Kind == ast.KindIdentifier && n != name {
+			if n.AsIdentifier().Text == target && isReferenceIdentifier(n) {
+				used = true
+				return true
+			}
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(scope)
+	return used
+}
+
+// isComponentOrHookFunction delegates to the shared classifier.
+func isComponentOrHookFunction(fn *ast.Node) bool {
+	return react_hooksutil.IsComponentOrHookFn(fn)
+}
+
+// getUnknownDependenciesMessage mirrors upstream's same-named helper.
+func getUnknownDependenciesMessage(reactiveHookName string) string {
+	return fmt.Sprintf(
+		"React Hook %s received a function whose dependencies are unknown. Pass an inline function instead.",
+		reactiveHookName,
+	)
+}
+
+// reactiveHookName returns just the hook's bare name (after stripping
+// `React.`). Used for `additionalHooks` matching and message rendering.
+func reactiveHookName(callee *ast.Node) string {
+	n := react_hooksutil.StripReactNamespace(callee)
+	if n != nil && n.Kind == ast.KindIdentifier {
+		return n.AsIdentifier().Text
+	}
+	return ""
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.md
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.md
@@ -1,0 +1,146 @@
+# react-hooks/exhaustive-deps
+
+## Rule Details
+
+Verifies the list of dependencies for Hooks like `useEffect`, `useCallback`,
+`useMemo`, `useImperativeHandle`, `useLayoutEffect` and `useInsertionEffect`.
+Reports missing, unnecessary or duplicate entries in the second argument
+of these Hooks, and offers a suggested fix.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function MyComponent({ id }) {
+  // 'id' is captured by the effect but missing from deps
+  useEffect(() => {
+    console.log(id);
+  }, []);
+}
+```
+
+```javascript
+function MyComponent({ a, b }) {
+  // 'b' is in deps but never used inside the callback
+  useCallback(() => a, [a, b]);
+}
+```
+
+```javascript
+function MyComponent({ list }) {
+  // Spread elements can't be statically checked
+  useEffect(() => {}, [...list]);
+}
+```
+
+```javascript
+function MyComponent() {
+  const ref = useRef(null);
+  useEffect(() => {
+    return () => {
+      // ref.current may have changed by cleanup time
+      console.log(ref.current);
+    };
+  }, []);
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function MyComponent({ id }) {
+  useEffect(() => {
+    console.log(id);
+  }, [id]);
+}
+```
+
+```javascript
+function MyComponent({ list }) {
+  useMemo(() => list.length, [list]);
+}
+```
+
+```javascript
+function MyComponent() {
+  // useState setter is stable; no need to list it
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    setCount(c => c + 1);
+  }, []);
+}
+```
+
+```javascript
+function MyComponent({ theme }) {
+  // useEffectEvent return values are stable
+  const onClick = useEffectEvent(() => {
+    console.log(theme);
+  });
+  useEffect(() => {
+    onClick();
+  }, []);
+}
+```
+
+## Options
+
+The rule accepts a single options object:
+
+```json
+{
+  "react-hooks/exhaustive-deps": [
+    "error",
+    {
+      "additionalHooks": "(useMyEffect|useAsync)",
+      "enableDangerousAutofixThisMayCauseInfiniteLoops": false,
+      "requireExplicitEffectDeps": false
+    }
+  ]
+}
+```
+
+- **`additionalHooks`** (string regex, default empty): Treat the named
+  custom hooks as effect-style Hooks (callback at index 0). Only matches
+  bare-identifier callees — `Foo.useBar` and `React.useBar` are NOT
+  matched even if the identifier suffix is in the regex (mirrors
+  upstream's `node === calleeNode` gate). Falls back to
+  `settings['react-hooks'].additionalHooks` when omitted or empty.
+  ```json
+  { "react-hooks/exhaustive-deps": ["error", { "additionalHooks": "(useMyEffect|useAsync)" }] }
+  ```
+- **`enableDangerousAutofixThisMayCauseInfiniteLoops`** (boolean, default
+  `false`): Promote the first suggestion's first fix into a top-level
+  autofix while keeping the suggestion array. Off by default because
+  applying it without code review can introduce render loops.
+- **`requireExplicitEffectDeps`** (boolean, default `false`): Require
+  effect-style Hooks to be passed an explicit deps array (or
+  `undefined`). Useful in codebases that disable the deps-array fallback
+  to make every effect's reactive surface explicit.
+- **`experimental_autoDependenciesHooks`** (string array, default `[]`):
+  Skip dependency analysis entirely for the named custom hooks when their
+  deps argument is `null` or absent (the hook is expected to infer deps
+  itself). Used by tooling that does its own dep auto-injection.
+  ```json
+  {
+    "react-hooks/exhaustive-deps": [
+      "error",
+      { "experimental_autoDependenciesHooks": ["useAutoEffect"] }
+    ]
+  }
+  ```
+
+## Differences from ESLint
+
+- Components written in Flow syntax (`component MyComp() { ... }` or
+  `hook useFoo() { ... }`) are not analyzed; the rule produces no
+  diagnostics on them.
+- When multiple diagnostics are emitted for the same source line, the
+  order in the diagnostics list may differ from ESLint. The set of
+  diagnostics, their messages, and their fix outputs are identical;
+  only the position of each entry within the array can vary. IDEs and
+  CLI reporters that sort by source position display them identically.
+
+## Original Documentation
+
+- [react.dev — Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks)
+- [Source code](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts)

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_boundary_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_boundary_test.go
@@ -1,0 +1,441 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDepsRule_Boundary covers boundary cases that the
+// upstream suite under-exercises: deeply nested effects/callbacks,
+// IIFE async wrappers inside synchronous effects, hooks inside switch /
+// try-catch / for-of bodies, multi-component files, big-int / regex
+// literal deps, useEffectEvent diagnostic singularity, and other
+// real-world shapes that have caused regressions in similar ports.
+func TestExhaustiveDepsRule_Boundary(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		boundaryValid,
+		boundaryInvalid,
+	)
+}
+
+var boundaryValid = []rule_tester.ValidTestCase{
+	// IIFE async inside sync effect — the outer effect is sync, so the
+	// async-effect diagnostic must NOT fire. The inner async function's
+	// captures still count as effect deps.
+	{Code: `
+		function MyComponent({ id }: { id: number }) {
+			useEffect(() => {
+				(async () => {
+					await fetch('/api/' + id);
+				})();
+			}, [id]);
+		}
+	`, Tsx: true},
+
+	// async function declaration inside sync effect — same rationale.
+	{Code: `
+		function MyComponent({ id }: { id: number }) {
+			useEffect(() => {
+				async function load() {
+					await fetch('/api/' + id);
+				}
+				load();
+			}, [id]);
+		}
+	`, Tsx: true},
+
+	// setTimeout with async callback — the async is the timer cb, not
+	// the effect itself.
+	{Code: `
+		function MyComponent({ id }: { id: number }) {
+			useEffect(() => {
+				const t = setTimeout(async () => {
+					await fetch('/api/' + id);
+				}, 1000);
+				return () => clearTimeout(t);
+			}, [id]);
+		}
+	`, Tsx: true},
+
+	// Multiple components in one file — each should be analyzed
+	// independently, with no cross-contamination of state symbols.
+	{Code: `
+		function A({ id }: { id: number }) {
+			useEffect(() => { console.log(id); }, [id]);
+		}
+		function B({ name }: { name: string }) {
+			useEffect(() => { console.log(name); }, [name]);
+		}
+	`, Tsx: true},
+
+	// Hook inside a for-of loop — rules-of-hooks would flag this, but
+	// exhaustive-deps still analyzes it correctly (and the deps are OK).
+	{Code: `
+		function MyComponent({ items }: { items: number[] }) {
+			for (const item of items) {
+				useEffect(() => { console.log(item); }, [item]);
+			}
+		}
+	`, Tsx: true},
+
+	// useImperativeHandle: ref param itself should NOT be considered
+	// a dep (callback is at index 1).
+	{Code: `
+		function MyComponent({ value }: { value: number }, ref: any) {
+			useImperativeHandle(ref, () => ({ get: () => value }), [value]);
+		}
+	`, Tsx: true},
+}
+
+var boundaryInvalid = []rule_tester.InvalidTestCase{
+	// IIFE async inside sync effect — captured `id` must still be a dep.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				useEffect(() => {
+					(async () => { await fetch('/api/' + id); })();
+				}, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				useEffect(() => {
+					(async () => { await fetch('/api/' + id); })();
+				}, [id]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// useEffectEvent in deps array — verifies the dedicated diagnostic
+	// fires AND no spurious "unnecessary"/"missing" diagnostic fires
+	// alongside it (single diagnostic about the use-effect-event
+	// inclusion only).
+	{
+		Code: `
+			function MyComponent({ theme }: { theme: string }) {
+				const onClick = useEffectEvent(() => { console.log(theme); });
+				useEffect(() => { onClick(); }, [onClick]);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "Functions returned from `useEffectEvent` must not be included in the dependency array. Remove `onClick` from the list.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ theme }: { theme: string }) {
+				const onClick = useEffectEvent(() => { console.log(theme); });
+				useEffect(() => { onClick(); }, []);
+			}
+		`}},
+			},
+		},
+	},
+
+	// BigInt literal in deps.
+	{
+		Code: `
+			function MyComponent() {
+				useEffect(() => {}, [123n]);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "The 123n literal is not a valid dependency because it never changes. You can safely remove it."},
+		},
+	},
+
+	// Regex literal in deps.
+	{
+		Code: `
+			function MyComponent() {
+				useEffect(() => {}, [/foo/]);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "The /foo/ literal is not a valid dependency because it never changes. You can safely remove it."},
+		},
+	},
+
+	// Two components in one file, second has missing dep — must NOT
+	// confuse with first component's locals.
+	{
+		Code: `
+			function A({ id }: { id: number }) {
+				useEffect(() => { console.log(id); }, [id]);
+			}
+			function B({ name }: { name: string }) {
+				useEffect(() => { console.log(name); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'name'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function A({ id }: { id: number }) {
+				useEffect(() => { console.log(id); }, [id]);
+			}
+			function B({ name }: { name: string }) {
+				useEffect(() => { console.log(name); }, [name]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// Empty additionalHooks (rule-level falsy) falls back to settings.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				useTracked(() => { console.log(id); }, []);
+			}
+		`,
+		Tsx:      true,
+		Options:  map[string]interface{}{"additionalHooks": ""},
+		Settings: map[string]interface{}{"react-hooks": map[string]interface{}{"additionalHooks": "(useTracked)"}},
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useTracked has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				useTracked(() => { console.log(id); }, [id]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// useState updater message uses the right initial character for a
+	// non-ASCII state name. Exercises the rune-iteration fix in
+	// setStateRecommendation.
+	{
+		Code: `
+			function MyComponent() {
+				const [状态, set状态] = useState(0);
+				useEffect(() => { set状态(状态 + 1); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				// Initial-char of the missing dep "状态" must be its first
+				// rune ("状"), not a sliced byte that would corrupt the UTF-8.
+				Message: "React Hook useEffect has a missing dependency: '状态'. Either include it or remove the dependency array. You can also do a functional update 'set状态(状 => ...)' if you only need '状态' in the 'set状态' call.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent() {
+				const [状态, set状态] = useState(0);
+				useEffect(() => { set状态(状态 + 1); }, [状态]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// useReducer dispatch is registered in setStateCallSites so that
+	// `setState-without-deps` detection fires for `dispatch()` inside
+	// an effect with no deps array. Lock-in for F1.
+	{
+		Code: `
+			function MyComponent() {
+				const [state, dispatch] = useReducer((s: number) => s + 1, 0);
+				useEffect(() => { dispatch(); });
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect contains a call to 'dispatch'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass [] as a second argument to the useEffect Hook.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent() {
+				const [state, dispatch] = useReducer((s: number) => s + 1, 0);
+				useEffect(() => { dispatch(); }, []);
+			}
+		`}},
+			},
+		},
+	},
+
+	// Compound assignment to setter (F7 — `setX += 1`) — flags it as
+	// extra write, so setter is no longer stable, missing dep emitted.
+	{
+		Code: `
+			function MyComponent() {
+				let [count, setCount] = useState(0);
+				setCount += 1 as any;
+				useEffect(() => { setCount(c => c + 1); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'setCount'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent() {
+				let [count, setCount] = useState(0);
+				setCount += 1 as any;
+				useEffect(() => { setCount(c => c + 1); }, [setCount]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// Postfix increment (F7 — `setX++`) — same as above.
+	{
+		Code: `
+			function MyComponent() {
+				let [count, setCount] = useState(0);
+				(setCount as any)++;
+				useEffect(() => { setCount(c => c + 1); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'setCount'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent() {
+				let [count, setCount] = useState(0);
+				(setCount as any)++;
+				useEffect(() => { setCount(c => c + 1); }, [setCount]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// Function reassignment (F8) — handler is reassigned, so its
+	// `isFunctionWithoutCapturedValues` stability is invalidated and
+	// it must be listed as a dep.
+	{
+		Code: `
+			function MyComponent({ flag }: { flag: boolean }) {
+				let handler = () => 1;
+				if (flag) handler = () => 2;
+				useEffect(() => { handler(); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'handler'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ flag }: { flag: boolean }) {
+				let handler = () => 1;
+				if (flag) handler = () => 2;
+				useEffect(() => { handler(); }, [handler]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// ElementAccess assignment LHS (F3) — `obj['x'] = ...` should yield
+	// dep key `obj` (the receiver), matching `.x = ...`.
+	{
+		Code: `
+			function MyComponent({ obj }: { obj: Record<string, number> }) {
+				useEffect(() => { obj['x'] = 1; }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'obj'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ obj }: { obj: Record<string, number> }) {
+				useEffect(() => { obj['x'] = 1; }, [obj]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// useEffectEvent rejection + enableDangerousAutofix (F6) — promote
+	// suggestion to top-level autofix. Output field captures the fixed
+	// code; suggestion array is also kept.
+	{
+		Code: `
+			function MyComponent({ theme }: { theme: string }) {
+				const onClick = useEffectEvent(() => { console.log(theme); });
+				useEffect(() => { onClick(); }, [onClick]);
+			}
+		`,
+		Tsx:     true,
+		Options: map[string]interface{}{"enableDangerousAutofixThisMayCauseInfiniteLoops": true},
+		Output: []string{`
+			function MyComponent({ theme }: { theme: string }) {
+				const onClick = useEffectEvent(() => { console.log(theme); });
+				useEffect(() => { onClick(); }, []);
+			}
+		`},
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "Functions returned from `useEffectEvent` must not be included in the dependency array. Remove `onClick` from the list.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ theme }: { theme: string }) {
+				const onClick = useEffectEvent(() => { console.log(theme); });
+				useEffect(() => { onClick(); }, []);
+			}
+		`}},
+			},
+		},
+	},
+
+	// Nested useEffect inside useEffect callback — mirrors upstream's
+	// `gatherDependenciesRecursively` walk, which descends into every
+	// child scope of the callback (including nested function bodies).
+	// The outer hook collects BOTH `inner` (captured transitively via
+	// the nested callback) AND `outer` as missing deps, producing one
+	// combined "missing dependencies: 'inner' and 'outer'" report.
+	// The inner hook is analyzed independently in its own listener pass.
+	{
+		Code: `
+			function MyComponent({ outer, inner }: { outer: number; inner: number }) {
+				useEffect(() => {
+					console.log(outer);
+					useEffect(() => { console.log(inner); }, []);
+				}, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				// Outer effect's combined missing deps. The visitor fires
+				// the outer CallExpression listener before descending
+				// into the callback body, so this report comes first.
+				Message: "React Hook useEffect has missing dependencies: 'inner' and 'outer'. Either include them or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ outer, inner }: { outer: number; inner: number }) {
+				useEffect(() => {
+					console.log(outer);
+					useEffect(() => { console.log(inner); }, []);
+				}, [inner, outer]);
+			}
+		`}},
+			},
+			{
+				// Inner effect's missing dep, fired during the descent.
+				Message: "React Hook useEffect has a missing dependency: 'inner'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ outer, inner }: { outer: number; inner: number }) {
+				useEffect(() => {
+					console.log(outer);
+					useEffect(() => { console.log(inner); }, [inner]);
+				}, []);
+			}
+		`}},
+			},
+		},
+	},
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_destructure_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_destructure_test.go
@@ -1,0 +1,276 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDepsRule_Destructure exercises all destructure-binding
+// forms found in real-world React code. Each shape exercises a TC
+// resolution path that, before the rsbuild-found regression, could
+// silently mis-classify the binding's symbol as external (TC sometimes
+// returns the SOURCE TYPE's property symbol rather than the local
+// BindingElement, especially when the source object is typed via an
+// external `.d.ts`).
+//
+// Lock-in goal: when the destructure-bound name is captured in the
+// callback AND listed in deps, NO diagnostic must fire (the receiver
+// reference must NOT be silently dropped). When it's NOT in deps, the
+// missing-dep diagnostic fires correctly.
+func TestExhaustiveDepsRule_Destructure(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		destructureValid,
+		destructureInvalid,
+	)
+}
+
+var destructureValid = []rule_tester.ValidTestCase{
+	// Plain destructure rename — the rsbuild regression case.
+	{Code: `
+		declare function useData(): { siteData: { lang: string } };
+		function MyHook() {
+			const { siteData: { lang: defaultLang } } = useData();
+			return useCallback((url: string) => defaultLang + url, [defaultLang]);
+		}
+	`, Tsx: true},
+
+	// Same as above but flat (no nested) — TC may resolve differently.
+	{Code: `
+		declare function useData(): { value: number };
+		function MyHook() {
+			const { value: localValue } = useData();
+			return useCallback(() => localValue, [localValue]);
+		}
+	`, Tsx: true},
+
+	// Array destructure with rename via tuple typing.
+	{Code: `
+		declare function useTuple(): readonly [number, string];
+		function MyHook() {
+			const [num, str] = useTuple();
+			return useCallback(() => num + str, [num, str]);
+		}
+	`, Tsx: true},
+
+	// Destructure with default value.
+	{Code: `
+		declare function useData(): { value?: number };
+		function MyHook() {
+			const { value = 0 } = useData();
+			return useCallback(() => value, [value]);
+		}
+	`, Tsx: true},
+
+	// Destructure of a parameter (props is an Object pattern parameter).
+	{Code: `
+		function MyComponent({ id, name }: { id: number; name: string }) {
+			useEffect(() => { console.log(id, name); }, [id, name]);
+		}
+	`, Tsx: true},
+
+	// Nested destructure with property chain in body — declaring the
+	// receiver covers nested member access.
+	{Code: `
+		declare function useShape(): { a: { b: number } };
+		function MyHook() {
+			const { a } = useShape();
+			return useCallback(() => a.b, [a]);
+		}
+	`, Tsx: true},
+
+	// Destructure rename + the renamed binding is referenced as receiver
+	// of property chain in callback.
+	{Code: `
+		declare function useShape(): { user: { profile: { name: string } } };
+		function MyHook() {
+			const { user: u } = useShape();
+			return useCallback(() => u.profile.name, [u.profile]);
+		}
+	`, Tsx: true},
+
+	// Destructure with `as` cast — common pattern when refining types.
+	{Code: `
+		declare function useData(): unknown;
+		function MyHook() {
+			const { id } = useData() as { id: number };
+			return useCallback(() => id, [id]);
+		}
+	`, Tsx: true},
+
+	// Spread in destructure — bound name is local.
+	{Code: `
+		declare function useData(): { id: number; rest: any };
+		function MyHook() {
+			const { id, ...other } = useData();
+			void other;
+			return useCallback(() => id, [id]);
+		}
+	`, Tsx: true},
+
+	// Multiple useCallback referencing the same destructured renamed binding.
+	{Code: `
+		declare function useData(): { siteData: { lang: string } };
+		function MyHook() {
+			const { siteData: { lang: defaultLang } } = useData();
+			const a = useCallback(() => defaultLang + 'a', [defaultLang]);
+			const b = useCallback(() => defaultLang + 'b', [defaultLang]);
+			return [a, b];
+		}
+	`, Tsx: true},
+}
+
+var destructureInvalid = []rule_tester.InvalidTestCase{
+	// Plain destructure rename — missing.
+	{
+		Code: `
+			declare function useData(): { siteData: { lang: string } };
+			function MyHook() {
+				const { siteData: { lang: defaultLang } } = useData();
+				return useCallback((url: string) => defaultLang + url, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useCallback has a missing dependency: 'defaultLang'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			declare function useData(): { siteData: { lang: string } };
+			function MyHook() {
+				const { siteData: { lang: defaultLang } } = useData();
+				return useCallback((url: string) => defaultLang + url, [defaultLang]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// Renamed destructure declared as dep but NOT used — unnecessary.
+	// Lock-in: the diagnostic must NOT carry the "Outer scope values"
+	// suffix (which is the rsbuild regression we fixed). The bound name
+	// is local to the component, so the suffix is suppressed.
+	{
+		Code: `
+			declare function useData(): { siteData: { lang: string } };
+			function MyHook({ id }: { id: number }) {
+				const { siteData: { lang: defaultLang } } = useData();
+				void defaultLang;
+				return useCallback(() => id, [id, defaultLang]);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				// Plain "unnecessary" — no "Outer scope values" suffix.
+				Message: "React Hook useCallback has an unnecessary dependency: 'defaultLang'. Either exclude it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			declare function useData(): { siteData: { lang: string } };
+			function MyHook({ id }: { id: number }) {
+				const { siteData: { lang: defaultLang } } = useData();
+				void defaultLang;
+				return useCallback(() => id, [id]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// Destructured prop, renamed; property chain read inside callback.
+	// Dep key is the full chain `u.name` (matches upstream's getDependency
+	// behavior — non-call, non-.current reads ascend the receiver chain).
+	{
+		Code: `
+			function MyComponent({ user: u }: { user: { name: string } }) {
+				useEffect(() => { console.log(u.name); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'u.name'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ user: u }: { user: { name: string } }) {
+				useEffect(() => { console.log(u.name); }, [u.name]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// Tuple destructure — TC may resolve `num` to the tuple element type.
+	{
+		Code: `
+			declare function useTuple(): readonly [number, string];
+			function MyHook() {
+				const [num, str] = useTuple();
+				void str;
+				return useCallback(() => num, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useCallback has a missing dependency: 'num'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			declare function useTuple(): readonly [number, string];
+			function MyHook() {
+				const [num, str] = useTuple();
+				void str;
+				return useCallback(() => num, [num]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// Renamed destructure with default value, missing in deps.
+	{
+		Code: `
+			declare function useData(): { value?: number };
+			function MyHook() {
+				const { value: v = 0 } = useData();
+				return useCallback(() => v, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useCallback has a missing dependency: 'v'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			declare function useData(): { value?: number };
+			function MyHook() {
+				const { value: v = 0 } = useData();
+				return useCallback(() => v, [v]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// Two renamed destructures — both bound names captured via property
+	// chain, dep key is full `aliasA.name` / `aliasB.name`.
+	{
+		Code: `
+			declare function useShape(): { a: { name: string }; b: { name: string } };
+			function MyHook() {
+				const { a: aliasA, b: aliasB } = useShape();
+				return useCallback(() => aliasA.name + aliasB.name, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useCallback has missing dependencies: 'aliasA.name' and 'aliasB.name'. Either include them or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			declare function useShape(): { a: { name: string }; b: { name: string } };
+			function MyHook() {
+				const { a: aliasA, b: aliasB } = useShape();
+				return useCallback(() => aliasA.name + aliasB.name, [aliasA.name, aliasB.name]);
+			}
+		`}},
+			},
+		},
+	},
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_edge_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_edge_test.go
@@ -1,0 +1,481 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDepsRule_Edge holds final-mile edge cases:
+//
+//   - cross-file import resolution (L1/L2)
+//   - class field arrow inside non-component / component class (L4)
+//   - generator / async-generator callback shapes (L3/L5)
+//   - experimental_autoDependenciesHooks corner cases (L6)
+//   - nested useEffect + setter stable preservation (L7)
+//   - top-level hook lock-in (L8)
+//   - spread element followed by valid deps (L10)
+//   - additionalHooks regex with capture groups / non-trivial syntax (L9)
+//   - useState destructure with omitted state position (K7)
+//   - useState<T>() with explicit type argument (K3)
+//   - useEffect(fn, undefined as any) (K4)
+//   - typeof in TypeArgument inside callback (Q2)
+//   - useImperativeHandle ref param NOT a dep (K8)
+//
+// Each case carries a comment naming the audit point it locks in.
+func TestExhaustiveDepsRule_Edge(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		edgeValid,
+		edgeInvalid,
+	)
+}
+
+var edgeValid = []rule_tester.ValidTestCase{
+	// L1: cross-file imports — `useState` etc. resolve to symbols whose
+	// declarations live OUTSIDE the component scope, so they're treated
+	// as globals and not deps.
+	{Code: `
+		import { useState, useEffect } from 'react';
+		function MyComponent() {
+			const [count, setCount] = useState(0);
+			useEffect(() => { setCount(c => c + 1); }, []);
+			return count;
+		}
+	`, Tsx: true},
+
+	// L1: import an external function — used inside callback, NOT a dep
+	// because its declaration is outside the component (in module scope
+	// of another file).
+	{Code: `
+		import { format } from './format';
+		function MyComponent({ id }: { id: number }) {
+			useEffect(() => { console.log(format(id)); }, [id]);
+		}
+	`, Tsx: true},
+
+	// L4: class field arrow in a component-name class — exhaustive-deps
+	// itself doesn't react (class components don't use hooks; rules-of-hooks
+	// would flag, exhaustive-deps just analyzes any hook call it sees).
+	{Code: `
+		class Helper {
+			handler = () => 1;
+		}
+		function MyComponent() {
+			useEffect(() => {}, []);
+		}
+	`, Tsx: true},
+
+	// L7: setter stays stable when referenced from a nested callback inside
+	// an effect — no missing dep on setCount.
+	{Code: `
+		function MyComponent() {
+			const [count, setCount] = useState(0);
+			useEffect(() => {
+				const inner = () => { setCount(c => c + 1); };
+				inner();
+			}, []);
+			return count;
+		}
+	`, Tsx: true},
+
+	// L8: top-level hook call (no enclosing component) — silently
+	// ignored; component scope resolution returns nil and we bail.
+	{Code: `
+		useEffect(() => {}, []);
+	`, Tsx: true},
+
+	// L9: additionalHooks with alternation + capture group — Go regexp
+	// supports the same JS-style basic alternation used by upstream.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				useFooEffect(() => { console.log(id); }, [id]);
+				useBarEffect(() => { console.log(id); }, [id]);
+			}
+		`,
+		Tsx:     true,
+		Options: map[string]interface{}{"additionalHooks": "(useFooEffect|useBarEffect)"},
+	},
+
+	// L9: regex with anchors and character classes (Go RE2 supports these).
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				useV2Effect(() => { console.log(id); }, [id]);
+			}
+		`,
+		Tsx:     true,
+		Options: map[string]interface{}{"additionalHooks": "^useV[0-9]+Effect$"},
+	},
+
+	// L9: invalid regex string — silently ignored (matches upstream's
+	// lenient `try { new RegExp(...) }` shape via our `regexp.Compile`
+	// returning err handled by skipping).
+	{
+		Code: `
+			function MyComponent() {
+				useEffect(() => {}, []);
+			}
+		`,
+		Tsx:     true,
+		Options: map[string]interface{}{"additionalHooks": "[invalid"},
+	},
+
+	// S4: hoisted function declaration in component scope, referenced
+	// in an effect callback. `f` captures no reactive values
+	// (only globals like `console`), so isFunctionWithoutCapturedValues
+	// classifies it as stable → no missing-dep, no diagnostic.
+	{Code: `
+		function MyComponent() {
+			useEffect(() => { f(); }, []);
+			function f() { console.log('static'); }
+		}
+	`, Tsx: true},
+
+	// S4 negative twin: a hoisted function that DOES capture a reactive
+	// value (`id` from props). Mark `f` as unstable → must be listed.
+	// (Kept in invalid below since the lock-in is the missing-dep
+	// diagnostic.)
+
+	// K3: useState with explicit type argument — type args don't affect
+	// callee classification.
+	{Code: `
+		function MyComponent() {
+			const [count, setCount] = useState<number>(0);
+			useEffect(() => { setCount(count + 1); }, [count]);
+		}
+	`, Tsx: true},
+
+	// K7: useState destructure with omitted state position — only setter
+	// is bound, and setter is stable.
+	{Code: `
+		function MyComponent() {
+			const [, setCount] = useState(0);
+			useEffect(() => { setCount(c => c + 1); }, []);
+		}
+	`, Tsx: true},
+
+	// K4: useEffect(fn, undefined as any) — `as any` wrapper around
+	// undefined identifier is peeled by analyzePropertyChainText / our
+	// stripAsExpression on the deps argument.
+	{Code: `
+		function MyComponent() {
+			useEffect(() => {}, undefined as any);
+		}
+	`, Tsx: true},
+
+	// K8: useImperativeHandle ref param itself is NOT a dep — ref is
+	// the first argument, callback is the second, deps is the third.
+	{Code: `
+		function MyComponent({ value }: { value: number }, ref: any) {
+			useImperativeHandle(ref, () => ({ get: () => value }), [value]);
+		}
+	`, Tsx: true},
+
+	// L6: experimental_autoDependenciesHooks accepts both null literal
+	// AND `null as any`-wrapped null at deps position.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				useAuto(() => { console.log(id); }, null);
+			}
+		`,
+		Tsx: true,
+		Options: map[string]interface{}{
+			"additionalHooks":                    "(useAuto)",
+			"experimental_autoDependenciesHooks": []interface{}{"useAuto"},
+		},
+	},
+
+	// Q2: typeof inside type position of a generic — the `state`
+	// reference is purely type-level, NOT a runtime dep.
+	{Code: `
+		function MyComponent({ initial }: { initial: number }) {
+			const [state, setState] = useState<typeof initial>(initial);
+			useEffect(() => { console.log(state); }, [state]);
+			void setState;
+		}
+	`, Tsx: true},
+
+}
+
+var edgeInvalid = []rule_tester.InvalidTestCase{
+	// L1: imported function referenced but missing in deps — should
+	// remain external so NO diagnostic. (Negative — confirms imports
+	// are external.) For a true invalid, capture a local that wraps
+	// the import and verify it's a missing dep.
+	{
+		Code: `
+			import { format } from './format';
+			function MyComponent({ id }: { id: number }) {
+				const wrapped = (x: number) => format(x) + id;
+				useEffect(() => { console.log(wrapped(0)); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'wrapped'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			import { format } from './format';
+			function MyComponent({ id }: { id: number }) {
+				const wrapped = (x: number) => format(x) + id;
+				useEffect(() => { console.log(wrapped(0)); }, [wrapped]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// L9: additionalHooks alternation regex — second branch matched
+	// produces correct missing-dep diagnostic.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				useBarEffect(() => { console.log(id); }, []);
+			}
+		`,
+		Tsx:     true,
+		Options: map[string]interface{}{"additionalHooks": "(useFooEffect|useBarEffect)"},
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useBarEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				useBarEffect(() => { console.log(id); }, [id]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// K7: omitted state position with missing setter dep would be a
+	// stale-write case — but here we keep it valid-shaped to lock in
+	// that omitted+stable still works. Reuse L1 shape: setter SHOULD
+	// be stable (no diagnostic). The negative form is the second-tuple
+	// reassignment case below.
+	{
+		Code: `
+			function MyComponent() {
+				let [, setCount] = useState(0);
+				setCount = (() => 0) as any;
+				useEffect(() => { setCount(c => c + 1); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'setCount'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent() {
+				let [, setCount] = useState(0);
+				setCount = (() => 0) as any;
+				useEffect(() => { setCount(c => c + 1); }, [setCount]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// R1: deps array element is an OptionalCallExpression `obj?.()` —
+	// upstream `analyzePropertyChain` rejects all CallExpression-typed
+	// elements (it only accepts Identifier / MemberExpression /
+	// OptionalMemberExpression). The element falls through to the
+	// "complex expression" branch. The body's `obj` reference is
+	// captured but not declared (the `obj?.()` element doesn't count
+	// as a declared `obj`), so missing-dep is also reported.
+	{
+		Code: `
+			function MyComponent({ obj }: { obj?: () => void }) {
+				useEffect(() => { console.log(obj); }, [obj?.()]);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				// Main missing-dep diagnostic emitted first.
+				Message: "React Hook useEffect has a missing dependency: 'obj'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ obj }: { obj?: () => void }) {
+				useEffect(() => { console.log(obj); }, [obj]);
+			}
+		`}},
+			},
+			{
+				// Per-element complex-expression diagnostic flushed after.
+				Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked.",
+			},
+		},
+	},
+
+	// R3: JSX expression container reference inside the callback —
+	// `<Comp prop={dep} />` should mark `dep` as a captured reference.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				const make = useCallback(() => <div data-id={id} />, []);
+				return make();
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useCallback has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				const make = useCallback(() => <div data-id={id} />, [id]);
+				return make();
+			}
+		`}},
+			},
+		},
+	},
+
+	// S1: ref.current in cleanup + a missing non-ref dep in the body.
+	// Both diagnostics fire for the same effect.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				const ref = useRef(null);
+				useEffect(() => {
+					console.log(id);
+					return () => { console.log(ref.current); };
+				}, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				// ref.current cleanup warning — anchors the receiver.
+				Message: "The ref value 'ref.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'ref.current' to a variable inside the effect, and use that variable in the cleanup function.",
+			},
+			{
+				Message: "React Hook useEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				const ref = useRef(null);
+				useEffect(() => {
+					console.log(id);
+					return () => { console.log(ref.current); };
+				}, [id]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// S2: multiple setState calls in an effect with no deps — only the
+	// FIRST is reported (mirrors upstream's `if (setStateInsideEffectWithoutDeps)`
+	// short-circuit). One single diagnostic with the suggested deps array.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				const [, setX] = useState(0);
+				const [, setY] = useState(0);
+				useEffect(() => { setX(id); setY(id); });
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				// Only one diagnostic — the first detected setter wins.
+				Message: "React Hook useEffect contains a call to 'setX'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass [id] as a second argument to the useEffect Hook.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				const [, setX] = useState(0);
+				const [, setY] = useState(0);
+				useEffect(() => { setX(id); setY(id); }, [id]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// S3: setter aliasing — `const alias = setX; alias(...)` — `alias`
+	// is a fresh binding whose declaration is the const, NOT the useState
+	// destructure. So it's NOT stable, and must be listed as a dep.
+	{
+		Code: `
+			function MyComponent() {
+				const [, setX] = useState(0);
+				const alias = setX;
+				useEffect(() => { alias(1); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'alias'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent() {
+				const [, setX] = useState(0);
+				const alias = setX;
+				useEffect(() => { alias(1); }, [alias]);
+			}
+		`}},
+			},
+		},
+	},
+
+	// S4: hoisted function declaration that captures a prop — NOT stable,
+	// must be in deps. `f` is a FunctionDeclaration (not a parameter),
+	// so the "wrap in useCallback" suggestion suffix is NOT appended;
+	// upstream's `missingCallbackDep` only fires for parameter-typed
+	// declarations.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				useEffect(() => { f(); }, []);
+				function f() { console.log(id); }
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'f'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				useEffect(() => { f(); }, [f]);
+				function f() { console.log(id); }
+			}
+		`}},
+			},
+		},
+	},
+
+	// L7: nested setter usage inside an inner callback — still no missing
+	// dep on setCount (it's stable); the OUTER prop `id` IS a missing
+	// dep. Mirrors upstream's `inlineReducer` recommendation form
+	// (id resolves to a destructured parameter, not the state var, so
+	// the suffix is "switch to useReducer..." not "functional update...").
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				const [count, setCount] = useState(0);
+				useEffect(() => {
+					const inner = () => { setCount(c => c + id); };
+					inner();
+				}, []);
+				return count;
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'id'. Either include it or remove the dependency array. If 'setCount' needs the current value of 'id', you can also switch to useReducer instead of useState and read 'id' in the reducer.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				const [count, setCount] = useState(0);
+				useEffect(() => {
+					const inner = () => { setCount(c => c + id); };
+					inner();
+				}, [id]);
+				return count;
+			}
+		`}},
+			},
+		},
+	},
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_extras_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_extras_test.go
@@ -1,0 +1,470 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDepsRule_Extras covers edge cases that are NOT in the
+// upstream `ESLintRuleExhaustiveDeps-test.js` suite. The categories below
+// target two kinds of risk that the upstream suite under-exercises:
+//
+//   (1) tsgo AST quirks that ESTree flattens — paren-wrapped receivers,
+//       `as` / `satisfies` / `!` (non-null) wrappers, optional chains as
+//       PropertyAccess flags rather than ChainExpression wrappers, etc.
+//       Bugs in these categories are silent (rules look right on the
+//       upstream test suite but drift on real codebases).
+//
+//   (2) Real-world component shapes that don't appear upstream — class-
+//       field arrows, custom `forwardRef` / `memo` HOCs, deeply nested
+//       hooks inside conditionals/loops, useState destructuring with
+//       defaults, async function declarations inside effects, hooks
+//       inside switch / try-catch, etc.
+//
+// Each case carries a short comment explaining what aspect it locks in.
+func TestExhaustiveDepsRule_Extras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		extrasValid,
+		extrasInvalid,
+	)
+}
+
+var extrasValid = []rule_tester.ValidTestCase{
+	// ============================================================
+	// (1) tsgo AST quirks
+	// ============================================================
+
+	// Paren-wrapped hook callee — tsgo preserves ParenthesizedExpression
+	// where ESTree flattens it. The hook detector must see through.
+	{Code: `
+		function MyComponent({ id }) {
+			(useEffect)(() => { console.log(id); }, [id]);
+		}
+	`, Tsx: true},
+
+	// Paren-wrapped React namespace.
+	{Code: `
+		function MyComponent({ id }) {
+			(React).useEffect(() => { console.log(id); }, [id]);
+		}
+	`, Tsx: true},
+
+	// Paren-wrapped dep expression in deps array.
+	{Code: `
+		function MyComponent({ id }) {
+			useEffect(() => { console.log(id); }, [(id)]);
+		}
+	`, Tsx: true},
+
+	// Paren-wrapped property access in deps array.
+	{Code: `
+		function MyComponent(props) {
+			useEffect(() => { console.log(props.foo); }, [(props.foo)]);
+		}
+	`, Tsx: true},
+
+	// `as` cast on a dep is allowed — should normalize to the underlying chain.
+	{Code: `
+		function MyComponent({ id }: { id: number }) {
+			useEffect(() => { console.log(id); }, [id as number]);
+		}
+	`, Tsx: true},
+
+	// Non-null assertion `!` on receiver inside the callback. Mirrors
+	// upstream: the dep key for `user!.name` is the receiver `user` (the
+	// NonNullExpression breaks the receiver walk in `getDependency`),
+	// matching what we declare in deps.
+	{Code: `
+		function MyComponent({ user }: { user?: { name: string } }) {
+			useEffect(() => { console.log(user!.name); }, [user]);
+		}
+	`, Tsx: true},
+
+	// `satisfies` clause around the dep array.
+	{Code: `
+		function MyComponent({ id }: { id: number }) {
+			useEffect(() => { console.log(id); }, [id] satisfies readonly unknown[]);
+		}
+	`, Tsx: true},
+
+	// Optional chain in callback body, with declared dep covering the
+	// receiver. tsgo represents `?.` as a flag on PropertyAccessExpression
+	// rather than wrapping in ChainExpression.
+	{Code: `
+		function MyComponent({ user }: { user?: { name?: string } }) {
+			useEffect(() => { console.log(user?.name?.length); }, [user?.name?.length]);
+		}
+	`, Tsx: true},
+
+	// Optional method call. The callee receiver is the dep; the inner
+	// member access is a method call (don't recurse).
+	{Code: `
+		function MyComponent({ items }: { items?: { forEach: (fn: any) => void } }) {
+			useEffect(() => { items?.forEach(x => x); }, [items]);
+		}
+	`, Tsx: true},
+
+	// Nested template literals inside deps — Literal kinds in tsgo split
+	// `Literal` into NoSubstitutionTemplateLiteral / StringLiteral / etc.
+	{Code: `
+		function MyComponent() {
+			useEffect(() => {}, []);
+		}
+	`, Tsx: true},
+
+	// JSX attribute value is callback identifier — JSX is a tsgo extension
+	// and reference detection on JSX attributes must not mis-classify.
+	{Code: `
+		function MyComponent({ onClick }: { onClick: () => void }) {
+			const memo = useCallback(onClick, [onClick]);
+			return <button onClick={memo} />;
+		}
+	`, Tsx: true},
+
+	// Computed property name in deps array entry: `[obj['x']]` is element
+	// access, upstream rejects (complex expression). We bail safely.
+	// (No diagnostic when callback doesn't reference anything.)
+	{Code: `
+		function MyComponent() {
+			useEffect(() => {}, []);
+		}
+	`, Tsx: true},
+
+	// ============================================================
+	// (2) Real-world component shapes
+	// ============================================================
+
+	// forwardRef + useImperativeHandle (callback-at-index-1 hook) —
+	// receiver-less ref param.
+	{Code: `
+		const MyComp = React.forwardRef((props: { value: number }, ref) => {
+			React.useImperativeHandle(ref, () => ({
+				get: () => props.value,
+			}), [props.value]);
+			return null;
+		});
+	`, Tsx: true},
+
+	// memo wrapping the entire component — anonymous function inside.
+	{Code: `
+		const MyComp = React.memo((props: { id: string }) => {
+			React.useEffect(() => { console.log(props.id); }, [props.id]);
+			return null;
+		});
+	`, Tsx: true},
+
+	// Custom hook calling other hooks transitively.
+	{Code: `
+		function useTracker(deps: any[]) {
+			const ref = React.useRef(deps);
+			React.useEffect(() => { ref.current = deps; }, [deps]);
+			return ref;
+		}
+	`, Tsx: true},
+
+	// Hook called inside a top-level expression after a returned hook —
+	// the rule should still see deps captured in the inner hook.
+	{Code: `
+		function MyComponent({ a, b }: { a: number; b: number }) {
+			const x = useMemo(() => a + b, [a, b]);
+			useEffect(() => { console.log(x); }, [x]);
+		}
+	`, Tsx: true},
+
+	// Class-field arrow inside a non-component class — the rule must
+	// NOT treat the arrow as a component callback.
+	{Code: `
+		class NotAComponent {
+			handler = () => { console.log('not a hook'); };
+		}
+	`, Tsx: true},
+
+	// useEffect with explicit `undefined` deps — equivalent to no deps;
+	// not flagged unless requireExplicitEffectDeps is on.
+	{Code: `
+		function MyComponent() {
+			useEffect(() => {}, undefined);
+		}
+	`, Tsx: true},
+
+	// Setter from useReducer in deps — stable, may be omitted.
+	{Code: `
+		function MyComponent() {
+			const [state, dispatch] = useReducer((s: number) => s + 1, 0);
+			useEffect(() => { dispatch(); }, []);
+			return state;
+		}
+	`, Tsx: true},
+
+	// useState binding with default-valued destructure pattern.
+	{Code: `
+		function MyComponent() {
+			const [count = 0, setCount] = useState<number>(0);
+			useEffect(() => { setCount(count + 1); }, [count]);
+		}
+	`, Tsx: true},
+
+	// useEffectEvent return inside an arrow — referenced in another effect.
+	{Code: `
+		function MyComponent({ theme }: { theme: string }) {
+			const onClick = useEffectEvent(() => { console.log(theme); });
+			useLayoutEffect(() => { onClick(); }, []);
+			useInsertionEffect(() => { onClick(); }, []);
+		}
+	`, Tsx: true},
+
+	// Multiple hooks in same component — each independent, all valid.
+	{Code: `
+		function Multi({ a, b, c }: { a: number; b: number; c: number }) {
+			useEffect(() => { console.log(a); }, [a]);
+			useMemo(() => b * 2, [b]);
+			useCallback(() => c, [c]);
+		}
+	`, Tsx: true},
+
+	// Settings-level additionalHooks is a fallback for the rule-level option.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				useTrackedEffect(() => { console.log(id); }, [id]);
+			}
+		`,
+		Tsx:      true,
+		Settings: map[string]interface{}{"react-hooks": map[string]interface{}{"additionalHooks": "(useTrackedEffect)"}},
+	},
+
+	// Lock-in: `Namespace.useFoo` is NOT recognized as a hook by the
+	// additionalHooks regex (mirrors upstream's `node === calleeNode` gate
+	// where `node` is the post-namespace-strip identifier — only bare
+	// identifiers can be matched). The call below is treated as a regular
+	// function call, so the rule emits no diagnostics regardless of body.
+	{
+		Code: `
+			const Namespace = { useFoo: (cb: () => void, deps: any[]) => null };
+			function MyComponent({ id }: { id: number }) {
+				Namespace.useFoo(() => { console.log(id); }, []);
+			}
+		`,
+		Tsx:     true,
+		Options: map[string]interface{}{"additionalHooks": "Namespace\\.useFoo"},
+	},
+
+	// Lock-in: useRef returns are stable, so listing them in an effect's
+	// deps array is over-specification but EFFECTS allow that — upstream's
+	// `collectRecommendations` filters non-`.current`, non-external keys
+	// from `unnecessary` for effects. So this is valid.
+	{Code: `
+		function MyComponent() {
+			const a = useRef(0);
+			const b = useRef(0);
+			useEffect(() => { a.current = 1; b.current = 2; }, [a, b]);
+		}
+	`, Tsx: true},
+}
+
+var extrasInvalid = []rule_tester.InvalidTestCase{
+	// ============================================================
+	// (1) tsgo AST quirks — invalid forms
+	// ============================================================
+
+	// Paren-wrapped hook callee with missing dep.
+	{
+		Code: `
+			function MyComponent({ id }) {
+				(useEffect)(() => { console.log(id); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }) {
+				(useEffect)(() => { console.log(id); }, [id]);
+			}
+		`}}},
+		},
+	},
+
+	// Non-null assertion on receiver in callback — dep key for the chain
+	// is the receiver only (NonNullExpression terminates the receiver
+	// walk; matches upstream).
+	{
+		Code: `
+			function MyComponent({ user }: { user?: { name: string } }) {
+				useEffect(() => { console.log(user!.name); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a missing dependency: 'user'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ user }: { user?: { name: string } }) {
+				useEffect(() => { console.log(user!.name); }, [user]);
+			}
+		`}}},
+		},
+	},
+
+	// `as` cast inside callback body — type expression should be peeled.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				useEffect(() => { console.log((id as number) + 1); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				useEffect(() => { console.log((id as number) + 1); }, [id]);
+			}
+		`}}},
+		},
+	},
+
+	// Optional chain in body but not in deps — missing.
+	{
+		Code: `
+			function MyComponent({ user }: { user?: { name: string } }) {
+				useEffect(() => { console.log(user?.name); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a missing dependency: 'user?.name'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ user }: { user?: { name: string } }) {
+				useEffect(() => { console.log(user?.name); }, [user?.name]);
+			}
+		`}}},
+		},
+	},
+
+	// ============================================================
+	// (2) Real-world shapes — invalid forms
+	// ============================================================
+
+	// forwardRef component missing a dep.
+	{
+		Code: `
+			const MyComp = React.forwardRef((props: { value: number }, ref) => {
+				React.useImperativeHandle(ref, () => ({ get: () => props.value }), []);
+				return null;
+			});
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook React.useImperativeHandle has a missing dependency: 'props.value'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			const MyComp = React.forwardRef((props: { value: number }, ref) => {
+				React.useImperativeHandle(ref, () => ({ get: () => props.value }), [props.value]);
+				return null;
+			});
+		`}}},
+		},
+	},
+
+	// Memo-wrapped component missing a dep.
+	{
+		Code: `
+			const MyComp = React.memo((props: { id: string }) => {
+				React.useEffect(() => { console.log(props.id); }, []);
+				return null;
+			});
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook React.useEffect has a missing dependency: 'props.id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			const MyComp = React.memo((props: { id: string }) => {
+				React.useEffect(() => { console.log(props.id); }, [props.id]);
+				return null;
+			});
+		`}}},
+		},
+	},
+
+	// Multiple hooks: first valid, second missing dep — only second reports.
+	{
+		Code: `
+			function MyComponent({ a, b }: { a: number; b: number }) {
+				useEffect(() => { console.log(a); }, [a]);
+				useEffect(() => { console.log(b); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a missing dependency: 'b'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ a, b }: { a: number; b: number }) {
+				useEffect(() => { console.log(a); }, [a]);
+				useEffect(() => { console.log(b); }, [b]);
+			}
+		`}}},
+		},
+	},
+
+	// Hook inside a `try` body — still reports missing dep.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				try {
+					useEffect(() => { console.log(id); }, []);
+				} catch {}
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				try {
+					useEffect(() => { console.log(id); }, [id]);
+				} catch {}
+			}
+		`}}},
+		},
+	},
+
+	// Settings-level additionalHooks: deeply nested chain through it.
+	{
+		Code: `
+			function MyComponent({ id }: { id: number }) {
+				useTrackedEffect(() => { console.log(id); }, []);
+			}
+		`,
+		Tsx:      true,
+		Settings: map[string]interface{}{"react-hooks": map[string]interface{}{"additionalHooks": "(useTrackedEffect)"}},
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useTrackedEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+			function MyComponent({ id }: { id: number }) {
+				useTrackedEffect(() => { console.log(id); }, [id]);
+			}
+		`}}},
+		},
+	},
+
+	// ref.current in cleanup of a deeply nested effect — must still trigger.
+	{
+		Code: `
+			function MyComponent() {
+				const ref = useRef<HTMLDivElement>(null);
+				useLayoutEffect(() => {
+					return () => {
+						const node = ref.current;
+						if (node) node.removeEventListener('click', () => {});
+					};
+				}, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "The ref value 'ref.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'ref.current' to a variable inside the effect, and use that variable in the cleanup function."},
+		},
+	},
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_nil_tc_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_nil_tc_test.go
@@ -1,0 +1,121 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// TestExhaustiveDepsRule_NilTypeChecker verifies the rule operates
+// without panicking when the TypeChecker is unavailable. rslint
+// schedules rules without `RequiresTypeInfo: true` against "gap files"
+// (files in the program but not in `typeInfoFiles`) with a nil checker;
+// every code path that would normally consult TC must degrade
+// gracefully via the structural / name-walk fallback.
+//
+// The fixture below is shaped to exercise every TC-dependent branch:
+//   - useState binding (stable-known-hook-value)
+//   - useRef binding + ref.current cleanup
+//   - useEffectEvent binding + reference inside effect
+//   - missing dep with property chain (getDependency walk)
+//   - declared dep that resolves outside the component (computeExternalDeps)
+//   - construction warning (scanForConstructions)
+//   - additionalHooks via settings
+//
+// Success criterion: the rule's listeners run end-to-end without
+// panicking. Reports may differ from the TC-enabled path (the fallback
+// is structural and best-effort), so we don't assert specific messages
+// here — we only assert non-panic behavior.
+func TestExhaustiveDepsRule_NilTypeChecker(t *testing.T) {
+	t.Parallel()
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir, "react.tsx")
+	code := `
+function MyComponent({theme}) {
+  const [count, setCount] = useState(0);
+  const ref = useRef(null);
+  const onClick = useEffectEvent(() => {
+    console.log(theme);
+  });
+  const handler = () => {
+    return Store.subscribe(onClick);
+  };
+  useEffect(() => {
+    onClick();
+    setCount(count + 1);
+    handler();
+    console.log(props.foo.bar);
+    return () => {
+      console.log(ref.current);
+    };
+  }, []);
+  useTrackedEffect(() => { console.log(theme); }, []);
+}
+`
+	fs := utils.NewOverlayVFSForFile(filePath, code)
+	program, err := utils.CreateProgram(
+		true, fs, rootDir, "tsconfig.json", utils.CreateCompilerHost(rootDir, fs),
+	)
+	if err != nil {
+		t.Fatalf("CreateProgram: %v", err)
+	}
+	sourceFile := program.GetSourceFile(filePath)
+	if sourceFile == nil {
+		t.Fatalf("source file not found for %s", filePath)
+	}
+
+	// Settings include `additionalHooks` so the additional-hooks code
+	// path is also exercised under nil TC.
+	settings := map[string]interface{}{
+		"react-hooks": map[string]interface{}{"additionalHooks": "(useTrackedEffect)"},
+	}
+
+	ctx := rule.RuleContext{
+		SourceFile:  sourceFile,
+		Program:     program,
+		Settings:    settings,
+		TypeChecker: nil, // explicitly nil — this is the path under test
+		ReportNode: func(node *ast.Node, msg rule.RuleMessage) {
+			// noop — we only care that nothing panics.
+		},
+		ReportRange: func(_ core.TextRange, _ rule.RuleMessage) {
+		},
+		ReportNodeWithFixes: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleFix) {
+		},
+		ReportRangeWithFixes: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleFix) {
+		},
+		ReportNodeWithSuggestions: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
+		},
+		ReportRangeWithSuggestions: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
+		},
+		ReportNodeWithFixesAndSuggestions: func(_ *ast.Node, _ rule.RuleMessage, _ []rule.RuleFix, _ []rule.RuleSuggestion) {
+		},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ExhaustiveDepsRule.Run() panicked with nil TypeChecker: %v", r)
+		}
+	}()
+
+	listeners := ExhaustiveDepsRule.Run(ctx, nil)
+
+	var walk func(n *ast.Node) bool
+	walk = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if cb, ok := listeners[n.Kind]; ok {
+			cb(n)
+		}
+		n.ForEachChild(walk)
+		return false
+	}
+	walk(sourceFile.AsNode())
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_position_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_position_test.go
@@ -1,0 +1,123 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDepsRule_Positions exercises the diagnostic position
+// (Line / Column / EndLine / EndColumn) for every distinct diagnostic
+// shape the rule emits. Position errors don't surface in the
+// upstream-ported tests (upstream rarely asserts line/column), so we
+// dedicate a separate suite that checks each report site to detect
+// silent regressions in the trimmed-range output.
+//
+// Each case carries a single error whose location is asserted to the
+// 4-tuple (Line, Column, EndLine, EndColumn). The case body is shaped
+// so the start/end line numbers are obvious from the raw template.
+func TestExhaustiveDepsRule_Positions(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		nil,
+		positionInvalidCases,
+	)
+}
+
+var positionInvalidCases = []rule_tester.InvalidTestCase{
+	// Missing dep — the diagnostic is anchored at the deps array node.
+	{
+		Code: "function C({a}) {\n  useEffect(() => { a; }, []);\n}\n",
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'a'. Either include it or remove the dependency array.",
+				Line:    2, Column: 27, EndLine: 2, EndColumn: 29,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: "function C({a}) {\n  useEffect(() => { a; }, [a]);\n}\n"}},
+			},
+		},
+	},
+
+	// Spread element — anchored at the spread node.
+	{
+		Code: "function C({list}) {\n  useEffect(() => {}, [...list]);\n}\n",
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a spread element in its dependency array. This means we can't statically verify whether you've passed the correct dependencies.",
+				Line:    2, Column: 24, EndLine: 2, EndColumn: 31,
+			},
+		},
+	},
+
+	// Non-array deps — anchored at the deps argument expression.
+	{
+		Code: "function C({a}) {\n  useEffect(() => {}, a);\n}\n",
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies.",
+				Line:    2, Column: 23, EndLine: 2, EndColumn: 24,
+			},
+		},
+	},
+
+	// Async effect callback — anchored at the callback function node.
+	{
+		Code: "function C() {\n  useEffect(async () => { await foo(); }, []);\n}\n",
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Line: 2, Column: 13, EndLine: 2, EndColumn: 41,
+			},
+		},
+	},
+
+	// Missing callback — anchored at the hook callee.
+	{
+		Code: "function C() {\n  useEffect();\n}\n",
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect requires an effect callback. Did you forget to pass a callback to the hook?",
+				Line:    2, Column: 3, EndLine: 2, EndColumn: 12,
+			},
+		},
+	},
+
+	// Literal dep — anchored at the literal element.
+	{
+		Code: "function C() {\n  useEffect(() => {}, ['foo']);\n}\n",
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "The 'foo' literal is not a valid dependency because it never changes. You can safely remove it.",
+				Line:    2, Column: 24, EndLine: 2, EndColumn: 29,
+			},
+		},
+	},
+
+	// useMemo without deps — anchored at the hook callee.
+	{
+		Code: "function C({a}) {\n  useMemo(() => a);\n}\n",
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useMemo does nothing when called with only one argument. Did you forget to pass an array of dependencies?",
+				Line:    2, Column: 3, EndLine: 2, EndColumn: 10,
+			},
+		},
+	},
+
+	// ref.current in cleanup — anchored at the property name node.
+	{
+		Code: "function C() {\n  const ref = useRef(null);\n  useEffect(() => {\n    return () => { ref.current; };\n  }, []);\n}\n",
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Line: 4, Column: 24, EndLine: 4, EndColumn: 31,
+			},
+		},
+	},
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_test.go
@@ -1,0 +1,441 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDepsRule covers a curated subset of upstream
+// `ESLintRuleExhaustiveDeps-test.js`. Cases are grouped by category to
+// keep the file scrollable; comments above each case point at the
+// corresponding upstream block when applicable.
+//
+// Upstream coverage that is NOT exercised here (and the reason):
+//   - Flow-syntax tests (`component`, `hook`) — rslint's parser doesn't
+//     parse Flow.
+//   - Some scope-manager-dependent edge cases that require ESLint's
+//     write-tracking semantics — we mark these as `Skip: true` with a
+//     reason, so the file still documents the gap.
+func TestExhaustiveDepsRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		exhaustiveDepsValid,
+		exhaustiveDepsInvalid,
+	)
+}
+
+var exhaustiveDepsValid = []rule_tester.ValidTestCase{
+	// ---- Empty deps with no captures ----
+	{Code: `
+		function MyComponent(props) {
+			useEffect(() => {});
+		}
+	`, Tsx: true},
+	{Code: `
+		function MyComponent(props) {
+			useEffect(() => { console.log('hi'); }, []);
+		}
+	`, Tsx: true},
+	{Code: `
+		function MyComponent(props) {
+			useEffect(() => {
+				const local = {};
+				console.log(local);
+			}, []);
+		}
+	`, Tsx: true},
+
+	// ---- Stable hook values: setState / useRef.current / dispatch ----
+	{Code: `
+		function MyComponent() {
+			const [, setX] = useState(0);
+			useEffect(() => { setX(1); }, []);
+		}
+	`, Tsx: true},
+	{Code: `
+		function MyComponent() {
+			const ref = useRef(null);
+			useEffect(() => { ref.current = 1; }, []);
+		}
+	`, Tsx: true},
+	{Code: `
+		function MyComponent() {
+			const [, dispatch] = useReducer(reducer, 0);
+			useEffect(() => { dispatch({ type: 'a' }); }, []);
+		}
+	`, Tsx: true},
+
+	// ---- Effect callback referring to its own deps ----
+	{Code: `
+		function MyComponent({ id }) {
+			useEffect(() => { console.log(id); }, [id]);
+		}
+	`, Tsx: true},
+	{Code: `
+		function MyComponent({ items }) {
+			useMemo(() => items.length, [items]);
+		}
+	`, Tsx: true},
+	{Code: `
+		function MyComponent({ a, b }) {
+			useCallback(() => a + b, [a, b]);
+		}
+	`, Tsx: true},
+
+	// ---- useEffectEvent — return value is stable, no need to list ----
+	{Code: `
+		function MyComponent({ theme }) {
+			const onClick = useEffectEvent(() => { console.log(theme); });
+			useEffect(() => { onClick(); }, []);
+		}
+	`, Tsx: true},
+
+	// ---- useImperativeHandle (callbackIndex = 1) ----
+	{Code: `
+		function MyComponent({ value }, ref) {
+			useImperativeHandle(ref, () => ({ get: () => value }), [value]);
+		}
+	`, Tsx: true},
+
+	// ---- Optional chain in deps ----
+	{Code: `
+		function MyComponent({ user }) {
+			useEffect(() => { console.log(user?.name); }, [user?.name]);
+		}
+	`, Tsx: true},
+
+	// ---- Property chain: declaring 'props.foo' covers 'props.foo.bar' ----
+	{Code: `
+		function MyComponent(props) {
+			useEffect(() => { console.log(props.foo.bar); }, [props.foo]);
+		}
+	`, Tsx: true},
+
+	// ---- Reference to an external (module-scope) value — not a dep ----
+	{Code: `
+		const CONSTANT = 1;
+		function MyComponent() {
+			useEffect(() => { console.log(CONSTANT); }, []);
+		}
+	`, Tsx: true},
+
+	// ---- additionalHooks option matching ----
+	{
+		Code: `
+			function MyComponent({ id }) {
+				useMyEffect(() => { console.log(id); }, [id]);
+			}
+		`,
+		Tsx:     true,
+		Options: map[string]interface{}{"additionalHooks": "(useMyEffect)"},
+	},
+
+	// ---- nested function inside callback captures the value indirectly ----
+	{Code: `
+		function MyComponent({ id }) {
+			useEffect(() => {
+				function inner() { console.log(id); }
+				inner();
+			}, [id]);
+		}
+	`, Tsx: true},
+
+	// ---- TS as expression around deps array ----
+	{Code: `
+		function MyComponent({ id }) {
+			useEffect(() => { console.log(id); }, ([id] as const));
+		}
+	`, Tsx: true},
+
+	// ---- useLayoutEffect / useInsertionEffect treated as effects ----
+	{Code: `
+		function MyComponent({ id }) {
+			useLayoutEffect(() => { console.log(id); }, [id]);
+			useInsertionEffect(() => { console.log(id); }, [id]);
+		}
+	`, Tsx: true},
+
+	// ---- React.useEffect via namespace ----
+	{Code: `
+		function MyComponent({ id }) {
+			React.useEffect(() => { console.log(id); }, [id]);
+		}
+	`, Tsx: true},
+
+	// ---- Top-level call (not inside a component) — no diagnostic ----
+	{Code: `
+		useEffect(() => { /* no enclosing fn */ }, []);
+	`, Tsx: true},
+}
+
+var exhaustiveDepsInvalid = []rule_tester.InvalidTestCase{
+	// ---- Missing dep: simple ----
+	{
+		Code: `
+			function MyComponent({ id }) {
+				useEffect(() => { console.log(id); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{Output: `
+			function MyComponent({ id }) {
+				useEffect(() => { console.log(id); }, [id]);
+			}
+		`},
+				},
+			},
+		},
+	},
+
+	// ---- Missing dep with property chain ----
+	{
+		Code: `
+			function MyComponent(props) {
+				useEffect(() => { console.log(props.id); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useEffect has a missing dependency: 'props.id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{Output: `
+			function MyComponent(props) {
+				useEffect(() => { console.log(props.id); }, [props.id]);
+			}
+		`},
+				},
+			},
+		},
+	},
+
+	// ---- Unnecessary dep on useCallback ----
+	{
+		Code: `
+			function MyComponent({ a, b }) {
+				useCallback(() => a, [a, b]);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useCallback has an unnecessary dependency: 'b'. Either exclude it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{Output: `
+			function MyComponent({ a, b }) {
+				useCallback(() => a, [a]);
+			}
+		`},
+				},
+			},
+		},
+	},
+
+	// ---- Duplicate dep ----
+	{
+		Code: `
+			function MyComponent({ a }) {
+				useCallback(() => a, [a, a]);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				Message: "React Hook useCallback has a duplicate dependency: 'a'. Either omit it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{Output: `
+			function MyComponent({ a }) {
+				useCallback(() => a, [a]);
+			}
+		`},
+				},
+			},
+		},
+	},
+
+	// ---- Async useEffect ----
+	{
+		Code: `
+			function MyComponent() {
+				useEffect(async () => { await foo(); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: ""},
+		},
+	},
+
+	// ---- useMemo with no deps array ----
+	{
+		Code: `
+			function MyComponent({ a }) {
+				useMemo(() => a);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useMemo does nothing when called with only one argument. Did you forget to pass an array of dependencies?"},
+		},
+	},
+
+	// ---- useCallback with no deps array ----
+	{
+		Code: `
+			function MyComponent({ a }) {
+				useCallback(() => a);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useCallback does nothing when called with only one argument. Did you forget to pass an array of dependencies?"},
+		},
+	},
+
+	// ---- Spread element in deps ----
+	{
+		Code: `
+			function MyComponent({ list }) {
+				useEffect(() => {}, [...list]);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a spread element in its dependency array. This means we can't statically verify whether you've passed the correct dependencies."},
+		},
+	},
+
+	// ---- Deps array is not an array literal ----
+	{
+		Code: `
+			function MyComponent({ a }) {
+				useEffect(() => {}, a);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies."},
+		},
+	},
+
+	// ---- String literal in deps ----
+	{
+		Code: `
+			function MyComponent() {
+				useEffect(() => {}, ['foo']);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "The 'foo' literal is not a valid dependency because it never changes. You can safely remove it."},
+		},
+	},
+
+	// ---- ref.current in cleanup ----
+	{
+		Code: `
+			function MyComponent() {
+				const ref = useRef(null);
+				useEffect(() => {
+					return () => { console.log(ref.current); };
+				}, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "The ref value 'ref.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'ref.current' to a variable inside the effect, and use that variable in the cleanup function."},
+		},
+	},
+
+	// ---- Async useEffect callback ----
+	{
+		Code: `
+			function MyComponent() {
+				useEffect(async () => { await foo(); }, []);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "Effect callbacks are synchronous to prevent race conditions. " +
+				"Put the async function inside:\n\n" +
+				"useEffect(() => {\n" +
+				"  async function fetchData() {\n" +
+				"    // You can await here\n" +
+				"    const response = await MyAPI.getData(someId);\n" +
+				"    // ...\n" +
+				"  }\n" +
+				"  fetchData();\n" +
+				"}, [someId]); // Or [] if effect doesn't need props or state\n\n" +
+				"Learn more about data fetching with Hooks: https://react.dev/link/hooks-data-fetching"},
+		},
+	},
+
+	// ---- useEffect missing callback argument ----
+	{
+		Code: `
+			function MyComponent() {
+				useEffect();
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect requires an effect callback. Did you forget to pass a callback to the hook?"},
+		},
+	},
+
+	// ---- Numeric literal in deps ----
+	{
+		Code: `
+			function MyComponent() {
+				useEffect(() => {}, [42]);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "The 42 literal is not a valid dependency because it never changes. You can safely remove it."},
+		},
+	},
+
+	// ---- Functions returned from useEffectEvent must not be in deps ----
+	{
+		Code: `
+			function MyComponent({ theme }) {
+				const onClick = useEffectEvent(() => { console.log(theme); });
+				useEffect(() => { onClick(); }, [onClick]);
+			}
+		`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "Functions returned from `useEffectEvent` must not be included in the dependency array. Remove `onClick` from the list.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{Output: `
+			function MyComponent({ theme }) {
+				const onClick = useEffectEvent(() => { console.log(theme); });
+				useEffect(() => { onClick(); }, []);
+			}
+		`},
+				}},
+		},
+	},
+
+	// ---- requireExplicitEffectDeps: missing deps array on useEffect ----
+	{
+		Code: `
+			function MyComponent() {
+				useEffect(() => {});
+			}
+		`,
+		Tsx:     true,
+		Options: map[string]interface{}{"requireExplicitEffectDeps": true},
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect always requires dependencies. Please add a dependency array or an explicit `undefined`"},
+		},
+	},
+}
+

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/rule.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/rule.go
@@ -1,0 +1,2060 @@
+package exhaustive_deps
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// runCaches holds per-Run (per-file lint pass) memoization tables.
+//
+// Several helpers in this rule (`hasExtraWriteToSymbol`,
+// `hasCurrentAssignment`, `isUsedOutsideHook`) traverse a chunk of the
+// AST to answer a question about a particular symbol or identifier.
+// Without caching, those traversals re-run for every hook listener in
+// the file — easily O(N×hooks×file_size) on large codebases. Caches
+// here key on the stable identity (symbol pointer for the first two,
+// declaration-Identifier node for the last) so each query pays the
+// walk cost at most once per file.
+//
+// Lifetime: created once at the top of `Run` and kept alive for the
+// duration of that listener registration. The runtime calls listeners
+// many times for the same file but always within the same Run scope,
+// so map identity is preserved.
+type runCaches struct {
+	extraWrite    map[*ast.Symbol]bool
+	currentAssign map[*ast.Symbol]bool
+	usedOutside   map[*ast.Node]bool
+}
+
+// ExhaustiveDepsRule is the rslint port of upstream `react-hooks/exhaustive-deps`.
+//
+// Architectural difference from upstream: instead of relying on ESLint's
+// scope manager to enumerate `scope.references`, we walk the callback body
+// and resolve each Identifier reference via the TypeChecker. The
+// "pure scope" check (does this identifier resolve to a binding declared
+// outside the callback but inside the component?) is encoded as
+// `containsNode(componentBody, declSite) && !containsNode(callback, declSite)`.
+// When the TypeChecker is unavailable, the same check degrades to a
+// best-effort name walk over the component body.
+//
+// Diagnostics intentionally mirror upstream wording for switchover parity.
+var ExhaustiveDepsRule = rule.Rule{
+	Name: "react-hooks/exhaustive-deps",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options, ctx.Settings)
+		sf := ctx.SourceFile
+		tc := ctx.TypeChecker
+
+		// Run-scoped caches shared across every hook listener invocation
+		// in this file. Each cache is keyed by a stable identity (symbol
+		// pointer or AST node) and computed by walking the relevant
+		// component scope at most once per key. This avoids the
+		// previous O(N×hooks×file_size) re-scan pattern that surfaced
+		// in PR-808 review feedback for large codebases.
+		caches := &runCaches{
+			extraWrite:     map[*ast.Symbol]bool{},
+			currentAssign:  map[*ast.Symbol]bool{},
+			usedOutside:    map[*ast.Node]bool{},
+		}
+
+		report := func(node *ast.Node, msg string) {
+			ctx.ReportNode(node, rule.RuleMessage{Description: msg})
+		}
+		reportWithSuggestions := func(node *ast.Node, msg string, sugs ...rule.RuleSuggestion) {
+			if opts.EnableDangerousAutofixThisMayCauseInfiniteLoops && len(sugs) > 0 && len(sugs[0].FixesArr) > 0 {
+				// Mirrors upstream's
+				// `problem.fix = problem.suggest[0].fix`: promote the
+				// first suggestion's first fix only (singular `.fix`,
+				// not the entire FixesArr), AND keep the suggestions.
+				// `ReportNodeWithFixesAndSuggestions` is the preferred
+				// path; harnesses without it fall back to a fix-only
+				// report.
+				firstFix := []rule.RuleFix{sugs[0].FixesArr[0]}
+				if ctx.ReportNodeWithFixesAndSuggestions != nil {
+					ctx.ReportNodeWithFixesAndSuggestions(node, rule.RuleMessage{Description: msg}, firstFix, sugs)
+					return
+				}
+				ctx.ReportNodeWithFixes(node, rule.RuleMessage{Description: msg}, firstFix...)
+				return
+			}
+			if len(sugs) == 0 {
+				ctx.ReportNode(node, rule.RuleMessage{Description: msg})
+				return
+			}
+			ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{Description: msg}, sugs...)
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				visitCall(ctx, sf, tc, opts, caches, node, report, reportWithSuggestions)
+			},
+		}
+	},
+}
+
+// visitCall is the entry point for each CallExpression. It mirrors
+// upstream's `visitCallExpression` body — argument resolution, special
+// cases for missing callback / missing deps, and dispatch to
+// `visitFunctionWithDependencies` when the callback is inline.
+func visitCall(
+	ctx rule.RuleContext,
+	sf *ast.SourceFile,
+	tc *checker.Checker,
+	opts Options,
+	caches *runCaches,
+	node *ast.Node,
+	report func(*ast.Node, string),
+	reportWithSuggestions func(*ast.Node, string, ...rule.RuleSuggestion),
+) {
+	call := node.AsCallExpression()
+	callee := call.Expression
+	cbIdx := getReactiveHookCallbackIndex(callee, opts.AdditionalHooks)
+	if cbIdx == -1 {
+		return
+	}
+	args := []*ast.Node{}
+	if call.Arguments != nil {
+		args = call.Arguments.Nodes
+	}
+	if cbIdx >= len(args) {
+		// The hook needs a callback but none is provided.
+		hookName := reactiveHookName(callee)
+		report(callee, fmt.Sprintf(
+			"React Hook %s requires an effect callback. Did you forget to pass a callback to the hook?",
+			hookName,
+		))
+		return
+	}
+	callback := args[cbIdx]
+	hookName := reactiveHookName(callee)
+	isEffect := effectNameRegex.MatchString(hookName)
+	isAutoDepsHook := opts.AutoDepsHooks[hookName]
+
+	var depsNode *ast.Node
+	if cbIdx+1 < len(args) {
+		maybe := args[cbIdx+1]
+		if !hasUndefinedIdentifier(maybe) {
+			depsNode = maybe
+		}
+	}
+
+	// experimental_autoDependenciesHooks: when configured for this hook,
+	// `null` literal as the deps argument means "auto-infer", and a
+	// missing argument also means "auto" — either way we skip analysis.
+	if isAutoDepsHook {
+		if depsNode == nil {
+			return
+		}
+		if stripped := stripAsExpression(depsNode); stripped != nil && stripped.Kind == ast.KindNullKeyword {
+			return
+		}
+	}
+
+	// Missing deps array branch.
+	if depsNode == nil {
+		if !isEffect {
+			// Memo / Callback with no deps array: report.
+			if hookName == "useMemo" || hookName == "useCallback" {
+				report(callee, fmt.Sprintf(
+					"React Hook %s does nothing when called with only one argument. Did you forget to pass an array of dependencies?",
+					hookName,
+				))
+			}
+			return
+		}
+		// Effect with no deps array: still analyze for setState-without-deps
+		// infinite-loop warning. Handled inside visitFunctionWithDependencies
+		// when depsNode is nil.
+		if opts.RequireExplicitEffectDeps {
+			report(callee, fmt.Sprintf(
+				"React Hook %s always requires dependencies. Please add a dependency array or an explicit `undefined`",
+				hookName,
+			))
+		}
+	}
+
+	// Resolve callback to a function-like.
+	cb := stripAsExpression(callback)
+	switch cb.Kind {
+	case ast.KindFunctionExpression, ast.KindArrowFunction:
+		visitFunctionWithDependencies(ctx, sf, tc, opts, caches, cb, depsNode, callee, hookName, isEffect, node, reportWithSuggestions)
+	case ast.KindIdentifier:
+		// useEffect(myFn, deps): try to follow the symbol.
+		// Without a deps array we can't fault anything (effect always runs).
+		if depsNode == nil {
+			return
+		}
+		// If the deps array literally contains this identifier, accept.
+		if depArrayContainsName(depsNode, cb.AsIdentifier().Text) {
+			return
+		}
+		// Resolve via TypeChecker to classify the binding kind. A Parameter
+		// (or any binding whose declaration is not a reachable function /
+		// variable-with-function-init) yields the upstream
+		// `getUnknownDependenciesMessage` diagnostic instead of the
+		// "missing dep <callback-name>" autofix branch.
+		if tc != nil {
+			sym := tc.GetSymbolAtLocation(cb)
+			if sym != nil && len(sym.Declarations) > 0 {
+				decl := sym.Declarations[0]
+				// Walk up: a BindingElement nested in a Parameter (a
+				// destructured prop, e.g. `function C({myEffect})`) should
+				// be treated as Parameter for the unknown-deps decision.
+				isParameter := decl.Kind == ast.KindParameter
+				if !isParameter && decl.Kind == ast.KindBindingElement {
+					for cur := decl.Parent; cur != nil; cur = cur.Parent {
+						if cur.Kind == ast.KindParameter {
+							isParameter = true
+							break
+						}
+						if isFunctionLikeContainer(cur) {
+							break
+						}
+					}
+				}
+				if isParameter {
+					report(callee, getUnknownDependenciesMessage(hookName))
+					return
+				}
+				switch decl.Kind {
+				case ast.KindFunctionDeclaration:
+					visitFunctionWithDependencies(ctx, sf, tc, opts, caches, decl, depsNode, callee, hookName, isEffect, node, reportWithSuggestions)
+					return
+				case ast.KindVariableDeclaration:
+					vd := decl.AsVariableDeclaration()
+					if vd.Initializer != nil {
+						init := stripAsExpression(vd.Initializer)
+						if init != nil && (init.Kind == ast.KindArrowFunction || init.Kind == ast.KindFunctionExpression) {
+							visitFunctionWithDependencies(ctx, sf, tc, opts, caches, init, depsNode, callee, hookName, isEffect, node, reportWithSuggestions)
+							return
+						}
+					}
+				}
+			}
+		}
+		// Fallback: suggest adding the identifier to the deps array.
+		fix := rule.RuleFixReplace(sf, depsNode, "["+cb.AsIdentifier().Text+"]")
+		reportWithSuggestions(callee,
+			fmt.Sprintf(
+				"React Hook %s has a missing dependency: '%s'. Either include it or remove the dependency array.",
+				hookName, cb.AsIdentifier().Text,
+			),
+			rule.RuleSuggestion{
+				Message:  rule.RuleMessage{Description: "Update the dependencies array to be: [" + cb.AsIdentifier().Text + "]"},
+				FixesArr: []rule.RuleFix{fix},
+			},
+		)
+	default:
+		// Any other expression at the callback position (CallExpression,
+		// member call, etc.). Mirrors upstream's catch-all `getUnknownDependenciesMessage`.
+		report(callee, getUnknownDependenciesMessage(hookName))
+	}
+}
+
+// depArrayContainsName reports whether `depsNode` is an array literal
+// containing the identifier `name` as one of its bare identifier elements.
+func depArrayContainsName(depsNode *ast.Node, name string) bool {
+	depsNode = stripAsExpression(depsNode)
+	if depsNode == nil || depsNode.Kind != ast.KindArrayLiteralExpression {
+		return false
+	}
+	arr := depsNode.AsArrayLiteralExpression()
+	if arr.Elements == nil {
+		return false
+	}
+	for _, el := range arr.Elements.Nodes {
+		if el == nil {
+			continue
+		}
+		e := ast.SkipParentheses(el)
+		if e.Kind == ast.KindIdentifier && e.AsIdentifier().Text == name {
+			return true
+		}
+	}
+	return false
+}
+
+// visitFunctionWithDependencies mirrors upstream's same-named function:
+// it walks the callback body, gathers used dependencies, compares them
+// to declared deps, and reports diagnostics.
+func visitFunctionWithDependencies(
+	ctx rule.RuleContext,
+	sf *ast.SourceFile,
+	tc *checker.Checker,
+	opts Options,
+	caches *runCaches,
+	callback *ast.Node,
+	depsNode *ast.Node,
+	reactiveHook *ast.Node,
+	hookName string,
+	isEffect bool,
+	hookCall *ast.Node,
+	reportWithSuggestions func(*ast.Node, string, ...rule.RuleSuggestion),
+) {
+	if isEffect && hasAsyncModifier(callback) {
+		ctx.ReportNode(callback, rule.RuleMessage{Description: "Effect callbacks are synchronous to prevent race conditions. " +
+			"Put the async function inside:\n\n" +
+			"useEffect(() => {\n" +
+			"  async function fetchData() {\n" +
+			"    // You can await here\n" +
+			"    const response = await MyAPI.getData(someId);\n" +
+			"    // ...\n" +
+			"  }\n" +
+			"  fetchData();\n" +
+			"}, [someId]); // Or [] if effect doesn't need props or state\n\n" +
+			"Learn more about data fetching with Hooks: https://react.dev/link/hooks-data-fetching"})
+	}
+
+	callbackBody := getCallbackBody(callback)
+	if callbackBody == nil {
+		return
+	}
+
+	// Component scope = the nearest enclosing function-like that
+	// classifies as a React component or custom hook (PascalCase or
+	// `use*`). Walk past intermediate anonymous IIFEs / non-component
+	// closures (e.g. nested useEffect callbacks) so that a hook defined
+	// inside another hook's body still resolves component-scope props
+	// correctly. Mirrors upstream's `componentScope = currentScope`
+	// loop in `visitFunctionWithDependencies`.
+	componentFn := findEnclosingFunction(callback)
+	for componentFn != nil && !isComponentOrHookFunction(componentFn) {
+		componentFn = findEnclosingFunction(componentFn)
+	}
+	if componentFn == nil {
+		return
+	}
+
+	// Tracks `setState` callees and the corresponding state Identifier.
+	setStateCallSites := map[*ast.Symbol]*ast.Node{}
+	stateVariableSymbols := map[*ast.Symbol]bool{}
+	useEffectEventSymbols := map[*ast.Symbol]bool{}
+
+	// Pre-scan the component body: identify all `useState` / `useReducer` /
+	// `useTransition` / `useRef` / `useEffectEvent` declarations so we can
+	// stamp their "stable identity" on references during the gather phase.
+	primeStableSymbols(tc, sf, caches, componentFn, setStateCallSites, stateVariableSymbols, useEffectEventSymbols)
+
+	// Gather references inside the callback body.
+	dependencies := map[string]*dependency{}
+	optionalChains := map[string]bool{}
+
+	gatherDeps(
+		ctx, sf, tc, caches, callback, callbackBody, componentFn,
+		setStateCallSites, stateVariableSymbols,
+		dependencies, optionalChains,
+		isEffect,
+	)
+
+	stableDeps := map[string]bool{}
+	for key, dep := range dependencies {
+		if dep.IsStable {
+			stableDeps[key] = true
+		}
+	}
+
+	// Stale-assignment warnings: assignments to outer-scope variables from
+	// inside the hook callback are usually mistakes. Reported in source
+	// order. For each dep with at least one write, pick the earliest write
+	// position; then sort entries by that position. This matches upstream's
+	// observable order (iterates each variable's references in declaration
+	// order; first-write wins per variable).
+	type staleEntry struct {
+		writeExpr *ast.Node
+		key       string
+	}
+	staleByKey := map[string]*ast.Node{}
+	for key, dep := range dependencies {
+		for _, ref := range dep.Refs {
+			if ref.WriteExpr == nil {
+				continue
+			}
+			if existing, ok := staleByKey[key]; !ok || ref.WriteExpr.Pos() < existing.Pos() {
+				staleByKey[key] = ref.WriteExpr
+			}
+		}
+	}
+	staleEntries := make([]staleEntry, 0, len(staleByKey))
+	for key, we := range staleByKey {
+		staleEntries = append(staleEntries, staleEntry{we, key})
+	}
+	sort.Slice(staleEntries, func(i, j int) bool {
+		return staleEntries[i].writeExpr.Pos() < staleEntries[j].writeExpr.Pos()
+	})
+	for _, se := range staleEntries {
+		ctx.ReportNode(se.writeExpr, rule.RuleMessage{Description: fmt.Sprintf(
+			"Assignments to the '%s' variable from inside React Hook %s "+
+				"will be lost after each render. To preserve the value over time, "+
+				"store it in a useRef Hook and keep the mutable value in the '.current' property. "+
+				"Otherwise, you can move this variable directly inside %s.",
+			se.key, getCalleeText(sf, reactiveHook), getCalleeText(sf, reactiveHook),
+		)})
+	}
+	if len(staleEntries) > 0 {
+		return
+	}
+
+	// No deps array case: only emit the setState-without-deps diagnostic.
+	if depsNode == nil {
+		emitSetStateInsideEffectWarning(ctx, sf, tc, hookCall, reactiveHook, hookName, callback,
+			dependencies, setStateCallSites, stableDeps, optionalChains, reportWithSuggestions)
+		return
+	}
+
+	// Parse declared deps. Per-element diagnostics are deferred so they can
+	// be flushed after the main missing-dep diagnostic — matching upstream's
+	// report order.
+	declared, deferredElementDiags, depsArrayBad := parseDeclaredDeps(ctx, sf, tc, reactiveHook, hookCall, depsNode,
+		dependencies, useEffectEventSymbols, componentFn)
+	if depsArrayBad {
+		return
+	}
+
+	// External dependencies: declared deps that resolve outside componentFn
+	// (i.e., globals / imports), used to suppress the "unnecessary" verdict
+	// for effects and to drive the "Outer scope values" hint.
+	externalDeps := computeExternalDeps(declared, componentFn, tc, sf)
+
+	rec := collectRecommendations(dependencies, declared, stableDeps, externalDeps, isEffect)
+
+	suggestedDeps := rec.Suggested
+	problemCount := len(rec.Duplicate) + len(rec.Missing) + len(rec.Unnecessary)
+	if problemCount == 0 {
+		// No deps issues: check for constructions that change every render.
+		emitConstructionWarnings(ctx, sf, tc, callback, depsNode, declared, hookName, opts, reportWithSuggestions)
+		flushDeferredDiagnostics(ctx, deferredElementDiags, opts.EnableDangerousAutofixThisMayCauseInfiniteLoops)
+		return
+	}
+
+	// For non-effect hooks with missing deps, recompute suggestions from scratch.
+	if !isEffect && len(rec.Missing) > 0 {
+		rec2 := collectRecommendations(dependencies, []declaredDependency{}, stableDeps, externalDeps, isEffect)
+		suggestedDeps = rec2.Suggested
+	}
+
+	// Alphabetize suggestions iff the originals were alphabetized.
+	if areDeclaredDepsAlphabetized(declared) {
+		sort.Strings(suggestedDeps)
+	}
+
+	// Build the warning message.
+	hookCalleeText := getCalleeText(sf, reactiveHook)
+	msg := buildDepDiagnostic(hookCalleeText, rec, externalDeps, dependencies,
+		hookName, optionalChains, setStateCallSites, stateVariableSymbols, componentFn, tc, callback)
+
+	// Build suggestion text.
+	formatted := make([]string, len(suggestedDeps))
+	for i, k := range suggestedDeps {
+		formatted[i] = formatDependency(k, optionalChains)
+	}
+	suggestionText := "[" + strings.Join(formatted, ", ") + "]"
+	fix := rule.RuleFixReplace(sf, depsNode, suggestionText)
+	reportWithSuggestions(depsNode, msg,
+		rule.RuleSuggestion{
+			Message:  rule.RuleMessage{Description: "Update the dependencies array to be: " + suggestionText},
+			FixesArr: []rule.RuleFix{fix},
+		},
+	)
+	// Flush per-element diagnostics AFTER the main report — upstream's
+	// observable order is missing-dep first, element errors after.
+	flushDeferredDiagnostics(ctx, deferredElementDiags, opts.EnableDangerousAutofixThisMayCauseInfiniteLoops)
+}
+
+// buildDepDiagnostic constructs the "React Hook X has a/an missing/unnecessary
+// /duplicate dependencies: 'a', 'b'." message body, including any of the
+// "Mutable values like ref.current aren't valid"/"Outer scope values like..."
+// /setStateRecommendation extra warnings.
+func buildDepDiagnostic(
+	hookText string,
+	rec recommendations,
+	externalDeps map[string]bool,
+	dependencies map[string]*dependency,
+	hookName string,
+	optionalChains map[string]bool,
+	setStateCallSites map[*ast.Symbol]*ast.Node,
+	stateVariableSymbols map[*ast.Symbol]bool,
+	componentFn *ast.Node,
+	tc *checker.Checker,
+	callback *ast.Node,
+) string {
+	body := getWarningMessage(rec.Missing, "a", "missing", "include", optionalChains)
+	if body == "" {
+		body = getWarningMessage(rec.Unnecessary, "an", "unnecessary", "exclude", optionalChains)
+	}
+	if body == "" {
+		body = getWarningMessage(rec.Duplicate, "a", "duplicate", "omit", optionalChains)
+	}
+	extra := ""
+	// `ref.current` mutable warning.
+	if len(rec.Unnecessary) > 0 {
+		var badRef string
+		keys := make([]string, 0, len(rec.Unnecessary))
+		for k := range rec.Unnecessary {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if strings.HasSuffix(k, ".current") {
+				badRef = k
+				break
+			}
+		}
+		if badRef != "" {
+			extra = fmt.Sprintf(
+				" Mutable values like '%s' aren't valid dependencies because mutating them doesn't re-render the component.",
+				badRef,
+			)
+		} else if len(externalDeps) > 0 {
+			extKeys := make([]string, 0, len(externalDeps))
+			for k := range externalDeps {
+				extKeys = append(extKeys, k)
+			}
+			sort.Strings(extKeys)
+			// Mirrors upstream's `!scope.set.has(dep)` gate: when the
+			// "external" name is also locally declared inside the callback
+			// (e.g. `const fetchData = ...; useEffect(() => { fetchData() }, [fetchData])`),
+			// the user clearly meant the local — don't add the outer-scope
+			// hint. We don't have ESLint's scope manager, so we check by
+			// walking the callback body for a matching declaration name.
+			if !nameDeclaredInsideCallback(extKeys[0], callback) {
+				extra = fmt.Sprintf(
+					" Outer scope values like '%s' aren't valid dependencies because mutating them doesn't re-render the component.",
+					extKeys[0],
+				)
+			}
+		}
+	}
+	// `props.foo()` marks `props` as a dep — the warning is confusing, so
+	// upstream appends a clarification. Mirrors upstream's
+	// `isPropsOnlyUsedInMembers`.
+	if extra == "" && rec.Missing["props"] {
+		extra = propsOnlyMembersHint(dependencies, hookName)
+	}
+	// missingCallbackDep: when the only missing dep is a parameter that's
+	// being called as a function, suggest wrapping it in useCallback in the
+	// parent component. Mirrors upstream's same-named branch.
+	if extra == "" && len(rec.Missing) > 0 {
+		extra = missingCallbackDepHint(rec.Missing, dependencies, componentFn, tc)
+	}
+	// setState recommendation: when a missing dep is read inside a setState
+	// call, append the appropriate hint. Mirrors upstream's three forms.
+	if extra == "" && len(rec.Missing) > 0 {
+		extra = setStateRecommendation(rec.Missing, dependencies, setStateCallSites,
+			stateVariableSymbols, componentFn, tc)
+	}
+	return fmt.Sprintf("React Hook %s has %s%s", hookText, body, extra)
+}
+
+// nameDeclaredInsideCallback reports whether `name` is the name of a
+// VariableDeclaration / FunctionDeclaration / ClassDeclaration / parameter
+// inside `callback`'s body — i.e., it is a "local" rather than an "outer"
+// scope value. Used to suppress the "Outer scope values" hint when the
+// user clearly meant the local binding.
+func nameDeclaredInsideCallback(name string, callback *ast.Node) bool {
+	body := getCallbackBody(callback)
+	if body == nil {
+		return false
+	}
+	found := false
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if found {
+			return true
+		}
+		switch n.Kind {
+		case ast.KindVariableDeclaration:
+			if vn := n.AsVariableDeclaration().Name(); vn != nil && vn.Kind == ast.KindIdentifier && vn.AsIdentifier().Text == name {
+				found = true
+				return true
+			}
+		case ast.KindFunctionDeclaration, ast.KindClassDeclaration:
+			if vn := n.Name(); vn != nil && vn.Kind == ast.KindIdentifier && vn.AsIdentifier().Text == name {
+				found = true
+				return true
+			}
+		case ast.KindParameter:
+			if vn := n.AsParameterDeclaration().Name(); vn != nil && vn.Kind == ast.KindIdentifier && vn.AsIdentifier().Text == name {
+				found = true
+				return true
+			}
+		case ast.KindBindingElement:
+			if vn := n.AsBindingElement().Name(); vn != nil && vn.Kind == ast.KindIdentifier && vn.AsIdentifier().Text == name {
+				found = true
+				return true
+			}
+		}
+		// Don't descend into nested function-likes — their bindings don't
+		// shadow the outer callback's scope. Exception: the callback itself,
+		// which we already entered via getCallbackBody.
+		if isFunctionLikeContainer(n) && n != callback {
+			return false
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(body)
+	return found
+}
+
+// propsOnlyMembersHint mirrors upstream's `isPropsOnlyUsedInMembers`
+// check: when `props` is missing AND every observed reference of `props`
+// inside the callback is `props.<member>` (never bare `props`), append
+// the destructure-outside-the-hook recommendation.
+func propsOnlyMembersHint(dependencies map[string]*dependency, hookName string) string {
+	dep, ok := dependencies["props"]
+	if !ok {
+		return ""
+	}
+	for _, ref := range dep.Refs {
+		id := ref.Identifier
+		if id == nil {
+			return ""
+		}
+		p := id.Parent
+		if p == nil {
+			return ""
+		}
+		if p.Kind != ast.KindPropertyAccessExpression {
+			return ""
+		}
+		// `props` must be the receiver (object), not the property name.
+		if p.AsPropertyAccessExpression().Expression != id {
+			return ""
+		}
+	}
+	return fmt.Sprintf(
+		" However, 'props' will change when *any* prop changes, so the preferred fix is to destructure the 'props' object outside of the %s call and refer to those specific props inside %s.",
+		hookName, hookName,
+	)
+}
+
+// missingCallbackDepHint mirrors upstream's `missingCallbackDep` branch.
+// For each missing dep that:
+//   - resolves to a Parameter declaration (i.e., a destructured prop), AND
+//   - is called at least once inside the callback body
+//
+// emit "If 'X' changes too often, find the parent component that defines
+// it and wrap that definition in useCallback." Returns "" otherwise.
+func missingCallbackDepHint(
+	missing map[string]bool,
+	dependencies map[string]*dependency,
+	componentFn *ast.Node,
+	tc *checker.Checker,
+) string {
+	if tc == nil {
+		return ""
+	}
+	missingKeys := make([]string, 0, len(missing))
+	for k := range missing {
+		missingKeys = append(missingKeys, k)
+	}
+	sort.Strings(missingKeys)
+	for _, dep := range missingKeys {
+		used, ok := dependencies[dep]
+		if !ok || len(used.Refs) == 0 {
+			continue
+		}
+		// Symbol must be a Parameter declared in the component scope.
+		first := used.Refs[0]
+		if first.Symbol == nil || len(first.Symbol.Declarations) == 0 {
+			continue
+		}
+		decl := first.Symbol.Declarations[0]
+		if decl.Kind != ast.KindParameter {
+			// Could also be BindingElement nested inside a Parameter (destructured).
+			cur := decl
+			isParam := false
+			for cur != nil {
+				if cur.Kind == ast.KindParameter {
+					isParam = true
+					break
+				}
+				cur = cur.Parent
+			}
+			if !isParam {
+				continue
+			}
+		}
+		// Must be called somewhere.
+		isCalled := false
+		for _, ref := range used.Refs {
+			id := ref.Identifier
+			if id.Parent != nil && id.Parent.Kind == ast.KindCallExpression {
+				if id.Parent.AsCallExpression().Expression == id {
+					isCalled = true
+					break
+				}
+			}
+		}
+		if !isCalled {
+			continue
+		}
+		return fmt.Sprintf(
+			" If '%s' changes too often, find the parent component that defines it and wrap that definition in useCallback.",
+			dep,
+		)
+	}
+	return ""
+}
+
+// setStateRecommendation mirrors upstream's same-named computation. For
+// each missing dep, walks references upward looking for a CallExpression
+// whose callee was registered in `setStateCallSites`. When found,
+// classifies into three forms:
+//
+//   - "updater"      — `setX(x + 1)`: missing dep IS the state variable for `setX`
+//   - "reducer"      — `setCount(count + increment)`: missing dep IS a state variable for some other setter
+//   - "inlineReducer"— `setX(...prop...)`: missing dep is a parameter (prop)
+//
+// Returns the suffix (with leading space) or "" when no recommendation matches.
+func setStateRecommendation(
+	missing map[string]bool,
+	dependencies map[string]*dependency,
+	setStateCallSites map[*ast.Symbol]*ast.Node,
+	stateVariableSymbols map[*ast.Symbol]bool,
+	componentFn *ast.Node,
+	tc *checker.Checker,
+) string {
+	if tc == nil || componentFn == nil {
+		return ""
+	}
+	missingKeys := make([]string, 0, len(missing))
+	for k := range missing {
+		missingKeys = append(missingKeys, k)
+	}
+	sort.Strings(missingKeys)
+	for _, dep := range missingKeys {
+		used, ok := dependencies[dep]
+		if !ok {
+			continue
+		}
+		for _, ref := range used.Refs {
+			id := ref.Identifier
+			cur := id.Parent
+			for cur != nil && cur != componentFn {
+				if cur.Kind == ast.KindCallExpression {
+					call := cur.AsCallExpression()
+					calleeSym := tc.GetSymbolAtLocation(call.Expression)
+					if calleeSym != nil {
+						if stateForSetter, isSetter := setStateCallSites[calleeSym]; isSetter {
+							setterName := ""
+							if c := call.Expression; c != nil && c.Kind == ast.KindIdentifier {
+								setterName = c.AsIdentifier().Text
+							}
+							// Form selection.
+							if stateForSetter != nil && stateForSetter.Kind == ast.KindIdentifier &&
+								stateForSetter.AsIdentifier().Text == dep {
+								// updater form: setCount(count + 1)
+								// Mirrors upstream's `missingDep.slice(0, 1)` —
+								// JS string indexing is over UTF-16 code units;
+								// for ASCII state names this matches `dep[:1]`,
+								// but for multi-byte names (CJK / emoji /
+								// accented Latin) Go's byte slice would
+								// truncate. Use rune iteration for the first
+								// scalar character.
+								initial := dep
+								for _, r := range dep {
+									initial = string(r)
+									break
+								}
+								return fmt.Sprintf(
+									" You can also do a functional update '%s(%s => ...)' if you only need '%s' in the '%s' call.",
+									setterName, initial, dep, setterName,
+								)
+							}
+							if ref.Symbol != nil && stateVariableSymbols[ref.Symbol] {
+								return fmt.Sprintf(
+									" You can also replace multiple useState variables with useReducer if '%s' needs the current value of '%s'.",
+									setterName, dep,
+								)
+							}
+							if ref.Symbol != nil && len(ref.Symbol.Declarations) > 0 {
+								d := ref.Symbol.Declarations[0]
+								// Direct Parameter or BindingElement nested in Parameter
+								// (destructured prop) — both count as "from props".
+								isParam := d.Kind == ast.KindParameter
+								if !isParam && d.Kind == ast.KindBindingElement {
+									for cur := d.Parent; cur != nil; cur = cur.Parent {
+										if cur.Kind == ast.KindParameter {
+											isParam = true
+											break
+										}
+										if isFunctionLikeContainer(cur) {
+											break
+										}
+									}
+								}
+								if isParam {
+									return fmt.Sprintf(
+										" If '%s' needs the current value of '%s', you can also switch to useReducer instead of useState and read '%s' in the reducer.",
+										setterName, dep, dep,
+									)
+								}
+							}
+							break
+						}
+					}
+				}
+				cur = cur.Parent
+			}
+		}
+	}
+	return ""
+}
+
+// computeExternalDeps mirrors upstream's external-dep tracking: declared
+// deps whose root identifier resolves outside the component scope.
+func computeExternalDeps(declared []declaredDependency, componentFn *ast.Node, tc *checker.Checker, sf *ast.SourceFile) map[string]bool {
+	out := map[string]bool{}
+	if componentFn == nil {
+		return out
+	}
+	for _, dd := range declared {
+		// Walk down the dep node to find the root identifier (the leftmost
+		// identifier in `a.b.c`).
+		root := dd.Node
+		for root != nil && root.Kind == ast.KindPropertyAccessExpression {
+			root = ast.SkipParentheses(root.AsPropertyAccessExpression().Expression)
+		}
+		if root == nil || root.Kind != ast.KindIdentifier {
+			continue
+		}
+		// Hybrid resolution mirroring `processIdentifier`: trust TC when
+		// it returns a declaration inside the component; otherwise fall
+		// back to an AST walk for a same-named local binding (covers
+		// destructure-rename forms whose TC sym resolves to the source
+		// type's property in an external file).
+		var decl *ast.Node
+		if tc != nil {
+			sym := tc.GetSymbolAtLocation(root)
+			if sym != nil && len(sym.Declarations) > 0 {
+				if anyDeclWithinComponent(sym, componentFn) {
+					// Pick the first declaration that lies inside componentFn
+					// — that's the local binding we care about.
+					for _, d := range sym.Declarations {
+						if d != nil && containsNode(componentFn, d) {
+							decl = d
+							break
+						}
+					}
+				}
+			}
+		}
+		if decl == nil {
+			decl = resolveDeclaration(nil, root, root.AsIdentifier().Text, componentFn)
+		}
+		if decl == nil {
+			out[dd.Key] = true
+			continue
+		}
+		if !containsNode(componentFn, decl) {
+			out[dd.Key] = true
+		}
+	}
+	return out
+}
+
+// emitSetStateInsideEffectWarning mirrors upstream's "infinite chain of
+// updates" diagnostic for `useEffect(() => { setX(...); })` with no deps.
+func emitSetStateInsideEffectWarning(
+	ctx rule.RuleContext,
+	sf *ast.SourceFile,
+	tc *checker.Checker,
+	hookCall *ast.Node,
+	reactiveHook *ast.Node,
+	hookName string,
+	callback *ast.Node,
+	dependencies map[string]*dependency,
+	setStateCallSites map[*ast.Symbol]*ast.Node,
+	stableDeps map[string]bool,
+	optionalChains map[string]bool,
+	reportWithSuggestions func(*ast.Node, string, ...rule.RuleSuggestion),
+) {
+	var found string
+	// Iterate dep keys in source order so the "first setState in callback"
+	// detected matches upstream's deterministic walk.
+	keys := make([]string, 0, len(dependencies))
+	for k := range dependencies {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		dep := dependencies[key]
+		if found != "" {
+			break
+		}
+		for _, ref := range dep.Refs {
+			if ref.Symbol != nil {
+				if _, ok := setStateCallSites[ref.Symbol]; ok {
+					// Verify the ref is inside the effect callback directly,
+					// not nested.
+					encl := findEnclosingFunction(ref.Identifier)
+					if encl == callback {
+						found = key
+						break
+					}
+				}
+			}
+		}
+	}
+	if found == "" {
+		return
+	}
+	// Collect recommendations using stableDeps so setState/dispatch (and
+	// other stable identities) are filtered out of the suggested array.
+	rec := collectRecommendations(dependencies, []declaredDependency{}, stableDeps, map[string]bool{}, true)
+	formatted := make([]string, len(rec.Suggested))
+	for i, k := range rec.Suggested {
+		formatted[i] = formatDependency(k, optionalChains)
+	}
+	suggestionText := "[" + strings.Join(formatted, ", ") + "]"
+	// Insert AFTER the callback (not after the whole call expression),
+	// matching upstream's `fixer.insertTextAfter(node, ...)`. Using
+	// hookCall.End() would put the deps array INSIDE the closing `)`.
+	fix := rule.RuleFix{
+		Text:  ", " + suggestionText,
+		Range: callback.Loc.WithPos(callback.End()),
+	}
+	_ = sf
+	_ = tc
+	_ = reactiveHook
+	reportWithSuggestions(hookCall,
+		fmt.Sprintf(
+			"React Hook %s contains a call to '%s'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass %s as a second argument to the %s Hook.",
+			hookName, found, suggestionText, hookName,
+		),
+		rule.RuleSuggestion{
+			Message:  rule.RuleMessage{Description: "Add dependencies array: " + suggestionText},
+			FixesArr: []rule.RuleFix{fix},
+		},
+	)
+}
+
+// emitConstructionWarnings mirrors upstream's `scanForConstructions`
+// branch when declared deps have no missing / unnecessary / duplicate
+// problems but some declared deps refer to function/object/etc.
+// expressions that change identity every render.
+func emitConstructionWarnings(
+	ctx rule.RuleContext,
+	sf *ast.SourceFile,
+	tc *checker.Checker,
+	callback *ast.Node,
+	depsNode *ast.Node,
+	declared []declaredDependency,
+	hookName string,
+	opts Options,
+	reportWithSuggestions func(*ast.Node, string, ...rule.RuleSuggestion),
+) {
+	componentFn := findEnclosingFunction(callback)
+	if componentFn == nil {
+		return
+	}
+	consts := scanForConstructions(declared, depsNode, componentFn, callback, tc, sf)
+	depsLine, _ := lineOf(sf, depsNode)
+	for _, c := range consts {
+		wrapper := "useMemo"
+		ctype := "initialization"
+		if c.DepType == "function" {
+			wrapper = "useCallback"
+			ctype = "definition"
+		}
+		nameText := ""
+		if c.Variable != nil && c.Variable.Kind == ast.KindIdentifier {
+			nameText = c.Variable.AsIdentifier().Text
+		}
+		defaultAdvice := fmt.Sprintf(
+			"wrap the %s of '%s' in its own %s() Hook.",
+			ctype, nameText, wrapper,
+		)
+		var advice string
+		if c.IsUsedOutsideHook {
+			advice = "To fix this, " + defaultAdvice
+		} else {
+			advice = fmt.Sprintf(
+				"Move it inside the %s callback. Alternatively, %s",
+				hookName, defaultAdvice,
+			)
+		}
+		causation := "makes"
+		if c.DepType == "conditional" || c.DepType == "logical expression" {
+			causation = "could make"
+		}
+		msg := fmt.Sprintf(
+			"The '%s' %s %s the dependencies of %s Hook (at line %d) change on every render. %s",
+			nameText, c.DepType, causation, hookName, depsLine, advice,
+		)
+		var sugs []rule.RuleSuggestion
+		if c.IsUsedOutsideHook && c.Decl != nil && c.Decl.Kind == ast.KindVariableDeclaration && c.DepType == "function" {
+			before := "useCallback("
+			after := ")"
+			if wrapper == "useMemo" {
+				before = "useMemo(() => { return "
+				after = "; })"
+			}
+			sugs = []rule.RuleSuggestion{{
+				Message: rule.RuleMessage{Description: fmt.Sprintf(
+					"Wrap the %s of '%s' in its own %s() Hook.",
+					ctype, nameText, wrapper,
+				)},
+				FixesArr: []rule.RuleFix{
+					rule.RuleFixInsertBefore(sf, c.InitNode, before),
+					rule.RuleFixInsertAfter(c.InitNode, after),
+				},
+			}}
+		}
+		reportWithSuggestions(c.Decl, msg, sugs...)
+	}
+	_ = opts
+}
+
+// lineOf returns the 1-based line number of `node`.
+func lineOf(sf *ast.SourceFile, node *ast.Node) (int, error) {
+	if node == nil {
+		return 0, nil
+	}
+	tr := utils.TrimNodeTextRange(sf, node)
+	line, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, tr.Pos())
+	return line + 1, nil
+}
+
+// elementDiagnostic is a deferred error for one entry in the deps array.
+// Held in a slice so the caller can flush it AFTER the main missing/
+// unnecessary diagnostic is emitted, matching upstream's report order.
+type elementDiagnostic struct {
+	node    *ast.Node
+	message string
+	// suggestion is non-nil only for the useEffectEvent variant — every
+	// other element diagnostic upstream is suggestion-less.
+	suggestion *rule.RuleSuggestion
+}
+
+// parseDeclaredDeps mirrors upstream's loop over the array literal: for
+// each element, normalize via `analyzePropertyChainText`; on failure,
+// queue the "complex expression" / "literal not a valid dependency"
+// diagnostic. The diagnostics are returned (not emitted) so the caller
+// can flush them after the main missing-dep diagnostic — upstream's
+// per-element reports come later in the output stream.
+//
+// Returns `bad=true` to signal that the deps array itself is malformed
+// and the caller should bail out (no further missing-dep reports).
+func parseDeclaredDeps(
+	ctx rule.RuleContext,
+	sf *ast.SourceFile,
+	tc *checker.Checker,
+	reactiveHook *ast.Node,
+	hookCall *ast.Node,
+	depsNode *ast.Node,
+	dependencies map[string]*dependency,
+	useEffectEventSymbols map[*ast.Symbol]bool,
+	componentFn *ast.Node,
+) (declared []declaredDependency, deferred []elementDiagnostic, bad bool) {
+	depsNodeStripped := stripAsExpression(depsNode)
+	if depsNodeStripped == nil || depsNodeStripped.Kind != ast.KindArrayLiteralExpression {
+		// Upstream still emits the missing-dep diagnostic afterwards
+		// using an empty declared-deps list, so don't return bad=true here.
+		// The "not an array literal" error itself is still reported.
+		ctx.ReportNode(depsNode, rule.RuleMessage{Description: fmt.Sprintf(
+			"React Hook %s was passed a dependency list that is not an array literal. "+
+				"This means we can't statically verify whether you've passed the correct dependencies.",
+			getCalleeText(sf, reactiveHook),
+		)})
+		return nil, nil, false
+	}
+	arr := depsNodeStripped.AsArrayLiteralExpression()
+	if arr.Elements == nil {
+		return nil, nil, false
+	}
+	for _, el := range arr.Elements.Nodes {
+		if el == nil || isElidedComma(el) {
+			continue
+		}
+		if el.Kind == ast.KindSpreadElement {
+			deferred = append(deferred, elementDiagnostic{
+				node: el,
+				message: fmt.Sprintf(
+					"React Hook %s has a spread element in its dependency array. "+
+						"This means we can't statically verify whether you've passed the correct dependencies.",
+					getCalleeText(sf, reactiveHook),
+				),
+			})
+			continue
+		}
+		// useEffectEvent rejection — emitted with a `Remove the dependency` suggestion.
+		if tc != nil && el.Kind == ast.KindIdentifier {
+			sym := tc.GetSymbolAtLocation(el)
+			if sym != nil && useEffectEventSymbols[sym] {
+				removeRange := utils.TrimNodeTextRange(sf, el)
+				deferred = append(deferred, elementDiagnostic{
+					node: el,
+					message: fmt.Sprintf(
+						"Functions returned from `useEffectEvent` must not be included in the dependency array. Remove `%s` from the list.",
+						getCalleeText(sf, el),
+					),
+					suggestion: &rule.RuleSuggestion{
+						Message:  rule.RuleMessage{Description: fmt.Sprintf("Remove the dependency `%s`", getCalleeText(sf, el))},
+						FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(removeRange)},
+					},
+				})
+			}
+		}
+
+		key, ok := analyzePropertyChainText(el, nil)
+		if !ok {
+			// Literal value or complex expression. Mirrors upstream's full
+			// set of `Literal` value kinds — string, number, bigint, null,
+			// boolean, regex. Each gets the "literal is not a valid dep"
+			// diagnostic; everything else falls through to "complex
+			// expression".
+			elInner := stripAsExpression(el)
+			switch elInner.Kind {
+			case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral:
+				val := ""
+				if elInner.Kind == ast.KindStringLiteral {
+					val = elInner.AsStringLiteral().Text
+				} else {
+					val = elInner.AsNoSubstitutionTemplateLiteral().Text
+				}
+				var msg string
+				if dependencies[val] != nil {
+					msg = fmt.Sprintf(
+						"The %s literal is not a valid dependency because it never changes. "+
+							"Did you mean to include %s in the array instead?",
+						getCalleeText(sf, el), val,
+					)
+				} else {
+					msg = fmt.Sprintf(
+						"The %s literal is not a valid dependency because it never changes. You can safely remove it.",
+						getCalleeText(sf, el),
+					)
+				}
+				deferred = append(deferred, elementDiagnostic{node: el, message: msg})
+				continue
+			case ast.KindNumericLiteral, ast.KindBigIntLiteral, ast.KindNullKeyword,
+				ast.KindTrueKeyword, ast.KindFalseKeyword, ast.KindRegularExpressionLiteral:
+				deferred = append(deferred, elementDiagnostic{
+					node: el,
+					message: fmt.Sprintf(
+						"The %s literal is not a valid dependency because it never changes. You can safely remove it.",
+						getCalleeText(sf, el),
+					),
+				})
+				continue
+			default:
+				deferred = append(deferred, elementDiagnostic{
+					node: el,
+					message: fmt.Sprintf(
+						"React Hook %s has a complex expression in the dependency array. "+
+							"Extract it to a separate variable so it can be statically checked.",
+						getCalleeText(sf, reactiveHook),
+					),
+				})
+				continue
+			}
+		}
+		declared = append(declared, declaredDependency{Key: key, Node: el})
+	}
+	return declared, deferred, false
+}
+
+// flushDeferredDiagnostics emits the per-element diagnostics queued by
+// parseDeclaredDeps. Called by the caller AFTER the main missing-dep
+// diagnostic, so the output order matches upstream.
+//
+// `enableDangerous` mirrors upstream's `reportProblem` promotion gate:
+// when `enableDangerousAutofixThisMayCauseInfiniteLoops` is on and the
+// diagnostic carries a suggestion, the first suggestion's first fix is
+// promoted to a top-level autofix while keeping the suggestion array.
+// This applies to every `reportProblem` call in upstream — including
+// the per-element useEffectEvent rejection — so we plumb the flag here.
+func flushDeferredDiagnostics(ctx rule.RuleContext, deferred []elementDiagnostic, enableDangerous bool) {
+	for _, d := range deferred {
+		if d.suggestion != nil {
+			if enableDangerous && len(d.suggestion.FixesArr) > 0 && ctx.ReportNodeWithFixesAndSuggestions != nil {
+				firstFix := []rule.RuleFix{d.suggestion.FixesArr[0]}
+				ctx.ReportNodeWithFixesAndSuggestions(
+					d.node,
+					rule.RuleMessage{Description: d.message},
+					firstFix,
+					[]rule.RuleSuggestion{*d.suggestion},
+				)
+				continue
+			}
+			ctx.ReportNodeWithSuggestions(d.node, rule.RuleMessage{Description: d.message}, *d.suggestion)
+		} else {
+			ctx.ReportNode(d.node, rule.RuleMessage{Description: d.message})
+		}
+	}
+}
+
+// getCallbackBody returns the body of the function-like callback. For
+// arrow functions with a non-block body, the expression itself is the
+// "body" we walk.
+func getCallbackBody(fn *ast.Node) *ast.Node {
+	if fn == nil {
+		return nil
+	}
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		return fn.AsFunctionDeclaration().Body
+	case ast.KindFunctionExpression:
+		return fn.AsFunctionExpression().Body
+	case ast.KindArrowFunction:
+		return fn.AsArrowFunction().Body
+	}
+	return nil
+}
+
+// primeStableSymbols pre-walks the component body to populate the
+// `setStateCallSites`, `stateVariableSymbols`, and `useEffectEventSymbols`
+// caches. These drive both the stable-known-hook-value classification and
+// the setState-without-deps diagnostic.
+func primeStableSymbols(
+	tc *checker.Checker,
+	sf *ast.SourceFile,
+	caches *runCaches,
+	componentFn *ast.Node,
+	setStateCallSites map[*ast.Symbol]*ast.Node,
+	stateVariableSymbols map[*ast.Symbol]bool,
+	useEffectEventSymbols map[*ast.Symbol]bool,
+) {
+	if componentFn == nil || tc == nil {
+		return
+	}
+	body := getCallbackBody(componentFn)
+	if body == nil {
+		return
+	}
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if n.Kind == ast.KindVariableDeclaration {
+			vd := n.AsVariableDeclaration()
+			if vd.Initializer != nil {
+				init := stripAsExpression(vd.Initializer)
+				if init.Kind == ast.KindCallExpression {
+					callee := stripReactNamespace(init.AsCallExpression().Expression)
+					if callee != nil && callee.Kind == ast.KindIdentifier {
+						name := callee.AsIdentifier().Text
+						switch name {
+						case "useState":
+							recordStateBindings(tc, vd, setStateCallSites, stateVariableSymbols, componentFn, caches)
+						case "useReducer", "useActionState":
+							// dispatch / setState (second tuple element) is
+							// registered too — used by setState-without-deps
+							// detection and the setStateRecommendation reducer
+							// form. The state variable for these hooks is NOT
+							// recorded in `stateVariableSymbols` (mirrors
+							// upstream — only useState's first element).
+							recordReducerBindings(tc, vd, setStateCallSites, componentFn, caches)
+						case "useEffectEvent":
+							if bn := vd.Name(); bn != nil && bn.Kind == ast.KindIdentifier {
+								if sym := tc.GetSymbolAtLocation(bn); sym != nil {
+									useEffectEventSymbols[sym] = true
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		if isFunctionLikeContainer(n) && n != componentFn {
+			return false
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(body)
+}
+
+// recordStateBindings populates setStateCallSites and stateVariableSymbols
+// for a `const [x, setX] = useState(...)` declaration. Mirrors upstream's
+// `writeCount > 1` gate: if the setter binding is reassigned anywhere in
+// the source, treat it as no longer stable (don't register).
+func recordStateBindings(
+	tc *checker.Checker,
+	vd *ast.VariableDeclaration,
+	setStateCallSites map[*ast.Symbol]*ast.Node,
+	stateVariableSymbols map[*ast.Symbol]bool,
+	scope *ast.Node,
+	caches *runCaches,
+) {
+	bindingName := vd.Name()
+	if bindingName == nil || bindingName.Kind != ast.KindArrayBindingPattern {
+		return
+	}
+	arr := bindingName.AsBindingPattern()
+	if arr.Elements == nil || len(arr.Elements.Nodes) != 2 {
+		return
+	}
+	stateEl := arr.Elements.Nodes[0]
+	setterEl := arr.Elements.Nodes[1]
+	stateName := bindingElementName(stateEl)
+	setterName := bindingElementName(setterEl)
+	if stateName != nil {
+		if sym := tc.GetSymbolAtLocation(stateName); sym != nil {
+			stateVariableSymbols[sym] = true
+		}
+	}
+	if setterName != nil {
+		if sym := tc.GetSymbolAtLocation(setterName); sym != nil {
+			// Skip registration if the setter is reassigned. Upstream's
+			// `writeCount > 1` test counts the binding declaration itself
+			// as 1 write, so any further assignment makes it unstable.
+			if !cachedHasExtraWrite(sym, scope, tc, caches) {
+				setStateCallSites[sym] = stateName
+			}
+		}
+	}
+}
+
+// cachedHasExtraWrite is the memoized wrapper around
+// `hasExtraWriteToSymbol`. Keys on the symbol pointer; result is stable
+// across a single Run.
+func cachedHasExtraWrite(sym *ast.Symbol, scope *ast.Node, tc *checker.Checker, caches *runCaches) bool {
+	if caches == nil {
+		return hasExtraWriteToSymbol(sym, scope, tc)
+	}
+	if v, ok := caches.extraWrite[sym]; ok {
+		return v
+	}
+	v := hasExtraWriteToSymbol(sym, scope, tc)
+	caches.extraWrite[sym] = v
+	return v
+}
+
+// cachedHasCurrentAssignment is the memoized wrapper around
+// `hasExtraWriteToSymbol`'s sibling helper for `<sym>.current = ...`.
+// Same caching rationale.
+func cachedHasCurrentAssignment(sym *ast.Symbol, scope *ast.Node, tc *checker.Checker, caches *runCaches) bool {
+	if caches == nil {
+		return hasCurrentAssignment(sym, scope, tc)
+	}
+	if v, ok := caches.currentAssign[sym]; ok {
+		return v
+	}
+	v := hasCurrentAssignment(sym, scope, tc)
+	caches.currentAssign[sym] = v
+	return v
+}
+
+// recordReducerBindings registers the dispatch (second tuple element)
+// of `const [state, dispatch] = useReducer(...)` / `useActionState(...)`
+// as a stable setter. Mirrors the useState branch but does NOT mark the
+// state variable in `stateVariableSymbols` — that map is consulted only
+// for the useState-specific "reducer" recommendation form.
+func recordReducerBindings(
+	tc *checker.Checker,
+	vd *ast.VariableDeclaration,
+	setStateCallSites map[*ast.Symbol]*ast.Node,
+	scope *ast.Node,
+	caches *runCaches,
+) {
+	bindingName := vd.Name()
+	if bindingName == nil || bindingName.Kind != ast.KindArrayBindingPattern {
+		return
+	}
+	arr := bindingName.AsBindingPattern()
+	if arr.Elements == nil || len(arr.Elements.Nodes) != 2 {
+		return
+	}
+	stateName := bindingElementName(arr.Elements.Nodes[0])
+	setterName := bindingElementName(arr.Elements.Nodes[1])
+	if setterName != nil {
+		if sym := tc.GetSymbolAtLocation(setterName); sym != nil {
+			if !cachedHasExtraWrite(sym, scope, tc, caches) {
+				setStateCallSites[sym] = stateName
+			}
+		}
+	}
+}
+
+// hasExtraWriteToSymbol reports whether the given symbol has any
+// non-declaration write reference. Mirrors upstream's `writeCount > 1`
+// detection on stable hook bindings (used by `recordStateBindings` to
+// disable setter stability under reassignment, and by stableForId for
+// `isFunctionWithoutCapturedValues` to disable function stability when
+// the function binding itself is later reassigned).
+//
+// Covers four write shapes:
+//   - `setX = ...`            simple assignment
+//   - `setX += 1`             compound assignment (`+=`/`-=`/`*=`/...)
+//   - `({setX} = obj)` / `[setX] = arr`  destructuring assignment
+//   - `setX++` / `--setX`     update expression
+//
+// Element-access writes like `obj.setX = ...` are NOT counted — those
+// touch the property, not the binding.
+//
+// `scope` bounds the walk. Pass `componentFn` whenever possible (the
+// rule only cares about writes within the surrounding component or
+// hook); fall back to `sf.AsNode()` if the call site doesn't have a
+// component scope handy. Limiting the walk to the component avoids the
+// O(file_size) per-call cost that surfaced in PR-808 review.
+func hasExtraWriteToSymbol(sym *ast.Symbol, scope *ast.Node, tc *checker.Checker) bool {
+	if sym == nil || scope == nil || tc == nil {
+		return false
+	}
+	target := ""
+	if len(sym.Declarations) > 0 {
+		if n := sym.Declarations[0].Name(); n != nil && n.Kind == ast.KindIdentifier {
+			target = n.AsIdentifier().Text
+		}
+	}
+	if target == "" {
+		return false
+	}
+	matchesIdent := func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		// Walk past paren / TS-only expression wrappers so shapes like
+		// `(setCount as any)++` reach the inner Identifier.
+		x := stripAsExpression(n)
+		if x == nil || x.Kind != ast.KindIdentifier || x.AsIdentifier().Text != target {
+			return false
+		}
+		s := tc.GetSymbolAtLocation(x)
+		return s != nil && s == sym
+	}
+	found := false
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if found {
+			return true
+		}
+		switch n.Kind {
+		case ast.KindBinaryExpression:
+			be := n.AsBinaryExpression()
+			if be.OperatorToken != nil {
+				switch be.OperatorToken.Kind {
+				case ast.KindEqualsToken,
+					ast.KindPlusEqualsToken, ast.KindMinusEqualsToken,
+					ast.KindAsteriskEqualsToken, ast.KindAsteriskAsteriskEqualsToken,
+					ast.KindSlashEqualsToken, ast.KindPercentEqualsToken,
+					ast.KindLessThanLessThanEqualsToken, ast.KindGreaterThanGreaterThanEqualsToken,
+					ast.KindGreaterThanGreaterThanGreaterThanEqualsToken,
+					ast.KindAmpersandEqualsToken, ast.KindBarEqualsToken,
+					ast.KindCaretEqualsToken,
+					ast.KindAmpersandAmpersandEqualsToken, ast.KindBarBarEqualsToken,
+					ast.KindQuestionQuestionEqualsToken:
+					lhs := ast.SkipParentheses(be.Left)
+					if matchesIdent(lhs) {
+						found = true
+						return true
+					}
+					// Destructuring assignment: `({setX} = obj)` /
+					// `[setX] = arr` — LHS is an ObjectLiteral / Array
+					// literal that visit-recursion will descend into;
+					// the inner Identifier still resolves to `sym` and
+					// would be a reference, but here we want only the
+					// LHS-binding form (ShorthandPropertyAssignment /
+					// element). Walk `lhs`'s children explicitly.
+					if walkAssignmentTargetForBinding(lhs, matchesIdent) {
+						found = true
+						return true
+					}
+				}
+			}
+		case ast.KindPrefixUnaryExpression:
+			pu := n.AsPrefixUnaryExpression()
+			if pu.Operator == ast.KindPlusPlusToken || pu.Operator == ast.KindMinusMinusToken {
+				if matchesIdent(pu.Operand) {
+					found = true
+					return true
+				}
+			}
+		case ast.KindPostfixUnaryExpression:
+			pu := n.AsPostfixUnaryExpression()
+			if pu.Operator == ast.KindPlusPlusToken || pu.Operator == ast.KindMinusMinusToken {
+				if matchesIdent(pu.Operand) {
+					found = true
+					return true
+				}
+			}
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(scope)
+	return found
+}
+
+// walkAssignmentTargetForBinding inspects an assignment LHS that is an
+// ObjectLiteral (`({x} = ...)`) or ArrayLiteral (`[x] = ...`) destructure
+// pattern, looking for a binding-position Identifier matching `match`.
+// Returns true on first hit. Property values inside ObjectLiteral are the
+// binding targets (e.g., `({a: x} = obj)` binds `x`).
+func walkAssignmentTargetForBinding(lhs *ast.Node, match func(*ast.Node) bool) bool {
+	if lhs == nil {
+		return false
+	}
+	switch lhs.Kind {
+	case ast.KindObjectLiteralExpression:
+		ole := lhs.AsObjectLiteralExpression()
+		if ole.Properties == nil {
+			return false
+		}
+		for _, p := range ole.Properties.Nodes {
+			switch p.Kind {
+			case ast.KindShorthandPropertyAssignment:
+				name := p.Name()
+				if match(name) {
+					return true
+				}
+			case ast.KindPropertyAssignment:
+				pa := p.AsPropertyAssignment()
+				if walkAssignmentTargetForBinding(pa.Initializer, match) {
+					return true
+				}
+			case ast.KindSpreadAssignment:
+				sa := p.AsSpreadAssignment()
+				if match(sa.Expression) || walkAssignmentTargetForBinding(sa.Expression, match) {
+					return true
+				}
+			}
+		}
+	case ast.KindArrayLiteralExpression:
+		ale := lhs.AsArrayLiteralExpression()
+		if ale.Elements == nil {
+			return false
+		}
+		for _, el := range ale.Elements.Nodes {
+			if el == nil {
+				continue
+			}
+			if el.Kind == ast.KindOmittedExpression {
+				continue
+			}
+			if el.Kind == ast.KindSpreadElement {
+				se := el.AsSpreadElement()
+				if match(se.Expression) || walkAssignmentTargetForBinding(se.Expression, match) {
+					return true
+				}
+				continue
+			}
+			if match(el) {
+				return true
+			}
+			if walkAssignmentTargetForBinding(el, match) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// bindingElementName returns the binding's Identifier name node.
+func bindingElementName(be *ast.Node) *ast.Node {
+	if be == nil || be.Kind != ast.KindBindingElement {
+		return nil
+	}
+	n := be.AsBindingElement().Name()
+	if n == nil || n.Kind != ast.KindIdentifier {
+		return nil
+	}
+	return n
+}
+
+// gatherDeps walks every Identifier reference inside the callback body
+// and records it as a dependency when the resolved declaration sits in
+// the component scope (between the callback and the component body
+// boundary).
+func gatherDeps(
+	ctx rule.RuleContext,
+	sf *ast.SourceFile,
+	tc *checker.Checker,
+	caches *runCaches,
+	callback *ast.Node,
+	body *ast.Node,
+	componentFn *ast.Node,
+	setStateCallSites map[*ast.Symbol]*ast.Node,
+	stateVariableSymbols map[*ast.Symbol]bool,
+	dependencies map[string]*dependency,
+	optionalChains map[string]bool,
+	isEffect bool,
+) {
+	// Cache: for each resolved symbol, whether it's "stable known".
+	stableSymCache := map[*ast.Symbol]bool{}
+	hasExtraWrite := func(s *ast.Symbol) bool {
+		return cachedHasExtraWrite(s, componentFn, tc, caches)
+	}
+	// Forward-declared so isFunctionWithoutCapturedValues can recurse
+	// through it for transitive function stability.
+	var stableForId func(id *ast.Node, sym *ast.Symbol) bool
+	stableForId = func(id *ast.Node, sym *ast.Symbol) bool {
+		if sym == nil {
+			return false
+		}
+		if v, ok := stableSymCache[sym]; ok {
+			return v
+		}
+		// Tag the symbol as in-progress to break recursion cycles
+		// (mutual recursion between two functions): treat as not-stable
+		// while we're still computing.
+		stableSymCache[sym] = false
+		// Setter / dispatch from useState/useReducer/useTransition.
+		if _, ok := setStateCallSites[sym]; ok {
+			stableSymCache[sym] = true
+			return true
+		}
+		if len(sym.Declarations) > 0 {
+			decl := sym.Declarations[0]
+			// BindingElement decls live inside the VariableDeclaration's
+			// pattern. Walk up to the declaring VariableDeclaration so
+			// `isStableHookValue` can inspect the initializer.
+			bindingId := decl.Name()
+			vdNode := decl
+			if decl.Kind == ast.KindBindingElement {
+				vdNode = decl.Parent
+				for vdNode != nil && vdNode.Kind != ast.KindVariableDeclaration {
+					vdNode = vdNode.Parent
+				}
+			}
+			stable, _ := isStableHookValue(vdNode, bindingId)
+			if stable {
+				// Mirrors upstream's `writeCount > 1` gate: a stable hook
+				// binding that is reassigned anywhere is no longer stable.
+				if tc != nil && hasExtraWrite(sym) {
+					return false
+				}
+				stableSymCache[sym] = true
+				return true
+			}
+			// Upstream's `isFunctionWithoutCapturedValues`: a user-defined
+			// function declared in component scope is stable iff it
+			// doesn't capture any non-stable variables from pure scope.
+			// We use the TypeChecker to resolve every Identifier inside
+			// the function body to its declaring symbol, then test each
+			// captured one against `stableForId` recursively. This mirrors
+			// upstream's `fnScope.through` walk (which we don't have access
+			// to without ESLint's scope manager).
+			//
+			// Reassignment guard: if the binding itself is reassigned
+			// elsewhere (e.g. `handler = somethingElse`), the resolved
+			// function may no longer point at our analyzed body. Mirrors
+			// upstream's `writeCount > 1` gate that disables the
+			// stable-function classification under reassignment.
+			if tc != nil && !hasExtraWrite(sym) {
+				if isFunctionWithoutCapturedValues(decl, componentFn, tc, stableForId) {
+					stableSymCache[sym] = true
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Cleanup ref.current tracking.
+	currentRefsInCleanup := map[string]struct {
+		dependency string
+		ref        *depReference
+	}{}
+
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		// Stop at nested function-likes? No — references nested inside
+		// callbacks within the effect still need to be analyzed (their
+		// captures are part of the effect's deps).
+		if n.Kind == ast.KindIdentifier && isReferenceIdentifier(n) {
+			processIdentifier(ctx, sf, tc, n, callback, componentFn, isEffect,
+				setStateCallSites, stableForId, dependencies, optionalChains, currentRefsInCleanup)
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(body)
+
+	// Emit the effect-cleanup ref.current warnings.
+	for dep, rec := range currentRefsInCleanup {
+		// If the ref is reassigned anywhere (`ref.current = ...`), upstream
+		// suppresses the warning.
+		if cachedHasCurrentAssignment(rec.ref.Symbol, componentFn, tc, caches) {
+			continue
+		}
+		// `dependencyNode.parent.property` — the `.current` property name.
+		// We approximate via the depReference's parent if it points to a
+		// property access.
+		idNode := rec.ref.Identifier
+		if idNode == nil || idNode.Parent == nil || idNode.Parent.Kind != ast.KindPropertyAccessExpression {
+			continue
+		}
+		propName := idNode.Parent.AsPropertyAccessExpression().Name()
+		if propName == nil {
+			continue
+		}
+		ctx.ReportNode(propName, rule.RuleMessage{Description: fmt.Sprintf(
+			"The ref value '%s.current' will likely have changed by the time this effect cleanup function runs. "+
+				"If this ref points to a node rendered by React, copy '%s.current' to a variable inside the effect, "+
+				"and use that variable in the cleanup function.",
+			dep, dep,
+		)})
+	}
+}
+
+// processIdentifier records a single identifier reference as a dep.
+func processIdentifier(
+	ctx rule.RuleContext,
+	sf *ast.SourceFile,
+	tc *checker.Checker,
+	id *ast.Node,
+	callback *ast.Node,
+	componentFn *ast.Node,
+	isEffect bool,
+	setStateCallSites map[*ast.Symbol]*ast.Node,
+	stableForId func(*ast.Node, *ast.Symbol) bool,
+	dependencies map[string]*dependency,
+	optionalChains map[string]bool,
+	currentRefsInCleanup map[string]struct {
+		dependency string
+		ref        *depReference
+	},
+) {
+	// Resolve.
+	var sym *ast.Symbol
+	if tc != nil {
+		sym = tc.GetSymbolAtLocation(id)
+	}
+	// Determine if the symbol's declaration is in component scope (between
+	// callback exclusive and componentFn inclusive).
+	//
+	// TC behavior nuance: for a destructured rename like
+	// `const { foo: bar } = obj()`, TC may sometimes resolve `bar` to
+	// the SOURCE object's property symbol rather than the local
+	// BindingElement, so `sym.Declarations` is populated but every
+	// declaration sits outside the component (in `obj`'s declared type).
+	// We detect that exact "all declarations are outside the component
+	// AND none lives inside the callback" condition and fall back to an
+	// AST walk for a same-named binding inside the component. If the
+	// walk finds nothing, the reference really is external (skip).
+	// In any other case (declaration in callback, in component scope,
+	// etc.), trust TC's verdict.
+	if sym != nil {
+		if isInComponentPureScope(sym, callback, componentFn) {
+			// Pure scope hit — proceed.
+		} else if !anyDeclWithinComponent(sym, componentFn) {
+			astDecl := resolveDeclaration(nil, id, id.AsIdentifier().Text, componentFn)
+			if astDecl == nil {
+				return
+			}
+			if !containsNode(componentFn, astDecl) || containsNode(callback, astDecl) {
+				return
+			}
+		} else {
+			// TC sees declarations inside the component but the strict
+			// pure-scope check excluded them (e.g. they're inside the
+			// callback). Trust TC: not a dep.
+			return
+		}
+	} else {
+		// No symbol — fall back to AST walk only.
+		decl := resolveDeclaration(nil, id, id.AsIdentifier().Text, componentFn)
+		if decl == nil {
+			return
+		}
+		if !containsNode(componentFn, decl) || containsNode(callback, decl) {
+			return
+		}
+	}
+
+	if isInsideTypePosition(id) {
+		return
+	}
+
+	// Compute dep root + key.
+	depRoot := getDependencyNode(id)
+	key, ok := analyzePropertyChainText(depRoot, optionalChains)
+	if !ok {
+		return
+	}
+
+	// Skip references to the callback's own binding. Two patterns to cover:
+	//
+	//   (a) `const myEffect = () => {...}; useEffect(myEffect, ...)`
+	//       — `myEffect`'s declaration has the callback as its initializer.
+	//
+	//   (b) `const foo = useCallback(() => foo(), [])`
+	//       — upstream's check: `def.node.init === node.parent`. Here
+	//       `node` is the callback ArrowFunction; `node.parent` is the
+	//       enclosing CallExpression (`useCallback(...)`); `def.node.init`
+	//       is exactly that CallExpression. So a reference to `foo` from
+	//       inside the callback is the binding's own self-reference.
+	if sym != nil {
+		for _, decl := range sym.Declarations {
+			if decl.Kind == ast.KindVariableDeclaration {
+				vd := decl.AsVariableDeclaration()
+				if vd.Initializer != nil {
+					init := stripAsExpression(vd.Initializer)
+					if init == callback {
+						return
+					}
+					// Pattern (b): vd.Initializer is the hook call, and the
+					// hook call is the callback's parent.
+					if callback.Parent != nil && init == callback.Parent {
+						return
+					}
+				}
+			}
+		}
+	}
+
+	// Effect cleanup `.current` tracking.
+	inCleanup := false
+	if isEffect && id.Parent != nil && id.Parent.Kind == ast.KindPropertyAccessExpression {
+		pae := id.Parent.AsPropertyAccessExpression()
+		if pae.Expression == id {
+			propName := pae.Name()
+			if propName != nil && propName.Kind == ast.KindIdentifier && propName.AsIdentifier().Text == "current" {
+				if isInsideEffectCleanup(id, callback) {
+					inCleanup = true
+				}
+			}
+		}
+	}
+
+	// writeExpr if this is the LHS of an assignment.
+	var writeExpr *ast.Node
+	if id.Parent != nil {
+		if be, ok := getAssignmentBinaryExpr(id.Parent); ok && be.Left == id {
+			writeExpr = id.Parent
+		}
+	}
+
+	stable := stableForId(id, sym)
+	dep, exists := dependencies[key]
+	if !exists {
+		dep = &dependency{IsStable: stable, First: id}
+		dependencies[key] = dep
+	}
+	ref := &depReference{
+		Identifier:  id,
+		Symbol:      sym,
+		WriteExpr:   writeExpr,
+		InCleanup:   inCleanup,
+		DepNodeRoot: depRoot,
+	}
+	dep.Refs = append(dep.Refs, ref)
+
+	if inCleanup {
+		if _, has := currentRefsInCleanup[key]; !has {
+			currentRefsInCleanup[key] = struct {
+				dependency string
+				ref        *depReference
+			}{dependency: key, ref: ref}
+		}
+	}
+}
+
+// anyDeclWithinComponent reports whether the symbol has at least one
+// declaration whose source range lies inside `componentFn`. Used as the
+// gate for the AST-walk fallback in `processIdentifier`: when none of
+// the symbol's declarations is local to the component, TC has resolved
+// to an external (type-property / cross-module) symbol and we may
+// safely consult the AST for a same-named local binding.
+func anyDeclWithinComponent(sym *ast.Symbol, componentFn *ast.Node) bool {
+	if sym == nil || componentFn == nil {
+		return false
+	}
+	for _, d := range sym.Declarations {
+		if d == nil {
+			continue
+		}
+		if containsNode(componentFn, d) {
+			return true
+		}
+	}
+	return false
+}
+
+// isInComponentPureScope reports whether the symbol's declaration sits
+// strictly between the callback (exclusive) and the component body
+// (inclusive). External symbols (imports, globals) are excluded.
+func isInComponentPureScope(sym *ast.Symbol, callback *ast.Node, componentFn *ast.Node) bool {
+	if sym == nil {
+		return false
+	}
+	if len(sym.Declarations) == 0 {
+		return false
+	}
+	for _, decl := range sym.Declarations {
+		if decl == nil {
+			continue
+		}
+		if !containsNode(componentFn, decl) {
+			continue
+		}
+		if containsNode(callback, decl) {
+			continue
+		}
+		// Skip type-only declarations.
+		switch decl.Kind {
+		case ast.KindTypeAliasDeclaration, ast.KindInterfaceDeclaration,
+			ast.KindTypeParameter:
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// hasCurrentAssignment scans `scope` (typically the surrounding component)
+// for `<sym>.current = ...`. When TypeChecker is available, compares
+// symbols; otherwise falls back to a name match against the symbol's
+// binding name. Mirrors upstream's "found a `<ref>.current = ...` write"
+// gate that suppresses the cleanup warning when the user is the one
+// managing the ref.
+//
+// `scope` bounds the walk — pass `componentFn` (or `sf.AsNode()` if no
+// component scope is available). The previous full-SF walk was an
+// O(file_size) per-cleanup-ref hot path that PR-808 review flagged.
+func hasCurrentAssignment(sym *ast.Symbol, scope *ast.Node, tc *checker.Checker) bool {
+	if sym == nil || scope == nil {
+		return false
+	}
+	targetName := ""
+	if len(sym.Declarations) > 0 {
+		if n := sym.Declarations[0].Name(); n != nil && n.Kind == ast.KindIdentifier {
+			targetName = n.AsIdentifier().Text
+		}
+	}
+	found := false
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if found {
+			return true
+		}
+		if n.Kind == ast.KindBinaryExpression {
+			be := n.AsBinaryExpression()
+			if be.OperatorToken != nil && be.OperatorToken.Kind == ast.KindEqualsToken {
+				lhs := ast.SkipParentheses(be.Left)
+				if lhs.Kind == ast.KindPropertyAccessExpression {
+					pae := lhs.AsPropertyAccessExpression()
+					prop := pae.Name()
+					if prop != nil && prop.Kind == ast.KindIdentifier && prop.AsIdentifier().Text == "current" {
+						obj := ast.SkipParentheses(pae.Expression)
+						if obj.Kind == ast.KindIdentifier {
+							if tc != nil {
+								if s := tc.GetSymbolAtLocation(obj); s != nil && s == sym {
+									found = true
+									return true
+								}
+							} else if targetName != "" && obj.AsIdentifier().Text == targetName {
+								found = true
+								return true
+							}
+						}
+					}
+				}
+			}
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(scope)
+	return found
+}
+
+// isFunctionWithoutCapturedValues mirrors upstream's same-named helper.
+// Given a VariableDeclaration / FunctionDeclaration / BindingElement
+// declaring a function-typed binding, returns true iff the function body
+// does not capture any non-stable variables from the component pure scope.
+//
+// Implementation strategy:
+//
+//   - Resolve every reference Identifier inside the function body via
+//     TypeChecker. The resolved symbol's declaration tells us which scope
+//     the reference belongs to.
+//   - A reference is a "capture" iff its declaration sits in component
+//     scope (inside componentFn) but outside the function being tested.
+//   - We're stable iff every capture is itself a stable hook value.
+//
+// `isStable` is the recursive `stableForId` so a chain of pure functions
+// (`const a = () => 1; const b = () => a()`) classifies as stable.
+//
+// Without a TypeChecker we conservatively return false (callers degrade
+// to the un-stabilized behavior).
+func isFunctionWithoutCapturedValues(
+	decl *ast.Node,
+	componentFn *ast.Node,
+	tc *checker.Checker,
+	isStable func(*ast.Node, *ast.Symbol) bool,
+) bool {
+	if decl == nil || componentFn == nil || tc == nil {
+		return false
+	}
+	// Locate the function-like body associated with this declaration.
+	var fnNode *ast.Node
+	switch decl.Kind {
+	case ast.KindFunctionDeclaration:
+		fnNode = decl
+	case ast.KindVariableDeclaration:
+		init := decl.AsVariableDeclaration().Initializer
+		if init == nil {
+			return false
+		}
+		init = stripAsExpression(init)
+		switch init.Kind {
+		case ast.KindArrowFunction, ast.KindFunctionExpression:
+			fnNode = init
+		}
+	case ast.KindBindingElement:
+		init := decl.AsBindingElement().Initializer
+		if init == nil {
+			return false
+		}
+		init = stripAsExpression(init)
+		switch init.Kind {
+		case ast.KindArrowFunction, ast.KindFunctionExpression:
+			fnNode = init
+		}
+	default:
+		return false
+	}
+	if fnNode == nil {
+		return false
+	}
+	// `fnNode` must itself live inside the component scope; otherwise the
+	// "captures from pure scope" question is not well-defined.
+	if !containsNode(componentFn, fnNode) {
+		return false
+	}
+	body := getCallbackBody(fnNode)
+	if body == nil {
+		return false
+	}
+	captured := false
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if captured {
+			return true
+		}
+		if n.Kind == ast.KindIdentifier && isReferenceIdentifier(n) {
+			sym := tc.GetSymbolAtLocation(n)
+			if sym != nil && len(sym.Declarations) > 0 {
+				d := sym.Declarations[0]
+				// Capture iff declaration is in component scope but
+				// outside fnNode itself. Self-reference (the function
+				// referencing its own binding) is allowed.
+				if containsNode(componentFn, d) && !containsNode(fnNode, d) {
+					// Self-reference (recursion) — skip.
+					if d == decl {
+						return false
+					}
+					if !isStable(n, sym) {
+						captured = true
+						return true
+					}
+				}
+			}
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(body)
+	return !captured
+}
+

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_callback_arg_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_callback_arg_test.go
@@ -1,0 +1,139 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_CallbackArg holds the upstream cases whose primary
+// diagnostic falls into the "callback_arg" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamCallbackArgValid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamCallbackArgInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function MyComponent(props) {
+  const value = useMemo(() => { return 2*2; });
+  const fn = useCallback(() => { alert('foo'); });
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useMemo does nothing when called with only one argument. Did you forget to pass an array of dependencies?"},
+		{Message: "React Hook useCallback does nothing when called with only one argument. Did you forget to pass an array of dependencies?"},
+	},
+},
+
+{
+	Code: `
+function MyComponent({ fn1, fn2 }) {
+  const value = useMemo(fn1);
+  const fn = useCallback(fn2);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useMemo does nothing when called with only one argument. Did you forget to pass an array of dependencies?"},
+		{Message: "React Hook useCallback does nothing when called with only one argument. Did you forget to pass an array of dependencies?"},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  useEffect()
+  useLayoutEffect()
+  useCallback()
+  useMemo()
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect requires an effect callback. Did you forget to pass a callback to the hook?"},
+		{Message: "React Hook useLayoutEffect requires an effect callback. Did you forget to pass a callback to the hook?"},
+		{Message: "React Hook useCallback requires an effect callback. Did you forget to pass a callback to the hook?"},
+		{Message: "React Hook useMemo requires an effect callback. Did you forget to pass a callback to the hook?"},
+	},
+},
+
+{
+	Code: `
+function Thing() {
+  useEffect(async () => {}, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "Effect callbacks are synchronous to prevent race conditions. Put the async function inside:\n\nuseEffect(() => {\n  async function fetchData() {\n    // You can await here\n    const response = await MyAPI.getData(someId);\n    // ...\n  }\n  fetchData();\n}, [someId]); // Or [] if effect doesn't need props or state\n\nLearn more about data fetching with Hooks: https://react.dev/link/hooks-data-fetching"},
+	},
+},
+
+{
+	Code: `
+function Thing() {
+  useEffect(async () => {});
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "Effect callbacks are synchronous to prevent race conditions. Put the async function inside:\n\nuseEffect(() => {\n  async function fetchData() {\n    // You can await here\n    const response = await MyAPI.getData(someId);\n    // ...\n  }\n  fetchData();\n}, [someId]); // Or [] if effect doesn't need props or state\n\nLearn more about data fetching with Hooks: https://react.dev/link/hooks-data-fetching"},
+	},
+},
+
+{
+	Code: `
+function MyComponent({myEffect}) {
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect received a function whose dependencies are unknown. Pass an inline function instead."},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(debounce(() => {
+    console.log(local);
+  }, delay), []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect received a function whose dependencies are unknown. Pass an inline function instead."},
+	},
+},
+
+{
+	Code: `
+function useCustomCallback(callback, deps) {
+  return useCallback(callback, deps)
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback received a function whose dependencies are unknown. Pass an inline function instead."},
+	},
+},
+}
+
+func TestExhaustiveDeps_Upstream_CallbackArg(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamCallbackArgValid,
+		upstreamCallbackArgInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_construction_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_construction_test.go
@@ -1,0 +1,807 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_Construction holds the upstream cases whose primary
+// diagnostic falls into the "construction" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamConstructionValid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamConstructionInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function MyComponent(props) {
+  let [, setState] = useState();
+
+  function handleNext(value) {
+    setState(value);
+  }
+
+  useEffect(() => {
+    return Store.subscribe(handleNext);
+  }, [handleNext]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'handleNext' function makes the dependencies of useEffect Hook (at line 11) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'handleNext' in its own useCallback() Hook."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let [, setState] = useState();
+
+  const handleNext = (value) => {
+    setState(value);
+  };
+
+  useEffect(() => {
+    return Store.subscribe(handleNext);
+  }, [handleNext]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'handleNext' function makes the dependencies of useEffect Hook (at line 11) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'handleNext' in its own useCallback() Hook."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let [, setState] = useState();
+
+  const handleNext = (value) => {
+    setState(value);
+  };
+
+  useEffect(() => {
+    return Store.subscribe(handleNext);
+  }, [handleNext]);
+
+  return <div onClick={handleNext} />;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'handleNext' function makes the dependencies of useEffect Hook (at line 11) change on every render. To fix this, wrap the definition of 'handleNext' in its own useCallback() Hook.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let [, setState] = useState();
+
+  const handleNext = useCallback((value) => {
+    setState(value);
+  });
+
+  useEffect(() => {
+    return Store.subscribe(handleNext);
+  }, [handleNext]);
+
+  return <div onClick={handleNext} />;
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  function handleNext1() {
+    console.log('hello');
+  }
+  const handleNext2 = () => {
+    console.log('hello');
+  };
+  let handleNext3 = function() {
+    console.log('hello');
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, [handleNext1]);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, [handleNext2]);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, [handleNext3]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'handleNext1' function makes the dependencies of useEffect Hook (at line 14) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'handleNext1' in its own useCallback() Hook."},
+		{Message: "The 'handleNext2' function makes the dependencies of useLayoutEffect Hook (at line 17) change on every render. Move it inside the useLayoutEffect callback. Alternatively, wrap the definition of 'handleNext2' in its own useCallback() Hook."},
+		{Message: "The 'handleNext3' function makes the dependencies of useMemo Hook (at line 20) change on every render. Move it inside the useMemo callback. Alternatively, wrap the definition of 'handleNext3' in its own useCallback() Hook."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  function handleNext1() {
+    console.log('hello');
+  }
+  const handleNext2 = () => {
+    console.log('hello');
+  };
+  let handleNext3 = function() {
+    console.log('hello');
+  };
+  useEffect(() => {
+    handleNext1();
+    return Store.subscribe(() => handleNext1());
+  }, [handleNext1]);
+  useLayoutEffect(() => {
+    handleNext2();
+    return Store.subscribe(() => handleNext2());
+  }, [handleNext2]);
+  useMemo(() => {
+    handleNext3();
+    return Store.subscribe(() => handleNext3());
+  }, [handleNext3]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'handleNext1' function makes the dependencies of useEffect Hook (at line 15) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'handleNext1' in its own useCallback() Hook."},
+		{Message: "The 'handleNext2' function makes the dependencies of useLayoutEffect Hook (at line 19) change on every render. Move it inside the useLayoutEffect callback. Alternatively, wrap the definition of 'handleNext2' in its own useCallback() Hook."},
+		{Message: "The 'handleNext3' function makes the dependencies of useMemo Hook (at line 23) change on every render. Move it inside the useMemo callback. Alternatively, wrap the definition of 'handleNext3' in its own useCallback() Hook."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  function handleNext1() {
+    console.log('hello');
+  }
+  const handleNext2 = () => {
+    console.log('hello');
+  };
+  let handleNext3 = function() {
+    console.log('hello');
+  };
+  useEffect(() => {
+    handleNext1();
+    return Store.subscribe(() => handleNext1());
+  }, [handleNext1]);
+  useLayoutEffect(() => {
+    handleNext2();
+    return Store.subscribe(() => handleNext2());
+  }, [handleNext2]);
+  useMemo(() => {
+    handleNext3();
+    return Store.subscribe(() => handleNext3());
+  }, [handleNext3]);
+  return (
+    <div
+      onClick={() => {
+        handleNext1();
+        setTimeout(handleNext2);
+        setTimeout(() => {
+          handleNext3();
+        });
+      }}
+    />
+  );
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'handleNext1' function makes the dependencies of useEffect Hook (at line 15) change on every render. To fix this, wrap the definition of 'handleNext1' in its own useCallback() Hook."},
+		{Message: "The 'handleNext2' function makes the dependencies of useLayoutEffect Hook (at line 19) change on every render. To fix this, wrap the definition of 'handleNext2' in its own useCallback() Hook.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  function handleNext1() {
+    console.log('hello');
+  }
+  const handleNext2 = useCallback(() => {
+    console.log('hello');
+  });
+  let handleNext3 = function() {
+    console.log('hello');
+  };
+  useEffect(() => {
+    handleNext1();
+    return Store.subscribe(() => handleNext1());
+  }, [handleNext1]);
+  useLayoutEffect(() => {
+    handleNext2();
+    return Store.subscribe(() => handleNext2());
+  }, [handleNext2]);
+  useMemo(() => {
+    handleNext3();
+    return Store.subscribe(() => handleNext3());
+  }, [handleNext3]);
+  return (
+    <div
+      onClick={() => {
+        handleNext1();
+        setTimeout(handleNext2);
+        setTimeout(() => {
+          handleNext3();
+        });
+      }}
+    />
+  );
+}
+`}}},
+		{Message: "The 'handleNext3' function makes the dependencies of useMemo Hook (at line 23) change on every render. To fix this, wrap the definition of 'handleNext3' in its own useCallback() Hook.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  function handleNext1() {
+    console.log('hello');
+  }
+  const handleNext2 = () => {
+    console.log('hello');
+  };
+  let handleNext3 = useCallback(function() {
+    console.log('hello');
+  });
+  useEffect(() => {
+    handleNext1();
+    return Store.subscribe(() => handleNext1());
+  }, [handleNext1]);
+  useLayoutEffect(() => {
+    handleNext2();
+    return Store.subscribe(() => handleNext2());
+  }, [handleNext2]);
+  useMemo(() => {
+    handleNext3();
+    return Store.subscribe(() => handleNext3());
+  }, [handleNext3]);
+  return (
+    <div
+      onClick={() => {
+        handleNext1();
+        setTimeout(handleNext2);
+        setTimeout(() => {
+          handleNext3();
+        });
+      }}
+    />
+  );
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const handleNext1 = () => {
+    console.log('hello');
+  };
+  function handleNext2() {
+    console.log('hello');
+  }
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+    return Store.subscribe(handleNext2);
+  }, [handleNext1, handleNext2]);
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+    return Store.subscribe(handleNext2);
+  }, [handleNext1, handleNext2]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'handleNext1' function makes the dependencies of useEffect Hook (at line 12) change on every render. To fix this, wrap the definition of 'handleNext1' in its own useCallback() Hook.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const handleNext1 = useCallback(() => {
+    console.log('hello');
+  });
+  function handleNext2() {
+    console.log('hello');
+  }
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+    return Store.subscribe(handleNext2);
+  }, [handleNext1, handleNext2]);
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+    return Store.subscribe(handleNext2);
+  }, [handleNext1, handleNext2]);
+}
+`}}},
+		{Message: "The 'handleNext2' function makes the dependencies of useEffect Hook (at line 12) change on every render. To fix this, wrap the definition of 'handleNext2' in its own useCallback() Hook."},
+		{Message: "The 'handleNext1' function makes the dependencies of useEffect Hook (at line 16) change on every render. To fix this, wrap the definition of 'handleNext1' in its own useCallback() Hook.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const handleNext1 = useCallback(() => {
+    console.log('hello');
+  });
+  function handleNext2() {
+    console.log('hello');
+  }
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+    return Store.subscribe(handleNext2);
+  }, [handleNext1, handleNext2]);
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+    return Store.subscribe(handleNext2);
+  }, [handleNext1, handleNext2]);
+}
+`}}},
+		{Message: "The 'handleNext2' function makes the dependencies of useEffect Hook (at line 16) change on every render. To fix this, wrap the definition of 'handleNext2' in its own useCallback() Hook."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let handleNext = () => {
+    console.log('hello');
+  };
+  if (props.foo) {
+    handleNext = () => {
+      console.log('hello');
+    };
+  }
+  useEffect(() => {
+    return Store.subscribe(handleNext);
+  }, [handleNext]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'handleNext' function makes the dependencies of useEffect Hook (at line 13) change on every render. To fix this, wrap the definition of 'handleNext' in its own useCallback() Hook.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let handleNext = useCallback(() => {
+    console.log('hello');
+  });
+  if (props.foo) {
+    handleNext = () => {
+      console.log('hello');
+    };
+  }
+  useEffect(() => {
+    return Store.subscribe(handleNext);
+  }, [handleNext]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let taint = props.foo;
+
+  function handleNext(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+
+  useEffect(() => {
+    return Store.subscribe(handleNext);
+  }, [handleNext]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'handleNext' function makes the dependencies of useEffect Hook (at line 14) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'handleNext' in its own useCallback() Hook."},
+	},
+},
+
+{
+	Code: `
+function Counter({ step }) {
+  let [count, setCount] = useState(0);
+
+  function increment(x) {
+    return x + step;
+  }
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => increment(count));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [increment]);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'increment' function makes the dependencies of useEffect Hook (at line 14) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'increment' in its own useCallback() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = {};
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = [];
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' array makes the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = () => {};
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' function makes the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the definition of 'foo' in its own useCallback() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = function bar(){};
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' function makes the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the definition of 'foo' in its own useCallback() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = class {};
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' class makes the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = true ? {} : "fine";
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' conditional could make the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = bar || {};
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' logical expression could make the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = bar ?? {};
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' logical expression could make the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = bar && {};
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' logical expression could make the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = bar ? baz ? {} : null : null;
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' conditional could make the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  let foo = {};
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  var foo = {};
+  useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useMemo Hook (at line 4) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = {};
+  useCallback(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useCallback Hook (at line 6) change on every render. Move it inside the useCallback callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = {};
+  useEffect(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useEffect Hook (at line 6) change on every render. Move it inside the useEffect callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = {};
+  useLayoutEffect(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useLayoutEffect Hook (at line 6) change on every render. Move it inside the useLayoutEffect callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Component() {
+  const foo = {};
+  useImperativeHandle(
+    ref,
+    () => {
+       console.log(foo);
+    },
+    [foo]
+  );
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useImperativeHandle Hook (at line 9) change on every render. Move it inside the useImperativeHandle callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Foo(section) {
+  const foo = section.section_components?.edges ?? [];
+  useEffect(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' logical expression could make the dependencies of useEffect Hook (at line 6) change on every render. Move it inside the useEffect callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Foo(section) {
+  const foo = {};
+  console.log(foo);
+  useMemo(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useMemo Hook (at line 7) change on every render. To fix this, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Foo() {
+  const foo = <>Hi!</>;
+  useMemo(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' JSX fragment makes the dependencies of useMemo Hook (at line 6) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Foo() {
+  const foo = <div>Hi!</div>;
+  useMemo(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' JSX element makes the dependencies of useMemo Hook (at line 6) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Foo() {
+  const foo = bar = {};
+  useMemo(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' assignment expression makes the dependencies of useMemo Hook (at line 6) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Foo() {
+  const foo = new String('foo'); // Note 'foo' will be boxed, and thus an object and thus compared by reference.
+  useMemo(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object construction makes the dependencies of useMemo Hook (at line 6) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Foo() {
+  const foo = new Map([]);
+  useMemo(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object construction makes the dependencies of useMemo Hook (at line 6) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Foo() {
+  const foo = /reg/;
+  useMemo(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' regular expression makes the dependencies of useMemo Hook (at line 6) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Foo() {
+  class Bar {};
+  useMemo(() => {
+    console.log(new Bar());
+  }, [Bar]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'Bar' class makes the dependencies of useMemo Hook (at line 6) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'Bar' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function Foo() {
+  const foo = {};
+  useLayoutEffect(() => {
+    console.log(foo);
+  }, [foo]);
+  useEffect(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useLayoutEffect Hook (at line 6) change on every render. To fix this, wrap the initialization of 'foo' in its own useMemo() Hook."},
+		{Message: "The 'foo' object makes the dependencies of useEffect Hook (at line 9) change on every render. To fix this, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+}
+
+func TestExhaustiveDeps_Upstream_Construction(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamConstructionValid,
+		upstreamConstructionInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_dep_array_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_dep_array_test.go
@@ -1,0 +1,169 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_DepArray holds the upstream cases whose primary
+// diagnostic falls into the "dep_array" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamDepArrayValid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamDepArrayInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function MyComponent(props) {
+  useSpecialEffect(() => {
+    console.log(props.foo);
+  }, null);
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"additionalHooks": "useSpecialEffect"},
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useSpecialEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies."},
+		{Message: "React Hook useSpecialEffect has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useSpecialEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  useEffect(() => {}, ['foo']);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' literal is not a valid dependency because it never changes. You can safely remove it."},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const dependencies = [];
+  useEffect(() => {}, dependencies);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies."},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  const dependencies = [local];
+  useEffect(() => {
+    console.log(local);
+  }, dependencies);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies."},
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  const dependencies = [local];
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = someFunc();
+  useEffect(() => {
+    console.log(local);
+  }, [local, ...dependencies]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a spread element in its dependency array. This means we can't statically verify whether you've passed the correct dependencies."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.items[0]);
+  }, [props.items, props.items[0]]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked."},
+	},
+},
+
+{
+	Code: `
+function MyComponent({ items }) {
+  useEffect(() => {
+    console.log(items[0]);
+  }, [items, items[0]]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {}, [props?.attribute.method()]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {}, [props.method()]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked."},
+	},
+},
+}
+
+func TestExhaustiveDeps_Upstream_DepArray(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamDepArrayValid,
+		upstreamDepArrayInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_duplicate_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_duplicate_test.go
@@ -1,0 +1,76 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_Duplicate holds the upstream cases whose primary
+// diagnostic falls into the "duplicate" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamDuplicateValid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamDuplicateInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+    console.log(local);
+  }, [local, local]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a duplicate dependency: 'local'. Either omit it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, [local, local]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a duplicate dependency: 'local'. Either omit it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+}
+
+func TestExhaustiveDeps_Upstream_Duplicate(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamDuplicateValid,
+		upstreamDuplicateInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_flow_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_flow_test.go
@@ -1,0 +1,96 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_UpstreamFlow ports the small "upstream_flow_test" upstream group.
+
+var upstreamFlowValid = []rule_tester.ValidTestCase{
+// SKIP: rslint does not parse Flow
+{
+	Skip: true,
+	Code: `
+function Example({ prop }) {
+  const bar = useEffect(<T>(a: T): Hello => {
+    prop();
+  }, [prop]);
+}
+`,
+	Tsx:  true,
+},
+
+// SKIP: rslint does not parse Flow
+{
+	Skip: true,
+	Code: `
+function MyComponent() {
+  type ColumnKey = 'id' | 'name';
+  type Item = {id: string, name: string};
+
+  const columns = useMemo(
+    () => [
+      {
+        type: 'text',
+        key: 'id',
+      } as TextColumn<ColumnKey, Item>,
+    ],
+    [],
+  );
+}
+`,
+	Tsx:  true,
+},
+}
+
+var upstreamFlowInvalid = []rule_tester.InvalidTestCase{
+// SKIP: rslint does not parse Flow
+{
+	Skip: true,
+	Code: `
+hook useExample(a) {
+  useEffect(() => {
+    console.log(a);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'a'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+hook useExample(a) {
+  useEffect(() => {
+    console.log(a);
+  }, [a]);
+}
+`}}},
+	},
+},
+
+// SKIP: rslint does not parse Flow
+{
+	Skip: true,
+	Code: `
+function Foo() {
+  const foo = ({}: any);
+  useMemo(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useMemo Hook (at line 6) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+}
+
+func TestExhaustiveDeps_UpstreamFlow(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamFlowValid,
+		upstreamFlowInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_missing_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_missing_test.go
@@ -1,0 +1,2698 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_Missing holds the upstream cases whose primary
+// diagnostic falls into the "missing" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamMissingValid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamMissingInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.toString());
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.toString());
+  }, [props.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function ComponentUsingFormState(props) {
+  const [state7, dispatch3] = useFormState();
+  const [state8, dispatch4] = ReactDOM.useFormState();
+  useEffect(() => {
+    dispatch3();
+    dispatch4();
+
+    // dynamic
+    console.log(state7);
+    console.log(state8);
+
+  }, [state7, state8]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'dispatch3' and 'dispatch4'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function ComponentUsingFormState(props) {
+  const [state7, dispatch3] = useFormState();
+  const [state8, dispatch4] = ReactDOM.useFormState();
+  useEffect(() => {
+    dispatch3();
+    dispatch4();
+
+    // dynamic
+    console.log(state7);
+    console.log(state8);
+
+  }, [dispatch3, dispatch4, state7, state8]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.bar.baz);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'props.foo?.bar.baz'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.bar.baz);
+  }, [props.foo?.bar.baz]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.bar?.baz);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'props.foo?.bar?.baz'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.bar?.baz);
+  }, [props.foo?.bar?.baz]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.bar.toString());
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'props.foo?.bar'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.bar.toString());
+  }, [props.foo?.bar]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = someFunc();
+  useEffect(() => {
+    console.log(local);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = someFunc();
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Counter(unstableProp) {
+  let [count, setCount] = useState(0);
+  setCount = unstableProp
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(c => c + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'setCount'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Counter(unstableProp) {
+  let [count, setCount] = useState(0);
+  setCount = unstableProp
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(c => c + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [setCount]);
+
+  return <h1>{count}</h1>;
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  let local = 42;
+  useEffect(() => {
+    console.log(local);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  let local = 42;
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = /foo/;
+  useEffect(() => {
+    console.log(local);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = /foo/;
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = someFunc();
+  useEffect(() => {
+    if (true) {
+      console.log(local);
+    }
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = someFunc();
+  useEffect(() => {
+    if (true) {
+      console.log(local);
+    }
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    try {
+      console.log(local);
+    } finally {}
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    try {
+      console.log(local);
+    } finally {}
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    function inner() {
+      console.log(local);
+    }
+    inner();
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    function inner() {
+      console.log(local);
+    }
+    inner();
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = someFunc();
+  {
+    const local2 = someFunc();
+    useEffect(() => {
+      console.log(local1);
+      console.log(local2);
+    }, []);
+  }
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'local1' and 'local2'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local1 = someFunc();
+  {
+    const local2 = someFunc();
+    useEffect(() => {
+      console.log(local1);
+      console.log(local2);
+    }, [local1, local2]);
+  }
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = {};
+  const local2 = {};
+  useEffect(() => {
+    console.log(local1);
+    console.log(local2);
+  }, [local1]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local2'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local1 = {};
+  const local2 = {};
+  useEffect(() => {
+    console.log(local1);
+    console.log(local2);
+  }, [local1, local2]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = someFunc();
+  function MyNestedComponent() {
+    const local2 = {};
+    useCallback(() => {
+      console.log(local1);
+      console.log(local2);
+    }, [local1]);
+  }
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'local2'. Either include it or remove the dependency array. Outer scope values like 'local1' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local1 = someFunc();
+  function MyNestedComponent() {
+    const local2 = {};
+    useCallback(() => {
+      console.log(local1);
+      console.log(local2);
+    }, [local2]);
+  }
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+    console.log(local);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent({ history }) {
+  useEffect(() => {
+    return history.listen();
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'history'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent({ history }) {
+  useEffect(() => {
+    return history.listen();
+  }, [history]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent({ history }) {
+  useEffect(() => {
+    return [
+      history.foo.bar[2].dobedo.listen(),
+      history.foo.bar().dobedo.listen[2]
+    ];
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'history.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent({ history }) {
+  useEffect(() => {
+    return [
+      history.foo.bar[2].dobedo.listen(),
+      history.foo.bar().dobedo.listen[2]
+    ];
+  }, [history.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent({ history }) {
+  useEffect(() => {
+    return [
+      history?.foo
+    ];
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'history?.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent({ history }) {
+  useEffect(() => {
+    return [
+      history?.foo
+    ];
+  }, [history?.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent({ foo, bar, baz }) {
+  useEffect(() => {
+    console.log(foo, bar, baz);
+  }, ['foo', 'bar']);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'bar', 'baz', and 'foo'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent({ foo, bar, baz }) {
+  useEffect(() => {
+    console.log(foo, bar, baz);
+  }, [bar, baz, foo]);
+}
+`}}},
+		{Message: "The 'foo' literal is not a valid dependency because it never changes. Did you mean to include foo in the array instead?"},
+		{Message: "The 'bar' literal is not a valid dependency because it never changes. Did you mean to include bar in the array instead?"},
+	},
+},
+
+{
+	Code: `
+function MyComponent({ foo, bar, baz }) {
+  useEffect(() => {
+    console.log(foo, bar, baz);
+  }, [42, false, null]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'bar', 'baz', and 'foo'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent({ foo, bar, baz }) {
+  useEffect(() => {
+    console.log(foo, bar, baz);
+  }, [bar, baz, foo]);
+}
+`}}},
+		{Message: "The 42 literal is not a valid dependency because it never changes. You can safely remove it."},
+		{Message: "The false literal is not a valid dependency because it never changes. You can safely remove it."},
+		{Message: "The null literal is not a valid dependency because it never changes. You can safely remove it."},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  const dependencies = [local];
+  useEffect(() => {
+    console.log(local);
+  }, [...dependencies]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  const dependencies = [local];
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+		{Message: "React Hook useEffect has a spread element in its dependency array. This means we can't statically verify whether you've passed the correct dependencies."},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, [computeCacheKey(local)]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+		{Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.items[0]);
+  }, [props.items[0]]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props.items'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.items[0]);
+  }, [props.items]);
+}
+`}}},
+		{Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked."},
+	},
+},
+
+{
+	Code: `
+function MyComponent({ items }) {
+  useEffect(() => {
+    console.log(items[0]);
+  }, [items[0]]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'items'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent({ items }) {
+  useEffect(() => {
+    console.log(items[0]);
+  }, [items]);
+}
+`}}},
+		{Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const local = {};
+  useCallback(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has missing dependencies: 'props.bar' and 'props.foo'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const local = {};
+  useCallback(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+  }, [props.bar, props.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {id: 42};
+  useEffect(() => {
+    console.log(local);
+  }, [local.id]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {id: 42};
+  useEffect(() => {
+    console.log(local);
+  }, [local, local.id]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {id: 42};
+  const fn = useCallback(() => {
+    console.log(local);
+  }, [local.id]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {id: 42};
+  const fn = useCallback(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props.foo.bar.baz);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'props.foo.bar.baz'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props.foo.bar.baz);
+  }, [props.foo.bar.baz]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let color = {}
+  const fn = useCallback(() => {
+    console.log(props.foo.bar.baz);
+    console.log(color);
+  }, [props.foo, props.foo.bar.baz]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'color'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let color = {}
+  const fn = useCallback(() => {
+    console.log(props.foo.bar.baz);
+    console.log(color);
+  }, [color, props.foo.bar.baz]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props.foo.bar.baz);
+    console.log(props.foo.fizz.bizz);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has missing dependencies: 'props.foo.bar.baz' and 'props.foo.fizz.bizz'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props.foo.bar.baz);
+    console.log(props.foo.fizz.bizz);
+  }, [props.foo.bar.baz, props.foo.fizz.bizz]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props.foo.bar);
+  }, [props.foo.bar.baz]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'props.foo.bar'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props.foo.bar);
+  }, [props.foo.bar]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props);
+    console.log(props.hello);
+  }, [props.foo.bar.baz]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'props'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props);
+    console.log(props.hello);
+  }, [props]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'props.bar' and 'props.foo'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+  }, [props.bar, props.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let a, b, c, d, e, f, g;
+  useEffect(() => {
+    console.log(b, e, d, c, a, g, f);
+  }, [c, a, g]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'b', 'd', 'e', and 'f'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let a, b, c, d, e, f, g;
+  useEffect(() => {
+    console.log(b, e, d, c, a, g, f);
+  }, [c, a, g, b, e, d, f]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let a, b, c, d, e, f, g;
+  useEffect(() => {
+    console.log(b, e, d, c, a, g, f);
+  }, [a, c, g]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'b', 'd', 'e', and 'f'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let a, b, c, d, e, f, g;
+  useEffect(() => {
+    console.log(b, e, d, c, a, g, f);
+  }, [a, b, c, d, e, f, g]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let a, b, c, d, e, f, g;
+  useEffect(() => {
+    console.log(b, e, d, c, a, g, f);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'a', 'b', 'c', 'd', 'e', 'f', and 'g'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let a, b, c, d, e, f, g;
+  useEffect(() => {
+    console.log(b, e, d, c, a, g, f);
+  }, [a, b, c, d, e, f, g]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const local = {};
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+    console.log(local);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'local', 'props.bar', and 'props.foo'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const local = {};
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+    console.log(local);
+  }, [local, props.bar, props.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const local = {};
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+    console.log(local);
+  }, [props]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const local = {};
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+    console.log(local);
+  }, [local, props]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  React.useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.notReactiveHook(() => {
+    console.log(props.foo);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+  useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  React.useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.notReactiveHook(() => {
+    console.log(props.foo);
+  }, []);
+}
+`}}},
+		{Message: "React Hook useCallback has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  useCallback(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+  useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  React.useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.notReactiveHook(() => {
+    console.log(props.foo);
+  }, []);
+}
+`}}},
+		{Message: "React Hook useMemo has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  useMemo(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  React.useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.notReactiveHook(() => {
+    console.log(props.foo);
+  }, []);
+}
+`}}},
+		{Message: "React Hook React.useEffect has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+  React.useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  React.useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.notReactiveHook(() => {
+    console.log(props.foo);
+  }, []);
+}
+`}}},
+		{Message: "React Hook React.useCallback has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useCallback(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+  React.useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.notReactiveHook(() => {
+    console.log(props.foo);
+  }, []);
+}
+`}}},
+		{Message: "React Hook React.useMemo has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  useMemo(() => {
+    console.log(props.foo);
+  }, []);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useCallback(() => {
+    console.log(props.foo);
+  }, []);
+  React.useMemo(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+  React.notReactiveHook(() => {
+    console.log(props.foo);
+  }, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, []);
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useCustomEffect(() => {
+    console.log(props.foo);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"additionalHooks": "useCustomEffect"},
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCustomEffect has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useCustomEffect(() => {
+    console.log(props.foo);
+  }, []);
+}
+`}}},
+		{Message: "React Hook useEffect has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, []);
+  useEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useCustomEffect(() => {
+    console.log(props.foo);
+  }, []);
+}
+`}}},
+		{Message: "React Hook React.useEffect has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, []);
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+  React.useEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+  React.useCustomEffect(() => {
+    console.log(props.foo);
+  }, []);
+}
+`}}},
+	},
+},
+
+// SKIP: unsupported settings shape
+{
+	Skip: true,
+	Code: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCustomEffect has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, [a ? local : b]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+		{Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked."},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, [a && local]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+		{Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked."},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const ref = useRef();
+  const [state, setState] = useState();
+  useEffect(() => {
+    ref.current = {};
+    setState(state + 1);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'state'. Either include it or remove the dependency array. You can also do a functional update 'setState(s => ...)' if you only need 'state' in the 'setState' call.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const ref = useRef();
+  const [state, setState] = useState();
+  useEffect(() => {
+    ref.current = {};
+    setState(state + 1);
+  }, [state]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const ref = useRef();
+  const [state, setState] = useState();
+  useEffect(() => {
+    ref.current = {};
+    setState(state + 1);
+  }, [ref]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'state'. Either include it or remove the dependency array. You can also do a functional update 'setState(s => ...)' if you only need 'state' in the 'setState' call.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const ref = useRef();
+  const [state, setState] = useState();
+  useEffect(() => {
+    ref.current = {};
+    setState(state + 1);
+  }, [ref, state]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const ref1 = useRef();
+  const ref2 = useRef();
+  useEffect(() => {
+    ref1.current.focus();
+    console.log(ref2.current.textContent);
+    alert(props.someOtherRefs.current.innerHTML);
+    fetch(props.color);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'props.color' and 'props.someOtherRefs'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const ref1 = useRef();
+  const ref2 = useRef();
+  useEffect(() => {
+    ref1.current.focus();
+    console.log(ref2.current.textContent);
+    alert(props.someOtherRefs.current.innerHTML);
+    fetch(props.color);
+  }, [props.color, props.someOtherRefs]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+const MyComponent = forwardRef((props, ref) => {
+  useImperativeHandle(ref, () => ({
+    focus() {
+      alert(props.hello);
+    }
+  }), [])
+});
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useImperativeHandle has a missing dependency: 'props.hello'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+const MyComponent = forwardRef((props, ref) => {
+  useImperativeHandle(ref, () => ({
+    focus() {
+      alert(props.hello);
+    }
+  }), [props.hello])
+});
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    if (props.onChange) {
+      props.onChange();
+    }
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props'. Either include it or remove the dependency array. However, 'props' will change when *any* prop changes, so the preferred fix is to destructure the 'props' object outside of the useEffect call and refer to those specific props inside useEffect.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    if (props.onChange) {
+      props.onChange();
+    }
+  }, [props]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    if (props?.onChange) {
+      props?.onChange();
+    }
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props'. Either include it or remove the dependency array. However, 'props' will change when *any* prop changes, so the preferred fix is to destructure the 'props' object outside of the useEffect call and refer to those specific props inside useEffect.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    if (props?.onChange) {
+      props?.onChange();
+    }
+  }, [props]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    function play() {
+      props.onPlay();
+    }
+    function pause() {
+      props.onPause();
+    }
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props'. Either include it or remove the dependency array. However, 'props' will change when *any* prop changes, so the preferred fix is to destructure the 'props' object outside of the useEffect call and refer to those specific props inside useEffect.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    function play() {
+      props.onPlay();
+    }
+    function pause() {
+      props.onPause();
+    }
+  }, [props]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    if (props.foo.onChange) {
+      props.foo.onChange();
+    }
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props.foo'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    if (props.foo.onChange) {
+      props.foo.onChange();
+    }
+  }, [props.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    props.onChange();
+    if (props.foo.onChange) {
+      props.foo.onChange();
+    }
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props'. Either include it or remove the dependency array. However, 'props' will change when *any* prop changes, so the preferred fix is to destructure the 'props' object outside of the useEffect call and refer to those specific props inside useEffect.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    props.onChange();
+    if (props.foo.onChange) {
+      props.foo.onChange();
+    }
+  }, [props]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const [skillsCount] = useState();
+  useEffect(() => {
+    if (skillsCount === 0 && !props.isEditMode) {
+      props.toggleEditMode();
+    }
+  }, [skillsCount, props.isEditMode, props.toggleEditMode]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props'. Either include it or remove the dependency array. However, 'props' will change when *any* prop changes, so the preferred fix is to destructure the 'props' object outside of the useEffect call and refer to those specific props inside useEffect.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const [skillsCount] = useState();
+  useEffect(() => {
+    if (skillsCount === 0 && !props.isEditMode) {
+      props.toggleEditMode();
+    }
+  }, [skillsCount, props.isEditMode, props.toggleEditMode, props]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const [skillsCount] = useState();
+  useEffect(() => {
+    if (skillsCount === 0 && !props.isEditMode) {
+      props.toggleEditMode();
+    }
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'props' and 'skillsCount'. Either include them or remove the dependency array. However, 'props' will change when *any* prop changes, so the preferred fix is to destructure the 'props' object outside of the useEffect call and refer to those specific props inside useEffect.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const [skillsCount] = useState();
+  useEffect(() => {
+    if (skillsCount === 0 && !props.isEditMode) {
+      props.toggleEditMode();
+    }
+  }, [props, skillsCount]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    externalCall(props);
+    props.onChange();
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    externalCall(props);
+    props.onChange();
+  }, [props]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    props.onChange();
+    externalCall(props);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  useEffect(() => {
+    props.onChange();
+    externalCall(props);
+  }, [props]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = 42;
+  const local2 = '42';
+  const local3 = null;
+  const local4 = {};
+  useEffect(() => {
+    console.log(local1);
+    console.log(local2);
+    console.log(local3);
+    console.log(local4);
+  }, [local1, local3]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local4'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local1 = 42;
+  const local2 = '42';
+  const local3 = null;
+  const local4 = {};
+  useEffect(() => {
+    console.log(local1);
+    console.log(local2);
+    console.log(local3);
+    console.log(local4);
+  }, [local1, local3, local4]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    setTimeout(() => console.log(taint));
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'handleNext1'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    setTimeout(() => console.log(taint));
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, [handleNext1]);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`}}},
+		{Message: "React Hook useLayoutEffect has a missing dependency: 'handleNext2'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    setTimeout(() => console.log(taint));
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, [handleNext2]);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`}}},
+		{Message: "React Hook useMemo has a missing dependency: 'handleNext3'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    setTimeout(() => console.log(taint));
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, [handleNext3]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  // Shouldn't affect anything
+  function handleChange() {}
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    console.log(taint);
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'handleNext1'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  // Shouldn't affect anything
+  function handleChange() {}
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    console.log(taint);
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, [handleNext1]);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`}}},
+		{Message: "React Hook useLayoutEffect has a missing dependency: 'handleNext2'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  // Shouldn't affect anything
+  function handleChange() {}
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    console.log(taint);
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, [handleNext2]);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`}}},
+		{Message: "React Hook useMemo has a missing dependency: 'handleNext3'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  // Shouldn't affect anything
+  function handleChange() {}
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    console.log(taint);
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, [handleNext3]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  // Shouldn't affect anything
+  const handleChange = () => {};
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    console.log(taint);
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'handleNext1'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  // Shouldn't affect anything
+  const handleChange = () => {};
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    console.log(taint);
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, [handleNext1]);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`}}},
+		{Message: "React Hook useLayoutEffect has a missing dependency: 'handleNext2'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  // Shouldn't affect anything
+  const handleChange = () => {};
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    console.log(taint);
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, [handleNext2]);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`}}},
+		{Message: "React Hook useMemo has a missing dependency: 'handleNext3'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+  let taint = props.foo;
+
+  // Shouldn't affect anything
+  const handleChange = () => {};
+
+  function handleNext1(value) {
+    let value2 = value * taint;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(taint(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    console.log(taint);
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, [handleNext3]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Counter() {
+  let [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'count'. Either include it or remove the dependency array. You can also do a functional update 'setCount(c => ...)' if you only need 'count' in the 'setCount' call.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Counter() {
+  let [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [count]);
+
+  return <h1>{count}</h1>;
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Counter() {
+  let [count, setCount] = useState(0);
+  let [increment, setIncrement] = useState(0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count + increment);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'count' and 'increment'. Either include them or remove the dependency array. You can also do a functional update 'setCount(c => ...)' if you only need 'count' in the 'setCount' call.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Counter() {
+  let [count, setCount] = useState(0);
+  let [increment, setIncrement] = useState(0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count + increment);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [count, increment]);
+
+  return <h1>{count}</h1>;
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Counter() {
+  let [count, setCount] = useState(0);
+  let [increment, setIncrement] = useState(0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => count + increment);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'increment'. Either include it or remove the dependency array. You can also replace multiple useState variables with useReducer if 'setCount' needs the current value of 'increment'.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Counter() {
+  let [count, setCount] = useState(0);
+  let [increment, setIncrement] = useState(0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => count + increment);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [increment]);
+
+  return <h1>{count}</h1>;
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Counter() {
+  let [count, setCount] = useState(0);
+  let increment = useCustomHook();
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => count + increment);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'increment'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Counter() {
+  let [count, setCount] = useState(0);
+  let increment = useCustomHook();
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => count + increment);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [increment]);
+
+  return <h1>{count}</h1>;
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Counter({ step }) {
+  let [count, setCount] = useState(0);
+
+  function increment(x) {
+    return x + step;
+  }
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => increment(count));
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'increment'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Counter({ step }) {
+  let [count, setCount] = useState(0);
+
+  function increment(x) {
+    return x + step;
+  }
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => increment(count));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [increment]);
+
+  return <h1>{count}</h1>;
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Counter({ increment }) {
+  let [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => count + increment);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'increment'. Either include it or remove the dependency array. If 'setCount' needs the current value of 'increment', you can also switch to useReducer instead of useState and read 'increment' in the reducer.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Counter({ increment }) {
+  let [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => count + increment);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [increment]);
+
+  return <h1>{count}</h1>;
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Counter() {
+  const [count, setCount] = useState(0);
+
+  function tick() {
+    setCount(count + 1);
+  }
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      tick();
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'tick'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Counter() {
+  const [count, setCount] = useState(0);
+
+  function tick() {
+    setCount(count + 1);
+  }
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      tick();
+    }, 1000);
+    return () => clearInterval(id);
+  }, [tick]);
+
+  return <h1>{count}</h1>;
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Podcasts() {
+  useEffect(() => {
+    alert(podcasts);
+  }, []);
+  let [podcasts, setPodcasts] = useState(null);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'podcasts'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Podcasts() {
+  useEffect(() => {
+    alert(podcasts);
+  }, [podcasts]);
+  let [podcasts, setPodcasts] = useState(null);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Podcasts({ fetchPodcasts, id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    fetchPodcasts(id).then(setPodcasts);
+  }, [id]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'fetchPodcasts'. Either include it or remove the dependency array. If 'fetchPodcasts' changes too often, find the parent component that defines it and wrap that definition in useCallback.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Podcasts({ fetchPodcasts, id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    fetchPodcasts(id).then(setPodcasts);
+  }, [fetchPodcasts, id]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Podcasts({ api: { fetchPodcasts }, id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    fetchPodcasts(id).then(setPodcasts);
+  }, [id]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'fetchPodcasts'. Either include it or remove the dependency array. If 'fetchPodcasts' changes too often, find the parent component that defines it and wrap that definition in useCallback.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Podcasts({ api: { fetchPodcasts }, id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    fetchPodcasts(id).then(setPodcasts);
+  }, [fetchPodcasts, id]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Podcasts({ fetchPodcasts, fetchPodcasts2, id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    setTimeout(() => {
+      console.log(id);
+      fetchPodcasts(id).then(setPodcasts);
+      fetchPodcasts2(id).then(setPodcasts);
+    });
+  }, [id]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'fetchPodcasts' and 'fetchPodcasts2'. Either include them or remove the dependency array. If 'fetchPodcasts' changes too often, find the parent component that defines it and wrap that definition in useCallback.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Podcasts({ fetchPodcasts, fetchPodcasts2, id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    setTimeout(() => {
+      console.log(id);
+      fetchPodcasts(id).then(setPodcasts);
+      fetchPodcasts2(id).then(setPodcasts);
+    });
+  }, [fetchPodcasts, fetchPodcasts2, id]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Podcasts({ fetchPodcasts, id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    console.log(fetchPodcasts);
+    fetchPodcasts(id).then(setPodcasts);
+  }, [id]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'fetchPodcasts'. Either include it or remove the dependency array. If 'fetchPodcasts' changes too often, find the parent component that defines it and wrap that definition in useCallback.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Podcasts({ fetchPodcasts, id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    console.log(fetchPodcasts);
+    fetchPodcasts(id).then(setPodcasts);
+  }, [fetchPodcasts, id]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Podcasts({ fetchPodcasts, id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    console.log(fetchPodcasts);
+    fetchPodcasts?.(id).then(setPodcasts);
+  }, [id]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'fetchPodcasts'. Either include it or remove the dependency array. If 'fetchPodcasts' changes too often, find the parent component that defines it and wrap that definition in useCallback.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Podcasts({ fetchPodcasts, id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    console.log(fetchPodcasts);
+    fetchPodcasts?.(id).then(setPodcasts);
+  }, [fetchPodcasts, id]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Example({ prop }) {
+  const foo = useCallback(() => {
+    prop.hello(foo);
+  }, [foo]);
+  const bar = useCallback(() => {
+    foo();
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has a missing dependency: 'prop'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Example({ prop }) {
+  const foo = useCallback(() => {
+    prop.hello(foo);
+  }, [prop]);
+  const bar = useCallback(() => {
+    foo();
+  }, [foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  function myEffect() {
+    console.log(local);
+  }
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  function myEffect() {
+    console.log(local);
+  }
+  useEffect(myEffect, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  const myEffect = () => {
+    console.log(local);
+  };
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  const myEffect = () => {
+    console.log(local);
+  };
+  useEffect(myEffect, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  const myEffect = function() {
+    console.log(local);
+  };
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  const myEffect = function() {
+    console.log(local);
+  };
+  useEffect(myEffect, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  const myEffect = () => {
+    otherThing();
+  };
+  const otherThing = () => {
+    console.log(local);
+  };
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'otherThing'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  const myEffect = () => {
+    otherThing();
+  };
+  const otherThing = () => {
+    console.log(local);
+  };
+  useEffect(myEffect, [otherThing]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  const myEffect = debounce(() => {
+    console.log(local);
+  }, delay);
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'myEffect'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  const myEffect = debounce(() => {
+    console.log(local);
+  }, delay);
+  useEffect(myEffect, [myEffect]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  const myEffect = debounce(() => {
+    console.log(local);
+  }, delay);
+  useEffect(myEffect, [local]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'myEffect'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  const myEffect = debounce(() => {
+    console.log(local);
+  }, delay);
+  useEffect(myEffect, [myEffect]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"enableDangerousAutofixThisMayCauseInfiniteLoops": true},
+	Output: []string{`
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`},
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let foo = {}
+  useEffect(() => {
+    foo.bar.baz = 43;
+    props.foo.bar.baz = 1;
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'foo.bar' and 'props.foo.bar'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let foo = {}
+  useEffect(() => {
+    foo.bar.baz = 43;
+    props.foo.bar.baz = 1;
+  }, [foo.bar, props.foo.bar]);
+}
+`}}},
+	},
+},
+}
+
+func TestExhaustiveDeps_Upstream_Missing(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamMissingValid,
+		upstreamMissingInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_ref_cleanup_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_ref_cleanup_test.go
@@ -1,0 +1,163 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_RefCleanup holds the upstream cases whose primary
+// diagnostic falls into the "ref_cleanup" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamRefCleanupValid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamRefCleanupInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function MyComponent() {
+  const myRef = useRef();
+  useEffect(() => {
+    const handleMove = () => {};
+    myRef.current.addEventListener('mousemove', handleMove);
+    return () => myRef.current.removeEventListener('mousemove', handleMove);
+  }, []);
+  return <div ref={myRef} />;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The ref value 'myRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'myRef.current' to a variable inside the effect, and use that variable in the cleanup function."},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const myRef = useRef();
+  useEffect(() => {
+    const handleMove = () => {};
+    myRef?.current?.addEventListener('mousemove', handleMove);
+    return () => myRef?.current?.removeEventListener('mousemove', handleMove);
+  }, []);
+  return <div ref={myRef} />;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The ref value 'myRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'myRef.current' to a variable inside the effect, and use that variable in the cleanup function."},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const myRef = useRef();
+  useEffect(() => {
+    const handleMove = () => {};
+    myRef.current.addEventListener('mousemove', handleMove);
+    return () => myRef.current.removeEventListener('mousemove', handleMove);
+  });
+  return <div ref={myRef} />;
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The ref value 'myRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'myRef.current' to a variable inside the effect, and use that variable in the cleanup function."},
+	},
+},
+
+{
+	Code: `
+function useMyThing(myRef) {
+  useEffect(() => {
+    const handleMove = () => {};
+    myRef.current.addEventListener('mousemove', handleMove);
+    return () => myRef.current.removeEventListener('mousemove', handleMove);
+  }, [myRef]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The ref value 'myRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'myRef.current' to a variable inside the effect, and use that variable in the cleanup function."},
+	},
+},
+
+{
+	Code: `
+function useMyThing(myRef) {
+  useEffect(() => {
+    const handleMouse = () => {};
+    myRef.current.addEventListener('mousemove', handleMouse);
+    myRef.current.addEventListener('mousein', handleMouse);
+    return function() {
+      setTimeout(() => {
+        myRef.current.removeEventListener('mousemove', handleMouse);
+        myRef.current.removeEventListener('mousein', handleMouse);
+      });
+    }
+  }, [myRef]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The ref value 'myRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'myRef.current' to a variable inside the effect, and use that variable in the cleanup function."},
+	},
+},
+
+{
+	Code: `
+function useMyThing(myRef, active) {
+  useEffect(() => {
+    const handleMove = () => {};
+    if (active) {
+      myRef.current.addEventListener('mousemove', handleMove);
+      return function() {
+        setTimeout(() => {
+          myRef.current.removeEventListener('mousemove', handleMove);
+        });
+      }
+    }
+  }, [myRef, active]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The ref value 'myRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'myRef.current' to a variable inside the effect, and use that variable in the cleanup function."},
+	},
+},
+
+{
+	Code: `
+        function MyComponent() {
+          const myRef = useRef();
+          useLayoutEffect_SAFE_FOR_SSR(() => {
+            const handleMove = () => {};
+            myRef.current.addEventListener('mousemove', handleMove);
+            return () => myRef.current.removeEventListener('mousemove', handleMove);
+          });
+          return <div ref={myRef} />;
+        }
+      `,
+	Tsx:  true,
+	Options: map[string]interface{}{"additionalHooks": "useLayoutEffect_SAFE_FOR_SSR"},
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The ref value 'myRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'myRef.current' to a variable inside the effect, and use that variable in the cleanup function."},
+	},
+},
+}
+
+func TestExhaustiveDeps_Upstream_RefCleanup(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamRefCleanupValid,
+		upstreamRefCleanupInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_setstate_no_deps_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_setstate_no_deps_test.go
@@ -1,0 +1,122 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_SetStateNoDeps holds the upstream cases whose primary
+// diagnostic falls into the "setstate_no_deps" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamSetStateNoDepsValid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamSetStateNoDepsInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function Hello() {
+  const [state, setState] = useState(0);
+  useEffect(() => {
+    setState({});
+  });
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect contains a call to 'setState'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass [] as a second argument to the useEffect Hook.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Hello() {
+  const [state, setState] = useState(0);
+  useEffect(() => {
+    setState({});
+  }, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Hello() {
+  const [data, setData] = useState(0);
+  useEffect(() => {
+    fetchData.then(setData);
+  });
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect contains a call to 'setData'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass [] as a second argument to the useEffect Hook.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Hello() {
+  const [data, setData] = useState(0);
+  useEffect(() => {
+    fetchData.then(setData);
+  }, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Hello({ country }) {
+  const [data, setData] = useState(0);
+  useEffect(() => {
+    fetchData(country).then(setData);
+  });
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect contains a call to 'setData'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass [country] as a second argument to the useEffect Hook.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Hello({ country }) {
+  const [data, setData] = useState(0);
+  useEffect(() => {
+    fetchData(country).then(setData);
+  }, [country]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Hello({ prop1, prop2 }) {
+  const [state, setState] = useState(0);
+  useEffect(() => {
+    if (prop1) {
+      setState(prop2);
+    }
+  });
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect contains a call to 'setState'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass [prop1, prop2] as a second argument to the useEffect Hook.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Hello({ prop1, prop2 }) {
+  const [state, setState] = useState(0);
+  useEffect(() => {
+    if (prop1) {
+      setState(prop2);
+    }
+  }, [prop1, prop2]);
+}
+`}}},
+	},
+},
+}
+
+func TestExhaustiveDeps_Upstream_SetStateNoDeps(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamSetStateNoDepsValid,
+		upstreamSetStateNoDepsInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_stale_assignment_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_stale_assignment_test.go
@@ -1,0 +1,89 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_StaleAssignment holds the upstream cases whose primary
+// diagnostic falls into the "stale_assignment" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamStaleAssignmentValid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamStaleAssignmentInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function MyComponent(props) {
+  let value;
+  let value2;
+  let value3;
+  let value4;
+  let asyncValue;
+  useEffect(() => {
+    if (value4) {
+      value = {};
+    }
+    value2 = 100;
+    value = 43;
+    value4 = true;
+    console.log(value2);
+    console.log(value3);
+    setTimeout(() => {
+      asyncValue = 100;
+    });
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "Assignments to the 'value' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect."},
+		{Message: "Assignments to the 'value2' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect."},
+		{Message: "Assignments to the 'value4' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect."},
+		{Message: "Assignments to the 'asyncValue' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let value;
+  let value2;
+  let value3;
+  let asyncValue;
+  useEffect(() => {
+    value = {};
+    value2 = 100;
+    value = 43;
+    console.log(value2);
+    console.log(value3);
+    setTimeout(() => {
+      asyncValue = 100;
+    });
+  }, [value, value2, value3]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "Assignments to the 'value' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect."},
+		{Message: "Assignments to the 'value2' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect."},
+		{Message: "Assignments to the 'asyncValue' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect."},
+	},
+},
+}
+
+func TestExhaustiveDeps_Upstream_StaleAssignment(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamStaleAssignmentValid,
+		upstreamStaleAssignmentInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_ts_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_ts_test.go
@@ -1,0 +1,439 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_UpstreamTs ports the small "upstream_ts_test" upstream group.
+
+var upstreamTsValid = []rule_tester.ValidTestCase{
+{
+	Code: `
+function MyComponent() {
+  const ref = useRef() as React.MutableRefObject<HTMLDivElement>;
+  useEffect(() => {
+    console.log(ref.current);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const [state, setState] = React.useState<number>(0);
+
+  useEffect(() => {
+    const someNumber: typeof state = 2;
+    setState(prevState => prevState + someNumber);
+  }, [])
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const [state, setState] = React.useState<number>(0);
+
+  useSpecialEffect(() => {
+    const someNumber: typeof state = 2;
+    setState(prevState => prevState + someNumber);
+  })
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"additionalHooks": "useSpecialEffect", "experimental_autoDependenciesHooks": []interface{}{"useSpecialEffect"}},
+},
+
+{
+	Code: `
+function App() {
+  const foo = {x: 1};
+  React.useEffect(() => {
+    const bar = {x: 2};
+    const baz = bar as typeof foo;
+    console.log(baz);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function App(props) {
+  React.useEffect(() => {
+    console.log(props.test);
+  }, [props.test] as const);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function App(props) {
+  React.useEffect(() => {
+    console.log(props.test);
+  }, [props.test] as any);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function App(props) {
+  React.useEffect((() => {
+    console.log(props.test);
+  }) as any, [props.test]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useMyThing<T>(): void {
+  useEffect(() => {
+    let foo: T;
+    console.log(foo);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+}
+
+var upstreamTsInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function MyComponent() {
+  const local = {} as string;
+  useEffect(() => {
+    console.log(local);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'local'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {} as string;
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function App() {
+  const foo = {x: 1};
+  const bar = {x: 2};
+  useEffect(() => {
+    const baz = bar as typeof foo;
+    console.log(baz);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'bar'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function App() {
+  const foo = {x: 1};
+  const bar = {x: 2};
+  useEffect(() => {
+    const baz = bar as typeof foo;
+    console.log(baz);
+  }, [bar]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const pizza = {};
+
+  useEffect(() => ({
+    crust: pizza.crust,
+    toppings: pizza?.toppings,
+  }), []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has missing dependencies: 'pizza.crust' and 'pizza?.toppings'. Either include them or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const pizza = {};
+
+  useEffect(() => ({
+    crust: pizza.crust,
+    toppings: pizza?.toppings,
+  }), [pizza.crust, pizza?.toppings]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const pizza = {};
+
+  useEffect(() => ({
+    crust: pizza?.crust,
+    density: pizza.crust.density,
+  }), []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'pizza.crust'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const pizza = {};
+
+  useEffect(() => ({
+    crust: pizza?.crust,
+    density: pizza.crust.density,
+  }), [pizza.crust]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const pizza = {};
+
+  useEffect(() => ({
+    crust: pizza.crust,
+    density: pizza?.crust.density,
+  }), []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'pizza.crust'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const pizza = {};
+
+  useEffect(() => ({
+    crust: pizza.crust,
+    density: pizza?.crust.density,
+  }), [pizza.crust]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const pizza = {};
+
+  useEffect(() => ({
+    crust: pizza?.crust,
+    density: pizza?.crust.density,
+  }), []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'pizza?.crust'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const pizza = {};
+
+  useEffect(() => ({
+    crust: pizza?.crust,
+    density: pizza?.crust.density,
+  }), [pizza?.crust]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Example(props) {
+  useEffect(() => {
+    let topHeight = 0;
+    topHeight = props.upperViewHeight;
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props.upperViewHeight'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Example(props) {
+  useEffect(() => {
+    let topHeight = 0;
+    topHeight = props.upperViewHeight;
+  }, [props.upperViewHeight]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Example(props) {
+  useEffect(() => {
+    let topHeight = 0;
+    topHeight = props?.upperViewHeight;
+  }, []);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'props?.upperViewHeight'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Example(props) {
+  useEffect(() => {
+    let topHeight = 0;
+    topHeight = props?.upperViewHeight;
+  }, [props?.upperViewHeight]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const [state, setState] = React.useState<number>(0);
+
+  useEffect(() => {
+    const someNumber: typeof state = 2;
+    setState(prevState => prevState + someNumber + state);
+  }, [])
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has a missing dependency: 'state'. Either include it or remove the dependency array. You can also do a functional update 'setState(s => ...)' if you only need 'state' in the 'setState' call.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const [state, setState] = React.useState<number>(0);
+
+  useEffect(() => {
+    const someNumber: typeof state = 2;
+    setState(prevState => prevState + someNumber + state);
+  }, [state])
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const [state, setState] = React.useState<number>(0);
+
+  useSpecialEffect(() => {
+    const someNumber: typeof state = 2;
+    setState(prevState => prevState + someNumber + state);
+  }, [])
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"additionalHooks": "useSpecialEffect", "experimental_autoDependenciesHooks": []interface{}{"useSpecialEffect"}},
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useSpecialEffect has a missing dependency: 'state'. Either include it or remove the dependency array. You can also do a functional update 'setState(s => ...)' if you only need 'state' in the 'setState' call.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const [state, setState] = React.useState<number>(0);
+
+  useSpecialEffect(() => {
+    const someNumber: typeof state = 2;
+    setState(prevState => prevState + someNumber + state);
+  }, [state])
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const [state, setState] = React.useState<number>(0);
+
+  useMemo(() => {
+    const someNumber: typeof state = 2;
+    console.log(someNumber);
+  }, [state])
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useMemo has an unnecessary dependency: 'state'. Either exclude it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const [state, setState] = React.useState<number>(0);
+
+  useMemo(() => {
+    const someNumber: typeof state = 2;
+    console.log(someNumber);
+  }, [])
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Foo() {
+  const foo = {} as any;
+  useMemo(() => {
+    console.log(foo);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "The 'foo' object makes the dependencies of useMemo Hook (at line 6) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'foo' in its own useMemo() Hook."},
+	},
+},
+
+{
+	Code: `
+function useCustomCallback(callback, deps) {
+  return useCallback(callback as any, deps)
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback received a function whose dependencies are unknown. Pass an inline function instead."},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  });
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"requireExplicitEffectDeps": true},
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect always requires dependencies. Please add a dependency array or an explicit `undefined`"},
+	},
+},
+}
+
+func TestExhaustiveDeps_UpstreamTs(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamTsValid,
+		upstreamTsInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_tsv4_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_tsv4_test.go
@@ -1,0 +1,44 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_UpstreamTsv4 ports the small "upstream_tsv4_test" upstream group.
+
+var upstreamTsv4Valid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamTsv4Invalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function Foo({ Component }) {
+  React.useEffect(() => {
+    console.log(<Component />);
+  }, []);
+};
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook React.useEffect has a missing dependency: 'Component'. Either include it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Foo({ Component }) {
+  React.useEffect(() => {
+    console.log(<Component />);
+  }, [Component]);
+};
+`}}},
+	},
+},
+}
+
+func TestExhaustiveDeps_UpstreamTsv4(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamTsv4Valid,
+		upstreamTsv4Invalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_unnecessary_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_unnecessary_test.go
@@ -1,0 +1,574 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_Unnecessary holds the upstream cases whose primary
+// diagnostic falls into the "unnecessary" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamUnnecessaryValid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamUnnecessaryInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function MyComponent() {
+  const local1 = {};
+  const local2 = {};
+  useMemo(() => {
+    console.log(local1);
+  }, [local1, local2]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useMemo has an unnecessary dependency: 'local2'. Either exclude it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local1 = {};
+  const local2 = {};
+  useMemo(() => {
+    console.log(local1);
+  }, [local1]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  useCallback(() => {}, [window]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has an unnecessary dependency: 'window'. Either exclude it or remove the dependency array. Outer scope values like 'window' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  useCallback(() => {}, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let local = props.foo;
+  useCallback(() => {}, [local]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has an unnecessary dependency: 'local'. Either exclude it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  let local = props.foo;
+  useCallback(() => {}, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const local = {};
+  useCallback(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+  }, [props, props.foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has an unnecessary dependency: 'props.foo'. Either exclude it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const local = {};
+  useCallback(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+  }, [props]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = {id: 42};
+  const fn = useCallback(() => {
+    console.log(local);
+  }, [local.id, local]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has an unnecessary dependency: 'local.id'. Either exclude it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local = {id: 42};
+  const fn = useCallback(() => {
+    console.log(local);
+  }, [local]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props.foo.bar.baz);
+  }, [props.foo.bar.baz, props.foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has an unnecessary dependency: 'props.foo.bar.baz'. Either exclude it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props.foo.bar.baz);
+  }, [props.foo]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = {};
+  useCallback(() => {
+    const local1 = {};
+    console.log(local1);
+  }, [local1]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has an unnecessary dependency: 'local1'. Either exclude it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local1 = {};
+  useCallback(() => {
+    const local1 = {};
+    console.log(local1);
+  }, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = {};
+  useCallback(() => {}, [local1]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has an unnecessary dependency: 'local1'. Either exclude it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const local1 = {};
+  useCallback(() => {}, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const ref1 = useRef();
+  const ref2 = useRef();
+  useEffect(() => {
+    ref1.current.focus();
+    console.log(ref2.current.textContent);
+    alert(props.someOtherRefs.current.innerHTML);
+    fetch(props.color);
+  }, [ref1.current, ref2.current, props.someOtherRefs, props.color]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has unnecessary dependencies: 'ref1.current' and 'ref2.current'. Either exclude them or remove the dependency array. Mutable values like 'ref1.current' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const ref1 = useRef();
+  const ref2 = useRef();
+  useEffect(() => {
+    ref1.current.focus();
+    console.log(ref2.current.textContent);
+    alert(props.someOtherRefs.current.innerHTML);
+    fetch(props.color);
+  }, [props.someOtherRefs, props.color]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const ref1 = useRef();
+  const ref2 = useRef();
+  useEffect(() => {
+    ref1?.current?.focus();
+    console.log(ref2?.current?.textContent);
+    alert(props.someOtherRefs.current.innerHTML);
+    fetch(props.color);
+  }, [ref1?.current, ref2?.current, props.someOtherRefs, props.color]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has unnecessary dependencies: 'ref1.current' and 'ref2.current'. Either exclude them or remove the dependency array. Mutable values like 'ref1.current' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent(props) {
+  const ref1 = useRef();
+  const ref2 = useRef();
+  useEffect(() => {
+    ref1?.current?.focus();
+    console.log(ref2?.current?.textContent);
+    alert(props.someOtherRefs.current.innerHTML);
+    fetch(props.color);
+  }, [props.someOtherRefs, props.color]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const ref = useRef();
+  useEffect(() => {
+    console.log(ref.current);
+  }, [ref.current]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has an unnecessary dependency: 'ref.current'. Either exclude it or remove the dependency array. Mutable values like 'ref.current' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const ref = useRef();
+  useEffect(() => {
+    console.log(ref.current);
+  }, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent({ activeTab }) {
+  const ref1 = useRef();
+  const ref2 = useRef();
+  useEffect(() => {
+    ref1.current.scrollTop = 0;
+    ref2.current.scrollTop = 0;
+  }, [ref1.current, ref2.current, activeTab]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has unnecessary dependencies: 'ref1.current' and 'ref2.current'. Either exclude them or remove the dependency array. Mutable values like 'ref1.current' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent({ activeTab }) {
+  const ref1 = useRef();
+  const ref2 = useRef();
+  useEffect(() => {
+    ref1.current.scrollTop = 0;
+    ref2.current.scrollTop = 0;
+  }, [activeTab]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent({ activeTab, initY }) {
+  const ref1 = useRef();
+  const ref2 = useRef();
+  const fn = useCallback(() => {
+    ref1.current.scrollTop = initY;
+    ref2.current.scrollTop = initY;
+  }, [ref1.current, ref2.current, activeTab, initY]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has unnecessary dependencies: 'activeTab', 'ref1.current', and 'ref2.current'. Either exclude them or remove the dependency array. Mutable values like 'ref1.current' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent({ activeTab, initY }) {
+  const ref1 = useRef();
+  const ref2 = useRef();
+  const fn = useCallback(() => {
+    ref1.current.scrollTop = initY;
+    ref2.current.scrollTop = initY;
+  }, [initY]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  const ref = useRef();
+  useEffect(() => {
+    console.log(ref.current);
+  }, [ref.current, ref]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has an unnecessary dependency: 'ref.current'. Either exclude it or remove the dependency array. Mutable values like 'ref.current' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  const ref = useRef();
+  useEffect(() => {
+    console.log(ref.current);
+  }, [ref]);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function MyComponent() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [window]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has an unnecessary dependency: 'window'. Either exclude it or remove the dependency array. Outer scope values like 'window' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+import MutableStore from 'store';
+
+function MyComponent() {
+  useEffect(() => {
+    console.log(MutableStore.hello);
+  }, [MutableStore.hello]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has an unnecessary dependency: 'MutableStore.hello'. Either exclude it or remove the dependency array. Outer scope values like 'MutableStore.hello' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+import MutableStore from 'store';
+
+function MyComponent() {
+  useEffect(() => {
+    console.log(MutableStore.hello);
+  }, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+import MutableStore from 'store';
+let z = {};
+
+function MyComponent(props) {
+  let x = props.foo;
+  {
+    let y = props.bar;
+    useEffect(() => {
+      console.log(MutableStore.hello.world, props.foo, x, y, z, global.stuff);
+    }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
+  }
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has unnecessary dependencies: 'MutableStore.hello.world', 'global.stuff', and 'z'. Either exclude them or remove the dependency array. Outer scope values like 'MutableStore.hello.world' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+import MutableStore from 'store';
+let z = {};
+
+function MyComponent(props) {
+  let x = props.foo;
+  {
+    let y = props.bar;
+    useEffect(() => {
+      console.log(MutableStore.hello.world, props.foo, x, y, z, global.stuff);
+    }, [props.foo, x, y]);
+  }
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+import MutableStore from 'store';
+let z = {};
+
+function MyComponent(props) {
+  let x = props.foo;
+  {
+    let y = props.bar;
+    useEffect(() => {
+      // nothing
+    }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
+  }
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has unnecessary dependencies: 'MutableStore.hello.world', 'global.stuff', and 'z'. Either exclude them or remove the dependency array. Outer scope values like 'MutableStore.hello.world' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+import MutableStore from 'store';
+let z = {};
+
+function MyComponent(props) {
+  let x = props.foo;
+  {
+    let y = props.bar;
+    useEffect(() => {
+      // nothing
+    }, [props.foo, x, y]);
+  }
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+import MutableStore from 'store';
+let z = {};
+
+function MyComponent(props) {
+  let x = props.foo;
+  {
+    let y = props.bar;
+    const fn = useCallback(() => {
+      // nothing
+    }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
+  }
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has unnecessary dependencies: 'MutableStore.hello.world', 'global.stuff', 'props.foo', 'x', 'y', and 'z'. Either exclude them or remove the dependency array. Outer scope values like 'MutableStore.hello.world' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+import MutableStore from 'store';
+let z = {};
+
+function MyComponent(props) {
+  let x = props.foo;
+  {
+    let y = props.bar;
+    const fn = useCallback(() => {
+      // nothing
+    }, []);
+  }
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+import MutableStore from 'store';
+let z = {};
+
+function MyComponent(props) {
+  let x = props.foo;
+  {
+    let y = props.bar;
+    const fn = useCallback(() => {
+      // nothing
+    }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
+  }
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has unnecessary dependencies: 'MutableStore.hello.world', 'global.stuff', 'props.foo', 'x', 'y', and 'z'. Either exclude them or remove the dependency array. Outer scope values like 'MutableStore.hello.world' aren't valid dependencies because mutating them doesn't re-render the component.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+import MutableStore from 'store';
+let z = {};
+
+function MyComponent(props) {
+  let x = props.foo;
+  {
+    let y = props.bar;
+    const fn = useCallback(() => {
+      // nothing
+    }, []);
+  }
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Thing() {
+  useEffect(() => {
+    const fetchData = async () => {};
+    fetchData();
+  }, [fetchData]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useEffect has an unnecessary dependency: 'fetchData'. Either exclude it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Thing() {
+  useEffect(() => {
+    const fetchData = async () => {};
+    fetchData();
+  }, []);
+}
+`}}},
+	},
+},
+
+{
+	Code: `
+function Example() {
+  const foo = useCallback(() => {
+    foo();
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "React Hook useCallback has an unnecessary dependency: 'foo'. Either exclude it or remove the dependency array.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function Example() {
+  const foo = useCallback(() => {
+    foo();
+  }, []);
+}
+`}}},
+	},
+},
+}
+
+func TestExhaustiveDeps_Upstream_Unnecessary(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamUnnecessaryValid,
+		upstreamUnnecessaryInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_useeffectevent_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_useeffectevent_test.go
@@ -1,0 +1,75 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_UseEffectEvent holds the upstream cases whose primary
+// diagnostic falls into the "useeffectevent" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamUseEffectEventValid = []rule_tester.ValidTestCase{
+
+}
+
+var upstreamUseEffectEventInvalid = []rule_tester.InvalidTestCase{
+{
+	Code: `
+function MyComponent({ theme }) {
+  const onStuff = useEffectEvent(() => {
+    showNotification(theme);
+  });
+  useEffect(() => {
+    onStuff();
+  }, [onStuff]);
+  React.useEffect(() => {
+    onStuff();
+  }, [onStuff]);
+}
+`,
+	Tsx:  true,
+	Errors: []rule_tester.InvalidTestCaseError{
+		{Message: "Functions returned from `useEffectEvent` must not be included in the dependency array. Remove `onStuff` from the list.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent({ theme }) {
+  const onStuff = useEffectEvent(() => {
+    showNotification(theme);
+  });
+  useEffect(() => {
+    onStuff();
+  }, []);
+  React.useEffect(() => {
+    onStuff();
+  }, [onStuff]);
+}
+`}}},
+		{Message: "Functions returned from `useEffectEvent` must not be included in the dependency array. Remove `onStuff` from the list.", Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function MyComponent({ theme }) {
+  const onStuff = useEffectEvent(() => {
+    showNotification(theme);
+  });
+  useEffect(() => {
+    onStuff();
+  }, [onStuff]);
+  React.useEffect(() => {
+    onStuff();
+  }, []);
+}
+`}}},
+	},
+},
+}
+
+func TestExhaustiveDeps_Upstream_UseEffectEvent(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamUseEffectEventValid,
+		upstreamUseEffectEventInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_valid_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/upstream_valid_test.go
@@ -1,0 +1,1705 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestExhaustiveDeps_Upstream_Valid holds the upstream cases whose primary
+// diagnostic falls into the "valid" category. Cases were routed by
+// matching the first expected error's message against a small regex
+// table in the test generator (see /tmp/gen_exhaustive_deps_go_tests.js).
+// Splitting upstream's monolithic test file by diagnostic kind makes
+// it easier to locate a regression: when one diagnostic path drifts,
+// the impact is contained to a single file.
+
+var upstreamValidValid = []rule_tester.ValidTestCase{
+{
+	Code: `
+function MyComponent() {
+  const local = {};
+  useEffect(() => {
+    console.log(local);
+  });
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  useEffect(() => {
+    const local = {};
+    console.log(local);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = someFunc();
+  useEffect(() => {
+    console.log(local);
+  }, [local]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  useEffect(() => {
+    console.log(props.foo);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = {};
+  {
+    const local2 = {};
+    useEffect(() => {
+      console.log(local1);
+      console.log(local2);
+    });
+  }
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = someFunc();
+  {
+    const local2 = someFunc();
+    useCallback(() => {
+      console.log(local1);
+      console.log(local2);
+    }, [local1, local2]);
+  }
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = someFunc();
+  function MyNestedComponent() {
+    const local2 = someFunc();
+    useCallback(() => {
+      console.log(local1);
+      console.log(local2);
+    }, [local2]);
+  }
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = someFunc();
+  useEffect(() => {
+    console.log(local);
+    console.log(local);
+  }, [local]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  useEffect(() => {
+    console.log(unresolved);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = someFunc();
+  useEffect(() => {
+    console.log(local);
+  }, [,,,local,,,]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({ foo }) {
+  useEffect(() => {
+    console.log(foo.length);
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({ foo }) {
+  useEffect(() => {
+    console.log(foo.length);
+    console.log(foo.slice(0));
+  }, [foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({ history }) {
+  useEffect(() => {
+    return history.listen();
+  }, [history]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {});
+  useLayoutEffect(() => {});
+  useImperativeHandle(props.innerRef, () => {});
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+  }, [props.bar, props.foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+  }, [props.foo, props.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const local = someFunc();
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+    console.log(local);
+  }, [props.foo, props.bar, local]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const local = {};
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.bar);
+  }, [props, props.foo]);
+
+  let color = someFunc();
+  useEffect(() => {
+    console.log(props.foo.bar.baz);
+    console.log(color);
+  }, [props.foo, props.foo.bar.baz, color]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo?.bar?.baz ?? null);
+  }, [props.foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo?.bar);
+  }, [props.foo?.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo?.bar);
+  }, [props.foo.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo.bar);
+  }, [props.foo?.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo.bar);
+    console.log(props.foo?.bar);
+  }, [props.foo?.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo.bar);
+    console.log(props.foo?.bar);
+  }, [props.foo.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo);
+    console.log(props.foo?.bar);
+  }, [props.foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo?.toString());
+  }, [props.foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useMemo(() => {
+    console.log(props.foo?.toString());
+  }, [props.foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.toString());
+  }, [props.foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo.bar?.toString());
+  }, [props.foo.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.bar?.toString());
+  }, [props.foo.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo.bar.toString());
+  }, [props?.foo?.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCallback(() => {
+    console.log(props.foo?.bar?.baz);
+  }, [props?.foo.bar?.baz]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const myEffect = () => {
+    // Doesn't use anything
+  };
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+const local = {};
+function MyComponent() {
+  const myEffect = () => {
+    console.log(local);
+  };
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+const local = {};
+function MyComponent() {
+  function myEffect() {
+    console.log(local);
+  }
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local = someFunc();
+  function myEffect() {
+    console.log(local);
+  }
+  useEffect(myEffect, [local]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  function myEffect() {
+    console.log(global);
+  }
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+const local = {};
+function MyComponent() {
+  const myEffect = () => {
+    otherThing()
+  }
+  const otherThing = () => {
+    console.log(local);
+  }
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({delay}) {
+  const local = {};
+  const myEffect = debounce(() => {
+    console.log(local);
+  }, delay);
+  useEffect(myEffect, [myEffect]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({myEffect}) {
+  useEffect(myEffect, [,myEffect]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({myEffect}) {
+  useEffect(myEffect, [,myEffect,,]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+let local = {};
+function myEffect() {
+  console.log(local);
+}
+function MyComponent() {
+  useEffect(myEffect, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({myEffect}) {
+  useEffect(myEffect, [myEffect]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({myEffect}) {
+  useEffect(myEffect);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  });
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"additionalHooks": "useCustomEffect"},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useSpecialEffect(() => {
+    console.log(props.foo);
+  }, null);
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"additionalHooks": "useSpecialEffect", "experimental_autoDependenciesHooks": []interface{}{"useSpecialEffect"}},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"additionalHooks": "useCustomEffect"},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"additionalHooks": "useAnotherEffect"},
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useWithoutEffectSuffix(() => {
+    console.log(props.foo);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  return renderHelperConfusedWithEffect(() => {
+    console.log(props.foo);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+const local = {};
+useEffect(() => {
+  console.log(local);
+}, []);
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+const local1 = {};
+{
+  const local2 = {};
+  useEffect(() => {
+    console.log(local1);
+    console.log(local2);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const ref = useRef();
+  useEffect(() => {
+    console.log(ref.current);
+  }, [ref]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const ref = useRef();
+  useEffect(() => {
+    console.log(ref.current);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({ maybeRef2, foo }) {
+  const definitelyRef1 = useRef();
+  const definitelyRef2 = useRef();
+  const maybeRef1 = useSomeOtherRefyThing();
+  const [state1, setState1] = useState();
+  const [state2, setState2] = React.useState();
+  const [state3, dispatch1] = useReducer();
+  const [state4, dispatch2] = React.useReducer();
+  const [state5, maybeSetState] = useFunnyState();
+  const [state6, maybeDispatch] = useFunnyReducer();
+  const [state9, dispatch5] = useActionState();
+  const [state10, dispatch6] = React.useActionState();
+  const [isPending1] = useTransition();
+  const [isPending2, startTransition2] = useTransition();
+  const [isPending3] = React.useTransition();
+  const [isPending4, startTransition4] = React.useTransition();
+  const mySetState = useCallback(() => {}, []);
+  let myDispatch = useCallback(() => {}, []);
+
+  useEffect(() => {
+    // Known to be static
+    console.log(definitelyRef1.current);
+    console.log(definitelyRef2.current);
+    console.log(maybeRef1.current);
+    console.log(maybeRef2.current);
+    setState1();
+    setState2();
+    dispatch1();
+    dispatch2();
+    dispatch5();
+    dispatch6();
+    startTransition1();
+    startTransition2();
+    startTransition3();
+    startTransition4();
+
+    // Dynamic
+    console.log(state1);
+    console.log(state2);
+    console.log(state3);
+    console.log(state4);
+    console.log(state5);
+    console.log(state6);
+    console.log(isPending2);
+    console.log(isPending4);
+    mySetState();
+    myDispatch();
+
+    // Not sure; assume dynamic
+    maybeSetState();
+    maybeDispatch();
+  }, [
+    // Dynamic
+    state1, state2, state3, state4, state5, state6, state9, state10,
+    maybeRef1, maybeRef2,
+    isPending2, isPending4,
+
+    // Not sure; assume dynamic
+    mySetState, myDispatch,
+    maybeSetState, maybeDispatch
+
+    // In this test, we don't specify static deps.
+    // That should be okay.
+  ]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({ maybeRef2 }) {
+  const definitelyRef1 = useRef();
+  const definitelyRef2 = useRef();
+  const maybeRef1 = useSomeOtherRefyThing();
+
+  const [state1, setState1] = useState();
+  const [state2, setState2] = React.useState();
+  const [state3, dispatch1] = useReducer();
+  const [state4, dispatch2] = React.useReducer();
+
+  const [state5, maybeSetState] = useFunnyState();
+  const [state6, maybeDispatch] = useFunnyReducer();
+
+  const mySetState = useCallback(() => {}, []);
+  let myDispatch = useCallback(() => {}, []);
+
+  useEffect(() => {
+    // Known to be static
+    console.log(definitelyRef1.current);
+    console.log(definitelyRef2.current);
+    console.log(maybeRef1.current);
+    console.log(maybeRef2.current);
+    setState1();
+    setState2();
+    dispatch1();
+    dispatch2();
+
+    // Dynamic
+    console.log(state1);
+    console.log(state2);
+    console.log(state3);
+    console.log(state4);
+    console.log(state5);
+    console.log(state6);
+    mySetState();
+    myDispatch();
+
+    // Not sure; assume dynamic
+    maybeSetState();
+    maybeDispatch();
+  }, [
+    // Dynamic
+    state1, state2, state3, state4, state5, state6,
+    maybeRef1, maybeRef2,
+
+    // Not sure; assume dynamic
+    mySetState, myDispatch,
+    maybeSetState, maybeDispatch,
+
+    // In this test, we specify static deps.
+    // That should be okay too!
+    definitelyRef1, definitelyRef2, setState1, setState2, dispatch1, dispatch2
+  ]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+const MyComponent = forwardRef((props, ref) => {
+  useImperativeHandle(ref, () => ({
+    focus() {
+      alert(props.hello);
+    }
+  }))
+});
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+const MyComponent = forwardRef((props, ref) => {
+  useImperativeHandle(ref, () => ({
+    focus() {
+      alert(props.hello);
+    }
+  }), [props.hello])
+});
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let obj = someFunc();
+  useEffect(() => {
+    obj.foo = true;
+  }, [obj]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let foo = {}
+  useEffect(() => {
+    foo.bar.baz = 43;
+  }, [foo.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const myRef = useRef();
+  useEffect(() => {
+    const handleMove = () => {};
+    myRef.current = {};
+    return () => {
+      console.log(myRef.current.toString())
+    };
+  }, []);
+  return <div />;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const myRef = useRef();
+  useEffect(() => {
+    const handleMove = () => {};
+    myRef.current = {};
+    return () => {
+      console.log(myRef?.current?.toString())
+    };
+  }, []);
+  return <div />;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useMyThing(myRef) {
+  useEffect(() => {
+    const handleMove = () => {};
+    myRef.current = {};
+    return () => {
+      console.log(myRef.current.toString())
+    };
+  }, [myRef]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const myRef = useRef();
+  useEffect(() => {
+    const handleMove = () => {};
+    const node = myRef.current;
+    node.addEventListener('mousemove', handleMove);
+    return () => node.removeEventListener('mousemove', handleMove);
+  }, []);
+  return <div ref={myRef} />;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useMyThing(myRef) {
+  useEffect(() => {
+    const handleMove = () => {};
+    const node = myRef.current;
+    node.addEventListener('mousemove', handleMove);
+    return () => node.removeEventListener('mousemove', handleMove);
+  }, [myRef]);
+  return <div ref={myRef} />;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useMyThing(myRef) {
+  useCallback(() => {
+    const handleMouse = () => {};
+    myRef.current.addEventListener('mousemove', handleMouse);
+    myRef.current.addEventListener('mousein', handleMouse);
+    return function() {
+      setTimeout(() => {
+        myRef.current.removeEventListener('mousemove', handleMouse);
+        myRef.current.removeEventListener('mousein', handleMouse);
+      });
+    }
+  }, [myRef]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useMyThing() {
+  const myRef = useRef();
+  useEffect(() => {
+    const handleMove = () => {
+      console.log(myRef.current)
+    };
+    window.addEventListener('mousemove', handleMove);
+    return () => window.removeEventListener('mousemove', handleMove);
+  }, []);
+  return <div ref={myRef} />;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useMyThing() {
+  const myRef = useRef();
+  useEffect(() => {
+    const handleMove = () => {
+      return () => window.removeEventListener('mousemove', handleMove);
+    };
+    window.addEventListener('mousemove', handleMove);
+    return () => {};
+  }, []);
+  return <div ref={myRef} />;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = 42;
+  const local2 = '42';
+  const local3 = null;
+  useEffect(() => {
+    console.log(local1);
+    console.log(local2);
+    console.log(local3);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const local1 = 42;
+  const local2 = '42';
+  const local3 = null;
+  useEffect(() => {
+    console.log(local1);
+    console.log(local2);
+    console.log(local3);
+  }, [local1, local2, local3]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const local = props.local;
+  useEffect(() => {}, [local]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Foo({ activeTab }) {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [activeTab]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  useEffect(() => {
+    console.log(props.foo.bar.baz);
+  }, [props]);
+  useEffect(() => {
+    console.log(props.foo.bar.baz);
+  }, [props.foo]);
+  useEffect(() => {
+    console.log(props.foo.bar.baz);
+  }, [props.foo.bar]);
+  useEffect(() => {
+    console.log(props.foo.bar.baz);
+  }, [props.foo.bar.baz]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  const fn = useCallback(() => {
+    console.log(props.foo.bar.baz);
+  }, [props]);
+  const fn2 = useCallback(() => {
+    console.log(props.foo.bar.baz);
+  }, [props.foo]);
+  const fn3 = useMemo(() => {
+    console.log(props.foo.bar.baz);
+  }, [props.foo.bar]);
+  const fn4 = useMemo(() => {
+    console.log(props.foo.bar.baz);
+  }, [props.foo.bar.baz]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  function handleNext1() {
+    console.log('hello');
+  }
+  const handleNext2 = () => {
+    console.log('hello');
+  };
+  let handleNext3 = function() {
+    console.log('hello');
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  function handleNext() {
+    console.log('hello');
+  }
+  useEffect(() => {
+    return Store.subscribe(handleNext);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent(props) {
+  let [, setState] = useState();
+  let [, dispatch] = React.useReducer();
+
+  function handleNext1(value) {
+    let value2 = value * 100;
+    setState(value2);
+    console.log('hello');
+  }
+  const handleNext2 = (value) => {
+    setState(foo(value));
+    console.log('hello');
+  };
+  let handleNext3 = function(value) {
+    console.log(value);
+    dispatch({ type: 'x', value });
+  };
+  useEffect(() => {
+    return Store.subscribe(handleNext1);
+  }, []);
+  useLayoutEffect(() => {
+    return Store.subscribe(handleNext2);
+  }, []);
+  useMemo(() => {
+    return Store.subscribe(handleNext3);
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useInterval(callback, delay) {
+  const savedCallback = useRef();
+  useEffect(() => {
+    savedCallback.current = callback;
+  });
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      let id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Counter() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(c => c + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Counter(unstableProp) {
+  let [count, setCount] = useState(0);
+  setCount = unstableProp
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(c => c + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [setCount]);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Counter() {
+  const [count, setCount] = useState(0);
+
+  function tick() {
+    setCount(c => c + 1);
+  }
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      tick();
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Counter() {
+  const [count, dispatch] = useReducer((state, action) => {
+    if (action === 'inc') {
+      return state + 1;
+    }
+  }, 0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      dispatch('inc');
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Counter() {
+  const [count, dispatch] = useReducer((state, action) => {
+    if (action === 'inc') {
+      return state + 1;
+    }
+  }, 0);
+
+  const tick = () => {
+    dispatch('inc');
+  };
+
+  useEffect(() => {
+    let id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Podcasts() {
+  useEffect(() => {
+    setPodcasts([]);
+  }, []);
+  let [podcasts, setPodcasts] = useState(null);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function withFetch(fetchPodcasts) {
+  return function Podcasts({ id }) {
+    let [podcasts, setPodcasts] = useState(null);
+    useEffect(() => {
+      fetchPodcasts(id).then(setPodcasts);
+    }, [id]);
+  }
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Podcasts({ id }) {
+  let [podcasts, setPodcasts] = useState(null);
+  useEffect(() => {
+    function doFetch({ fetchPodcasts }) {
+      fetchPodcasts(id).then(setPodcasts);
+    }
+    doFetch({ fetchPodcasts: API.fetchPodcasts });
+  }, [id]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Counter() {
+  let [count, setCount] = useState(0);
+
+  function increment(x) {
+    return x + 1;
+  }
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(increment);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Counter() {
+  let [count, setCount] = useState(0);
+
+  function increment(x) {
+    return x + 1;
+  }
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => increment(count));
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+import increment from './increment';
+function Counter() {
+  let [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let id = setInterval(() => {
+      setCount(count => count + increment);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function withStuff(increment) {
+  return function Counter() {
+    let [count, setCount] = useState(0);
+
+    useEffect(() => {
+      let id = setInterval(() => {
+        setCount(count => count + increment);
+      }, 1000);
+      return () => clearInterval(id);
+    }, []);
+
+    return <h1>{count}</h1>;
+  }
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function App() {
+  const [query, setQuery] = useState('react');
+  const [state, setState] = useState(null);
+  useEffect(() => {
+    let ignore = false;
+    fetchSomething();
+    async function fetchSomething() {
+      const result = await (await fetch('http://hn.algolia.com/api/v1/search?query=' + query)).json();
+      if (!ignore) setState(result);
+    }
+    return () => { ignore = true; };
+  }, [query]);
+  return (
+    <>
+      <input value={query} onChange={e => setQuery(e.target.value)} />
+      {JSON.stringify(state)}
+    </>
+  );
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Example() {
+  const foo = useCallback(() => {
+    foo();
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Example({ prop }) {
+  const foo = useCallback(() => {
+    if (prop) {
+      foo();
+    }
+  }, [prop]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Hello() {
+  const [state, setState] = useState(0);
+  useEffect(() => {
+    const handleResize = () => setState(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  });
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Example() {
+  useEffect(() => {
+    arguments
+  }, [])
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Example() {
+  useEffect(() => {
+    const bar = () => {
+      arguments;
+    };
+    bar();
+  }, [])
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Example(props) {
+  useEffect(() => {
+    let topHeight = 0;
+    topHeight = props.upperViewHeight;
+  }, [props.upperViewHeight]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Example(props) {
+  useEffect(() => {
+    let topHeight = 0;
+    topHeight = props?.upperViewHeight;
+  }, [props?.upperViewHeight]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function Example(props) {
+  useEffect(() => {
+    let topHeight = 0;
+    topHeight = props?.upperViewHeight;
+  }, [props]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useFoo(foo){
+  return useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useFoo(){
+  const foo = "hi!";
+  return useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useFoo(){
+  let {foo} = {foo: 1};
+  return useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useFoo(){
+  let [foo] = [1];
+  return useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function useFoo() {
+  const foo = "fine";
+  if (true) {
+    // Shadowed variable with constant construction in a nested scope is fine.
+    const foo = {};
+  }
+  return useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({foo}) {
+  return useMemo(() => foo, [foo])
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  const foo = true ? "fine" : "also fine";
+  return useMemo(() => foo, [foo]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent() {
+  useEffect(() => {
+    console.log('banana banana banana');
+  }, undefined);
+}
+`,
+	Tsx:  true,
+},
+
+// SKIP: unsupported settings shape
+{
+	Skip: true,
+	Code: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  });
+}
+`,
+	Tsx:  true,
+},
+
+// SKIP: unsupported settings shape
+{
+	Skip: true,
+	Code: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+}
+`,
+	Tsx:  true,
+},
+
+// SKIP: unsupported settings shape
+{
+	Skip: true,
+	Code: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, []);
+}
+`,
+	Tsx:  true,
+	Options: map[string]interface{}{"additionalHooks": "useAnotherEffect"},
+},
+
+// SKIP: unsupported settings shape
+{
+	Skip: true,
+	Code: `
+function MyComponent(props) {
+  useCustomEffect(() => {
+    console.log(props.foo);
+  }, [props.foo]);
+  useAnotherEffect(() => {
+    console.log(props.bar);
+  }, [props.bar]);
+}
+`,
+	Tsx:  true,
+},
+
+{
+	Code: `
+function MyComponent({ theme }) {
+  const onStuff = useEffectEvent(() => {
+    showNotification(theme);
+  });
+  useEffect(() => {
+    onStuff();
+  }, []);
+  React.useEffect(() => {
+    onStuff();
+  }, []);
+}
+`,
+	Tsx:  true,
+},
+}
+
+var upstreamValidInvalid = []rule_tester.InvalidTestCase{
+
+}
+
+func TestExhaustiveDeps_Upstream_Valid(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		upstreamValidValid,
+		upstreamValidInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.go
@@ -9,19 +9,10 @@ import (
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
-
-// hookNameTailRegex matches the suffix part of a hook identifier:
-// after the leading `use`, the next character must be uppercase Latin or a digit.
-// Mirrors upstream's `/^use[A-Z0-9]/`.
-var hookNameTailRegex = regexp.MustCompile(`^use[A-Z0-9]`)
-
-// pascalCaseRegex matches identifiers whose first character is an uppercase Latin letter.
-// Mirrors upstream's `/^[A-Z].*/` predicate (used both for component-name and
-// PascalCase namespace detection).
-var pascalCaseRegex = regexp.MustCompile(`^[A-Z]`)
 
 // flowSuppressionRegex matches `$FlowFixMe[react-rule-hook]` comments. Used to
 // gate `hasFlowSuppression`, which mirrors upstream's same-named helper —
@@ -29,108 +20,31 @@ var pascalCaseRegex = regexp.MustCompile(`^[A-Z]`)
 // suppression marker.
 var flowSuppressionRegex = regexp.MustCompile(`\$FlowFixMe\[react-rule-hook\]`)
 
-// isHookName reports whether `s` follows the React hook naming convention:
-// either the bare name `use` (the React `use(...)` hook) or `useFoo` / `use1`
-// (`use` followed by uppercase letter or digit).
-func isHookName(s string) bool {
-	return s == "use" || hookNameTailRegex.MatchString(s)
-}
+// Aliases over `react_hooksutil` so the call sites in this file stay terse
+// while every predicate's authoritative definition lives in the shared
+// package. See `react_hooksutil` package docs for semantics.
+var (
+	isHookCallee    = react_hooksutil.IsHookCallee
+	isUseIdentifier = react_hooksutil.IsUseIdentifier
+)
 
-// isComponentNameStr reports whether `s` looks like a React component name —
-// PascalCase. Upstream's `isComponentName` is identical.
-func isComponentNameStr(s string) bool {
-	if s == "" {
-		return false
-	}
-	return pascalCaseRegex.MatchString(s)
-}
-
-// isHookCallee mirrors upstream's `isHook(node)`: the callee is either an
-// Identifier whose name is a hook, or a non-computed member expression
-// `Namespace.useFoo` whose object is a PascalCase identifier and whose
-// property is itself a hook name.
-func isHookCallee(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	n := ast.SkipParentheses(node)
-	switch n.Kind {
-	case ast.KindIdentifier:
-		return isHookName(n.AsIdentifier().Text)
-	case ast.KindPropertyAccessExpression:
-		pae := n.AsPropertyAccessExpression()
-		prop := pae.Name()
-		if prop == nil || prop.Kind != ast.KindIdentifier {
-			return false
-		}
-		if !isHookName(prop.AsIdentifier().Text) {
-			return false
-		}
-		obj := ast.SkipParentheses(pae.Expression)
-		if obj == nil || obj.Kind != ast.KindIdentifier {
-			return false
-		}
-		return isComponentNameStr(obj.AsIdentifier().Text)
-	}
-	return false
-}
-
-// isReactFunction matches `<name>` (bare identifier) or `React.<name>`
-// (PropertyAccessExpression with object `React` and property `<name>`).
-// Mirrors upstream's `isReactFunction(node, functionName)`.
-func isReactFunction(node *ast.Node, name string) bool {
-	if node == nil {
-		return false
-	}
-	n := ast.SkipParentheses(node)
-	switch n.Kind {
-	case ast.KindIdentifier:
-		return n.AsIdentifier().Text == name
-	case ast.KindPropertyAccessExpression:
-		pae := n.AsPropertyAccessExpression()
-		obj := ast.SkipParentheses(pae.Expression)
-		prop := pae.Name()
-		if obj == nil || obj.Kind != ast.KindIdentifier {
-			return false
-		}
-		if prop == nil || prop.Kind != ast.KindIdentifier {
-			return false
-		}
-		return obj.AsIdentifier().Text == "React" && prop.AsIdentifier().Text == name
-	}
-	return false
-}
-
-// isUseIdentifier mirrors upstream's `isUseIdentifier(node)`: matches the
-// React `use(...)` hook callee — bare `use` or `React.use`.
-func isUseIdentifier(node *ast.Node) bool {
-	return isReactFunction(node, "use")
-}
-
-// stripReactNamespace returns `prop` for `React.prop` member expressions, or
-// the original node otherwise. Used when classifying a callee as an effect
-// hook regardless of whether the user qualified it with `React.`.
-func stripReactNamespace(node *ast.Node) *ast.Node {
-	if node == nil {
-		return node
-	}
-	n := ast.SkipParentheses(node)
-	if n.Kind == ast.KindPropertyAccessExpression {
-		pae := n.AsPropertyAccessExpression()
-		obj := ast.SkipParentheses(pae.Expression)
-		prop := pae.Name()
-		if obj != nil && obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == "React" &&
-			prop != nil && prop.Kind == ast.KindIdentifier {
-			return prop
-		}
-	}
-	return n
-}
+// All AST predicates above (stripReactNamespace, isFunctionLikeContainer,
+// findEnclosingFunction, getFunctionBody, hasAsyncModifier, ...) live in
+// `react_hooksutil`. The aliases below keep the call sites unchanged
+// while removing the second copy.
+var (
+	stripReactNamespace     = react_hooksutil.StripReactNamespace
+	isFunctionLikeContainer = react_hooksutil.IsFunctionLikeContainer
+	findEnclosingFunction   = react_hooksutil.FindEnclosingFunction
+	getFunctionBody         = react_hooksutil.GetFunctionBody
+	hasAsyncModifier        = react_hooksutil.HasAsyncModifier
+)
 
 // isEffectCalleeName reports whether `node` (post-namespace-strip) names one
 // of the built-in effect hooks (`useEffect` / `useLayoutEffect` /
 // `useInsertionEffect`) or matches the user-configured `additionalEffectHooks`
-// regex from settings.
+// regex from settings. Specific to rules-of-hooks (the additional-effect-hooks
+// gate is exclusive to this rule), so it's not promoted to the shared util.
 func isEffectCalleeName(node *ast.Node, additional *regexp.Regexp) bool {
 	n := stripReactNamespace(node)
 	if n == nil || n.Kind != ast.KindIdentifier {
@@ -147,79 +61,9 @@ func isEffectCalleeName(node *ast.Node, additional *regexp.Regexp) bool {
 	return false
 }
 
-// isUseEffectEventCallee reports whether `node` is `useEffectEvent` or
-// `React.useEffectEvent`.
+// isUseEffectEventCallee delegates to the shared helper.
 func isUseEffectEventCallee(node *ast.Node) bool {
-	n := stripReactNamespace(node)
-	return n != nil && n.Kind == ast.KindIdentifier && n.AsIdentifier().Text == "useEffectEvent"
-}
-
-// isFunctionLikeContainer reports whether `node` is one of the function-like
-// kinds the upstream rule treats as a "code path" boundary — anywhere a hook
-// call's enclosing function is computed.
-func isFunctionLikeContainer(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
-		ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
-		return true
-	}
-	return false
-}
-
-// findEnclosingFunction walks up from `node` and returns the nearest
-// function-like ancestor, or nil when `node` is at top level (no enclosing
-// function).
-func findEnclosingFunction(node *ast.Node) *ast.Node {
-	if node == nil {
-		return nil
-	}
-	p := node.Parent
-	for p != nil {
-		if isFunctionLikeContainer(p) {
-			return p
-		}
-		p = p.Parent
-	}
-	return nil
-}
-
-// getFunctionBody returns the body of a function-like node — Block for normal
-// functions, the BlockOrExpression body for arrow functions, or nil for
-// abstract/declared signatures with no body.
-func getFunctionBody(fn *ast.Node) *ast.Node {
-	if fn == nil {
-		return nil
-	}
-	switch fn.Kind {
-	case ast.KindFunctionDeclaration:
-		return fn.AsFunctionDeclaration().Body
-	case ast.KindFunctionExpression:
-		return fn.AsFunctionExpression().Body
-	case ast.KindArrowFunction:
-		return fn.AsArrowFunction().Body
-	case ast.KindMethodDeclaration:
-		return fn.AsMethodDeclaration().Body
-	case ast.KindGetAccessor:
-		return fn.AsGetAccessorDeclaration().Body
-	case ast.KindSetAccessor:
-		return fn.AsSetAccessorDeclaration().Body
-	case ast.KindConstructor:
-		return fn.AsConstructorDeclaration().Body
-	}
-	return nil
-}
-
-// hasAsyncModifier reports whether the function-like node carries the `async`
-// modifier. Upstream reads `codePathNode.async` directly; we use tsgo's
-// modifier-flag helper for the same effect.
-func hasAsyncModifier(fn *ast.Node) bool {
-	if fn == nil {
-		return false
-	}
-	return ast.HasSyntacticModifier(fn, ast.ModifierFlagsAsync)
+	return react_hooksutil.IsUseEffectEventCallee(node)
 }
 
 // isInsideTryCatchOfFunction reports whether `node` is inside a TryStatement
@@ -286,163 +130,15 @@ func isInsideLoopOfFunction(node *ast.Node, fn *ast.Node) bool {
 	return false
 }
 
-// getFunctionName mirrors upstream's `getFunctionName(node)`. Returns:
-//   - For named FunctionDeclaration / FunctionExpression: the `id` Identifier.
-//   - For MethodDeclaration / GetAccessor / SetAccessor inside an
-//     ObjectLiteralExpression: the method's own name (mirrors ESTree's
-//     `Property { method: true, value: FunctionExpression }` shape).
-//   - For ArrowFunction / anonymous FunctionExpression: the assignment
-//     target — VariableDeclaration name, BinaryExpression LHS, PropertyAssignment
-//     name, BindingElement name, or ShorthandPropertyAssignment name.
-//   - nil otherwise.
-//
-// MethodDeclaration / GetAccessor / SetAccessor inside a class body
-// intentionally returns nil so the class branch can take over and emit
-// classError. Upstream has the same effect because ESTree exposes the inner
-// FunctionExpression with no id, and getFunctionName falls through.
-func getFunctionName(fn *ast.Node) *ast.Node {
-	if fn == nil {
-		return nil
-	}
-	switch fn.Kind {
-	case ast.KindFunctionDeclaration:
-		return fn.Name()
-	case ast.KindFunctionExpression:
-		if name := fn.Name(); name != nil {
-			return name
-		}
-		// fall through to anonymous handling
-	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
-		if fn.Parent != nil && fn.Parent.Kind == ast.KindObjectLiteralExpression {
-			return fn.Name()
-		}
-		return nil
-	case ast.KindArrowFunction:
-		// fall through
-	default:
-		return nil
-	}
-	p := fn.Parent
-	if p == nil {
-		return nil
-	}
-	switch p.Kind {
-	case ast.KindVariableDeclaration:
-		vd := p.AsVariableDeclaration()
-		if vd.Initializer == fn {
-			return p.Name()
-		}
-	case ast.KindBinaryExpression:
-		be := p.AsBinaryExpression()
-		if be.OperatorToken != nil && be.OperatorToken.Kind == ast.KindEqualsToken && be.Right == fn {
-			return be.Left
-		}
-	case ast.KindPropertyAssignment:
-		pa := p.AsPropertyAssignment()
-		if pa.Initializer == fn {
-			return p.Name()
-		}
-	case ast.KindBindingElement:
-		be := p.AsBindingElement()
-		if be.Initializer == fn {
-			return p.Name()
-		}
-	case ast.KindShorthandPropertyAssignment:
-		spa := p.AsShorthandPropertyAssignment()
-		if spa.ObjectAssignmentInitializer == fn {
-			return p.Name()
-		}
-	case ast.KindParenthesizedExpression:
-		// `const x = (() => {})` — the paren-wrapped expression is the
-		// declarator's initializer. Recurse on the wrapper so the parent-shape
-		// switch above retries against the grandparent.
-		return getFunctionName(p)
-	}
-	return nil
-}
-
-// isForwardRefOrMemoCallback reports whether `fn` is the immediate argument
-// of a CallExpression whose callee is `forwardRef` / `memo` / `React.forwardRef`
-// / `React.memo`. Upstream's `isForwardRefCallback` and `isMemoCallback`
-// are unified here for brevity.
-func isForwardRefOrMemoCallback(fn *ast.Node, name string) bool {
-	if fn == nil || fn.Parent == nil {
-		return false
-	}
-	p := fn.Parent
-	if p.Kind != ast.KindCallExpression {
-		return false
-	}
-	callee := ast.SkipParentheses(p.AsCallExpression().Expression)
-	return isReactFunction(callee, name)
-}
-
-// classifyContainerName reports whether the function-like's resolved name
-// represents a component or a hook.
-func classifyContainerName(name *ast.Node) bool {
-	if name == nil {
-		return false
-	}
-	switch name.Kind {
-	case ast.KindIdentifier:
-		text := name.AsIdentifier().Text
-		return isComponentNameStr(text) || isHookName(text)
-	case ast.KindPropertyAccessExpression:
-		// `Namespace.useHook` style — defer to isHookCallee, which already
-		// enforces PascalCase namespace + hook-named property.
-		return isHookCallee(name)
-	}
-	return false
-}
-
-// isComponentOrHookFn reports whether the function-like itself is a React
-// component or hook (named appropriately, or an anonymous arg to forwardRef/memo).
-// Mirrors upstream's `isDirectlyInsideComponentOrHook` predicate at the function level.
-func isComponentOrHookFn(fn *ast.Node) bool {
-	name := getFunctionName(fn)
-	if name != nil {
-		return classifyContainerName(name)
-	}
-	return isForwardRefOrMemoCallback(fn, "forwardRef") || isForwardRefOrMemoCallback(fn, "memo")
-}
-
-// isInsideComponentOrHook walks up from `node` and returns true once any
-// ancestor function-like classifies as a component or hook. Mirrors
-// upstream's `isInsideComponentOrHook(node)`.
-func isInsideComponentOrHook(node *ast.Node) bool {
-	cur := node
-	for cur != nil {
-		if isFunctionLikeContainer(cur) && isComponentOrHookFn(cur) {
-			return true
-		}
-		cur = cur.Parent
-	}
-	return false
-}
-
-// isClassMember reports whether `fn` is a member of a class — either a
-// MethodDeclaration / GetAccessor / SetAccessor / Constructor whose direct
-// parent is a class, or an ArrowFunction / FunctionExpression that initializes
-// a class PropertyDeclaration (class-field arrow). Mirrors upstream's
-// MethodDefinition / ClassProperty / PropertyDefinition branch.
-func isClassMember(fn *ast.Node) bool {
-	if fn == nil || fn.Parent == nil {
-		return false
-	}
-	p := fn.Parent
-	switch fn.Kind {
-	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
-		return p.Kind == ast.KindClassDeclaration || p.Kind == ast.KindClassExpression
-	case ast.KindArrowFunction, ast.KindFunctionExpression:
-		if p.Kind == ast.KindPropertyDeclaration {
-			gp := p.Parent
-			if gp != nil && (gp.Kind == ast.KindClassDeclaration || gp.Kind == ast.KindClassExpression) {
-				return true
-			}
-		}
-	}
-	return false
-}
+// All function-name / forwardRef / classifier predicates live in the
+// shared `react_hooksutil` package. The aliases below preserve the
+// existing call sites unchanged.
+var (
+	getFunctionName         = react_hooksutil.GetFunctionName
+	isComponentOrHookFn     = react_hooksutil.IsComponentOrHookFn
+	isInsideComponentOrHook    = react_hooksutil.IsInsideComponentOrHook
+	isClassMember              = react_hooksutil.IsClassMember
+)
 
 // isConditionalAncestor reports whether the position of `child` within `parent`
 // places it on a conditional execution path (only entered on certain
@@ -847,31 +543,9 @@ func isInsideEffectArgument(idNode *ast.Node, additional *regexp.Regexp) bool {
 	return false
 }
 
-// getAdditionalEffectHooks reads `settings['react-hooks'].additionalEffectHooks`
-// and compiles it as a regex. Returns nil when the setting is absent or
-// invalid — matching upstream's lenient behavior of silently ignoring
-// malformed regex strings.
+// getAdditionalEffectHooks delegates to the shared settings reader.
 func getAdditionalEffectHooks(settings map[string]interface{}) *regexp.Regexp {
-	if settings == nil {
-		return nil
-	}
-	raw, ok := settings["react-hooks"]
-	if !ok {
-		return nil
-	}
-	m, ok := raw.(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	pattern, ok := m["additionalEffectHooks"].(string)
-	if !ok || pattern == "" {
-		return nil
-	}
-	re, err := regexp.Compile(pattern)
-	if err != nil {
-		return nil
-	}
-	return re
+	return react_hooksutil.AdditionalHooksFromSettings(settings, "additionalEffectHooks")
 }
 
 // eeRegistry tracks `const X = useEffectEvent(...)` declarations per enclosing

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -179,6 +179,18 @@ type RuleContext struct {
 	ReportNode                 func(node *ast.Node, msg RuleMessage)
 	ReportNodeWithFixes        func(node *ast.Node, msg RuleMessage, fixes ...RuleFix)
 	ReportNodeWithSuggestions  func(node *ast.Node, msg RuleMessage, suggestions ...RuleSuggestion)
+	// ReportNodeWithFixesAndSuggestions emits a single diagnostic carrying
+	// BOTH an autofix and one or more suggestions. Used by rules that follow
+	// upstream's "promote first suggestion to fix while keeping the
+	// suggestion" pattern (e.g., ESLint's
+	// `enableDangerousAutofixThisMayCauseInfiniteLoops` in
+	// react-hooks/exhaustive-deps).
+	ReportNodeWithFixesAndSuggestions func(node *ast.Node, msg RuleMessage, fixes []RuleFix, suggestions []RuleSuggestion)
+	// ReportRangeWithFixesAndSuggestions is the range-keyed twin of
+	// ReportNodeWithFixesAndSuggestions. Same semantics, anchors the
+	// diagnostic at an explicit TextRange instead of a node's trimmed
+	// range.
+	ReportRangeWithFixesAndSuggestions func(textRange core.TextRange, msg RuleMessage, fixes []RuleFix, suggestions []RuleSuggestion)
 }
 
 func ReportNodeWithFixesOrSuggestions(ctx RuleContext, node *ast.Node, fix bool, msg RuleMessage, suggestionMsg RuleMessage, fixes ...RuleFix) {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -130,6 +130,7 @@ export default defineConfig({
 
     // eslint-plugin-react-hooks
     './tests/eslint-plugin-react-hooks/rules/rules-of-hooks.test.ts',
+    './tests/eslint-plugin-react-hooks/rules/exhaustive-deps.test.ts',
 
     // typescript-eslint
     './tests/typescript-eslint/rules/adjacent-overload-signatures.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rslint.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rslint.json
@@ -8,7 +8,9 @@
         "project": ["./tsconfig.files.json", "./tsconfig.virtual.json"]
       }
     },
-    "rules": {},
+    "rules": {
+      "react-hooks/exhaustive-deps": "warn"
+    },
     "plugins": ["react-hooks"]
   }
 ]

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/exhaustive-deps.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/exhaustive-deps.test.ts
@@ -1,0 +1,245 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('exhaustive-deps', {} as never, {
+  valid: [
+    // No captured values, empty deps
+    {
+      code: `
+        function MyComponent(props) {
+          useEffect(() => {});
+        }
+      `,
+    },
+    {
+      code: `
+        function MyComponent(props) {
+          useEffect(() => { console.log('hi'); }, []);
+        }
+      `,
+    },
+    // Stable hook values: setState / dispatch / useRef.current
+    {
+      code: `
+        function MyComponent() {
+          const [, setX] = useState(0);
+          useEffect(() => { setX(1); }, []);
+        }
+      `,
+    },
+    {
+      code: `
+        function MyComponent() {
+          const ref = useRef(null);
+          useEffect(() => { ref.current = 1; }, []);
+        }
+      `,
+    },
+    {
+      code: `
+        function MyComponent() {
+          const [, dispatch] = useReducer(reducer, 0);
+          useEffect(() => { dispatch({ type: 'a' }); }, []);
+        }
+      `,
+    },
+    // Effect referring to its declared dep
+    {
+      code: `
+        function MyComponent({ id }) {
+          useEffect(() => { console.log(id); }, [id]);
+        }
+      `,
+    },
+    // useEffectEvent — return value is stable, no dep needed
+    {
+      code: `
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => { console.log(theme); });
+          useEffect(() => { onClick(); }, []);
+        }
+      `,
+    },
+    // Property chain: declaring 'props.foo' covers 'props.foo.bar'
+    {
+      code: `
+        function MyComponent(props) {
+          useEffect(() => { console.log(props.foo.bar); }, [props.foo]);
+        }
+      `,
+    },
+    // Optional chain
+    {
+      code: `
+        function MyComponent({ user }) {
+          useEffect(() => { console.log(user?.name); }, [user?.name]);
+        }
+      `,
+    },
+    // External (module-scope) value — not a dep
+    {
+      code: `
+        const CONSTANT = 1;
+        function MyComponent() {
+          useEffect(() => { console.log(CONSTANT); }, []);
+        }
+      `,
+    },
+    // additionalHooks rule option
+    {
+      code: `
+        function MyComponent({ id }) {
+          useMyEffect(() => { console.log(id); }, [id]);
+        }
+      `,
+      options: [{ additionalHooks: '(useMyEffect)' }],
+    },
+  ],
+  invalid: [
+    // Missing dep
+    {
+      code: `
+        function MyComponent({ id }) {
+          useEffect(() => { console.log(id); }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
+        },
+      ],
+    },
+    // Missing dep with property chain
+    {
+      code: `
+        function MyComponent(props) {
+          useEffect(() => { console.log(props.id); }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'props.id'. Either include it or remove the dependency array.",
+        },
+      ],
+    },
+    // Unnecessary dep
+    {
+      code: `
+        function MyComponent({ a, b }) {
+          useCallback(() => a, [a, b]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useCallback has an unnecessary dependency: 'b'. Either exclude it or remove the dependency array.",
+        },
+      ],
+    },
+    // Duplicate dep
+    {
+      code: `
+        function MyComponent({ a }) {
+          useCallback(() => a, [a, a]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useCallback has a duplicate dependency: 'a'. Either omit it or remove the dependency array.",
+        },
+      ],
+    },
+    // useMemo without deps array
+    {
+      code: `
+        function MyComponent({ a }) {
+          useMemo(() => a);
+        }
+      `,
+      errors: [
+        {
+          message:
+            'React Hook useMemo does nothing when called with only one argument. Did you forget to pass an array of dependencies?',
+        },
+      ],
+    },
+    // Spread element
+    {
+      code: `
+        function MyComponent({ list }) {
+          useEffect(() => {}, [...list]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a spread element in its dependency array. This means we can't statically verify whether you've passed the correct dependencies.",
+        },
+      ],
+    },
+    // Non-array deps
+    {
+      code: `
+        function MyComponent({ a }) {
+          useEffect(() => {}, a);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies.",
+        },
+      ],
+    },
+    // Literal dep
+    {
+      code: `
+        function MyComponent() {
+          useEffect(() => {}, ['foo']);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "The 'foo' literal is not a valid dependency because it never changes. You can safely remove it.",
+        },
+      ],
+    },
+    // ref.current in cleanup
+    {
+      code: `
+        function MyComponent() {
+          const ref = useRef(null);
+          useEffect(() => {
+            return () => { console.log(ref.current); };
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "The ref value 'ref.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'ref.current' to a variable inside the effect, and use that variable in the cleanup function.",
+        },
+      ],
+    },
+    // useEffectEvent return value used in deps
+    {
+      code: `
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => { console.log(theme); });
+          useEffect(() => { onClick(); }, [onClick]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            'Functions returned from `useEffectEvent` must not be included in the dependency array. Remove `onClick` from the list.',
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -282,3 +282,15 @@ HTTPSURL
 BARBAZ
 dedupe
 basenames
+hooksutil
+dobedo
+bizz
+mousemove
+mousein
+Refy
+addl
+ctype
+fname
+preresolved
+vname
+useeffectevent


### PR DESCRIPTION
## Summary

Port the `react-hooks/exhaustive-deps` rule from `eslint-plugin-react-hooks` to rslint.

The rule verifies dependency lists for `useEffect` / `useLayoutEffect` / `useInsertionEffect` / `useCallback` / `useMemo` / `useImperativeHandle` (and any user-configured `additionalHooks` matching). It reports missing, unnecessary, and duplicate dependencies, ref-current cleanup mistakes, async-effect bodies, stale assignments, setState-without-deps infinite-loop hazards, construction-on-every-render warnings, and `useEffectEvent`-in-deps mistakes; offers suggestions and an opt-in autofix.

Implementation highlights:

- Scope analysis is performed via the TypeScript TypeChecker, with a structural AST + name-walk fallback when the checker is unavailable (gap files / parse errors). Stable-known-hook values (`useState` / `useReducer` / `useRef` / `useTransition` / `useActionState` / `useEffectEvent` / `useState`-style setters with `writeCount > 1` reassignment detection), `isFunctionWithoutCapturedValues` (transitive function stability), `getDependency` (method-call receiver, optional chain, `as`/`satisfies` peeling), `setStateRecommendation` (updater / reducer / inlineReducer forms), `missingCallbackDep`, and `isPropsOnlyUsedInMembers` are all implemented.
- All 4 upstream options are supported: `additionalHooks` (with settings fallback), `enableDangerousAutofixThisMayCauseInfiniteLoops` (promotes first suggestion fix to autofix while keeping the suggestion array), `requireExplicitEffectDeps`, and `experimental_autoDependenciesHooks`.
- Shared helpers between `rules-of-hooks` and `exhaustive-deps` were extracted to a new `internal/plugins/react_hooks/react_hooksutil/` package.
- A new `RuleContext.ReportNodeWithFixesAndSuggestions` (and range twin) infra API was added to support upstream's "promote first suggestion to fix while keeping the suggestion" pattern.

Test coverage:

- All 311 upstream cases ported across `upstream_js_{1..6}_test.go`, `upstream_ts_test.go`, `upstream_tsv4_test.go`, and `upstream_flow_test.go` (Flow group is `Skip:true` because rslint's TypeScript parser doesn't accept Flow syntax).
- 7 dedicated suites for tsgo AST quirks, real-world component shapes, async / nested / multi-component boundaries, position assertions, TypeChecker-nil fallback, destructure-rename forms, and edge categories — total ~120 additional cases.
- Validated against rsbuild (1197 files, 0 errors) and rspack (390 files, 1 expected error in `Mermaid.tsx`); a false positive on destructure-rename surfaced during rsbuild validation was diagnosed and fixed (TC sometimes resolves a destructure-renamed binding to the source type's property symbol instead of the local BindingElement; the rule now consults the AST when no declaration of the resolved symbol lies inside the component).

## Related Links

- ESLint plugin: <https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md>
- Rule source: <https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts>

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).