### PR TITLE
feat: port rule no-multi-assign

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,7 @@ import (
 	core_no_loop_func "github.com/web-infra-dev/rslint/internal/rules/no_loop_func"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
 	"github.com/web-infra-dev/rslint/internal/rules/no_misleading_character_class"
+	"github.com/web-infra-dev/rslint/internal/rules/no_multi_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
 	"github.com/web-infra-dev/rslint/internal/rules/no_nested_ternary"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new"
@@ -663,6 +664,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-new-func", no_new_func.NoNewFuncRule)
 	GlobalRuleRegistry.Register("no-new-wrappers", no_new_wrappers.NoNewWrappersRule)
 	GlobalRuleRegistry.Register("no-restricted-imports", no_restricted_imports.NoRestrictedImportsRule)
+	GlobalRuleRegistry.Register("no-multi-assign", no_multi_assign.NoMultiAssignRule)
 	GlobalRuleRegistry.Register("no-multi-str", no_multi_str.NoMultiStrRule)
 	GlobalRuleRegistry.Register("no-nested-ternary", no_nested_ternary.NoNestedTernaryRule)
 	GlobalRuleRegistry.Register("no-octal", no_octal.NoOctalRule)

--- a/internal/rules/no_multi_assign/no_multi_assign.go
+++ b/internal/rules/no_multi_assign/no_multi_assign.go
@@ -1,0 +1,88 @@
+package no_multi_assign
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-multi-assign
+var NoMultiAssignRule = rule.Rule{
+	Name: "no-multi-assign",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				binExpr := node.AsBinaryExpression()
+				if binExpr == nil || binExpr.OperatorToken == nil {
+					return
+				}
+				if !ast.IsAssignmentOperator(binExpr.OperatorToken.Kind) {
+					return
+				}
+
+				// ESTree drops ParenthesizedExpression nodes, so the rule's
+				// `VariableDeclarator > AssignmentExpression.init`-style
+				// selectors look through enclosing parens. tsgo keeps parens
+				// explicit, so ascend past them to find the effective parent
+				// and unwrap the parent's relevant child the same way.
+				parent := ast.WalkUpParenthesizedExpressions(node.Parent)
+				if parent == nil {
+					return
+				}
+
+				switch parent.Kind {
+				case ast.KindVariableDeclaration:
+					decl := parent.AsVariableDeclaration()
+					if decl != nil && decl.Initializer != nil &&
+						ast.SkipParentheses(decl.Initializer) == node {
+						ctx.ReportNode(node, buildMessage())
+					}
+				case ast.KindPropertyDeclaration:
+					decl := parent.AsPropertyDeclaration()
+					if decl != nil && decl.Initializer != nil &&
+						ast.SkipParentheses(decl.Initializer) == node {
+						ctx.ReportNode(node, buildMessage())
+					}
+				case ast.KindBinaryExpression:
+					if opts.ignoreNonDeclaration {
+						return
+					}
+					outer := parent.AsBinaryExpression()
+					if outer == nil || outer.OperatorToken == nil {
+						return
+					}
+					if !ast.IsAssignmentOperator(outer.OperatorToken.Kind) {
+						return
+					}
+					if outer.Right != nil && ast.SkipParentheses(outer.Right) == node {
+						ctx.ReportNode(node, buildMessage())
+					}
+				}
+			},
+		}
+	},
+}
+
+type noMultiAssignOptions struct {
+	ignoreNonDeclaration bool
+}
+
+func parseOptions(options any) noMultiAssignOptions {
+	opts := noMultiAssignOptions{ignoreNonDeclaration: false}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["ignoreNonDeclaration"].(bool); ok {
+			opts.ignoreNonDeclaration = v
+		}
+	}
+	return opts
+}
+
+func buildMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpectedChain",
+		Description: "Unexpected chained assignment.",
+	}
+}

--- a/internal/rules/no_multi_assign/no_multi_assign.md
+++ b/internal/rules/no_multi_assign/no_multi_assign.md
@@ -1,0 +1,88 @@
+# no-multi-assign
+
+## Rule Details
+
+This rule disallows chained assignment expressions within a single statement, such as `a = b = c`. Chained assignments are often a sign of a typo (`foo = bar == 0` was meant) and they hide whether each name is being declared or merely reassigned, which can lead to surprising scope and `const`-vs-`let` mistakes.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var a = b = c = 5;
+
+const foo = bar = "baz";
+
+let a =
+  b =
+    c;
+
+class Foo {
+  a = b = 10;
+}
+
+a = b = "quux";
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var a = 5;
+var b = 5;
+var c = 5;
+
+const foo = "baz";
+const bar = "baz";
+
+let a = 5;
+let b = 5;
+let c = 5;
+
+class Foo {
+  a = 10;
+  b = 10;
+}
+
+a = "quux";
+b = "quux";
+```
+
+## Options
+
+This rule has an object option:
+
+- `"ignoreNonDeclaration"`: When set to `true`, allows chained assignments that do not introduce new declarations (i.e. plain `AssignmentExpression`s). Defaults to `false`.
+
+Examples of **correct** code for this rule with `{ "ignoreNonDeclaration": true }`:
+
+```json
+{ "no-multi-assign": ["error", { "ignoreNonDeclaration": true }] }
+```
+
+```javascript
+let a;
+let b;
+a = b = "baz";
+
+const x = {};
+const y = {};
+x.one = y.one = 1;
+```
+
+Examples of **incorrect** code for this rule with `{ "ignoreNonDeclaration": true }`:
+
+```json
+{ "no-multi-assign": ["error", { "ignoreNonDeclaration": true }] }
+```
+
+```javascript
+let a = b = "baz";
+
+const foo = bar = 1;
+
+class Foo {
+  a = b = 10;
+}
+```
+
+## Original Documentation
+
+- [ESLint no-multi-assign](https://eslint.org/docs/latest/rules/no-multi-assign)

--- a/internal/rules/no_multi_assign/no_multi_assign_test.go
+++ b/internal/rules/no_multi_assign/no_multi_assign_test.go
@@ -1,0 +1,600 @@
+package no_multi_assign
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoMultiAssignRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoMultiAssignRule,
+		[]rule_tester.ValidTestCase{
+			// ---- ESLint upstream valid cases ----
+			{Code: "var a, b, c,\nd = 0;"},
+			{Code: "var a = 1; var b = 2; var c = 3;\nvar d = 0;"},
+			{Code: "var a = 1 + (b === 10 ? 5 : 4);"},
+			{Code: "const a = 1, b = 2, c = 3;"},
+			{Code: "const a = 1;\nconst b = 2;\n const c = 3;"},
+			{Code: "for(var a = 0, b = 0;;){}"},
+			{Code: "for(let a = 0, b = 0;;){}"},
+			{Code: "for(const a = 0, b = 0;;){}"},
+			{Code: "export let a, b;"},
+			{Code: "export let a,\n b = 0;"},
+			{
+				Code:    "const x = {};const y = {};x.one = y.one = 1;",
+				Options: map[string]interface{}{"ignoreNonDeclaration": true},
+			},
+			{
+				Code:    "let a, b;a = b = 1",
+				Options: map[string]interface{}{"ignoreNonDeclaration": true},
+			},
+			{Code: "class C { [foo = 0] = 0 }"},
+
+			// ---- Additional edge cases (not in upstream suite) ----
+
+			// Assignment in a computed object key — outside the rule's scope
+			{Code: "({ [a = 1]: 1 })"},
+			// Assignment as a property value (object literal, not class field)
+			{Code: "({ a: b = 1 })"},
+			// Assignment as default in object pattern destructuring
+			{Code: "let { a = 1 } = {};"},
+			// Plain assignment with one target — not chained
+			{Code: "a = 1;"},
+			{Code: "var a = 1;"},
+			// Compound assignment alone — not chained
+			{Code: "a += 1;"},
+			// Logical assignment alone
+			{Code: "a ||= 1;"},
+			// Destructuring assignment alone
+			{Code: "[a, b] = [1, 2];"},
+			{Code: "({ a, b } = { a: 1, b: 2 });"},
+			// TypeScript type annotation with single value
+			{Code: "let x: number = 1;"},
+			// Class field without initializer
+			{Code: "class C { x; }"},
+			// Class field with non-assignment init
+			{Code: "class C { x = 1; }"},
+			// Skipped declarations
+			{Code: "class C { declare x: number; }"},
+			// `ignoreNonDeclaration: true` allows property-target assignment chains
+			{
+				Code:    "let a; let b; a = b = 'baz';",
+				Options: map[string]interface{}{"ignoreNonDeclaration": true},
+			},
+			// `ignoreNonDeclaration: true` with logical assignment in non-declaration
+			{
+				Code:    "let a, b; a = b ||= 1;",
+				Options: map[string]interface{}{"ignoreNonDeclaration": true},
+			},
+			// Default value inside destructuring pattern is not an init
+			{Code: "var { a = 1 } = obj;"},
+			{Code: "var { a = b = c } = obj;"},
+			{Code: "var [ a = b = c ] = arr;"},
+			// Assignment as RHS of a non-assignment binary operator
+			{Code: "var a = b + (c = d);"},
+			{Code: "var a = (b = c) + d;"},
+			// Chain inside computed key of a method/getter (not init / value)
+			{Code: "class C { [foo = bar] = 1 }"},
+			{Code: "({ [a = b]: 1 })"},
+			// Multi-declarator: only the relevant declarator carries a chain
+			{Code: "var a = 1, b = 2;"},
+			// Logical assignment alone (no chain)
+			{Code: "a ??= 1;"},
+			// Assignments scattered across conditional branches — each branch
+			// is a standalone assignment, not a chain.
+			{Code: "var a = cond ? (b = c) : (d = e);"},
+			// Assignment as a conditional branch — the conditional sits between
+			// the two assignments, so neither side is the `.right` of the other.
+			{Code: "a = cond ? b = c : d;"},
+			// Sequence (comma) operator wrapping standalone assignments.
+			{Code: "var a = (b = 1, c = 2);"},
+			// Assignment as a function argument — argument position, not chain.
+			{Code: "fn(a = 1, b = 2);"},
+			// Assignment inside `return` — not a chain when single.
+			{Code: "function f() { return a = 1; }"},
+			// Standalone yield with assignment.
+			{Code: "function* g() { yield a = 1; }"},
+			// Update / unary expressions on declared values
+			{Code: "var a = b++;"},
+			{Code: "var a = !b;"},
+			// Class field whose value is a function — body never counts as init
+			{Code: "class C { handler = () => { let a; a = 1; }; }"},
+			// Class field whose value is an arrow with chained assignment in
+			// BODY — body of arrow is its own scope, the field's init is the
+			// arrow node itself, not the inner assignment.
+			{Code: "class C { handler = () => { var a; a = b; }; }"},
+			// Type-only declaration in TS — no Initializer, can't fire.
+			{Code: "let a: number;"},
+			// Object property value assignment — not class field, not chained.
+			{Code: "var obj = { a: b = 1 };"},
+			// JSX-ish attribute literal value (still parseable as TS expr).
+			{Code: "var x = { value: a = 1 };"},
+			// Named export of a single declaration with no init.
+			{Code: "export const PI = 3.14;"},
+			// Comment between operator and RHS — should not change semantics.
+			{Code: "var a = /* hi */ 1;"},
+			// Type assertion / `as` / `satisfies` on init — not assignments.
+			{Code: "var a = b as number;"},
+			{Code: "var a = (b satisfies number);"},
+			{Code: "var a = b!;"},
+			// Optional chain on init — not assignment.
+			{Code: "var a = b?.c;"},
+			// Tagged template / call assignments — single, not chain.
+			{Code: "var a = tag`x`;"},
+			{Code: "var a = fn();"},
+			// Class with multiple non-chained fields — sanity.
+			{Code: "class C { a = 1; b = 2; static c = 3; }"},
+			// Parameter property in class constructor — not a class field
+			// initializer in our sense.
+			{Code: "class C { constructor(public x = 1) {} }"},
+			// IIFE returning an assignment.
+			{Code: "var a = (() => b = 1)();"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- ESLint upstream invalid cases ----
+			{
+				Code: "var a = b = c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: "var a = b = c = d;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+					{MessageId: "unexpectedChain", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: "let foo = bar = cee = 100;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 11},
+					{MessageId: "unexpectedChain", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: "a=b=c=d=e",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 3},
+					{MessageId: "unexpectedChain", Line: 1, Column: 5},
+					{MessageId: "unexpectedChain", Line: 1, Column: 7},
+				},
+			},
+			{
+				Code: "a=b=c",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: "a\n=b\n=c",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 2, Column: 2},
+				},
+			},
+			{
+				Code: "var a = (b) = (((c)))",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: "var a = ((b)) = (c)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: "var a = b = ( (c * 12) + 2)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: "var a =\n((b))\n = (c)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: "a = b = '=' + c + 'foo';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: "a = b = 7 * 12 + 5;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code:    "const x = {};\nconst y = x.one = 1;",
+				Options: map[string]interface{}{"ignoreNonDeclaration": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 2, Column: 11},
+				},
+			},
+			{
+				Code:    "let a, b;a = b = 1",
+				Options: map[string]interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:    "let x, y;x = y = 'baz'",
+				Options: map[string]interface{}{"ignoreNonDeclaration": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:    "const a = b = 1",
+				Options: map[string]interface{}{"ignoreNonDeclaration": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code: "class C { field = foo = 0 }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code:    "class C { field = foo = 0 }",
+				Options: map[string]interface{}{"ignoreNonDeclaration": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 19},
+				},
+			},
+
+			// ---- Additional edge cases ----
+
+			// Paren-wrapped inner assignment in declaration: ESTree drops parens, so
+			// the rule still matches. Locks in the parent walk through paren nodes.
+			{
+				Code: "var a = (b = c);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 10},
+				},
+			},
+			// Multiple paren layers wrapping the inner assignment.
+			{
+				Code: "var a = ((b = c));",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 11},
+				},
+			},
+			// Paren wrapping the inner of a non-declaration chain.
+			{
+				Code: "a = (b = c);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 6},
+				},
+			},
+			// Compound assignment in declaration init: `+=` is still an
+			// AssignmentExpression in ESTree, so the rule reports it.
+			{
+				Code: "var a = b += c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			// Logical assignment in declaration init.
+			{
+				Code: "var a = b ||= c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			// Logical assignment as inner of non-declaration chain.
+			{
+				Code: "a = b ??= c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 5},
+				},
+			},
+			// Compound assignment as the OUTER of the chain still triggers
+			// the .right selector.
+			{
+				Code: "a += b = c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 6},
+				},
+			},
+			// For-loop init declaration with chain.
+			{
+				Code: "for (let i = j = 0;;) {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 14},
+				},
+			},
+			// Static class field with chain.
+			{
+				Code: "class C { static x = y = 1 }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 22},
+				},
+			},
+			// Private class field with chain.
+			{
+				Code: "class C { #x = y = 1 }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 16},
+				},
+			},
+			// TypeScript-typed declaration with chain.
+			{
+				Code: "let a: number = b = 1;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 17},
+				},
+			},
+			// `ignoreNonDeclaration: true` still reports declaration chains.
+			{
+				Code:    "let a = b = 1",
+				Options: map[string]interface{}{"ignoreNonDeclaration": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			// Long chain across many operators: every link reported.
+			{
+				Code: "var a = b = c = d = e = f;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+					{MessageId: "unexpectedChain", Line: 1, Column: 13},
+					{MessageId: "unexpectedChain", Line: 1, Column: 17},
+					{MessageId: "unexpectedChain", Line: 1, Column: 21},
+				},
+			},
+			// Multi-declarator: only the declarator with a chain reports.
+			{
+				Code: "var a = b = c, d = e = f;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+					{MessageId: "unexpectedChain", Line: 1, Column: 20},
+				},
+			},
+			// Mix: chain + plain compound on RHS of outer.
+			{
+				Code: "a = b = c ??= d",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 5},
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			// Chain inside template literal expression — outer is non-declaration.
+			{
+				Code: "`${a = b = c}`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 8},
+				},
+			},
+			// Chain inside arrow body.
+			{
+				Code: "() => a = b = c",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 11},
+				},
+			},
+			// Class field with paren-wrapped chain.
+			{
+				Code: "class C { x = (y = 1); }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 16},
+				},
+			},
+			// Nested class chain — outer field's init is itself a class with a field chain.
+			{
+				Code: "class A { x = class { y = z = 1 } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 27},
+				},
+			},
+			// Chain inside an IIFE init.
+			{
+				Code: "var a = (() => { return b = c = 1; })();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 29},
+				},
+			},
+			// Chain across newlines / comments.
+			{
+				Code: "var a = b /* hi */ = c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: "var a =\n  b =\n  c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 2, Column: 3},
+				},
+			},
+			// Chain inside arrow with body block + return.
+			{
+				Code: "const f = () => { return a = b = 1; };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 30},
+				},
+			},
+			// Chain on member-access targets.
+			{
+				Code: "obj.a = obj.b = 1;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			// Chain on element-access target.
+			{
+				Code: "obj['a'] = obj['b'] = 1;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 12},
+				},
+			},
+			// Chain with `this.x`.
+			{
+				Code: "this.x = this.y = 1;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 10},
+				},
+			},
+			// Chain with computed-style target.
+			{
+				Code: "a[k] = b[k] = v;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 8},
+				},
+			},
+			// Static class field with paren-wrapped chain.
+			{
+				Code: "class C { static x = (y = 1); }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 23},
+				},
+			},
+			// Chain inside parenthesized init: `var a = ((b) = c)` — left of inner has paren.
+			{
+				Code: "var a = ((b) = c);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 10},
+				},
+			},
+			// Chain on an LHS through TS `as` cast — `(b as any) = c`. Even though
+			// `b as any` cast as LHS is valid TS, it's still an assignment chain.
+			{
+				Code: "var a = (b as any) = c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			// Mixed-style chain crossing `=` and `**=`.
+			{
+				Code: "var a = b **= c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 9},
+				},
+			},
+			// Chain assigned through optional class field with definite-assignment `!`.
+			{
+				Code: "class C { x!: number = y = 1; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 24},
+				},
+			},
+			// `using` declaration with chain (TS 5.2+).
+			{
+				Code: "{ using a = b = c; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 13},
+				},
+			},
+			// Export with chain.
+			{
+				Code: "export let a = b = c;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 16},
+				},
+			},
+			// Block-scoped chain.
+			{
+				Code: "{ let a = b = 1; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 11},
+				},
+			},
+			// Chain inside switch case body.
+			{
+				Code: "switch (x) { case 1: a = b = 2; break; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 26},
+				},
+			},
+			// Chain with deeply nested parens on inner.
+			{
+				Code: "var a = ((((b = c))));",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 13},
+				},
+			},
+			// Chain with paren around outer right side: `a = ((b = c))`.
+			{
+				Code: "a = ((b = c));",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 7},
+				},
+			},
+			// `ignoreNonDeclaration: true` — paren-wrapped declaration init still reports.
+			{
+				Code:    "let a = (b = 1);",
+				Options: map[string]interface{}{"ignoreNonDeclaration": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 10},
+				},
+			},
+			// `ignoreNonDeclaration: true` — class field paren-wrapped still reports.
+			{
+				Code:    "class C { x = (y = 1); }",
+				Options: map[string]interface{}{"ignoreNonDeclaration": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedChain", Line: 1, Column: 16},
+				},
+			},
+		},
+	)
+}
+
+// Locks in the message-text contract — the rule emits exactly
+// "Unexpected chained assignment." on every variant, with no interpolation.
+func TestNoMultiAssignMessageText(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoMultiAssignRule,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: "a = b = c",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedChain",
+						Message:   "Unexpected chained assignment.",
+						Line:      1,
+						Column:    5,
+					},
+				},
+			},
+			{
+				Code: "var a = b = c",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedChain",
+						Message:   "Unexpected chained assignment.",
+						Line:      1,
+						Column:    9,
+					},
+				},
+			},
+			{
+				Code: "class C { x = y = 1 }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedChain",
+						Message:   "Unexpected chained assignment.",
+						Line:      1,
+						Column:    15,
+					},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -329,6 +329,7 @@ export default defineConfig({
     './tests/eslint/rules/no-labels.test.ts',
     './tests/eslint/rules/no-lone-blocks.test.ts',
     './tests/eslint/rules/no-loop-func.test.ts',
+    './tests/eslint/rules/no-multi-assign.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',
     './tests/eslint/rules/no-nested-ternary.test.ts',
     './tests/eslint/rules/object-shorthand.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-multi-assign.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-multi-assign.test.ts.snap
@@ -1,0 +1,1651 @@
+// Rstest Snapshot v1
+
+exports[`no-multi-assign > invalid 1`] = `
+{
+  "code": "var a = b = c;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 2`] = `
+{
+  "code": "var a = b = c = d;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 3`] = `
+{
+  "code": "let foo = bar = cee = 100;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 4`] = `
+{
+  "code": "a=b=c=d=e",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 5`] = `
+{
+  "code": "a=b=c",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 6`] = `
+{
+  "code": "a
+=b
+=c",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 3,
+        },
+        "start": {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 7`] = `
+{
+  "code": "var a = (b) = (((c)))",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 8`] = `
+{
+  "code": "var a = ((b)) = (c)",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 9`] = `
+{
+  "code": "var a = b = ( (c * 12) + 2)",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 10`] = `
+{
+  "code": "var a =
+((b))
+ = (c)",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 11`] = `
+{
+  "code": "a = b = '=' + c + 'foo';",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 12`] = `
+{
+  "code": "a = b = 7 * 12 + 5;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 13`] = `
+{
+  "code": "const x = {};
+const y = x.one = 1;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 14`] = `
+{
+  "code": "let a, b;a = b = 1",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 15`] = `
+{
+  "code": "let x, y;x = y = 'baz'",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 16`] = `
+{
+  "code": "const a = b = 1",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 17`] = `
+{
+  "code": "class C { field = foo = 0 }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 18`] = `
+{
+  "code": "class C { field = foo = 0 }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 19`] = `
+{
+  "code": "var a = (b = c);",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 20`] = `
+{
+  "code": "var a = ((b = c));",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 21`] = `
+{
+  "code": "a = (b = c);",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 22`] = `
+{
+  "code": "var a = b += c;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 23`] = `
+{
+  "code": "var a = b ||= c;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 24`] = `
+{
+  "code": "a = b ??= c;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 25`] = `
+{
+  "code": "a += b = c;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 26`] = `
+{
+  "code": "for (let i = j = 0;;) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 27`] = `
+{
+  "code": "class C { static x = y = 1 }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 28`] = `
+{
+  "code": "class C { #x = y = 1 }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 29`] = `
+{
+  "code": "let a: number = b = 1;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 30`] = `
+{
+  "code": "let a = b = 1",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 31`] = `
+{
+  "code": "var a = b = c = d = e = f;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 32`] = `
+{
+  "code": "var a = b = c, d = e = f;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 33`] = `
+{
+  "code": "a = b = c ??= d",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 34`] = `
+{
+  "code": "\`\${a = b = c}\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 35`] = `
+{
+  "code": "() => a = b = c",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 36`] = `
+{
+  "code": "class C { x = (y = 1); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 37`] = `
+{
+  "code": "class A { x = class { y = z = 1 } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 38`] = `
+{
+  "code": "var a = (() => { return b = c = 1; })();",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 39`] = `
+{
+  "code": "var a = b /* hi */ = c;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 40`] = `
+{
+  "code": "var a =
+  b =
+  c;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 41`] = `
+{
+  "code": "const f = () => { return a = b = 1; };",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 42`] = `
+{
+  "code": "obj.a = obj.b = 1;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 43`] = `
+{
+  "code": "obj['a'] = obj['b'] = 1;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 44`] = `
+{
+  "code": "this.x = this.y = 1;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 45`] = `
+{
+  "code": "a[k] = b[k] = v;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 46`] = `
+{
+  "code": "class C { static x = (y = 1); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 47`] = `
+{
+  "code": "var a = ((b) = c);",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 48`] = `
+{
+  "code": "var a = (b as any) = c;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 49`] = `
+{
+  "code": "var a = b **= c;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 50`] = `
+{
+  "code": "class C { x!: number = y = 1; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 51`] = `
+{
+  "code": "{ using a = b = c; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 52`] = `
+{
+  "code": "export let a = b = c;",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 53`] = `
+{
+  "code": "{ let a = b = 1; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 54`] = `
+{
+  "code": "switch (x) { case 1: a = b = 2; break; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 55`] = `
+{
+  "code": "var a = ((((b = c))));",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 56`] = `
+{
+  "code": "a = ((b = c));",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 57`] = `
+{
+  "code": "let a = (b = 1);",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-assign > invalid 58`] = `
+{
+  "code": "class C { x = (y = 1); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected chained assignment.",
+      "messageId": "unexpectedChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-multi-assign.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-multi-assign.test.ts
@@ -1,0 +1,349 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-multi-assign', {
+  valid: [
+    // ---- ESLint upstream valid cases ----
+    'var a, b, c,\nd = 0;',
+    'var a = 1; var b = 2; var c = 3;\nvar d = 0;',
+    'var a = 1 + (b === 10 ? 5 : 4);',
+    'const a = 1, b = 2, c = 3;',
+    'const a = 1;\nconst b = 2;\n const c = 3;',
+    'for(var a = 0, b = 0;;){}',
+    'for(let a = 0, b = 0;;){}',
+    'for(const a = 0, b = 0;;){}',
+    'export let a, b;',
+    'export let a,\n b = 0;',
+    {
+      code: 'const x = {};const y = {};x.one = y.one = 1;',
+      options: { ignoreNonDeclaration: true },
+    },
+    {
+      code: 'let a, b;a = b = 1',
+      options: { ignoreNonDeclaration: true },
+    },
+    'class C { [foo = 0] = 0 }',
+
+    // ---- Additional edge cases ----
+    '({ [a = 1]: 1 })',
+    '({ a: b = 1 })',
+    'let { a = 1 } = {};',
+    'a = 1;',
+    'a += 1;',
+    'a ||= 1;',
+    '[a, b] = [1, 2];',
+    '({ a, b } = { a: 1, b: 2 });',
+    'let x: number = 1;',
+    'class C { x; }',
+    'class C { x = 1; }',
+    'class C { declare x: number; }',
+    {
+      code: "let a; let b; a = b = 'baz';",
+      options: { ignoreNonDeclaration: true },
+    },
+    {
+      code: 'let a, b; a = b ||= 1;',
+      options: { ignoreNonDeclaration: true },
+    },
+    'var { a = 1 } = obj;',
+    'var { a = b = c } = obj;',
+    'var [ a = b = c ] = arr;',
+    'var a = b + (c = d);',
+    'var a = (b = c) + d;',
+    'class C { [foo = bar] = 1 }',
+    '({ [a = b]: 1 })',
+    'var a = 1, b = 2;',
+    'a ??= 1;',
+    'var a = cond ? (b = c) : (d = e);',
+    'a = cond ? b = c : d;',
+    'var a = (b = 1, c = 2);',
+    'fn(a = 1, b = 2);',
+    'function f() { return a = 1; }',
+    'function* g() { yield a = 1; }',
+    'var a = b++;',
+    'var a = !b;',
+    'class C { handler = () => { let a; a = 1; }; }',
+    'class C { handler = () => { var a; a = b; }; }',
+    'let a: number;',
+    'var obj = { a: b = 1 };',
+    'var x = { value: a = 1 };',
+    'export const PI = 3.14;',
+    'var a = /* hi */ 1;',
+    'var a = b as number;',
+    'var a = (b satisfies number);',
+    'var a = b!;',
+    'var a = b?.c;',
+    'var a = tag`x`;',
+    'var a = fn();',
+    'class C { a = 1; b = 2; static c = 3; }',
+    'class C { constructor(public x = 1) {} }',
+    'var a = (() => b = 1)();',
+  ],
+  invalid: [
+    // ---- ESLint upstream invalid cases ----
+    {
+      code: 'var a = b = c;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = b = c = d;',
+      errors: [
+        { messageId: 'unexpectedChain' },
+        { messageId: 'unexpectedChain' },
+      ],
+    },
+    {
+      code: 'let foo = bar = cee = 100;',
+      errors: [
+        { messageId: 'unexpectedChain' },
+        { messageId: 'unexpectedChain' },
+      ],
+    },
+    {
+      code: 'a=b=c=d=e',
+      errors: [
+        { messageId: 'unexpectedChain' },
+        { messageId: 'unexpectedChain' },
+        { messageId: 'unexpectedChain' },
+      ],
+    },
+    {
+      code: 'a=b=c',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'a\n=b\n=c',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = (b) = (((c)))',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = ((b)) = (c)',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = b = ( (c * 12) + 2)',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a =\n((b))\n = (c)',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: "a = b = '=' + c + 'foo';",
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'a = b = 7 * 12 + 5;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'const x = {};\nconst y = x.one = 1;',
+      options: { ignoreNonDeclaration: true },
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'let a, b;a = b = 1',
+      options: {},
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: "let x, y;x = y = 'baz'",
+      options: { ignoreNonDeclaration: false },
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'const a = b = 1',
+      options: { ignoreNonDeclaration: true },
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'class C { field = foo = 0 }',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'class C { field = foo = 0 }',
+      options: { ignoreNonDeclaration: true },
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+
+    // ---- Additional edge cases ----
+    {
+      code: 'var a = (b = c);',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = ((b = c));',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'a = (b = c);',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = b += c;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = b ||= c;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'a = b ??= c;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'a += b = c;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'for (let i = j = 0;;) {}',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'class C { static x = y = 1 }',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'class C { #x = y = 1 }',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'let a: number = b = 1;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'let a = b = 1',
+      options: { ignoreNonDeclaration: true },
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = b = c = d = e = f;',
+      errors: [
+        { messageId: 'unexpectedChain' },
+        { messageId: 'unexpectedChain' },
+        { messageId: 'unexpectedChain' },
+        { messageId: 'unexpectedChain' },
+      ],
+    },
+    {
+      code: 'var a = b = c, d = e = f;',
+      errors: [
+        { messageId: 'unexpectedChain' },
+        { messageId: 'unexpectedChain' },
+      ],
+    },
+    {
+      code: 'a = b = c ??= d',
+      errors: [
+        { messageId: 'unexpectedChain' },
+        { messageId: 'unexpectedChain' },
+      ],
+    },
+    {
+      code: '`${a = b = c}`',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: '() => a = b = c',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'class C { x = (y = 1); }',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'class A { x = class { y = z = 1 } }',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = (() => { return b = c = 1; })();',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = b /* hi */ = c;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a =\n  b =\n  c;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'const f = () => { return a = b = 1; };',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'obj.a = obj.b = 1;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: "obj['a'] = obj['b'] = 1;",
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'this.x = this.y = 1;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'a[k] = b[k] = v;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'class C { static x = (y = 1); }',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = ((b) = c);',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = (b as any) = c;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = b **= c;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'class C { x!: number = y = 1; }',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: '{ using a = b = c; }',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'export let a = b = c;',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: '{ let a = b = 1; }',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'switch (x) { case 1: a = b = 2; break; }',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'var a = ((((b = c))));',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'a = ((b = c));',
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'let a = (b = 1);',
+      options: { ignoreNonDeclaration: true },
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+    {
+      code: 'class C { x = (y = 1); }',
+      options: { ignoreNonDeclaration: true },
+      errors: [{ messageId: 'unexpectedChain' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-multi-assign` rule from ESLint to rslint.

This rule disallows chained assignment expressions within a single statement (e.g. `var a = b = c`), which can produce unexpected results around variable scope and `const`/`let` choice.

Verified against `web-infra-dev/rsbuild` (0 reports) and `web-infra-dev/rspack` (9 reports — all valid `var X = Y = …` chains and `const X = (Y = …)` paren-wrapped declarator inits).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-multi-assign
- Source: https://github.com/eslint/eslint/blob/main/lib/rules/no-multi-assign.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).