### PR TITLE
perf: use tinyglobby for downward config scan

### DIFF
--- a/packages/rslint/package.json
+++ b/packages/rslint/package.json
@@ -80,6 +80,7 @@
     "@rslint/win32-x64": "workspace:*"
   },
   "dependencies": {
-    "picomatch": "4.0.4"
+    "picomatch": "4.0.4",
+    "tinyglobby": "0.2.15"
   }
 }

--- a/packages/rslint/src/utils/config-discovery.ts
+++ b/packages/rslint/src/utils/config-discovery.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import picomatch from 'picomatch';
+import { globSync as tinyglobbySync } from 'tinyglobby';
 import { type RslintConfigEntry } from '../define-config.ts';
 
 export const JS_CONFIG_FILES = [
@@ -9,8 +10,6 @@ export const JS_CONFIG_FILES = [
   'rslint.config.ts',
   'rslint.config.mts',
 ];
-
-const SCAN_EXCLUDE_DIRS = new Set(['node_modules', '.git']);
 
 export function findJSConfig(cwd: string): string | null {
   for (const name of JS_CONFIG_FILES) {
@@ -38,43 +37,21 @@ export function findJSConfigUp(startDir: string): string | null {
 /**
  * Recursively scan a directory for all rslint JS/TS config files.
  * Skips node_modules and .git directories (aligned with ESLint defaults).
- * Uses native fs.globSync when available (Node 22+, C++ impl), falls back
- * to hand-written recursive walk.
+ * Uses tinyglobby (fdir-backed) for fast directory traversal.
+ *
+ * tinyglobby returns POSIX-style paths even on Windows, so the result is
+ * normalized through path.normalize to match the native separator that
+ * findJSConfigUp / path.join produce. Without this, Map<configPath, ...>
+ * dedupe against findJSConfigUp results fails on Windows.
  */
 export function findJSConfigsInDir(startDir: string): string[] {
   const resolved = path.resolve(startDir);
-
-  // Node 22+ native globSync (C++ implementation, faster)
-  if (typeof fs.globSync === 'function') {
-    const pattern = '**/rslint.config.{js,mjs,ts,mts}';
-    return fs
-      .globSync(pattern, {
-        cwd: resolved,
-        exclude: (f: string) => SCAN_EXCLUDE_DIRS.has(path.basename(f)),
-      })
-      .map((p: string) => path.join(resolved, p));
-  }
-
-  // Fallback: recursive walk
-  const configs: string[] = [];
-  const walk = (dir: string): void => {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        if (SCAN_EXCLUDE_DIRS.has(entry.name)) continue;
-        walk(path.join(dir, entry.name));
-      } else if (JS_CONFIG_FILES.includes(entry.name)) {
-        configs.push(path.join(dir, entry.name));
-      }
-    }
-  };
-  walk(resolved);
-  return configs;
+  return tinyglobbySync(['**/rslint.config.{js,mjs,ts,mts}'], {
+    cwd: resolved,
+    absolute: true,
+    dot: true,
+    ignore: ['**/node_modules/**', '**/.git/**'],
+  }).map((p) => path.normalize(p));
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       picomatch:
         specifier: 4.0.4
         version: 4.0.4
+      tinyglobby:
+        specifier: 0.2.15
+        version: 0.2.15
     devDependencies:
       '@rslint/api':
         specifier: workspace:*

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -294,3 +294,5 @@ fname
 preresolved
 vname
 useeffectevent
+tinyglobby
+fdir


### PR DESCRIPTION
## Summary

Swap `findJSConfigsInDir` (in `packages/rslint/src/utils/config-discovery.ts`) from `fs.globSync` + hand-written walk fallback to `tinyglobby`'s `globSync`. The function signature, return shape (absolute paths), and exclusion semantics (`node_modules`, `.git` at any depth) are preserved; only the underlying scanner changes.

The change targets the **downward scan** branch of `discoverConfigs`, which dominates the wall-clock when running `rslint` with no args or a directory argument in a large monorepo.

### Measured impact

Benchmarks taken on a 31 GB monorepo (~16k non-blacklisted dirs, 251 first-level `node_modules`, Node v22.18.0):

| Layer | Scenario | BEFORE median | AFTER median | Δ |
|---|---|---:|---:|---:|
| pure discovery | `findJSConfigsInDir` | 3493 ms | 2174 ms | **−38%** |
| pure discovery | `discoverConfigs` (no args) | 3883 ms | 2120 ms | **−45%** |
| pure discovery | `discoverConfigs` (dir arg) | 2542 ms | 2080 ms | −18% |
| end-to-end bin (n=10 interleaved) | `bin/rslint.cjs` (no args) mean | 9.62 s | 8.28 s | **−1.34 s** (Welch t=3.19) |
| end-to-end bin | `bin/rslint.cjs` `--config` (control, short-circuit) | 5.41 s | 5.31 s | −0.10 s (within noise) |
| end-to-end bin | `bin/rslint.cjs` `<file>` (control, no scan) | 0.28 s | 0.29 s | ~0 |

`fs.globSync` and `tinyglobby` produce the same result set for this repo (`size=1` in both implementations). The `--config` and file-arg control groups confirm that the saving is attributable to the scanner change alone, not to incidental side effects.

Variance also shrinks meaningfully on the discovery layer: `discoverConfigs` (no args) max drops from 5594 ms to 2228 ms (−96%).

### Behavior preserved

- `node_modules` / `.git` skipped at any depth (exclude switched from basename callback to `ignore: ['**/node_modules/**', '**/.git/**']`)
- Dot-prefixed directories like `.cache/` still get descended into (`dot: true`)
- Absolute paths returned (`absolute: true`)
- `JS_CONFIG_FILES` priority order in `findJSConfig` / `findJSConfigUp` untouched

All 119 tests in `@rslint/core` pass, including the 40 cases in `tests/config-discovery.test.ts` that lock the discovery contract.

### Trade-off

Adds one production dependency: `tinyglobby@0.2.15` (already a transitive dep via `rsbuild-plugin-dts`; pulls in `fdir` underneath). The hand-written `walk()` fallback for pre-Node-22 environments is removed since tinyglobby works on every supported Node version. `picomatch` (already a direct dep) is unaffected.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required). — Existing `config-discovery.test.ts` covers the contract; no new tests needed.
- [x] Documentation updated (or not required). — User-facing behavior unchanged.