### PR TITLE
feat: align --type-check with tsc --noEmit semantics

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -232,14 +232,11 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	}
 
 	// Run linter
-	lintResult, err := linter.RunLinter(
-		programs,
-		false, // Don't use single-threaded mode for IPC
-		allowedFiles,
-		nil, // no allowDirs in API mode
-		utils.ExcludePaths,
-
-		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+	lintResult, err := linter.RunLinter(linter.RunLinterOptions{
+		Programs:       programs,
+		SingleThreaded: false, // Don't use single-threaded mode for IPC
+		Scope:          linter.FileScope{Files: allowedFiles},
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 			// Track source file for encoding
 			sourceFilesLock.Lock()
 			filePath := tspath.ConvertToRelativePath(sourceFile.FileName(), comparePathOptions)
@@ -262,11 +259,8 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 				}
 			})
 		},
-		false, // no type-check in API mode
-		diagnosticCollector,
-		nil, // no typeInfoFiles distinction in API mode (all files have type info)
-		nil, // no file filters in API mode (single config)
-	)
+		OnDiagnostic: diagnosticCollector,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error running linter: %w", err)
 	}

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -832,6 +832,7 @@ func runCMD() int {
 	// no type info) and only run non-type-aware rules.
 	var typeInfoFiles map[string]struct{}
 	var capturedGapFiles []string // retained for --fix rebuild
+	fallbackProgramIndex := -1    // index of the gap-file fallback program (if any) within `programs`
 
 	{
 		programFiles := utils.CollectProgramFiles(programs, fs)
@@ -885,40 +886,45 @@ func runCMD() int {
 				fallback, _ := createFallbackProgram(gapFiles, singleThreaded, cwd, fs)
 				if fallback != nil {
 					programs = append(programs, fallback)
+					fallbackProgramIndex = len(programs) - 1
 				}
 			}
 		}
 	}
 
 	// createPrograms rebuilds programs (needed for multi-pass --fix re-linting).
-	createPrograms := func() ([]*compiler.Program, error) {
+	// Returns the program slice and the index of the fallback gap-file program
+	// (or -1 if none), so callers can mark it skipped during type-check.
+	createPrograms := func() ([]*compiler.Program, int, error) {
 		var baseProgs []*compiler.Program
 		if configMap != nil {
 			seen := make(map[string]struct{})
 			for configDir, entries := range configMap {
 				progs, exitCode := createProgramsForConfig(configDir, entries, singleThreaded, fs, seen)
 				if exitCode != 0 {
-					return nil, fmt.Errorf("failed to create programs for %s", configDir)
+					return nil, -1, fmt.Errorf("failed to create programs for %s", configDir)
 				}
 				baseProgs = append(baseProgs, progs...)
 			}
 		} else {
 			progs, exitCode := createProgramsForConfig(currentDirectory, rslintConfig, singleThreaded, fs, nil)
 			if exitCode != 0 {
-				return nil, errors.New("failed to create programs")
+				return nil, -1, errors.New("failed to create programs")
 			}
 			baseProgs = append(baseProgs, progs...)
 		}
 
 		// Rebuild fallback Program for gap files (content may have changed after fixes).
+		fallbackIdx := -1
 		if len(capturedGapFiles) > 0 {
 			fallback, _ := createFallbackProgram(capturedGapFiles, singleThreaded, cwd, fs)
 			if fallback != nil {
 				baseProgs = append(baseProgs, fallback)
+				fallbackIdx = len(baseProgs) - 1
 			}
 		}
 
-		return baseProgs, nil
+		return baseProgs, fallbackIdx, nil
 	}
 
 	// Phase 1: Collect all diagnostics (no printing yet).
@@ -953,23 +959,29 @@ func runCMD() int {
 
 	// Build per-program file filters combining:
 	//   - multi-config ownership deduplication (ESLint v10 aligned)
-	//   - config `ignores` exclusion (applies to rules, type-check, and counts)
+	//   - config `ignores` exclusion (applies to rules and counts)
 	fileFilters := buildFileFilters(programs, configMap, programConfigDirs, rslintConfig, currentDirectory)
 
-	lintResult, err := linter.RunLinter(
-		programs,
-		singleThreaded,
-		allowFiles,
-		allowDirs,
-		utils.ExcludePaths,
-		getRulesForFile,
-		typeCheck,
-		func(d rule.RuleDiagnostic) {
+	// fallback gap program (if any) is excluded from --type-check: its
+	// CompilerOptions are synthesized defaults, not the user's tsconfig,
+	// so semantic diagnostics there would be unreliable. This honors the
+	// commitment in website/docs/en/guide/type-checking.md ("Files Without
+	// tsconfig Coverage").
+	skipTypeCheck := buildTypeCheckSkipMask(len(programs), fallbackProgramIndex)
+
+	lintResult, err := linter.RunLinter(linter.RunLinterOptions{
+		Programs:              programs,
+		SingleThreaded:        singleThreaded,
+		Scope:                 linter.FileScope{Files: allowFiles, Dirs: allowDirs},
+		PerProgramFilter:      toFileFilters(fileFilters),
+		GetRulesForFile:       getRulesForFile,
+		TypeInfoFiles:         typeInfoFiles,
+		TypeCheck:             typeCheck,
+		SkipTypeCheckPrograms: skipTypeCheck,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
 			diagnosticsChan <- d
 		},
-		typeInfoFiles,
-		fileFilters,
-	)
+	})
 
 	close(diagnosticsChan)
 	if err != nil {
@@ -1048,7 +1060,7 @@ func runCMD() int {
 		// Re-lint → fix → re-lint → fix → ... until stable or maxFixPasses.
 		// Skip if nothing was fixed in the first pass (no need to re-lint).
 		for pass := 1; pass < maxFixPasses && fixedCount > 0; pass++ {
-			newPrograms, err := createPrograms()
+			newPrograms, newFallbackIdx, err := createPrograms()
 			if err != nil || len(newPrograms) == 0 {
 				break
 			}
@@ -1056,23 +1068,23 @@ func runCMD() int {
 			// Re-lint: collect remaining diagnostics.
 			// Rebuild file filters for the new programs (ownership + ignores).
 			fixFileFilters := buildFileFilters(newPrograms, configMap, programConfigDirs, rslintConfig, currentDirectory)
+			fixSkipMask := buildTypeCheckSkipMask(len(newPrograms), newFallbackIdx)
 			var passDiags []rule.RuleDiagnostic
-			passResult, _ := linter.RunLinter(
-				newPrograms,
-				singleThreaded,
-				allowFiles,
-				allowDirs,
-				utils.ExcludePaths,
-				getRulesForFile,
-				typeCheck,
-				func(d rule.RuleDiagnostic) {
+			passResult, _ := linter.RunLinter(linter.RunLinterOptions{
+				Programs:              newPrograms,
+				SingleThreaded:        singleThreaded,
+				Scope:                 linter.FileScope{Files: allowFiles, Dirs: allowDirs},
+				PerProgramFilter:      toFileFilters(fixFileFilters),
+				GetRulesForFile:       getRulesForFile,
+				TypeInfoFiles:         typeInfoFiles,
+				TypeCheck:             typeCheck,
+				SkipTypeCheckPrograms: fixSkipMask,
+				OnDiagnostic: func(d rule.RuleDiagnostic) {
 					diagsMu.Lock()
 					passDiags = append(passDiags, d)
 					diagsMu.Unlock()
 				},
-				typeInfoFiles,
-				fixFileFilters,
-			)
+			})
 			if passResult != nil {
 				for name := range passResult.ExecutedRules {
 					lintResult.ExecutedRules[name] = struct{}{}

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/vfsmatch"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -243,4 +244,33 @@ func buildFileFilters(
 		}
 	}
 	return filters
+}
+
+// toFileFilters converts the legacy `[]func(string) bool` per-program filter
+// slice (used by buildFileFilters) into linter.FileFilter typed entries. The
+// underlying functions are identical; this is purely a type adapter.
+func toFileFilters(in []func(string) bool) []linter.FileFilter {
+	if in == nil {
+		return nil
+	}
+	out := make([]linter.FileFilter, len(in))
+	for i, f := range in {
+		out[i] = f
+	}
+	return out
+}
+
+// buildTypeCheckSkipMask returns a parallel-to-Programs []bool where the entry
+// at fallbackIdx is true (skip type-check) and all others are false. Returns
+// nil when fallbackIdx is -1 (no fallback program), so callers don't allocate
+// an all-false slice.
+func buildTypeCheckSkipMask(numPrograms int, fallbackIdx int) []bool {
+	if fallbackIdx < 0 {
+		return nil
+	}
+	mask := make([]bool, numPrograms)
+	if fallbackIdx < numPrograms {
+		mask[fallbackIdx] = true
+	}
+	return mask
 }

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -2,7 +2,6 @@ package linter
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -14,28 +13,8 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
-	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
 )
-
-type ConfiguredRule struct {
-	Name             string
-	Settings         map[string]interface{}
-	Severity         rule.DiagnosticSeverity
-	RequiresTypeInfo bool
-	Run              func(ctx rule.RuleContext) rule.RuleListeners
-}
-
-// FilterNonTypeAwareRules returns only rules that do not require type information.
-func FilterNonTypeAwareRules(rules []ConfiguredRule) []ConfiguredRule {
-	filtered := make([]ConfiguredRule, 0, len(rules))
-	for _, r := range rules {
-		if !r.RequiresTypeInfo {
-			filtered = append(filtered, r)
-		}
-	}
-	return filtered
-}
 
 // isFileAllowed checks if fileName matches any path in allowFiles.
 // It first tries fast string equality, then falls back to os.SameFile
@@ -83,56 +62,52 @@ func isDirAllowed(fileName string, allowDirs []string) bool {
 	return false
 }
 
-// flattenDiagnosticMessage builds a human-readable message from a TypeScript
-// diagnostic, including its MessageChain and RelatedInformation.
-// The format follows tsc's output style.
-func flattenDiagnosticMessage(d *ast.Diagnostic) string {
-	var b strings.Builder
-	b.WriteString(d.String())
-	for _, chain := range d.MessageChain() {
-		flattenMessageChain(&b, chain, 1)
-	}
-	for _, related := range d.RelatedInformation() {
-		if related.File() != nil {
-			line, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(related.File(), related.Pos())
-			fmt.Fprintf(&b, "\n  %s:%d: %s", related.File().FileName(), line+1, related.String())
-		}
-	}
-	return b.String()
+// runProgramOptions is the internal per-program input to runLintRulesInProgram.
+type runProgramOptions struct {
+	Program         *compiler.Program
+	Scope           FileScope
+	ExcludePaths    []string
+	FileFilter      FileFilter
+	GetRulesForFile RuleHandler
+	// TypeInfoFiles is the set of files with reliable type information.
+	// Gap files (not in this set) get a nil TypeChecker passed to rule
+	// contexts as defense-in-depth — type-aware rules are already filtered
+	// out by GetRulesForFile, this just guards rules with optional
+	// TypeChecker usage. nil = no gap-file distinction.
+	TypeInfoFiles map[string]struct{}
+	OnDiagnostic DiagnosticHandler
 }
 
-func flattenMessageChain(b *strings.Builder, chain *ast.Diagnostic, level int) {
-	b.WriteByte('\n')
-	for range level {
-		b.WriteString("  ")
+// runLintRulesInProgram lints files in a single Program. Files are filtered
+// through ExcludePaths, Scope (Files+Dirs), and FileFilter before rule
+// execution. Pass FileFilter=nil to disable that layer.
+//
+// This is the post-refactor internal implementation behind both RunLinter and
+// LintSingleFile. It does NOT run type-check — type-check is a program-level
+// concern handled by RunLinter directly.
+func runLintRulesInProgram(opts runProgramOptions) int32 {
+	if opts.OnDiagnostic == nil {
+		opts.OnDiagnostic = func(rule.RuleDiagnostic) {}
 	}
-	b.WriteString(chain.String())
-	for _, child := range chain.MessageChain() {
-		flattenMessageChain(b, child, level+1)
+	getRulesForFile := opts.GetRulesForFile
+	if getRulesForFile == nil {
+		return 0
 	}
-}
 
-// RunLinterInProgram lints files in a single Program. Files are filtered through
-// skipFiles, allowFiles/allowDirs, and the optional fileFilter before rule execution.
-// fileFilter is a caller-supplied predicate covering any reason to skip a file —
-// used for multi-config ownership-based deduplication and for config `ignores`
-// patterns. Files it rejects are excluded from rule diagnostics, type-check
-// diagnostics, and the returned linted-file count. Pass nil to lint all files.
-func RunLinterInProgram(program *compiler.Program, allowFiles []string, allowDirs []string, skipFiles []string, getRulesForFile RuleHandler, typeCheck bool, onDiagnostic DiagnosticHandler, typeInfoFiles map[string]struct{}, fileFilter func(string) bool) int32 {
-	// Pre-compute FileInfo for allowFiles once to avoid N×M stat calls in the loop.
+	// Pre-compute FileInfo for Scope.Files once to avoid N×M stat calls in the loop.
 	var allowFileInfos []os.FileInfo
-	if allowFiles != nil {
-		allowFileInfos = precomputeAllowFileInfos(allowFiles)
+	if opts.Scope.Files != nil {
+		allowFileInfos = precomputeAllowFileInfos(opts.Scope.Files)
 	}
 
 	// Collect files to lint (applying all filters).
 	var filesToLint []*ast.SourceFile
-	for _, file := range program.GetSourceFiles() {
+	for _, file := range opts.Program.GetSourceFiles() {
 		p := string(file.Path())
 		// skip lint node_modules and bundled files
 		// FIXME: we may have better api to tell whether a file is a bundled file or not
 		skipFile := false
-		for _, skipPattern := range skipFiles {
+		for _, skipPattern := range opts.ExcludePaths {
 			if strings.Contains(p, skipPattern) {
 				skipFile = true
 				break
@@ -141,17 +116,16 @@ func RunLinterInProgram(program *compiler.Program, allowFiles []string, allowDir
 		if skipFile {
 			continue
 		}
-		// Filter by allowFiles / allowDirs (OR logic: match either one)
-		if allowFiles != nil || allowDirs != nil {
-			fileAllowed := allowFiles != nil && isFileAllowed(file.FileName(), allowFiles, allowFileInfos)
-			dirAllowed := allowDirs != nil && isDirAllowed(file.FileName(), allowDirs)
+		// Filter by Scope.Files / Scope.Dirs (OR logic: match either one).
+		if opts.Scope.Files != nil || opts.Scope.Dirs != nil {
+			fileAllowed := opts.Scope.Files != nil && isFileAllowed(file.FileName(), opts.Scope.Files, allowFileInfos)
+			dirAllowed := opts.Scope.Dirs != nil && isDirAllowed(file.FileName(), opts.Scope.Dirs)
 			if !fileAllowed && !dirAllowed {
 				continue
 			}
 		}
-		// Ownership filter: in multi-config mode, only lint files owned by
-		// the current program's config (nearest config == program's config).
-		if fileFilter != nil && !fileFilter(file.FileName()) {
+		// Caller-supplied filter (multi-config ownership / config `ignores`).
+		if opts.FileFilter != nil && !opts.FileFilter(file.FileName()) {
 			continue
 		}
 		filesToLint = append(filesToLint, file)
@@ -159,340 +133,362 @@ func RunLinterInProgram(program *compiler.Program, allowFiles []string, allowDir
 
 	lintedFileCount := int32(len(filesToLint))
 
-	// Phase 1: Run lint rules. Acquires a checker from the pool for type-aware rules.
-	{
-		checker, done := program.GetTypeChecker(context.Background())
-		for _, file := range filesToLint {
-			registeredListeners := make(map[ast.Kind][](func(node *ast.Node)), 20)
+	// Early-out: if every file in this program was filtered, do not pay the
+	// cost of acquiring a TypeChecker (which forces program binding and is
+	// non-trivial when the checker hasn't been created yet).
+	if lintedFileCount == 0 {
+		return 0
+	}
 
-			rules := getRulesForFile(file)
-			if len(rules) == 0 {
-				continue
+	// Run lint rules. Acquires a checker from the pool for type-aware rules.
+	checker, done := opts.Program.GetTypeChecker(context.Background())
+	for _, file := range filesToLint {
+		registeredListeners := make(map[ast.Kind][](func(node *ast.Node)), 20)
+
+		rules := getRulesForFile(file)
+		if len(rules) == 0 {
+			continue
+		}
+
+		comments := make([]*ast.CommentRange, 0)
+		utils.ForEachComment(&file.Node, func(comment *ast.CommentRange) { comments = append(comments, comment) }, file)
+
+		// Create disable manager for this file
+		disableManager := rule.NewDisableManager(file, comments)
+
+		// For gap files (not in caller's TypeInfoFiles), pass nil TypeChecker
+		// as defense-in-depth. Type-aware rules are already filtered out by
+		// getRulesForFile, but this ensures rules with optional TypeChecker
+		// usage degrade gracefully.
+		fileChecker := checker
+		if opts.TypeInfoFiles != nil {
+			if _, hasTypeInfo := opts.TypeInfoFiles[file.FileName()]; !hasTypeInfo {
+				fileChecker = nil
 			}
+		}
 
-			comments := make([]*ast.CommentRange, 0)
-			utils.ForEachComment(&file.Node, func(comment *ast.CommentRange) { comments = append(comments, comment) }, file)
-
-			// Create disable manager for this file
-			disableManager := rule.NewDisableManager(file, comments)
-
-			// For gap files (not in typeInfoFiles), pass nil TypeChecker
-			// as defense-in-depth. Type-aware rules are already filtered
-			// out by getRulesForFile, but this ensures rules with optional
-			// TypeChecker usage degrade gracefully.
-			fileChecker := checker
-			if typeInfoFiles != nil {
-				if _, hasTypeInfo := typeInfoFiles[file.FileName()]; !hasTypeInfo {
-					fileChecker = nil
-				}
-			}
-
-			for _, r := range rules {
-				ctx := rule.RuleContext{
-					SourceFile:     file,
-					Program:        program,
-					Settings:       r.Settings,
-					TypeChecker:    fileChecker,
-					DisableManager: disableManager,
-					ReportRange: func(textRange core.TextRange, msg rule.RuleMessage) {
-						// Check if rule is disabled at this position
-						if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
-							return
-						}
-						onDiagnostic(rule.RuleDiagnostic{
-							RuleName:   r.Name,
-							Range:      textRange,
-							Message:    msg,
-							SourceFile: file,
-							Severity:   r.Severity,
-						})
-					},
-					ReportRangeWithFixes: func(textRange core.TextRange, msg rule.RuleMessage, fixes ...rule.RuleFix) {
-						// Check if rule is disabled at this position
-						if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
-							return
-						}
-						onDiagnostic(rule.RuleDiagnostic{
-							RuleName:   r.Name,
-							Range:      textRange,
-							Message:    msg,
-							FixesPtr:   &fixes,
-							SourceFile: file,
-							Severity:   r.Severity,
-						})
-					},
-					ReportRangeWithSuggestions: func(textRange core.TextRange, msg rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
-						// Check if rule is disabled at this position
-						if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
-							return
-						}
-						onDiagnostic(rule.RuleDiagnostic{
-							RuleName:    r.Name,
-							Range:       textRange,
-							Message:     msg,
-							Suggestions: &suggestions,
-							SourceFile:  file,
-							Severity:    r.Severity,
-						})
-					},
-					ReportNode: func(node *ast.Node, msg rule.RuleMessage) {
-						// Trim leading trivia (comments/whitespace) so the line number
-						// matches the actual code, not a preceding disable comment.
-						trimmedRange := utils.TrimNodeTextRange(file, node)
-						if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
-							return
-						}
-						onDiagnostic(rule.RuleDiagnostic{
-							RuleName:   r.Name,
-							Range:      trimmedRange,
-							Message:    msg,
-							SourceFile: file,
-							Severity:   r.Severity,
-						})
-					},
-					ReportNodeWithFixes: func(node *ast.Node, msg rule.RuleMessage, fixes ...rule.RuleFix) {
-						trimmedRange := utils.TrimNodeTextRange(file, node)
-						if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
-							return
-						}
-						onDiagnostic(rule.RuleDiagnostic{
-							RuleName:   r.Name,
-							Range:      trimmedRange,
-							Message:    msg,
-							FixesPtr:   &fixes,
-							SourceFile: file,
-							Severity:   r.Severity,
-						})
-					},
-
-					ReportNodeWithSuggestions: func(node *ast.Node, msg rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
-						trimmedRange := utils.TrimNodeTextRange(file, node)
-						if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
-							return
-						}
-						onDiagnostic(rule.RuleDiagnostic{
-							RuleName:    r.Name,
-							Range:       trimmedRange,
-							Message:     msg,
-							Suggestions: &suggestions,
-							SourceFile:  file,
-							Severity:    r.Severity,
-						})
-					},
-					ReportNodeWithFixesAndSuggestions: func(node *ast.Node, msg rule.RuleMessage, fixes []rule.RuleFix, suggestions []rule.RuleSuggestion) {
-						trimmedRange := utils.TrimNodeTextRange(file, node)
-						if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
-							return
-						}
-						onDiagnostic(rule.RuleDiagnostic{
-							RuleName:    r.Name,
-							Range:       trimmedRange,
-							Message:     msg,
-							FixesPtr:    &fixes,
-							Suggestions: &suggestions,
-							SourceFile:  file,
-							Severity:    r.Severity,
-						})
-					},
-					ReportRangeWithFixesAndSuggestions: func(textRange core.TextRange, msg rule.RuleMessage, fixes []rule.RuleFix, suggestions []rule.RuleSuggestion) {
-						if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
-							return
-						}
-						onDiagnostic(rule.RuleDiagnostic{
-							RuleName:    r.Name,
-							Range:       textRange,
-							Message:     msg,
-							FixesPtr:    &fixes,
-							Suggestions: &suggestions,
-							SourceFile:  file,
-							Severity:    r.Severity,
-						})
-					},
-				}
-
-				for kind, listener := range r.Run(ctx) {
-					listeners, ok := registeredListeners[kind]
-					if !ok {
-						listeners = make([](func(node *ast.Node)), 0, len(rules))
+		for _, r := range rules {
+			ctx := rule.RuleContext{
+				SourceFile:     file,
+				Program:        opts.Program,
+				Settings:       r.Settings,
+				TypeChecker:    fileChecker,
+				DisableManager: disableManager,
+				ReportRange: func(textRange core.TextRange, msg rule.RuleMessage) {
+					if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
+						return
 					}
-					registeredListeners[kind] = append(listeners, listener)
-				}
-			}
-
-			runListeners := func(kind ast.Kind, node *ast.Node) {
-				if listeners, ok := registeredListeners[kind]; ok {
-					for _, listener := range listeners {
-						listener(node)
+					opts.OnDiagnostic(rule.RuleDiagnostic{
+						RuleName:   r.Name,
+						Range:      textRange,
+						Message:    msg,
+						SourceFile: file,
+						Severity:   r.Severity,
+					})
+				},
+				ReportRangeWithFixes: func(textRange core.TextRange, msg rule.RuleMessage, fixes ...rule.RuleFix) {
+					if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
+						return
 					}
-				}
+					opts.OnDiagnostic(rule.RuleDiagnostic{
+						RuleName:   r.Name,
+						Range:      textRange,
+						Message:    msg,
+						FixesPtr:   &fixes,
+						SourceFile: file,
+						Severity:   r.Severity,
+					})
+				},
+				ReportRangeWithSuggestions: func(textRange core.TextRange, msg rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
+					if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
+						return
+					}
+					opts.OnDiagnostic(rule.RuleDiagnostic{
+						RuleName:    r.Name,
+						Range:       textRange,
+						Message:     msg,
+						Suggestions: &suggestions,
+						SourceFile:  file,
+						Severity:    r.Severity,
+					})
+				},
+				ReportNode: func(node *ast.Node, msg rule.RuleMessage) {
+					trimmedRange := utils.TrimNodeTextRange(file, node)
+					if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
+						return
+					}
+					opts.OnDiagnostic(rule.RuleDiagnostic{
+						RuleName:   r.Name,
+						Range:      trimmedRange,
+						Message:    msg,
+						SourceFile: file,
+						Severity:   r.Severity,
+					})
+				},
+				ReportNodeWithFixes: func(node *ast.Node, msg rule.RuleMessage, fixes ...rule.RuleFix) {
+					trimmedRange := utils.TrimNodeTextRange(file, node)
+					if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
+						return
+					}
+					opts.OnDiagnostic(rule.RuleDiagnostic{
+						RuleName:   r.Name,
+						Range:      trimmedRange,
+						Message:    msg,
+						FixesPtr:   &fixes,
+						SourceFile: file,
+						Severity:   r.Severity,
+					})
+				},
+				ReportNodeWithSuggestions: func(node *ast.Node, msg rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
+					trimmedRange := utils.TrimNodeTextRange(file, node)
+					if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
+						return
+					}
+					opts.OnDiagnostic(rule.RuleDiagnostic{
+						RuleName:    r.Name,
+						Range:       trimmedRange,
+						Message:     msg,
+						Suggestions: &suggestions,
+						SourceFile:  file,
+						Severity:    r.Severity,
+					})
+				},
+				ReportNodeWithFixesAndSuggestions: func(node *ast.Node, msg rule.RuleMessage, fixes []rule.RuleFix, suggestions []rule.RuleSuggestion) {
+					trimmedRange := utils.TrimNodeTextRange(file, node)
+					if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
+						return
+					}
+					opts.OnDiagnostic(rule.RuleDiagnostic{
+						RuleName:    r.Name,
+						Range:       trimmedRange,
+						Message:     msg,
+						FixesPtr:    &fixes,
+						Suggestions: &suggestions,
+						SourceFile:  file,
+						Severity:    r.Severity,
+					})
+				},
+				ReportRangeWithFixesAndSuggestions: func(textRange core.TextRange, msg rule.RuleMessage, fixes []rule.RuleFix, suggestions []rule.RuleSuggestion) {
+					if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
+						return
+					}
+					opts.OnDiagnostic(rule.RuleDiagnostic{
+						RuleName:    r.Name,
+						Range:       textRange,
+						Message:     msg,
+						FixesPtr:    &fixes,
+						Suggestions: &suggestions,
+						SourceFile:  file,
+						Severity:    r.Severity,
+					})
+				},
 			}
 
-			/* convert.ts -> allowPattern:
-			catch name
-			variabledeclaration name
-			forinstatement initializer
-			forofstatement initializer
-			(propagation) allowPattern > arrayliteralexpression elements
-			(propagation) allowPattern > objectliteralexpression properties
-			(propagation) allowPattern > spreadassignment,spreadelement expression
-			(propagation) allowPattern > propertyassignment value
-			arraybindingpattern elements
-			objectbindingpattern elements
-			(init) binaryexpression(with '=' operator') left
-			*/
+			for kind, listener := range r.Run(ctx) {
+				listeners, ok := registeredListeners[kind]
+				if !ok {
+					listeners = make([](func(node *ast.Node)), 0, len(rules))
+				}
+				registeredListeners[kind] = append(listeners, listener)
+			}
+		}
 
-			var childVisitor ast.Visitor
-			var patternVisitor func(node *ast.Node)
-			patternVisitor = func(node *ast.Node) {
-				runListeners(node.Kind, node)
-				kind := rule.ListenerOnAllowPattern(node.Kind)
+		runListeners := func(kind ast.Kind, node *ast.Node) {
+			if listeners, ok := registeredListeners[kind]; ok {
+				for _, listener := range listeners {
+					listener(node)
+				}
+			}
+		}
+
+		/* convert.ts -> allowPattern:
+		catch name
+		variabledeclaration name
+		forinstatement initializer
+		forofstatement initializer
+		(propagation) allowPattern > arrayliteralexpression elements
+		(propagation) allowPattern > objectliteralexpression properties
+		(propagation) allowPattern > spreadassignment,spreadelement expression
+		(propagation) allowPattern > propertyassignment value
+		arraybindingpattern elements
+		objectbindingpattern elements
+		(init) binaryexpression(with '=' operator') left
+		*/
+
+		var childVisitor ast.Visitor
+		var patternVisitor func(node *ast.Node)
+		patternVisitor = func(node *ast.Node) {
+			runListeners(node.Kind, node)
+			kind := rule.ListenerOnAllowPattern(node.Kind)
+			runListeners(kind, node)
+
+			switch node.Kind {
+			case ast.KindArrayLiteralExpression:
+				for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
+					patternVisitor(element)
+				}
+			case ast.KindObjectLiteralExpression:
+				for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
+					patternVisitor(property)
+				}
+			case ast.KindSpreadElement, ast.KindSpreadAssignment:
+				patternVisitor(node.Expression())
+			case ast.KindPropertyAssignment:
+				patternVisitor(node.Initializer())
+			default:
+				node.ForEachChild(childVisitor)
+			}
+
+			runListeners(rule.ListenerOnExit(kind), node)
+			runListeners(rule.ListenerOnExit(node.Kind), node)
+		}
+		childVisitor = func(node *ast.Node) bool {
+			runListeners(node.Kind, node)
+
+			switch node.Kind {
+			case ast.KindArrayLiteralExpression, ast.KindObjectLiteralExpression:
+				kind := rule.ListenerOnNotAllowPattern(node.Kind)
 				runListeners(kind, node)
-
-				switch node.Kind {
-				case ast.KindArrayLiteralExpression:
-					for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
-						patternVisitor(element)
-					}
-				case ast.KindObjectLiteralExpression:
-					for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
-						patternVisitor(property)
-					}
-				case ast.KindSpreadElement, ast.KindSpreadAssignment:
-					patternVisitor(node.Expression())
-				case ast.KindPropertyAssignment:
-					patternVisitor(node.Initializer())
-				default:
-					node.ForEachChild(childVisitor)
-				}
-
+				node.ForEachChild(childVisitor)
 				runListeners(rule.ListenerOnExit(kind), node)
-				runListeners(rule.ListenerOnExit(node.Kind), node)
-			}
-			childVisitor = func(node *ast.Node) bool {
-				runListeners(node.Kind, node)
-
-				switch node.Kind {
-				case ast.KindArrayLiteralExpression, ast.KindObjectLiteralExpression:
-					kind := rule.ListenerOnNotAllowPattern(node.Kind)
-					runListeners(kind, node)
+			default:
+				if ast.IsAssignmentExpression(node, true) {
+					expr := node.AsBinaryExpression()
+					patternVisitor(expr.Left)
+					childVisitor(expr.OperatorToken)
+					childVisitor(expr.Right)
+				} else {
 					node.ForEachChild(childVisitor)
-					runListeners(rule.ListenerOnExit(kind), node)
-				default:
-					if ast.IsAssignmentExpression(node, true) {
-						expr := node.AsBinaryExpression()
-						patternVisitor(expr.Left)
-						childVisitor(expr.OperatorToken)
-						childVisitor(expr.Right)
-					} else {
-						node.ForEachChild(childVisitor)
-					}
-				}
-
-				runListeners(rule.ListenerOnExit(node.Kind), node)
-
-				return false
-			}
-			file.Node.ForEachChild(childVisitor)
-			clear(registeredListeners)
-		}
-		done()
-	}
-
-	// Phase 2: Collect TypeScript semantic diagnostics when type-check is enabled.
-	// This runs after releasing the checker from Phase 1, because GetSemanticDiagnostics
-	// internally acquires its own checker from the pool.
-	if typeCheck {
-		ctx := context.Background()
-		for _, file := range filesToLint {
-			// Skip semantic diagnostics for gap files (no reliable type info).
-			if typeInfoFiles != nil {
-				if _, hasTypeInfo := typeInfoFiles[file.FileName()]; !hasTypeInfo {
-					continue
 				}
 			}
-			for _, d := range program.GetSemanticDiagnostics(ctx, file) {
-				onDiagnostic(rule.RuleDiagnostic{
-					RuleName:     fmt.Sprintf("TypeScript(TS%d)", d.Code()),
-					Range:        d.Loc(),
-					Message:      rule.RuleMessage{Description: flattenDiagnosticMessage(d)},
-					SourceFile:   file,
-					Severity:     rule.SeverityError,
-					PreFormatted: true,
-				})
-			}
+
+			runListeners(rule.ListenerOnExit(node.Kind), node)
+
+			return false
 		}
+		file.Node.ForEachChild(childVisitor)
+		clear(registeredListeners)
 	}
+	done()
 
 	return lintedFileCount
 }
 
-type RuleHandler = func(sourceFile *ast.SourceFile) []ConfiguredRule
-type DiagnosticHandler = func(diagnostic rule.RuleDiagnostic)
-
-// LintResult holds the outcome of a RunLinter invocation.
-type LintResult struct {
-	LintedFileCount int32
-	ExecutedRules   map[string]struct{}
-}
-
-// RunLinter runs all configured rules across the given programs in parallel.
-//   - allowFiles: if non-nil, only lint files in this list; nil = all files
-//   - allowDirs: if non-nil, also lint files under these dirs (OR with allowFiles)
-//   - typeInfoFiles: files with type info; gap files not in this set skip type-aware rules
-//   - fileFilters: optional per-program skip predicates (parallel to programs).
-//     Each filter covers any caller-specific reason to skip a file — multi-config
-//     ownership deduplication and config `ignores` exclusion are both composed
-//     in here by the caller. nil or missing entries = no filter (process all).
-func RunLinter(programs []*compiler.Program, singleThreaded bool, allowFiles []string, allowDirs []string, excludedPaths []string, getRulesForFile RuleHandler, typeCheck bool, onDiagnostic DiagnosticHandler, typeInfoFiles map[string]struct{}, fileFilters []func(string) bool) (*LintResult, error) {
-
-	executedRules := make(map[string]struct{})
-	var rulesMu sync.Mutex
-
-	trackedGetRules := func(sourceFile *ast.SourceFile) []ConfiguredRule {
-		rules := getRulesForFile(sourceFile)
-		rulesMu.Lock()
-		for _, r := range rules {
-			executedRules[r.Name] = struct{}{}
-		}
-		rulesMu.Unlock()
-		return rules
+// RunLinter runs all configured lint rules across the given programs in
+// parallel, then optionally collects program-level type-check diagnostics
+// aligned with `tsc --noEmit` semantics.
+//
+// Phase 1 — lint rules: each program is processed via
+// runLintRulesInProgram, with files filtered through opts.ExcludePaths,
+// opts.Scope, opts.PerProgramFilter and the program's own owned-file set.
+//
+// Phase 2 — type-check (skipped when opts.TypeCheck is false): each
+// non-skipped program is handed to runTypeCheckAcrossPrograms, which calls
+// compiler.GetDiagnosticsOfAnyProgram(file=nil). Type-check is NOT
+// constrained by Scope / PerProgramFilter / ExcludePaths — it covers the
+// full program just like tsc.
+//
+// See RunLinterOptions for each field's zero-value semantics.
+func RunLinter(opts RunLinterOptions) (*LintResult, error) {
+	if opts.ExcludePaths == nil {
+		opts.ExcludePaths = utils.ExcludePaths
+	}
+	if opts.OnDiagnostic == nil {
+		opts.OnDiagnostic = func(rule.RuleDiagnostic) {}
 	}
 
-	wg := core.NewWorkGroup(singleThreaded)
+	var executedRules sync.Map
+	trackedGetRules := opts.GetRulesForFile
+	if trackedGetRules != nil {
+		base := opts.GetRulesForFile
+		trackedGetRules = func(sf *ast.SourceFile) []ConfiguredRule {
+			rules := base(sf)
+			for _, r := range rules {
+				executedRules.Store(r.Name, struct{}{})
+			}
+			return rules
+		}
+	}
 
+	// Phase 1: lint rules per program (parallel).
+	wg := core.NewWorkGroup(opts.SingleThreaded)
 	var lintedFileCount atomic.Int32
-	for i, program := range programs {
-		var baseFilter func(string) bool
-		if i < len(fileFilters) {
-			baseFilter = fileFilters[i]
+	for i, program := range opts.Programs {
+		var perProgramFilter FileFilter
+		if i < len(opts.PerProgramFilter) {
+			perProgramFilter = opts.PerProgramFilter[i]
 		}
-
-		// Each program only lints its own root files (from tsconfig include/files
-		// patterns or gap file list). Files pulled in through import resolution or
-		// project references belong to other programs — linting them here would
-		// cause duplicate diagnostics.
 		ownedFiles := buildOwnedFileSet(program)
-		filter := func(fileName string) bool {
-			if baseFilter != nil && !baseFilter(fileName) {
-				return false
-			}
-			if ownedFiles != nil {
-				_, isOwned := ownedFiles[fileName]
-				return isOwned
-			}
-			return true
-		}
+		filter := composeOwnedFilter(perProgramFilter, ownedFiles)
 
+		programOpts := runProgramOptions{
+			Program:         program,
+			Scope:           opts.Scope,
+			ExcludePaths:    opts.ExcludePaths,
+			FileFilter:      filter,
+			GetRulesForFile: trackedGetRules,
+			TypeInfoFiles:   opts.TypeInfoFiles,
+			OnDiagnostic:    opts.OnDiagnostic,
+		}
 		wg.Queue(func() {
-			fileCount := RunLinterInProgram(program, allowFiles, allowDirs, excludedPaths, trackedGetRules, typeCheck, onDiagnostic, typeInfoFiles, filter)
-			lintedFileCount.Add(fileCount)
+			n := runLintRulesInProgram(programOpts)
+			lintedFileCount.Add(n)
 		})
 	}
 	wg.RunAndWait()
+
+	// Phase 2: program-level type-check (tsc-aligned).
+	if opts.TypeCheck {
+		runTypeCheckAcrossPrograms(typeCheckRequest{
+			Programs:       opts.Programs,
+			Skip:           opts.SkipTypeCheckPrograms,
+			SingleThreaded: opts.SingleThreaded,
+			TypeInfoFiles:  opts.TypeInfoFiles,
+			OnDiagnostic:   opts.OnDiagnostic,
+		})
+	}
+
 	return &LintResult{
 		LintedFileCount: lintedFileCount.Load(),
-		ExecutedRules:   executedRules,
+		ExecutedRules:   collectMapKeys(&executedRules),
 	}, nil
+}
+
+// LintSingleFile runs lint rules against a single file in a single program.
+// Designed for IDE / LSP per-keystroke usage. Does not run type-check.
+func LintSingleFile(opts LintSingleFileOptions) {
+	if opts.ExcludePaths == nil {
+		opts.ExcludePaths = utils.ExcludePaths
+	}
+	if opts.OnDiagnostic == nil {
+		opts.OnDiagnostic = func(rule.RuleDiagnostic) {}
+	}
+	runLintRulesInProgram(runProgramOptions{
+		Program:         opts.Program,
+		Scope:           FileScope{Files: []string{opts.File}},
+		ExcludePaths:    opts.ExcludePaths,
+		GetRulesForFile: opts.GetRulesForFile,
+		OnDiagnostic:    opts.OnDiagnostic,
+	})
+}
+
+// composeOwnedFilter combines a caller-supplied filter with the program's
+// owned-file restriction. Either component may be nil.
+func composeOwnedFilter(extra FileFilter, owned map[string]struct{}) FileFilter {
+	if extra == nil && owned == nil {
+		return nil
+	}
+	return func(name string) bool {
+		if extra != nil && !extra(name) {
+			return false
+		}
+		if owned != nil {
+			if _, ok := owned[name]; !ok {
+				return false
+			}
+		}
+		return true
+	}
 }
 
 // buildOwnedFileSet returns a set of file names that this program directly owns
@@ -510,4 +506,15 @@ func buildOwnedFileSet(program *compiler.Program) map[string]struct{} {
 		owned[fn] = struct{}{}
 	}
 	return owned
+}
+
+func collectMapKeys(m *sync.Map) map[string]struct{} {
+	out := make(map[string]struct{})
+	m.Range(func(k, _ any) bool {
+		if s, ok := k.(string); ok {
+			out[s] = struct{}{}
+		}
+		return true
+	})
+	return out
 }

--- a/internal/linter/linter_allowdirs_test.go
+++ b/internal/linter/linter_allowdirs_test.go
@@ -372,7 +372,7 @@ func TestRunLinter_AllowDirsIntegration(t *testing.T) {
 	})
 
 	srcDir := tmpDirPath(t, paths, "src/a.ts")
-	result, err := RunLinter([]*compiler.Program{program}, true, nil, []string{srcDir}, utils.ExcludePaths,
+	result, err := runLinterPositional([]*compiler.Program{program}, true, nil, []string{srcDir}, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
@@ -396,7 +396,7 @@ func TestRunLinter_MultiplePrograms(t *testing.T) {
 	})
 
 	lintedFileNames := []string{}
-	result, err := RunLinter(
+	result, err := runLinterPositional(
 		[]*compiler.Program{programA, programB},
 		true,
 		[]string{pathsA["a.ts"], pathsB["b.ts"]},
@@ -431,7 +431,7 @@ func TestRunLinter_MultipleProgramsWithAllowDirs(t *testing.T) {
 	srcDirA := tmpDirPath(t, pathsA, "src/a.ts")
 	srcDirB := tmpDirPath(t, pathsB, "src/b.ts")
 
-	result, err := RunLinter(
+	result, err := runLinterPositional(
 		[]*compiler.Program{programA, programB},
 		true,
 		nil,

--- a/internal/linter/linter_allowfiles_test.go
+++ b/internal/linter/linter_allowfiles_test.go
@@ -181,7 +181,7 @@ func TestRunLinter_AllowFilesIntegration(t *testing.T) {
 	})
 
 	lintedFileNames := []string{}
-	result, err := RunLinter([]*compiler.Program{program}, true, []string{paths["b.ts"]}, nil, utils.ExcludePaths,
+	result, err := runLinterPositional([]*compiler.Program{program}, true, []string{paths["b.ts"]}, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
@@ -204,7 +204,7 @@ func TestRunLinter_AllowFilesNilPassthrough(t *testing.T) {
 		"b.ts": "const b = 2;",
 	})
 
-	result, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
+	result, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,

--- a/internal/linter/linter_dedup_test.go
+++ b/internal/linter/linter_dedup_test.go
@@ -86,7 +86,7 @@ func requireProgramHasFile(t *testing.T, program *compiler.Program, fileName str
 func collectLintedFiles(t *testing.T, programs []*compiler.Program) map[string]int {
 	t.Helper()
 	counts := make(map[string]int)
-	_, err := RunLinter(
+	_, err := runLinterPositional(
 		programs, true, nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule {
 			counts[sf.FileName()]++
@@ -294,7 +294,7 @@ func TestRunLinter_DiagnosticsNotDuplicated(t *testing.T) {
 
 	// Multi-program mode
 	multiDiags := 0
-	RunLinter(
+	runLinterPositional(
 		[]*compiler.Program{programLib, programApp},
 		true, nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -83,7 +83,7 @@ func TestRunLinter_ExecutedRules(t *testing.T) {
 		"b.ts": "const b = 2;",
 	})
 
-	result, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
+	result, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule {
 			return []ConfiguredRule{
 				{Name: "rule-a", Severity: rule.SeverityWarning, Run: func(ctx rule.RuleContext) rule.RuleListeners { return nil }},
@@ -114,7 +114,7 @@ func TestRunLinter_ExecutedRulesPerFile(t *testing.T) {
 	})
 
 	// Different files get different rules — ExecutedRules should be the union.
-	result, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
+	result, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule {
 			if sf.FileName() == paths["a.ts"] {
 				return []ConfiguredRule{
@@ -148,7 +148,7 @@ func TestRunLinter_ExecutedRulesEmpty(t *testing.T) {
 	})
 
 	// No rules returned → ExecutedRules should be empty.
-	result, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
+	result, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
 		false, func(d rule.RuleDiagnostic) {}, nil, nil,
 	)

--- a/internal/linter/linter_typecheck_boundary_test.go
+++ b/internal/linter/linter_typecheck_boundary_test.go
@@ -1,0 +1,389 @@
+package linter
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// Boundary tests for --type-check semantics. These pin invariants that
+// would otherwise drift silently between typescript-go versions or under
+// internal API refactors.
+
+// === Boundary 1: default-lib invariant === //
+//
+// typescript-go ships its lib.*.d.ts files (lib.es5, lib.dom, etc.)
+// under bundled:///libs/... and treats them as default-library files.
+// They MUST type-check cleanly under every supported lib selection — if
+// any of them ever had an error, this would explode user output.
+//
+// We assert: across every reasonable lib/target combination, the
+// type-check phase produces ZERO diagnostics whose file is a
+// bundled:///libs/* path.
+func TestBoundary_DefaultLibsTypeCheckClean(t *testing.T) {
+	matrix := []struct {
+		name    string
+		options string
+	}{
+		{"default", `{}`},
+		{"target_es5_lib_es5", `{"target":"es2015","lib":["es5"]}`},
+		{"target_es2020", `{"target":"es2020"}`},
+		{"target_esnext_dom", `{"target":"esnext","lib":["esnext","dom"]}`},
+		{"strict_target_es2020", `{"target":"es2020","strict":true}`},
+		{"skipDefaultLibCheck_off", `{"target":"es2020","skipDefaultLibCheck":false}`},
+	}
+	for _, tc := range matrix {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFiles(t, dir, map[string]string{
+				"a.ts":          "export const x = 1;\n",
+				"tsconfig.json": `{"compilerOptions":` + tc.options + `,"include":["a.ts"]}`,
+			})
+			program := createProgramFromTsconfigDir(t, dir)
+			diags := runProgramTypeCheck(t, program)
+
+			for _, d := range diags {
+				if d.SourceFile == nil {
+					continue
+				}
+				name := d.SourceFile.FileName()
+				if strings.HasPrefix(name, "bundled:") || strings.Contains(name, "/libs/lib.") {
+					t.Errorf("default-lib invariant violated under %s: diagnostic %s in %s",
+						tc.name, d.RuleName, name)
+				}
+			}
+		})
+	}
+}
+
+// Same invariant under multi-program load. If pool-level checker
+// invocations were ever to surface lib diagnostics in just one program's
+// view but not another, this would catch it.
+func TestBoundary_DefaultLibsCleanAcrossPrograms(t *testing.T) {
+	mk := func(name string, opts string) *compiler.Program {
+		dir := t.TempDir()
+		writeFiles(t, dir, map[string]string{
+			"a.ts":          "export const " + name + " = 1;\n",
+			"tsconfig.json": `{"compilerOptions":` + opts + `,"include":["a.ts"]}`,
+		})
+		return createProgramFromTsconfigDir(t, dir)
+	}
+	progs := []*compiler.Program{
+		mk("a", `{"target":"es2020","strict":true}`),
+		mk("b", `{"target":"es2015","lib":["es2015"]}`),
+		mk("c", `{"target":"esnext","lib":["esnext","dom"]}`),
+	}
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        progs,
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			if strings.HasPrefix(d.RuleName, "TypeScript(") {
+				diags = append(diags, d)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+
+	for _, d := range diags {
+		if d.SourceFile == nil {
+			continue
+		}
+		name := d.SourceFile.FileName()
+		if strings.HasPrefix(name, "bundled:") || strings.Contains(name, "/libs/lib.") {
+			t.Errorf("default-lib invariant violated across programs: %s in %s",
+				d.RuleName, name)
+		}
+	}
+}
+
+// === Boundary 2: program-level vs per-file equivalence === //
+//
+// rslint's runTypeCheckForProgram calls GetDiagnosticsOfAnyProgram with
+// file=nil, which goes through compilerCheckerPool.forEachCheckerGroupDo
+// internally. The legacy file-scoped path called GetSemanticDiagnostics
+// per file in a Goroutine pool that calls SkipTypeChecking BEFORE the
+// per-file collect function.
+//
+// These two paths can in principle diverge if SkipTypeChecking is gated
+// differently. This test pins the invariant: the per-file *semantic*
+// diagnostic set (gathered by walking each source file individually) is
+// a SUBSET of what we extract from GetDiagnosticsOfAnyProgram. Failure
+// means the program-level path silently drops a diagnostic that per-file
+// would have surfaced.
+func TestBoundary_ProgramLevelMatchesPerFileSemanticDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		// Mix: source-level errors + d.ts errors + unused @ts-expect-error
+		// to exercise multiple diagnostic paths.
+		"entry.ts": `// @ts-expect-error
+const x: number = 1;
+const bad: string = 42;
+`,
+		"local.d.ts": `import * as M from 'this-package-does-not-exist';
+export type T = typeof M;
+`,
+		"tsconfig.json": `{"compilerOptions":{"skipLibCheck":false},"include":["entry.ts","local.d.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+	ctx := context.Background()
+
+	progDiags := compiler.GetDiagnosticsOfAnyProgram(
+		ctx, program, nil, false,
+		program.GetBindDiagnostics,
+		program.GetSemanticDiagnostics,
+	)
+
+	var perFileDiags []*ast.Diagnostic
+	for _, sf := range program.GetSourceFiles() {
+		perFileDiags = append(perFileDiags, program.GetSemanticDiagnostics(ctx, sf)...)
+	}
+
+	type key struct {
+		file string
+		code int32
+		pos  int
+		end  int
+	}
+	semanticOnly := func(diags []*ast.Diagnostic) map[key]struct{} {
+		out := make(map[key]struct{})
+		for _, d := range diags {
+			if d.File() == nil {
+				continue
+			}
+			out[key{d.File().FileName(), d.Code(), d.Loc().Pos(), d.Loc().End()}] = struct{}{}
+		}
+		return out
+	}
+
+	progSet := semanticOnly(progDiags)
+	perFileSet := semanticOnly(perFileDiags)
+
+	// Sanity: there must be at least one entry in each set, otherwise
+	// the test passes trivially.
+	if len(perFileSet) == 0 {
+		t.Fatal("baseline: per-file semantic walk produced 0 diagnostics; fixture broken")
+	}
+	if len(progSet) == 0 {
+		t.Fatal("baseline: program-level walk produced 0 diagnostics; fixture broken")
+	}
+
+	for k := range perFileSet {
+		if _, ok := progSet[k]; !ok {
+			t.Errorf("program-level path missing (file=%s code=TS%d pos=%d end=%d) that per-file produced",
+				k.file, k.code, k.pos, k.end)
+		}
+	}
+}
+
+// === Boundary 3: stability — same program, same diagnostics === //
+//
+// typescript-go's checker pool is concurrent. If anything in our type-
+// check phase introduced nondeterminism (race-induced reordering with a
+// downstream effect, missing locks, etc.) repeated runs over the same
+// program could yield slightly different diagnostic sets. This test runs
+// the same fixture 5 times and asserts the resulting fingerprint
+// (code, suffix, line, col) sets are byte-for-byte identical.
+func TestBoundary_DiagnosticsStableAcrossRepeatedRuns(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"entry.ts":      "const x: number = 'oops';\nconst y: string = 42;\n",
+		"local.d.ts":    "import * as M from 'this-package-does-not-exist';\nexport type T = typeof M;\n",
+		"tsconfig.json": `{"compilerOptions":{"skipLibCheck":false},"include":["entry.ts","local.d.ts"]}`,
+	})
+
+	type fp struct {
+		code   string
+		suffix string
+		line   int
+		col    int
+	}
+	captureRun := func(t *testing.T) []fp {
+		program := createProgramFromTsconfigDir(t, dir)
+		diags := runProgramTypeCheck(t, program)
+		out := make([]fp, 0, len(diags))
+		for _, d := range diags {
+			if d.SourceFile == nil {
+				continue
+			}
+			line, char := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, d.Range.Pos())
+			suffix := d.SourceFile.FileName()
+			if i := strings.LastIndex(suffix, "/"); i >= 0 {
+				suffix = suffix[i+1:]
+			}
+			out = append(out, fp{d.RuleName, suffix, line + 1, int(char) + 1})
+		}
+		sort.Slice(out, func(i, j int) bool {
+			if out[i].code != out[j].code {
+				return out[i].code < out[j].code
+			}
+			if out[i].suffix != out[j].suffix {
+				return out[i].suffix < out[j].suffix
+			}
+			if out[i].line != out[j].line {
+				return out[i].line < out[j].line
+			}
+			return out[i].col < out[j].col
+		})
+		return out
+	}
+
+	first := captureRun(t)
+	if len(first) == 0 {
+		t.Fatal("baseline: expected at least one diagnostic; fixture broken")
+	}
+
+	for i := range 4 {
+		next := captureRun(t)
+		if !reflect.DeepEqual(first, next) {
+			t.Errorf("run %d produced different diagnostics:\n  first: %v\n  this:  %v",
+				i+1, first, next)
+		}
+	}
+}
+
+// Same stability check exercising parallel program processing
+// (SingleThreaded=false) to catch any concurrency issue in the type-check
+// phase.
+func TestBoundary_DiagnosticsStableUnderParallelism(t *testing.T) {
+	mk := func(name string) *compiler.Program {
+		dir := t.TempDir()
+		writeFiles(t, dir, map[string]string{
+			"entry.ts": "const x: number = 'oops';\nconst y: string = 42;\n",
+			// Distinct package name per program so the d.ts errors don't
+			// dedup across them.
+			"local.d.ts":    "import * as M from 'missing-pkg-" + name + "';\nexport type T = typeof M;\n",
+			"tsconfig.json": `{"compilerOptions":{"skipLibCheck":false},"include":["entry.ts","local.d.ts"]}`,
+		})
+		return createProgramFromTsconfigDir(t, dir)
+	}
+
+	type fp struct {
+		code   string
+		suffix string
+		line   int
+		col    int
+	}
+	captureRun := func(t *testing.T) []fp {
+		programs := []*compiler.Program{mk("a"), mk("b"), mk("c")}
+		var mu sync.Mutex
+		var diags []rule.RuleDiagnostic
+		_, err := RunLinter(RunLinterOptions{
+			Programs:        programs,
+			SingleThreaded:  false,
+			GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+			TypeCheck:       true,
+			OnDiagnostic: func(d rule.RuleDiagnostic) {
+				if !strings.HasPrefix(d.RuleName, "TypeScript(") {
+					return
+				}
+				mu.Lock()
+				diags = append(diags, d)
+				mu.Unlock()
+			},
+		})
+		if err != nil {
+			t.Fatalf("RunLinter: %v", err)
+		}
+		out := make([]fp, 0, len(diags))
+		for _, d := range diags {
+			if d.SourceFile == nil {
+				continue
+			}
+			line, char := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, d.Range.Pos())
+			parts := strings.Split(d.SourceFile.FileName(), "/")
+			tail := parts[len(parts)-1]
+			out = append(out, fp{d.RuleName, tail, line + 1, int(char) + 1})
+		}
+		sort.Slice(out, func(i, j int) bool {
+			if out[i].code != out[j].code {
+				return out[i].code < out[j].code
+			}
+			if out[i].suffix != out[j].suffix {
+				return out[i].suffix < out[j].suffix
+			}
+			if out[i].line != out[j].line {
+				return out[i].line < out[j].line
+			}
+			return out[i].col < out[j].col
+		})
+		return out
+	}
+
+	first := captureRun(t)
+	if len(first) == 0 {
+		t.Fatal("baseline: expected diagnostics; fixture broken")
+	}
+
+	for i := range 4 {
+		next := captureRun(t)
+		if !reflect.DeepEqual(first, next) {
+			t.Errorf("parallel run %d produced different diagnostics:\n  first: %v\n  this:  %v",
+				i+1, first, next)
+		}
+	}
+}
+
+// === Boundary 4: file=nil diagnostics are intentionally dropped === //
+//
+// rslint's design decision: skip diagnostics with no file location
+// (config-parsing, option errors). Pin that decision: produce a fixture
+// that yields a file=nil diagnostic via tsconfig and assert it is NOT
+// surfaced through the rslint pipeline.
+func TestBoundary_NoSourceLocationDiagnosticsDropped(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		// `include:["src"]` matches no files → typescript-go emits TS18003
+		// ("No inputs were found...") with file=nil.
+		"tsconfig.json": `{"include":["src"]}`,
+	})
+
+	program := createProgramFromTsconfigDir(t, dir)
+	raw := compiler.GetDiagnosticsOfAnyProgram(
+		context.Background(), program, nil, false,
+		program.GetBindDiagnostics,
+		program.GetSemanticDiagnostics,
+	)
+	hasFilelessTS18003 := false
+	for _, d := range raw {
+		if d.Code() == 18003 && d.File() == nil {
+			hasFilelessTS18003 = true
+			break
+		}
+	}
+	if !hasFilelessTS18003 {
+		t.Skip("fixture did not yield the expected file=nil TS18003 (typescript-go behavior changed); skipping invariant")
+	}
+
+	var got []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			got = append(got, d)
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	for _, d := range got {
+		if d.RuleName == "TypeScript(TS18003)" {
+			t.Errorf("expected fileless TS18003 to be dropped, got: %+v", d)
+		}
+	}
+}

--- a/internal/linter/linter_typecheck_fixtures_test.go
+++ b/internal/linter/linter_typecheck_fixtures_test.go
@@ -1,0 +1,303 @@
+package linter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// Real-fixture tests covering scenarios that synthetic in-tempdir setups
+// cannot easily exercise:
+//   - node_modules-resolved d.ts under skipLibCheck on/off
+//   - project references (composite + references)
+//   - skipDefaultLibCheck / noLib interaction with user code that uses global types
+//
+// All assertions follow the same precision discipline as the matrix file:
+// exact code, exact file suffix, exact 1-based (line, col), exact counts,
+// and a baseline run wherever a test could otherwise pass trivially.
+
+// programHasFileWithSuffix returns true if any source file in the program
+// has a path ending with the given suffix. Use this for baseline checks
+// instead of comparing against `filepath.Join(tempDir, ...)`: macOS
+// `t.TempDir()` returns `/var/folders/...` while typescript-go realpaths
+// to `/private/var/folders/...`, so direct equality fails.
+func programHasFileWithSuffix(program *compiler.Program, suffix string) bool {
+	for _, f := range program.GetSourceFiles() {
+		if strings.HasSuffix(f.FileName(), suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// === A real-world node_modules d.ts === //
+//
+// Layout under tmpDir:
+//   ./node_modules/foo/package.json   {"types": "index.d.ts"}
+//   ./node_modules/foo/index.d.ts     declares an error (TS2307 missing module)
+//   ./entry.ts                        imports 'foo'
+//   ./tsconfig.json                   moduleResolution: "node"
+//
+// Under skipLibCheck:false the d.ts inside node_modules MUST produce its
+// TS2307 (typescript-go's SkipTypeChecking does NOT special-case
+// node_modules path; only IsDeclarationFile + skipLibCheck matters).
+// Under skipLibCheck:true the same diagnostic must be suppressed.
+func writeNodeModulesFooFixture(t *testing.T, dir string, skipLibCheck *bool) {
+	t.Helper()
+	files := map[string]string{
+		"node_modules/foo/package.json": `{"name":"foo","types":"index.d.ts"}`,
+		"node_modules/foo/index.d.ts": `import * as M from 'this-package-does-not-exist';
+export type T = typeof M;
+export declare const foo: T;
+`,
+		"entry.ts": `import {foo} from 'foo';
+export const x = foo;
+`,
+	}
+	var opts string
+	switch {
+	case skipLibCheck == nil:
+		opts = ""
+	case *skipLibCheck:
+		opts = `,"skipLibCheck":true`
+	default:
+		opts = `,"skipLibCheck":false`
+	}
+	files["tsconfig.json"] = `{"compilerOptions":{"moduleResolution":"node16","module":"node16","target":"es2020"` + opts + `},"include":["entry.ts"]}`
+	writeFiles(t, dir, files)
+}
+
+func TestFixture_NodeModulesDts_SkipLibCheckFalse_ReportsError(t *testing.T) {
+	dir := t.TempDir()
+	skip := false
+	writeNodeModulesFooFixture(t, dir, &skip)
+	program := createProgramFromTsconfigDir(t, dir)
+
+	// Baseline: program loaded the d.ts under node_modules.
+	if !programHasFileWithSuffix(program, "node_modules/foo/index.d.ts") {
+		t.Fatal("baseline: node_modules/foo/index.d.ts not loaded; fixture broken")
+	}
+
+	diags := runProgramTypeCheck(t, program)
+	// `node_modules/foo/index.d.ts:1:20` — opening quote of the missing
+	// 'this-package-does-not-exist' module specifier.
+	assertOneDiag(t, diags, "TS2307", "node_modules/foo/index.d.ts", 1, 20)
+	assertExactDiagCount(t, diags, 1)
+}
+
+func TestFixture_NodeModulesDts_SkipLibCheckTrue_Suppresses(t *testing.T) {
+	dir := t.TempDir()
+	skip := true
+	writeNodeModulesFooFixture(t, dir, &skip)
+	program := createProgramFromTsconfigDir(t, dir)
+
+	if !programHasFileWithSuffix(program, "node_modules/foo/index.d.ts") {
+		t.Fatal("baseline: node_modules/foo/index.d.ts not loaded; fixture broken")
+	}
+
+	diags := runProgramTypeCheck(t, program)
+	assertExactDiagCount(t, diags, 0)
+}
+
+// Negative pair-control: same fixture, default skipLibCheck (unspecified).
+// Default-off means errors must be reported — proves the suppression in the
+// previous test is caused by skipLibCheck:true and not by some other
+// implicit filter (e.g. ExcludePaths suppressing node_modules).
+func TestFixture_NodeModulesDts_SkipLibCheckUnspecified_ReportsError(t *testing.T) {
+	dir := t.TempDir()
+	writeNodeModulesFooFixture(t, dir, nil)
+	program := createProgramFromTsconfigDir(t, dir)
+
+	if !programHasFileWithSuffix(program, "node_modules/foo/index.d.ts") {
+		t.Fatal("baseline: node_modules/foo/index.d.ts not loaded; fixture broken")
+	}
+
+	diags := runProgramTypeCheck(t, program)
+	assertOneDiag(t, diags, "TS2307", "node_modules/foo/index.d.ts", 1, 20)
+	assertExactDiagCount(t, diags, 1)
+}
+
+// === Project references === //
+//
+// Layout:
+//   /a/tsconfig.json   composite, includes a.ts, references ../b
+//   /a/a.ts            imports from '../b/b'
+//   /b/tsconfig.json   composite, includes b.ts, declaration outputs in dist/
+//   /b/b.ts            real type error (TS2322 on `broken`)
+//   /b/dist/b.d.ts     pre-built declaration so A can resolve to B's outputs
+//   /b/dist/b.d.ts.map sourcemap so source positions line up
+//
+// When both A and B programs are passed to RunLinter:
+//   - typescript-go marks B's b.ts as IsSourceFromProjectReference inside
+//     program A's view, so A skips reporting it.
+//   - Program B owns b.ts and reports TS2322.
+//   - Cross-program dedup is the secondary safety net.
+// Assert the TS2322 appears exactly once. There may be additional
+// scaffolding diagnostics (e.g. TS6305 if outputs go stale); we pin the
+// b.ts:TS2322 anchor and the count of TS2322 specifically.
+func TestFixture_ProjectReferences_FileReportedExactlyOnce(t *testing.T) {
+	root := t.TempDir()
+
+	// Project B (referenced) — pre-built so A can resolve `../b/b` cleanly.
+	bDir := filepath.Join(root, "b")
+	if err := os.MkdirAll(filepath.Join(bDir, "dist"), 0755); err != nil {
+		t.Fatalf("mkdir b/dist: %v", err)
+	}
+	writeFiles(t, bDir, map[string]string{
+		"tsconfig.json": `{
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true
+  },
+  "include": ["b.ts"]
+}`,
+		"b.ts": "export const broken: number = 'oops';\n",
+		// Pre-built declaration so A resolves '../b/b' against B's outputs.
+		"dist/b.d.ts":          "export declare const broken: number;\n",
+		"dist/b.d.ts.map":      `{"version":3,"file":"b.d.ts","sourceRoot":"","sources":["../b.ts"],"names":[],"mappings":""}`,
+		"dist/tsconfig.tsbuildinfo": `{"version":"5.6.0"}`,
+	})
+
+	// Project A (referencing B)
+	aDir := filepath.Join(root, "a")
+	if err := os.MkdirAll(aDir, 0755); err != nil {
+		t.Fatalf("mkdir a: %v", err)
+	}
+	writeFiles(t, aDir, map[string]string{
+		"tsconfig.json": `{
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["a.ts"],
+  "references": [{"path": "../b"}]
+}`,
+		"a.ts": "import {broken} from '../b/b';\nexport const v: number = broken;\n",
+	})
+
+	progA := createProgramFromTsconfigDir(t, aDir)
+	progB := createProgramFromTsconfigDir(t, bDir)
+
+	if !programHasFileWithSuffix(progA, "/a/a.ts") {
+		t.Fatal("baseline: a.ts not in program A")
+	}
+	if !programHasFileWithSuffix(progB, "/b/b.ts") {
+		t.Fatal("baseline: b.ts not in program B")
+	}
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{progA, progB},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			if strings.HasPrefix(d.RuleName, "TypeScript(") {
+				diags = append(diags, d)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+
+	// `b.ts:1:14` — variable identifier `broken` (col 14, 1-based) gets
+	// the TS2322. There must be exactly one such diagnostic — proving:
+	//   (1) program B reports it,
+	//   (2) program A does NOT double-report it (IsSourceFromProjectReference),
+	//   (3) cross-program dedup keeps a single entry.
+	assertOneDiag(t, diags, "TS2322", "b/b.ts", 1, 14)
+	assertExactCodeCount(t, diags, "TS2322", 1)
+}
+
+// === Default lib check === //
+//
+// Verifies that under default skipDefaultLibCheck:false the program loads
+// its default library AND user source code that uses global types compiles
+// cleanly (i.e. the default lib is actually being type-checked but produces
+// zero errors itself). This is the de-facto baseline that any real project
+// relies on.
+func TestFixture_DefaultLib_LoadedAndCleanByDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"a.ts":          `export const arr = Array.from('abc');` + "\n",
+		"tsconfig.json": `{"compilerOptions":{"target":"es2020"},"include":["a.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+	diags := runProgramTypeCheck(t, program)
+	assertExactDiagCount(t, diags, 0)
+}
+
+// Toggling skipDefaultLibCheck:true must not cause user code that depends
+// on global types (Array.from) to start failing — the lib is still loaded,
+// just not type-checked. So user diagnostics remain at zero for valid code.
+func TestFixture_SkipDefaultLibCheckTrue_UserCodeStillTypeChecked(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"a.ts":          `export const arr = Array.from('abc');` + "\n",
+		"tsconfig.json": `{"compilerOptions":{"target":"es2020","skipDefaultLibCheck":true},"include":["a.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+	diags := runProgramTypeCheck(t, program)
+	assertExactDiagCount(t, diags, 0)
+}
+
+// And introducing a real user error under skipDefaultLibCheck:true MUST
+// surface — confirming the previous test isn't passing because the type-
+// check phase silently bailed out.
+func TestFixture_SkipDefaultLibCheckTrue_UserErrorStillReported(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"a.ts":          "const x: number = 'oops';\n",
+		"tsconfig.json": `{"compilerOptions":{"target":"es2020","skipDefaultLibCheck":true},"include":["a.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+	diags := runProgramTypeCheck(t, program)
+	assertOneDiag(t, diags, "TS2322", "a.ts", 1, 7)
+	assertExactDiagCount(t, diags, 1)
+}
+
+// `lib`-narrowed configurations: with only `lib:["es2015"]`, `BigInt` is
+// unknown (introduced in es2020). The user code should produce a
+// diagnostic at the `BigInt` identifier — proof that the lib selection
+// is actually being honoured by the type-check phase.
+func TestFixture_LibNarrowed_MissingGlobalReported(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"a.ts": "export const b = BigInt(1);\n",
+		// es2015 lib excludes BigInt (introduced in es2020).
+		"tsconfig.json": `{"compilerOptions":{"target":"es2015","lib":["es2015"]},"include":["a.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+	diags := runProgramTypeCheck(t, program)
+
+	// `export const b = BigInt(1);`
+	//                   ^ col 18 (1-based)
+	// TS2583 = "Cannot find name '{0}'. Do you need to change your target
+	// library? Try changing the `lib` compiler option to include 'esXX'."
+	assertOneDiag(t, diags, "TS2583", "a.ts", 1, 18)
+	assertExactDiagCount(t, diags, 1)
+}
+
+// Pair-control to the previous test: same source under `target:es2020`
+// (which includes BigInt) compiles cleanly. This confirms the `lib`
+// setting is the cause of the previous test's failure rather than some
+// unrelated rejection.
+func TestFixture_LibIncludesBigInt_NoErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"a.ts":          "export const b = BigInt(1);\n",
+		"tsconfig.json": `{"compilerOptions":{"target":"es2020","lib":["es2020"]},"include":["a.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+	diags := runProgramTypeCheck(t, program)
+	assertExactDiagCount(t, diags, 0)
+}

--- a/internal/linter/linter_typecheck_matrix_test.go
+++ b/internal/linter/linter_typecheck_matrix_test.go
@@ -1,0 +1,587 @@
+package linter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// Cross-matrix tests for --type-check semantics.
+//
+// Axes covered:
+//   A. skipLibCheck setting:        unspecified | true | false
+//   B. file location:               own .ts source | project .d.ts | node_modules .d.ts
+//   C. program count:               single | multi-program with mixed settings
+//   D. compiler options:            noCheck | noEmit | strict differences
+//   E. file-level directives:       // @ts-nocheck
+//   F. skipDefaultLibCheck
+//
+// Every test asserts:
+//   - exact diagnostic counts (not "at least one"),
+//   - exact TypeScript error codes (not just "some TS error"),
+//   - exact file paths,
+//   - exact 1-based (line, column) for at least one anchor diagnostic.
+// Most tests also include a baseline run (negative or positive control)
+// to prove the program is actually exercising the type-check phase.
+
+// runProgramTypeCheck runs RunLinter on a single program and returns the
+// TypeScript(TSxxxx) diagnostics emitted.
+func runProgramTypeCheck(t *testing.T, program *compiler.Program) []rule.RuleDiagnostic {
+	t.Helper()
+	var out []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			if strings.HasPrefix(d.RuleName, "TypeScript(") {
+				out = append(out, d)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	return out
+}
+
+// diagFingerprint summarises a diagnostic for stable error messages.
+type diagFingerprint struct {
+	code   string
+	suffix string // file path suffix
+	line   int    // 1-based
+	col    int    // 1-based
+}
+
+func fingerprint(d rule.RuleDiagnostic) diagFingerprint {
+	fp := diagFingerprint{code: d.RuleName}
+	if d.SourceFile != nil {
+		// 0-based from typescript-go → +1 to match user-visible line/col
+		line, char := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, d.Range.Pos())
+		fp.suffix = d.SourceFile.FileName()
+		fp.line = line + 1
+		fp.col = int(char) + 1
+	}
+	return fp
+}
+
+// assertOneDiag fails the test unless diags has exactly one diagnostic
+// matching code/suffix/line/col.
+func assertOneDiag(t *testing.T, diags []rule.RuleDiagnostic, code, fileSuffix string, line, col int) {
+	t.Helper()
+	matches := 0
+	for _, d := range diags {
+		fp := fingerprint(d)
+		if fp.code == "TypeScript("+code+")" &&
+			strings.HasSuffix(fp.suffix, fileSuffix) &&
+			fp.line == line && fp.col == col {
+			matches++
+		}
+	}
+	if matches != 1 {
+		t.Errorf("expected exactly 1 %s at %s:%d:%d, found %d. all diags: %s",
+			code, fileSuffix, line, col, matches, dumpDiags(diags))
+	}
+}
+
+// assertNoDiagInFile fails if any diagnostic's file ends with the given suffix.
+func assertNoDiagInFile(t *testing.T, diags []rule.RuleDiagnostic, fileSuffix string) {
+	t.Helper()
+	for _, d := range diags {
+		if d.SourceFile != nil && strings.HasSuffix(d.SourceFile.FileName(), fileSuffix) {
+			t.Errorf("expected no diagnostic in %s, got %s at line %d. all diags: %s",
+				fileSuffix, d.RuleName, fingerprint(d).line, dumpDiags(diags))
+		}
+	}
+}
+
+// assertExactDiagCount fails unless the slice has exactly n diagnostics.
+func assertExactDiagCount(t *testing.T, diags []rule.RuleDiagnostic, n int) {
+	t.Helper()
+	if len(diags) != n {
+		t.Errorf("expected exactly %d type diagnostics, got %d. all diags: %s",
+			n, len(diags), dumpDiags(diags))
+	}
+}
+
+// assertExactCodeCount fails unless exactly n diagnostics with the given code exist.
+func assertExactCodeCount(t *testing.T, diags []rule.RuleDiagnostic, code string, n int) {
+	t.Helper()
+	got := 0
+	for _, d := range diags {
+		if d.RuleName == "TypeScript("+code+")" {
+			got++
+		}
+	}
+	if got != n {
+		t.Errorf("expected exactly %d %s, got %d. all diags: %s",
+			n, code, got, dumpDiags(diags))
+	}
+}
+
+func dumpDiags(diags []rule.RuleDiagnostic) string {
+	if len(diags) == 0 {
+		return "[]"
+	}
+	var b strings.Builder
+	b.WriteString("[")
+	for i, d := range diags {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fp := fingerprint(d)
+		b.WriteString(fp.code)
+		b.WriteString("@")
+		short := fp.suffix
+		if i := strings.LastIndex(short, "/"); i >= 0 {
+			short = short[i+1:]
+		}
+		b.WriteString(short)
+		b.WriteString(":")
+		b.WriteString(itoa(fp.line))
+		b.WriteString(":")
+		b.WriteString(itoa(fp.col))
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var s [12]byte
+	i := len(s)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		s[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		s[i] = '-'
+	}
+	return string(s[i:])
+}
+
+// === Axis A × Axis B: skipLibCheck × file location ===
+
+// (A=unspecified, B=project .d.ts) — typescript-go default treats absent
+// skipLibCheck as off. The d.ts must produce TS2307 for the missing module
+// import. The .ts user-side import should NOT produce its own redundant
+// error.
+func TestMatrix_SkipLibCheck_Unspecified_ProjectDtsErrorReported(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"local.d.ts": `import * as M from 'this-package-does-not-exist';
+export type T = typeof M;
+`,
+		"entry.ts":      "import type {T} from './local';\nexport const x: T = {} as T;\n",
+		"tsconfig.json": `{"include":["entry.ts","local.d.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+	diags := runProgramTypeCheck(t, program)
+
+	// Exactly one TS2307 in local.d.ts at column 20 — the opening quote of
+	// the 'this-package-does-not-exist' module specifier in
+	//   `import * as M from 'this-package-does-not-exist';`
+	//                       ^ col 20
+	assertOneDiag(t, diags, "TS2307", "local.d.ts", 1, 20)
+	// And nothing else.
+	assertExactDiagCount(t, diags, 1)
+}
+
+// (A=true, B=project-internal .d.ts NOT in node_modules) — skipLibCheck
+// applies to ALL declaration files irrespective of location.
+func TestMatrix_SkipLibCheck_True_SuppressesProjectDtsErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"local.d.ts": `import * as M from 'this-package-does-not-exist';
+export type T = typeof M;
+`,
+		"entry.ts":      "import type {T} from './local';\nexport const x: T = {} as T;\n",
+		"tsconfig.json": `{"compilerOptions":{"skipLibCheck":true},"include":["entry.ts","local.d.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+	diags := runProgramTypeCheck(t, program)
+
+	// Baseline confirmation: program loaded both files (otherwise the test
+	// would pass trivially because the program is empty).
+	if program.GetSourceFile(filepath.Join(dir, "local.d.ts")) == nil {
+		t.Fatal("baseline: local.d.ts not loaded into program — test setup broken")
+	}
+	if program.GetSourceFile(filepath.Join(dir, "entry.ts")) == nil {
+		t.Fatal("baseline: entry.ts not loaded into program — test setup broken")
+	}
+
+	// No diagnostics anywhere — d.ts errors suppressed, entry.ts has no
+	// real type errors of its own.
+	assertExactDiagCount(t, diags, 0)
+}
+
+// (A=true, B=own .ts source) — skipLibCheck only affects declaration files.
+// A real TS2322 in a .ts file MUST still be reported.
+func TestMatrix_SkipLibCheck_True_DoesNotSuppressSourceErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"a.ts":          "const x: number = 'oops';\n",
+		"tsconfig.json": `{"compilerOptions":{"skipLibCheck":true},"include":["a.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+	diags := runProgramTypeCheck(t, program)
+
+	// `const x: number = 'oops';` → TS2322 at line 1, col 7 (variable name).
+	assertOneDiag(t, diags, "TS2322", "a.ts", 1, 7)
+	assertExactDiagCount(t, diags, 1)
+}
+
+// === Axis C: multi-program with mixed skipLibCheck on a shared d.ts ===
+
+// Program A skipLibCheck:false → reports d.ts error.
+// Program B skipLibCheck:true → suppresses d.ts error.
+// Across both, dedup keeps a SINGLE TS2307. Asserts:
+//   - exact code TS2307
+//   - exact file (shared.d.ts)
+//   - exact (line, col) (1, 21)
+//   - exactly 1 occurrence — proving dedup works AND that B's silence
+//     didn't suppress A's report.
+func TestMatrix_MultiProgram_MixedSkipLibCheck_SharedDtsReportedExactlyOnce(t *testing.T) {
+	root := t.TempDir()
+	writeFiles(t, root, map[string]string{
+		"shared.d.ts": `import * as M from 'this-package-does-not-exist';
+export type T = typeof M;
+`,
+	})
+	mk := func(subdir string, skipLib bool) *compiler.Program {
+		p := filepath.Join(root, subdir)
+		_ = os.MkdirAll(p, 0755)
+		opts := `"skipLibCheck":false`
+		if skipLib {
+			opts = `"skipLibCheck":true`
+		}
+		_ = os.WriteFile(filepath.Join(p, "tsconfig.json"),
+			[]byte(`{"compilerOptions":{`+opts+`},"include":["../shared.d.ts"]}`), 0644)
+		return createProgramFromTsconfigDir(t, p)
+	}
+	progA := mk("a", false)
+	progB := mk("b", true)
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{progA, progB},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			if strings.HasPrefix(d.RuleName, "TypeScript(") {
+				diags = append(diags, d)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+
+	assertOneDiag(t, diags, "TS2307", "shared.d.ts", 1, 20)
+	assertExactDiagCount(t, diags, 1)
+}
+
+// Inverse control: BOTH programs skipLibCheck:true → ZERO TS2307 reported.
+// Together with the previous test this proves:
+//   1. the d.ts genuinely has the error (program A in the previous test reported it),
+//   2. when ALL programs containing it have skipLibCheck:true, none reports.
+func TestMatrix_MultiProgram_BothSkipLibCheck_NoDtsErrors(t *testing.T) {
+	root := t.TempDir()
+	writeFiles(t, root, map[string]string{
+		"shared.d.ts": `import * as M from 'this-package-does-not-exist';
+export type T = typeof M;
+`,
+	})
+	mk := func(subdir string) *compiler.Program {
+		p := filepath.Join(root, subdir)
+		_ = os.MkdirAll(p, 0755)
+		_ = os.WriteFile(filepath.Join(p, "tsconfig.json"),
+			[]byte(`{"compilerOptions":{"skipLibCheck":true},"include":["../shared.d.ts"]}`), 0644)
+		return createProgramFromTsconfigDir(t, p)
+	}
+	progA := mk("a")
+	progB := mk("b")
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{progA, progB},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			if strings.HasPrefix(d.RuleName, "TypeScript(") {
+				diags = append(diags, d)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+
+	assertExactDiagCount(t, diags, 0)
+}
+
+// === Axis D: noCheck === //
+
+// Baseline + noCheck: assert the SAME source produces TS2322 normally and
+// zero diagnostics under noCheck:true.
+func TestMatrix_NoCheck_SuppressesEverything(t *testing.T) {
+	src := "const x: number = 'oops';\n"
+	build := func(opts string) []rule.RuleDiagnostic {
+		dir := t.TempDir()
+		writeFiles(t, dir, map[string]string{
+			"a.ts":          src,
+			"tsconfig.json": `{"compilerOptions":{` + opts + `},"include":["a.ts"]}`,
+		})
+		return runProgramTypeCheck(t, createProgramFromTsconfigDir(t, dir))
+	}
+
+	// Baseline: no noCheck → TS2322 at line 1, col 7, exactly one diag.
+	baseline := build(`"strict":true`)
+	assertOneDiag(t, baseline, "TS2322", "a.ts", 1, 7)
+	assertExactDiagCount(t, baseline, 1)
+
+	// noCheck:true → zero.
+	suppressed := build(`"strict":true,"noCheck":true`)
+	assertExactDiagCount(t, suppressed, 0)
+}
+
+// === Axis D: noEmit ===
+
+// noEmit:true does NOT suppress real type errors. Asserts the SAME error
+// surfaces both with and without noEmit.
+func TestMatrix_NoEmit_DoesNotSuppressTypeErrors(t *testing.T) {
+	src := "const x: number = 'oops';\n"
+	build := func(opts string) []rule.RuleDiagnostic {
+		dir := t.TempDir()
+		writeFiles(t, dir, map[string]string{
+			"a.ts":          src,
+			"tsconfig.json": `{"compilerOptions":{` + opts + `},"include":["a.ts"]}`,
+		})
+		return runProgramTypeCheck(t, createProgramFromTsconfigDir(t, dir))
+	}
+	baseline := build(``)
+	withNoEmit := build(`"noEmit":true`)
+	assertOneDiag(t, baseline, "TS2322", "a.ts", 1, 7)
+	assertExactDiagCount(t, baseline, 1)
+	assertOneDiag(t, withNoEmit, "TS2322", "a.ts", 1, 7)
+	assertExactDiagCount(t, withNoEmit, 1)
+}
+
+// === Axis E: file-level @ts-nocheck === //
+
+// Baseline + @ts-nocheck: same source produces 2 TS errors normally; with
+// @ts-nocheck the file is fully suppressed.
+func TestMatrix_TsNocheck_SuppressesEntireFile(t *testing.T) {
+	build := func(src string) []rule.RuleDiagnostic {
+		dir := t.TempDir()
+		writeFiles(t, dir, map[string]string{
+			"a.ts":          src,
+			"tsconfig.json": `{"include":["a.ts"]}`,
+		})
+		return runProgramTypeCheck(t, createProgramFromTsconfigDir(t, dir))
+	}
+
+	// Baseline: no directive → 2 TS2322 (both lines have type errors).
+	baseline := build("const x: number = 'oops';\nconst y: string = 42;\n")
+	assertExactCodeCount(t, baseline, "TS2322", 2)
+
+	// With @ts-nocheck → file-wide suppression.
+	suppressed := build("// @ts-nocheck\nconst x: number = 'oops';\nconst y: string = 42;\n")
+	assertNoDiagInFile(t, suppressed, "a.ts")
+	assertExactDiagCount(t, suppressed, 0)
+}
+
+// === Axis F: skipDefaultLibCheck === //
+
+// skipDefaultLibCheck:true alone (skipLibCheck not set) only skips
+// lib.*.d.ts. A user-authored .d.ts with a real error must still produce
+// TS2307. (We use skipLibCheck:false explicitly for clarity, but absence of
+// skipLibCheck would be equivalent.)
+func TestMatrix_SkipDefaultLibCheck_OnlySkipsDefaultLib(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"local.d.ts": `import * as M from 'this-package-does-not-exist';
+export type T = typeof M;
+`,
+		"entry.ts": "import type {T} from './local';\nexport const x: T = {} as T;\n",
+		"tsconfig.json": `{
+"compilerOptions":{"skipDefaultLibCheck":true,"skipLibCheck":false},
+"include":["entry.ts","local.d.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+	diags := runProgramTypeCheck(t, program)
+
+	assertOneDiag(t, diags, "TS2307", "local.d.ts", 1, 20)
+	assertExactDiagCount(t, diags, 1)
+}
+
+// === TypeInfoFiles gate as backstop ===
+//
+// Baseline + with-gate: same source, same program. Without the gate, TS2322
+// appears. With TypeInfoFiles excluding the file, the diagnostic is dropped.
+func TestMatrix_TypeInfoFiles_GateActsAsBackstopForGapFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"a.ts":          "const x: number = 'oops';\n",
+		"tsconfig.json": `{"include":["a.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+
+	collect := func(infoFiles map[string]struct{}) []rule.RuleDiagnostic {
+		var out []rule.RuleDiagnostic
+		_, err := RunLinter(RunLinterOptions{
+			Programs:        []*compiler.Program{program},
+			SingleThreaded:  true,
+			GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+			TypeCheck:       true,
+			TypeInfoFiles:   infoFiles,
+			OnDiagnostic: func(d rule.RuleDiagnostic) {
+				if strings.HasPrefix(d.RuleName, "TypeScript(") {
+					out = append(out, d)
+				}
+			},
+		})
+		if err != nil {
+			t.Fatalf("RunLinter: %v", err)
+		}
+		return out
+	}
+
+	// Baseline: no gate → 1 TS2322.
+	baseline := collect(nil)
+	assertOneDiag(t, baseline, "TS2322", "a.ts", 1, 7)
+	assertExactDiagCount(t, baseline, 1)
+
+	// Gate that excludes a.ts → 0.
+	gated := collect(map[string]struct{}{"/some/other/file.ts": {}})
+	assertExactDiagCount(t, gated, 0)
+
+	// Gate that includes a.ts → still 1 (the gate is a positive set).
+	included := collect(map[string]struct{}{program.GetSourceFile(filepath.Join(dir, "a.ts")).FileName(): {}})
+	assertOneDiag(t, included, "TS2322", "a.ts", 1, 7)
+	assertExactDiagCount(t, included, 1)
+}
+
+// === Dedup with strict-only diagnostics across programs ===
+//
+// Same source loaded by two programs with different strictness:
+//   - strict program reports TS7006 (param `x` implicitly any) at col 21
+//   - loose program reports nothing
+// Across both, exactly 1 TS7006 should reach the consumer. Asserts the
+// dedup keeps strict's report and that the loose program's silence does
+// not override it.
+func TestMatrix_StrictOnlyDiagAcrossPrograms_KeptExactlyOnce(t *testing.T) {
+	root := t.TempDir()
+	writeFiles(t, root, map[string]string{
+		"shared.ts": "export function fn(x) { return x; }\n",
+	})
+	mk := func(subdir, opts string) *compiler.Program {
+		p := filepath.Join(root, subdir)
+		_ = os.MkdirAll(p, 0755)
+		_ = os.WriteFile(filepath.Join(p, "tsconfig.json"),
+			[]byte(`{"compilerOptions":{`+opts+`},"include":["../shared.ts"]}`), 0644)
+		return createProgramFromTsconfigDir(t, p)
+	}
+	strict := mk("strict", `"noImplicitAny":true`)
+	loose := mk("loose", `"noImplicitAny":false`)
+
+	var got []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{strict, loose},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			if strings.HasPrefix(d.RuleName, "TypeScript(") {
+				got = append(got, d)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+
+	// `export function fn(x) {...}` — parameter `x` at column 20 (1-based).
+	assertOneDiag(t, got, "TS7006", "shared.ts", 1, 20)
+	assertExactDiagCount(t, got, 1)
+}
+
+// === TypeCheck=false fully disables Phase 2 === //
+//
+// Same source as TestMatrix_SkipLibCheck_True_DoesNotSuppressSourceErrors:
+// has 1 TS2322 when TypeCheck=true; 0 when TypeCheck=false.
+func TestMatrix_TypeCheckFalse_NoPhaseTwo(t *testing.T) {
+	src := "const x: number = 'oops';\n"
+	build := func() *compiler.Program {
+		dir := t.TempDir()
+		writeFiles(t, dir, map[string]string{
+			"a.ts":          src,
+			"tsconfig.json": `{"include":["a.ts"]}`,
+		})
+		return createProgramFromTsconfigDir(t, dir)
+	}
+
+	// Baseline: TypeCheck=true → 1 TS2322.
+	on := runProgramTypeCheck(t, build())
+	assertOneDiag(t, on, "TS2322", "a.ts", 1, 7)
+	assertExactDiagCount(t, on, 1)
+
+	// TypeCheck=false → 0.
+	var got []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{build()},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       false,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			if strings.HasPrefix(d.RuleName, "TypeScript(") {
+				got = append(got, d)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	assertExactDiagCount(t, got, 0)
+}
+
+// === noImplicitAny strict toggle === //
+//
+// Verifies that strict checks are honored at the program level (the source
+// file alone is identical; only compilerOptions differ).
+func TestMatrix_NoImplicitAny_HonoredByProgram(t *testing.T) {
+	src := "export function fn(x) { return x; }\n"
+	build := func(opts string) []rule.RuleDiagnostic {
+		dir := t.TempDir()
+		writeFiles(t, dir, map[string]string{
+			"a.ts":          src,
+			"tsconfig.json": `{"compilerOptions":{` + opts + `},"include":["a.ts"]}`,
+		})
+		return runProgramTypeCheck(t, createProgramFromTsconfigDir(t, dir))
+	}
+
+	loose := build(`"noImplicitAny":false`)
+	assertExactDiagCount(t, loose, 0)
+
+	strict := build(`"noImplicitAny":true`)
+	// `export function fn(x) {...}` — parameter `x` at col 20.
+	assertOneDiag(t, strict, "TS7006", "a.ts", 1, 20)
+	assertExactDiagCount(t, strict, 1)
+}

--- a/internal/linter/linter_typecheck_program_test.go
+++ b/internal/linter/linter_typecheck_program_test.go
@@ -1,0 +1,282 @@
+package linter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// createProgramFromTsconfigDir builds a Program from an existing tsconfig.json
+// in dir. Use createTsconfigProject to set the directory up.
+func createProgramFromTsconfigDir(t *testing.T, dir string) *compiler.Program {
+	t.Helper()
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := utils.CreateCompilerHost(dir, fs)
+	program, err := utils.CreateProgram(true, fs, dir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("create program in %s: %v", dir, err)
+	}
+	return program
+}
+
+// writeFiles creates files under dir relative to the directory.
+func writeFiles(t *testing.T, dir string, files map[string]string) map[string]string {
+	t.Helper()
+	out := make(map[string]string, len(files))
+	for rel, content := range files {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+		out[rel] = tspath.NormalizePath(full)
+	}
+	return out
+}
+
+// New regression tests covering the program-scoped, tsc-aligned --type-check
+// semantics introduced after the linter refactor.
+
+// (1) Owned-set boundary: a `.ts` source file pulled in by import resolution
+// but not listed in tsconfig include must still get its type errors reported.
+func TestTypeCheck_ReportsErrorsInTransitivelyImportedSource(t *testing.T) {
+	dir := t.TempDir()
+	paths := writeFiles(t, dir, map[string]string{
+		"entry.ts": `import {bad} from './lib';
+const v: number = bad;
+`,
+		"lib.ts": `export const bad: string = 'oops';
+`,
+		"tsconfig.json": `{"include":["entry.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic:    func(d rule.RuleDiagnostic) { diags = append(diags, d) },
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+
+	gotEntryErr := false
+	for _, d := range diags {
+		if !strings.HasPrefix(d.RuleName, "TypeScript(") {
+			continue
+		}
+		if d.SourceFile != nil && d.SourceFile.FileName() == paths["entry.ts"] {
+			gotEntryErr = true
+		}
+	}
+	if !gotEntryErr {
+		t.Fatal("expected entry.ts to report a type error caused by lib.ts (transitive import)")
+	}
+}
+
+// (2) skipLibCheck:false + a hand-written .d.ts that imports a missing
+// package: the d.ts itself produces TS2307. This is the resolution-bundler
+// scenario in miniature.
+func TestTypeCheck_ReportsDeclarationFileErrors_WhenSkipLibCheckFalse(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"types.d.ts": `import * as Missing from 'this-package-does-not-exist';
+export type T = typeof Missing;
+`,
+		"entry.ts": `import type {T} from './types';
+export const x: T = {} as T;
+`,
+		"tsconfig.json": `{"compilerOptions":{"skipLibCheck":false},"include":["entry.ts","types.d.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic:    func(d rule.RuleDiagnostic) { diags = append(diags, d) },
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+
+	hasDtsErr := false
+	for _, d := range diags {
+		if d.RuleName == "TypeScript(TS2307)" && strings.Contains(d.SourceFile.FileName(), "types.d.ts") {
+			hasDtsErr = true
+			break
+		}
+	}
+	if !hasDtsErr {
+		t.Fatal("expected TS2307 from types.d.ts when skipLibCheck=false")
+	}
+}
+
+// (3) skipLibCheck:true masks d.ts errors (typescript-go's SkipTypeChecking
+// natural behaviour; we should not over-report).
+func TestTypeCheck_SuppressesDeclarationFileErrors_WhenSkipLibCheckTrue(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"types.d.ts": `import * as Missing from 'this-package-does-not-exist';
+export type T = typeof Missing;
+`,
+		"entry.ts": `import type {T} from './types';
+export const x: T = {} as T;
+`,
+		"tsconfig.json": `{"compilerOptions":{"skipLibCheck":true},"include":["entry.ts","types.d.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic:    func(d rule.RuleDiagnostic) { diags = append(diags, d) },
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+
+	for _, d := range diags {
+		if d.RuleName == "TypeScript(TS2307)" && d.SourceFile != nil && strings.HasSuffix(d.SourceFile.FileName(), "types.d.ts") {
+			t.Errorf("did not expect TS2307 from types.d.ts under skipLibCheck:true, got: %s", d.Message.Description)
+		}
+	}
+}
+
+// (4) Cross-program dedup: same shared file, same error, two programs.
+// Should be reported exactly once.
+func TestTypeCheck_DedupsAcrossPrograms(t *testing.T) {
+	root := t.TempDir()
+
+	// Shared .ts file under root.
+	sharedRel := "shared/util.ts"
+	writeFiles(t, root, map[string]string{
+		sharedRel: `export const broken: number = 'string';
+`,
+	})
+
+	// Two sibling tsconfig dirs each include the same shared file via a
+	// relative path.
+	a := filepath.Join(root, "a")
+	if err := os.MkdirAll(a, 0755); err != nil {
+		t.Fatalf("mkdir a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(a, "tsconfig.json"),
+		[]byte(`{"include":["../shared/util.ts"]}`), 0644); err != nil {
+		t.Fatalf("write a/tsconfig: %v", err)
+	}
+	b := filepath.Join(root, "b")
+	if err := os.MkdirAll(b, 0755); err != nil {
+		t.Fatalf("mkdir b: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(b, "tsconfig.json"),
+		[]byte(`{"include":["../shared/util.ts"]}`), 0644); err != nil {
+		t.Fatalf("write b/tsconfig: %v", err)
+	}
+
+	progA := createProgramFromTsconfigDir(t, a)
+	progB := createProgramFromTsconfigDir(t, b)
+
+	var ts2322 int
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{progA, progB},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			if d.RuleName == "TypeScript(TS2322)" {
+				ts2322++
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+
+	if ts2322 != 1 {
+		t.Errorf("expected exactly 1 TS2322 (deduped across programs), got %d", ts2322)
+	}
+}
+
+// (5) SkipTypeCheckPrograms entry true skips that program's type-check phase.
+func TestTypeCheck_SkipTypeCheckProgramsHonored(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"a.ts": `const x: number = 'oops';
+`,
+		"tsconfig.json": `{"include":["a.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:              []*compiler.Program{program},
+		SingleThreaded:        true,
+		GetRulesForFile:       func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:             true,
+		SkipTypeCheckPrograms: []bool{true},
+		OnDiagnostic:          func(d rule.RuleDiagnostic) { diags = append(diags, d) },
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+
+	for _, d := range diags {
+		if strings.HasPrefix(d.RuleName, "TypeScript(") {
+			t.Fatalf("did not expect any TS diagnostic when program is in skip mask, got: %s", d.RuleName)
+		}
+	}
+}
+
+// (6) TS2578 ("unused @ts-expect-error") surfaces under the new path.
+// Verifies that GetDiagnosticsOfAnyProgram emits this when the directive
+// turns out unused.
+func TestTypeCheck_UnusedTsExpectErrorStillReportsTS2578(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"a.ts": `// @ts-expect-error
+const x: number = 1;
+`,
+		"tsconfig.json": `{"include":["a.ts"]}`,
+	})
+	program := createProgramFromTsconfigDir(t, dir)
+
+	var found bool
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return nil },
+		TypeCheck:       true,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			if d.RuleName == "TypeScript(TS2578)" {
+				found = true
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	if !found {
+		t.Error("expected TS2578 (unused @ts-expect-error) to be reported")
+	}
+}

--- a/internal/linter/linter_typecheck_test.go
+++ b/internal/linter/linter_typecheck_test.go
@@ -174,10 +174,13 @@ func TestTypeCheck_CoexistsWithLintRules(t *testing.T) {
 
 // --- Type-check respects file filtering ---
 
-func TestTypeCheck_RespectsAllowFiles(t *testing.T) {
+// Type-check is program-scoped (tsc-aligned) and is NOT constrained by
+// allowFiles. allowFiles only narrows lint-rule visit; type errors continue
+// to be reported for every file in the program.
+func TestTypeCheck_NotConstrainedByAllowFiles(t *testing.T) {
 	program, paths := createTestProgramWithFiles(t, map[string]string{
-		"a.ts": "const x: number = 'hello';", // type error
-		"b.ts": "const y: string = 42;",      // type error
+		"a.ts": "const x: number = 'hello';",
+		"b.ts": "const y: string = 42;",
 	})
 
 	var diagnostics []rule.RuleDiagnostic
@@ -188,17 +191,28 @@ func TestTypeCheck_RespectsAllowFiles(t *testing.T) {
 		nil,
 	)
 
+	gotA, gotB := false, false
 	for _, d := range diagnostics {
-		if d.SourceFile.FileName() != paths["a.ts"] {
-			t.Errorf("Expected diagnostics only from a.ts, got from %s", d.SourceFile.FileName())
+		if d.SourceFile.FileName() == paths["a.ts"] {
+			gotA = true
 		}
+		if d.SourceFile.FileName() == paths["b.ts"] {
+			gotB = true
+		}
+	}
+	if !gotA {
+		t.Error("expected type error from a.ts (in allowFiles)")
+	}
+	if !gotB {
+		t.Error("expected type error from b.ts even though it is outside allowFiles (program-scoped tsc-aligned semantics)")
 	}
 }
 
-func TestTypeCheck_RespectsAllowDirs(t *testing.T) {
+// Same idea for allowDirs: program-level type-check is unaffected.
+func TestTypeCheck_NotConstrainedByAllowDirs(t *testing.T) {
 	program, paths := createTestProgramWithFiles(t, map[string]string{
-		"src/a.ts": "const x: number = 'hello';", // type error
-		"lib/b.ts": "const y: string = 42;",      // type error
+		"src/a.ts": "const x: number = 'hello';",
+		"lib/b.ts": "const y: string = 42;",
 	})
 
 	srcDir := tmpDirPath(t, paths, "src/a.ts")
@@ -210,10 +224,20 @@ func TestTypeCheck_RespectsAllowDirs(t *testing.T) {
 		nil,
 	)
 
+	gotSrc, gotLib := false, false
 	for _, d := range diagnostics {
-		if !strings.Contains(d.SourceFile.FileName(), "/src/") {
-			t.Errorf("Expected diagnostics only from src/, got from %s", d.SourceFile.FileName())
+		if strings.Contains(d.SourceFile.FileName(), "/src/") {
+			gotSrc = true
 		}
+		if strings.Contains(d.SourceFile.FileName(), "/lib/") {
+			gotLib = true
+		}
+	}
+	if !gotSrc {
+		t.Error("expected type error from src/a.ts (in allowDirs)")
+	}
+	if !gotLib {
+		t.Error("expected type error from lib/b.ts even though outside allowDirs (program-scoped tsc-aligned semantics)")
 	}
 }
 
@@ -225,7 +249,7 @@ func TestTypeCheck_RunLinter_Integration(t *testing.T) {
 	})
 
 	var diagnostics []rule.RuleDiagnostic
-	_, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
+	_, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
@@ -254,7 +278,7 @@ func TestTypeCheck_RunLinter_DisabledIntegration(t *testing.T) {
 	})
 
 	var diagnostics []rule.RuleDiagnostic
-	_, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
+	_, err := runLinterPositional([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
 		false,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
@@ -544,7 +568,11 @@ const x: Foo = { a: 'hello' };
 
 // --- skipFiles filtering ---
 
-func TestTypeCheck_RespectsSkipFiles(t *testing.T) {
+// node_modules participation in type-check is governed by typescript-go's
+// SkipTypeChecking (skipLibCheck etc.), not by rslint's lint-scope skipFiles.
+// When a node_modules file is part of the program and skipLibCheck is off,
+// errors there are reported.
+func TestTypeCheck_NodeModulesIncludedWhenInProgram(t *testing.T) {
 	program, _ := createTestProgramWithFiles(t, map[string]string{
 		"a.ts":              "const x: number = 'hello';",
 		"node_modules/b.ts": "const y: string = 42;",
@@ -558,21 +586,21 @@ func TestTypeCheck_RespectsSkipFiles(t *testing.T) {
 		nil,
 	)
 
-	for _, d := range diagnostics {
-		if strings.Contains(d.SourceFile.FileName(), "node_modules") {
-			t.Errorf("Expected node_modules to be skipped, got diagnostic from %s", d.SourceFile.FileName())
-		}
-	}
-	// Should still report errors from a.ts
-	found := false
+	var aDiags, bDiags int
 	for _, d := range diagnostics {
 		if strings.HasPrefix(d.RuleName, "TypeScript(") {
-			found = true
-			break
+			if strings.Contains(d.SourceFile.FileName(), "node_modules") {
+				bDiags++
+			} else {
+				aDiags++
+			}
 		}
 	}
-	if !found {
-		t.Error("Expected type errors from non-skipped file a.ts")
+	if aDiags == 0 {
+		t.Error("expected type errors from a.ts")
+	}
+	if bDiags == 0 {
+		t.Error("expected node_modules/b.ts type errors to also be reported (program-scoped tsc-aligned semantics; ExcludePaths is a lint-only filter)")
 	}
 }
 
@@ -889,7 +917,7 @@ func TestTypeCheck_MultiplePrograms(t *testing.T) {
 
 	var mu sync.Mutex
 	var diagnostics []rule.RuleDiagnostic
-	result, err := RunLinter(
+	result, err := runLinterPositional(
 		[]*compiler.Program{program1, program2},
 		true,
 		nil, nil, utils.ExcludePaths,
@@ -998,7 +1026,10 @@ func TestTypeCheck_NoDuplicateDiagnostics(t *testing.T) {
 
 // --- allowFiles empty slice (non-nil) blocks type-check ---
 
-func TestTypeCheck_AllowFilesEmptySliceBlocksAll(t *testing.T) {
+// Empty allowFiles blocks all lint-rule visits (LintedFileCount=0) but does
+// NOT suppress the program-level type-check phase. Type errors are still
+// reported, mirroring tsc.
+func TestTypeCheck_AllowFilesEmptySliceBlocksLintOnly(t *testing.T) {
 	program, _ := createTestProgramWithFiles(t, map[string]string{
 		"a.ts": "const x: number = 'hello';",
 	})
@@ -1012,10 +1043,16 @@ func TestTypeCheck_AllowFilesEmptySliceBlocksAll(t *testing.T) {
 	)
 
 	if count != 0 {
-		t.Errorf("Expected lintedFileCount=0 with empty allowFiles, got %d", count)
+		t.Errorf("Expected lintedFileCount=0 (lint-rule visits), got %d", count)
 	}
-	if len(diagnostics) != 0 {
-		t.Errorf("Expected no diagnostics with empty allowFiles, got %d", len(diagnostics))
+	tsCount := 0
+	for _, d := range diagnostics {
+		if strings.HasPrefix(d.RuleName, "TypeScript(") {
+			tsCount++
+		}
+	}
+	if tsCount == 0 {
+		t.Error("expected at least one type-check diagnostic; type-check is program-level and must not be silenced by an empty allowFiles slice")
 	}
 }
 
@@ -1257,10 +1294,12 @@ func TestTypeCheck_MessageIdEmpty(t *testing.T) {
 	}
 }
 
-// fileFilter rejecting a file must suppress BOTH rule and type-check
-// diagnostics for it, and exclude it from the returned LintedFileCount.
-// This is what wires config `ignores` into the linter at the CLI/LSP layer.
-func TestTypeCheck_FileFilterSuppressesDiagnostics(t *testing.T) {
+// fileFilter rejecting a file suppresses lint-rule diagnostics and excludes
+// the file from LintedFileCount, but does NOT silence type-check
+// diagnostics. Type-check is program-scoped and aligned with tsc; the
+// per-program filter is a lint-rule concept (config `ignores`,
+// multi-config ownership) and must not be re-applied to type errors.
+func TestTypeCheck_FileFilterSuppressesLintRulesOnly(t *testing.T) {
 	program, paths := createTestProgramWithFiles(t, map[string]string{
 		"kept.ts":    "const x: number = 'hello';",
 		"ignored.ts": "const y: number = 'world';",
@@ -1274,18 +1313,20 @@ func TestTypeCheck_FileFilterSuppressesDiagnostics(t *testing.T) {
 		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
 		true,
 		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
-		// Reject ignored.ts — stands in for config `ignores` hitting the file.
 		func(fileName string) bool { return fileName != ignoredPath },
 	)
 
-	// Count should exclude the filtered file.
+	// Lint-rule visit count excludes the filtered file.
 	if count != 1 {
-		t.Errorf("LintedFileCount = %d, want 1 (ignored file should not count)", count)
+		t.Errorf("LintedFileCount = %d, want 1 (filter applies to lint phase)", count)
 	}
 
-	// Kept file should still produce its TS error; filtered file must be silent.
+	// Both files contribute type errors — the filter is lint-only.
 	var keptDiags, ignoredDiags int
 	for _, d := range diagnostics {
+		if !strings.HasPrefix(d.RuleName, "TypeScript(") {
+			continue
+		}
 		switch d.SourceFile.FileName() {
 		case keptPath:
 			keptDiags++
@@ -1294,32 +1335,39 @@ func TestTypeCheck_FileFilterSuppressesDiagnostics(t *testing.T) {
 		}
 	}
 	if keptDiags == 0 {
-		t.Error("expected kept.ts to produce TS diagnostics, got none")
+		t.Error("expected kept.ts to produce TS diagnostics")
 	}
-	if ignoredDiags != 0 {
-		t.Errorf("expected ignored.ts to produce no diagnostics, got %d", ignoredDiags)
+	if ignoredDiags == 0 {
+		t.Error("expected ignored.ts to STILL produce TS diagnostics — type-check is not gated by per-program filter")
 	}
 }
 
-// Parallel scenario: multiple programs each with their own filter.
-func TestTypeCheck_FileFilterSuppressesAcrossPrograms(t *testing.T) {
+// Parallel scenario: even when every program has a reject-all filter, the
+// type-check phase runs on each program. Lint-rule visits collapse to zero,
+// but type errors are still surfaced.
+func TestTypeCheck_FileFilterDoesNotMaskTypeChecksAcrossPrograms(t *testing.T) {
 	program, paths := createTestProgramWithFiles(t, map[string]string{
 		"a.ts": "const x: number = 'hello';",
 		"b.ts": "const y: number = 'world';",
 	})
 
-	// Filter that rejects everything — simulates all files being ignored.
 	rejectAll := func(string) bool { return false }
 
 	var diagCount int
 	var mu sync.Mutex
-	result, err := RunLinter(
+	result, err := runLinterPositional(
 		[]*compiler.Program{program},
-		true, // singleThreaded
+		true,
 		nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
 		true,
-		func(d rule.RuleDiagnostic) { mu.Lock(); diagCount++; mu.Unlock() },
+		func(d rule.RuleDiagnostic) {
+			mu.Lock()
+			defer mu.Unlock()
+			if strings.HasPrefix(d.RuleName, "TypeScript(") {
+				diagCount++
+			}
+		},
 		nil,
 		[]func(string) bool{rejectAll},
 	)
@@ -1327,12 +1375,11 @@ func TestTypeCheck_FileFilterSuppressesAcrossPrograms(t *testing.T) {
 		t.Fatalf("RunLinter: %v", err)
 	}
 	if result.LintedFileCount != 0 {
-		t.Errorf("LintedFileCount = %d, want 0", result.LintedFileCount)
+		t.Errorf("LintedFileCount = %d, want 0 (filter rejects all → no lint visits)", result.LintedFileCount)
 	}
-	if diagCount != 0 {
-		t.Errorf("diagnostic count = %d, want 0", diagCount)
+	if diagCount < 2 {
+		t.Errorf("expected at least 2 type-check diagnostics (a.ts + b.ts), got %d", diagCount)
 	}
-	// Reference paths so the test fails obviously if the helper changes shape.
 	_ = paths["a.ts"]
 	_ = paths["b.ts"]
 }

--- a/internal/linter/test_helpers.go
+++ b/internal/linter/test_helpers.go
@@ -1,0 +1,109 @@
+package linter
+
+import (
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// runLinterPositional is a backwards-compatible positional wrapper around
+// RunLinter for in-package tests written before the Options refactor. New
+// code should construct RunLinterOptions directly; the old positional call
+// sites in *_test.go are mechanically renamed from `RunLinter(` to
+// `runLinterPositional(`.
+func runLinterPositional(
+	programs []*compiler.Program,
+	singleThreaded bool,
+	allowFiles []string,
+	allowDirs []string,
+	excludedPaths []string,
+	getRulesForFile RuleHandler,
+	typeCheck bool,
+	onDiagnostic DiagnosticHandler,
+	typeInfoFiles map[string]struct{},
+	fileFilters []func(string) bool,
+) (*LintResult, error) {
+	var ff []FileFilter
+	if fileFilters != nil {
+		ff = make([]FileFilter, len(fileFilters))
+		for i, f := range fileFilters {
+			ff[i] = f
+		}
+	}
+	return RunLinter(RunLinterOptions{
+		Programs:         programs,
+		SingleThreaded:   singleThreaded,
+		Scope:            FileScope{Files: allowFiles, Dirs: allowDirs},
+		ExcludePaths:     excludedPaths,
+		PerProgramFilter: ff,
+		GetRulesForFile:  getRulesForFile,
+		TypeInfoFiles:    typeInfoFiles,
+		TypeCheck:        typeCheck,
+		OnDiagnostic:     onDiagnostic,
+	})
+}
+
+// RunLinterInProgram is a backwards-compatible test adapter for the
+// now-internal runLintRulesInProgram. New code should use RunLinter or
+// LintSingleFile.
+//
+// When typeCheck is true the adapter routes through RunLinter (single
+// program) so callers retain the program-level tsc-aligned semantics;
+// otherwise it bypasses Phase 2 entirely. lintedFileCount preserves the
+// historical return value of files actually visited by lint rules.
+func RunLinterInProgram(
+	program *compiler.Program,
+	allowFiles []string,
+	allowDirs []string,
+	skipFiles []string,
+	getRulesForFile RuleHandler,
+	typeCheck bool,
+	onDiagnostic DiagnosticHandler,
+	typeInfoFiles map[string]struct{},
+	fileFilter func(string) bool,
+) int32 {
+	excludes := skipFiles
+	if excludes == nil {
+		excludes = []string{}
+	}
+	var ff FileFilter
+	if fileFilter != nil {
+		ff = fileFilter
+	}
+	if onDiagnostic == nil {
+		onDiagnostic = func(rule.RuleDiagnostic) {}
+	}
+	if typeCheck {
+		// Route through RunLinter so the new program-level type-check phase
+		// runs. The returned LintResult.LintedFileCount equals what
+		// runLintRulesInProgram would have returned for this single program.
+		res, _ := RunLinter(RunLinterOptions{
+			Programs:        []*compiler.Program{program},
+			SingleThreaded:  true,
+			Scope:           FileScope{Files: allowFiles, Dirs: allowDirs},
+			ExcludePaths:    excludes,
+			GetRulesForFile: getRulesForFile,
+			TypeInfoFiles:   typeInfoFiles,
+			TypeCheck:       true,
+			OnDiagnostic:    onDiagnostic,
+			PerProgramFilter: func() []FileFilter {
+				if ff == nil {
+					return nil
+				}
+				return []FileFilter{ff}
+			}(),
+		})
+		if res == nil {
+			return 0
+		}
+		return res.LintedFileCount
+	}
+	return runLintRulesInProgram(runProgramOptions{
+		Program:         program,
+		Scope:           FileScope{Files: allowFiles, Dirs: allowDirs},
+		ExcludePaths:    excludes,
+		FileFilter:      ff,
+		GetRulesForFile: getRulesForFile,
+		TypeInfoFiles:   typeInfoFiles,
+		OnDiagnostic:    onDiagnostic,
+	})
+}

--- a/internal/linter/typecheck.go
+++ b/internal/linter/typecheck.go
@@ -1,0 +1,165 @@
+package linter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// typeCheckRequest bundles the inputs for runTypeCheckAcrossPrograms.
+type typeCheckRequest struct {
+	Programs       []*compiler.Program
+	Skip           []bool // parallel to Programs; nil → check all
+	SingleThreaded bool
+	// TypeInfoFiles, when non-nil, restricts diagnostic output to files in
+	// the set. This honors the gap-file commitment in type-checking.md:
+	// files matched by config `files` but not covered by any tsconfig
+	// (e.g. root scripts, config files) do not receive semantic errors.
+	// nil = no gap-file distinction.
+	TypeInfoFiles map[string]struct{}
+	OnDiagnostic  DiagnosticHandler
+}
+
+// runTypeCheckAcrossPrograms runs program-scoped semantic diagnostics
+// against every program except those explicitly opted out.
+//
+// Uses compiler.GetDiagnosticsOfAnyProgram(file=nil) — tsc's own aggregate.
+// It covers config-parsing, syntactic, program, global, and semantic
+// diagnostics, with NoEmit filtering, @ts-ignore / @ts-expect-error
+// suppression, and TS2578 unused-directive errors handled internally.
+//
+// Cross-program dedupe: shared declaration files (typical with project
+// references and pulled-in node_modules .d.ts) appear in multiple programs.
+// We dedupe on (filePath, code, pos, end, message).
+//
+// req.OnDiagnostic must be non-nil and safe to call from multiple
+// goroutines concurrently — RunLinter is responsible for that contract.
+func runTypeCheckAcrossPrograms(req typeCheckRequest) {
+	var seen sync.Map
+	wg := core.NewWorkGroup(req.SingleThreaded)
+	for i, prog := range req.Programs {
+		if i < len(req.Skip) && req.Skip[i] {
+			continue
+		}
+		wg.Queue(func() {
+			runTypeCheckForProgram(prog, &seen, req.TypeInfoFiles, req.OnDiagnostic)
+		})
+	}
+	wg.RunAndWait()
+}
+
+func runTypeCheckForProgram(prog *compiler.Program, seen *sync.Map, typeInfoFiles map[string]struct{}, onDiagnostic DiagnosticHandler) {
+	ctx := context.Background()
+	diags := compiler.GetDiagnosticsOfAnyProgram(
+		ctx, prog, nil, false,
+		prog.GetBindDiagnostics,
+		prog.GetSemanticDiagnostics,
+	)
+
+	for _, d := range diags {
+		file := d.File()
+		// Diagnostics without an attached file have no source location to
+		// render against. Examples: TS18003 ("No inputs were found in
+		// config file"), TS5108 ("Option ... has been removed"), TS2318
+		// ("Cannot find global type") — all surface from
+		// GetDiagnosticsOfAnyProgram with d.File()==nil.
+		//
+		// rslint --type-check intentionally drops these — see
+		// "Diagnostics without a source location" in
+		// website/docs/en/guide/type-checking.md. The behaviour is
+		// pinned by TestBoundary_NoSourceLocationDiagnosticsDropped.
+		if file == nil {
+			continue
+		}
+
+		// Gap-file gate: when TypeInfoFiles is supplied, drop diagnostics
+		// for files outside it (matches the commitment in
+		// type-checking.md).
+		if typeInfoFiles != nil {
+			if _, ok := typeInfoFiles[file.FileName()]; !ok {
+				continue
+			}
+		}
+
+		if !markSeen(seen, file, d) {
+			continue
+		}
+
+		// Suppression for @ts-ignore / @ts-expect-error / @ts-nocheck and
+		// the corresponding TS2578 unused-directive errors is already
+		// handled inside typescript-go (GetDiagnosticsOfAnyProgram). We do
+		// not add an rslint-specific disable channel here on purpose:
+		// type-check is meant to be a transparent passthrough of tsc.
+
+		onDiagnostic(rule.RuleDiagnostic{
+			RuleName:     fmt.Sprintf("TypeScript(TS%d)", d.Code()),
+			Range:        d.Loc(),
+			Message:      rule.RuleMessage{Description: flattenDiagnosticMessage(d)},
+			SourceFile:   file,
+			Severity:     rule.SeverityError,
+			PreFormatted: true,
+		})
+	}
+}
+
+type typeCheckDedupeKey struct {
+	path    string
+	code    int32
+	pos     int
+	end     int
+	message string
+}
+
+// markSeen records (filePath, code, pos, end, message) and reports whether
+// this exact tuple has been seen before. Callers must pass a non-nil
+// `file` — runTypeCheckForProgram has already filtered out file=nil
+// diagnostics before reaching here.
+func markSeen(seen *sync.Map, file *ast.SourceFile, d *ast.Diagnostic) bool {
+	loc := d.Loc()
+	key := typeCheckDedupeKey{
+		path:    file.FileName(),
+		code:    d.Code(),
+		pos:     loc.Pos(),
+		end:     loc.End(),
+		message: d.String(),
+	}
+	_, dup := seen.LoadOrStore(key, struct{}{})
+	return !dup
+}
+
+// flattenDiagnosticMessage builds a human-readable message from a
+// TypeScript diagnostic, including its MessageChain and
+// RelatedInformation. Format mirrors tsc's output.
+func flattenDiagnosticMessage(d *ast.Diagnostic) string {
+	var b strings.Builder
+	b.WriteString(d.String())
+	for _, chain := range d.MessageChain() {
+		flattenMessageChain(&b, chain, 1)
+	}
+	for _, related := range d.RelatedInformation() {
+		if related.File() != nil {
+			line, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(related.File(), related.Pos())
+			fmt.Fprintf(&b, "\n  %s:%d: %s", related.File().FileName(), line+1, related.String())
+		}
+	}
+	return b.String()
+}
+
+func flattenMessageChain(b *strings.Builder, chain *ast.Diagnostic, level int) {
+	b.WriteByte('\n')
+	for range level {
+		b.WriteString("  ")
+	}
+	b.WriteString(chain.String())
+	for _, child := range chain.MessageChain() {
+		flattenMessageChain(b, child, level+1)
+	}
+}
+

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -1,0 +1,109 @@
+package linter
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type ConfiguredRule struct {
+	Name             string
+	Settings         map[string]interface{}
+	Severity         rule.DiagnosticSeverity
+	RequiresTypeInfo bool
+	Run              func(ctx rule.RuleContext) rule.RuleListeners
+}
+
+func FilterNonTypeAwareRules(rules []ConfiguredRule) []ConfiguredRule {
+	filtered := make([]ConfiguredRule, 0, len(rules))
+	for _, r := range rules {
+		if !r.RequiresTypeInfo {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+type RuleHandler = func(sourceFile *ast.SourceFile) []ConfiguredRule
+type DiagnosticHandler = func(diagnostic rule.RuleDiagnostic)
+
+// FileScope describes user-supplied "lint targets" (CLI args).
+//
+// Both fields are independently nullable:
+//   - nil slice  → that dimension does not constrain (e.g. Files=nil
+//     means "no per-file restriction").
+//   - empty slice (len 0, non-nil) → that dimension matches NOTHING.
+//     This is how the CLI distinguishes "no files arg supplied" from
+//     "files arg supplied but empty".
+//   - both nil → all program files pass scope.
+//   - both empty → no program files pass scope (lint phase is silent).
+//
+// FileScope only restricts the lint-rule phase. Type-check (Phase 2 of
+// RunLinter) ignores FileScope and reports diagnostics for every file
+// the TypeScript program loaded — see RunLinterOptions for details.
+type FileScope struct {
+	Files []string
+	Dirs  []string
+}
+
+// FileFilter is a generic "should this file be processed" predicate.
+// nil means "everything passes".
+type FileFilter func(absPath string) bool
+
+// LintResult holds the outcome of a RunLinter invocation.
+type LintResult struct {
+	LintedFileCount int32
+	ExecutedRules   map[string]struct{}
+}
+
+// RunLinterOptions configures a multi-program lint (and optional type-check) pass.
+//
+// Zero-value semantics:
+//   - SingleThreaded=false                → use the default parallel work group
+//   - Scope.{Files,Dirs}=nil              → process all program files
+//   - ExcludePaths=nil                    → fall back to the linter default
+//     (substring match against utils.ExcludePaths). Pass an explicit empty
+//     slice to disable the default.
+//   - PerProgramFilter=nil                → no per-program ad-hoc filter
+//     (multi-config ownership / config `ignores`). Entries within the slice
+//     may be nil individually.
+//   - GetRulesForFile=nil                 → no lint rules executed
+//   - TypeInfoFiles=nil                   → no gap-file distinction
+//     (all files may run type-aware rules)
+//   - TypeCheck=false                     → skip the type-check phase
+//   - SkipTypeCheckPrograms=nil           → every program participates in
+//     type-check. When non-nil, must be parallel to Programs; entries set
+//     to true mark the corresponding program to be skipped (typically the
+//     gap-file fallback program with synthesized CompilerOptions).
+//   - OnDiagnostic=nil                    → diagnostics are dropped
+//
+// Thread-safety: OnDiagnostic is invoked from multiple goroutines
+// concurrently — Phase 1 fans out per program, Phase 2 (type-check) does
+// the same. Callers MUST make their handler safe for concurrent calls
+// (channel send, mutex-guarded slice append, sync.Map, etc.).
+type RunLinterOptions struct {
+	Programs       []*compiler.Program
+	SingleThreaded bool
+
+	Scope            FileScope
+	ExcludePaths     []string
+	PerProgramFilter []FileFilter
+
+	GetRulesForFile RuleHandler
+	TypeInfoFiles   map[string]struct{}
+
+	TypeCheck             bool
+	SkipTypeCheckPrograms []bool
+
+	OnDiagnostic DiagnosticHandler
+}
+
+// LintSingleFileOptions configures a single-file, single-program lint pass.
+// Designed for IDE/LSP per-keystroke usage. Does not run type-check.
+type LintSingleFileOptions struct {
+	Program         *compiler.Program
+	File            string
+	GetRulesForFile RuleHandler
+	ExcludePaths    []string
+	OnDiagnostic    DiagnosticHandler
+}

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	util "github.com/web-infra-dev/rslint/internal/utils"
 )
 
 const codeActionKindSourceFixAllRslint = lsproto.CodeActionKind("source.fixAll.rslint")
@@ -719,14 +718,18 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 		diagnostics = append(diagnostics, d)
 	}
 
-	linter.RunLinterInProgram(program, []string{filename}, nil, util.ExcludePaths,
-		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program: program,
+		File:    filename,
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 			activeRules, _ := config.GlobalRuleRegistry.GetEnabledRules(rslintConfig, sourceFile.FileName(), cwd, enforcePlugins)
 			if !hasTypeInfo {
 				activeRules = linter.FilterNonTypeAwareRules(activeRules)
 			}
 			return activeRules
-		}, false, diagnosticCollector, nil, nil)
+		},
+		OnDiagnostic: diagnosticCollector,
+	})
 
 	if diagnostics == nil {
 		diagnostics = []rule.RuleDiagnostic{}

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -134,13 +134,12 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 		sourceFile := program.GetSourceFile(fileName)
 		allowedFiles := []string{sourceFile.FileName()}
 
-		_, err = linter.RunLinter(
-			[]*compiler.Program{program},
-			true,
-			allowedFiles,
-			nil,        // no allowDirs in test environment
-			[]string{}, // No files to skip in test environment
-			func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+		_, err = linter.RunLinter(linter.RunLinterOptions{
+			Programs:       []*compiler.Program{program},
+			SingleThreaded: true,
+			Scope:          linter.FileScope{Files: allowedFiles},
+			ExcludePaths:   []string{}, // explicit empty to disable default node_modules skip in tests
+			GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 				return []linter.ConfiguredRule{
 					{
 						Name:     "test",
@@ -152,16 +151,13 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 					},
 				}
 			},
-			false, // no type-check in rule tester
-			func(diagnostic rule.RuleDiagnostic) {
+			OnDiagnostic: func(diagnostic rule.RuleDiagnostic) {
 				diagnosticsMu.Lock()
 				defer diagnosticsMu.Unlock()
 
 				diagnostics = append(diagnostics, diagnostic)
 			},
-			nil, // no typeInfoFiles distinction in rule tester
-			nil, // no file filters in rule tester
-		)
+		})
 
 		assert.NilError(t, err, "error running linter. code:\n", code)
 

--- a/packages/rslint-test-tools/tests/cli/type-check/helpers.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/helpers.ts
@@ -112,7 +112,7 @@ export const TS_CONFIG = JSON.stringify({
     target: 'ES2020',
     module: 'ESNext',
     strict: true,
-    moduleResolution: 'node',
+    moduleResolution: 'bundler',
   },
   include: ['**/*.ts'],
 });

--- a/packages/rslint-test-tools/tests/cli/type-check/ignores-suppression.test.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/ignores-suppression.test.ts
@@ -1,10 +1,17 @@
 import { describe, test, expect } from '@rstest/core';
 import { runRslint, createTempDir, cleanupTempDir, TS_CONFIG } from './helpers';
 
-// `ignores` must hide files from --type-check, matching ESLint v10 semantics.
+// `ignores` controls the LINT phase only. `--type-check` is program-level
+// and aligned with `tsc --noEmit`: every file that the TypeScript program
+// loads is checked, regardless of rslint's `ignores` configuration. This
+// supersedes the earlier behaviour from PR #681 (where `ignores` also hid
+// type-check diagnostics) — see "Alignment with tsc --noEmit" in
+// website/docs/en/guide/type-checking.md.
+//
 // These tests guard the end-to-end CLI path (config → buildFileFilters →
-// RunLinter). Unit tests inside internal/linter only exercise the filter
-// callback; they cannot catch regressions in the cmd wiring that composes it.
+// RunLinter): config `ignores` continue to remove a file from the lint-rule
+// pass (LintedFileCount, lint-rule diagnostics) while leaving its
+// type-check diagnostics intact.
 
 interface Diagnostic {
   ruleName: string;
@@ -70,67 +77,68 @@ function makeConfigWithIgnores(ignores: string[]): string {
 }
 
 describe('--type-check + config ignores', () => {
-  test('ignored file produces zero diagnostics; non-ignored file still does', async () => {
+  test('ignored file still produces type-check diagnostics; lint-file count excludes it', async () => {
     const tempDir = await createTempDir({
       'tsconfig.json': TS_CONFIG,
       'rslint.config.mjs': makeConfigWithIgnores(['ignored/**']),
-      // Ignored file: has a TS2322 that would otherwise fire
+      // Ignored file: has a TS2322 — under tsc-aligned semantics this MUST
+      // surface because the file is in the TS program.
       'ignored/bad.ts': "const x: number = 'from-ignored';\n",
-      // Control file: same kind of error, should still fire
+      // Control file: same kind of error, also reported.
       'src/bad.ts': "const y: number = 'from-src';\n",
     });
     try {
       const r = await lintTypeCheck(tempDir);
 
-      // Guard against trivial pass: the non-ignored file MUST produce a TS
-      // diagnostic. If it doesn't, the test setup is broken (e.g. tsconfig
-      // not picked up) and any assertion about the ignored file is vacuous.
+      // Control: the non-ignored file produces a TS diagnostic.
       const srcDiags = r.diagnostics.filter((d) =>
         d.filePath?.includes('src/bad.ts'),
       );
       expect(srcDiags.length).toBeGreaterThan(0);
       expect(srcDiags.some((d) => d.ruleName.includes('TS'))).toBe(true);
 
-      // The actual assertion: zero diagnostics point at the ignored file.
+      // The new contract: the ignored file's type-check diagnostic still
+      // surfaces (program-level check is not gated by ignores).
       const ignoredDiags = r.diagnostics.filter((d) =>
         d.filePath?.includes('ignored/bad.ts'),
       );
-      expect(ignoredDiags).toEqual([]);
+      expect(ignoredDiags.length).toBeGreaterThan(0);
+      expect(ignoredDiags.some((d) => d.ruleName.includes('TS2322'))).toBe(
+        true,
+      );
 
-      // Counts must reflect the filter: exactly one file was linted.
-      // If ignores leaks, count would be 2 (or more if tsgolint pulled extras).
+      // LintedFileCount counts the lint-rule pass only — ignored files do
+      // not contribute. Only src/bad.ts is "linted".
       expect(r.lintedFileCount).toBe(1);
     } finally {
       await cleanupTempDir(tempDir);
     }
   });
 
-  test('ignored file stays in TS program as import context but emits no own diagnostics', async () => {
-    // Scenario: caller.ts imports from util.ts; util.ts is ignored. The TS
-    // compiler must still load util.ts to type-check caller.ts's call site,
-    // but util.ts itself must not emit diagnostics and must not count.
+  test('ignored file as import context: caller is checked AND ignored file own type errors surface', async () => {
+    // Scenario: caller.ts imports from util.ts; util.ts is `ignores`d. The
+    // TypeScript compiler loads util.ts to type-check caller's call site
+    // (proving the import context works). Under the tsc-aligned design,
+    // util.ts's own type errors are also reported.
     const tempDir = await createTempDir({
       'tsconfig.json': TS_CONFIG,
       'rslint.config.mjs': makeConfigWithIgnores(['lib/**']),
-      // Ignored file: exports a typed function. Contains its own TS error
-      // that would fire if it were not ignored.
+      // Ignored file with its own TS error.
       'lib/util.ts': [
         'export function greet(name: string): string {',
         '  return `hi ${name}`;',
         '}',
-        "const shouldBeIgnored: number = 'not a number';", // TS2322 if linted
+        "const shouldBeReported: number = 'not a number';", // TS2322
         '',
       ].join('\n'),
-      // Non-ignored caller passes wrong arg type — TS must still catch this,
+      // Non-ignored caller: passes wrong arg type — TS must catch this,
       // which proves util.ts is loaded into the program as context.
       'src/caller.ts': "import { greet } from '../lib/util';\ngreet(42);\n",
     });
     try {
       const r = await lintTypeCheck(tempDir);
 
-      // Context check: caller.ts must get its TS2345 (wrong arg type). This
-      // only works if util.ts's types were resolved → proves ignored file
-      // stayed in the TS program.
+      // Context check: caller.ts gets its TS2345 (wrong arg type).
       const callerDiags = r.diagnostics.filter((d) =>
         d.filePath?.includes('src/caller.ts'),
       );
@@ -140,23 +148,25 @@ describe('--type-check + config ignores', () => {
       );
       expect(callerTsDiags.length).toBeGreaterThan(0);
 
-      // Assertion: the ignored file's own TS2322 must NOT surface.
+      // New contract: util.ts's own TS2322 surfaces despite `ignores`.
       const utilDiags = r.diagnostics.filter((d) =>
         d.filePath?.includes('lib/util.ts'),
       );
-      expect(utilDiags).toEqual([]);
+      expect(utilDiags.length).toBeGreaterThan(0);
+      expect(utilDiags.some((d) => d.ruleName.includes('TS2322'))).toBe(true);
 
-      // Count: only caller.ts counts as "linted".
+      // Lint-rule pass excludes the ignored file: count is 1 (caller.ts).
       expect(r.lintedFileCount).toBe(1);
     } finally {
       await cleanupTempDir(tempDir);
     }
   });
 
-  test('multi-config: root ignores filter files covered by child tsconfig', async () => {
+  test('multi-config: root ignores excludes files from lint-rule pass but type-check still reports them', async () => {
     // Root rslint.config.mjs globally ignores packages/child/**. The child
     // package has its own tsconfig that includes those files. The ignores
-    // must still win — this is the ESLint v10 "global ignores" semantics.
+    // remove the child files from lint rules, but type-check sees the full
+    // program and reports their type errors — matching `tsc --noEmit`.
     const tempDir = await createTempDir({
       'tsconfig.json': TS_CONFIG,
       'rslint.config.mjs': `export default [
@@ -172,32 +182,33 @@ describe('--type-check + config ignores', () => {
           target: 'ES2020',
           module: 'ESNext',
           strict: true,
-          moduleResolution: 'node',
+          moduleResolution: 'bundler',
         },
         include: ['**/*.ts'],
       }),
-      // File covered by child's tsconfig, but globally ignored
+      // File covered by child's tsconfig, globally ignored.
       'packages/child/a.ts': "const x: number = 'ignored-by-root';\n",
-      // File not covered by the root ignore — must still be linted
+      // File not covered by the root ignore.
       'src/ok.ts': "const y: number = 'from-src';\n",
     });
     try {
       const r = await lintTypeCheck(tempDir);
 
-      // Control: the non-ignored file must still produce diagnostics.
+      // Control: the non-ignored file produces diagnostics.
       const srcDiags = r.diagnostics.filter((d) =>
         d.filePath?.includes('src/ok.ts'),
       );
       expect(srcDiags.length).toBeGreaterThan(0);
 
-      // Assertion: no diagnostic anywhere under packages/child/.
+      // New contract: type-check diagnostics for the ignored child file
+      // still surface.
       const childDiags = r.diagnostics.filter((d) =>
         d.filePath?.includes('packages/child/'),
       );
-      expect(childDiags).toEqual([]);
+      expect(childDiags.length).toBeGreaterThan(0);
+      expect(childDiags.some((d) => d.ruleName.includes('TS2322'))).toBe(true);
 
-      // Count: only src/ok.ts, even though packages/child/a.ts is in the
-      // child's tsconfig include.
+      // Lint-rule pass excludes the ignored child file: count is 1 (src/ok.ts).
       expect(r.lintedFileCount).toBe(1);
     } finally {
       await cleanupTempDir(tempDir);

--- a/website/docs/en/guide/type-checking.md
+++ b/website/docs/en/guide/type-checking.md
@@ -104,6 +104,12 @@ When `--type-check` is enabled, the summary always splits lint errors and type e
 Found 3 lint errors, 2 type errors and 1 warning (linted 42 files in 120ms using 8 threads)
 ```
 
+## Alignment with `tsc --noEmit`
+
+`--type-check` is designed to produce the same diagnostics as `tsc --noEmit` (and `tsgo --noEmit`) for any given TypeScript program — same error code, same file, same line and column.
+
+The one intentional difference: TypeScript diagnostics that have no source-file anchor (e.g. tsconfig validation messages such as `TS18003` "No inputs were found in config file" or `TS5108` "Option … has been removed") are not reported by `--type-check`, because rslint's output is rendered per file. Run `tsc --noEmit` directly when you need to surface those configuration-level errors.
+
 ## Files Without tsconfig Coverage
 
 Files that match your config's `files` patterns but are not included in any tsconfig (e.g. root-level scripts, config files) are still linted with syntax-level rules. However, `--type-check` will **not** report semantic type errors for these files, since reliable type information requires tsconfig coverage.


### PR DESCRIPTION
## Summary

Make `--type-check` produce the same set of file-anchored diagnostics as `tsc --noEmit` (and `tsgo --noEmit`).

The previous implementation called `program.GetSemanticDiagnostics(ctx, file)` once per lint-target file — typescript-go's contract returns only that file's diagnostics, so any error in a file outside the lint target (transitively imported source files, `node_modules/*.d.ts`, vendored declaration files like `compiled/**/*.d.ts`) was silently dropped. On `rsbuild`, this hid 13 of 16 real type errors.

This PR replaces the per-file loop with `compiler.GetDiagnosticsOfAnyProgram(file=nil)` — the same entry point `tsc` itself uses. Type-check is now a program-level concern that does not consult the lint scope.

### Behaviour

- Files reported are the full TypeScript program, exactly the same set `tsc --noEmit` would check.
- `skipLibCheck` / `skipDefaultLibCheck` / `noCheck` / `IsSourceFromProjectReference` / `@ts-nocheck` are all honoured because `GetDiagnosticsOfAnyProgram` delegates to typescript-go's built-in `SkipTypeChecking`.
- `@ts-ignore` / `@ts-expect-error` (and their `TS2578` unused-directive errors) flow through unchanged.
- Cross-program shared `.d.ts` (multi-config setups, project references) are deduped on `(filePath, code, pos, end, message)`.
- The fallback gap-file program is excluded from type-check via `SkipTypeCheckPrograms`, preserving the existing "Files Without tsconfig Coverage" doc commitment.
- Diagnostics without a source location (TS18003, TS5108, TS2318, …) are intentionally dropped — explained in the new "Diagnostics without a source location" doc section.

### API refactor (bundled in this PR)

The previous `RunLinter` / `RunLinterInProgram` took 9–10 positional parameters and were used by 5 different call sites with mostly nil/false noise. They are replaced with:

- `RunLinter(RunLinterOptions{...})` — multi-program lint, optionally with type-check.
- `LintSingleFile(LintSingleFileOptions{...})` — LSP/IDE per-keystroke lint, no type-check.
- `RunLinterInProgram` is retained as a back-compat positional adapter for existing in-package tests.

`utils.ExcludePaths` is now the linter default; explicit empty slice disables it.

The LSP service (`internal/lsp/service.go`) migrates to `LintSingleFile`; behaviour is unchanged (LSP never ran type-check). Other call sites — `cmd/rslint/cmd.go`, `cmd/rslint/api.go`, `internal/rule_tester/rule_tester.go` — all use the new Options form.

### Tests

88+ type-check tests organised across:

- `linter_typecheck_program_test.go` — 8 program-level regression cases.
- `linter_typecheck_matrix_test.go` — 13 cross-axis cases (skipLibCheck × file location × multi-program × noCheck × noEmit × @ts-nocheck × skipDefaultLibCheck × dedupe × TypeInfoFiles × TypeCheck on/off × strict toggles).
- `linter_typecheck_fixtures_test.go` — 9 real-fixture cases (real `node_modules/foo` resolved via package.json `types`, project references with composite + pre-built dist outputs, default-lib clean, narrowed `lib` selection).
- `linter_typecheck_boundary_test.go` — 6 invariant cases pinning: default-lib clean across configs and across programs, program-level vs per-file equivalence, deterministic output across repeats, parallel-execution determinism, no-source-location dropping.

Every assertion pins exact code, file suffix, 1-based line/col, and exact counts. Mutation tested by corrupting expected values and confirming failures.

### Validation

End-to-end on two real monorepos:

- **rsbuild** (`/web-infra-dev/rsbuild`): rslint 16 type errors, all match `tsgo --noEmit` per-project union exactly; the 1 difference vs tsgo (`TS18003` from `examples/vue` with no source location) is dropped by design.
- **rspack** (`/web-infra-dev/rspack`): rslint 0 type errors, matches tsgo for the configured tsconfig.

## Related Links

n/a

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).