### PR TITLE
feat: add eslint-plugin-react-hooks recommended config

### DIFF
--- a/packages/rslint/src/configs/index.ts
+++ b/packages/rslint/src/configs/index.ts
@@ -2,6 +2,7 @@ import type { RslintConfigEntry } from '../define-config.js';
 import { recommended as tsRecommended } from './typescript.js';
 import { recommended as jsRecommended } from './javascript.js';
 import { recommended as reactRecommended } from './react.js';
+import { recommended as reactHooksRecommended } from './react-hooks.js';
 import { recommended as importRecommended } from './import.js';
 import { recommended as promiseRecommended } from './promise.js';
 import { recommended as jestRecommended } from './jest.js';
@@ -20,6 +21,10 @@ export const js: PluginExport = {
 
 export const reactPlugin: PluginExport = {
   configs: { recommended: reactRecommended },
+};
+
+export const reactHooksPlugin: PluginExport = {
+  configs: { recommended: reactHooksRecommended },
 };
 
 export const importPlugin: PluginExport = {

--- a/packages/rslint/src/configs/react-hooks.ts
+++ b/packages/rslint/src/configs/react-hooks.ts
@@ -1,0 +1,27 @@
+import type { RslintConfigEntry } from '../define-config.js';
+
+// Aligned with official eslint-plugin-react-hooks@7.x recommended.
+// Rules commented out with "not implemented" are in the official preset but not yet available.
+const recommended: RslintConfigEntry = {
+  plugins: ['react-hooks'],
+  rules: {
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
+    // 'react-hooks/config': 'error', // not implemented
+    // 'react-hooks/error-boundaries': 'error', // not implemented
+    // 'react-hooks/gating': 'error', // not implemented
+    // 'react-hooks/globals': 'error', // not implemented
+    // 'react-hooks/immutability': 'error', // not implemented
+    // 'react-hooks/incompatible-library': 'warn', // not implemented
+    // 'react-hooks/preserve-manual-memoization': 'error', // not implemented
+    // 'react-hooks/purity': 'error', // not implemented
+    // 'react-hooks/refs': 'error', // not implemented
+    // 'react-hooks/set-state-in-effect': 'error', // not implemented
+    // 'react-hooks/set-state-in-render': 'error', // not implemented
+    // 'react-hooks/static-components': 'error', // not implemented
+    // 'react-hooks/unsupported-syntax': 'warn', // not implemented
+    // 'react-hooks/use-memo': 'error', // not implemented
+  },
+};
+
+export { recommended };

--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -15,6 +15,7 @@ export {
   ts,
   js,
   reactPlugin,
+  reactHooksPlugin,
   importPlugin,
   promisePlugin,
   jestPlugin,


### PR DESCRIPTION
## Summary

- Adds `packages/rslint/src/configs/react-hooks.ts` aligned with `eslint-plugin-react-hooks@7.x` recommended preset.
- Enables the two ported rules (`react-hooks/rules-of-hooks: error`, `react-hooks/exhaustive-deps: warn`); the React Compiler rules are listed as `// not implemented` placeholders, matching the convention in `react.ts` / `promise.ts`.
- Re-exports the new config as `reactHooksPlugin` from `packages/rslint/src/index.ts` so users can drop it into a flat config.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).