### PR TITLE
perf: parallelize Go-side gitignore reading and gap-file discovery

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -494,12 +494,63 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
 
 ### Concurrency Model
 
-Current concurrency is driven by ts-go `core.NewWorkGroup()`:
+The Go side has four parallelism points; each one honors `--singleThreaded`,
+which is the user-facing escape hatch for serial / reproducible execution.
 
-- `RunLinter()` queues work per Program
-- `--singleThreaded` disables work-group parallelism
-- file ownership filtering avoids duplicate work in multi-config mode
-- LSP uses a different orchestration model and keeps session access on its main dispatch loop
+1. **Linter work group** (`RunLinter()` via `core.NewWorkGroup`)
+   - Schedules per-Program lint work; runs rules in parallel within a Program.
+   - `--singleThreaded` collapses the work group to serial execution.
+
+2. **gitignore reading ‖ Program creation** (in `cmd/rslint/cmd.go`)
+   - `ReadGitignoreAsGlobs` walks `.gitignore` for each config; it is independent
+     of `createProgramsForConfig` (which only reads
+     `languageOptions.parserOptions.project`, never `Ignores`). The two are
+     dispatched as parallel goroutines per config.
+   - In multi-config mode, gitignore reads also fan out across configs in
+     parallel; `createProgramsForConfig` invocations run serially across configs
+     (typescript-go's API is invoked one config at a time).
+   - `--singleThreaded` runs both stages sequentially — no goroutines spawned.
+
+3. **Gap-file directory walker** (`internal/config/file_discovery.go`)
+   - `DiscoverGapFiles` uses a fixed-size worker pool (`walkPool`) that walks
+     the directory tree. Live goroutine count is capped at `workers`, not the
+     number of directories.
+   - Default `workers = max(2, GOMAXPROCS)`; `--singleThreaded` forces
+     `workers = 1`, which degenerates into a fully serial DFS-style traversal.
+   - The walker is built on a `vfsAdapter` with `followSymlinks = false`:
+     symlinked subdirectories are skipped. This matches ESLint v10's
+     flat-config file walker, which uses `@humanfs/node` and recurses only
+     when `Dirent.isDirectory()` is true (Node's `readdir({withFileTypes:
+true})` reports the dirent type without following symlinks, so
+     `Dirent.isDirectory()` is false for symlinks). The skip also eliminates
+     scheduling-dependent non-determinism that a parallel walker would
+     otherwise introduce.
+
+4. **Multi-config gap discovery** (`DiscoverGapFilesMultiConfig`)
+   - Iterates `configMap` serially, calling `DiscoverGapFiles` once per config.
+   - Each call is itself bounded by its own worker pool, so total live
+     goroutines remain bounded by `workers`, not `len(configMap) × workers`.
+
+Other invariants:
+
+- File-ownership filtering avoids duplicate work in multi-config mode.
+- LSP uses a different orchestration model and keeps session access on its
+  main dispatch loop.
+
+#### `--singleThreaded` semantics
+
+`--singleThreaded` is honored in every parallelism point above:
+
+| Point                          | Effect when set                                               |
+| ------------------------------ | ------------------------------------------------------------- |
+| Linter work group              | Collapsed to serial via `core.NewWorkGroup(true)`.            |
+| gitignore ‖ Program creation   | Both stages run sequentially in the main goroutine.           |
+| Multi-config gitignore fan-out | Replaced by a sequential for-loop.                            |
+| Gap-file walker workers        | Forced to 1 (single goroutine, no concurrency).               |
+| Multi-config gap discovery     | Already serial across configs; inner walker also forced to 1. |
+
+End result: with `--singleThreaded`, the Go side spawns no goroutines beyond
+those typescript-go itself creates for syntactic / semantic work.
 
 ## 10. Performance & Memory Considerations
 

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -672,15 +672,56 @@ func runCMD() int {
 			// the .gitignore scan. This is safe because isDirPathBlocked is
 			// the same function used by the linter — blocked dirs' files
 			// are never linted, so their .gitignore patterns are irrelevant.
-			for configDir, entries := range configMap {
-				configIgnores := rslintconfig.ExtractConfigIgnores(entries)
-				gitGlobs := rslintconfig.ReadGitignoreAsGlobs(configDir, fs, configIgnores)
-				if len(gitGlobs) > 0 {
-					configMap[configDir] = append(
-						rslintconfig.RslintConfig{{Ignores: gitGlobs}},
-						entries...,
-					)
+			//
+			// Concurrency:
+			//   - When singleThreaded is set, both stages run sequentially in
+			//     the main goroutine (no goroutines spawned at all).
+			//   - Otherwise, gitignore reads run in parallel across configs
+			//     (independent FS reads via cachedvfs, which is concurrent-
+			//     safe). createProgramsForConfig still runs serially in the
+			//     main goroutine — typescript-go's API is invoked one config
+			//     at a time. The two stages overlap: gitignore goroutines
+			//     run alongside the createPrograms loop.
+			//
+			// configMap is NOT mutated by gitignore goroutines; results are
+			// collected via channel and merged in the main goroutine after
+			// the createPrograms loop, so the createPrograms loop sees the
+			// pre-augmentation entries (createProgramsForConfig only reads
+			// languageOptions.parserOptions.project — Ignores entries are
+			// no-ops for it; verified in LoadTsConfigsFromRslintConfig).
+			type giResult struct {
+				configDir string
+				globs     []string
+			}
+			var (
+				giResults chan giResult
+				giWG      sync.WaitGroup
+			)
+			if singleThreaded {
+				// Inline serial gitignore reads.
+				giResults = nil
+				for configDir, entries := range configMap {
+					configIgnores := rslintconfig.ExtractConfigIgnores(entries)
+					globs := rslintconfig.ReadGitignoreAsGlobs(configDir, fs, configIgnores)
+					if len(globs) > 0 {
+						configMap[configDir] = append(
+							rslintconfig.RslintConfig{{Ignores: globs}},
+							configMap[configDir]...,
+						)
+					}
 				}
+			} else {
+				giResults = make(chan giResult, len(configMap))
+				for configDir, entries := range configMap {
+					configIgnores := rslintconfig.ExtractConfigIgnores(entries)
+					giWG.Add(1)
+					go func(dir string, ignores []string) {
+						defer giWG.Done()
+						globs := rslintconfig.ReadGitignoreAsGlobs(dir, fs, ignores)
+						giResults <- giResult{configDir: dir, globs: globs}
+					}(configDir, configIgnores)
+				}
+				go func() { giWG.Wait(); close(giResults) }()
 			}
 
 			seenTsConfigs := make(map[string]struct{})
@@ -695,22 +736,36 @@ func runCMD() int {
 				}
 				programs = append(programs, progs...)
 			}
+
+			// Drain gitignore results (parallel path only) and merge into
+			// configMap. Must complete before DiscoverGapFiles, which relies
+			// on the augmented configMap.
+			if giResults != nil {
+				for r := range giResults {
+					if len(r.globs) > 0 {
+						configMap[r.configDir] = append(
+							rslintconfig.RslintConfig{{Ignores: r.globs}},
+							configMap[r.configDir]...,
+						)
+					}
+				}
+			}
 		} else {
 			// Legacy single-config format
 			rslintConfig = payload.SingleConfig
 			currentDirectory = payload.SingleConfigDir
 
-			// Inject .gitignore patterns as global ignores.
-			configIgnores := rslintconfig.ExtractConfigIgnores(rslintConfig)
-			gitGlobs := rslintconfig.ReadGitignoreAsGlobs(currentDirectory, fs, configIgnores)
-			if len(gitGlobs) > 0 {
-				rslintConfig = append(
-					rslintconfig.RslintConfig{{Ignores: gitGlobs}},
-					rslintConfig...,
-				)
-			}
-
-			progs, exitCode := createProgramsForConfig(currentDirectory, rslintConfig, singleThreaded, fs, nil)
+			// Inject .gitignore patterns as global ignores. Run gitignore
+			// reading in parallel with createProgramsForConfig — they're
+			// independent (createProgramsForConfig only reads
+			// languageOptions.parserOptions.project, not Ignores).
+			var (
+				progs    []*compiler.Program
+				exitCode int
+			)
+			rslintConfig, progs, exitCode = parallelGitignoreAndPrograms(
+				rslintConfig, currentDirectory, fs, singleThreaded, nil,
+			)
 			if exitCode != 0 {
 				return exitCode
 			}
@@ -720,17 +775,15 @@ func runCMD() int {
 		// Load configuration from file (JSON config path, isJSConfig stays false)
 		rslintConfig, _, currentDirectory = rslintconfig.LoadConfigurationWithFallback(config, currentDirectory, fs)
 
-		// Inject .gitignore patterns as global ignores.
-		configIgnores := rslintconfig.ExtractConfigIgnores(rslintConfig)
-		gitGlobs := rslintconfig.ReadGitignoreAsGlobs(currentDirectory, fs, configIgnores)
-		if len(gitGlobs) > 0 {
-			rslintConfig = append(
-				rslintconfig.RslintConfig{{Ignores: gitGlobs}},
-				rslintConfig...,
-			)
-		}
-
-		progs, exitCode := createProgramsForConfig(currentDirectory, rslintConfig, singleThreaded, fs, nil)
+		// Inject .gitignore patterns as global ignores. Run gitignore reading
+		// in parallel with createProgramsForConfig (see comment above).
+		var (
+			progs    []*compiler.Program
+			exitCode int
+		)
+		rslintConfig, progs, exitCode = parallelGitignoreAndPrograms(
+			rslintConfig, currentDirectory, fs, singleThreaded, nil,
+		)
 		if exitCode != 0 {
 			return exitCode
 		}
@@ -785,9 +838,9 @@ func runCMD() int {
 
 		var gapFiles []string
 		if configMap != nil {
-			gapFiles = rslintconfig.DiscoverGapFilesMultiConfig(configMap, fs, programFiles, allowFiles, allowDirs)
+			gapFiles = rslintconfig.DiscoverGapFilesMultiConfig(configMap, fs, programFiles, allowFiles, allowDirs, singleThreaded)
 		} else {
-			gapFiles = rslintconfig.DiscoverGapFiles(rslintConfig, currentDirectory, fs, programFiles, allowFiles, allowDirs)
+			gapFiles = rslintconfig.DiscoverGapFiles(rslintConfig, currentDirectory, fs, programFiles, allowFiles, allowDirs, singleThreaded)
 		}
 
 		// CLI file args bypass config `files` patterns (ESLint behavior):

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
@@ -12,6 +13,67 @@ import (
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+// parallelGitignoreAndPrograms runs ReadGitignoreAsGlobs and createProgramsForConfig
+// for a single rslint config (single-config and legacy JSON paths).
+//
+// When singleThreaded is true, both run sequentially in the calling goroutine
+// — honoring the user's --singleThreaded flag (no concurrency at all).
+// Otherwise the two are dispatched as parallel goroutines: they have no data
+// dependency, since createProgramsForConfig only reads
+// entry.LanguageOptions.ParserOptions.Project (see
+// LoadTsConfigsFromRslintConfig), never entry.Ignores. Calling it before vs.
+// after gitignore globs are prepended is equivalent for TS Program creation.
+//
+// The returned config is the gitignore-augmented config (gitignore globs
+// prepended when non-empty), suitable for downstream DiscoverGapFiles /
+// GetConfigForFile.
+//
+// Returns: (augmentedConfig, programs, exitCode). On non-zero exitCode,
+// augmentedConfig and programs may be nil/partial — caller should propagate
+// exitCode without using them.
+func parallelGitignoreAndPrograms(
+	rslintConfig rslintconfig.RslintConfig,
+	configDir string,
+	fsys vfs.FS,
+	singleThreaded bool,
+	seenTsConfigs map[string]struct{},
+) (rslintconfig.RslintConfig, []*compiler.Program, int) {
+	configIgnores := rslintconfig.ExtractConfigIgnores(rslintConfig)
+
+	var (
+		gitGlobs []string
+		progs    []*compiler.Program
+		exitCode int
+	)
+	if singleThreaded {
+		gitGlobs = rslintconfig.ReadGitignoreAsGlobs(configDir, fsys, configIgnores)
+		progs, exitCode = createProgramsForConfig(configDir, rslintConfig, singleThreaded, fsys, seenTsConfigs)
+	} else {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			gitGlobs = rslintconfig.ReadGitignoreAsGlobs(configDir, fsys, configIgnores)
+		}()
+		go func() {
+			defer wg.Done()
+			progs, exitCode = createProgramsForConfig(configDir, rslintConfig, singleThreaded, fsys, seenTsConfigs)
+		}()
+		wg.Wait()
+	}
+
+	if exitCode != 0 {
+		return rslintConfig, nil, exitCode
+	}
+	if len(gitGlobs) > 0 {
+		rslintConfig = append(
+			rslintconfig.RslintConfig{{Ignores: gitGlobs}},
+			rslintConfig...,
+		)
+	}
+	return rslintConfig, progs, 0
+}
 
 // createProgramsForConfig creates TypeScript programs for a single config entry.
 // It handles tsconfig extraction, auto-detection, deduplication, and the no-tsconfig fallback.

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -3,7 +3,10 @@ package config
 import (
 	"io/fs"
 	"path"
+	"runtime"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/microsoft/typescript-go/shim/tspath"
@@ -30,15 +33,25 @@ var defaultExcludeDirs = func() map[string]struct{} {
 //  3. Not already in programFiles (existing tsconfig Programs)
 //  4. Pass GetConfigForFile (would actually receive lint rules)
 //
-// Uses single-pass fs.WalkDir with directory-level pruning (node_modules, .git,
-// and isDirBlocked patterns are skipped at walk time, not after traversal).
+// Walking model:
+//   - A bounded worker pool (see walkPool) traverses the directory tree.
+//     Total live goroutines at any moment is at most `workers`.
+//   - Default workers = max(2, GOMAXPROCS); singleThreaded forces workers=1
+//     for fully serial traversal (a knob users rely on for debugging,
+//     reproducibility, and constrained environments).
+//   - The vfsAdapter is constructed with followSymlinks=false, so symlinked
+//     subdirectories are skipped entirely. This matches ESLint v10's
+//     flat-config file walker, which uses @humanfs/node and recurses only
+//     when Dirent.isDirectory() is true (Node returns false for symlinks).
+//     It also avoids the otherwise scheduling-dependent "first writer wins"
+//     non-determinism a parallel walker would introduce.
 //
 // When allowFiles/allowDirs are provided (CLI args), only files within scope.
 //
 // Returns:
 //   - nil: no config entry has a `files` field → caller uses legacy tsconfig-only behavior
 //   - []: `files` present but no gaps found
-//   - [...]: gap files to create a fallback Program for
+//   - [...]: gap files to create a fallback Program for (sorted lexically)
 func DiscoverGapFiles(
 	config RslintConfig,
 	configDir string,
@@ -46,6 +59,7 @@ func DiscoverGapFiles(
 	programFiles map[string]struct{},
 	allowFiles []string,
 	allowDirs []string,
+	singleThreaded bool,
 ) []string {
 	// 1. Collect global ignore patterns and files patterns from config entries.
 	globalIgnores := ExtractConfigIgnores(config)
@@ -99,13 +113,16 @@ func DiscoverGapFiles(
 			}
 			gapFiles = append(gapFiles, f)
 		}
-		return deduplicate(gapFiles)
+		gapFiles = deduplicate(gapFiles)
+		// Map iteration order is non-deterministic; sort to match the walker
+		// path and keep output stable across runs.
+		sort.Strings(gapFiles)
+		return gapFiles
 	}
 
-	// 3. Walk directory tree once with directory-level pruning, matching all
-	// patterns per file. This replaces the previous per-pattern GlobWalk
-	// approach which could not prune directories (node_modules, .git, etc.)
-	// and resulted in O(patterns × all_files) traversal.
+	// 3. Walk the tree with a bounded worker pool. Goroutine count is capped
+	// at `workers`; symlinks are skipped (see vfsAdapter doc) so the result
+	// set is deterministic regardless of scheduling.
 	normalizedConfigDir := normalizeGlobPath(configDir)
 	fsAdapter := &vfsAdapter{vfs: fsys, root: normalizedConfigDir}
 
@@ -116,41 +133,27 @@ func DiscoverGapFiles(
 		relativePatterns[i] = strings.TrimPrefix(normalizedPattern, normalizedConfigDir+"/")
 	}
 
-	// Cache for directory ignore checks.
-	dirIgnoreCache := make(map[string]bool)
+	var (
+		gapMu     sync.Mutex
+		seen      sync.Map // map[string]struct{} — file dedupe
+		dirIgnore sync.Map // map[string]bool — pattern check cache, write-once per path
+	)
 
-	seen := make(map[string]struct{})
+	// Defer the parallelism limit to GOMAXPROCS (Go's standard knob; aligned
+	// with container CGroup CPU limits). Lower bound of 2 keeps the walker
+	// useful on single-core CI runners. singleThreaded overrides to 1 for
+	// fully serial traversal — a knob users depend on for reproducibility,
+	// debugging, and constrained environments.
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 2 {
+		workers = 2
+	}
+	if singleThreaded {
+		workers = 1
+	}
 
-	_ = fs.WalkDir(fsAdapter, ".", func(walkPath string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil //nolint:nilerr // intentionally skip unreadable entries and continue walking
-		}
-
-		if d.IsDir() {
-			// Prune default-excluded directories (node_modules, .git).
-			if _, excluded := defaultExcludeDirs[d.Name()]; excluded && walkPath != "." {
-				return fs.SkipDir
-			}
-
-			// Prune directories blocked by global ignores (directory-level patterns).
-			if walkPath != "." {
-				if blocked, ok := dirIgnoreCache[walkPath]; ok {
-					if blocked {
-						return fs.SkipDir
-					}
-				} else {
-					blocked = isDirPathBlocked(walkPath, globalIgnores)
-					dirIgnoreCache[walkPath] = blocked
-					if blocked {
-						return fs.SkipDir
-					}
-				}
-			}
-
-			return nil
-		}
-
-		// File: check if it matches any files pattern.
+	processFile := func(walkPath string) {
+		// 1. pattern match
 		matched := false
 		for _, pattern := range relativePatterns {
 			if ok, _ := doublestar.Match(pattern, walkPath); ok {
@@ -159,22 +162,20 @@ func DiscoverGapFiles(
 			}
 		}
 		if !matched {
-			return nil
+			return
 		}
 
 		fullPath := tspath.NormalizePath(path.Join(normalizedConfigDir, walkPath))
 
-		// Skip files already in tsconfig Programs.
+		// 2. already in tsconfig Programs
 		if _, exists := programFiles[fullPath]; exists {
-			return nil
+			return
 		}
-
-		// Skip files in global ignores (file-level evaluation with ! support).
+		// 3. file-level global ignores
 		if isFileIgnored(fullPath, globalIgnores, configDir) {
-			return nil
+			return
 		}
-
-		// Scope to CLI args if provided.
+		// 4. CLI scope
 		if allowFileSet != nil || allowDirs != nil {
 			inScope := false
 			if allowFileSet != nil {
@@ -191,39 +192,94 @@ func DiscoverGapFiles(
 				}
 			}
 			if !inScope {
-				return nil
+				return
 			}
 		}
-
-		// Final check: would this file actually receive lint rules?
+		// 5. final config check
 		if config.GetConfigForFile(fullPath, configDir) == nil {
+			return
+		}
+		// 6. dedupe + append
+		if _, loaded := seen.LoadOrStore(fullPath, struct{}{}); loaded {
+			return
+		}
+		gapMu.Lock()
+		gapFiles = append(gapFiles, fullPath)
+		gapMu.Unlock()
+	}
+
+	work := func(walkPath string) []string {
+		f, err := fsAdapter.Open(walkPath)
+		if err != nil {
 			return nil
 		}
-
-		if _, exists := seen[fullPath]; !exists {
-			seen[fullPath] = struct{}{}
-			gapFiles = append(gapFiles, fullPath)
+		rdf, ok := f.(fs.ReadDirFile)
+		if !ok {
+			f.Close()
+			return nil
 		}
-		return nil
-	})
+		entries, _ := rdf.ReadDir(-1)
+		f.Close()
 
+		var childDirs []string
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() {
+				if _, excluded := defaultExcludeDirs[name]; excluded {
+					continue
+				}
+				childPath := path.Join(walkPath, name)
+				if cached, ok := dirIgnore.Load(childPath); ok {
+					blocked, _ := cached.(bool) // dirIgnore only stores bool (set by Store below)
+					if blocked {
+						continue
+					}
+				} else {
+					blocked := isDirPathBlocked(childPath, globalIgnores)
+					dirIgnore.Store(childPath, blocked)
+					if blocked {
+						continue
+					}
+				}
+				childDirs = append(childDirs, childPath)
+			} else {
+				processFile(path.Join(walkPath, name))
+			}
+		}
+		return childDirs
+	}
+
+	pool := newWalkPool(workers)
+	pool.submitMany([]string{"."})
+	pool.run(work)
+
+	sort.Strings(gapFiles)
 	return gapFiles
 }
 
 // DiscoverGapFilesMultiConfig runs DiscoverGapFiles for each config in a
 // monorepo config map and returns the union of all gap files.
+//
+// Configs are processed serially. Each DiscoverGapFiles invocation already
+// uses an internal worker pool, so the total live goroutine count is bounded
+// by the worker pool size, not by `len(configMap) × workers`. Cross-config
+// parallelism can be added later if benchmarks justify it.
 func DiscoverGapFilesMultiConfig(
 	configMap map[string]RslintConfig,
 	fsys vfs.FS,
 	programFiles map[string]struct{},
 	allowFiles []string,
 	allowDirs []string,
+	singleThreaded bool,
 ) []string {
+	if len(configMap) == 0 {
+		return nil
+	}
+
 	seen := make(map[string]struct{})
 	var allGapFiles []string
-
 	for configDir, cfg := range configMap {
-		gapFiles := DiscoverGapFiles(cfg, configDir, fsys, programFiles, allowFiles, allowDirs)
+		gapFiles := DiscoverGapFiles(cfg, configDir, fsys, programFiles, allowFiles, allowDirs, singleThreaded)
 		for _, f := range gapFiles {
 			if _, exists := seen[f]; !exists {
 				seen[f] = struct{}{}
@@ -235,7 +291,117 @@ func DiscoverGapFilesMultiConfig(
 	if len(allGapFiles) == 0 {
 		return nil
 	}
+	sort.Strings(allGapFiles)
 	return allGapFiles
+}
+
+// walkPool is a fixed-size worker pool with an unbounded internal LIFO queue,
+// used by DiscoverGapFiles to walk directory trees with a bounded number of
+// live goroutines. Properties:
+//
+//   - At most `workers` goroutines exist concurrently.
+//   - submitMany never blocks (queue grows as needed; total memory ~ peak
+//     queue size, bounded by FS branching × depth).
+//   - run() returns once all submitted work and all transitively submitted
+//     work have completed. Detection: when every worker is simultaneously
+//     idle and the queue is empty.
+//
+// workers=1 degenerates to an effectively serial DFS-style traversal (LIFO
+// pops the most recently submitted dir); the only goroutine is the worker
+// itself. This is what --singleThreaded relies on.
+type walkPool struct {
+	mu      sync.Mutex
+	cond    *sync.Cond
+	queue   []string
+	idle    int
+	workers int
+	done    bool
+}
+
+func newWalkPool(workers int) *walkPool {
+	if workers < 1 {
+		workers = 1
+	}
+	p := &walkPool{workers: workers}
+	p.cond = sync.NewCond(&p.mu)
+	return p
+}
+
+// submitMany appends dirs to the queue and wakes idle workers. Safe to call
+// from any goroutine.
+func (p *walkPool) submitMany(dirs []string) {
+	if len(dirs) == 0 {
+		return
+	}
+	p.mu.Lock()
+	p.queue = append(p.queue, dirs...)
+	p.mu.Unlock()
+	if len(dirs) == 1 {
+		p.cond.Signal()
+	} else {
+		p.cond.Broadcast()
+	}
+}
+
+// take pops a job from the queue, blocking if empty. Returns ("", false)
+// only when the queue is empty AND every worker is simultaneously idle —
+// which means no more work will ever appear.
+func (p *walkPool) take() (string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for {
+		if len(p.queue) > 0 {
+			n := len(p.queue) - 1
+			dir := p.queue[n]
+			p.queue = p.queue[:n]
+			return dir, true
+		}
+		p.idle++
+		if p.idle == p.workers {
+			p.done = true
+			p.cond.Broadcast()
+			return "", false
+		}
+		p.cond.Wait()
+		if p.done {
+			return "", false
+		}
+		p.idle--
+	}
+}
+
+// run drives the worker pool. Each worker pulls jobs and calls work(dir),
+// which returns the child directories to enqueue. Returns when all reachable
+// work is processed.
+//
+// When workers == 1, runs the loop on the calling goroutine directly — no
+// goroutines are spawned at all. This is what --singleThreaded relies on:
+// callers can rely on the Go side spawning no extra goroutines.
+func (p *walkPool) run(work func(string) []string) {
+	if p.workers == 1 {
+		for {
+			dir, ok := p.take()
+			if !ok {
+				return
+			}
+			p.submitMany(work(dir))
+		}
+	}
+	var wg sync.WaitGroup
+	for range p.workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				dir, ok := p.take()
+				if !ok {
+					return
+				}
+				p.submitMany(work(dir))
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // deduplicate returns a copy of the input slice with duplicates removed, preserving order.

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -3,15 +3,22 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"gotest.tools/v3/assert"
 )
+
+func strconvI(i int) string { return strconv.Itoa(i) }
 
 // setupDiscoveryFixture creates a temp dir with the given file paths and returns
 // the normalized configDir and a map of short name → normalized absolute path.
@@ -47,7 +54,7 @@ func TestDiscoverGapFiles_Basic(t *testing.T) {
 		paths["src/a.ts"]: {},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil, "should not be nil when config has files")
 	assert.Equal(t, len(gapFiles), 1)
@@ -71,7 +78,7 @@ func TestDiscoverGapFiles_GlobalIgnoresExclude(t *testing.T) {
 		paths["src/a.ts"]: {},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	// scripts/b.ts should be excluded by global ignores
 	assert.Assert(t, gapFiles != nil)
@@ -94,7 +101,7 @@ func TestDiscoverGapFiles_ProgramFilesSkipped(t *testing.T) {
 		paths["src/b.ts"]: {},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
 	assert.Equal(t, len(gapFiles), 0)
@@ -119,7 +126,7 @@ func TestDiscoverGapFiles_GetConfigForFilePreFilter(t *testing.T) {
 		paths["src/a.ts"]: {},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	// test/b.ts matches **/*.ts but is excluded by entry-level ignores →
 	// GetConfigForFile returns nil → not a gap file
@@ -137,7 +144,7 @@ func TestDiscoverGapFiles_NoFilesField_ReturnsNil(t *testing.T) {
 		{Rules: Rules{"test-rule": "error"}},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
 
 	// Should return nil (backward compat signal)
 	assert.Assert(t, gapFiles == nil, "should return nil when no entry has files field")
@@ -158,7 +165,7 @@ func TestDiscoverGapFiles_AllowDirsScope(t *testing.T) {
 
 	// Only allow scripts/ directory
 	scriptsDir := tspath.NormalizePath(filepath.Join(configDir, "scripts"))
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, []string{scriptsDir})
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, []string{scriptsDir}, false)
 
 	assert.Assert(t, gapFiles != nil)
 	assert.Equal(t, len(gapFiles), 1)
@@ -180,7 +187,7 @@ func TestDiscoverGapFiles_MultipleFilesPatterns(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
 	sort.Strings(gapFiles)
@@ -207,7 +214,7 @@ func TestDiscoverGapFiles_JsFilesNotDiscoveredWithoutPattern(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
 	// b.js should NOT be discovered because no entry has files: ['**/*.js']
@@ -229,7 +236,9 @@ func TestDiscoverGapFiles_AllowFilesScope(t *testing.T) {
 
 	// Only allow scripts/b.ts via allowFiles
 	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles,
-		[]string{paths["scripts/b.ts"]}, nil)
+		[]string{paths["scripts/b.ts"]}, nil,
+		false,
+	)
 
 	assert.Assert(t, gapFiles != nil)
 	assert.Equal(t, len(gapFiles), 1)
@@ -250,7 +259,7 @@ func TestDiscoverGapFiles_AllExtensionsDiscoveredByPattern(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
 	// All files matching the pattern should be discovered (no extension filter)
@@ -276,7 +285,7 @@ func TestDiscoverGapFilesMultiConfig(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFilesMultiConfig(configMap, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFilesMultiConfig(configMap, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
 	assert.Equal(t, len(gapFiles), 2)
@@ -301,7 +310,7 @@ func TestDiscoverGapFiles_EmptyFilesArray(t *testing.T) {
 		{Files: []string{}, Rules: Rules{"test-rule": "error"}},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
 
 	// Empty files array has no patterns to match → same as no files field → nil (legacy mode)
 	assert.Assert(t, gapFiles == nil, "should return nil for empty files array")
@@ -319,7 +328,7 @@ func TestDiscoverGapFiles_FilesButNoRules(t *testing.T) {
 		{Files: []string{"**/*.ts"}},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
 
 	// GetConfigForFile returns non-nil (entry matched), so the file IS a gap file.
 	// The linter will subsequently skip it because it has no rules, but that's
@@ -344,7 +353,7 @@ func TestDiscoverGapFiles_DirIgnoreBlocksTraversal(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
 	// build/ entirely blocked — neither keep.ts nor other.ts discovered
@@ -378,7 +387,7 @@ func TestDiscoverGapFiles_FileIgnoreAllowsNegation(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
 
@@ -413,7 +422,7 @@ func TestDiscoverGapFiles_WildcardMiddleDirIgnoreBlocks(t *testing.T) {
 	}
 
 	programFiles := map[string]struct{}{}
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	gapSet := make(map[string]struct{})
 	for _, f := range gapFiles {
@@ -444,7 +453,7 @@ func TestDiscoverGapFiles_CrossEntryDirIgnoreAndNegation(t *testing.T) {
 	}
 
 	programFiles := map[string]struct{}{}
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	for _, f := range gapFiles {
 		if f == paths["build/keep.ts"] || f == paths["build/other.ts"] {
@@ -467,7 +476,7 @@ func TestDiscoverGapFiles_DoubleStarDirIgnoreBlocksNested(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
 	for _, f := range gapFiles {
@@ -490,7 +499,7 @@ func TestDiscoverGapFiles_DefaultExcludesNodeModules(t *testing.T) {
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
 	for _, f := range gapFiles {
@@ -518,7 +527,7 @@ func TestDiscoverGapFiles_DefaultExcludesGitDir(t *testing.T) {
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
 	for _, f := range gapFiles {
@@ -535,17 +544,29 @@ func TestDiscoverGapFiles_DefaultExcludesGitDir(t *testing.T) {
 // is the difference between <100ms and 7s.
 
 // spyFS wraps a vfs.FS and records which directories had their contents listed.
-// GetAccessibleEntries is called by vfsAdapter.ReadDir only when fs.WalkDir
-// actually enters a directory. If a directory is pruned (fs.SkipDir), this
-// method is never called for it.
+// GetAccessibleEntries is called by vfsAdapter.ReadDir only when the walker
+// actually enters a directory. If a directory is pruned, this method is
+// never called for it.
+//
+// DiscoverGapFiles walks concurrently, so the recorder needs a lock.
 type spyFS struct {
 	vfs.FS
+	mu           sync.Mutex
 	accessedDirs []string
 }
 
 func (s *spyFS) GetAccessibleEntries(path string) vfs.Entries {
+	s.mu.Lock()
 	s.accessedDirs = append(s.accessedDirs, path)
+	s.mu.Unlock()
 	return s.FS.GetAccessibleEntries(path)
+}
+
+func (s *spyFS) snapshotAccessedDirs() []string {
+	s.mu.Lock()
+	out := append([]string(nil), s.accessedDirs...)
+	s.mu.Unlock()
+	return out
 }
 
 func TestDiscoverGapFiles_PrunesNodeModulesAtWalkLevel(t *testing.T) {
@@ -560,9 +581,9 @@ func TestDiscoverGapFiles_PrunesNodeModulesAtWalkLevel(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil)
+	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
 
-	for _, dir := range spy.accessedDirs {
+	for _, dir := range spy.snapshotAccessedDirs() {
 		if strings.Contains(dir, "node_modules") {
 			t.Errorf("node_modules directory was entered during walk (GetAccessibleEntries called for %s)", dir)
 		}
@@ -580,9 +601,9 @@ func TestDiscoverGapFiles_PrunesGitDirAtWalkLevel(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil)
+	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
 
-	for _, dir := range spy.accessedDirs {
+	for _, dir := range spy.snapshotAccessedDirs() {
 		if strings.Contains(dir, ".git") {
 			t.Errorf(".git directory was entered during walk (GetAccessibleEntries called for %s)", dir)
 		}
@@ -602,9 +623,9 @@ func TestDiscoverGapFiles_PrunesUserIgnoredDirAtWalkLevel(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil)
+	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
 
-	for _, dir := range spy.accessedDirs {
+	for _, dir := range spy.snapshotAccessedDirs() {
 		if strings.Contains(dir, "vendor") {
 			t.Errorf("vendor directory was entered during walk (GetAccessibleEntries called for %s)", dir)
 		}
@@ -624,12 +645,12 @@ func TestDiscoverGapFiles_PrunesNestedIgnoredDirButEntersParent(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
 
 	// build/ should be entered (not blocked)
 	buildEntered := false
 	outputEntered := false
-	for _, dir := range spy.accessedDirs {
+	for _, dir := range spy.snapshotAccessedDirs() {
 		if strings.HasSuffix(dir, "/build") || strings.HasSuffix(dir, "build") {
 			buildEntered = true
 		}
@@ -662,12 +683,12 @@ func TestDiscoverGapFiles_EntersNonExcludedDirs(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil)
+	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
 
 	// src/ and lib/ should be entered
 	srcEntered := false
 	libEntered := false
-	for _, dir := range spy.accessedDirs {
+	for _, dir := range spy.snapshotAccessedDirs() {
 		if strings.HasSuffix(dir, "/src") {
 			srcEntered = true
 		}
@@ -713,7 +734,7 @@ func e2eSetup(t *testing.T, files map[string]string, config RslintConfig, progra
 		programFiles = map[string]struct{}{}
 	}
 
-	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), programFiles, nil, nil, false)
 	return dir, gapFiles, config
 }
 
@@ -910,7 +931,7 @@ func TestE2E_ProgramFilesExcluded(t *testing.T) {
 		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
 	}
 
-	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), programFiles, nil, nil)
+	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), programFiles, nil, nil, false)
 	gapSet := toSet(gapFiles)
 
 	// index.ts in program → NOT a gap file
@@ -1026,7 +1047,7 @@ func TestE2E_AllowDirsWithConfigIgnores(t *testing.T) {
 
 	// Only allow packages/foo/
 	fooDir := tspath.NormalizePath(dir + "/packages/foo")
-	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, nil, []string{fooDir})
+	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, nil, []string{fooDir}, false)
 	gapSet := toSet(gapFiles)
 
 	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/packages/foo/src/a.ts")], "packages/foo/src/a.ts should be discovered (in allowDirs)")
@@ -1058,7 +1079,7 @@ func TestE2E_AllowFilesWithGitignore(t *testing.T) {
 	distFile := tspath.NormalizePath(dir + "/dist/bundle.ts")
 
 	// Simulate lint-staged passing both files explicitly.
-	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, []string{srcFile, distFile}, nil)
+	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, []string{srcFile, distFile}, nil, false)
 	gapSet := toSet(gapFiles)
 
 	assert.Assert(t, gapSet[srcFile], "src/index.ts should be discovered (explicit allowFile)")
@@ -1071,4 +1092,212 @@ func toSet(items []string) map[string]bool {
 		m[item] = true
 	}
 	return m
+}
+
+// --- Concurrency/correctness regressions ---
+
+// Symlinks are never followed in DiscoverGapFiles, so symlinked subtrees do
+// not contribute gap files even if their target would otherwise match the
+// `files` pattern. This guarantees output determinism regardless of how the
+// concurrent walker schedules sibling directories.
+func TestDiscoverGapFiles_SkipsSymlinkedDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := tspath.NormalizePath(tmpDir)
+
+	realDir := filepath.Join(tmpDir, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "in_real.ts"), []byte("// in_real"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Two symlinks to the same target — both must be skipped, regardless
+	// of which a concurrent walker would visit first.
+	if err := os.Symlink(realDir, filepath.Join(tmpDir, "link_a")); err != nil {
+		t.Fatalf("symlink a: %v", err)
+	}
+	if err := os.Symlink(realDir, filepath.Join(tmpDir, "link_b")); err != nil {
+		t.Fatalf("symlink b: %v", err)
+	}
+
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},
+	}
+
+	for _, single := range []bool{false, true} {
+		gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(),
+			map[string]struct{}{}, nil, nil, single)
+		assert.Equal(t, len(gapFiles), 1, "singleThreaded=%v: only the real path should produce a gap file", single)
+		realPath := tspath.NormalizePath(filepath.Join(realDir, "in_real.ts"))
+		assert.Equal(t, gapFiles[0], realPath, "singleThreaded=%v: gap file should be the canonical realpath", single)
+	}
+}
+
+// singleThreaded=true and singleThreaded=false must produce the same gap-file
+// set. The concurrent walker is correctness-preserving; --singleThreaded is a
+// performance/debuggability knob, not a behavioral one.
+func TestDiscoverGapFiles_SingleThreadedEquivalence(t *testing.T) {
+	configDir, _ := setupDiscoveryFixture(t, []string{
+		"src/a.ts",
+		"src/nested/deep/b.ts",
+		"scripts/c.ts",
+		"scripts/sub/d.ts",
+		"tools/e.ts",
+		"tools/skip/f.ts",
+	})
+	config := RslintConfig{
+		{Ignores: []string{"**/skip/**"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},
+	}
+
+	parallelGaps := DiscoverGapFiles(config, configDir, osvfs.FS(),
+		map[string]struct{}{}, nil, nil, false)
+	serialGaps := DiscoverGapFiles(config, configDir, osvfs.FS(),
+		map[string]struct{}{}, nil, nil, true)
+
+	// Both already sorted by DiscoverGapFiles; equality is exact.
+	assert.Equal(t, len(parallelGaps), len(serialGaps), "must produce same count")
+	for i := range parallelGaps {
+		assert.Equal(t, parallelGaps[i], serialGaps[i], "diverged at i=%d", i)
+	}
+}
+
+// allowFiles fast path must produce a deterministic, sorted result. The
+// implementation iterates a map, so without an explicit sort the output
+// order is randomized across runs.
+func TestDiscoverGapFiles_AllowFilesFastPathSorted(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"a.ts",
+		"b.ts",
+		"c.ts",
+		"d.ts",
+		"e.ts",
+	})
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},
+	}
+	allow := []string{paths["e.ts"], paths["a.ts"], paths["c.ts"], paths["b.ts"], paths["d.ts"]}
+	expected := []string{paths["a.ts"], paths["b.ts"], paths["c.ts"], paths["d.ts"], paths["e.ts"]}
+	sort.Strings(expected)
+
+	// Run multiple times to give Go's randomized map iteration a chance to
+	// surface non-determinism if the sort is missing.
+	for i := range 8 {
+		got := DiscoverGapFiles(config, configDir, osvfs.FS(),
+			map[string]struct{}{}, allow, nil, false)
+		assert.Equal(t, len(got), len(expected), "run %d: count mismatch", i)
+		for j := range expected {
+			assert.Equal(t, got[j], expected[j], "run %d, idx %d: not in lexical order", i, j)
+		}
+	}
+}
+
+// walkPool must hold concurrent execution of `work` to at most `workers`
+// at any moment. Tested with an atomic counter inside the work function —
+// independent of process-wide goroutine count, so it is robust under
+// `go test -race`, varied GOMAXPROCS, and CI background noise.
+func TestWalkPool_BoundsConcurrency(t *testing.T) {
+	const (
+		workers   = 4
+		dirCount  = 200
+		hold      = 2 * time.Millisecond // make work observable
+		fanout    = 3
+		maxDepth  = 3 // 3^3 = 27 leaves per root × 200 roots ≈ thousands of jobs
+	)
+
+	pool := newWalkPool(workers)
+	// Seed with `dirCount` independent root jobs so the queue has enough
+	// fan-out to actually exercise concurrency.
+	roots := make([]string, dirCount)
+	for i := range roots {
+		roots[i] = "r/" + strconvI(i)
+	}
+	pool.submitMany(roots)
+
+	var (
+		active    atomic.Int32
+		maxActive atomic.Int32
+		jobsRun   atomic.Int32
+	)
+
+	work := func(dir string) []string {
+		cur := active.Add(1)
+		// Track high-water mark.
+		for {
+			old := maxActive.Load()
+			if cur <= old || maxActive.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		// Hold the slot briefly to let other workers pile up if they could.
+		time.Sleep(hold)
+		active.Add(-1)
+		jobsRun.Add(1)
+
+		// Fan out a few children up to maxDepth so the pool keeps having
+		// work to dispatch.
+		depth := strings.Count(dir, "/")
+		if depth >= maxDepth+1 { // r/<i> already has 1 slash
+			return nil
+		}
+		out := make([]string, fanout)
+		for k := range fanout {
+			out[k] = dir + "/" + strconvI(k)
+		}
+		return out
+	}
+
+	pool.run(work)
+
+	if got := maxActive.Load(); got > workers {
+		t.Fatalf("walkPool exceeded its concurrency cap: maxActive=%d > workers=%d", got, workers)
+	}
+	// Sanity: it actually did work.
+	if got := jobsRun.Load(); got < int32(dirCount) {
+		t.Fatalf("walkPool did not process all jobs: jobsRun=%d < dirCount=%d", got, dirCount)
+	}
+}
+
+// Verifies the workers==1 specialization in walkPool.run: the pool must
+// drive all work on the calling goroutine without spawning any helper.
+// We assert by checking the caller goroutine ID is the only one observed
+// inside the work function via runtime.Stack.
+func TestWalkPool_SingleWorkerNoGoroutine(t *testing.T) {
+	pool := newWalkPool(1)
+	pool.submitMany([]string{"a", "b", "c"})
+
+	caller := goroutineID()
+	seen := make(map[int]struct{})
+	work := func(dir string) []string {
+		seen[goroutineID()] = struct{}{}
+		return nil
+	}
+	pool.run(work)
+
+	if _, ok := seen[caller]; !ok {
+		t.Fatalf("work was not run on caller goroutine; seen=%v, caller=%d", seen, caller)
+	}
+	if len(seen) != 1 {
+		t.Fatalf("workers=1 must run all work on a single goroutine; observed %d goroutines: %v", len(seen), seen)
+	}
+}
+
+// goroutineID parses the current goroutine ID from runtime.Stack output.
+// Used only by tests to verify the workers==1 specialization.
+func goroutineID() int {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	// Format: "goroutine 12 [running]:"
+	s := string(buf[:n])
+	const prefix = "goroutine "
+	s = strings.TrimPrefix(s, prefix)
+	end := strings.IndexByte(s, ' ')
+	if end < 0 {
+		return -1
+	}
+	id, err := strconv.Atoi(s[:end])
+	if err != nil {
+		return -1
+	}
+	return id
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -196,7 +196,11 @@ func (loader *ConfigLoader) expandProjectGlob(configDirectory string, pattern st
 	}
 
 	relativePattern := strings.TrimPrefix(resolvedPattern, searchRoot+"/")
-	fsys := &vfsAdapter{vfs: loader.fs, root: searchRoot}
+	// expandProjectGlob historically follows symlinks (e.g. tsconfig
+	// referenced via packages/*/tsconfig.json where packages may be
+	// symlinks in pnpm workspaces). It runs single-threaded under
+	// doublestar.GlobWalk, so the cycle dedupe is deterministic.
+	fsys := &vfsAdapter{vfs: loader.fs, root: searchRoot, followSymlinks: true}
 
 	matches := []string{}
 	err := doublestar.GlobWalk(fsys, relativePattern, func(path string, d fs.DirEntry) error {

--- a/internal/config/vfs_adapter.go
+++ b/internal/config/vfs_adapter.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/fs"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/microsoft/typescript-go/shim/tspath"
@@ -11,20 +12,36 @@ import (
 )
 
 // vfsAdapter adapts a vfs.FS to a standard fs.FS rooted at a given directory,
-// used by fs.WalkDir in DiscoverGapFiles and doublestar.GlobWalk in
-// expandProjectGlob. It is NOT a general-purpose fs.FS implementation —
-// Open() always returns a directory handle (vfsDirFile) because both
-// callers only open directories (WalkDir by design, GlobWalk because
-// expandProjectGlob is only called when the pattern contains glob
-// meta characters).
+// used by the gap-file walker in DiscoverGapFiles and by doublestar.GlobWalk
+// in expandProjectGlob. It is NOT a general-purpose fs.FS implementation —
+// Open() always returns a directory handle (vfsDirFile) because both callers
+// only open directories.
 //
-// It tracks visited symlink targets to prevent infinite recursion caused by
-// symlink cycles, since the underlying VFS follows symlinks transparently
-// and doublestar cannot detect them through this adapter.
+// followSymlinks controls how directory symlinks are handled in ReadDir:
+//
+//   - false (default, used by DiscoverGapFiles): symlinked subdirectories are
+//     skipped entirely. This matches ESLint v10's flat-config file walker:
+//     it uses @humanfs/node, whose walk() recurses only when
+//     Dirent.isDirectory() is true — and Dirent.isDirectory() returns false
+//     for symbolic links because Node's readdir({withFileTypes: true})
+//     reports the dirent type without following links. The result for the
+//     gap-file walker is the same: symlinked directories are not entered,
+//     output is deterministic regardless of the concurrency model, and
+//     cycles cannot occur.
+//
+//   - true (used by expandProjectGlob): symlinks are followed, with cycle
+//     detection via visitedSymTargets. expandProjectGlob runs single-threaded
+//     under doublestar.GlobWalk, so the dedupe decision order is bounded by
+//     the FS layout (no goroutine scheduling concern).
+//
+// visitedSymTargets uses sync.Map so the followSymlinks=true path is also
+// safe under future concurrent callers, but it is currently exercised only
+// by the single-threaded loader.
 type vfsAdapter struct {
 	vfs               vfs.FS
 	root              string
-	visitedSymTargets map[string]struct{}
+	followSymlinks    bool
+	visitedSymTargets sync.Map
 }
 
 var _ fs.FS = (*vfsAdapter)(nil)
@@ -77,10 +94,6 @@ func (f *vfsDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 		accessible := f.adapter.vfs.GetAccessibleEntries(f.path)
 		parentRealPath := f.adapter.vfs.Realpath(f.path)
 
-		if f.adapter.visitedSymTargets == nil {
-			f.adapter.visitedSymTargets = make(map[string]struct{})
-		}
-
 		f.entries = make([]fs.DirEntry, 0, len(accessible.Directories)+len(accessible.Files))
 
 		for _, dir := range accessible.Directories {
@@ -88,14 +101,21 @@ func (f *vfsDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 			dirRealPath := f.adapter.vfs.Realpath(dirPath)
 
 			// A regular subdirectory's realpath equals parentRealPath + "/" + name.
-			// If it differs, the entry is a symlink. Track symlink targets to
-			// detect cycles: if the target was already visited, skip the entry.
+			// If it differs, the entry is a symlink.
 			expectedRealPath := parentRealPath + "/" + dir
-			if dirRealPath != expectedRealPath {
-				if _, seen := f.adapter.visitedSymTargets[dirRealPath]; seen {
+			isSymlink := dirRealPath != expectedRealPath
+
+			if isSymlink {
+				if !f.adapter.followSymlinks {
+					// Skip symlinks entirely. See the type doc on vfsAdapter
+					// for why this is the default for DiscoverGapFiles.
 					continue
 				}
-				f.adapter.visitedSymTargets[dirRealPath] = struct{}{}
+				// Cycle dedupe: LoadOrStore returns loaded=true on second
+				// encounter of the same realpath; skip in that case.
+				if _, loaded := f.adapter.visitedSymTargets.LoadOrStore(dirRealPath, struct{}{}); loaded {
+					continue
+				}
 			}
 
 			f.entries = append(f.entries, &vfsDirEntry{name: dir, isDir: true})

--- a/internal/config/vfs_adapter_test.go
+++ b/internal/config/vfs_adapter_test.go
@@ -135,25 +135,58 @@ func TestVfsDirFile_ReadDirPaginated(t *testing.T) {
 	assert.Assert(t, len(entries) == 0)
 }
 
-func TestVfsAdapter_SymlinkCycleFiltered(t *testing.T) {
+// Default vfsAdapter (followSymlinks=false) skips symlinks entirely. This is
+// what DiscoverGapFiles relies on for deterministic concurrent traversal.
+func TestVfsAdapter_SymlinksSkippedByDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirA := filepath.Join(tmpDir, "a")
+	assert.NilError(t, os.MkdirAll(dirA, 0o755))
+	// a/link -> tmpDir/a (any symlinked dir; cycle isn't required for this test)
+	assert.NilError(t, os.Symlink(dirA, filepath.Join(dirA, "link")))
+	createTestFile(t, filepath.Join(dirA, "real.ts"))
+
+	adapter := &vfsAdapter{vfs: osvfs.FS(), root: tmpDir}
+
+	f, err := adapter.Open("a")
+	assert.NilError(t, err)
+	defer f.Close()
+
+	entries, err := f.(fs.ReadDirFile).ReadDir(-1)
+	assert.NilError(t, err)
+
+	hasLink := false
+	hasReal := false
+	for _, e := range entries {
+		if e.Name() == "link" {
+			hasLink = true
+		}
+		if e.Name() == "real.ts" {
+			hasReal = true
+		}
+	}
+	assert.Assert(t, !hasLink, "symlinks must be skipped when followSymlinks=false")
+	assert.Assert(t, hasReal, "regular files must still be returned")
+}
+
+// Opt-in vfsAdapter (followSymlinks=true) follows symlinks but dedupes cycles.
+// This is what loader.expandProjectGlob uses (single-threaded).
+func TestVfsAdapter_SymlinkCycleFilteredWhenFollowing(t *testing.T) {
 	tmpDir := t.TempDir()
 	dirA := filepath.Join(tmpDir, "a")
 	assert.NilError(t, os.MkdirAll(dirA, 0o755))
 	// a/loop -> tmpDir creates a cycle: a/loop/a/loop/...
 	assert.NilError(t, os.Symlink(tmpDir, filepath.Join(dirA, "loop")))
 
-	adapter := &vfsAdapter{vfs: osvfs.FS(), root: tmpDir}
+	adapter := &vfsAdapter{vfs: osvfs.FS(), root: tmpDir, followSymlinks: true}
 
-	// Open "a" and read its entries
+	// Open "a" and read its entries — first encounter of the symlink is kept.
 	f, err := adapter.Open("a")
 	assert.NilError(t, err)
 	defer f.Close()
 
-	dirFile := f.(fs.ReadDirFile)
-	entries, err := dirFile.ReadDir(-1)
+	entries, err := f.(fs.ReadDirFile).ReadDir(-1)
 	assert.NilError(t, err)
 
-	// "loop" symlink target is tmpDir, which hasn't been visited yet → included
 	hasLoop := false
 	for _, e := range entries {
 		if e.Name() == "loop" {
@@ -162,16 +195,14 @@ func TestVfsAdapter_SymlinkCycleFiltered(t *testing.T) {
 	}
 	assert.Assert(t, hasLoop, "first encounter of symlink should be included")
 
-	// Now open "a/loop" (which resolves to tmpDir) and read its entries
+	// Open "a/loop" (resolves to tmpDir) and read its entries.
 	f2, err := adapter.Open("a/loop")
 	assert.NilError(t, err)
 	defer f2.Close()
 
-	dirFile2 := f2.(fs.ReadDirFile)
-	entries2, err := dirFile2.ReadDir(-1)
+	entries2, err := f2.(fs.ReadDirFile).ReadDir(-1)
 	assert.NilError(t, err)
 
-	// Inside a/loop (=tmpDir), there's "a" directory.
 	hasA := false
 	for _, e := range entries2 {
 		if e.Name() == "a" {
@@ -180,18 +211,17 @@ func TestVfsAdapter_SymlinkCycleFiltered(t *testing.T) {
 	}
 	assert.Assert(t, hasA, "should see 'a' directory inside the symlink target")
 
-	// Open a/loop/a and verify "loop" is now filtered
+	// Open a/loop/a — second encounter of the cycle target → deduped.
 	f3, err := adapter.Open("a/loop/a")
 	assert.NilError(t, err)
 	defer f3.Close()
 
-	dirFile3 := f3.(fs.ReadDirFile)
-	entries3, err := dirFile3.ReadDir(-1)
+	entries3, err := f3.(fs.ReadDirFile).ReadDir(-1)
 	assert.NilError(t, err)
 
 	for _, e := range entries3 {
 		if e.Name() == "loop" {
-			t.Fatal("symlink cycle should have been filtered out")
+			t.Fatal("symlink cycle should have been deduped on second encounter")
 		}
 	}
 }

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -296,3 +296,7 @@ vname
 useeffectevent
 tinyglobby
 fdir
+goroutines
+GOMAXPROCS
+fanout
+humanfs


### PR DESCRIPTION
## Summary

Three Go-side parallelizations that take the linting pipeline from strictly serial to bounded-concurrent. None invoke `typescript-go`'s public API concurrently — `createProgramsForConfig` still runs serially across configs, so this PR does not require typescript-go to support concurrent invocation.

### What runs in parallel now

1. **`ReadGitignoreAsGlobs` ‖ `createProgramsForConfig`** (single-config, multi-config, JSON-config paths). No data dependency: `createProgramsForConfig` only reads `languageOptions.parserOptions.project`, never `Ignores` (verified in `LoadTsConfigsFromRslintConfig`). For multi-config, gitignore reads are parallelized across configs and merged after the createPrograms loop completes.

2. **`DiscoverGapFiles`** uses a fixed-size worker pool (`walkPool`) that walks the directory tree. **Live goroutines are capped at `workers`**, not the number of directories. `workers = max(2, GOMAXPROCS)`; `--singleThreaded` forces `workers = 1` and runs the loop on the calling goroutine — no goroutines spawned at all.

3. **`DiscoverGapFilesMultiConfig`** iterates configs serially. Each call uses its own walker, so total live goroutines remain bounded by `workers`, not `len(configMap) × workers`.

### `--singleThreaded` is honored everywhere

| Parallelism point | Effect when `--singleThreaded` is set |
|---|---|
| `parallelGitignoreAndPrograms` | Both stages run sequentially in the main goroutine; no goroutines spawned. |
| Multi-config gitignore fan-out | Replaced by a sequential for-loop. |
| `DiscoverGapFiles` walker | `workers = 1`; `walkPool.run` runs the loop directly on the caller, no goroutines spawned. |
| `DiscoverGapFilesMultiConfig` | Already serial across configs; inner walker is also `workers = 1`. |
| Linter work group (existing) | Unchanged — already collapsed to serial via `core.NewWorkGroup(true)`. |

End result: with `--singleThreaded`, the Go side spawns no goroutines beyond what typescript-go itself creates for syntactic / semantic work.

### Symlink determinism

`vfsAdapter` gains a `followSymlinks` field. The walker used by `DiscoverGapFiles` sets `followSymlinks = false`: symlinked subdirectories are skipped entirely. This matches **ESLint v10's flat-config file walker**, which uses `@humanfs/node` and recurses only when `Dirent.isDirectory()` is true — and Node's `readdir({withFileTypes: true})` reports the dirent type without following links, so `Dirent.isDirectory()` returns false for symlinks. Determinism is guaranteed by construction; no cycle tracking is needed for the gap-file walk.

The other call site that needs symlink following (`loader.expandProjectGlob`, used by `parserOptions.project` glob resolution) opts in with `followSymlinks=true`. It runs single-threaded under `doublestar.GlobWalk`, so deterministic cycle dedupe is preserved on that path.

### Behavior change

- **Files reachable only via a symlink inside the lint scope are no longer discovered as gap files.** Concretely: a file is affected if and only if the walker cannot reach it without traversing a symlinked directory (the symlink target may be inside or outside the repo). Files reachable directly are unaffected; files in `tsconfig include` are unaffected (typescript-go loads those itself, not via the gap walker). If you rely on a symlink to bring code into lint scope, make the path directly reachable — by adding it to a tsconfig `include`, or by removing the gitignore rule that hides the canonical location.

No other observable behavior changes. `gapFiles` is sorted before return so output ordering is deterministic.

### Documentation

`architecture.md` Section "Concurrency Model" is rewritten to enumerate the four parallelism points (linter work group + the three new ones) and the precise effect of `--singleThreaded` at each.

### Performance

Measured on `webinfra/rspack` (~16k non-blacklisted dirs, 251 first-level `node_modules`), `bin/rslint.cjs` no-args, **interleaved sampling** (alternate BEFORE/AFTER per run, n=10 each), warm cache, on M-series macOS. Baseline is current `main` (already includes `tinyglobby` from #812).

| Group                                  | n  | median | mean   | std  | min  | max  |
|----------------------------------------|---:|-------:|-------:|-----:|-----:|-----:|
| BEFORE (`main`: tinyglobby only)       | 10 | 7.89 s | 7.97 s | 0.50 | 7.34 | 8.89 |
| AFTER  (this PR: + Go parallel)        | 10 | **4.83 s** | **4.86 s** | 0.17 | 4.65 | 5.22 |
| **Δ mean**                             |    |        | **−3.11 s** |      |      |      |
| **Δ %**                                |    |        | **−39.0%** |      |      |      |
| Welch t                                |    |        | **−18.73** |      |      |      |

Variance also drops markedly (std 0.50 → 0.17).

#### Cumulative (#812 + #815)

| Stage                                    | mean | cumulative Δ vs original `main` |
|------------------------------------------|-----:|--------------------------------:|
| original `main` (before #812 #815)       | ~9.62 s | — |
| `main` after #812 (tinyglobby)           | 7.97 s | −1.65 s (−17%) |
| `main` after #812 + this PR              | **4.86 s** | **−4.76 s (−49%)** |

The two PRs together roughly halve the wall-clock end-to-end on this monorepo.

### What this PR does NOT do

- Does not touch `typescript-go` source.
- Does not invoke `utils.CreateProgram` / `createProgramsForConfig` concurrently across configs (deferred — would require verifying typescript-go's concurrent-invocation safety).
- Does not change the JS-side config discovery (already merged in #812).
- Does not parallelize across configs in `DiscoverGapFilesMultiConfig` (kept serial to guarantee `live goroutines ≤ workers`; can be added later if benchmarks justify it).

## Related Links

- Companion JS-side optimization (already merged): #812 (`tinyglobby` for `findJSConfigsInDir`).

## Checklist

- [x] Tests updated. Concurrency-correctness tests added (symlink skip default + opt-in follow, gap walker symlink behavior, `--singleThreaded` equivalence, `walkPool` concurrency cap, single-worker no-goroutine, allowFiles fast-path determinism).
- [x] Documentation updated. `architecture.md` Concurrency Model section rewritten.