### PR TITLE
feat: port rule unicorn/no-static-only-class

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -2,11 +2,13 @@ package unicorn_plugin
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		filename_case.FilenameCaseRule,
+		no_static_only_class.NoStaticOnlyClassRule,
 	}
 }

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.go
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.go
@@ -246,13 +246,22 @@ func memberContentEnd(member *ast.Node) int {
 	return member.End()
 }
 
-// findFollowingSemicolonElement returns the SemicolonClassElement that
-// immediately follows `members[idx]`, if any.
-func findFollowingSemicolonElement(members []*ast.Node, idx int) *ast.Node {
-	if idx+1 < len(members) && members[idx+1] != nil && ast.IsSemicolonClassElement(members[idx+1]) {
-		return members[idx+1]
+// followingSemicolonElements returns the run of SemicolonClassElement nodes
+// that immediately follows `members[idx]` (ESTree omits these as they are
+// just stray `;` between members). Used to redirect the trailing comma to
+// the first `;` and clear the rest, so that
+// `class A { static a() {};; static b() {}; }` no longer leaves a stray
+// `;` in the rewritten object literal.
+func followingSemicolonElements(members []*ast.Node, idx int) []*ast.Node {
+	var out []*ast.Node
+	for j := idx + 1; j < len(members); j++ {
+		m := members[j]
+		if m == nil || !ast.IsSemicolonClassElement(m) {
+			break
+		}
+		out = append(out, m)
 	}
-	return nil
+	return out
 }
 
 // isExportDefault reports whether the class node is `export default class
@@ -262,15 +271,13 @@ func isExportDefault(node *ast.Node) bool {
 	return flags&ast.ModifierFlagsExport != 0 && flags&ast.ModifierFlagsDefault != 0
 }
 
-// linePosition returns the 1-based line number of `pos` in `text`.
-func linePosition(text string, pos int) int {
-	line := 1
-	for i := 0; i < pos && i < len(text); i++ {
-		if text[i] == '\n' {
-			line++
-		}
-	}
-	return line
+// sameLine reports whether `a` and `b` lie on the same source line. We use
+// the source file's pre-computed ECMA line map (binary search via
+// `scanner.ComputeLineOfPosition`) instead of scanning the source text.
+func sameLine(sf *ast.SourceFile, a, b int) bool {
+	lineStarts := sf.ECMALineMap()
+	return scanner.ComputeLineOfPosition(lineStarts, a) ==
+		scanner.ComputeLineOfPosition(lineStarts, b)
 }
 
 // trimmedTextBetween reports whether the source between `[start, end)` has
@@ -366,14 +373,9 @@ func buildFix(node *ast.Node, sf *ast.SourceFile) []rule.RuleFix {
 	// parent line && trimmed text between class end and brace > 0` arm.
 	if isClassExpr {
 		parent := node.Parent
-		bracePosLine := linePosition(text, bracePos)
-		var parentLine int
-		if parent != nil {
-			parentLine = linePosition(text, parent.Pos())
-		}
 		isReturnSpecial := parent != nil &&
 			parent.Kind == ast.KindReturnStatement &&
-			bracePosLine != parentLine &&
+			!sameLine(sf, parent.Pos(), bracePos) &&
 			trimmedTextBetween(text, classEnd, bracePos) != ""
 
 		if isReturnSpecial {
@@ -435,13 +437,22 @@ func buildFix(node *ast.Node, sf *ast.SourceFile) []rule.RuleFix {
 			}
 			continue
 		}
-		// Method / accessor / constructor: a separate SemicolonClassElement
-		// after the method, if any, holds the `;`. Replace just the `;`
-		// token (skip leading trivia so any comments between `}` and `;`
-		// are preserved, matching ESLint's `replaceText(token, ',')`).
-		if semi := findFollowingSemicolonElement(members, i); semi != nil {
-			semiStart := scanner.SkipTrivia(text, semi.Pos())
-			addFix(semiStart, semi.End(), ",")
+		// Method / accessor / constructor: SemicolonClassElement entries
+		// after the method (a stray `;` between members) carry the `;`.
+		// Replace the *first* `;` with `,` (matching upstream's
+		// `replaceText(token, ',')` — leading trivia / comments preserved)
+		// and erase the `;` character of any further consecutive `;`,
+		// preserving their trivia. This handles `static a() {};;` cleanly.
+		semis := followingSemicolonElements(members, i)
+		if len(semis) > 0 {
+			for k, semi := range semis {
+				semiStart := scanner.SkipTrivia(text, semi.Pos())
+				if k == 0 {
+					addFix(semiStart, semi.End(), ",")
+				} else {
+					addFix(semiStart, semi.End(), "")
+				}
+			}
 			continue
 		}
 		// No `;` follows — append `,` after the method body.

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.go
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.go
@@ -1,0 +1,535 @@
+package no_static_only_class
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// modifierFlagsDisqualifying captures the TS-only modifiers that exclude a
+// member from "valid static" status: the three accessibility keywords
+// (`public` / `private` / `protected`), `readonly`, `declare` (ambient), and
+// any class-element decorator. tsgo carries decorators on the same modifier
+// list as keywords, so a single flag check covers both.
+const modifierFlagsDisqualifying = ast.ModifierFlagsAccessibilityModifier |
+	ast.ModifierFlagsReadonly |
+	ast.ModifierFlagsAmbient |
+	ast.ModifierFlagsDecorator
+
+// isClassElementMethodLike reports whether a class element is one of the
+// kinds the upstream rule treats as `MethodDefinition`: regular method,
+// getter, setter, or constructor.
+//
+// KindConstructor is included because tsgo parses `static constructor()` as
+// a real ConstructorDeclaration even though, with `static`, it is
+// semantically just a method named "constructor". Upstream's ESTree treats
+// `static constructor()` as a `MethodDefinition` and the `IsStatic` check
+// below filters out actual (non-static) constructors.
+func isClassElementMethodLike(node *ast.Node) bool {
+	return ast.IsMethodDeclaration(node) ||
+		ast.IsGetAccessorDeclaration(node) ||
+		ast.IsSetAccessorDeclaration(node) ||
+		ast.IsConstructorDeclaration(node)
+}
+
+// isStaticMember mirrors upstream's `isStaticMember` predicate: a class
+// element counts as a "valid" static member only when it is a public,
+// non-decorated, non-readonly, non-declare static field, method, accessor,
+// or static-named-constructor with a non-private key.
+func isStaticMember(member *ast.Node) bool {
+	if member == nil {
+		return false
+	}
+	if !ast.IsPropertyDeclaration(member) && !isClassElementMethodLike(member) {
+		return false
+	}
+	if !ast.HasStaticModifier(member) {
+		return false
+	}
+	if ast.IsPrivateIdentifierClassElementDeclaration(member) {
+		return false
+	}
+	if ast.HasSyntacticModifier(member, modifierFlagsDisqualifying) {
+		return false
+	}
+	return true
+}
+
+// classKeywordPos returns the start position of the `class` keyword,
+// skipping over modifiers (`export`, `default`, `abstract`, decorators, …)
+// and any leading trivia. tsgo carries those modifiers on the class node,
+// while ESTree puts them on a wrapping `Export*Declaration`.
+func classKeywordPos(node *ast.Node, sourceText string) int {
+	pos := node.Pos()
+	if mods := node.Modifiers(); mods != nil && len(mods.Nodes) > 0 {
+		pos = mods.Nodes[len(mods.Nodes)-1].End()
+	}
+	return scanner.SkipTrivia(sourceText, pos)
+}
+
+// classHeadRange returns the range from the `class` keyword to the end of
+// the last token before the body's `{`, matching ESLint's
+// `getClassHeadLocation`. We scan tokens forward and update `end` to each
+// token's end until we encounter `{`. Comments and whitespace between
+// tokens are handled transparently by the scanner; this avoids the
+// off-by-one problems of using `typeParameters.End()` (which excludes the
+// closing `>`).
+func classHeadRange(node *ast.Node, sf *ast.SourceFile) core.TextRange {
+	start := classKeywordPos(node, sf.Text())
+	end := start + len("class")
+
+	s := scanner.GetScannerForSourceFile(sf, start)
+	for {
+		kind := s.Token()
+		if kind == ast.KindOpenBraceToken || kind == ast.KindEndOfFile {
+			break
+		}
+		end = s.TokenEnd()
+		s.Scan()
+	}
+
+	return core.NewTextRange(start, end)
+}
+
+// openBracePos returns the position of the class body's opening `{`. We
+// scan forward from the `class` keyword.
+func openBracePos(node *ast.Node, sf *ast.SourceFile) int {
+	s := scanner.GetScannerForSourceFile(sf, classKeywordPos(node, sf.Text()))
+	for {
+		kind := s.Token()
+		if kind == ast.KindOpenBraceToken || kind == ast.KindEndOfFile {
+			return s.TokenStart()
+		}
+		s.Scan()
+	}
+}
+
+// staticKeywordToken finds the `static` modifier token on a class member.
+// Returns the range of the keyword *token only* (leading trivia stripped).
+// The caller must guarantee `static` is present (it is for any member that
+// passed `isStaticMember`).
+func staticKeywordToken(member *ast.Node, sourceText string) (core.TextRange, bool) {
+	if mods := member.Modifiers(); mods != nil {
+		for _, m := range mods.Nodes {
+			if m != nil && m.Kind == ast.KindStaticKeyword {
+				start := scanner.SkipTrivia(sourceText, m.Pos())
+				return core.NewTextRange(start, m.End()), true
+			}
+		}
+	}
+	return core.TextRange{}, false
+}
+
+// skipWhitespaceForward returns the position of the first non-whitespace
+// character (per JS `\s*`) at or after `pos`.
+func skipWhitespaceForward(text string, pos int) int {
+	for pos < len(text) {
+		c := text[pos]
+		switch c {
+		case ' ', '\t', '\n', '\r', '\v', '\f':
+			pos++
+		default:
+			// U+00A0 (NBSP) and other Unicode whitespace are rare in source
+			// code; matching `\s` here is overkill — ASCII coverage is enough
+			// for fix correctness on real-world code.
+			return pos
+		}
+	}
+	return pos
+}
+
+// findTrailingSemicolonInRange uses the scanner to locate a `;` token
+// starting at `startPos`, bounded by `endPos`. The scanner skips both
+// whitespace and comments, so this correctly handles cases like
+// `static a /* c */;`.
+func findTrailingSemicolonInRange(sf *ast.SourceFile, startPos, endPos int) (int, bool) {
+	if startPos >= endPos {
+		return 0, false
+	}
+	s := scanner.GetScannerForSourceFile(sf, startPos)
+	if s.TokenStart() >= endPos {
+		return 0, false
+	}
+	if s.Token() == ast.KindSemicolonToken {
+		return s.TokenStart(), true
+	}
+	return 0, false
+}
+
+// findEqualsToken locates the `=` token of a PropertyDeclaration's
+// initializer assignment. Scans tokens from after the property name. The
+// computed-key form `[((c))] = ((2))` is handled correctly because we scan
+// at token granularity, skipping over balanced `]`/`)` etc.
+func findEqualsToken(member *ast.Node, sf *ast.SourceFile) (core.TextRange, bool) {
+	startPos := member.Pos()
+	if name := member.Name(); name != nil {
+		startPos = name.End()
+	}
+	s := scanner.GetScannerForSourceFile(sf, startPos)
+	for s.TokenStart() < member.End() {
+		if s.Token() == ast.KindEqualsToken {
+			return core.NewTextRange(s.TokenStart(), s.TokenEnd()), true
+		}
+		s.Scan()
+	}
+	return core.TextRange{}, false
+}
+
+// propertyBlocksClassFix reports whether a PropertyDeclaration blocks the
+// class-level autofix.
+//
+// Upstream cases (mirrored as-is):
+//   - TS type annotation (`static a: number = 1`) — not representable on an
+//     object literal property.
+//   - Raw initializer text includes `this` — upstream uses
+//     `sourceCode.getText(value)` (no leading trivia), so we strip trivia
+//     via `scanner.SkipTrivia` to align: `static a = /* this */ 1` is fine.
+//
+// rslint additions (suppress when fix output would be invalid TypeScript):
+//   - PostfixToken `?` (optional). Object members can't be declared optional
+//     (TS1162: "An object member cannot be declared optional.").
+//   - PostfixToken `!` (definite assignment assertion). TS1255: "A definite
+//     assignment assertion '!' is not permitted in this context."
+//
+// Upstream's typescript-eslint preserves these tokens in the fix output and
+// produces invalid TS; rslint refuses the fix instead.
+func propertyBlocksClassFix(member *ast.Node, text string) bool {
+	if !ast.IsPropertyDeclaration(member) {
+		return false
+	}
+	pd := member.AsPropertyDeclaration()
+	if pd == nil {
+		return false
+	}
+	if pd.Type != nil {
+		return true
+	}
+	if pd.PostfixToken != nil {
+		return true
+	}
+	if pd.Initializer != nil {
+		init := pd.Initializer
+		start := scanner.SkipTrivia(text, init.Pos())
+		if strings.Contains(text[start:init.End()], "this") {
+			return true
+		}
+	}
+	return false
+}
+
+// memberContentEnd returns the position after the last "real" token of a
+// member (excluding any trailing `;` for methods/accessors/constructors,
+// which is a separate SemicolonClassElement in tsgo).
+func memberContentEnd(member *ast.Node) int {
+	switch {
+	case ast.IsPropertyDeclaration(member):
+		pd := member.AsPropertyDeclaration()
+		if pd.Initializer != nil {
+			return pd.Initializer.End()
+		}
+		if pd.Type != nil {
+			return pd.Type.End()
+		}
+		if pd.PostfixToken != nil {
+			return pd.PostfixToken.End()
+		}
+		if name := member.Name(); name != nil {
+			return name.End()
+		}
+	}
+	if body := member.Body(); body != nil {
+		return body.End()
+	}
+	return member.End()
+}
+
+// findFollowingSemicolonElement returns the SemicolonClassElement that
+// immediately follows `members[idx]`, if any.
+func findFollowingSemicolonElement(members []*ast.Node, idx int) *ast.Node {
+	if idx+1 < len(members) && members[idx+1] != nil && ast.IsSemicolonClassElement(members[idx+1]) {
+		return members[idx+1]
+	}
+	return nil
+}
+
+// isExportDefault reports whether the class node is `export default class
+// ...`. In tsgo the `export default` modifiers are on the class itself.
+func isExportDefault(node *ast.Node) bool {
+	flags := node.ModifierFlags()
+	return flags&ast.ModifierFlagsExport != 0 && flags&ast.ModifierFlagsDefault != 0
+}
+
+// linePosition returns the 1-based line number of `pos` in `text`.
+func linePosition(text string, pos int) int {
+	line := 1
+	for i := 0; i < pos && i < len(text); i++ {
+		if text[i] == '\n' {
+			line++
+		}
+	}
+	return line
+}
+
+// trimmedTextBetween reports whether the source between `[start, end)` has
+// any non-whitespace content (used to detect comments between `class` and
+// `{` in the multi-line `return class /* c */\n{` upstream edge case).
+func trimmedTextBetween(text string, start, end int) string {
+	if start >= end || end > len(text) {
+		return ""
+	}
+	return strings.TrimSpace(text[start:end])
+}
+
+// buildFix walks the class members and produces the list of fixes. Returns
+// nil when the rule's autofix preconditions aren't met (declare/abstract/
+// implements, named class expression, named export-default class, property
+// with type annotation, or property with `this` in its initializer).
+func buildFix(node *ast.Node, sf *ast.SourceFile) []rule.RuleFix {
+	text := sf.Text()
+	flags := node.ModifierFlags()
+
+	// Upstream's `switchClassToObject` early-out:
+	//   - declare class
+	//   - abstract class
+	//   - class with `implements`
+	if flags&(ast.ModifierFlagsAmbient|ast.ModifierFlagsAbstract) != 0 {
+		return nil
+	}
+	// `implements` heritage check.
+	if hc := getHeritageClauses(node); hc != nil {
+		for _, clause := range hc.Nodes {
+			if clause != nil && clause.AsHeritageClause().Token == ast.KindImplementsKeyword {
+				return nil
+			}
+		}
+	}
+
+	isClassExpr := node.Kind == ast.KindClassExpression
+	hasName := node.Name() != nil
+	exportDefault := isExportDefault(node)
+
+	// Named class expression — upstream skips fix.
+	if isClassExpr && hasName {
+		return nil
+	}
+	// Named `export default class A` — upstream skips fix.
+	if exportDefault && hasName {
+		return nil
+	}
+
+	// Type parameters: rslint suppresses the autofix when the class declares
+	// `<T, ...>`. Upstream's `switchClassToObject` blindly replaces `class`
+	// with `const` and keeps the name+type-parameters region intact, which
+	// produces `const A<T> = { ... }` — syntactically invalid TypeScript
+	// (`const` declarations don't accept type parameters). The diagnostic is
+	// still reported. Documented under "Differences from ESLint".
+	if hasTypeParameters(node) {
+		return nil
+	}
+
+	// Per-member autofix preconditions.
+	for _, m := range node.Members() {
+		if m == nil {
+			continue
+		}
+		if propertyBlocksClassFix(m, text) {
+			return nil
+		}
+		// `accessor` (TC39 auto-accessor) on a property — `{ accessor a:
+		// ..., }` is not valid object literal syntax. Diagnostic stays.
+		if ast.IsPropertyDeclaration(m) && ast.HasSyntacticModifier(m, ast.ModifierFlagsAccessor) {
+			return nil
+		}
+		// Method-like member without a body (overload signature). Object
+		// literal methods must have bodies; emitting `a(): void;,` would
+		// be invalid TS. Diagnostic stays.
+		if isClassElementMethodLike(m) && m.Body() == nil {
+			return nil
+		}
+	}
+
+	fixes := make([]rule.RuleFix, 0, 8)
+	addFix := func(start, end int, replacement string) {
+		fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(start, end), replacement))
+	}
+
+	classPos := classKeywordPos(node, text)
+	classEnd := classPos + len("class")
+	bracePos := openBracePos(node, sf)
+
+	// Special-case: ClassExpression directly inside `return class /* c */\n{`
+	// (or with line break) where there's a comment between `class` and `{`.
+	// Matches upstream's `parent.type === 'ReturnStatement' && body line !=
+	// parent line && trimmed text between class end and brace > 0` arm.
+	if isClassExpr {
+		parent := node.Parent
+		bracePosLine := linePosition(text, bracePos)
+		var parentLine int
+		if parent != nil {
+			parentLine = linePosition(text, parent.Pos())
+		}
+		isReturnSpecial := parent != nil &&
+			parent.Kind == ast.KindReturnStatement &&
+			bracePosLine != parentLine &&
+			trimmedTextBetween(text, classEnd, bracePos) != ""
+
+		if isReturnSpecial {
+			// Replace `class` with `{`, then remove the original `{`.
+			addFix(classPos, classEnd, "{")
+			addFix(bracePos, bracePos+1, "")
+		} else {
+			// Anonymous class expression: drop `class` and any whitespace
+			// after it (matches `removeSpacesAfter`).
+			endRm := skipWhitespaceForward(text, classEnd)
+			addFix(classPos, endRm, "")
+		}
+	} else if exportDefault {
+		// `export default class { ... }` (anonymous) → drop `class` plus
+		// trailing whitespace.
+		endRm := skipWhitespaceForward(text, classEnd)
+		addFix(classPos, endRm, "")
+	} else {
+		// `class A { ... }` (declaration) or `export class A { ... }` →
+		// `const A = { ... };`. We keep any `export` modifier untouched,
+		// only the `class` keyword is replaced.
+		addFix(classPos, classEnd, "const")
+		addFix(bracePos, bracePos, "= ")
+		addFix(node.End(), node.End(), ";")
+	}
+
+	// Per-member transformations.
+	members := node.Members()
+	for i, m := range members {
+		if m == nil || ast.IsSemicolonClassElement(m) {
+			continue
+		}
+		// Remove `static` keyword + trailing whitespace. Use the keyword's
+		// token range (leading trivia stripped) so we don't accidentally
+		// eat the indentation BEFORE `static`.
+		if loc, ok := staticKeywordToken(m, text); ok {
+			endRm := skipWhitespaceForward(text, loc.End())
+			addFix(loc.Pos(), endRm, "")
+		}
+
+		// PropertyDeclaration: replace `=` with `:`, OR insert `: undefined`.
+		if ast.IsPropertyDeclaration(m) {
+			pd := m.AsPropertyDeclaration()
+			contentEnd := memberContentEnd(m)
+			semiPos, hasSemi := findTrailingSemicolonInRange(sf, contentEnd, m.End())
+			if pd.Initializer != nil {
+				if eq, ok := findEqualsToken(m, sf); ok {
+					addFix(eq.Pos(), eq.End(), ":")
+				}
+			} else if hasSemi {
+				addFix(semiPos, semiPos, ": undefined")
+			} else {
+				addFix(contentEnd, contentEnd, ": undefined")
+			}
+			if hasSemi {
+				addFix(semiPos, semiPos+1, ",")
+			} else {
+				addFix(contentEnd, contentEnd, ",")
+			}
+			continue
+		}
+		// Method / accessor / constructor: a separate SemicolonClassElement
+		// after the method, if any, holds the `;`. Replace just the `;`
+		// token (skip leading trivia so any comments between `}` and `;`
+		// are preserved, matching ESLint's `replaceText(token, ',')`).
+		if semi := findFollowingSemicolonElement(members, i); semi != nil {
+			semiStart := scanner.SkipTrivia(text, semi.Pos())
+			addFix(semiStart, semi.End(), ",")
+			continue
+		}
+		// No `;` follows — append `,` after the method body.
+		appendAt := m.End()
+		if body := m.Body(); body != nil {
+			appendAt = body.End()
+		}
+		addFix(appendAt, appendAt, ",")
+	}
+
+	return fixes
+}
+
+// hasTypeParameters reports whether the class declares `<T, ...>`.
+func hasTypeParameters(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindClassDeclaration:
+		tp := node.AsClassDeclaration().TypeParameters
+		return tp != nil && len(tp.Nodes) > 0
+	case ast.KindClassExpression:
+		tp := node.AsClassExpression().TypeParameters
+		return tp != nil && len(tp.Nodes) > 0
+	}
+	return false
+}
+
+// getHeritageClauses returns the heritage clause list for a class node.
+// Inlined here to keep the rule self-contained without dragging the
+// `internal/utils` import for one helper call.
+func getHeritageClauses(node *ast.Node) *ast.NodeList {
+	switch node.Kind {
+	case ast.KindClassDeclaration:
+		return node.AsClassDeclaration().HeritageClauses
+	case ast.KindClassExpression:
+		return node.AsClassExpression().HeritageClauses
+	}
+	return nil
+}
+
+var NoStaticOnlyClassRule = rule.Rule{
+	Name: "unicorn/no-static-only-class",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		check := func(node *ast.Node) {
+			// Skip classes that extend another class — the static members
+			// might be supplementing inherited instance members.
+			if ast.GetExtendsHeritageClauseElement(node) != nil {
+				return
+			}
+
+			// Skip class-level decorators.
+			if ast.HasDecorators(node) {
+				return
+			}
+
+			// Iterate members. SemicolonClassElement entries (a stray `;`
+			// between members) have no ESTree analog — treat them as
+			// whitespace. Any non-static-member disqualifies the class.
+			hasMember := false
+			for _, m := range node.Members() {
+				if m == nil || ast.IsSemicolonClassElement(m) {
+					continue
+				}
+				hasMember = true
+				if !isStaticMember(m) {
+					return
+				}
+			}
+			if !hasMember {
+				return
+			}
+
+			msg := rule.RuleMessage{
+				Id:          "noStaticOnlyClass",
+				Description: "Use an object instead of a class with only static members.",
+			}
+			headRange := classHeadRange(node, ctx.SourceFile)
+
+			fixes := buildFix(node, ctx.SourceFile)
+			if len(fixes) == 0 {
+				ctx.ReportRange(headRange, msg)
+				return
+			}
+			ctx.ReportRangeWithFixes(headRange, msg, fixes...)
+		}
+
+		return rule.RuleListeners{
+			ast.KindClassDeclaration: check,
+			ast.KindClassExpression:  check,
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.md
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.md
@@ -1,0 +1,94 @@
+# no-static-only-class
+
+## Rule Details
+
+A class with only static members has no instance behavior — it's effectively
+just a namespace for a bag of values and functions. Use a plain object instead.
+
+This rule reports any `class` declaration or expression where every member is
+a public static field or method. Classes that extend another class, that have
+private (`#name`) members, that carry class-level decorators, that contain a
+`static {}` initialization block, or that mix in any non-static member are
+left alone.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+class StaticOnly {
+  static foo = 1;
+  static bar() {}
+}
+
+const Counter = class {
+  static value = 0;
+  static increment() {
+    Counter.value++;
+  }
+};
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const StaticOnly = {
+  foo: 1,
+  bar() {},
+};
+
+// Has a non-static member — leave it as a class.
+class WithInstance {
+  static greeting = "hi";
+  log() {
+    console.log(WithInstance.greeting);
+  }
+}
+
+// Extends another class — the static members might supplement inherited
+// instance behavior.
+class Sub extends Base {
+  static helper() {}
+}
+
+// Private members force the class form.
+class PrivateOnly {
+  static #secret = 42;
+  static reveal() {
+    return PrivateOnly.#secret;
+  }
+}
+
+// Static initialization blocks keep the class form.
+class WithStaticBlock {
+  static {
+    /* setup */
+  }
+  static run() {}
+}
+```
+
+## Differences from ESLint
+
+The autofix is suppressed in a few TypeScript-only cases where ESLint's
+algorithm would produce syntactically invalid TypeScript. The diagnostic
+is still reported in all of them.
+
+- Class with type parameters (`class A<T> { ... }`). ESLint's autofix
+  yields `const A<T> = { ... }`; `const` declarations do not accept type
+  parameters.
+- Property with the optional postfix `?` (`static a?`). ESLint's autofix
+  yields `{ a?: ... }`; object members cannot be declared optional
+  (TS1162).
+- Property with the definite-assignment assertion postfix `!`
+  (`static a! = 1`). ESLint's autofix yields `{ a! : ... }`; the `!`
+  assertion is not permitted in this context (TS1255).
+- Property declared with the TC39 `accessor` keyword
+  (`static accessor a = 1`). The keyword has no object-literal analog.
+- Method-like member (method, getter, setter, or constructor) declared
+  without a body, e.g. an overload signature
+  (`static a(x: number): void;`). Object-literal methods must have a
+  body.
+
+## Original Documentation
+
+- ESLint plugin documentation: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-static-only-class.md>
+- Source code: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-static-only-class.js>

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class_test.go
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class_test.go
@@ -1,0 +1,633 @@
+package no_static_only_class_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// All upstream `valid` / `invalid` cases (from `test/no-static-only-class.js`)
+// are migrated below in declaration order. The upstream uses three test blocks:
+//   - `test.snapshot` (JS) — see "JS snapshot block"
+//   - `test.typescript` (TS-specific) — see "TS block"
+//   - bare `test()` (JS) — see "JS bare block"
+//
+// Inline `Locks in upstream` comments mark cases we add for branches the
+// upstream test suite itself does not exercise.
+func TestNoStaticOnlyClass(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_static_only_class.NoStaticOnlyClassRule,
+		[]rule_tester.ValidTestCase{
+			// ---- JS snapshot block: valid ----
+
+			// Empty class
+			{Code: `class A {}`},
+			{Code: `const A = class {}`},
+
+			// `superClass`
+			{Code: `class A extends B { static a() {}; }`},
+			{Code: `const A = class extends B { static a() {}; }`},
+
+			// Not static
+			{Code: `class A { a() {} }`},
+			{Code: `class A { constructor() {} }`},
+			{Code: `class A { get a() {} }`},
+			{Code: `class A { set a(value) {} }`},
+
+			// `private` (PrivateIdentifier on key)
+			{Code: `class A3 { static #a() {}; }`},
+			{Code: `class A3 { static #a = 1; }`},
+			{Code: `const A3 = class { static #a() {}; }`},
+			{Code: `const A3 = class { static #a = 1; }`},
+
+			// Static block — KindClassStaticBlockDeclaration is not a property
+			// or method, so isStaticMember returns false and the class is not
+			// reported.
+			{Code: `class A2 { static {}; }`},
+
+			// ---- TS block: valid ----
+
+			// `private` repeated under TS-specific config (snapshot block already
+			// covers these; upstream re-runs them under the TS suite).
+			{Code: `class A { static #a() {}; }`},
+			{Code: `class A { static #a = 1; }`},
+			{Code: `const A = class { static #a() {}; }`},
+			{Code: `const A = class { static #a = 1; }`},
+
+			// TS class — TypeScript modifiers on a static field disqualify the
+			// member from "static only" detection.
+			{Code: `class A { static public a = 1; }`},
+			{Code: `class A { static private a = 1; }`},
+			{Code: `class A { static readonly a = 1; }`},
+			{Code: `class A { static declare a = 1; }`},
+
+			// Static block under TS
+			{Code: `class A { static {}; }`},
+
+			// ---- Lock-in cases (branches not directly covered upstream) ----
+
+			// Locks in: a class containing both a static field AND a non-static
+			// method must NOT be reported (the `body.some(!isStaticMember)`
+			// branch returns early).
+			{Code: `class A { static a = 1; b() {} }`},
+
+			// Locks in: a static getter / setter alone (without other static
+			// members) IS reported. The valid counter-test is the same shape
+			// with a non-static getter — must not be reported.
+			{Code: `class A { get a() {} static b() {} }`},
+
+			// Locks in: ClassStaticBlockDeclaration mixed with valid static
+			// members — the static block makes the rule skip the class.
+			{Code: `class A { static {}; static a() {} }`},
+
+			// Locks in: a static accessor / method with a `protected` modifier
+			// is excluded (ModifierFlagsAccessibilityModifier covers protected).
+			{Code: `class A { static protected a = 1; }`},
+
+			// Locks in: a class-level decorator skips the rule even with a
+			// static member.
+			{Code: `@Foo class A { static a = 1; } function Foo(_:any){}`},
+
+			// Locks in: a member-level decorator on a static field excludes the
+			// member (ModifierFlagsDecorator).
+			{Code: `class A { @bar static a = 1; } function bar(_:any,__:any){}`},
+
+			// Locks in: an extends-only class with no static members is fine.
+			{Code: `class A extends B {}`},
+
+			// Locks in: outer class with a non-static method is NOT reported
+			// even when its method body holds a *non-static-only* inner class.
+			// Verifies the listener doesn't bleed past the class boundary.
+			{Code: `class Outer { static helper() {} foo() { class Inner { instance() {} static a() {} } return Inner; } }`},
+
+			// Locks in: TS abstract member modifier alone does NOT disqualify
+			// a member. (Upstream's `isStaticMember` only checks accessibility,
+			// readonly, declare, decorators, private — not abstract.) But an
+			// abstract member is never `static`, so it is filtered by
+			// `HasStaticModifier`. Class containing one abstract method has a
+			// non-static-member → not reported.
+			{Code: `abstract class A { abstract foo(): void; }`},
+
+			// Locks in: a class containing only an index signature
+			// (`[k: string]: any`). Index signatures are not
+			// PropertyDeclaration / MethodDeclaration / accessor / constructor,
+			// so they fail `isStaticMember` and the class is not reported.
+			{Code: `class A { [k: string]: any; }`},
+
+			// Locks in: a non-static field disqualifies the class even when
+			// every method is static.
+			{Code: `class A { static a() {} b = 1; }`},
+
+			// Locks in: a class that extends through a parenthesized
+			// expression. `extends (B)` — still an extends clause.
+			{Code: `class A extends (B) { static a() {} }`},
+
+			// Locks in: numeric / string / computed keys on static members
+			// alone are still all-static and reported (covered in invalid)
+			// — here, mixing one non-static numeric key blocks the rule.
+			{Code: `class A { static 0() {} 1() {} }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- JS snapshot block: invalid ----
+
+			// `class A { static a() {}; }` — head is `class A` (length 7).
+			// Autofix: class → const, insert `= ` before `{`, append `;`.
+			{
+				Code:   `class A { static a() {}; }`,
+				Output: []string{`const A = { a() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Message:   "Use an object instead of a class with only static members.",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			{
+				Code:   `class A { static a() {} }`,
+				Output: []string{`const A = { a() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			// Named class expression — autofix is suppressed upstream.
+			{
+				Code: `const A = class A { static a() {}; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 11, EndLine: 1, EndColumn: 18,
+				}},
+			},
+			// Anonymous class expression — autofix drops `class`.
+			{
+				Code:   `const A = class { static a() {}; }`,
+				Output: []string{`const A = { a() {}, }`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 11, EndLine: 1, EndColumn: 16,
+				}},
+			},
+			// `static constructor()` — in tsgo this is a regular static method.
+			{
+				Code:   `class A { static constructor() {}; }`,
+				Output: []string{`const A = { constructor() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			// `export default class A` — modifiers are stripped from the head
+			// range, so the report starts at `class` (column 16), matching
+			// ESLint's ESTree where the ClassDeclaration child starts at `class`.
+			// Named export-default → upstream skips autofix.
+			{
+				Code: `export default class A { static a() {}; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 16, EndLine: 1, EndColumn: 23,
+				}},
+			},
+			// Anonymous `export default class` — autofix drops `class`.
+			{
+				Code:   `export default class { static a() {}; }`,
+				Output: []string{`export default { a() {}, }`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 16, EndLine: 1, EndColumn: 21,
+				}},
+			},
+			// `export class A` — head starts at `class` (column 8). Autofix
+			// keeps `export` and rewrites `class A` → `const A = ...`.
+			{
+				Code:   `export class A { static a() {}; }`,
+				Output: []string{`export const A = { a() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 15,
+				}},
+			},
+
+			// Multi-line class expression — autofix collapses `class\n\t{` →
+			// `{`.
+			{
+				Code:   "function a() {\n\treturn class\n\t{\n\t\tstatic a() {}\n\t}\n}",
+				Output: []string{"function a() {\n\treturn {\n\t\ta() {},\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      2, Column: 9, EndLine: 2, EndColumn: 14,
+				}},
+			},
+			// Same with block-comment between `class` and `{` — special arm
+			// replaces `class` with `{` and removes original `{`.
+			{
+				Code:   "function a() {\n\treturn class /* comment */\n\t{\n\t\tstatic a() {}\n\t}\n}",
+				Output: []string{"function a() {\n\treturn { /* comment */\n\t\n\t\ta() {},\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      2, Column: 9, EndLine: 2, EndColumn: 14,
+				}},
+			},
+			// Same with line-comment between `class` and `{`.
+			{
+				Code:   "function a() {\n\treturn class // comment\n\t{\n\t\tstatic a() {}\n\t}\n}",
+				Output: []string{"function a() {\n\treturn { // comment\n\t\n\t\ta() {},\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      2, Column: 9, EndLine: 2, EndColumn: 14,
+				}},
+			},
+
+			// Breaking edge cases — autofix produces a `const` with no
+			// surrounding spaces (because the original had none).
+			{
+				Code:   "class A {static a(){}}\nclass B extends A {}",
+				Output: []string{"const A = {a(){},};\nclass B extends A {}"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			{
+				Code:   "class A {static a(){}}\nconsole.log(typeof A)",
+				Output: []string{"const A = {a(){},};\nconsole.log(typeof A)"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			{
+				Code:   "class A {static a(){}}\nconst a = new A;",
+				Output: []string{"const A = {a(){},};\nconst a = new A;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// ---- TS block: invalid ----
+
+			// Big multi-member class — single diagnostic + full autofix.
+			{
+				Code:   "class A {\n\tstatic a\n\tstatic b = 1\n\tstatic [c] = 2\n\tstatic [d]\n\tstatic e() {}\n\tstatic [f]() {}\n}",
+				Output: []string{"const A = {\n\ta: undefined,\n\tb : 1,\n\t[c] : 2,\n\t[d]: undefined,\n\te() {},\n\t[f]() {},\n};"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			// Same shape with explicit semicolons / extra parens.
+			{
+				Code:   "class A {\n\tstatic a;\n\tstatic b = 1;\n\tstatic [((c))] = ((2));\n\tstatic [d];\n\tstatic e() {};\n\tstatic [f]() {};\n}",
+				Output: []string{"const A = {\n\ta: undefined,\n\tb : 1,\n\t[((c))] : ((2)),\n\t[d]: undefined,\n\te() {},\n\t[f]() {},\n};"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			// Comments between every token — diagnostic location is the head;
+			// fix preserves all interior comments verbatim, replacing only
+			// `class`/`static`/`=`/`;` tokens.
+			{
+				Code:   "/* */\nclass /* */ A /* */ {\n\t/* */ static /* */ a /* */; /* */\n\t/* */ static /* */ b /* */ = /* */ 1 /* */; /* */\n\t/* */ static /* */ [ /* */ c /* */ ] /* */ = /* */ 2 /* */;  /* */\n\t/* */ static /* */ [/* */ d /* */] /* */;  /* */\n\t/* */ static /* */ /* */ e /* */ ( /* */ ) {/* */}/* */;  /* */\n\t/* */ static /* */ [/* */ f /* */ ] /* */ ( /* */ ) {/* */ }/* */ ;  /* */\n}\n/* */",
+				Output: []string{"/* */\nconst /* */ A /* */ = {\n\t/* */ /* */ a /* */: undefined, /* */\n\t/* */ /* */ b /* */ : /* */ 1 /* */, /* */\n\t/* */ /* */ [ /* */ c /* */ ] /* */ : /* */ 2 /* */,  /* */\n\t/* */ /* */ [/* */ d /* */] /* */: undefined,  /* */\n\t/* */ /* */ /* */ e /* */ ( /* */ ) {/* */}/* */,  /* */\n\t/* */ /* */ [/* */ f /* */ ] /* */ ( /* */ ) {/* */ }/* */ ,  /* */\n};\n/* */"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      2, Column: 1,
+				}},
+			},
+
+			// `this` in member value — still reported (no-fix case upstream).
+			{
+				Code: "class A {\n\tstatic a = 1;\n\tstatic b = this.a;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			// `this` in computed key — reported. Upstream still autofixes
+			// because the value-text-includes-`this` check only inspects the
+			// initializer's text, not the key.
+			{
+				Code:   `class A {static [this.a] = 1}`,
+				Output: []string{`const A = {[this.a] : 1,};`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			// String value containing 'this' — reported.
+			{
+				Code: "class A {\n\tstatic a = 1;\n\tstatic b = \"this\";\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// `declare class` — reported (no-fix upstream); class-level
+			// `declare` modifier doesn't disqualify the class.
+			{
+				Code: `declare class A { static a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 9, EndLine: 1, EndColumn: 16,
+				}},
+			},
+			// `abstract class` — reported.
+			{
+				Code: `abstract class A { static a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 10, EndLine: 1, EndColumn: 17,
+				}},
+			},
+			// `implements` heritage — reported (only `extends` exempts).
+			{
+				Code: `class A implements B { static a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 21,
+				}},
+			},
+			// vscode-style realistic case — typed initialized fields, reported.
+			{
+				Code: "class NotebookKernelProviderAssociationRegistry {\n\tstatic extensionIds: (string | null)[] = [];\n\tstatic extensionDescriptions: string[] = [];\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 48,
+				}},
+			},
+
+			// ---- JS bare block: invalid ----
+
+			// Already covered above, but the bare block adds this exact case.
+			// (Duplicate of the very first invalid case — kept to mirror upstream
+			// layout faithfully.)
+			{
+				Code:   `class A { static a() {} }`,
+				Output: []string{`const A = { a() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// ---- Lock-in cases (additional coverage) ----
+
+			// Locks in: a class with only a static getter — head is reported,
+			// fix preserves `get` keyword.
+			{
+				Code:   `class A { static get a() {} }`,
+				Output: []string{`const A = { get a() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			// Locks in: only a static setter — reported and fixed.
+			{
+				Code:   `class A { static set a(v) {} }`,
+				Output: []string{`const A = { set a(v) {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			// Locks in: nested static-only class expression inside a method
+			// body of an OUTER (non-static-only) class. Only the inner class
+			// is reported; the outer is not. Fix rewrites the inner.
+			{
+				Code:   `class Outer { foo() { return class { static a() {} }; } }`,
+				Output: []string{`class Outer { foo() { return { a() {}, }; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 30, EndLine: 1, EndColumn: 35,
+				}},
+			},
+
+			// Locks in: type parameters appear in the head range. Autofix is
+			// suppressed (intentional rslint divergence — see rule .md).
+			{
+				Code: `class A<T> { static a(): T { return null!; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 11,
+				}},
+			},
+			{
+				Code: `class A<T extends B> { static a(): T { return null!; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 21,
+				}},
+			},
+
+			// Locks in: doubly-nested static-only class. Both inner classes
+			// are independently invalid → 2 reports + 2 fixes applied.
+			{
+				Code:   "class A {\n\tstatic a() {}\n}\nclass B {\n\tstatic b() {}\n}",
+				Output: []string{"const A = {\n\ta() {},\n};\nconst B = {\n\tb() {},\n};"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noStaticOnlyClass", Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+					{MessageId: "noStaticOnlyClass", Line: 4, Column: 1, EndLine: 4, EndColumn: 8},
+				},
+			},
+
+			// Locks in: numeric / string keyed static members are still
+			// reported and fixed.
+			{
+				Code:   `class A { static 0() {}; static "x"() {} }`,
+				Output: []string{`const A = { 0() {}, "x"() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: two methods with no separators — verify per-method
+			// `,` insertion order doesn't leave the second member without a
+			// trailing comma.
+			{
+				Code:   `class A { static a() {} static b() {} }`,
+				Output: []string{`const A = { a() {}, b() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: mixed property + method.
+			{
+				Code:   `class A { static a = 1; static b() {} }`,
+				Output: []string{`const A = { a : 1, b() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: comment between value and trailing `;` in a property.
+			// `findTrailingSemicolonInRange` must skip the comment when
+			// locating `;`.
+			{
+				Code:   "class A { static a /* c */; }",
+				Output: []string{"const A = { a /* c */: undefined, };"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: comment between `=` and value that contains `this`.
+			// upstream's `getText(value)` excludes leading trivia, so the
+			// fix proceeds despite the `this` token sitting in the comment.
+			{
+				Code:   "class A { static a = /* this */ 1 }",
+				Output: []string{"const A = { a : /* this */ 1, };"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: computed-key static method — fix preserves `[k]`.
+			{
+				Code:   `class A { static [k]() {} }`,
+				Output: []string{`const A = { [k]() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: generator method as a sole static member.
+			{
+				Code:   `class A { static *gen() { yield 1; } }`,
+				Output: []string{`const A = { *gen() { yield 1; }, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: async method — `async` modifier sits between
+			// `static` and the name; we only remove `static` and its
+			// trailing whitespace, leaving `async` intact.
+			{
+				Code:   `class A { static async fn() {} }`,
+				Output: []string{`const A = { async fn() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// ---- Go / tsgo-specific edge coverage ----
+
+			// Locks in: async generator. `static async *fn() {}` should
+			// preserve `async` and `*` after removing `static`. tsgo carries
+			// `async` as a modifier and `*` as a separate AsteriskToken
+			// (asteriskToken on MethodDeclaration), neither of which lives
+			// in the slice we delete.
+			{
+				Code:   "class A { static async *fn() { yield 1; } }",
+				Output: []string{"const A = { async *fn() { yield 1; }, };"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: arrow-function static field. The initializer text
+			// is `() => 1` (no `this`) so the autofix proceeds. Verifies
+			// the trivia-skipping `this` heuristic doesn't reach into the
+			// arrow body's syntactic tokens.
+			{
+				Code:   `class A { static a = () => 1 }`,
+				Output: []string{`const A = { a : () => 1, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: JSDoc on a class member is leading trivia in tsgo.
+			// staticKeywordToken uses scanner.SkipTrivia from the static
+			// modifier's Pos, so JSDoc is preserved when `static ` is
+			// removed.
+			{
+				Code:   "class A {\n\t/** keep me */\n\tstatic a() {}\n}",
+				Output: []string{"const A = {\n\t/** keep me */\n\ta() {},\n};"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: class not at line 1 — head range columns/lines must
+			// reflect the class's actual position. The leading code path
+			// goes through scanner.GetScannerForSourceFile with a non-zero
+			// start.
+			{
+				Code: "// header line 1\n// header line 2\nclass A {\n\tstatic foo() {}\n}",
+				Output: []string{
+					"// header line 1\n// header line 2\nconst A = {\n\tfoo() {},\n};",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      3, Column: 1, EndLine: 3, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: PropertyDeclaration with PostfixToken `!` (definite
+			// assignment assertion). Autofix is suppressed because
+			// `{ a! : 1, }` would be invalid TS (TS1255). See
+			// "Differences from ESLint".
+			{
+				Code: `class A { static a! = 1 }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: PropertyDeclaration with PostfixToken `?` (optional).
+			// Autofix is suppressed because `{ a?: undefined, }` would be
+			// invalid TS (TS1162). See "Differences from ESLint".
+			{
+				Code: `class A { static a? = 1 }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: TC39 `accessor` field. Autofix suppressed because
+			// `accessor` has no object-literal analog. See "Differences
+			// from ESLint".
+			{
+				Code: `class A { static accessor a = 1 }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
+			// Locks in: static overload signatures. The first two methods
+			// have no body (Body() == nil); object-literal methods must
+			// have bodies, so the autofix is suppressed. Diagnostic still
+			// fires (the class is logically static-only).
+			{
+				Code: "class A {\n\tstatic a(x: number): void;\n\tstatic a(x: string): void;\n\tstatic a(x: any): void {}\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class_test.go
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class_test.go
@@ -606,6 +606,33 @@ func TestNoStaticOnlyClass(t *testing.T) {
 				}},
 			},
 
+			// Locks in: multiple consecutive `;` between methods. Each
+			// stray SemicolonClassElement is its own member in tsgo;
+			// upstream's ESTree absorbs them as filler and ESLint's fix
+			// only redirects the first to a comma. rslint extends the
+			// cleanup so that subsequent `;` characters are also erased
+			// (their trivia/comments preserved), keeping the rewritten
+			// output valid for `static a() {};; static b() {};` etc.
+			{
+				Code:   `class A { static a() {};; static b() {}; }`,
+				Output: []string{`const A = { a() {}, b() {}, };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+			// Locks in: trivia between consecutive `;` is preserved when
+			// each extra `;` token is erased (only the `;` char goes —
+			// the comment between `;` and `;` survives).
+			{
+				Code:   `class A { static a() {} /*A*/ ; /*B*/ ; /*C*/ }`,
+				Output: []string{`const A = { a() {} /*A*/ , /*B*/  /*C*/ };`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticOnlyClass",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+				}},
+			},
+
 			// Locks in: TC39 `accessor` field. Autofix suppressed because
 			// `accessor` has no object-literal analog. See "Differences
 			// from ESLint".

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -365,6 +365,7 @@ export default defineConfig({
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
 
     './tests/eslint/rules/no-shadow-restricted-names.test.ts',
   ],

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts
@@ -1,0 +1,116 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string) => ({ code });
+
+ruleTester.run('no-static-only-class', null as never, {
+  valid: [
+    // Empty class
+    valid('class A {}'),
+    valid('const A = class {}'),
+    // `superClass`
+    valid('class A extends B { static a() {}; }'),
+    valid('const A = class extends B { static a() {}; }'),
+    // Not static
+    valid('class A { a() {} }'),
+    valid('class A { constructor() {} }'),
+    valid('class A { get a() {} }'),
+    valid('class A { set a(value) {} }'),
+    // `private` (PrivateIdentifier on key)
+    valid('class A3 { static #a() {}; }'),
+    valid('class A3 { static #a = 1; }'),
+    valid('const A3 = class { static #a() {}; }'),
+    valid('const A3 = class { static #a = 1; }'),
+    // Static block
+    valid('class A2 { static {}; }'),
+    // TS-only modifiers exclude the member from the "static only" check
+    valid('class A { static public a = 1; }'),
+    valid('class A { static private a = 1; }'),
+    valid('class A { static readonly a = 1; }'),
+    valid('class A { static declare a = 1; }'),
+  ],
+  invalid: [
+    { code: 'class A { static a() {}; }', errors: 1 },
+    { code: 'class A { static a() {} }', errors: 1 },
+    { code: 'const A = class A { static a() {}; }', errors: 1 },
+    { code: 'const A = class { static a() {}; }', errors: 1 },
+    { code: 'class A { static constructor() {}; }', errors: 1 },
+    { code: 'export default class A { static a() {}; }', errors: 1 },
+    { code: 'export default class { static a() {}; }', errors: 1 },
+    { code: 'export class A { static a() {}; }', errors: 1 },
+    {
+      code:
+        'function a() {\n' +
+        '\treturn class\n' +
+        '\t{\n' +
+        '\t\tstatic a() {}\n' +
+        '\t}\n' +
+        '}',
+      errors: 1,
+    },
+    {
+      code:
+        'function a() {\n' +
+        '\treturn class /* comment */\n' +
+        '\t{\n' +
+        '\t\tstatic a() {}\n' +
+        '\t}\n' +
+        '}',
+      errors: 1,
+    },
+    {
+      code:
+        'function a() {\n' +
+        '\treturn class // comment\n' +
+        '\t{\n' +
+        '\t\tstatic a() {}\n' +
+        '\t}\n' +
+        '}',
+      errors: 1,
+    },
+    // Breaking edge cases
+    {
+      code: 'class A {static a(){}}\nclass B extends A {}',
+      errors: 1,
+    },
+    {
+      code: 'class A {static a(){}}\nconsole.log(typeof A)',
+      errors: 1,
+    },
+    {
+      code: 'class A {static a(){}}\nconst a = new A;',
+      errors: 1,
+    },
+
+    // TS-specific
+    {
+      code:
+        'class A {\n' +
+        '\tstatic a\n' +
+        '\tstatic b = 1\n' +
+        '\tstatic [c] = 2\n' +
+        '\tstatic [d]\n' +
+        '\tstatic e() {}\n' +
+        '\tstatic [f]() {}\n' +
+        '}',
+      errors: 1,
+    },
+    {
+      code: 'class A {\n\tstatic a = 1;\n\tstatic b = this.a;\n}',
+      errors: 1,
+    },
+    { code: 'class A {static [this.a] = 1}', errors: 1 },
+    { code: 'declare class A { static a = 1; }', errors: 1 },
+    { code: 'abstract class A { static a = 1; }', errors: 1 },
+    { code: 'class A implements B { static a = 1; }', errors: 1 },
+    {
+      code:
+        'class NotebookKernelProviderAssociationRegistry {\n' +
+        '\tstatic extensionIds: (string | null)[] = [];\n' +
+        '\tstatic extensionDescriptions: string[] = [];\n' +
+        '}',
+      errors: 1,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `unicorn/no-static-only-class` rule from [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn) to rslint.

The rule reports any `class` declaration or expression where every member is a public static field, method, accessor, or static-named-constructor — recommending a plain object literal instead. Classes with `extends`, class-level decorators, `#name` private members, `static {}` blocks, or any non-static / TS-only-modifier (`private`/`public`/`protected`/`readonly`/`declare`) member are left alone.

Includes a fix that rewrites the class to an object literal, with all upstream's safety guards (named class expression, named `export default class`, `declare`/`abstract`/`implements`, type-annotated property, property whose initializer text contains `this`).

### Differences from ESLint

The autofix is suppressed in five TypeScript-specific cases where ESLint's algorithm would produce syntactically invalid TypeScript. The diagnostic still fires in all of them:

- Class with type parameters (`class A<T> { ... }`) — `const A<T> = { ... }` is invalid.
- Property with optional postfix `?` — `{ a?: ... }` violates TS1162.
- Property with definite-assignment postfix `!` — `{ a! : ... }` violates TS1255.
- TC39 `accessor` field — keyword has no object-literal analog.
- Method-like member without a body (overload signature) — object-literal methods must have a body.

## Related Links

- ESLint rule: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-static-only-class.md>
- Source code: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-static-only-class.js>

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).