### PR TITLE
feat: port rule @typescript-eslint/no-loop-func

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,6 @@ import (
 	promisePlugin "github.com/web-infra-dev/rslint/internal/plugins/promise"
 	reactPlugin "github.com/web-infra-dev/rslint/internal/plugins/react"
 	reactHooksPlugin "github.com/web-infra-dev/rslint/internal/plugins/react_hooks"
-	unicornPlugin "github.com/web-infra-dev/rslint/internal/plugins/unicorn"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/adjacent_overload_signatures"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/array_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/await_thenable"
@@ -51,6 +50,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_implied_eval"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_inferrable_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_invalid_void_type"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_loop_func"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_magic_numbers"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_meaningless_void_operator"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_misused_new"
@@ -98,6 +98,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_optional_chain"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_readonly"
+	unicornPlugin "github.com/web-infra-dev/rslint/internal/plugins/unicorn"
 
 	// "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_readonly_parameter_types" // Temporarily disabled - incomplete implementation
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_reduce_type_parameter"
@@ -172,7 +173,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_label_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_lone_blocks"
-	"github.com/web-infra-dev/rslint/internal/rules/no_loop_func"
+	core_no_loop_func "github.com/web-infra-dev/rslint/internal/rules/no_loop_func"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
 	"github.com/web-infra-dev/rslint/internal/rules/no_misleading_character_class"
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
@@ -525,6 +526,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-for-in-array", no_for_in_array.NoForInArrayRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-implied-eval", no_implied_eval.NoImpliedEvalRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-inferrable-types", no_inferrable_types.NoInferrableTypesRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-loop-func", no_loop_func.NoLoopFuncRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-magic-numbers", no_magic_numbers.NoMagicNumbersRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-meaningless-void-operator", no_meaningless_void_operator.NoMeaninglessVoidOperatorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-misused-new", no_misused_new.NoMisusedNewRule)
@@ -650,7 +652,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-inner-declarations", no_inner_declarations.NoInnerDeclarationsRule)
 	GlobalRuleRegistry.Register("no-irregular-whitespace", no_irregular_whitespace.NoIrregularWhitespaceRule)
 	GlobalRuleRegistry.Register("no-lone-blocks", no_lone_blocks.NoLoneBlocksRule)
-	GlobalRuleRegistry.Register("no-loop-func", no_loop_func.NoLoopFuncRule)
+	GlobalRuleRegistry.Register("no-loop-func", core_no_loop_func.NoLoopFuncRule)
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)
 	GlobalRuleRegistry.Register("no-misleading-character-class", no_misleading_character_class.NoMisleadingCharacterClassRule)
 	GlobalRuleRegistry.Register("no-new", no_new.NoNewRule)

--- a/internal/plugins/typescript/rules/no_loop_func/no_loop_func.go
+++ b/internal/plugins/typescript/rules/no_loop_func/no_loop_func.go
@@ -1,0 +1,149 @@
+package no_loop_func
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	core "github.com/web-infra-dev/rslint/internal/rules/no_loop_func"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// isSafe mirrors the upstream @typescript-eslint/no-loop-func `isSafe`.
+// Differs from the rslint core variant in two ways:
+//   - Only `const` is treated as a constant binding. `using` / `await using`
+//     are NOT (matches the ts-eslint plugin, which forks an older ESLint
+//     core that didn't yet recognize them).
+//   - Type-only references are filtered out earlier (in CollectThroughReferences),
+//     mirroring upstream's `reference.isTypeReference` short-circuit.
+func isSafe(s *core.RunState, loopNode *ast.Node, ref core.ReferenceEntry) bool {
+	sym := ref.Symbol()
+	if sym == nil || len(sym.Declarations) == 0 {
+		return true
+	}
+	decl := sym.Declarations[0]
+
+	declList := core.GetDeclListForSymbolDecl(decl)
+	kind := core.GetVarDeclListKind(declList)
+
+	if kind == "const" {
+		return true
+	}
+
+	sf := s.Ctx.SourceFile
+	loopRange := utils.TrimNodeTextRange(sf, loopNode)
+
+	if kind == "let" && declList != nil {
+		declRange := utils.TrimNodeTextRange(sf, declList)
+		if declRange.Pos() > loopRange.Pos() && declRange.End() < loopRange.End() {
+			return true
+		}
+	}
+
+	var excluded *ast.Node
+	if kind == "let" {
+		excluded = declList
+	}
+	top := s.GetTopLoopNode(loopNode, excluded)
+	border := utils.TrimNodeTextRange(sf, top).Pos()
+
+	varScope := utils.FindEnclosingScope(decl)
+
+	safe := true
+	s.ForEachReference(sym, func(refNode *ast.Node) bool {
+		if !core.IsWriteRef(refNode) {
+			return false
+		}
+		refScope := utils.FindEnclosingScope(refNode)
+		if refScope == varScope {
+			refPos := utils.TrimNodeTextRange(sf, refNode).Pos()
+			if refPos < border {
+				return false
+			}
+		}
+		safe = false
+		return true
+	})
+	return safe
+}
+
+// checkForLoops mirrors upstream's `checkForLoops`. Unlike the rslint core
+// variant, unsafe variable names are NOT deduplicated — repeated occurrences
+// of the same name appear repeatedly in the message, matching ts-eslint.
+func checkForLoops(s *core.RunState, node *ast.Node) {
+	loopNode := s.GetContainingLoopNode(node)
+	if loopNode == nil {
+		return
+	}
+
+	refs := s.CollectThroughReferences(node)
+
+	if !core.IsAsyncOrGenerator(node) && core.IsIIFE(node) {
+		isFunctionExpression := node.Kind == ast.KindFunctionExpression
+		name := node.Name()
+		isFunctionReferenced := false
+		if isFunctionExpression && name != nil {
+			refName := name.Text()
+			for _, r := range refs {
+				if r.Name() == refName {
+					isFunctionReferenced = true
+					break
+				}
+			}
+		}
+		if !isFunctionReferenced {
+			s.SkippedIIFEs[node] = true
+			return
+		}
+	}
+
+	var names []string
+	for _, r := range refs {
+		if r.Symbol() == nil {
+			continue
+		}
+		if isSafe(s, loopNode, r) {
+			continue
+		}
+		names = append(names, r.Name())
+	}
+
+	if len(names) == 0 {
+		return
+	}
+
+	varNames := "'" + strings.Join(names, "', '") + "'"
+	s.Ctx.ReportNode(node, core.BuildUnsafeRefsMessage(varNames))
+}
+
+// NoLoopFuncRule is @typescript-eslint/no-loop-func. It diverges from the
+// rslint core no-loop-func in two intentional ways to stay 1:1 with the
+// upstream ts-eslint plugin (which forks an older ESLint core):
+//   - `using` / `await using` are not treated as constant bindings.
+//   - Repeated unsafe variable names are not deduplicated.
+var NoLoopFuncRule = rule.CreateRule(rule.Rule{
+	Name:             "no-loop-func",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		if ctx.TypeChecker == nil {
+			return rule.RuleListeners{}
+		}
+		s := core.NewRunState(ctx)
+		check := func(node *ast.Node) {
+			checkForLoops(s, node)
+		}
+		return rule.RuleListeners{
+			ast.KindArrowFunction:       check,
+			ast.KindFunctionExpression:  check,
+			ast.KindFunctionDeclaration: check,
+			// tsgo splits class/object methods, getters, setters and
+			// constructors out of FunctionExpression. ESLint's ESTree
+			// flattens them under FunctionExpression, so we register
+			// the extra kinds explicitly to match upstream's coverage.
+			ast.KindMethodDeclaration: check,
+			ast.KindGetAccessor:       check,
+			ast.KindSetAccessor:       check,
+			ast.KindConstructor:       check,
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_loop_func/no_loop_func.md
+++ b/internal/plugins/typescript/rules/no_loop_func/no_loop_func.md
@@ -1,0 +1,61 @@
+# no-loop-func
+
+Disallow function declarations that contain unsafe references inside loop statements.
+
+## Rule Details
+
+This is the TypeScript-aware version of the ESLint [`no-loop-func`](https://eslint.org/docs/latest/rules/no-loop-func) rule. It reports any function created inside a loop body that closes over a variable that may be modified across iterations, which typically indicates a mistake — every closure ends up reading the final value of the variable instead of the value at the time the closure was created.
+
+Type-only references (used as TypeScript type annotations) are not flagged, because they have no runtime impact.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+for (var i = 0; i < 10; i++) {
+  function foo() {
+    console.log(i);
+  }
+}
+```
+
+```typescript
+for (var i = 0; i < 10; i++) {
+  const handler = (event: Event) => {
+    console.log(i);
+  };
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+for (let i = 0; i < 10; i++) {
+  function foo() {
+    console.log(i);
+  }
+}
+```
+
+```typescript
+let someArray: MyType[] = [];
+for (let i = 0; i < 10; i += 1) {
+  someArray = someArray.filter((item: MyType) => !!item);
+}
+```
+
+```typescript
+type MyType = 1;
+let someArray: MyType[] = [];
+for (let i = 0; i < 10; i += 1) {
+  someArray = someArray.filter((item: MyType) => !!item);
+}
+```
+
+## When Not To Use It
+
+If you do not want to be notified about functions defined inside loops, you can safely disable this rule.
+
+## Original Documentation
+
+- [typescript-eslint/no-loop-func](https://typescript-eslint.io/rules/no-loop-func/)
+- [ESLint no-loop-func](https://eslint.org/docs/latest/rules/no-loop-func)

--- a/internal/plugins/typescript/rules/no_loop_func/no_loop_func_test.go
+++ b/internal/plugins/typescript/rules/no_loop_func/no_loop_func_test.go
@@ -850,6 +850,16 @@ for (var i = 0; i < l; i++) {
 					MessageId: "unsafeRefs",
 				}},
 			},
+			// Shorthand property `{port}` in object literal value position.
+			// The identifier is a real read of the variable, not a property
+			// name — `port` must be picked up as a through reference.
+			{
+				Code: `declare function setup(opts: any, cb: () => void): void; declare const tryLimits: number; let port = 3000; let found = false; let attempts = 0; const host = 'localhost'; while (!found && attempts <= tryLimits) { try { new Promise((resolve, reject) => { setup({ port, host }, () => { found = true; resolve(0); }); }); } catch { port++; } attempts++; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'port', 'found'.",
+				}},
+			},
 		},
 	)
 }

--- a/internal/plugins/typescript/rules/no_loop_func/no_loop_func_test.go
+++ b/internal/plugins/typescript/rules/no_loop_func/no_loop_func_test.go
@@ -1,0 +1,855 @@
+package no_loop_func
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoLoopFuncRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoLoopFuncRule,
+		[]rule_tester.ValidTestCase{
+			// ---- typescript-eslint specific tests ----
+			{Code: `
+for (let i = 0; i < 10; i++) {
+  function foo() {
+    console.log('A');
+  }
+}`},
+			{Code: `
+let someArray: MyType[] = [];
+for (let i = 0; i < 10; i += 1) {
+  someArray = someArray.filter((item: MyType) => !!item);
+}`},
+			{Code: `
+type MyType = 1;
+let someArray: MyType[] = [];
+for (let i = 0; i < 10; i += 1) {
+  someArray = someArray.filter((item: MyType) => !!item);
+}`},
+
+			// ---- Forked ESLint tests ----
+
+			// Not inside a loop.
+			{Code: `string = 'function a() {}';`},
+			{Code: `for (var i=0; i<l; i++) { } var a = function() { i; };`},
+
+			// Function declared in for-init — not considered "inside the loop".
+			{Code: `for (var i=0, a=function() { i; }; i<l; i++) { }`},
+
+			// Function declared in the for-in/for-of iterable — not "inside the loop".
+			{Code: `for (var x in xs.filter(function(x) { return x != upper; })) { }`},
+			{Code: `for (var x of xs.filter(function(x) { return x != upper; })) { }`},
+
+			// No reference to loop-modified variables.
+			{Code: `for (var i=0; i<l; i++) { (function() {}) }`},
+			{Code: `for (var i in {}) { (function() {}) }`},
+			{Code: `for (var i of {}) { (function() {}) }`},
+
+			// Functions using unmodified `let` / `const` are OK (fresh per iteration).
+			{Code: `for (let i=0; i<l; i++) { (function() { i; }) }`},
+			{Code: `for (let i in {}) { i = 7; (function() { i; }) }`},
+			{Code: `for (const i of {}) { (function() { i; }) }`},
+
+			// Nested loops with `let` iteration variables.
+			{Code: `for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }`},
+
+			// Closures over outer-scope `let` / `var` that aren't modified are OK.
+			{Code: `let a = 0; for (let i=0; i<l; i++) { (function() { a; }); }`},
+			{Code: `let a = 0; for (let i in {}) { (function() { a; }); }`},
+			{Code: `let a = 0; for (let i of {}) { (function() { a; }); }`},
+			{Code: `let a = 0; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); }`},
+			{Code: `let a = 0; for (let i in {}) { function foo() { (function() { a; }); } }`},
+			{Code: `let a = 0; for (let i of {}) { (() => { (function() { a; }); }); }`},
+			{Code: `var a = 0; for (let i=0; i<l; i++) { (function() { a; }); }`},
+			{Code: `var a = 0; for (let i in {}) { (function() { a; }); }`},
+			{Code: `var a = 0; for (let i of {}) { (function() { a; }); }`},
+
+			// Closure over outer const — safe even though reassigned later (runtime error).
+			{Code: `
+let result = {};
+for (const score in scores) {
+  const letters = scores[score];
+  letters.split('').forEach(letter => {
+    result[letter] = score;
+  });
+}
+result.__default = 6;`},
+
+			// Variable declared after the loop — no modification visible.
+			{Code: `
+while (true) {
+  (function() { a; });
+}
+let a;`},
+
+			// Undeclared variables in the loop condition are picked up by no-undef.
+			{Code: `while(i) { (function() { i; }) }`},
+			{Code: `do { (function() { i; }) } while (i)`},
+
+			// Variables declared outside the loop and not updated.
+			{Code: `var i; while(i) { (function() { i; }) }`},
+			{Code: `var i; do { (function() { i; }) } while (i)`},
+
+			// Undeclared references — handled by no-undef, not here.
+			{Code: `for (var i=0; i<l; i++) { (function() { undeclared; }) }`},
+			{Code: `for (let i=0; i<l; i++) { (function() { undeclared; }) }`},
+			{Code: `for (var i in {}) { i = 7; (function() { undeclared; }) }`},
+			{Code: `for (let i in {}) { i = 7; (function() { undeclared; }) }`},
+			{Code: `for (const i of {}) { (function() { undeclared; }) }`},
+			{Code: `for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != undeclared)) {  } }`},
+
+			// IIFE — immediately invoked, not saved off.
+			{Code: `
+let current = getStart();
+while (current) {
+  (() => {
+    current;
+    current.a;
+    current.b;
+    current.c;
+    current.d;
+  })();
+
+  current = current.upper;
+}`},
+			{Code: `for (var i=0; (function() { i; })(), i<l; i++) { }`},
+			{Code: `for (var i=0; i<l; (function() { i; })(), i++) { }`},
+			{Code: `for (var i = 0; i < 10; ++i) { (()=>{ i;})() }`},
+			{Code: `for (var i = 0; i < 10; ++i) { (function a(){i;})() }`},
+			{Code: `
+var arr = [];
+for (var i = 0; i < 5; i++) {
+  arr.push((f => f)((() => i)()));
+}`},
+			{Code: `
+var arr = [];
+for (var i = 0; i < 5; i++) {
+  arr.push((() => {
+    return (() => i)();
+  })());
+}`},
+
+			// ---- ts-eslint specific: const captures are still safe ----
+			// Parallel valid cases for the using/await-using invalid cases below — only
+			// the writable form must be unsafe. `const` outside the loop is
+			// safe because it has no writes anywhere.
+			{Code: `const k = 10; for (var i = 0; i < l; i++) { (function () { k; }); }`},
+			// Class declaration / Enum const-like binding.
+			{Code: `class K {} for (var i = 0; i < l; i++) { (function () { K; }); }`},
+			{Code: `enum E { A } for (var i = 0; i < l; i++) { (function () { E.A; }); }`},
+			// `const` block-scoped inside the loop — fresh per iteration.
+			{Code: `for (var i = 0; i < l; i++) { const k = i; (function () { k; }); }`},
+
+			// ---- Real-world / edge cases (verified against ts-eslint upstream) ----
+
+			// Closure references only an unmodified outer `let`.
+			{Code: `let unchanged = 1; for (var i = 0; i < 5; i++) { (function () { unchanged; })(); }`},
+			// Optional chain IIFE — `(arrow)?.()` still IIFE-shaped.
+			{Code: `for (var i = 0; i < 5; i++) { ((() => i)?.()); }`},
+			// Tagged template with arrow capturing fresh `let i`.
+			{Code: "declare function tag(s: TemplateStringsArray, x: any): any; for (let i = 0; i < l; i++) { tag`${() => i}`; }"},
+			// Spread arg with arrow capturing fresh `let i`.
+			{Code: `declare function foo(...args: any[]): void; for (let i = 0; i < l; i++) { foo(...[() => i]); }`},
+			// Labeled loop, closure references only its own locals.
+			{Code: `outer: for (var i = 0; i < l; i++) { (function () { var inner = 1; inner; }); }`},
+			// Function declared in for-init, references init's `let i`.
+			{Code: `for (let i = 0, f = function() { i; }; i < 5; i++) { f(); }`},
+			// Closure references only globals (no through refs to flag).
+			{Code: `for (var i = 0; i < 5; i++) { (function () { console.log("hi"); }); }`},
+			// Imported binding is read-only.
+			{Code: `import { foo } from "./mod"; for (var i = 0; i < l; i++) { (function () { foo; }); }`},
+			// `let i` block-scoped, plus `let f = () => i` block-scoped — both fresh.
+			{Code: `for (let i = 0; i < l; i++) { let f = () => i; f(); }`},
+			// Inner `let shadow = i` block-scoped per iteration; closure reads it, not the outer var.
+			{Code: `var shadow = 1; for (var i = 0; i < 5; i++) { let shadow = i; (function () { shadow; }); }`},
+			// Non-IIFE class field initializer is an expression, not a function — not flagged here
+			// (only the constructor / method below get flagged in the invalid suite).
+			{Code: `for (var i = 0; i < l; i++) { class C { f = i; } }`},
+
+			// `using` declared OUTSIDE the loop with no write inside — safe.
+			{Code: `async function f(bar: any) { using foo = bar(); for (var i = 0; i < 10; ++i) { (function () { foo; }); } }`},
+			// Closure body references only `this`, no through refs.
+			{Code: `class A { m(items: any[]) { for (var i = 0; i < items.length; i++) { (function (this: any) { console.log(this); }); } } }`},
+			// Closure body is empty.
+			{Code: `for (var i = 0; i < 5; i++) { (function () {}); }`},
+			// Closure references global function (not a through-write target).
+			{Code: `function helper() { return 1; } for (var i = 0; i < 5; i++) { (function () { helper(); }); }`},
+			// `eval("i")` — `i` is inside a string literal, not a real reference.
+			{Code: `for (var i = 0; i < 5; i++) { (function () { eval("i"); }); }`},
+			// `new` IIFE with `this` only — no through refs.
+			{Code: `for (var i = 0; i < 5; i++) { new (function () { this; })(); }`},
+			// Parameter consumed (no through ref to flag).
+			{Code: `for (var i = 0; i < 5; i++) { (function (x) { x; })(i); }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Each of these asserts complete position info to lock the report site
+			// for the canonical container shapes (FE, arrow, FD, var = FE, FD + call).
+			{
+				Code: `for (var i=0; i<l; i++) { (function() { i; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+					Line:      1,
+					Column:    28,
+				}},
+			},
+			{
+				Code: `for (var i=0; i<l; i++) { for (var j=0; j<m; j++) { (function() { i+j; }) } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i', 'j'.",
+					Line:      1,
+					Column:    54,
+				}},
+			},
+			{
+				Code: `for (var i in {}) { (function() { i; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+					Line:      1,
+					Column:    22,
+				}},
+			},
+			{
+				Code: `for (var i of {}) { (function() { i; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+					Line:      1,
+					Column:    22,
+				}},
+			},
+			{
+				Code: `for (var i=0; i < l; i++) { (() => { i; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      1,
+					Column:    30,
+				}},
+			},
+			{
+				Code: `for (var i=0; i < l; i++) { var a = function() { i; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      1,
+					Column:    37,
+				}},
+			},
+			{
+				Code: `for (var i=0; i < l; i++) { function a() { i; }; a(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      1,
+					Column:    29,
+				}},
+			},
+
+			// Closure captures a variable written inside the loop.
+			{
+				Code: `let a; for (let i=0; i<l; i++) { a = 1; (function() { a; });}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+				}},
+			},
+			{
+				Code: `let a; for (let i in {}) { (function() { a; }); a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; for (let i of {}) { (function() { a; }); } a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; for (let i in {}) { a = 1; function foo() { (function() { a; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; for (let i of {}) { (() => { (function() { a; }); }); } a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// Closure in nested loop captures the outer `var`.
+			{
+				Code: `for (var i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (let x of xs) { let a; for (let y of ys) { a = 1; (function() { a; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (var x of xs) { for (let y of ys) { (function() { x; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (var x of xs) { (function() { x; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// Write inside the loop occurs before/after the closure declaration.
+			{
+				Code: `var a; for (let x of xs) { a = 1; (function() { a; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `var a; for (let x of xs) { (function() { a; }); a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; function foo() { a = 10; } for (let x of xs) { (function() { a; }); } foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; function foo() { a = 10; for (let x of xs) { (function() { a; }); } } foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- TypeScript-specific: loop var captured by a typed function ----
+			{
+				Code: `
+for (var i = 0; i < 10; i++) {
+  function foo() {
+    console.log(i);
+  }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `
+for (var i = 0; i < 10; i++) {
+  const handler = (event: Event) => {
+    console.log(i);
+  };
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- ts-eslint vs ESLint-core divergence lock-ins ----
+			//
+			// The upstream @typescript-eslint/no-loop-func plugin forks an OLDER
+			// snapshot of ESLint's no-loop-func that pre-dates two later upstream
+			// changes:
+			//   (1) `using` / `await using` were not yet treated as constant
+			//       bindings (they go through the unsafe-write check).
+			//   (2) Repeated unsafe variable names were not deduplicated.
+			// rslint's core no-loop-func tracks the *current* ESLint behavior
+			// (so this plugin must NOT inherit it). The next 7 cases lock the
+			// ts-eslint behavior in.
+
+			// (1a) `using` declared inside a `var`-iteration loop body and
+			// captured by a closure: ts-eslint reports it; ESLint core no longer.
+			{
+				Code: `
+async function f(bar: any) {
+  for (var i = 0; i < 10; ++i) {
+    using foo = bar(i);
+    (function () { foo; });
+  }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'foo'.",
+				}},
+			},
+			// (1b) Same shape with `await using`.
+			{
+				Code: `
+async function g(bar: any) {
+  for (var i = 0; i < 10; ++i) {
+    await using x = bar(i);
+    (function () { x; });
+  }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'x'.",
+				}},
+			},
+			// (1c) `for (using i of ...)` — iteration writes the binding each
+			// step; ts-eslint reports.
+			{
+				Code: `async function h(foo: any) { for (using i of foo) { (function () { i; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+			// (1d) `for (await using i of ...)` — same as above for the async form.
+			{
+				Code: `async function h(foo: any) { for (await using i of foo) { (function () { i; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+
+			// (2a) Same name appearing N times must appear N times in the
+			// message. ESLint core de-duplicates; ts-eslint does not.
+			{
+				Code: `for (var i = 0; i < 10; i++) { (function () { i; i; i; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i', 'i', 'i'.",
+				}},
+			},
+			// (2b) Mixed names also preserve repetition order.
+			{
+				Code: `var a, b; for (var i = 0; i < l; i++) { a = i; b = i; (function () { a + b; a + b; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'a', 'b', 'a', 'b'.",
+				}},
+			},
+			// (2c) Single-occurrence reference still appears exactly once.
+			{
+				Code: `for (var i = 0; i < 10; i++) { (function () { i; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+
+			// ---- Additional tsgo edge-shape coverage (Dimensions 1–4) ----
+
+			// Class-field arrow re-creates the closure per iteration.
+			{
+				Code: `for (var i = 0; i < l; i++) { class C { f = () => i; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+			// Object-literal getter — tsgo splits accessors out of FE.
+			{
+				Code: `for (var i = 0; i < l; i++) { const o = { get x() { return i; } }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Class static block — transparent boundary; the inner FE leaks `i`.
+			{
+				Code: `
+for (var i = 0; i < l; i++) {
+  class C {
+    static {
+      var f = function () { i; };
+    }
+  }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      5,
+				}},
+			},
+			// Async IIFE — `async` flag bypasses the IIFE skip optimization.
+			{
+				Code: `
+let current: any = null;
+const arr: any[] = [];
+while (current) {
+  const p = (async () => {
+    await Promise.resolve();
+    current;
+  })();
+  arr.push(p);
+  current = current.upper;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'current'.",
+				}},
+			},
+			// Generator IIFE — same: `generator` flag bypasses the IIFE skip.
+			{
+				Code: `let a; for (var i = 0; i < l; i++) { (function* () { i; })(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Self-referencing named IIFE — referenced inside its own body, so
+			// it is not skipped.
+			{
+				Code: `
+let current: any = null;
+const arr: any[] = [];
+while (current) {
+  (function f() {
+    current;
+    arr.push(f);
+  })();
+  current = current.upper;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Catch-clause binding captured by a closure inside a loop — `e`
+			// rebinds per exception.
+			{
+				Code: `for (var i = 0; i < l; i++) { try { throw 0; } catch (e) { (function () { e; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'e'.",
+				}},
+			},
+			// Destructuring iteration writes the binding each step.
+			{
+				Code: `for (var {a} of arr) { (function () { a; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+				}},
+			},
+			// Computed key + function value both reference the loop var.
+			{
+				Code: `for (var i = 0; i < l; i++) { var o = { [i]: function () { return i; } }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Async FunctionDeclaration inside a loop.
+			{
+				Code: `for (var i = 0; i < l; i++) { async function fn() { i; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Real-world / edge cases (verified against ts-eslint upstream) ----
+
+			// `Array#forEach` callback inside a `var`-iter loop.
+			{
+				Code: `declare const items: any[]; for (var i = 0; i < items.length; i++) { items.forEach(function (it) { console.log(i, it); }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+			// Classic `setTimeout` capture-of-var pitfall.
+			{
+				Code: `for (var i = 0; i < 5; i++) { setTimeout(function () { console.log(i); }, 100); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+			// Promise.then arrow capture.
+			{
+				Code: `declare const xs: Promise<any>[]; for (var i = 0; i < xs.length; i++) { xs[i].then(v => console.log(i, v)); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Default parameter is itself an arrow capturing the loop var.
+			{
+				Code: `for (var i = 0; i < l; i++) { function m(x = (() => i)) { return x(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Self-reassigning FunctionDeclaration: `foo` becomes unsafe AFTER reassignment.
+			// Both the FD `foo` and the FE `g` get flagged (with different vars).
+			{
+				Code: `for (var i = 0; i < l; i++) { function foo() { return i; } foo = null as any; var g = function () { foo; }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeRefs"},
+					{MessageId: "unsafeRefs"},
+				},
+			},
+			// Conditional expression branching to an arrow.
+			{
+				Code: `declare const cond: boolean; for (var i = 0; i < l; i++) { const f = cond ? (() => i) : null; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Switch case closure.
+			{
+				Code: `declare const x: number; for (var i = 0; i < l; i++) { switch (x) { case 1: (function () { i; }); break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Deep curried arrow chain — outer arrow leaks `i` through 4 nestings.
+			{
+				Code: `for (var i = 0; i < 5; i++) { const f = () => () => () => () => i; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Destructuring assignment inside loop body counts as a write.
+			{
+				Code: `var a; for (var i = 0; i < l; i++) { ({a} = {a: i}); (function () { a; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+				}},
+			},
+			// Same-name nested var loops merge declarations; closure still unsafe.
+			{
+				Code: `for (var i = 0; i < 5; i++) { for (var i = 0; i < 5; i++) { (function () { i; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+			// Generator FunctionDeclaration.
+			{
+				Code: `for (var i = 0; i < l; i++) { function* gen() { yield i; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Async arrow IIFE inside a do-while.
+			{
+				Code: `let cur: any = null; const ps: Promise<any>[] = []; do { ps.push((async () => { await Promise.resolve(); cur; })()); cur = cur?.next; } while (cur);`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'cur'.",
+				}},
+			},
+			// Class with constructor + method both referencing loop var.
+			{
+				Code: `for (var i = 0; i < l; i++) { class C { f = i; constructor() { this.f = i; } m() { return i; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeRefs"},
+					{MessageId: "unsafeRefs"},
+				},
+			},
+			// `let` declared OUTSIDE the loop, modified AFTER the loop.
+			{
+				Code: `let modified = 0; const callbacks: Array<() => void> = []; for (let i = 0; i < 5; i++) { callbacks.push(() => modified); } modified = 99;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'modified'.",
+				}},
+			},
+			// Read-modify-write counter (++) is itself a write.
+			{
+				Code: `var counter = 0; for (var i = 0; i < 5; i++) { counter++; (function () { counter; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'counter'.",
+				}},
+			},
+			// Try/finally — closure in finally block.
+			{
+				Code: `for (var i = 0; i < l; i++) { try { } finally { (function () { i; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Array.from second-arg callback.
+			{
+				Code: `for (var i = 0; i < 5; i++) { Array.from({length: 3}, function (_, j) { return i + j; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Position assertions (multi-line, exact range) ----
+
+			// Multi-line FE — verifies report range spans full function expression.
+			{
+				Code: `
+for (var i = 0; i < l; i++) {
+  (function() {
+    i;
+  });
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+					Line:      3,
+					Column:    4,
+					EndLine:   5,
+					EndColumn: 4,
+				}},
+			},
+			// Mixed safe / unsafe closures in same loop body — only the second flags.
+			{
+				Code: `let safe = 1; for (var i = 0; i < l; i++) { (function () { safe; }); (function () { i; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+			// Two closures referring to the same loop var — both flagged independently.
+			{
+				Code: `for (var i = 0; i < l; i++) { (function () { i; }); (function () { i; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeRefs"},
+					{MessageId: "unsafeRefs"},
+				},
+			},
+
+			// ---- Real-user / additional edge shapes ----
+
+			// Decorator on a method — body still references loop var.
+			{
+				Code: `declare function dec(...args: any[]): any; for (var i = 0; i < l; i++) { class C { @dec m() { return i; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Arrow with rest param.
+			{
+				Code: `for (var i = 0; i < 5; i++) { const f = (...args: any[]) => i + args.length; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Object destructuring with rename.
+			{
+				Code: `declare const arr: any[]; for (var {a: x} of arr) { (function () { x; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'x'.",
+				}},
+			},
+			// Array destructuring with default.
+			{
+				Code: `declare const arr: any[]; for (var [x = 1] of arr) { (function () { x; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// 3-level nested destructuring.
+			{
+				Code: `declare const arr: any[]; for (var {a: {b: {c}}} of arr) { (function () { c; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Function inside method body — method scope is fine; the FE-in-loop is still inside the loop.
+			{
+				Code: `class A { m() { for (var i = 0; i < 5; i++) { const f = function () { return i; }; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// `typeof i` is still a reference to `i`.
+			{
+				Code: `for (var i = 0; i < 5; i++) { (function () { typeof i; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Assignment in `while` condition — `item` is rewritten each iteration.
+			{
+				Code: `declare const next: () => any; let item: any; while ((item = next())) { (function () { item; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'item'.",
+				}},
+			},
+			// `var local = i;` initializer is itself a write each iteration.
+			{
+				Code: `for (var i = 0; i < 5; i++) { var local = i; (function () { local; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'local'.",
+				}},
+			},
+			// Computed key with string concat + closure value.
+			{
+				Code: `for (var i = 0; i < 5; i++) { var o = { ["k" + i]: function () { return i; } }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Class extends + method referencing loop var.
+			{
+				Code: `declare const Base: any; for (var i = 0; i < 5; i++) { class C extends Base { m() { return i; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Function pushed into outer array (default-export pattern).
+			{
+				Code: `const fns: any[] = []; for (var i = 0; i < 5; i++) { fns.push(function () { return i; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// Closure that throws the captured var.
+			{
+				Code: `for (var i = 0; i < 5; i++) { (function () { throw i; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// `yield*` delegation in generator FunctionDeclaration.
+			{
+				Code: `for (var i = 0; i < 5; i++) { function* g() { yield* [i]; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// `??=` logical-assignment is a write to `x`.
+			{
+				Code: `let x: any = null; for (var i = 0; i < 5; i++) { x ??= i; (function () { x; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'x'.",
+				}},
+			},
+			// `||=` logical-assignment is a write to `x`.
+			{
+				Code: `let x: any = null; for (var i = 0; i < 5; i++) { x ||= i; (function () { x; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			// FE wrapped in `as any` type assertion still detected.
+			{
+				Code: `for (var i = 0; i < 5; i++) { const f = (function () { return i; }) as any; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/no_loop_func/no_loop_func_test.go
+++ b/internal/plugins/typescript/rules/no_loop_func/no_loop_func_test.go
@@ -860,6 +860,42 @@ for (var i = 0; i < l; i++) {
 					Message:   "Function declared in a loop contains unsafe references to variable(s) 'port', 'found'.",
 				}},
 			},
+			// Shorthand property in destructuring assignment write — closure
+			// after reads the same variable, which was overwritten.
+			{
+				Code: `let port = 0; for (var i = 0; i < 5; i++) { ({port} = {port: i}); (function () { port; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'port'.",
+				}},
+			},
+			// Closure body itself contains a destructuring shorthand write.
+			{
+				Code: `let port = 0; for (var i = 0; i < 5; i++) { (function () { ({port} = {port: i}); }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'port', 'i'.",
+				}},
+			},
+			// Private class field arrow capturing loop var. Only the field
+			// arrow is a function-in-loop; `g()` only calls `this.#f()`
+			// which contains no through reference to the loop var.
+			{
+				Code: `for (var i = 0; i < 5; i++) { class C { #f = () => i; g() { return this.#f(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+			// JSX expression container with arrow capturing loop var.
+			{
+				Code:     `declare const React: any; declare function Foo(p: any): any; function App() { const items: any[] = []; for (var i = 0; i < 5; i++) { items.push(<Foo onClick={() => i} />); } return items; }`,
+				FileName: "react.tsx",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
 		},
 	)
 }

--- a/internal/rules/no_loop_func/no_loop_func.go
+++ b/internal/rules/no_loop_func/no_loop_func.go
@@ -199,7 +199,19 @@ func (s *RunState) CollectThroughReferences(funcNode *ast.Node) []ReferenceEntry
 		}
 
 		if n.Kind == ast.KindIdentifier && isValueReferencePosition(n) {
-			sym := s.Ctx.TypeChecker.GetSymbolAtLocation(n)
+			// Shorthand property assignments dual-purpose the identifier as
+			// the property name AND a value reference to a same-named
+			// variable. GetSymbolAtLocation returns the property symbol;
+			// GetShorthandAssignmentValueSymbol returns the variable symbol.
+			// This applies in BOTH destructuring (`({port} = obj)`, where
+			// the variable is being written) and object literal value
+			// position (`f({port})`, where the variable is being read).
+			var sym *ast.Symbol
+			if n.Parent != nil && n.Parent.Kind == ast.KindShorthandPropertyAssignment {
+				sym = s.Ctx.TypeChecker.GetShorthandAssignmentValueSymbol(n.Parent)
+			} else {
+				sym = s.Ctx.TypeChecker.GetSymbolAtLocation(n)
+			}
 			if sym != nil && (sym.Flags&ast.SymbolFlagsValue) != 0 {
 				if !isSymbolDeclaredInside(sym, funcNode) {
 					refs = append(refs, ReferenceEntry{
@@ -500,9 +512,11 @@ func GetDeclListForSymbolDecl(decl *ast.Node) *ast.Node {
 
 // buildRefIndex performs a single pass over the source file and groups every
 // value-position identifier by its resolved symbol. ShorthandPropertyAssignment
-// inside destructuring needs special handling because TypeChecker resolves the
-// shorthand key to the property symbol, not the written-to variable symbol —
-// we store the name identifier keyed by the variable symbol instead.
+// nodes need special handling because TypeChecker.GetSymbolAtLocation resolves
+// the shorthand key to the property symbol, not the variable symbol — we use
+// GetShorthandAssignmentValueSymbol instead and key by the variable symbol.
+// This is needed BOTH for destructuring shorthand (which is a write) and for
+// object-literal shorthand (which is a read).
 func (s *RunState) buildRefIndex() {
 	if s.refIndex != nil {
 		return
@@ -515,10 +529,19 @@ func (s *RunState) buildRefIndex() {
 			return
 		}
 		if n.Kind == ast.KindIdentifier && isValueReferencePosition(n) {
-			if sym := tc.GetSymbolAtLocation(n); sym != nil {
+			var sym *ast.Symbol
+			if n.Parent != nil && n.Parent.Kind == ast.KindShorthandPropertyAssignment {
+				sym = tc.GetShorthandAssignmentValueSymbol(n.Parent)
+			} else {
+				sym = tc.GetSymbolAtLocation(n)
+			}
+			if sym != nil {
 				s.refIndex[sym] = append(s.refIndex[sym], n)
 			}
 		} else if n.Kind == ast.KindShorthandPropertyAssignment && utils.IsInDestructuringAssignment(n) {
+			// Already handled above via the Identifier branch in most cases,
+			// but keep this explicit indexing for the destructuring write
+			// path where the parent walk may not visit the Identifier directly.
 			if sym := tc.GetShorthandAssignmentValueSymbol(n); sym != nil {
 				if nameNode := n.AsShorthandPropertyAssignment().Name(); nameNode != nil {
 					s.refIndex[sym] = append(s.refIndex[sym], nameNode)

--- a/internal/rules/no_loop_func/no_loop_func.go
+++ b/internal/rules/no_loop_func/no_loop_func.go
@@ -9,16 +9,16 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-func buildUnsafeRefsMessage(varNames string) rule.RuleMessage {
+func BuildUnsafeRefsMessage(varNames string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unsafeRefs",
 		Description: fmt.Sprintf("Function declared in a loop contains unsafe references to variable(s) %s.", varNames),
 	}
 }
 
-type runState struct {
-	ctx          rule.RuleContext
-	skippedIIFEs map[*ast.Node]bool
+type RunState struct {
+	Ctx          rule.RuleContext
+	SkippedIIFEs map[*ast.Node]bool
 	// refIndex buckets every value-position identifier (and destructuring
 	// shorthand write target) in the source file by resolved symbol. Populated
 	// lazily on the first forEachReference call and reused for all subsequent
@@ -27,10 +27,18 @@ type runState struct {
 	refIndex map[*ast.Symbol][]*ast.Node
 }
 
+// NewRunState constructs a RunState ready for one source-file pass.
+func NewRunState(ctx rule.RuleContext) *RunState {
+	return &RunState{
+		Ctx:          ctx,
+		SkippedIIFEs: map[*ast.Node]bool{},
+	}
+}
+
 // getContainingLoopNode walks up from `node` and returns the nearest enclosing
 // loop statement. Returns nil if no loop is encountered before a non-skipped
 // function-like ancestor is reached.
-func (s *runState) getContainingLoopNode(node *ast.Node) *ast.Node {
+func (s *RunState) GetContainingLoopNode(node *ast.Node) *ast.Node {
 	for current := node; current.Parent != nil; current = current.Parent {
 		parent := current.Parent
 		switch parent.Kind {
@@ -54,7 +62,7 @@ func (s *runState) getContainingLoopNode(node *ast.Node) *ast.Node {
 			// static block runs once per class instantiation and each iteration
 			// creates a new class, so functions defined inside a static block
 			// inside a loop still exhibit the "closure per iteration" problem.
-			if s.skippedIIFEs[parent] {
+			if s.SkippedIIFEs[parent] {
 				continue
 			}
 			return nil
@@ -66,20 +74,20 @@ func (s *runState) getContainingLoopNode(node *ast.Node) *ast.Node {
 // getTopLoopNode walks up through containing loops until it finds the outermost
 // loop whose start is not before `excludedNode`'s end. If `excludedNode` is nil,
 // walks to the outermost loop.
-func (s *runState) getTopLoopNode(node *ast.Node, excludedNode *ast.Node) *ast.Node {
+func (s *RunState) GetTopLoopNode(node *ast.Node, excludedNode *ast.Node) *ast.Node {
 	border := 0
 	if excludedNode != nil {
-		border = utils.TrimNodeTextRange(s.ctx.SourceFile, excludedNode).End()
+		border = utils.TrimNodeTextRange(s.Ctx.SourceFile, excludedNode).End()
 	}
 	outermost := node
 	containing := node
 	for containing != nil {
-		pos := utils.TrimNodeTextRange(s.ctx.SourceFile, containing).Pos()
+		pos := utils.TrimNodeTextRange(s.Ctx.SourceFile, containing).Pos()
 		if pos < border {
 			break
 		}
 		outermost = containing
-		containing = s.getContainingLoopNode(containing)
+		containing = s.GetContainingLoopNode(containing)
 	}
 	return outermost
 }
@@ -87,7 +95,7 @@ func (s *runState) getTopLoopNode(node *ast.Node, excludedNode *ast.Node) *ast.N
 // isIIFE reports whether `node` is a function directly invoked as the callee
 // of a call expression (e.g. `(function () {})()`). The function may be
 // wrapped in one or more parenthesized expressions.
-func isIIFE(node *ast.Node) bool {
+func IsIIFE(node *ast.Node) bool {
 	if node.Kind != ast.KindFunctionExpression && node.Kind != ast.KindArrowFunction {
 		return false
 	}
@@ -108,7 +116,7 @@ func isIIFE(node *ast.Node) bool {
 
 // isAsyncOrGenerator reports whether a function-like node is declared `async`
 // or a generator (`function*` / `*m()`).
-func isAsyncOrGenerator(node *ast.Node) bool {
+func IsAsyncOrGenerator(node *ast.Node) bool {
 	if ast.HasSyntacticModifier(node, ast.ModifierFlagsAsync) {
 		return true
 	}
@@ -145,20 +153,29 @@ func getFunctionBodyRoots(node *ast.Node) []*ast.Node {
 	return roots
 }
 
-// referenceEntry captures a single identifier occurrence and its resolved
+// ReferenceEntry captures a single identifier occurrence and its resolved
 // variable symbol, preserved in source order for first-seen deduplication.
-type referenceEntry struct {
+type ReferenceEntry struct {
 	name   string
 	node   *ast.Node
 	symbol *ast.Symbol
 }
 
+// Name returns the textual name of the identifier reference.
+func (r ReferenceEntry) Name() string { return r.name }
+
+// Node returns the identifier AST node.
+func (r ReferenceEntry) Node() *ast.Node { return r.node }
+
+// Symbol returns the resolved symbol for the reference, or nil if unresolved.
+func (r ReferenceEntry) Symbol() *ast.Symbol { return r.symbol }
+
 // collectThroughReferences walks the function-like node's parameters and body
 // and returns all identifier references whose resolved symbol has at least one
 // declaration outside the function subtree. The function's own name node is
 // excluded from the walk (it's the declaration, not a reference).
-func (s *runState) collectThroughReferences(funcNode *ast.Node) []referenceEntry {
-	var refs []referenceEntry
+func (s *RunState) CollectThroughReferences(funcNode *ast.Node) []ReferenceEntry {
+	var refs []ReferenceEntry
 	nameNode := funcNode.Name()
 
 	var walk func(n *ast.Node)
@@ -182,10 +199,10 @@ func (s *runState) collectThroughReferences(funcNode *ast.Node) []referenceEntry
 		}
 
 		if n.Kind == ast.KindIdentifier && isValueReferencePosition(n) {
-			sym := s.ctx.TypeChecker.GetSymbolAtLocation(n)
+			sym := s.Ctx.TypeChecker.GetSymbolAtLocation(n)
 			if sym != nil && (sym.Flags&ast.SymbolFlagsValue) != 0 {
 				if !isSymbolDeclaredInside(sym, funcNode) {
-					refs = append(refs, referenceEntry{
+					refs = append(refs, ReferenceEntry{
 						name:   n.Text(),
 						node:   n,
 						symbol: sym,
@@ -287,19 +304,28 @@ func isSymbolDeclaredInside(sym *ast.Symbol, funcNode *ast.Node) bool {
 	return false
 }
 
-// getVarDeclListKind returns the kind of a VariableDeclarationList: one of
+// GetVarDeclListKind returns the kind of a VariableDeclarationList: one of
 // "const", "let", "var", "using", "await using", or "" for anything else.
-func getVarDeclListKind(declList *ast.Node) string {
+//
+// IMPORTANT: tsgo encodes `await using` as `NodeFlagsConst | NodeFlagsUsing`
+// (see the node-flags definitions in typescript-go's ast package), so the aggregate flag
+// `NodeFlagsAwaitUsing` is NOT a single bit. We must inspect the individual
+// `NodeFlagsUsing` and `NodeFlagsConst` bits and only report `"await using"`
+// when BOTH are set, otherwise `flags & NodeFlagsAwaitUsing != 0` would
+// collapse plain `const` and plain `using` into `"await using"`.
+func GetVarDeclListKind(declList *ast.Node) string {
 	if declList == nil || declList.Kind != ast.KindVariableDeclarationList {
 		return ""
 	}
 	flags := declList.Flags
+	hasUsing := flags&ast.NodeFlagsUsing != 0
+	hasConst := flags&ast.NodeFlagsConst != 0
 	switch {
-	case flags&ast.NodeFlagsAwaitUsing != 0:
+	case hasUsing && hasConst:
 		return "await using"
-	case flags&ast.NodeFlagsUsing != 0:
+	case hasUsing:
 		return "using"
-	case flags&ast.NodeFlagsConst != 0:
+	case hasConst:
 		return "const"
 	case flags&ast.NodeFlagsLet != 0:
 		return "let"
@@ -328,7 +354,7 @@ func enclosingVarDeclOfBindingElement(bindingElement *ast.Node) *ast.Node {
 // `var/let/const` declarations with initializers, the bindings introduced
 // by `for (var/let/const ... in/of ...)` iteration, and catch-clause
 // parameters (bound anew per thrown exception).
-func isWriteRef(node *ast.Node) bool {
+func IsWriteRef(node *ast.Node) bool {
 	if utils.IsWriteReference(node) {
 		return true
 	}
@@ -392,7 +418,7 @@ func isVarDeclInForInOrOf(varDecl *ast.Node) bool {
 // isSafe reports whether a through-reference `ref` to a symbol `sym` is safe
 // with respect to a loop node `loopNode`. Safe means: no write to `sym` can
 // modify the function's closed-over view of it during successive iterations.
-func (s *runState) isSafe(loopNode *ast.Node, ref referenceEntry) bool {
+func (s *RunState) isSafeCore(loopNode *ast.Node, ref ReferenceEntry) bool {
 	sym := ref.symbol
 	if sym == nil || len(sym.Declarations) == 0 {
 		return true
@@ -400,15 +426,15 @@ func (s *runState) isSafe(loopNode *ast.Node, ref referenceEntry) bool {
 	decl := sym.Declarations[0]
 
 	// Look up the enclosing VariableDeclarationList (for var/let/const/using).
-	declList := getDeclListForSymbolDecl(decl)
-	kind := getVarDeclListKind(declList)
+	declList := GetDeclListForSymbolDecl(decl)
+	kind := GetVarDeclListKind(declList)
 
 	// Constant bindings never get rewritten, so they're safe.
 	if kind == "const" || kind == "using" || kind == "await using" {
 		return true
 	}
 
-	sf := s.ctx.SourceFile
+	sf := s.Ctx.SourceFile
 	loopRange := utils.TrimNodeTextRange(sf, loopNode)
 
 	// `let` declared inside the loop gets a fresh binding per iteration.
@@ -423,7 +449,7 @@ func (s *runState) isSafe(loopNode *ast.Node, ref referenceEntry) bool {
 	if kind == "let" {
 		excluded = declList
 	}
-	top := s.getTopLoopNode(loopNode, excluded)
+	top := s.GetTopLoopNode(loopNode, excluded)
 	border := utils.TrimNodeTextRange(sf, top).Pos()
 
 	// The variable's "variable scope" — the nearest function-like scope of its
@@ -432,8 +458,8 @@ func (s *runState) isSafe(loopNode *ast.Node, ref referenceEntry) bool {
 	varScope := utils.FindEnclosingScope(decl)
 
 	safe := true
-	s.forEachReference(sym, func(refNode *ast.Node) bool {
-		if !isWriteRef(refNode) {
+	s.ForEachReference(sym, func(refNode *ast.Node) bool {
+		if !IsWriteRef(refNode) {
 			return false
 		}
 		refScope := utils.FindEnclosingScope(refNode)
@@ -451,7 +477,7 @@ func (s *runState) isSafe(loopNode *ast.Node, ref referenceEntry) bool {
 
 // getDeclListForSymbolDecl returns the VariableDeclarationList associated with
 // a declaration node, or nil if the declaration is not a variable-like binding.
-func getDeclListForSymbolDecl(decl *ast.Node) *ast.Node {
+func GetDeclListForSymbolDecl(decl *ast.Node) *ast.Node {
 	if decl == nil {
 		return nil
 	}
@@ -477,12 +503,12 @@ func getDeclListForSymbolDecl(decl *ast.Node) *ast.Node {
 // inside destructuring needs special handling because TypeChecker resolves the
 // shorthand key to the property symbol, not the written-to variable symbol —
 // we store the name identifier keyed by the variable symbol instead.
-func (s *runState) buildRefIndex() {
+func (s *RunState) buildRefIndex() {
 	if s.refIndex != nil {
 		return
 	}
 	s.refIndex = map[*ast.Symbol][]*ast.Node{}
-	tc := s.ctx.TypeChecker
+	tc := s.Ctx.TypeChecker
 	var walk func(n *ast.Node)
 	walk = func(n *ast.Node) {
 		if n == nil {
@@ -504,13 +530,13 @@ func (s *runState) buildRefIndex() {
 			return false
 		})
 	}
-	walk(s.ctx.SourceFile.AsNode())
+	walk(s.Ctx.SourceFile.AsNode())
 }
 
 // forEachReference invokes `cb` for every identifier node resolving to `sym`,
 // in source order. Returns early when `cb` returns true. The underlying index
 // is built on first use via buildRefIndex so subsequent calls are O(refs).
-func (s *runState) forEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
+func (s *RunState) ForEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
 	s.buildRefIndex()
 	for _, node := range s.refIndex[sym] {
 		if cb(node) {
@@ -521,19 +547,19 @@ func (s *runState) forEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
 
 // checkForLoops processes a function-like node: if it is inside a loop and
 // has unsafe through-references, it is reported.
-func (s *runState) checkForLoops(node *ast.Node) {
-	loopNode := s.getContainingLoopNode(node)
+func (s *RunState) checkForLoopsCore(node *ast.Node) {
+	loopNode := s.GetContainingLoopNode(node)
 	if loopNode == nil {
 		return
 	}
 
-	refs := s.collectThroughReferences(node)
+	refs := s.CollectThroughReferences(node)
 
 	// IIFE handling — matches ESLint: non-async, non-generator IIFEs that are
 	// not self-referenced (either anonymous or whose name isn't used inside the
 	// function body) are skipped. Skipping marks them so nested functions can
 	// walk through them to find the enclosing loop.
-	if !isAsyncOrGenerator(node) && isIIFE(node) {
+	if !IsAsyncOrGenerator(node) && IsIIFE(node) {
 		isFunctionExpression := node.Kind == ast.KindFunctionExpression
 		name := node.Name()
 		isFunctionReferenced := false
@@ -547,7 +573,7 @@ func (s *runState) checkForLoops(node *ast.Node) {
 			}
 		}
 		if !isFunctionReferenced {
-			s.skippedIIFEs[node] = true
+			s.SkippedIIFEs[node] = true
 			return
 		}
 	}
@@ -561,7 +587,7 @@ func (s *runState) checkForLoops(node *ast.Node) {
 		if seen[r.name] {
 			continue
 		}
-		if s.isSafe(loopNode, r) {
+		if s.isSafeCore(loopNode, r) {
 			continue
 		}
 		seen[r.name] = true
@@ -573,7 +599,7 @@ func (s *runState) checkForLoops(node *ast.Node) {
 	}
 
 	varNames := "'" + strings.Join(names, "', '") + "'"
-	s.ctx.ReportNode(node, buildUnsafeRefsMessage(varNames))
+	s.Ctx.ReportNode(node, BuildUnsafeRefsMessage(varNames))
 }
 
 // NoLoopFuncRule disallows function declarations that contain unsafe
@@ -588,12 +614,12 @@ var NoLoopFuncRule = rule.Rule{
 		if ctx.TypeChecker == nil {
 			return rule.RuleListeners{}
 		}
-		s := &runState{
-			ctx:          ctx,
-			skippedIIFEs: map[*ast.Node]bool{},
+		s := &RunState{
+			Ctx:          ctx,
+			SkippedIIFEs: map[*ast.Node]bool{},
 		}
 		check := func(node *ast.Node) {
-			s.checkForLoops(node)
+			s.checkForLoopsCore(node)
 		}
 		return rule.RuleListeners{
 			ast.KindArrowFunction:       check,

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -202,7 +202,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-inferrable-types.test.ts',
     // './tests/typescript-eslint/rules/no-invalid-this.test.ts',
     './tests/typescript-eslint/rules/no-invalid-void-type.test.ts',
-    // './tests/typescript-eslint/rules/no-loop-func.test.ts',
+    './tests/typescript-eslint/rules/no-loop-func.test.ts',
     // './tests/typescript-eslint/rules/no-loss-of-precision.test.ts',
     './tests/typescript-eslint/rules/no-magic-numbers.test.ts',
     // './tests/typescript-eslint/rules/no-meaningless-void-operator.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-loop-func.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-loop-func.test.ts.snap
@@ -1,0 +1,883 @@
+// Rstest Snapshot v1
+
+exports[`no-loop-func - ESLint tests > invalid 1`] = `
+{
+  "code": "
+for (var i = 0; i < l; i++) {
+  (function () {
+    i;
+  });
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 2`] = `
+{
+  "code": "
+for (var i = 0; i < l; i++) {
+  for (var j = 0; j < m; j++) {
+    (function () {
+      i + j;
+    });
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i', 'j'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 6,
+        },
+        "start": {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 3`] = `
+{
+  "code": "
+for (var i in {}) {
+  (function () {
+    i;
+  });
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 4`] = `
+{
+  "code": "
+for (var i of {}) {
+  (function () {
+    i;
+  });
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 5`] = `
+{
+  "code": "
+for (var i = 0; i < l; i++) {
+  () => {
+    i;
+  };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 6`] = `
+{
+  "code": "
+for (var i = 0; i < l; i++) {
+  var a = function () {
+    i;
+  };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 7`] = `
+{
+  "code": "
+for (var i = 0; i < l; i++) {
+  function a() {
+    i;
+  }
+  a();
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 8`] = `
+{
+  "code": "
+let a;
+for (let i = 0; i < l; i++) {
+  a = 1;
+  (function () {
+    a;
+  });
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 7,
+        },
+        "start": {
+          "column": 4,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 9`] = `
+{
+  "code": "
+let a;
+for (let i in {}) {
+  (function () {
+    a;
+  });
+  a = 1;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 4,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 10`] = `
+{
+  "code": "
+let a;
+for (let i of {}) {
+  (function () {
+    a;
+  });
+}
+a = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 4,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 11`] = `
+{
+  "code": "
+let a;
+for (let i = 0; i < l; i++) {
+  (function () {
+    (function () {
+      a;
+    });
+  });
+  a = 1;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 4,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 12`] = `
+{
+  "code": "
+let a;
+for (let i in {}) {
+  a = 1;
+  function foo() {
+    (function () {
+      a;
+    });
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 9,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 13`] = `
+{
+  "code": "
+let a;
+for (let i of {}) {
+  () => {
+    (function () {
+      a;
+    });
+  };
+}
+a = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 14`] = `
+{
+  "code": "
+for (var i = 0; i < 10; ++i) {
+  for (let x in xs.filter(x => x != i)) {
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 15`] = `
+{
+  "code": "
+for (let x of xs) {
+  let a;
+  for (let y of ys) {
+    a = 1;
+    (function () {
+      a;
+    });
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 8,
+        },
+        "start": {
+          "column": 6,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 16`] = `
+{
+  "code": "
+for (var x of xs) {
+  for (let y of ys) {
+    (function () {
+      x;
+    });
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'x'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 6,
+        },
+        "start": {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 17`] = `
+{
+  "code": "
+for (var x of xs) {
+  (function () {
+    x;
+  });
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'x'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 18`] = `
+{
+  "code": "
+var a;
+for (let x of xs) {
+  a = 1;
+  (function () {
+    a;
+  });
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 7,
+        },
+        "start": {
+          "column": 4,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 19`] = `
+{
+  "code": "
+var a;
+for (let x of xs) {
+  (function () {
+    a;
+  });
+  a = 1;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 4,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 20`] = `
+{
+  "code": "
+let a;
+function foo() {
+  a = 10;
+}
+for (let x of xs) {
+  (function () {
+    a;
+  });
+}
+foo();
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 9,
+        },
+        "start": {
+          "column": 4,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - ESLint tests > invalid 21`] = `
+{
+  "code": "
+let a;
+function foo() {
+  a = 10;
+  for (let x of xs) {
+    (function () {
+      a;
+    });
+  }
+}
+foo();
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 8,
+        },
+        "start": {
+          "column": 6,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - plugin divergences > invalid 1`] = `
+{
+  "code": "
+async function f(bar: any) {
+  for (var i = 0; i < 10; ++i) {
+    using foo = bar(i);
+    (function () { foo; });
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'foo'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 5,
+        },
+        "start": {
+          "column": 6,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - plugin divergences > invalid 2`] = `
+{
+  "code": "
+async function g(bar: any) {
+  for (var i = 0; i < 10; ++i) {
+    await using x = bar(i);
+    (function () { x; });
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'x'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 5,
+        },
+        "start": {
+          "column": 6,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - plugin divergences > invalid 3`] = `
+{
+  "code": "async function h(foo: any) { for (using i of foo) { (function () { i; }); } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - plugin divergences > invalid 4`] = `
+{
+  "code": "async function h(foo: any) { for (await using i of foo) { (function () { i; }); } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - plugin divergences > invalid 5`] = `
+{
+  "code": "for (var i = 0; i < 10; i++) { (function () { i; i; i; }); }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i', 'i', 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func - plugin divergences > invalid 6`] = `
+{
+  "code": "var a, b; for (var i = 0; i < l; i++) { a = i; b = i; (function () { a + b; a + b; }); }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a', 'b', 'a', 'b'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 85,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-loop-func.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-loop-func.test.ts
@@ -58,7 +58,7 @@ for (let i = 0; i < 10; i += 1) {
 });
 
 // Forked from https://github.com/eslint/eslint/blob/89a4a0a260b8eb11487fe3d5d4d80f4630933eb3/tests/lib/rules/no-loop-func.js
-ruleTester.run('no-loop-func ESLint tests', {
+ruleTester.run('no-loop-func', {
   valid: [
     "string = 'function a() {}';",
     `
@@ -862,4 +862,81 @@ foo();
       languageOptions: { parserOptions: { ecmaVersion: 6 } },
     },
   ],
-});
+}, { description: 'ESLint tests' });
+
+// Lock-ins for the @typescript-eslint plugin's intentional divergences from
+// the latest ESLint core no-loop-func: `using` / `await using` are NOT treated
+// as constant bindings, and repeated unsafe variable names are NOT deduped.
+ruleTester.run('no-loop-func', {
+  valid: [],
+  invalid: [
+    {
+      code: `
+async function f(bar: any) {
+  for (var i = 0; i < 10; ++i) {
+    using foo = bar(i);
+    (function () { foo; });
+  }
+}
+      `,
+      errors: [
+        {
+          data: { varNames: "'foo'" },
+          messageId: 'unsafeRefs',
+        },
+      ],
+    },
+    {
+      code: `
+async function g(bar: any) {
+  for (var i = 0; i < 10; ++i) {
+    await using x = bar(i);
+    (function () { x; });
+  }
+}
+      `,
+      errors: [
+        {
+          data: { varNames: "'x'" },
+          messageId: 'unsafeRefs',
+        },
+      ],
+    },
+    {
+      code: `async function h(foo: any) { for (using i of foo) { (function () { i; }); } }`,
+      errors: [
+        {
+          data: { varNames: "'i'" },
+          messageId: 'unsafeRefs',
+        },
+      ],
+    },
+    {
+      code: `async function h(foo: any) { for (await using i of foo) { (function () { i; }); } }`,
+      errors: [
+        {
+          data: { varNames: "'i'" },
+          messageId: 'unsafeRefs',
+        },
+      ],
+    },
+    {
+      code: `for (var i = 0; i < 10; i++) { (function () { i; i; i; }); }`,
+      errors: [
+        {
+          data: { varNames: "'i', 'i', 'i'" },
+          messageId: 'unsafeRefs',
+        },
+      ],
+    },
+    {
+      code: `var a, b; for (var i = 0; i < l; i++) { a = i; b = i; (function () { a + b; a + b; }); }`,
+      errors: [
+        {
+          data: { varNames: "'a', 'b', 'a', 'b'" },
+          messageId: 'unsafeRefs',
+        },
+      ],
+    },
+  ],
+}, { description: 'plugin divergences' });


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-loop-func` rule from typescript-eslint to rslint. The rule disallows function declarations that contain unsafe references inside loop statements, with TypeScript-aware filtering of type-only references.

The implementation is a thin wrapper over the existing rslint core `no-loop-func`, exporting reusable helpers from core (`RunState`, `IsIIFE`, `IsAsyncOrGenerator`, `IsWriteRef`, `GetVarDeclListKind`, `GetDeclListForSymbolDecl`, `CollectThroughReferences`, `GetContainingLoopNode`, `GetTopLoopNode`, `ForEachReference`, `BuildUnsafeRefsMessage`, `ReferenceEntry`) and overriding only the two divergence points so the plugin stays 1:1 with the upstream `@typescript-eslint/eslint-plugin` (which forks an older ESLint core snapshot):

- Only `kind === 'const'` is treated as a constant binding (`using` / `await using` go through the unsafe-write check)
- Repeated unsafe variable names are NOT deduplicated in the message

Also fixes a latent bug in core's `GetVarDeclListKind`: `NodeFlagsAwaitUsing` is defined as `NodeFlagsConst | NodeFlagsUsing` (an aggregate, not a single bit), so the previous `flags & NodeFlagsAwaitUsing != 0` check collapsed plain `const` and plain `using` into `"await using"`. The bug was masked in core because all three kinds were treated as safe; the plugin variant exposed it.

Test coverage: 142 Go test cases (65 valid + 77 invalid) + 8 JS test cases. All test expectations come from running the actual `@typescript-eslint/eslint-plugin` against ground-truth fixtures.

## Related Links

- typescript-eslint rule: https://typescript-eslint.io/rules/no-loop-func/
- ESLint base rule: https://eslint.org/docs/latest/rules/no-loop-func
- Upstream source: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-loop-func.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).