### PR TITLE
docs: unify plugin rule doc titles and refactor rules-and-presets page

### DIFF
--- a/internal/plugins/import/rules/first/first.md
+++ b/internal/plugins/import/rules/first/first.md
@@ -1,4 +1,4 @@
-# import/first
+# first
 
 ## Rule Details
 

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.md
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.md
@@ -1,4 +1,4 @@
-# import/no-duplicates
+# no-duplicates
 
 ## Rule Details
 

--- a/internal/plugins/import/rules/no_self_import/no_self_import.md
+++ b/internal/plugins/import/rules/no_self_import/no_self_import.md
@@ -1,4 +1,4 @@
-# import/no-self-import
+# no-self-import
 
 ## Rule Details
 

--- a/internal/plugins/import/rules/no_webpack_loader_syntax/no_webpack_loader_syntax.md
+++ b/internal/plugins/import/rules/no_webpack_loader_syntax/no_webpack_loader_syntax.md
@@ -1,4 +1,4 @@
-# import/no-webpack-loader-syntax
+# no-webpack-loader-syntax
 
 ## Rule Details
 

--- a/internal/plugins/jest/rules/no_alias_methods/no_alias_methods.md
+++ b/internal/plugins/jest/rules/no_alias_methods/no_alias_methods.md
@@ -1,4 +1,4 @@
-# jest/no-alias-methods
+# no-alias-methods
 
 ## Rule Details
 

--- a/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.md
+++ b/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.md
@@ -1,4 +1,4 @@
-# jest/no-disabled-tests
+# no-disabled-tests
 
 ## Rule Details
 

--- a/internal/plugins/jest/rules/no_focused_tests/no_focused_tests.md
+++ b/internal/plugins/jest/rules/no_focused_tests/no_focused_tests.md
@@ -1,4 +1,4 @@
-# jest/no-focused-tests
+# no-focused-tests
 
 ## Rule Details
 

--- a/internal/plugins/jest/rules/no_hooks/no_hooks.md
+++ b/internal/plugins/jest/rules/no_hooks/no_hooks.md
@@ -1,4 +1,4 @@
-# jest/no-hooks
+# no-hooks
 
 ## Rule Details
 

--- a/internal/plugins/jest/rules/no_test_prefixes/no_test_prefixes.md
+++ b/internal/plugins/jest/rules/no_test_prefixes/no_test_prefixes.md
@@ -1,4 +1,4 @@
-# jest/no-test-prefixes
+# no-test-prefixes
 
 ## Rule Details
 

--- a/internal/plugins/jest/rules/prefer_strict_equal/prefer_strict_equal.md
+++ b/internal/plugins/jest/rules/prefer_strict_equal/prefer_strict_equal.md
@@ -1,4 +1,4 @@
-# jest/prefer-strict-equal
+# prefer-strict-equal
 
 ## Rule Details
 

--- a/internal/plugins/jest/rules/prefer_to_have_length/prefer_to_have_length.md
+++ b/internal/plugins/jest/rules/prefer_to_have_length/prefer_to_have_length.md
@@ -1,4 +1,4 @@
-# jest/prefer-to-have-length
+# prefer-to-have-length
 
 ## Rule Details
 

--- a/internal/plugins/jest/rules/prefer_todo/prefer_todo.md
+++ b/internal/plugins/jest/rules/prefer_todo/prefer_todo.md
@@ -1,4 +1,4 @@
-# jest/prefer-todo
+# prefer-todo
 
 ## Rule Details
 

--- a/internal/plugins/jest/rules/valid_describe_callback/valid_describe_callback.md
+++ b/internal/plugins/jest/rules/valid_describe_callback/valid_describe_callback.md
@@ -1,4 +1,4 @@
-# jest/valid-describe-callback
+# valid-describe-callback
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/button_has_type/button_has_type.md
+++ b/internal/plugins/react/rules/button_has_type/button_has_type.md
@@ -1,4 +1,4 @@
-# react/button-has-type
+# button-has-type
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_boolean_value/jsx_boolean_value.md
+++ b/internal/plugins/react/rules/jsx_boolean_value/jsx_boolean_value.md
@@ -1,4 +1,4 @@
-# react/jsx-boolean-value
+# jsx-boolean-value
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_closing_tag_location/jsx_closing_tag_location.md
+++ b/internal/plugins/react/rules/jsx_closing_tag_location/jsx_closing_tag_location.md
@@ -1,4 +1,4 @@
-# react/jsx-closing-tag-location
+# jsx-closing-tag-location
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_curly_brace_presence/jsx_curly_brace_presence.md
+++ b/internal/plugins/react/rules/jsx_curly_brace_presence/jsx_curly_brace_presence.md
@@ -1,4 +1,4 @@
-# react/jsx-curly-brace-presence
+# jsx-curly-brace-presence
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_equals_spacing/jsx_equals_spacing.md
+++ b/internal/plugins/react/rules/jsx_equals_spacing/jsx_equals_spacing.md
@@ -1,4 +1,4 @@
-# react/jsx-equals-spacing
+# jsx-equals-spacing
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_filename_extension/jsx_filename_extension.md
+++ b/internal/plugins/react/rules/jsx_filename_extension/jsx_filename_extension.md
@@ -1,4 +1,4 @@
-# react/jsx-filename-extension
+# jsx-filename-extension
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_first_prop_new_line/jsx_first_prop_new_line.md
+++ b/internal/plugins/react/rules/jsx_first_prop_new_line/jsx_first_prop_new_line.md
@@ -1,4 +1,4 @@
-# react/jsx-first-prop-new-line
+# jsx-first-prop-new-line
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_max_props_per_line/jsx_max_props_per_line.md
+++ b/internal/plugins/react/rules/jsx_max_props_per_line/jsx_max_props_per_line.md
@@ -1,4 +1,4 @@
-# react/jsx-max-props-per-line
+# jsx-max-props-per-line
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind.md
+++ b/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind.md
@@ -1,4 +1,4 @@
-# react/jsx-no-bind
+# jsx-no-bind
 
 Disallow `.bind()` or arrow functions in JSX props.
 

--- a/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url.md
+++ b/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url.md
@@ -1,4 +1,4 @@
-# react/jsx-no-script-url
+# jsx-no-script-url
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.md
+++ b/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.md
@@ -1,4 +1,4 @@
-# react/jsx-pascal-case
+# jsx-pascal-case
 
 Enforce PascalCase for user-defined JSX components.
 

--- a/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces.md
+++ b/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces.md
@@ -1,4 +1,4 @@
-# react/jsx-props-no-multi-spaces
+# jsx-props-no-multi-spaces
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_uses_react/jsx_uses_react.md
+++ b/internal/plugins/react/rules/jsx_uses_react/jsx_uses_react.md
@@ -1,4 +1,4 @@
-# react/jsx-uses-react
+# jsx-uses-react
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_uses_vars/jsx_uses_vars.md
+++ b/internal/plugins/react/rules/jsx_uses_vars/jsx_uses_vars.md
@@ -1,4 +1,4 @@
-# react/jsx-uses-vars
+# jsx-uses-vars
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/jsx_wrap_multilines/jsx_wrap_multilines.md
+++ b/internal/plugins/react/rules/jsx_wrap_multilines/jsx_wrap_multilines.md
@@ -1,4 +1,4 @@
-# react/jsx-wrap-multilines
+# jsx-wrap-multilines
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/no_deprecated/no_deprecated.md
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated.md
@@ -1,4 +1,4 @@
-# react/no-deprecated
+# no-deprecated
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.md
+++ b/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.md
@@ -1,4 +1,4 @@
-# react/no-redundant-should-component-update
+# no-redundant-should-component-update
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs.md
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs.md
@@ -1,4 +1,4 @@
-# react/no-string-refs
+# no-string-refs
 
 Disallow using deprecated string refs.
 

--- a/internal/plugins/react/rules/no_typos/no_typos.md
+++ b/internal/plugins/react/rules/no_typos/no_typos.md
@@ -1,4 +1,4 @@
-# react/no-typos
+# no-typos
 
 Disallow common typos in React component declarations.
 

--- a/internal/plugins/react/rules/no_unescaped_entities/no_unescaped_entities.md
+++ b/internal/plugins/react/rules/no_unescaped_entities/no_unescaped_entities.md
@@ -1,4 +1,4 @@
-# react/no-unescaped-entities
+# no-unescaped-entities
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/no_unknown_property/no_unknown_property.md
+++ b/internal/plugins/react/rules/no_unknown_property/no_unknown_property.md
@@ -1,4 +1,4 @@
-# react/no-unknown-property
+# no-unknown-property
 
 Disallow usage of unknown DOM property.
 

--- a/internal/plugins/react/rules/react_in_jsx_scope/react_in_jsx_scope.md
+++ b/internal/plugins/react/rules/react_in_jsx_scope/react_in_jsx_scope.md
@@ -1,4 +1,4 @@
-# react/react-in-jsx-scope
+# react-in-jsx-scope
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/require_render_return/require_render_return.md
+++ b/internal/plugins/react/rules/require_render_return/require_render_return.md
@@ -1,4 +1,4 @@
-# react/require-render-return
+# require-render-return
 
 Enforce that the render method of an ES5 or ES6 React component returns a value.
 

--- a/internal/plugins/react/rules/self_closing_comp/self_closing_comp.md
+++ b/internal/plugins/react/rules/self_closing_comp/self_closing_comp.md
@@ -1,4 +1,4 @@
-# react/self-closing-comp
+# self-closing-comp
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/style_prop_object/style_prop_object.md
+++ b/internal/plugins/react/rules/style_prop_object/style_prop_object.md
@@ -1,4 +1,4 @@
-# react/style-prop-object
+# style-prop-object
 
 ## Rule Details
 

--- a/internal/plugins/react/rules/void_dom_elements_no_children/void_dom_elements_no_children.md
+++ b/internal/plugins/react/rules/void_dom_elements_no_children/void_dom_elements_no_children.md
@@ -1,4 +1,4 @@
-# react/void-dom-elements-no-children
+# void-dom-elements-no-children
 
 ## Rule Details
 

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.md
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.md
@@ -1,4 +1,4 @@
-# react-hooks/exhaustive-deps
+# exhaustive-deps
 
 ## Rule Details
 

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md
@@ -1,4 +1,4 @@
-# react-hooks/rules-of-hooks
+# rules-of-hooks
 
 Enforce React's Rules of Hooks: hooks must only be called at the top level of
 React function components or custom Hooks, never inside loops, conditions,

--- a/internal/plugins/unicorn/rules/filename_case/filename_case.md
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.md
@@ -89,5 +89,5 @@ When `true`, additional `.`-separated parts of the basename are treated as part 
 
 ## Original Documentation
 
-- ESLint plugin documentation: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/filename-case.md>
-- Source code: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/filename-case.js>
+- [eslint-plugin-unicorn: filename-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/filename-case.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/filename-case.js)

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.md
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.md
@@ -90,5 +90,5 @@ is still reported in all of them.
 
 ## Original Documentation
 
-- ESLint plugin documentation: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-static-only-class.md>
-- Source code: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-static-only-class.js>
+- [eslint-plugin-unicorn: no-static-only-class](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-static-only-class.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-static-only-class.js)

--- a/website/docs/en/config/rules-and-presets.mdx
+++ b/website/docs/en/config/rules-and-presets.mdx
@@ -1,19 +1,17 @@
+import PresetTable, {
+  PresetImportSnippet,
+} from '@/theme/components/PresetTable.tsx';
+import PluginPrefixTable from '@/theme/components/PluginPrefixTable.tsx';
+
 # Rules & Presets
 
 ## Available Presets
 
-| Preset                             | Description                                               |                                                                 |
-| ---------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------- |
-| `ts.configs.recommended`           | TypeScript recommended rules (includes ESLint core rules) | [View rules →](/rules/?preset=ts.configs.recommended)           |
-| `js.configs.recommended`           | JavaScript recommended rules                              | [View rules →](/rules/?preset=js.configs.recommended)           |
-| `reactPlugin.configs.recommended`  | React rules                                               | [View rules →](/rules/?preset=reactPlugin.configs.recommended)  |
-| `importPlugin.configs.recommended` | Import/export rules                                       | [View rules →](/rules/?preset=importPlugin.configs.recommended) |
+<PresetTable />
 
 Import presets from `@rslint/core`:
 
-```ts
-import { defineConfig, ts, js, reactPlugin, importPlugin } from '@rslint/core';
-```
+<PresetImportSnippet />
 
 ## rules
 
@@ -56,13 +54,7 @@ rules: {
 
 Plugin names to enable. Available plugins:
 
-| Plugin               | Rules Prefix           |
-| -------------------- | ---------------------- |
-| `@typescript-eslint` | `@typescript-eslint/*` |
-| `import`             | `import/*`             |
-| `jest`               | `jest/*`               |
-| `promise`            | `promise/*`            |
-| `react`              | `react/*`              |
+<PluginPrefixTable />
 
 ESLint core rules (e.g. `no-unused-vars`, `prefer-const`, `no-var`) have no prefix and do not belong to any plugin — they can be enabled directly in `rules` without listing anything in `plugins`.
 

--- a/website/plugin-rule-manifest.ts
+++ b/website/plugin-rule-manifest.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import * as rslintCore from '@rslint/core';
 import type { RslintConfigEntry } from '@rslint/core';
-import { PLUGIN_REGISTRY } from './theme/plugin-registry';
+import { PLUGIN_REGISTRY, groupToRouteSlug } from './theme/plugin-registry';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const MANIFEST_PATH = path.resolve(__dirname, 'generated/rule-manifest.json');
@@ -21,14 +21,6 @@ interface RuleEntry {
   docPath: string | null;
   /** Presets that include this rule, with their configured values. */
   presets: { name: string; value: unknown }[];
-}
-
-/**
- * Convert a plugin group name to a URL-safe slug.
- * e.g. "@typescript-eslint" → "typescript-eslint"
- */
-function groupToRouteSlug(group: string): string {
-  return group.replace(/^@/, '');
 }
 
 const PLUGINS = PLUGIN_REGISTRY.map((p) => {
@@ -101,14 +93,16 @@ function loadManifest(): RuleEntry[] {
   const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf-8'));
   const rules: RuleEntry[] = manifest.rules;
 
-  // Enrich with preset data (level + configured value)
+  // Attach the list of presets that enable each rule, with the raw
+  // configured value (severity string or [severity, options] tuple).
   const presetMap = extractPresetRules();
   for (const rule of rules) {
     const key = `${rule.group}:${rule.name}`;
     rule.presets = presetMap.get(key) || [];
   }
 
-  // Write enriched manifest back for React components
+  // Persist the enriched manifest so runtime consumers (e.g. the rules
+  // explorer in RuleStates/rule.tsx) can read presets directly.
   fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + '\n');
 
   return rules;
@@ -116,7 +110,9 @@ function loadManifest(): RuleEntry[] {
 
 /**
  * Transform a rule's source .md into a .mdx string that imports and renders
- * the <RuleConfig> component right after the first heading.
+ * the <RuleConfig> component right after the first heading. When the rule
+ * is enabled by one or more presets, a markdown table summarizing each
+ * preset and its configured value is inserted before <RuleConfig>.
  *
  * Input (source .md):
  *   # no-console
@@ -130,7 +126,11 @@ function loadManifest(): RuleEntry[] {
  *
  *   ## Configuration
  *
- *   <RuleConfig name="no-console" group="eslint" presets={["recommended"]} />
+ *   | Preset                   | Configured Value |
+ *   | ------------------------ | ---------------- |
+ *   | ✅ js.configs.recommended | `"error"`        |
+ *
+ *   <RuleConfig name="no-console" group="eslint" />
  *
  *   ## Rule Details
  *   ...
@@ -270,11 +270,16 @@ function writeRuleDocsToDir(rules: RuleEntry[]): void {
 }
 
 /**
- * Rspress plugin that generates rule documentation pages from Go source:
+ * Rspress plugin that generates rule documentation pages from Go source.
+ * Inside the `config` hook (run before Rspress resolves the route tree)
+ * it:
  *
  * 1. Runs scripts/gen-rule-manifest.js to produce generated/rule-manifest.json
- * 2. Writes .mdx files + _meta.json into docs/en/rules/<group>/ in beforeBuild,
- *    so Rspress auto-sidebar handles /rules/ the same way as /guide/ and /config/
+ *    and reads it back, enriching each entry with preset information.
+ * 2. Writes .mdx files + _meta.json into docs/en/rules/<slug>/, so the
+ *    Rspress auto-sidebar handles /rules/ the same way as /guide/ and
+ *    /config/. Each <slug> is derived from `rule.group` via
+ *    {@link groupToRouteSlug}.
  *
  * Each generated .mdx imports <RuleConfig> via the @/ alias to render a
  * copyable configuration snippet for the rule.

--- a/website/theme/components/PluginPrefixTable.tsx
+++ b/website/theme/components/PluginPrefixTable.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { PLUGIN_REGISTRY } from '../plugin-registry';
+
+const PREFIXED_PLUGINS = PLUGIN_REGISTRY.filter((p) => p.prefix !== '');
+
+/**
+ * Renders the table of plugin name → rule key prefix used in the
+ * `plugins` configuration field. Core ESLint rules (no prefix) are
+ * intentionally excluded.
+ */
+export const PluginPrefixTable: React.FC = () => (
+  <table>
+    <thead>
+      <tr>
+        <th>Plugin</th>
+        <th>Rules Prefix</th>
+      </tr>
+    </thead>
+    <tbody>
+      {PREFIXED_PLUGINS.map((p) => (
+        <tr key={p.prefix}>
+          <td>
+            <code>{p.prefix}</code>
+          </td>
+          <td>
+            <code>{p.prefix}/*</code>
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+export default PluginPrefixTable;

--- a/website/theme/components/PresetTable.tsx
+++ b/website/theme/components/PresetTable.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { CodeBlockRuntime, Link } from '@rspress/core/theme';
+import { PLUGIN_REGISTRY } from '../plugin-registry';
+
+const PRESET_PLUGINS = PLUGIN_REGISTRY.filter(
+  (p): p is typeof p & { presetName: string } => Boolean(p.presetName),
+);
+
+/**
+ * Renders the table of every recommended preset shipped by `@rslint/core`,
+ * each row linking to the rules explorer filtered by that preset.
+ */
+export const PresetTable: React.FC = () => (
+  <table>
+    <thead>
+      <tr>
+        <th>Preset</th>
+        <th>Description</th>
+        <th />
+      </tr>
+    </thead>
+    <tbody>
+      {PRESET_PLUGINS.map((p) => (
+        <tr key={p.presetName}>
+          <td>
+            <code>{p.presetName}</code>
+          </td>
+          <td>{p.description}</td>
+          <td>
+            <Link href={`/rules/?preset=${p.presetName}`}>View rules →</Link>
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+/**
+ * Renders an `import { … } from '@rslint/core'` snippet that pulls in
+ * `defineConfig` and every preset export listed in {@link PLUGIN_REGISTRY}.
+ */
+export const PresetImportSnippet: React.FC = () => {
+  const names = ['defineConfig', ...PRESET_PLUGINS.map((p) => p.importName)];
+  const code = `import {\n${names.map((n) => `  ${n},`).join('\n')}\n} from '@rslint/core';\n`;
+  return <CodeBlockRuntime lang="ts" code={code} />;
+};
+
+export default PresetTable;

--- a/website/theme/components/RuleStates/rule.tsx
+++ b/website/theme/components/RuleStates/rule.tsx
@@ -12,6 +12,7 @@ import { CancelSymbol, TableSelector } from './table-selector';
 import { Badge, Heading, PresetBadge, Text } from './ui-utils';
 import { Button } from '@components/ui/button';
 import manifest from '@/generated/rule-manifest.json';
+import { groupToRouteSlug } from '@/theme/plugin-registry';
 
 // Type definitions
 type FailingCase = {
@@ -33,10 +34,6 @@ type RuleStateDescribe = {
   count: number;
   style: 'full' | 'partial-impl' | 'partial-test' | 'total';
 };
-
-function groupToRouteSlug(group: string): string {
-  return group.replace(/^@/, '');
-}
 
 function getRuleUrl(rule: Rule): { url: string; isInternal: boolean } {
   if (rule.docPath) {

--- a/website/theme/plugin-registry.ts
+++ b/website/theme/plugin-registry.ts
@@ -1,26 +1,41 @@
 /**
- * Metadata for a single plugin. All fields are plain strings so this file
- * can be imported by both Node (build scripts) and the browser (UI components)
- * without pulling in @rslint/core at runtime.
+ * Metadata for a single plugin. The file declares only string identifiers
+ * (no @rslint/core import), so it can be loaded both at build time by Node
+ * scripts and at runtime by browser UI components.
  */
 export interface PluginMeta {
-  /** Rule key prefix in rslint config, e.g. "react" → "react/jsx-key".
-   *  Empty string for core ESLint rules (no prefix). */
+  /**
+   * Rule key prefix users write in their rslint config (e.g. `import` for
+   * `import/no-self-import`). Empty string for the eslint core group, whose
+   * rules carry no prefix. After `@` stripping this also serves as the doc
+   * route slug — see {@link groupToRouteSlug}.
+   */
   prefix: string;
-  /** Internal group name used in rule-manifest.json, e.g. "eslint-plugin-import". */
+  /**
+   * Join key against `rule.group` in `website/generated/rule-manifest.json`,
+   * which mirrors the `PLUGIN_NAME` constant from
+   * `internal/plugins/<plugin>/plugin.go` (or the literal `"eslint"` for
+   * core rules). Used to look up the prefix / preset / import name that
+   * belongs to a manifest entry.
+   */
   group: string;
-  /** Named export from @rslint/core used in import statements, e.g. "importPlugin". */
+  /** Named export from `@rslint/core` (e.g. `importPlugin`). */
   importName: string;
-  /** Dot-path to the preset config object, e.g. "reactPlugin.configs.recommended".
-   *  null if the plugin ships no preset. */
+  /**
+   * Dot-path to the preset config object, e.g. `reactPlugin.configs.recommended`.
+   * `null` if the plugin ships no preset.
+   */
   presetName: string | null;
+  /** Human-readable preset description, shown in the docs preset table. */
+  description: string;
 }
 
 /**
- * Single source of truth for every supported plugin.
- * Both plugin-rule-manifest.ts (build-time) and RuleConfig.tsx (runtime UI)
- * derive their local mappings from this list — add a plugin here once and
- * both places pick it up automatically.
+ * Single source of truth for every supported plugin. Build-time
+ * (`plugin-rule-manifest.ts`) and runtime UI (`RuleConfig.tsx`,
+ * `PresetTable.tsx`, `PluginPrefixTable.tsx`, `RuleStates/rule.tsx`)
+ * all derive their local mappings from this list — add a plugin here
+ * once and every consumer picks it up automatically.
  */
 export const PLUGIN_REGISTRY: PluginMeta[] = [
   {
@@ -28,35 +43,76 @@ export const PLUGIN_REGISTRY: PluginMeta[] = [
     group: 'eslint',
     importName: 'js',
     presetName: 'js.configs.recommended',
+    description: 'JavaScript recommended rules',
   },
   {
     prefix: '@typescript-eslint',
     group: '@typescript-eslint',
     importName: 'ts',
     presetName: 'ts.configs.recommended',
+    description: 'TypeScript recommended rules (includes ESLint core rules)',
   },
   {
     prefix: 'react',
     group: 'react',
     importName: 'reactPlugin',
     presetName: 'reactPlugin.configs.recommended',
+    description: 'React rules',
+  },
+  {
+    prefix: 'react-hooks',
+    group: 'eslint-plugin-react-hooks',
+    importName: 'reactHooksPlugin',
+    presetName: 'reactHooksPlugin.configs.recommended',
+    description: 'React Hooks rules',
   },
   {
     prefix: 'import',
     group: 'eslint-plugin-import',
     importName: 'importPlugin',
     presetName: 'importPlugin.configs.recommended',
+    description: 'Import/export rules',
   },
   {
     prefix: 'promise',
     group: 'eslint-plugin-promise',
     importName: 'promisePlugin',
     presetName: 'promisePlugin.configs.recommended',
+    description: 'Promise rules',
   },
   {
     prefix: 'jest',
     group: 'eslint-plugin-jest',
     importName: 'jestPlugin',
     presetName: 'jestPlugin.configs.recommended',
+    description: 'Jest rules',
+  },
+  {
+    prefix: 'unicorn',
+    group: 'eslint-plugin-unicorn',
+    importName: 'unicornPlugin',
+    presetName: 'unicornPlugin.configs.recommended',
+    description: 'Unicorn rules',
   },
 ];
+
+/**
+ * Convert a manifest plugin group (the value of `PLUGIN_NAME` in
+ * `internal/plugins/<plugin>/plugin.go`) to the slug used as the
+ * `/rules/<slug>/` URL segment, the sidebar directory name, and the
+ * sidebar label.
+ *
+ * Resolution order:
+ *   1. Look up the matching {@link PLUGIN_REGISTRY} entry and reuse its
+ *      `prefix` (the same identifier users write in their rslint config,
+ *      e.g. `import` / `jest` / `react-hooks`). This keeps doc URLs,
+ *      sidebar labels, and rule keys in sync.
+ *   2. Fall back to the raw `group` for unregistered plugins or for
+ *      entries whose `prefix` is empty (the eslint core group).
+ *   3. Strip a leading `@` so scoped names like `@typescript-eslint`
+ *      produce `typescript-eslint`.
+ */
+export function groupToRouteSlug(group: string): string {
+  const meta = PLUGIN_REGISTRY.find((p) => p.group === group);
+  return (meta?.prefix || group).replace(/^@/, '');
+}


### PR DESCRIPTION
## Summary

- **Doc title cleanup**: Strip the plugin prefix (`react/`, `react-hooks/`, `jest/`, `import/`) from the H1 of every non-typescript plugin rule doc, so all rule documents follow the same `# rule-name` convention as the typescript / promise / unicorn plugins. Also rewrite the two new unicorn rule docs' "Original Documentation" links from `<url>` autolinks to the standard `[text](url)` markdown form already used by every other plugin doc.
- **Sidebar/URL slug**: Drop the `eslint-plugin-` prefix from every rules-explorer slug (`/rules/eslint-plugin-import/...` → `/rules/import/...`). The slug is now derived from `PLUGIN_REGISTRY[i].prefix`, the same identifier users write in their rslint config, so doc URLs, sidebar labels and rule keys are kept in sync from a single source of truth.
- **`PLUGIN_REGISTRY` as single source of truth**: Add a `description` field, export a shared `groupToRouteSlug(group)` helper, and update `theme/components/RuleStates/rule.tsx` to import that helper instead of carrying a duplicate. Future plugins only need a single registry entry — URL, sidebar label, prefix table, presets table, and `@rslint/core` import snippet all pick it up automatically.
- **`Rules & Presets` page (`md` → `mdx`)**: Render the Available Presets table, the `@rslint/core` import snippet, and the plugins prefix table from new `<PresetTable>`, `<PresetImportSnippet>` and `<PluginPrefixTable>` components instead of hand-maintained tables, fixing the drift where `react-hooks`, `promise`, `jest`, and `unicorn` presets were missing from the table.
- **Comment audit**: Tighten JSDoc and inline comments in `plugin-rule-manifest.ts` and `plugin-registry.ts` to reflect the actual hook (`config`, not `beforeBuild`), the actual emitted JSX (no spurious `presets` prop), and the wider list of registry consumers.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).