### PR TITLE
test(vscode-extension): stabilize cold-start flakes on Linux/Windows CI

### DIFF
--- a/packages/vscode-extension/__tests__/suite/extension.test.ts
+++ b/packages/vscode-extension/__tests__/suite/extension.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
+import { executeCodeActionProviderWithRetry } from './fixall-helpers';
 
 suite('rslint extension', function () {
   this.timeout(90000);
@@ -178,9 +179,10 @@ suite('rslint extension', function () {
 
     if (typeAssertionDiag) {
       // Request code actions for the diagnostic range
-      const codeActions = await vscode.commands.executeCommand<
-        vscode.CodeAction[]
-      >('vscode.executeCodeActionProvider', doc.uri, typeAssertionDiag.range);
+      const codeActions = await executeCodeActionProviderWithRetry(
+        doc.uri,
+        typeAssertionDiag.range,
+      );
 
       assert.ok(
         codeActions && codeActions.length > 0,
@@ -219,9 +221,10 @@ suite('rslint extension', function () {
 
     if (unsafeDiag) {
       // Request code actions for the diagnostic range
-      const codeActions = await vscode.commands.executeCommand<
-        vscode.CodeAction[]
-      >('vscode.executeCodeActionProvider', doc.uri, unsafeDiag.range);
+      const codeActions = await executeCodeActionProviderWithRetry(
+        doc.uri,
+        unsafeDiag.range,
+      );
 
       assert.ok(
         codeActions && codeActions.length > 0,
@@ -271,9 +274,10 @@ suite('rslint extension', function () {
 
     if (unsafeDiag) {
       // Request code actions for the diagnostic range
-      const codeActions = await vscode.commands.executeCommand<
-        vscode.CodeAction[]
-      >('vscode.executeCodeActionProvider', doc.uri, unsafeDiag.range);
+      const codeActions = await executeCodeActionProviderWithRetry(
+        doc.uri,
+        unsafeDiag.range,
+      );
 
       assert.ok(
         codeActions && codeActions.length > 0,
@@ -317,10 +321,7 @@ suite('rslint extension', function () {
     await waitForDiagnostics(doc);
 
     // Test that code actions are only provided for ranges that overlap with diagnostics
-    const codeActionsEmptyRange = await vscode.commands.executeCommand<
-      vscode.CodeAction[]
-    >(
-      'vscode.executeCodeActionProvider',
+    const codeActionsEmptyRange = await executeCodeActionProviderWithRetry(
       doc.uri,
       new vscode.Range(100, 0, 100, 0), // Range with no diagnostics
     );
@@ -596,11 +597,7 @@ suite('rslint extension', function () {
     for (const diagnostic of diagnostics) {
       // Filter quick fixes
       const codeActions = (
-        await vscode.commands.executeCommand<vscode.CodeAction[]>(
-          'vscode.executeCodeActionProvider',
-          doc.uri,
-          diagnostic.range,
-        )
+        await executeCodeActionProviderWithRetry(doc.uri, diagnostic.range)
       ).filter(
         (action) => action.kind?.value === vscode.CodeActionKind.QuickFix.value,
       );

--- a/packages/vscode-extension/__tests__/suite/fixall-cascade.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-cascade.test.ts
@@ -2,7 +2,9 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import {
   waitForDiagnostics,
+  waitForContentChange,
   findFixAllAction,
+  prewarmOnSaveFixAll,
   requestFixAll,
   withTmpFile,
   withOnSaveFixAll,
@@ -10,7 +12,15 @@ import {
 } from './fixall-helpers';
 
 suite('rslint fixAll - cascade (multi-pass)', function () {
-  this.timeout(90000);
+  this.timeout(120000);
+
+  // Prime the on-save fixAll pipeline once so the first real test below
+  // doesn't pay VS Code's codeActionsOnSave + LSP cold-start cost (~30s on
+  // Windows under load). See fixall-helpers.ts:prewarmOnSaveFixAll.
+  suiteSetup(async function () {
+    this.timeout(120000);
+    await prewarmOnSaveFixAll();
+  });
 
   test('ban-types triggers no-inferrable-types in second pass', async () => {
     const cascadeContent = [
@@ -63,19 +73,17 @@ suite('rslint fixAll - cascade (multi-pass)', function () {
 
       await doc.save();
 
-      const startTime = Date.now();
-      while (
-        (doc.getText().includes(': String') ||
-          doc.getText().includes(': string')) &&
-        Date.now() - startTime < 30000
-      ) {
-        await new Promise((r) => setTimeout(r, 500));
-      }
-
-      const content = doc.getText();
-      assert.ok(
-        !content.includes(': String') && !content.includes(': string'),
-        `Single save should fix both cascade passes. Content: ${content}`,
+      // Event-driven wait: resolves the moment the on-save fixAll edit
+      // lands on the document, instead of polling on a 500ms interval.
+      // 60s budget gives Windows runners headroom even after pre-warm.
+      // The helper rejects with a descriptive timeout error including the
+      // last seen document content; let that propagate verbatim so the
+      // original stack survives.
+      await waitForContentChange(
+        doc,
+        (content) =>
+          !content.includes(': String') && !content.includes(': string'),
+        60000,
       );
     });
   });

--- a/packages/vscode-extension/__tests__/suite/fixall-error.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-error.test.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import {
   waitForDiagnostics,
   findFixAllAction,
+  prewarmOnSaveFixAll,
   requestFixAll,
   withTmpFile,
   withOnSaveFixAll,
@@ -10,7 +11,15 @@ import {
 } from './fixall-helpers';
 
 suite('rslint fixAll - error flows', function () {
-  this.timeout(90000);
+  this.timeout(120000);
+
+  // Prime the on-save fixAll pipeline once before the first test that
+  // exercises it. The helper is process-wide idempotent — if another
+  // suite has already warmed it, this resolves immediately.
+  suiteSetup(async function () {
+    this.timeout(120000);
+    await prewarmOnSaveFixAll();
+  });
 
   test('fixAll on file with syntax errors does not crash', async () => {
     const brokenContent = 'const x: string = \nfunction (\nexport { \n';

--- a/packages/vscode-extension/__tests__/suite/fixall-helpers.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-helpers.ts
@@ -115,19 +115,57 @@ export function findFixAllAction(
   );
 }
 
+/**
+ * Wraps `vscode.commands.executeCommand('vscode.executeCodeActionProvider', ...)`
+ * with retry-on-cancellation. The Code-Action provider's command receives an
+ * ambient cancellation token under the hood; on a freshly-started extension
+ * host (CI cold start) external events such as Settings Sync state
+ * transitions or async ConfigurationService initialization can fire that
+ * token mid-call, surfacing as a synthetic `Canceled` error whose stack is
+ * entirely inside `extensionHostProcess.js`. The call is otherwise a pure
+ * read of the diagnostic state, so a bounded retry with linear backoff is
+ * safe and recovers transparently.
+ *
+ * Only `Canceled` / `Cancellation` errors are retried — any other failure
+ * propagates immediately so genuine bugs surface fast.
+ */
+export async function executeCodeActionProviderWithRetry(
+  uri: vscode.Uri,
+  range: vscode.Range,
+  kind?: string,
+  retries = 3,
+): Promise<vscode.CodeAction[]> {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const args: unknown[] = ['vscode.executeCodeActionProvider', uri, range];
+      if (kind !== undefined) args.push(kind);
+      const result = await vscode.commands.executeCommand<vscode.CodeAction[]>(
+        ...(args as [string, vscode.Uri, vscode.Range, ...unknown[]]),
+      );
+      return result ?? [];
+    } catch (err) {
+      const isLast = attempt === retries - 1;
+      const message = err instanceof Error ? err.message : String(err);
+      const isCancellation = /cancel/i.test(message);
+      if (isLast || !isCancellation) throw err;
+      // Linear backoff: 200ms, 400ms, ...
+      await new Promise((r) => setTimeout(r, 200 * (attempt + 1)));
+    }
+  }
+  // Unreachable: the loop either returns or throws.
+  return [];
+}
+
 export async function requestFixAll(
   doc: vscode.TextDocument,
   kind: vscode.CodeActionKind = vscode.CodeActionKind.SourceFixAll.append(
     'rslint',
   ),
 ): Promise<vscode.CodeAction[]> {
-  return (
-    (await vscode.commands.executeCommand<vscode.CodeAction[]>(
-      'vscode.executeCodeActionProvider',
-      doc.uri,
-      new vscode.Range(0, 0, doc.lineCount, 0),
-      kind.value,
-    )) ?? []
+  return executeCodeActionProviderWithRetry(
+    doc.uri,
+    new vscode.Range(0, 0, doc.lineCount, 0),
+    kind.value,
   );
 }
 
@@ -160,6 +198,50 @@ export async function withTmpFile(
   }
 }
 
+/**
+ * Wait until `predicate(content)` becomes true. Subscribes to
+ * `vscode.workspace.onDidChangeTextDocument` and returns the moment a
+ * matching content arrives, instead of polling on a fixed interval.
+ *
+ * Use this in preference to a `while (...) await sleep(500)` loop when the
+ * test is waiting for a server-driven content change (e.g. on-save fixAll
+ * applying an edit): the event-driven path resolves with sub-millisecond
+ * latency once the change lands, so the only wall-clock cost is the
+ * server's actual response time.
+ *
+ * Rejects with a descriptive error (including the last seen content) when
+ * `timeoutMs` elapses without the predicate being satisfied.
+ */
+export async function waitForContentChange(
+  doc: vscode.TextDocument,
+  predicate: (content: string) => boolean,
+  timeoutMs: number,
+): Promise<string> {
+  const initial = doc.getText();
+  if (predicate(initial)) return initial;
+  return new Promise<string>((resolve, reject) => {
+    const docUriString = doc.uri.toString();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+      if (e.document.uri.toString() !== docUriString) return;
+      const current = doc.getText();
+      if (predicate(current)) {
+        if (timer) clearTimeout(timer);
+        disposable.dispose();
+        resolve(current);
+      }
+    });
+    timer = setTimeout(() => {
+      disposable.dispose();
+      reject(
+        new Error(
+          `waitForContentChange: predicate not satisfied within ${timeoutMs}ms. Last content:\n${doc.getText()}`,
+        ),
+      );
+    }, timeoutMs);
+  });
+}
+
 export async function replaceAll(
   editor: vscode.TextEditor,
   newContent: string,
@@ -171,6 +253,47 @@ export async function replaceAll(
   );
   const ok = await editor.edit((b) => b.replace(fullRange, newContent));
   assert.ok(ok, 'editor.edit should succeed');
+}
+
+/**
+ * Run the on-save fixAll pipeline once with a tiny ban-types fixture so
+ * subsequent tests that rely on `editor.codeActionsOnSave: { 'source.fixAll.rslint': 'explicit' }`
+ * skip the first-trigger cold-start cost (VS Code wiring up the on-save
+ * code-actions handler, the LSP `textDocument/codeAction` round-trip, the
+ * workspace edit application). Best-effort: if ban-types doesn't fire (rule
+ * disabled / config not loaded yet) we silently no-op rather than failing
+ * the suite — actual coverage lives in the real tests.
+ *
+ * Call from a suite-level `before()` of any suite whose first test
+ * exercises on-save fixAll. Idempotent across the entire test process via
+ * a module-level promise cache: the first call kicks off the warm-up; all
+ * subsequent calls (from any suite) await the same promise and return
+ * immediately once it resolves. Safe to wire up in every suite that uses
+ * `withOnSaveFixAll` without paying duplicate cost.
+ */
+let prewarmPromise: Promise<void> | undefined;
+export function prewarmOnSaveFixAll(): Promise<void> {
+  if (prewarmPromise) return prewarmPromise;
+  prewarmPromise = withOnSaveFixAll(async (doc, editor) => {
+    await replaceAll(
+      editor,
+      "const _prewarmOnSave: String = 'x';\nexport { _prewarmOnSave };\n",
+    );
+    const diags = await waitForDiagnostics(doc);
+    if (!diags.some((d) => d.message.includes('ban-types'))) return;
+    await doc.save();
+    try {
+      await waitForContentChange(
+        doc,
+        (content) => !content.includes(': String'),
+        60000,
+      );
+    } catch {
+      // Pre-warm is best-effort: if the fixAll didn't apply within 60s the
+      // actual test will surface a clearer assertion error.
+    }
+  });
+  return prewarmPromise;
 }
 
 export async function withOnSaveFixAll(

--- a/packages/vscode-extension/__tests__/suite/fixall-onsave.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-onsave.test.ts
@@ -6,12 +6,21 @@ import {
   waitForDiagnostics,
   waitForDiagnosticsCount,
   withOnSaveFixAll,
+  prewarmOnSaveFixAll,
   replaceAll,
   getFixturesDir,
 } from './fixall-helpers';
 
 suite('rslint fixAll - on-save', function () {
-  this.timeout(90000);
+  this.timeout(120000);
+
+  // Prime the on-save fixAll pipeline once before the first test that
+  // exercises it. The helper is process-wide idempotent — if another
+  // suite has already warmed it, this resolves immediately.
+  suiteSetup(async function () {
+    this.timeout(120000);
+    await prewarmOnSaveFixAll();
+  });
 
   test('generic source.fixAll triggers rslint via on-save', async () => {
     const fixturesDir = getFixturesDir();


### PR DESCRIPTION
## Summary

Two distinct vscode-extension test flakes traced to the same root cause — VS Code extension host cold start in CI under load — are eliminated together:

1. \`fixall-cascade.test.ts :: cascade on-save - single save fixes both passes\` (intermittent on Windows). The first test in the suite to exercise the on-save fixAll flow pays the full \`editor.codeActionsOnSave\` + LSP \`textDocument/codeAction\` round-trip first-trigger cost; on Windows under CI load this can exceed the 30s polling budget. Same test rerun under the JS-config matrix in the same CI run lands in ~750ms.
2. \`extension.test.ts :: code actions - auto fix\` (intermittent on Linux). The second test in the suite hits a synthetic \`Canceled\` error from \`vscode.commands.executeCommand('vscode.executeCodeActionProvider', ...)\`. The Code-Action command receives an ambient cancellation token; on a freshly-started extension host, async platform service init (Settings Sync state transition, ConfigurationService init, etc.) fires events that propagate the token mid-call. Same test rerun in the same CI run passes in <1s.

Five layered improvements, each useful on its own:

1. **Suite-level pre-warm.** New \`prewarmOnSaveFixAll()\` helper is invoked from a \`suiteSetup\` (mocha TDD interface — these suites use \`suite()\` / \`test()\`, not \`describe()\` / \`it()\`) of every suite that uses \`withOnSaveFixAll\`. The helper is process-wide idempotent via a module-level promise cache: only the first call does work; subsequent calls await the same promise. Removes the cold-start cost from every on-save test.
2. **Event-driven content wait.** New \`waitForContentChange(doc, predicate, timeoutMs)\` helper subscribes to \`vscode.workspace.onDidChangeTextDocument\` and resolves the moment the edit lands, replacing the 500ms \`setTimeout\` polling loop in \`fixall-cascade.test.ts\`. Real failures now surface a precise timeout error including the last seen content.
3. **Retry-on-cancellation for Code-Action lookups.** New \`executeCodeActionProviderWithRetry(uri, range, kind?)\` helper wraps \`vscode.commands.executeCommand('vscode.executeCodeActionProvider', ...)\` with bounded linear backoff (200ms / 400ms / 600ms). Only retries when the error message matches \`/cancel/i\` so genuine bugs propagate immediately. The Code-Action command is a pure read of diagnostic state, so retry is safe and recovers transparently. \`requestFixAll\` plus all five direct \`executeCodeActionProvider\` call sites in \`extension.test.ts\` go through this helper.
4. **Wait/suite timeout headroom.** 30s → 60s for the cascade content-wait, 90s → 120s for affected suite timeouts. With pre-warm in place this should never matter; cheap insurance against future infrastructure slowdowns.
5. **No reliance on mocha file ordering.** \`fixall-onsave.test.ts\` and \`fixall-error.test.ts\` also call \`prewarmOnSaveFixAll()\` from their own \`suiteSetup\`. Removes the implicit dependency on alphabetical filename ordering — any suite can now run in any order without re-paying cold-start cost.

The retry / event-driven helpers all live in \`fixall-helpers.ts\`. They are not strictly fixAll-specific — \`executeCodeActionProviderWithRetry\` in particular is a generic VS Code helper — but keeping them in one place avoids adding a new module just for two utility functions.

## Related Links

- Cascade flake observed against PR #818 Windows job: https://github.com/web-infra-dev/rslint/actions/runs/25039561397/job/73339176308
- \`code actions - auto fix\` Cancellation flake observed against PR #818 Linux job: https://github.com/web-infra-dev/rslint/actions/runs/25043099986/job/73356791871

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).