### PR TITLE
fix: mark type-checker-dependent rules with RequiresTypeInfo to fix LSP false positives on gap files

### DIFF
--- a/internal/config/all_rules_requires_typeinfo_test.go
+++ b/internal/config/all_rules_requires_typeinfo_test.go
@@ -1,0 +1,249 @@
+// cspell:ignore fset elts typeinfo
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestAllRules_NilTypeCheckerEarlyReturnImpliesRequiresTypeInfo is the static
+// counterpart to TestGapFile_OptionalTypeCheckerRules_DoNotPanic: the panic
+// sweep catches rules that crash when handed a nil TypeChecker, but it cannot
+// catch rules that *silently* short-circuit to zero diagnostics — those slip
+// through gap-file linting in CLI mode (nil checker) and then surface as false
+// positives in LSP mode (where typescript-go's project session hands the rule
+// an inferred-project TypeChecker that doesn't see `parserOptions.project` lib
+// types).
+//
+// A rule with the shape
+//
+//	if ctx.TypeChecker == nil { return rule.RuleListeners{} }
+//
+// inside its Run body is, by definition, useless without type info. It must
+// declare RequiresTypeInfo: true so the linter framework filters it out for
+// gap files and inferred-project files instead of leaving it silently broken.
+//
+// The check resolves each registered rule's Run function pointer back to its
+// source file via runtime.FuncForPC, then walks that file's AST to inspect
+// only the matching FuncLit. This avoids ambiguity for rules registered under
+// both bare and plugin-prefixed keys (e.g. `prefer-promise-reject-errors` and
+// `@typescript-eslint/prefer-promise-reject-errors`) where both packages
+// happen to use the same Go var name (`PreferPromiseRejectErrorsRule`) — a
+// var-name-based scan would collapse those into one entry and silently miss
+// regressions in one of the two packages.
+func TestAllRules_NilTypeCheckerEarlyReturnImpliesRequiresTypeInfo(t *testing.T) {
+	RegisterAllRules()
+	registry := GlobalRuleRegistry.GetAllRules()
+
+	// Iterate keys in sorted order so failure output is stable, which keeps
+	// CI logs and `go test -run` rerun targets deterministic.
+	keys := make([]string, 0, len(registry))
+	for k := range registry {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parser := newRuleSourceParser()
+	var failures []string
+	for _, key := range keys {
+		impl := registry[key]
+		if impl.RequiresTypeInfo {
+			continue
+		}
+		body, file, err := parser.runBodyFor(impl.Run)
+		if err != nil {
+			// We require an unambiguous file:line for every registered Run
+			// so the static check can never silently skip a rule. If the
+			// reflect→AST mapping fails, that's a test bug, not a false
+			// negative we should hide.
+			t.Fatalf("rule %q: %v", key, err)
+		}
+		if hasNilTCEarlyReturn(body) {
+			failures = append(failures, fmt.Sprintf(
+				"%s: rule %q returns rule.RuleListeners{} when ctx.TypeChecker == nil but does not declare RequiresTypeInfo: true",
+				file, key,
+			))
+		}
+	}
+
+	if len(failures) > 0 {
+		t.Fatalf("rules return rule.RuleListeners{} on nil TypeChecker but do not declare RequiresTypeInfo: true (LSP would still run them with an inferred-project checker, producing false positives that CLI hides):\n  %s",
+			strings.Join(failures, "\n  "))
+	}
+}
+
+// ruleSourceParser maps a rule's runtime Run function back to its source-tree
+// FuncLit body, caching parsed files so the cost stays at one parse per Go
+// source file regardless of how many rules live in it.
+type ruleSourceParser struct {
+	fset  *token.FileSet
+	files map[string]*ast.File
+}
+
+func newRuleSourceParser() *ruleSourceParser {
+	return &ruleSourceParser{
+		fset:  token.NewFileSet(),
+		files: make(map[string]*ast.File),
+	}
+}
+
+// runBodyFor returns the *ast.BlockStmt of the FuncLit registered as a rule's
+// Run, plus the source file path. It uses runtime.FuncForPC on the function
+// pointer to resolve (file, entry-line), then locates the innermost FuncLit
+// in the parsed file whose body brackets contain that line.
+func (p *ruleSourceParser) runBodyFor(run any) (*ast.BlockStmt, string, error) {
+	rv := reflect.ValueOf(run)
+	if !rv.IsValid() || rv.Kind() != reflect.Func {
+		return nil, "", errors.New("Run is not a function value")
+	}
+	pc := rv.Pointer()
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		return nil, "", errors.New("runtime.FuncForPC returned nil for Run pointer")
+	}
+	// fn.Entry() is the function's entry PC; FileLine on the entry typically
+	// reports the line of the function declaration's opening brace. That's
+	// inside the FuncLit body's range, which is what we want.
+	file, line := fn.FileLine(fn.Entry())
+	if file == "" {
+		return nil, "", errors.New("FileLine returned empty file for Run pointer")
+	}
+	parsed, err := p.parseFile(file)
+	if err != nil {
+		return nil, file, err
+	}
+	body := findFuncLitBodyAtLine(p.fset, parsed, line)
+	if body == nil {
+		return nil, file, fmt.Errorf("could not locate FuncLit at %s:%d", file, line)
+	}
+	return body, file, nil
+}
+
+func (p *ruleSourceParser) parseFile(path string) (*ast.File, error) {
+	if cached, ok := p.files[path]; ok {
+		return cached, nil
+	}
+	f, err := parser.ParseFile(p.fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	p.files[path] = f
+	return f, nil
+}
+
+// findFuncLitBodyAtLine walks the file and returns the body of the smallest
+// function-like node whose body brackets contain the given line. Both
+// FuncLits (used for inline `Run: func(...) {...}`) and FuncDecls (used for
+// `Run: run` references to a top-level function) are considered. Smallest-wins
+// because outer Run bodies can themselves contain inner FuncLits (listener
+// closures); we want the outer Run.
+func findFuncLitBodyAtLine(fset *token.FileSet, file *ast.File, line int) *ast.BlockStmt {
+	var found *ast.BlockStmt
+	var foundSpan int
+	consider := func(body *ast.BlockStmt) {
+		if body == nil {
+			return
+		}
+		startLine := fset.Position(body.Lbrace).Line
+		endLine := fset.Position(body.Rbrace).Line
+		if line < startLine || line > endLine {
+			return
+		}
+		span := endLine - startLine
+		if found == nil || span < foundSpan {
+			found = body
+			foundSpan = span
+		}
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.FuncLit:
+			consider(v.Body)
+		case *ast.FuncDecl:
+			consider(v.Body)
+		}
+		return true
+	})
+	return found
+}
+
+// hasNilTCEarlyReturn returns true if any statement in the function body is
+// `if ctx.TypeChecker == nil { return rule.RuleListeners{} }` (or the same
+// shape with `return nil`). The check is conservative: it only inspects
+// top-level statements of Run, since that's the documented "useless without
+// TC" pattern. Helpers that nil-guard internally are intentionally allowed.
+func hasNilTCEarlyReturn(body *ast.BlockStmt) bool {
+	for _, stmt := range body.List {
+		ifStmt, ok := stmt.(*ast.IfStmt)
+		if !ok {
+			continue
+		}
+		if !isNilTCComparison(ifStmt.Cond) {
+			continue
+		}
+		if returnsEmptyListeners(ifStmt.Body) {
+			return true
+		}
+	}
+	return false
+}
+
+func isNilTCComparison(expr ast.Expr) bool {
+	bin, ok := expr.(*ast.BinaryExpr)
+	if !ok || bin.Op != token.EQL {
+		return false
+	}
+	// Match `ctx.TypeChecker == nil` (in either order).
+	matchesField := func(e ast.Expr) bool {
+		sel, ok := e.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "TypeChecker" {
+			return false
+		}
+		x, ok := sel.X.(*ast.Ident)
+		return ok && x.Name == "ctx"
+	}
+	matchesNil := func(e ast.Expr) bool {
+		id, ok := e.(*ast.Ident)
+		return ok && id.Name == "nil"
+	}
+	return (matchesField(bin.X) && matchesNil(bin.Y)) ||
+		(matchesField(bin.Y) && matchesNil(bin.X))
+}
+
+func returnsEmptyListeners(body *ast.BlockStmt) bool {
+	if len(body.List) == 0 {
+		return false
+	}
+	ret, ok := body.List[0].(*ast.ReturnStmt)
+	if !ok {
+		return false
+	}
+	if len(ret.Results) == 0 {
+		return false
+	}
+	switch r := ret.Results[0].(type) {
+	case *ast.Ident:
+		return r.Name == "nil"
+	case *ast.CompositeLit:
+		// rule.RuleListeners{}
+		sel, ok := r.Type.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		if sel.Sel.Name != "RuleListeners" {
+			return false
+		}
+		x, ok := sel.X.(*ast.Ident)
+		return ok && x.Name == "rule" && len(r.Elts) == 0
+	}
+	return false
+}

--- a/internal/config/all_rules_silent_on_nil_tc_test.go
+++ b/internal/config/all_rules_silent_on_nil_tc_test.go
@@ -1,0 +1,179 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// TestAllRules_SilentOnNilTypeCheckerImpliesRequiresTypeInfo is the runtime
+// counterpart to TestAllRules_NilTypeCheckerEarlyReturnImpliesRequiresTypeInfo.
+//
+// The static check matches `if ctx.TypeChecker == nil { return RuleListeners{} }`
+// at the top of Run. Some rules instead push the nil-TC gate into a helper
+// (e.g. no-obj-calls's checkCallee, no-const-assign's checkIdentifierWrite,
+// no-ex-assign's checkReassignments, no-use-before-define's checkIdentifier)
+// — every listener funnels through that helper, so the rule emits zero
+// diagnostics without TC even though Run itself is unguarded.
+//
+// This test runs each rule on a fixture *known to trigger it* under two
+// configurations:
+//
+//  1. The rule's normal Run with a real, non-nil TypeChecker — must produce
+//     ≥1 diagnostic (proves the fixture is correct and the rule actually
+//     fires).
+//  2. The same fixture but with `ctx.TypeChecker` forcibly set to nil before
+//     calling Run — if the rule emits 0 diagnostics here while emitting ≥1
+//     above, the rule is silently broken in CLI gap-file mode and would also
+//     misbehave in LSP inferred-project mode, so it MUST declare
+//     RequiresTypeInfo: true.
+//
+// Adding a new rule to this table is the regression guard: if you write a
+// rule whose logic is meaningless without a TypeChecker, this test forces you
+// to declare the flag.
+func TestAllRules_SilentOnNilTypeCheckerImpliesRequiresTypeInfo(t *testing.T) {
+	RegisterAllRules()
+	registry := GlobalRuleRegistry.GetAllRules()
+
+	cases := []struct {
+		ruleKey  string
+		fileName string
+		source   string
+	}{
+		{
+			ruleKey:  "no-undef",
+			fileName: "no-undef.ts",
+			source:   `someUndefinedThing();`,
+		},
+		{
+			ruleKey:  "no-obj-calls",
+			fileName: "no-obj-calls.ts",
+			source:   `Math();`,
+		},
+		{
+			ruleKey:  "no-const-assign",
+			fileName: "no-const-assign.ts",
+			source:   `const x = 1; x = 2;`,
+		},
+		{
+			ruleKey:  "no-ex-assign",
+			fileName: "no-ex-assign.ts",
+			source:   `try { throw 1; } catch (e) { e = 2; }`,
+		},
+		{
+			ruleKey:  "prefer-const",
+			fileName: "prefer-const.ts",
+			source:   `let neverReassigned = 1; console.log(neverReassigned);`,
+		},
+		{
+			ruleKey:  "no-unmodified-loop-condition",
+			fileName: "no-unmodified-loop-condition.ts",
+			source:   `let n = 1; while (n < 10) { console.log(n); }`,
+		},
+		{
+			ruleKey:  "no-loop-func",
+			fileName: "no-loop-func.ts",
+			source:   `for (var i = 0; i < 3; i++) { setTimeout(function() { console.log(i); }); }`,
+		},
+		{
+			ruleKey:  "@typescript-eslint/no-use-before-define",
+			fileName: "no-use-before-define.ts",
+			source:   `useBefore(); function useBefore() {}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ruleKey, func(t *testing.T) {
+			impl, ok := registry[tc.ruleKey]
+			if !ok {
+				t.Fatalf("rule %q is not registered", tc.ruleKey)
+			}
+
+			withTC := countDiagnosticsForRule(t, tc.fileName, tc.source, impl, true)
+			if withTC == 0 {
+				t.Fatalf("fixture for %q produced 0 diagnostics with a real TypeChecker; the test fixture is wrong (it must trigger the rule so the without-TC comparison is meaningful)", tc.ruleKey)
+			}
+
+			withoutTC := countDiagnosticsForRule(t, tc.fileName, tc.source, impl, false)
+			if withoutTC == 0 && !impl.RequiresTypeInfo {
+				t.Fatalf("rule %q emits %d diagnostics with TypeChecker but 0 without; it is silently useless on gap files / LSP inferred-project files and MUST declare RequiresTypeInfo: true", tc.ruleKey, withTC)
+			}
+		})
+	}
+}
+
+// countDiagnosticsForRule runs a single rule on a single-file program and
+// returns how many diagnostics it produced. When withTypeChecker is false, the
+// rule receives a nil TypeChecker — simulating the gap-file / inferred-project
+// path that the existing FilterNonTypeAwareRules infrastructure is meant to
+// guard against.
+func countDiagnosticsForRule(t *testing.T, fileName, source string, impl rule.Rule, withTypeChecker bool) int {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	filePath := tspath.NormalizePath(filepath.Join(tmpDir, fileName))
+	if err := os.WriteFile(filePath, []byte(source), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	compilerOptions := &core.CompilerOptions{
+		Target:          core.ScriptTargetESNext,
+		Module:          core.ModuleKindCommonJS,
+		ESModuleInterop: core.TSTrue,
+		SkipLibCheck:    core.TSTrue,
+	}
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := utils.CreateCompilerHost(tmpDir, fs)
+	program, err := utils.CreateProgramFromOptionsLenient(true, compilerOptions, []string{filePath}, host)
+	if err != nil {
+		t.Fatalf("create program: %v", err)
+	}
+
+	configured := linter.ConfiguredRule{
+		Name:     impl.Name,
+		Severity: rule.SeverityWarning,
+		Run: func(ctx rule.RuleContext) rule.RuleListeners {
+			return impl.Run(ctx, nil)
+		},
+	}
+
+	var typeInfoFiles map[string]struct{}
+	if withTypeChecker {
+		// nil typeInfoFiles → linter passes the real TypeChecker to every rule.
+		typeInfoFiles = nil
+	} else {
+		// Non-nil but empty → file is treated as a gap file, so the linter
+		// substitutes a nil TypeChecker (matching CLI gap-file behavior).
+		typeInfoFiles = map[string]struct{}{}
+	}
+
+	count := 0
+	linter.RunLinterInProgram(program, nil, nil, utils.ExcludePaths,
+		func(sf *ast.SourceFile) []linter.ConfiguredRule {
+			if sf.FileName() != filePath {
+				return nil
+			}
+			return []linter.ConfiguredRule{configured}
+		},
+		false,
+		func(d rule.RuleDiagnostic) { count++ },
+		typeInfoFiles,
+		nil,
+	)
+	return count
+}
+
+// Compile-time anchor: keep the linter import live in case future trims of
+// the imports remove the only call site by accident.
+var _ = compiler.Program{}

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
@@ -378,7 +378,8 @@ func isEvaluatedDuringInitialization(refNode *ast.Node, decl *ast.Node) bool {
 // ---------------------------------------------------------------------------
 
 var NoUseBeforeDefineRule = rule.CreateRule(rule.Rule{
-	Name: "no-use-before-define",
+	Name:             "no-use-before-define",
+	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		return rule.RuleListeners{

--- a/internal/rules/no_const_assign/no_const_assign.go
+++ b/internal/rules/no_const_assign/no_const_assign.go
@@ -259,7 +259,8 @@ func checkIdentifierWrite(node *ast.Node, ctx *rule.RuleContext, constSymbols ma
 
 // NoConstAssignRule disallows reassigning const variables
 var NoConstAssignRule = rule.CreateRule(rule.Rule{
-	Name: "no-const-assign",
+	Name:             "no-const-assign",
+	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		// Track const declarations by their symbol
 		constSymbols := make(map[*ast.Symbol]bool)

--- a/internal/rules/no_ex_assign/no_ex_assign.go
+++ b/internal/rules/no_ex_assign/no_ex_assign.go
@@ -263,7 +263,8 @@ func checkReassignments(block *ast.Node, names []string, symbols []*ast.Symbol, 
 }
 
 var NoExAssignRule = rule.Rule{
-	Name: "no-ex-assign",
+	Name:             "no-ex-assign",
+	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCatchClause: func(node *ast.Node) {

--- a/internal/rules/no_loop_func/no_loop_func.go
+++ b/internal/rules/no_loop_func/no_loop_func.go
@@ -579,8 +579,12 @@ func (s *runState) checkForLoops(node *ast.Node) {
 // NoLoopFuncRule disallows function declarations that contain unsafe
 // references to variable(s) inside loop statements.
 var NoLoopFuncRule = rule.Rule{
-	Name: "no-loop-func",
+	Name:             "no-loop-func",
+	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// Defense-in-depth: RequiresTypeInfo: true filters this rule out for
+		// gap files / inferred-project files, but if a future caller bypasses
+		// the filter we still want to no-op rather than nil-deref.
 		if ctx.TypeChecker == nil {
 			return rule.RuleListeners{}
 		}

--- a/internal/rules/no_obj_calls/no_obj_calls.go
+++ b/internal/rules/no_obj_calls/no_obj_calls.go
@@ -20,7 +20,8 @@ func skipAssertionsAndParens(node *ast.Node) *ast.Node {
 
 // https://eslint.org/docs/latest/rules/no-obj-calls
 var NoObjCallsRule = rule.Rule{
-	Name: "no-obj-calls",
+	Name:             "no-obj-calls",
+	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		// isGlobalSymbol returns true if the symbol comes from lib.d.ts
 		// (none of its declarations are in the current source file).

--- a/internal/rules/no_undef/no_undef.go
+++ b/internal/rules/no_undef/no_undef.go
@@ -46,11 +46,14 @@ func parseGlobalComments(sourceText string) map[string]bool {
 }
 
 var NoUndefRule = rule.Rule{
-	Name: "no-undef",
+	Name:             "no-undef",
+	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		opts := parseOptions(options)
 
-		// Without TypeChecker, this rule cannot resolve symbols
+		// Defense-in-depth: RequiresTypeInfo: true filters this rule out for
+		// gap files / inferred-project files, but if a future caller bypasses
+		// the filter we still want to no-op rather than nil-deref.
 		if ctx.TypeChecker == nil {
 			return rule.RuleListeners{}
 		}

--- a/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
+++ b/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
@@ -291,8 +291,12 @@ func checkLoopCondition(ctx rule.RuleContext, condition *ast.Node, body *ast.Nod
 
 // NoUnmodifiedLoopConditionRule disallows variables in loop conditions that are not modified in the loop
 var NoUnmodifiedLoopConditionRule = rule.Rule{
-	Name: "no-unmodified-loop-condition",
+	Name:             "no-unmodified-loop-condition",
+	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// Defense-in-depth: RequiresTypeInfo: true filters this rule out for
+		// gap files / inferred-project files, but if a future caller bypasses
+		// the filter we still want to no-op rather than nil-deref.
 		if ctx.TypeChecker == nil {
 			return rule.RuleListeners{}
 		}

--- a/internal/rules/prefer_const/prefer_const.go
+++ b/internal/rules/prefer_const/prefer_const.go
@@ -41,8 +41,12 @@ type candidateInfo struct {
 
 // https://eslint.org/docs/latest/rules/prefer-const
 var PreferConstRule = rule.Rule{
-	Name: "prefer-const",
+	Name:             "prefer-const",
+	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// Defense-in-depth: RequiresTypeInfo: true filters this rule out for
+		// gap files / inferred-project files, but if a future caller bypasses
+		// the filter we still want to no-op rather than nil-deref.
 		if ctx.TypeChecker == nil {
 			return rule.RuleListeners{}
 		}


### PR DESCRIPTION
## Summary

Eight rules use `ctx.TypeChecker` and effectively no-op without it, but did not declare `RequiresTypeInfo: true`. CLI gap-file mode hides the issue because the linter forces a nil checker for gap files and the in-rule guard returns an empty listener set; LSP routes the same file into typescript-go's inferred project, which has a real but `parserOptions.project`-unaware checker, so the rule fires with the wrong type context — e.g. reporting `'process' is not defined` on a `.js` file outside any configured tsconfig in `js.configs.recommended`.

Adds the flag to: `no-undef`, `no-obj-calls`, `no-const-assign`, `no-ex-assign`, `prefer-const`, `no-unmodified-loop-condition`, `no-loop-func`, `@typescript-eslint/no-use-before-define`. Keeps each rule's `ctx.TypeChecker == nil` early-return as defense-in-depth.

Adds two regression tests in `internal/config`:

- a static AST scan that fails when a rule's `Run` body has the `if ctx.TypeChecker == nil { return rule.RuleListeners{} }` pattern but the Rule struct does not declare `RequiresTypeInfo: true`
- a runtime table-driven test that fails when a rule emits ≥1 diagnostic with a real TypeChecker but 0 with a nil one and is still missing the flag

The two new tests are complementary to the existing `TestGapFile_OptionalTypeCheckerRules_DoNotPanic` panic sweep — that test catches crashes, these catch silent zero-diagnostic regressions.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).