### PR TITLE
feat: port rule max-depth

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/for_direction"
 	"github.com/web-infra-dev/rslint/internal/rules/getter_return"
 	"github.com/web-infra-dev/rslint/internal/rules/guard_for_in"
+	"github.com/web-infra-dev/rslint/internal/rules/max_depth"
 	"github.com/web-infra-dev/rslint/internal/rules/max_lines"
 	"github.com/web-infra-dev/rslint/internal/rules/no_alert"
 	"github.com/web-infra-dev/rslint/internal/rules/no_async_promise_executor"
@@ -618,6 +619,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("for-direction", for_direction.ForDirectionRule)
 	GlobalRuleRegistry.Register("getter-return", getter_return.GetterReturnRule)
 	GlobalRuleRegistry.Register("guard-for-in", guard_for_in.GuardForInRule)
+	GlobalRuleRegistry.Register("max-depth", max_depth.MaxDepthRule)
 	GlobalRuleRegistry.Register("max-lines", max_lines.MaxLinesRule)
 	GlobalRuleRegistry.Register("no-alert", no_alert.NoAlertRule)
 	GlobalRuleRegistry.Register("no-async-promise-executor", no_async_promise_executor.NoAsyncPromiseExecutorRule)

--- a/internal/rules/max_depth/max_depth.go
+++ b/internal/rules/max_depth/max_depth.go
@@ -1,0 +1,188 @@
+package max_depth
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// MaxDepthRule enforces a maximum depth that blocks can be nested in a function.
+// https://eslint.org/docs/latest/rules/max-depth
+var MaxDepthRule = rule.Rule{
+	Name: "max-depth",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		maxDepth := parseMaxDepth(options)
+
+		// Stack of depth counters, one per scope-bearing container. The
+		// linter does not fire a KindSourceFile listener, so we seed the
+		// stack with one frame for the source file scope; function-likes
+		// and class static blocks push their own frames on top via
+		// startFunction.
+		stack := []int{0}
+
+		startFunction := func(node *ast.Node) {
+			stack = append(stack, 0)
+		}
+		endFunction := func(node *ast.Node) {
+			if len(stack) > 1 {
+				stack = stack[:len(stack)-1]
+			}
+		}
+		pushBlock := func(node *ast.Node) {
+			n := len(stack)
+			if n == 0 {
+				return
+			}
+			stack[n-1]++
+			depth := stack[n-1]
+			if depth > maxDepth {
+				ctx.ReportNode(node, buildTooDeeplyMessage(depth, maxDepth))
+			}
+		}
+		popBlock := func(node *ast.Node) {
+			n := len(stack)
+			if n == 0 {
+				return
+			}
+			stack[n-1]--
+		}
+
+		// `else if` chains: tsgo (like ESTree) represents `if (a) {} else if (b) {}`
+		// as `IfStatement(a) { alternate: IfStatement(b) }`. ESLint suppresses the
+		// inner push when the parent is itself an IfStatement so the chain counts
+		// as a single nesting level.
+		//
+		// NOTE: The exit handler is intentionally `popBlock` (unconditional),
+		// matching ESLint exactly. ESLint's `IfStatement:exit` pops on every
+		// IfStatement regardless of whether the entry was suppressed, which
+		// leaves a negative residual on the depth counter after each `else if`
+		// chain. Sibling code following the chain therefore enjoys an
+		// artificial allowance equal to the chain length. We mirror this
+		// behavior to preserve 1:1 parity with ESLint's diagnostics.
+		ifEnter := func(node *ast.Node) {
+			if node.Parent != nil && node.Parent.Kind == ast.KindIfStatement {
+				return
+			}
+			pushBlock(node)
+		}
+
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration:                              startFunction,
+			rule.ListenerOnExit(ast.KindFunctionDeclaration):         endFunction,
+			ast.KindFunctionExpression:                               startFunction,
+			rule.ListenerOnExit(ast.KindFunctionExpression):          endFunction,
+			ast.KindArrowFunction:                                    startFunction,
+			rule.ListenerOnExit(ast.KindArrowFunction):               endFunction,
+			ast.KindClassStaticBlockDeclaration:                      startFunction,
+			rule.ListenerOnExit(ast.KindClassStaticBlockDeclaration): endFunction,
+			// ESLint listens FunctionExpression for class/object methods,
+			// getters, setters, and constructors because ESTree wraps each in
+			// a FunctionExpression value. tsgo represents them as distinct
+			// kinds, so listen explicitly to keep depth tracking aligned.
+			ast.KindMethodDeclaration:                      startFunction,
+			rule.ListenerOnExit(ast.KindMethodDeclaration): endFunction,
+			ast.KindGetAccessor:                            startFunction,
+			rule.ListenerOnExit(ast.KindGetAccessor):       endFunction,
+			ast.KindSetAccessor:                            startFunction,
+			rule.ListenerOnExit(ast.KindSetAccessor):       endFunction,
+			ast.KindConstructor:                            startFunction,
+			rule.ListenerOnExit(ast.KindConstructor):       endFunction,
+
+			ast.KindIfStatement:                          ifEnter,
+			rule.ListenerOnExit(ast.KindIfStatement):     popBlock,
+			ast.KindSwitchStatement:                      pushBlock,
+			rule.ListenerOnExit(ast.KindSwitchStatement): popBlock,
+			ast.KindTryStatement:                         pushBlock,
+			rule.ListenerOnExit(ast.KindTryStatement):    popBlock,
+			ast.KindDoStatement:                          pushBlock,
+			rule.ListenerOnExit(ast.KindDoStatement):     popBlock,
+			ast.KindWhileStatement:                       pushBlock,
+			rule.ListenerOnExit(ast.KindWhileStatement):  popBlock,
+			ast.KindWithStatement:                        pushBlock,
+			rule.ListenerOnExit(ast.KindWithStatement):   popBlock,
+			ast.KindForStatement:                         pushBlock,
+			rule.ListenerOnExit(ast.KindForStatement):    popBlock,
+			ast.KindForInStatement:                       pushBlock,
+			rule.ListenerOnExit(ast.KindForInStatement):  popBlock,
+			ast.KindForOfStatement:                       pushBlock,
+			rule.ListenerOnExit(ast.KindForOfStatement):  popBlock,
+		}
+	},
+}
+
+func buildTooDeeplyMessage(depth, maxDepth int) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "tooDeeply",
+		Description: fmt.Sprintf("Blocks are nested too deeply (%d). Maximum allowed is %d.", depth, maxDepth),
+	}
+}
+
+// parseMaxDepth resolves the configured maximum depth, mirroring ESLint's
+// `option.maximum || option.max` coercion. The legacy `maximum` key is honored
+// only when truthy (matching JS coercion); otherwise `max` wins. When neither
+// key is present, the default is 4.
+func parseMaxDepth(options any) int {
+	const defaultMax = 4
+	if options == nil {
+		return defaultMax
+	}
+	// Number form: `3` or `[3]`.
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) == 0 {
+			return defaultMax
+		}
+		if n, ok := toInt(arr[0]); ok {
+			return n
+		}
+	} else if n, ok := toInt(options); ok {
+		return n
+	}
+	// Object form: `{ max: 3 }` or `[{ max: 3 }]`. Use the shared extractor so
+	// both the array-wrapped (rule_tester / multi-element CLI) and bare-object
+	// (single-option CLI) shapes are handled uniformly.
+	m := utils.GetOptionsMap(options)
+	if m == nil {
+		return defaultMax
+	}
+	_, hasMaximum := m["maximum"]
+	_, hasMax := m["max"]
+	if !hasMaximum && !hasMax {
+		// Matches ESLint: when neither key is present, the option object is
+		// ignored and the default is used.
+		return defaultMax
+	}
+	if hasMaximum {
+		if v, ok := toInt(m["maximum"]); ok && v != 0 {
+			return v
+		}
+	}
+	if hasMax {
+		if v, ok := toInt(m["max"]); ok {
+			return v
+		}
+	}
+	// `option.maximum` is present but coerces to 0 / non-numeric, and
+	// `option.max` is absent or non-numeric: ESLint sets `maxDepth = undefined`
+	// here, which makes every `len > maxDepth` comparison false and effectively
+	// disables the check. MaxInt produces the same observable behavior.
+	return math.MaxInt
+}
+
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	case float32:
+		return int(n), true
+	}
+	return 0, false
+}

--- a/internal/rules/max_depth/max_depth.md
+++ b/internal/rules/max_depth/max_depth.md
@@ -1,0 +1,108 @@
+# max-depth
+
+## Rule Details
+
+This rule enforces a maximum depth that blocks can be nested to reduce code complexity.
+
+Examples of **incorrect** code for this rule with the default `{ "max": 4 }` option:
+
+```javascript
+function foo() {
+  for (;;) {
+    // Depth 1
+    while (true) {
+      // Depth 2
+      if (true) {
+        // Depth 3
+        if (true) {
+          // Depth 4
+          if (true) {
+            // Depth 5
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Examples of **correct** code for this rule with the default `{ "max": 4 }` option:
+
+```javascript
+function foo() {
+  for (;;) {
+    // Depth 1
+    while (true) {
+      // Depth 2
+      if (true) {
+        // Depth 3
+        if (true) {
+          // Depth 4
+        }
+      }
+    }
+  }
+}
+```
+
+## Options
+
+This rule accepts a number, or an object with `max` (default: `4`). The legacy
+`maximum` key is also accepted for backward compatibility.
+
+Examples of **incorrect** code for this rule with `{ "max": 2 }`:
+
+```json
+{ "max-depth": ["error", { "max": 2 }] }
+```
+
+```javascript
+function foo() {
+  if (true) {
+    if (false) {
+      if (true) {
+      }
+    }
+  }
+}
+```
+
+Examples of **correct** code for this rule with `{ "max": 2 }`:
+
+```json
+{ "max-depth": ["error", { "max": 2 }] }
+```
+
+```javascript
+function foo() {
+  if (true) {
+    if (false) {
+    }
+  }
+}
+```
+
+`else if` chains are treated as a single depth level. Class static blocks reset
+the nesting counter — code inside `static {}` is measured from depth 0.
+
+```javascript
+function foo() {
+  if (true) {
+    // Depth 1
+    class C {
+      static {
+        if (true) {
+          // Depth 1 (resets in static block)
+          if (true) {
+            // Depth 2
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Original Documentation
+
+- [https://eslint.org/docs/latest/rules/max-depth](https://eslint.org/docs/latest/rules/max-depth)

--- a/internal/rules/max_depth/max_depth_test.go
+++ b/internal/rules/max_depth/max_depth_test.go
@@ -1,0 +1,1105 @@
+package max_depth
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestMaxDepth covers two corpora:
+//
+//  1. ESLint parity — every case from eslint/tests/lib/rules/max-depth.js
+//     migrated 1:1, with line / column added to every invalid case (upstream
+//     omits them on most cases — we lock them in here so subsequent refactors
+//     can't silently shift the report position).
+//  2. Additional edge cases — tsgo AST shape variants (class/object methods,
+//     getters/setters, constructor, arrow class fields) that ESLint's tests
+//     don't enumerate because ESTree collapses them into FunctionExpression /
+//     ArrowFunctionExpression. Plus statement-kind coverage (do / for-in /
+//     with) and an `else if` chain with a trailing sibling that exercises
+//     the asymmetric push/pop on IfStatement (see max_depth.go).
+func TestMaxDepth(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&MaxDepthRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// 1. ESLint parity — mirrors tests/lib/rules/max-depth.js
+			// ============================================================
+			{
+				Code:    "function foo() { if (true) { if (false) { if (true) { } } } }",
+				Options: 3,
+			},
+			{
+				Code:    "function foo() { if (true) { } else if (false) { } else if (true) { } else if (false) {} }",
+				Options: 3,
+			},
+			{
+				Code:    "var foo = () => { if (true) { if (false) { if (true) { } } } }",
+				Options: 3,
+			},
+			{
+				Code: "function foo() { if (true) { if (false) { if (true) { } } } }",
+			},
+
+			// object property options
+			{
+				Code:    "function foo() { if (true) { if (false) { if (true) { } } } }",
+				Options: map[string]interface{}{"max": 3},
+			},
+
+			{
+				Code:    "class C { static { if (1) { if (2) {} } } }",
+				Options: 2,
+			},
+			{
+				Code:    "class C { static { if (1) { if (2) {} } if (1) { if (2) {} } } }",
+				Options: 2,
+			},
+			{
+				Code:    "class C { static { if (1) { if (2) {} } } static { if (1) { if (2) {} } } }",
+				Options: 2,
+			},
+			{
+				Code:    "if (1) { class C { static { if (1) { if (2) {} } } } }",
+				Options: 2,
+			},
+			{
+				Code:    "function foo() { if (1) { class C { static { if (1) { if (2) {} } } } } }",
+				Options: 2,
+			},
+			{
+				Code:    "function foo() { if (1) { if (2) { class C { static { if (1) { if (2) {} } if (1) { if (2) {} } } } } } if (1) { if (2) {} } }",
+				Options: 2,
+			},
+
+			// ============================================================
+			// 2. Additional edge cases
+			// ============================================================
+
+			// --- Default option (max=4) ---
+			{
+				Code: "if (a) { if (b) { if (c) { if (d) {} } } }",
+			},
+
+			// --- Options shapes — ensure JSON path is exercised ---
+			// Number directly (not wrapped in array).
+			{Code: "function foo() { if (a) {} }", Options: 1},
+			// Bare object (single-option CLI shape).
+			{
+				Code:    "function foo() { if (a) { if (b) {} } }",
+				Options: map[string]interface{}{"max": 2},
+			},
+			// Array-wrapped object (multi-element / rule_tester shape).
+			{
+				Code:    "function foo() { if (a) { if (b) {} } }",
+				Options: []interface{}{map[string]interface{}{"max": 2}},
+			},
+			// Empty options array → defaults to 4.
+			{Code: "if (a) { if (b) { if (c) { if (d) {} } } }", Options: []interface{}{}},
+			// Legacy `maximum` key.
+			{
+				Code:    "function foo() { if (a) { if (b) { if (c) {} } } }",
+				Options: map[string]interface{}{"maximum": 3},
+			},
+
+			// --- Inner function resets the depth counter ---
+			{
+				Code:    "function outer() { if (1) { function inner() { if (2) { if (3) {} } } } }",
+				Options: 2,
+			},
+			{
+				Code:    "function outer() { if (1) { var inner = function () { if (2) { if (3) {} } }; } }",
+				Options: 2,
+			},
+			{
+				Code:    "function outer() { if (1) { var inner = () => { if (2) { if (3) {} } }; } }",
+				Options: 2,
+			},
+
+			// --- Class methods / object methods / getters / setters / ctor reset depth ---
+			{
+				Code:    "class C { method() { if (1) { if (2) { if (3) {} } } } }",
+				Options: 3,
+			},
+			{
+				Code:    "class C { get x() { if (1) { if (2) { if (3) {} } } } }",
+				Options: 3,
+			},
+			{
+				Code:    "class C { set x(v) { if (1) { if (2) { if (3) {} } } } }",
+				Options: 3,
+			},
+			{
+				Code:    "class C { constructor() { if (1) { if (2) { if (3) {} } } } }",
+				Options: 3,
+			},
+			{
+				Code:    "var obj = { method() { if (1) { if (2) { if (3) {} } } } }",
+				Options: 3,
+			},
+			{
+				Code:    "var obj = { get x() { if (1) { if (2) { if (3) {} } } } }",
+				Options: 3,
+			},
+			// Class field initializer arrow — its own ArrowFunction scope.
+			{
+				Code:    "class C { handler = () => { if (1) { if (2) { if (3) {} } } } }",
+				Options: 3,
+			},
+
+			// --- Statement kinds — every depth-increasing form, just under the limit ---
+			{
+				Code:    "function f() { for (;;) { while (true) { do { if (1) {} } while (1); } } }",
+				Options: 4,
+			},
+			{
+				Code:    "function f() { for (var k in o) { for (var v of a) { switch (k) {} } } }",
+				Options: 3,
+			},
+			{
+				Code:    "function f() { try { } catch (e) { } finally { } }",
+				Options: 1,
+			},
+
+			// --- `with` statement — depth-increasing ---
+			{
+				Code:    "function f() { with (o) { if (true) {} } }",
+				Options: 2,
+			},
+
+			// --- `else if` chain at the limit, no sibling ---
+			{
+				Code:    "function f() { if (a) {} else if (b) {} else if (c) {} else if (d) {} }",
+				Options: 1,
+			},
+
+			// --- TypeScript syntax — type annotations don't add depth ---
+			{
+				Code:    "function f<T extends { x: number }>(a: T): void { if (a.x) { if (true) {} } }",
+				Options: 2,
+			},
+			// Type guards / `as` / `satisfies` are expressions, not statements,
+			// and don't contribute to depth.
+			{
+				Code:    "function f(a: unknown) { if (a as string) { if (true) {} } }",
+				Options: 2,
+			},
+
+			// --- Lock-in: ESLint's asymmetric `IfStatement:exit` pop ---
+			// ESLint pushes only on the outer `if` of an else-if chain but pops
+			// on every chain link, leaving the depth counter negative after the
+			// chain ends. Subsequent sibling code therefore has a "discount"
+			// equal to the chain length. The if(f) below would be at depth 3
+			// under a naive read, but ESLint sees it at depth 1 (-2 residual +
+			// 3 nested ifs) and reports nothing. See max_depth.go for context.
+			{
+				Code:    "function f() { if (a) {} else if (b) {} else if (c) {} if (d) { if (e) { if (f) {} } } }",
+				Options: 2,
+			},
+			// Same shape, longer chain — confirms the residual scales linearly.
+			{
+				Code:    "if (a) {} else if (b) {} else if (c) {} else if (d) {} if (e) { if (f) { if (g) { if (h) {} } } }",
+				Options: 3,
+			},
+
+			// --- Function/scope boundary edge cases ---
+			// IIFE — depth resets inside the immediately invoked function;
+			// inner if(c)/if(d)/if(e) reach depth 3, which is at the limit.
+			{
+				Code:    "if (a) { if (b) { (function () { if (c) { if (d) { if (e) {} } } })(); } }",
+				Options: 3,
+			},
+			// Arrow IIFE — same.
+			{
+				Code:    "if (a) { if (b) { (() => { if (c) { if (d) { if (e) {} } } })(); } }",
+				Options: 3,
+			},
+			// Async / generator / async generator function-likes — same boundary.
+			{
+				Code:    "async function f() { if (a) { if (b) { if (c) {} } } }",
+				Options: 3,
+			},
+			{
+				Code:    "function* g() { if (a) { if (b) { if (c) {} } } }",
+				Options: 3,
+			},
+			{
+				Code:    "async function* g() { if (a) { if (b) { if (c) {} } } }",
+				Options: 3,
+			},
+			// Async arrow.
+			{
+				Code:    "var f = async () => { if (a) { if (b) { if (c) {} } } }",
+				Options: 3,
+			},
+			// Default-export anonymous function-likes.
+			{
+				Code:    "export default function () { if (a) { if (b) { if (c) {} } } }",
+				Options: 3,
+			},
+			{
+				Code:    "export default class { method() { if (a) { if (b) { if (c) {} } } } }",
+				Options: 3,
+			},
+			// Decorator on a class method — body still resets depth.
+			{
+				Code:    "function dec() { return (a, b, c) => {}; } class C { @dec() method() { if (a) { if (b) { if (c) {} } } } }",
+				Options: 3,
+			},
+
+			// --- Real-world nesting shapes (just under default limit of 4) ---
+			// fetch + retry pattern.
+			{
+				Code: `async function fetchWithRetry(url) {
+  for (let i = 0; i < 3; i++) {
+    try {
+      const r = await fetch(url);
+      if (r.ok) {
+        return r.json();
+      }
+    } catch (e) {
+      if (i === 2) throw e;
+    }
+  }
+}`,
+			},
+			// Validation / state-machine pattern.
+			{
+				Code: `function validate(input) {
+  switch (input.kind) {
+    case 'number':
+      if (input.value > 0) {
+        for (const c of input.constraints) {
+          if (!c.test(input.value)) return false;
+        }
+      }
+      break;
+  }
+  return true;
+}`,
+			},
+
+			// --- Type-only constructs do NOT contain executable nesting ---
+			// Interface body / type literal — no statements inside, no depth.
+			{
+				Code:    "interface I { x: { y: { z: { w: number } } } } function f() { if (a) {} }",
+				Options: 1,
+			},
+			// Type alias with nested object types.
+			{
+				Code:    "type T = { a: { b: { c: { d: number } } } }; function f() { if (a) {} }",
+				Options: 1,
+			},
+			// Conditional types are types, not statements.
+			{
+				Code:    "type T<X> = X extends Array<infer Y> ? (Y extends string ? Y : never) : never; function f() { if (a) {} }",
+				Options: 1,
+			},
+
+			// --- TS-only declarations / declaration merging ---
+			// Namespace body acts like a module — but rule doesn't reset on it.
+			// Still, no top-level depth-increasing statements here.
+			{
+				Code:    "namespace N { export function f() { if (a) { if (b) {} } } }",
+				Options: 2,
+			},
+			// Module declaration with nested function.
+			{
+				Code:    "declare module 'x' { export function f(): void; }",
+				Options: 1,
+			},
+			// Abstract / overload signatures (no body) — must not crash.
+			{
+				Code:    "abstract class A { abstract method(): void; }",
+				Options: 1,
+			},
+			{
+				Code:    "function f(x: number): number; function f(x: string): string; function f(x: any): any { if (x) {} }",
+				Options: 1,
+			},
+
+			// --- Empty / degenerate forms ---
+			{Code: ""},
+			{Code: "function f() {}", Options: 0},
+			{Code: "var f = () => {};", Options: 0},
+			{Code: "class C {}", Options: 0},
+			{Code: "class C { static {} }", Options: 0},
+			{Code: "function f() { try { } catch (e) { } finally { } }", Options: 1},
+
+			// --- Lone blocks do NOT increase depth (only listed kinds do) ---
+			{
+				Code:    "function f() { { { { if (a) {} } } } }",
+				Options: 1,
+			},
+
+			// --- Bare `else { if(){} }` (block alternate, not chained) ---
+			// The inner `if` parent is BlockStatement, so it pushes — distinct
+			// from `else if` chaining (parent: IfStatement, no push).
+			{
+				Code:    "function f() { if (a) {} else { if (b) {} } }",
+				Options: 2,
+			},
+
+			// --- `for await (...of...)` — same KindForOfStatement, counted ---
+			{
+				Code:    "async function f() { for await (const x of y) { if (a) { if (b) {} } } }",
+				Options: 3,
+			},
+
+			// --- LabeledStatement does NOT add depth — its child still counts ---
+			{
+				Code:    "function f() { outer: while (true) { if (a) {} } }",
+				Options: 2,
+			},
+
+			// --- Statement bodies without braces ---
+			{
+				Code:    "function f() { while (true) if (a) for (;;) {} }",
+				Options: 3,
+			},
+
+			// --- switch with default only / empty switch ---
+			{
+				Code:    "function f() { switch (x) {} }",
+				Options: 1,
+			},
+			{
+				Code:    "function f() { switch (x) { default: if (a) {} } }",
+				Options: 2,
+			},
+
+			// --- Class expression (vs declaration) ---
+			{
+				Code:    "var C = class { method() { if (a) { if (b) { if (c) {} } } } }",
+				Options: 3,
+			},
+
+			// --- Method parameter default with arrow — its own scope ---
+			{
+				Code:    "class C { method(cb = () => { if (a) { if (b) { if (c) {} } } }) {} }",
+				Options: 3,
+			},
+
+			// --- Namespace body — does NOT reset depth (tsgo + ESLint align) ---
+			{
+				Code:    "namespace N { if (a) { if (b) {} } }",
+				Options: 2,
+			},
+
+			// --- TS Enum body has no depth-increasing statements ---
+			{
+				Code:    "enum E { A, B, C } function f() { if (a) {} }",
+				Options: 1,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// 1. ESLint parity — mirrors tests/lib/rules/max-depth.js
+			// ============================================================
+			{
+				Code:    "function foo() { if (true) { if (false) { if (true) { } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    43,
+					},
+				},
+			},
+			{
+				Code:    "var foo = () => { if (true) { if (false) { if (true) { } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    44,
+					},
+				},
+			},
+			{
+				Code:    "function foo() { if (true) {} else { for(;;) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    38,
+					},
+				},
+			},
+			{
+				Code:    "function foo() { while (true) { if (true) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    33,
+					},
+				},
+			},
+			{
+				Code:    "function foo() { for (let x of foo) { if (true) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    39,
+					},
+				},
+			},
+			{
+				Code:    "function foo() { while (true) { if (true) { if (false) { } } } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    33,
+					},
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 1.",
+						Line:      1,
+						Column:    45,
+					},
+				},
+			},
+			{
+				Code: "function foo() { if (true) { if (false) { if (true) { if (false) { if (true) { } } } } } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (5). Maximum allowed is 4.",
+						Line:      1,
+						Column:    68,
+					},
+				},
+			},
+
+			// object property options
+			{
+				Code:    "function foo() { if (true) { if (false) { if (true) { } } } }",
+				Options: map[string]interface{}{"max": 2},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    43,
+					},
+				},
+			},
+
+			{
+				Code:    "function foo() { if (a) { if (b) { if (c) { if (d) { if (e) {} } } } } }",
+				Options: map[string]interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (5). Maximum allowed is 4.",
+						Line:      1,
+						Column:    54,
+					},
+				},
+			},
+			{
+				Code:    "function foo() { if (true) {} }",
+				Options: map[string]interface{}{"max": 0},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (1). Maximum allowed is 0.",
+						Line:      1,
+						Column:    18,
+					},
+				},
+			},
+
+			{
+				Code:    "class C { static { if (1) { if (2) { if (3) {} } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    38,
+					},
+				},
+			},
+			{
+				Code:    "if (1) { class C { static { if (1) { if (2) { if (3) {} } } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    47,
+					},
+				},
+			},
+			{
+				Code:    "function foo() { if (1) { class C { static { if (1) { if (2) { if (3) {} } } } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    64,
+					},
+				},
+			},
+			{
+				Code:    "function foo() { if (1) { class C { static { if (1) { if (2) {} } } } if (2) { if (3) {} } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    80,
+					},
+				},
+			},
+
+			// ============================================================
+			// 2. Additional edge cases
+			// ============================================================
+
+			// --- Top-level (no enclosing function) ---
+			{
+				Code:    "if (a) { if (b) { if (c) {} } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    19,
+					},
+				},
+			},
+
+			// --- Multi-line code: line/column precision ---
+			{
+				Code: `function foo() {
+    if (a) {
+        if (b) {
+            if (c) {
+            }
+        }
+    }
+}`,
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      4,
+						Column:    13,
+					},
+				},
+			},
+
+			// --- Statement kinds: do / switch / try / with / for-in ---
+			{
+				Code:    "function f() { do { if (a) {} } while (b); }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    21,
+					},
+				},
+			},
+			{
+				Code:    "function f() { switch (x) { case 1: if (a) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    37,
+					},
+				},
+			},
+			{
+				Code:    "function f() { try { if (a) {} } catch (e) {} }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    22,
+					},
+				},
+			},
+			{
+				Code:    "function f() { with (o) { if (a) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    27,
+					},
+				},
+			},
+			{
+				Code:    "function f() { for (var k in o) { if (a) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    35,
+					},
+				},
+			},
+
+			// --- Class method / getter / setter / constructor reset depth, but
+			//     deep nesting inside still triggers ---
+			{
+				Code:    "class C { method() { if (1) { if (2) { if (3) {} } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    40,
+					},
+				},
+			},
+			{
+				Code:    "class C { get x() { if (1) { if (2) { if (3) {} } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    39,
+					},
+				},
+			},
+			{
+				Code:    "class C { constructor() { if (1) { if (2) { if (3) {} } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    45,
+					},
+				},
+			},
+			{
+				Code:    "var obj = { method() { if (1) { if (2) { if (3) {} } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    42,
+					},
+				},
+			},
+			// Class field with arrow — ArrowFunction scope inside class.
+			{
+				Code:    "class C { handler = () => { if (1) { if (2) { if (3) {} } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    47,
+					},
+				},
+			},
+
+			// --- Legacy `maximum` key honoured ---
+			{
+				Code:    "function foo() { if (a) { if (b) { if (c) {} } } }",
+				Options: map[string]interface{}{"maximum": 2},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    36,
+					},
+				},
+			},
+			// `maximum` wins when both keys are present and `maximum` is truthy
+			// (matching ESLint's `option.maximum || option.max`).
+			{
+				Code:    "function foo() { if (a) { if (b) { if (c) {} } } }",
+				Options: map[string]interface{}{"maximum": 2, "max": 5},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    36,
+					},
+				},
+			},
+			// `{ maximum: 0 }` falls through to undefined in ESLint and disables
+			// the check; `{ max: 0 }` instead reports every block. This case
+			// uses `max: 0` to lock in the falsy-but-valid path.
+			{
+				Code:    "var x = () => { if (a) {} }",
+				Options: []interface{}{map[string]interface{}{"max": 0}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (1). Maximum allowed is 0.",
+						Line:      1,
+						Column:    17,
+					},
+				},
+			},
+
+			// --- IIFE — body has its own scope, but interior nesting still triggers ---
+			{
+				Code:    "(function () { if (a) { if (b) { if (c) {} } } })()",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    34,
+					},
+				},
+			},
+			{
+				Code:    "(() => { if (a) { if (b) { if (c) {} } } })()",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    28,
+					},
+				},
+			},
+
+			// --- async / generator / async generator function bodies ---
+			{
+				Code:    "async function f() { if (a) { if (b) { if (c) {} } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    40,
+					},
+				},
+			},
+			{
+				Code:    "function* g() { if (a) { if (b) { if (c) {} } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    35,
+					},
+				},
+			},
+
+			// --- Async method / async arrow class field ---
+			{
+				Code:    "class C { async method() { if (a) { if (b) { if (c) {} } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    46,
+					},
+				},
+			},
+			{
+				Code:    "class C { handler = async () => { if (a) { if (b) { if (c) {} } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    53,
+					},
+				},
+			},
+
+			// --- Catch / finally body still counts inside the surrounding try ---
+			{
+				Code:    "function f() { try { } catch (e) { if (a) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    36,
+					},
+				},
+			},
+			{
+				Code:    "function f() { try { } finally { if (a) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    34,
+					},
+				},
+			},
+
+			// --- switch with multiple case clauses, deep inside a case ---
+			{
+				Code:    "function f() { switch (x) { case 1: { for (;;) { if (a) {} } break; } case 2: break; } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    50,
+					},
+				},
+			},
+
+			// --- Top-level (no enclosing function) deep nesting ---
+			{
+				Code:    "for (;;) { while (true) { if (a) { if (b) {} } } }",
+				Options: 3,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (4). Maximum allowed is 3.",
+						Line:      1,
+						Column:    36,
+					},
+				},
+			},
+
+			// --- Multiple separate violations in one source ---
+			{
+				Code: `function a() { if (1) { if (2) { if (3) {} } } }
+function b() { while (1) { while (2) { while (3) {} } } }`,
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    34,
+					},
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      2,
+						Column:    40,
+					},
+				},
+			},
+
+			// --- Sibling violations under shared parent ---
+			{
+				Code:    "function f() { if (1) { if (2) { if (3) {} } if (4) { if (5) {} } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    34,
+					},
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    55,
+					},
+				},
+			},
+
+			// --- Violation inside a nested function — depth resets at the
+			//     function boundary, then deepens again inside the inner body ---
+			{
+				Code:    "function outer() { if (1) { function inner() { if (2) { if (3) { if (4) {} } } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    66,
+					},
+				},
+			},
+
+			// --- `else { if (b) {} }` — block alternate, NOT chained;
+			//     inner if pushes (parent is BlockStatement, not IfStatement) ---
+			{
+				Code:    "function f() { if (a) {} else { if (b) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    33,
+					},
+				},
+			},
+
+			// --- LabeledStatement — wrapper transparent, inner still counts ---
+			{
+				Code:    "function f() { outer: while (true) { if (a) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    38,
+					},
+				},
+			},
+
+			// --- `for await (...of...)` triggers like normal for-of ---
+			{
+				Code:    "async function f() { for await (const x of y) { if (a) {} } }",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (2). Maximum allowed is 1.",
+						Line:      1,
+						Column:    49,
+					},
+				},
+			},
+
+			// --- Body without braces (single-statement form) ---
+			{
+				Code:    "function f() { while (true) if (a) for (;;) {} }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    36,
+					},
+				},
+			},
+
+			// --- Class expression with method — same boundary as declaration ---
+			{
+				Code:    "var C = class { method() { if (a) { if (b) { if (c) {} } } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    46,
+					},
+				},
+			},
+
+			// --- Method parameter default arrow — independent depth scope ---
+			{
+				Code:    "class C { method(cb = () => { if (a) { if (b) { if (c) {} } } }) {} }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    49,
+					},
+				},
+			},
+
+			// --- Namespace body shares depth scope with its enclosing scope ---
+			{
+				Code:    "namespace N { if (a) { if (b) { if (c) {} } } }",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tooDeeply",
+						Message:   "Blocks are nested too deeply (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    33,
+					},
+				},
+			},
+
+			// --- Real-world example: callback chain — depth resets at every
+			//     arrow boundary, but each inner arrow body still nests beyond
+			//     the limit (max=1) ---
+			{
+				Code: `function load() {
+  fetch('a').then((r) => {
+    if (r.ok) {
+      r.json().then((d) => {
+        if (d.items) {
+          d.items.forEach((it) => {
+            if (it.active) {
+              if (it.score > 0) {
+              }
+            }
+          });
+        }
+      });
+    }
+  });
+}`,
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					// Inside arrow 3 (forEach callback): if(it.active) depth=1,
+					// if(it.score>0) depth=2 → reports at 2.
+					{MessageId: "tooDeeply", Line: 8, Column: 15},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -323,6 +323,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
     './tests/eslint/rules/no-alert.test.ts',
     './tests/eslint/rules/no-bitwise.test.ts',
+    './tests/eslint/rules/max-depth.test.ts',
     './tests/eslint/rules/max-lines.test.ts',
     './tests/eslint/rules/no-label-var.test.ts',
     './tests/eslint/rules/no-shadow.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-depth.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-depth.test.ts.snap
@@ -1,0 +1,775 @@
+// Rstest Snapshot v1
+
+exports[`max-depth > invalid 1`] = `
+{
+  "code": "function foo() { if (true) { if (false) { if (true) { } } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 2`] = `
+{
+  "code": "var foo = () => { if (true) { if (false) { if (true) { } } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 3`] = `
+{
+  "code": "function foo() { if (true) {} else { for(;;) {} } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (2). Maximum allowed is 1.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 4`] = `
+{
+  "code": "function foo() { while (true) { if (true) {} } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (2). Maximum allowed is 1.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 5`] = `
+{
+  "code": "function foo() { for (let x of foo) { if (true) {} } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (2). Maximum allowed is 1.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 6`] = `
+{
+  "code": "function foo() { while (true) { if (true) { if (false) { } } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (2). Maximum allowed is 1.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 1.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 7`] = `
+{
+  "code": "function foo() { if (true) { if (false) { if (true) { if (false) { if (true) { } } } } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (5). Maximum allowed is 4.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 81,
+          "line": 1,
+        },
+        "start": {
+          "column": 68,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 8`] = `
+{
+  "code": "function foo() { if (true) { if (false) { if (true) { } } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 9`] = `
+{
+  "code": "function foo() { if (a) { if (b) { if (c) { if (d) { if (e) {} } } } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (5). Maximum allowed is 4.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 10`] = `
+{
+  "code": "function foo() { if (true) {} }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (1). Maximum allowed is 0.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 11`] = `
+{
+  "code": "class C { static { if (1) { if (2) { if (3) {} } } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 12`] = `
+{
+  "code": "if (1) { class C { static { if (1) { if (2) { if (3) {} } } } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 13`] = `
+{
+  "code": "function foo() { if (1) { class C { static { if (1) { if (2) { if (3) {} } } } } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 64,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 14`] = `
+{
+  "code": "function foo() { if (1) { class C { static { if (1) { if (2) {} } } } if (2) { if (3) {} } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 1,
+        },
+        "start": {
+          "column": 80,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 15`] = `
+{
+  "code": "if (a) { if (b) { if (c) {} } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 16`] = `
+{
+  "code": "(function () { if (a) { if (b) { if (c) {} } } })()",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 17`] = `
+{
+  "code": "async function f() { if (a) { if (b) { if (c) {} } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 18`] = `
+{
+  "code": "function* g() { if (a) { if (b) { if (c) {} } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 19`] = `
+{
+  "code": "function f() { try { } catch (e) { if (a) {} } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (2). Maximum allowed is 1.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 20`] = `
+{
+  "code": "function f() { try { } finally { if (a) {} } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (2). Maximum allowed is 1.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 21`] = `
+{
+  "code": "function f() { switch (x) { case 1: { for (;;) { if (a) {} } break; } case 2: break; } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 22`] = `
+{
+  "code": "function a() { if (1) { if (2) { if (3) {} } } }
+function b() { while (1) { while (2) { while (3) {} } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 2,
+        },
+        "start": {
+          "column": 40,
+          "line": 2,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 23`] = `
+{
+  "code": "function f() { if (1) { if (2) { if (3) {} } if (4) { if (5) {} } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 24`] = `
+{
+  "code": "function foo() { if (a) { if (b) { if (c) {} } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 25`] = `
+{
+  "code": "function f() { if (a) {} else { if (b) {} } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (2). Maximum allowed is 1.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 26`] = `
+{
+  "code": "function f() { while (true) if (a) for (;;) {} }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 27`] = `
+{
+  "code": "var C = class { method() { if (a) { if (b) { if (c) {} } } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-depth > invalid 28`] = `
+{
+  "code": "namespace N { if (a) { if (b) { if (c) {} } } }",
+  "diagnostics": [
+    {
+      "message": "Blocks are nested too deeply (3). Maximum allowed is 2.",
+      "messageId": "tooDeeply",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-depth",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/max-depth.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/max-depth.test.ts
@@ -1,0 +1,440 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('max-depth', {
+  valid: [
+    {
+      code: 'function foo() { if (true) { if (false) { if (true) { } } } }',
+      options: [3] as any,
+    },
+    {
+      code: 'function foo() { if (true) { } else if (false) { } else if (true) { } else if (false) {} }',
+      options: [3] as any,
+    },
+    {
+      code: 'var foo = () => { if (true) { if (false) { if (true) { } } } }',
+      options: [3] as any,
+    },
+    'function foo() { if (true) { if (false) { if (true) { } } } }',
+    {
+      code: 'function foo() { if (true) { if (false) { if (true) { } } } }',
+      options: [{ max: 3 }] as any,
+    },
+    {
+      code: 'class C { static { if (1) { if (2) {} } } }',
+      options: [2] as any,
+    },
+    {
+      code: 'class C { static { if (1) { if (2) {} } if (1) { if (2) {} } } }',
+      options: [2] as any,
+    },
+    {
+      code: 'class C { static { if (1) { if (2) {} } } static { if (1) { if (2) {} } } }',
+      options: [2] as any,
+    },
+    {
+      code: 'if (1) { class C { static { if (1) { if (2) {} } } } }',
+      options: [2] as any,
+    },
+    {
+      code: 'function foo() { if (1) { class C { static { if (1) { if (2) {} } } } } }',
+      options: [2] as any,
+    },
+    {
+      code: 'function foo() { if (1) { if (2) { class C { static { if (1) { if (2) {} } if (1) { if (2) {} } } } } } if (1) { if (2) {} } }',
+      options: [2] as any,
+    },
+    // Class methods / object methods reset depth.
+    {
+      code: 'class C { method() { if (1) { if (2) { if (3) {} } } } }',
+      options: [3] as any,
+    },
+    {
+      code: 'var obj = { method() { if (1) { if (2) { if (3) {} } } } }',
+      options: [3] as any,
+    },
+    // async / generator / async generator function-likes — same boundary.
+    {
+      code: 'async function f() { if (a) { if (b) { if (c) {} } } }',
+      options: [3] as any,
+    },
+    {
+      code: 'function* g() { if (a) { if (b) { if (c) {} } } }',
+      options: [3] as any,
+    },
+    {
+      code: 'async function* g() { if (a) { if (b) { if (c) {} } } }',
+      options: [3] as any,
+    },
+    {
+      code: 'var f = async () => { if (a) { if (b) { if (c) {} } } }',
+      options: [3] as any,
+    },
+    // Class field arrow.
+    {
+      code: 'class C { handler = () => { if (a) { if (b) { if (c) {} } } } }',
+      options: [3] as any,
+    },
+    // Type-only constructs add no depth.
+    {
+      code: 'interface I { x: { y: { z: { w: number } } } } function f() { if (a) {} }',
+      options: [1] as any,
+    },
+    // Empty / degenerate sources.
+    '',
+    { code: 'function f() {}', options: [0] as any },
+    { code: 'class C { static {} }', options: [0] as any },
+    {
+      code: 'function f() { try { } catch (e) { } finally { } }',
+      options: [1] as any,
+    },
+    // Lock-in: ESLint's asymmetric `IfStatement:exit` pop leaves a residual
+    // negative count after else-if chains, giving sibling code an artificial
+    // discount. We mirror this exactly.
+    {
+      code: 'function f() { if (a) {} else if (b) {} else if (c) {} if (d) { if (e) { if (f) {} } } }',
+      options: [2] as any,
+    },
+    // Lone blocks don't increase depth.
+    { code: 'function f() { { { { if (a) {} } } } }', options: [1] as any },
+    // for-await-of, labeled while, single-statement bodies, namespace.
+    {
+      code: 'async function f() { for await (const x of y) { if (a) {} } }',
+      options: [2] as any,
+    },
+    {
+      code: 'function f() { outer: while (true) { if (a) {} } }',
+      options: [2] as any,
+    },
+    {
+      code: 'function f() { while (true) if (a) for (;;) {} }',
+      options: [3] as any,
+    },
+    { code: 'function f() { switch (x) {} }', options: [1] as any },
+    {
+      code: 'namespace N { if (a) { if (b) {} } }',
+      options: [2] as any,
+    },
+  ],
+  invalid: [
+    {
+      code: 'function foo() { if (true) { if (false) { if (true) { } } } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 43,
+        },
+      ],
+    },
+    {
+      code: 'var foo = () => { if (true) { if (false) { if (true) { } } } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 44,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { if (true) {} else { for(;;) {} } }',
+      options: [1] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 38,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { while (true) { if (true) {} } }',
+      options: [1] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 33,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { for (let x of foo) { if (true) {} } }',
+      options: [1] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 39,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { while (true) { if (true) { if (false) { } } } }',
+      options: [1] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 33,
+        },
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 45,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { if (true) { if (false) { if (true) { if (false) { if (true) { } } } } } }',
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 68,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { if (true) { if (false) { if (true) { } } } }',
+      options: [{ max: 2 }] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 43,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { if (a) { if (b) { if (c) { if (d) { if (e) {} } } } } }',
+      options: [{}] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 54,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { if (true) {} }',
+      options: [{ max: 0 }] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 18,
+        },
+      ],
+    },
+    {
+      code: 'class C { static { if (1) { if (2) { if (3) {} } } } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 38,
+        },
+      ],
+    },
+    {
+      code: 'if (1) { class C { static { if (1) { if (2) { if (3) {} } } } } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 47,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { if (1) { class C { static { if (1) { if (2) { if (3) {} } } } } } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 64,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { if (1) { class C { static { if (1) { if (2) {} } } } if (2) { if (3) {} } } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 80,
+        },
+      ],
+    },
+    // Top-level (no enclosing function) deep nesting.
+    {
+      code: 'if (a) { if (b) { if (c) {} } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 19,
+        },
+      ],
+    },
+    // IIFE — body has its own scope; interior nesting still triggers.
+    {
+      code: '(function () { if (a) { if (b) { if (c) {} } } })()',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 34,
+        },
+      ],
+    },
+    // Async / generator function bodies.
+    {
+      code: 'async function f() { if (a) { if (b) { if (c) {} } } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 40,
+        },
+      ],
+    },
+    {
+      code: 'function* g() { if (a) { if (b) { if (c) {} } } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 35,
+        },
+      ],
+    },
+    // Catch / finally body counted within the surrounding try.
+    {
+      code: 'function f() { try { } catch (e) { if (a) {} } }',
+      options: [1] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 36,
+        },
+      ],
+    },
+    {
+      code: 'function f() { try { } finally { if (a) {} } }',
+      options: [1] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 34,
+        },
+      ],
+    },
+    // switch case clauses, deep block in a case.
+    {
+      code: 'function f() { switch (x) { case 1: { for (;;) { if (a) {} } break; } case 2: break; } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 50,
+        },
+      ],
+    },
+    // Multiple separate violations in one source.
+    {
+      code: 'function a() { if (1) { if (2) { if (3) {} } } }\nfunction b() { while (1) { while (2) { while (3) {} } } }',
+      options: [2] as any,
+      errors: [
+        { messageId: 'tooDeeply', line: 1, column: 34 },
+        { messageId: 'tooDeeply', line: 2, column: 40 },
+      ],
+    },
+    // Sibling violations under shared parent.
+    {
+      code: 'function f() { if (1) { if (2) { if (3) {} } if (4) { if (5) {} } } }',
+      options: [2] as any,
+      errors: [
+        { messageId: 'tooDeeply', line: 1, column: 34 },
+        { messageId: 'tooDeeply', line: 1, column: 55 },
+      ],
+    },
+    // Legacy `maximum` key.
+    {
+      code: 'function foo() { if (a) { if (b) { if (c) {} } } }',
+      options: [{ maximum: 2 }] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 36,
+        },
+      ],
+    },
+    // `else { if (b) {} }` — block alternate, not chained — inner if pushes.
+    {
+      code: 'function f() { if (a) {} else { if (b) {} } }',
+      options: [1] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 33,
+        },
+      ],
+    },
+    // Body without braces.
+    {
+      code: 'function f() { while (true) if (a) for (;;) {} }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 36,
+        },
+      ],
+    },
+    // Class expression with method.
+    {
+      code: 'var C = class { method() { if (a) { if (b) { if (c) {} } } } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 46,
+        },
+      ],
+    },
+    // Namespace body shares depth scope with surrounding scope.
+    {
+      code: 'namespace N { if (a) { if (b) { if (c) {} } } }',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'tooDeeply',
+          line: 1,
+          column: 33,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `max-depth` rule from ESLint to rslint.

This rule enforces a maximum depth that blocks can be nested to reduce code complexity. Tracks nesting of `if`/`switch`/`try`/`do`/`while`/`with`/`for`/`for-in`/`for-of` within function-likes and class static blocks; depth resets at each function boundary; chained `else if` collapses to a single level.

Tested on real codebases (rsbuild, rspack) — every reported diagnostic was hand-verified for correct depth, location, and column. Behavior is byte-for-byte aligned with ESLint's main branch implementation, including its asymmetric \`IfStatement:exit\` pop quirk.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/max-depth
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/max-depth.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).