### PR TITLE
feat: port rule prefer-nullish-coalescing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_includes"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_literal_enum_member"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_namespace_keyword"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_nullish_coalescing"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_optional_chain"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_readonly"
@@ -577,6 +578,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-literal-enum-member", prefer_literal_enum_member.PreferLiteralEnumMemberRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-namespace-keyword", prefer_namespace_keyword.PreferNamespaceKeywordRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-for-of", prefer_for_of.PreferForOfRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/prefer-nullish-coalescing", prefer_nullish_coalescing.PreferNullishCoalescingRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-optional-chain", prefer_optional_chain.PreferOptionalChainRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-promise-reject-errors", prefer_promise_reject_errors.PreferPromiseRejectErrorsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-readonly", prefer_readonly.PreferReadonlyRule)

--- a/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.go
+++ b/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.go
@@ -1,0 +1,1071 @@
+package prefer_nullish_coalescing
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildNoStrictNullCheckMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noStrictNullCheck",
+		Description: "This rule requires the `strictNullChecks` compiler option to be turned on to function correctly.",
+	}
+}
+
+func buildPreferNullishOverAssignmentMessage(equals string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferNullishOverAssignment",
+		Description: fmt.Sprintf("Prefer using nullish coalescing operator (`??%s`) instead of an assignment expression, as it is simpler to read.", equals),
+	}
+}
+
+func buildPreferNullishOverOrMessage(description, equals string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferNullishOverOr",
+		Description: fmt.Sprintf("Prefer using nullish coalescing operator (`??%s`) instead of a logical %s (`||%s`), as it is a safer operator.", equals, description, equals),
+	}
+}
+
+func buildPreferNullishOverTernaryMessage(equals string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferNullishOverTernary",
+		Description: fmt.Sprintf("Prefer using nullish coalescing operator (`??%s`) instead of a ternary expression, as it is simpler to read.", equals),
+	}
+}
+
+func buildSuggestNullishMessage(equals string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "suggestNullish",
+		Description: fmt.Sprintf("Fix to nullish coalescing operator (`??%s`).", equals),
+	}
+}
+
+type ignorePrimitivesObj struct {
+	bigint  bool
+	boolean bool
+	number  bool
+	string_ bool
+}
+
+type Options struct {
+	allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing bool
+	ignoreBooleanCoercion                                  bool
+	ignoreConditionalTests                                 bool
+	ignoreIfStatements                                     bool
+	ignoreMixedLogicalExpressions                          bool
+	ignorePrimitivesAll                                    bool
+	ignorePrimitives                                       ignorePrimitivesObj
+	ignoreTernaryTests                                     bool
+}
+
+func defaultOptions() Options {
+	return Options{
+		ignoreConditionalTests: true,
+	}
+}
+
+func parseOptions(options any) Options {
+	opts := defaultOptions()
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing"].(bool); ok {
+		opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = v
+	}
+	if v, ok := optsMap["ignoreBooleanCoercion"].(bool); ok {
+		opts.ignoreBooleanCoercion = v
+	}
+	if v, ok := optsMap["ignoreConditionalTests"].(bool); ok {
+		opts.ignoreConditionalTests = v
+	}
+	if v, ok := optsMap["ignoreIfStatements"].(bool); ok {
+		opts.ignoreIfStatements = v
+	}
+	if v, ok := optsMap["ignoreMixedLogicalExpressions"].(bool); ok {
+		opts.ignoreMixedLogicalExpressions = v
+	}
+	if v, ok := optsMap["ignoreTernaryTests"].(bool); ok {
+		opts.ignoreTernaryTests = v
+	}
+	if v, ok := optsMap["ignorePrimitives"]; ok {
+		switch vv := v.(type) {
+		case bool:
+			if vv {
+				opts.ignorePrimitivesAll = true
+			}
+		case map[string]interface{}:
+			if b, ok := vv["bigint"].(bool); ok {
+				opts.ignorePrimitives.bigint = b
+			}
+			if b, ok := vv["boolean"].(bool); ok {
+				opts.ignorePrimitives.boolean = b
+			}
+			if b, ok := vv["number"].(bool); ok {
+				opts.ignorePrimitives.number = b
+			}
+			if b, ok := vv["string"].(bool); ok {
+				opts.ignorePrimitives.string_ = b
+			}
+		}
+	}
+	return opts
+}
+
+// nullishCheckOperator: '!', '!=', '!==', '', '==', '==='
+type nullishCheckOperator string
+
+const (
+	opTruthy   nullishCheckOperator = ""
+	opNotTruth nullishCheckOperator = "!"
+	opEqEq     nullishCheckOperator = "=="
+	opEqEqEq   nullishCheckOperator = "==="
+	opNotEq    nullishCheckOperator = "!="
+	opNotEqEq  nullishCheckOperator = "!=="
+)
+
+func isLogicalOrLikeOperator(op ast.Kind) bool {
+	return op == ast.KindBarBarToken || op == ast.KindBarBarEqualsToken
+}
+
+// isLogicalLikeOperator covers exactly what ESTree models as a
+// `LogicalExpression`: `||`, `&&`, `??`. The compound-assignment forms
+// (`||=`, `&&=`, `??=`) are `AssignmentExpression` in ESTree and upstream's
+// parent walks (`isConditionalTest` / `isBooleanConstructorContext`) don't
+// recurse through them, so neither do we.
+func isLogicalLikeOperator(op ast.Kind) bool {
+	switch op {
+	case ast.KindBarBarToken,
+		ast.KindAmpersandAmpersandToken,
+		ast.KindQuestionQuestionToken:
+		return true
+	}
+	return false
+}
+
+// isMemberAccessLike mirrors upstream's isNodeOfTypes([ChainExpression,
+// Identifier, MemberExpression]) exactly. In tsgo there's no
+// `ChainExpression` wrapper — optional chains are flagged on the access
+// expression itself — so PropertyAccessExpression / ElementAccessExpression
+// cover both the `MemberExpression` AND `ChainExpression` ESTree shapes.
+// `this` (ThisExpression) and `super` (Super) are NOT in upstream's set and
+// must be excluded here for parity.
+func isMemberAccessLike(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier,
+		ast.KindPropertyAccessExpression,
+		ast.KindElementAccessExpression:
+		return true
+	}
+	return false
+}
+
+func isNullLiteralOrUndefinedIdentifier(node *ast.Node) bool {
+	return utils.IsNullLiteral(node) || utils.IsUndefinedIdentifier(node)
+}
+
+func isNodeNullishComparisonBinary(bin *ast.BinaryExpression) bool {
+	return isNullLiteralOrUndefinedIdentifier(bin.Left) && isNullLiteralOrUndefinedIdentifier(bin.Right)
+}
+
+// isConditionalTest walks parents to see if the expression's value is used as
+// the test of a conditional/loop construct.
+func isConditionalTest(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	if parent.Kind == ast.KindParenthesizedExpression {
+		return isConditionalTest(parent)
+	}
+	if parent.Kind == ast.KindBinaryExpression {
+		bin := parent.AsBinaryExpression()
+		if isLogicalLikeOperator(bin.OperatorToken.Kind) {
+			return isConditionalTest(parent)
+		}
+		// SequenceExpression (`,`): only the trailing element flows up.
+		if bin.OperatorToken.Kind == ast.KindCommaToken {
+			if bin.Right == node {
+				return isConditionalTest(parent)
+			}
+			return false
+		}
+	}
+	if parent.Kind == ast.KindConditionalExpression {
+		ce := parent.AsConditionalExpression()
+		if ce.WhenTrue == node || ce.WhenFalse == node {
+			return isConditionalTest(parent)
+		}
+		if ce.Condition == node {
+			return true
+		}
+	}
+	if parent.Kind == ast.KindPrefixUnaryExpression {
+		if parent.AsPrefixUnaryExpression().Operator == ast.KindExclamationToken {
+			return isConditionalTest(parent)
+		}
+	}
+	switch parent.Kind {
+	case ast.KindIfStatement:
+		return parent.AsIfStatement().Expression == node
+	case ast.KindWhileStatement:
+		return parent.AsWhileStatement().Expression == node
+	case ast.KindDoStatement:
+		return parent.AsDoStatement().Expression == node
+	case ast.KindForStatement:
+		return parent.AsForStatement().Condition == node
+	}
+	return false
+}
+
+// isBooleanConstructorContext walks parents to see if this expression is used
+// as the first argument of a global Boolean(...) call.
+func isBooleanConstructorContext(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	if parent.Kind == ast.KindParenthesizedExpression {
+		return isBooleanConstructorContext(parent)
+	}
+	if parent.Kind == ast.KindBinaryExpression {
+		bin := parent.AsBinaryExpression()
+		if isLogicalLikeOperator(bin.OperatorToken.Kind) {
+			return isBooleanConstructorContext(parent)
+		}
+		if bin.OperatorToken.Kind == ast.KindCommaToken {
+			if bin.Right == node {
+				return isBooleanConstructorContext(parent)
+			}
+			return false
+		}
+	}
+	if parent.Kind == ast.KindConditionalExpression {
+		ce := parent.AsConditionalExpression()
+		if ce.WhenTrue == node || ce.WhenFalse == node {
+			return isBooleanConstructorContext(parent)
+		}
+	}
+	return isBuiltInBooleanCall(parent, node)
+}
+
+// isBuiltInBooleanCall reports whether `callNode` is a CallExpression to the
+// global Boolean(...) and `child` (paren-skipped) is its first argument.
+func isBuiltInBooleanCall(callNode *ast.Node, child *ast.Node) bool {
+	if callNode.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := callNode.AsCallExpression()
+	callee := ast.SkipParentheses(call.Expression)
+	if callee == nil || callee.Kind != ast.KindIdentifier {
+		return false
+	}
+	if callee.AsIdentifier().Text != "Boolean" {
+		return false
+	}
+	args := call.Arguments
+	if args == nil || len(args.Nodes) == 0 {
+		return false
+	}
+	// match either bare or paren-wrapped child
+	first := args.Nodes[0]
+	if first != child && ast.SkipParentheses(first) != child {
+		return false
+	}
+	return !utils.IsShadowed(callNode, "Boolean")
+}
+
+// isMixedLogicalExpression mirrors upstream's BFS over parent + left + right
+// looking for an `&&` operator.
+func isMixedLogicalExpression(node *ast.Node) bool {
+	seen := map[*ast.Node]bool{}
+	bin := node.AsBinaryExpression()
+	queue := []*ast.Node{node.Parent, bin.Left, bin.Right}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if current == nil || seen[current] {
+			continue
+		}
+		seen[current] = true
+		if current.Kind == ast.KindParenthesizedExpression {
+			queue = append(queue, current.AsParenthesizedExpression().Expression)
+			continue
+		}
+		if current.Kind == ast.KindBinaryExpression {
+			cb := current.AsBinaryExpression()
+			op := cb.OperatorToken.Kind
+			if op == ast.KindAmpersandAmpersandToken {
+				return true
+			}
+			if op == ast.KindBarBarToken || op == ast.KindBarBarEqualsToken {
+				queue = append(queue, current.Parent, cb.Left, cb.Right)
+			}
+		}
+	}
+	return false
+}
+
+// areNodesSimilarMemberAccess mirrors typescript-eslint's
+// areNodesSimilarMemberAccess + isNodeEqual byte-for-byte — including the
+// upstream limitation that `isNodeEqual` only handles a small set of node
+// kinds (ThisExpression / Literal / Identifier / MemberExpression). Anything
+// else (PrivateIdentifier, TSAsExpression-wrapped computed keys, …) falls
+// through to `return false`, which means rules don't pair the two branches.
+//
+// We deliberately NOT generalize this with `AreNodesStructurallyEqual` —
+// upstream's narrower compare is part of the rule's contract; widening it
+// would cause spurious reports relative to ESLint.
+func areNodesSimilarMemberAccess(sf *ast.SourceFile, a, b *ast.Node) bool {
+	a = ast.SkipParentheses(a)
+	b = ast.SkipParentheses(b)
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Kind == ast.KindNonNullExpression {
+		return areNodesSimilarMemberAccess(sf, a.AsNonNullExpression().Expression, b)
+	}
+	if b.Kind == ast.KindNonNullExpression {
+		return areNodesSimilarMemberAccess(sf, a, b.AsNonNullExpression().Expression)
+	}
+	aIsMember := isMemberExpressionLike(a)
+	bIsMember := isMemberExpressionLike(b)
+	if aIsMember && bIsMember {
+		// Recurse on objects.
+		if !areNodesSimilarMemberAccess(sf, utils.AccessExpressionObject(a), utils.AccessExpressionObject(b)) {
+			return false
+		}
+		// Property comparison — mirrors upstream's two-branch logic:
+		//   if (a.computed === b.computed) return isNodeEqual(a.property, b.property)
+		//   else if (a.property is Literal && b.property is Identifier) name-compare
+		//   else if vice versa, name-compare
+		//   else false
+		aProp, aComputed := memberProperty(a)
+		bProp, bComputed := memberProperty(b)
+		if aComputed == bComputed {
+			return isNodeEqual(aProp, bProp)
+		}
+		if isStringLikeLiteral(aProp) && bProp.Kind == ast.KindIdentifier {
+			return literalString(aProp) == bProp.AsIdentifier().Text
+		}
+		if aProp.Kind == ast.KindIdentifier && isStringLikeLiteral(bProp) {
+			return aProp.AsIdentifier().Text == literalString(bProp)
+		}
+		return false
+	}
+	if aIsMember != bIsMember {
+		return false
+	}
+	return isNodeEqual(a, b)
+}
+
+// isMemberExpressionLike reports whether `node` is a MemberExpression-shaped
+// access (PropertyAccessExpression / ElementAccessExpression in tsgo terms).
+// Mirrors upstream's "MemberExpression" kind.
+func isMemberExpressionLike(node *ast.Node) bool {
+	return node.Kind == ast.KindPropertyAccessExpression ||
+		node.Kind == ast.KindElementAccessExpression
+}
+
+// memberProperty returns the property node and whether it's a computed access.
+//   - PropertyAccessExpression: property = `.name` (Identifier / PrivateIdentifier), computed=false
+//   - ElementAccessExpression : property = `[arg]` (any Expression), computed=true
+func memberProperty(node *ast.Node) (*ast.Node, bool) {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		return node.AsPropertyAccessExpression().Name(), false
+	case ast.KindElementAccessExpression:
+		return node.AsElementAccessExpression().ArgumentExpression, true
+	}
+	return nil, false
+}
+
+// isNodeEqual mirrors upstream's restricted-set isNodeEqual exactly.
+// Only handles ThisExpression / Literal / Identifier / MemberExpression;
+// returns false for any other kind (PrivateIdentifier, TSAsExpression, etc.).
+func isNodeEqual(a, b *ast.Node) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	a = ast.SkipParentheses(a)
+	b = ast.SkipParentheses(b)
+	if a == nil || b == nil {
+		return false
+	}
+	switch a.Kind {
+	case ast.KindThisKeyword:
+		return b.Kind == ast.KindThisKeyword
+	case ast.KindIdentifier:
+		if b.Kind != ast.KindIdentifier {
+			return false
+		}
+		return a.AsIdentifier().Text == b.AsIdentifier().Text
+	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral:
+		if !isStringLikeLiteral(b) {
+			return false
+		}
+		return literalString(a) == literalString(b)
+	case ast.KindNumericLiteral:
+		if b.Kind != ast.KindNumericLiteral {
+			return false
+		}
+		return a.AsNumericLiteral().Text == b.AsNumericLiteral().Text
+	case ast.KindBigIntLiteral:
+		if b.Kind != ast.KindBigIntLiteral {
+			return false
+		}
+		return a.AsBigIntLiteral().Text == b.AsBigIntLiteral().Text
+	case ast.KindTrueKeyword, ast.KindFalseKeyword, ast.KindNullKeyword:
+		return a.Kind == b.Kind
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		if !isMemberExpressionLike(b) {
+			return false
+		}
+		aProp, aComputed := memberProperty(a)
+		bProp, bComputed := memberProperty(b)
+		if aComputed != bComputed {
+			return false
+		}
+		return isNodeEqual(aProp, bProp) &&
+			isNodeEqual(utils.AccessExpressionObject(a), utils.AccessExpressionObject(b))
+	}
+	// Any other kind (PrivateIdentifier, TSAsExpression, ComputedPropertyName,
+	// SpreadElement, …) — upstream's isNodeEqual returns false here, and so
+	// do we. Don't widen.
+	return false
+}
+
+// isStringLikeLiteral reports whether the node is a StringLiteral or a
+// no-substitution template literal — both map to ESTree's `Literal` with a
+// string value.
+func isStringLikeLiteral(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return node.Kind == ast.KindStringLiteral ||
+		node.Kind == ast.KindNoSubstitutionTemplateLiteral
+}
+
+// literalString returns the cooked string value of a string-like literal.
+func literalString(node *ast.Node) string {
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text
+	}
+	return ""
+}
+
+func getOperatorAndNodesInsideTestExpression(test *ast.Node) (operator nullishCheckOperator, nodes []*ast.Node, ok bool) {
+	test = ast.SkipParentheses(test)
+	if test == nil {
+		return "", nil, false
+	}
+	// Member-access-like (truthy check).
+	if isMemberAccessLike(test) {
+		return opTruthy, nil, true
+	}
+	if test.Kind == ast.KindPrefixUnaryExpression {
+		un := test.AsPrefixUnaryExpression()
+		if un.Operator == ast.KindExclamationToken {
+			arg := ast.SkipParentheses(un.Operand)
+			if isMemberAccessLike(arg) {
+				return opNotTruth, nil, true
+			}
+			return "", nil, false
+		}
+		return "", nil, false
+	}
+	if test.Kind != ast.KindBinaryExpression {
+		return "", nil, false
+	}
+	bin := test.AsBinaryExpression()
+	op := bin.OperatorToken.Kind
+	switch op {
+	case ast.KindEqualsEqualsToken:
+		return opEqEq, []*ast.Node{bin.Left, bin.Right}, true
+	case ast.KindEqualsEqualsEqualsToken:
+		return opEqEqEq, []*ast.Node{bin.Left, bin.Right}, true
+	case ast.KindExclamationEqualsToken:
+		return opNotEq, []*ast.Node{bin.Left, bin.Right}, true
+	case ast.KindExclamationEqualsEqualsToken:
+		return opNotEqEq, []*ast.Node{bin.Left, bin.Right}, true
+	}
+	if op != ast.KindBarBarToken && op != ast.KindBarBarEqualsToken && op != ast.KindAmpersandAmpersandToken {
+		return "", nil, false
+	}
+	leftRaw := ast.SkipParentheses(bin.Left)
+	rightRaw := ast.SkipParentheses(bin.Right)
+	if leftRaw == nil || rightRaw == nil ||
+		leftRaw.Kind != ast.KindBinaryExpression ||
+		rightRaw.Kind != ast.KindBinaryExpression {
+		return "", nil, false
+	}
+	leftBin := leftRaw.AsBinaryExpression()
+	rightBin := rightRaw.AsBinaryExpression()
+	if isNodeNullishComparisonBinary(leftBin) || isNodeNullishComparisonBinary(rightBin) {
+		return "", nil, false
+	}
+	lo := leftBin.OperatorToken.Kind
+	ro := rightBin.OperatorToken.Kind
+	nodes = []*ast.Node{leftBin.Left, leftBin.Right, rightBin.Left, rightBin.Right}
+	switch op {
+	case ast.KindBarBarToken, ast.KindBarBarEqualsToken:
+		if lo == ast.KindEqualsEqualsEqualsToken && ro == ast.KindEqualsEqualsEqualsToken {
+			return opEqEqEq, nodes, true
+		}
+		both := lo == ast.KindEqualsEqualsToken && ro == ast.KindEqualsEqualsToken
+		mixed := (lo == ast.KindEqualsEqualsEqualsToken || ro == ast.KindEqualsEqualsEqualsToken) &&
+			(lo == ast.KindEqualsEqualsToken || ro == ast.KindEqualsEqualsToken)
+		if both || mixed {
+			return opEqEq, nodes, true
+		}
+	case ast.KindAmpersandAmpersandToken:
+		if lo == ast.KindExclamationEqualsEqualsToken && ro == ast.KindExclamationEqualsEqualsToken {
+			return opNotEqEq, nodes, true
+		}
+		both := lo == ast.KindExclamationEqualsToken && ro == ast.KindExclamationEqualsToken
+		mixed := (lo == ast.KindExclamationEqualsEqualsToken || ro == ast.KindExclamationEqualsEqualsToken) &&
+			(lo == ast.KindExclamationEqualsToken || ro == ast.KindExclamationEqualsToken)
+		if both || mixed {
+			return opNotEq, nodes, true
+		}
+	}
+	return "", nil, false
+}
+
+func getBranchNodes(ce *ast.ConditionalExpression, op nullishCheckOperator) (nonNullish, nullish *ast.Node) {
+	switch op {
+	case opTruthy, opNotEq, opNotEqEq:
+		return ce.WhenTrue, ce.WhenFalse
+	}
+	return ce.WhenFalse, ce.WhenTrue
+}
+
+func (opts *Options) typeFlagsToIgnore() checker.TypeFlags {
+	var flags checker.TypeFlags
+	if opts.ignorePrimitivesAll || opts.ignorePrimitives.bigint {
+		flags |= checker.TypeFlagsBigIntLike
+	}
+	if opts.ignorePrimitivesAll || opts.ignorePrimitives.boolean {
+		flags |= checker.TypeFlagsBooleanLike
+	}
+	if opts.ignorePrimitivesAll || opts.ignorePrimitives.number {
+		flags |= checker.TypeFlagsNumberLike
+	}
+	if opts.ignorePrimitivesAll || opts.ignorePrimitives.string_ {
+		flags |= checker.TypeFlagsStringLike
+	}
+	return flags
+}
+
+// isTypeEligibleForPreferNullish mirrors upstream's
+// isTypeEligibleForPreferNullish: nullable AND (no ignored-primitive overlap).
+func isTypeEligibleForPreferNullish(t *checker.Type, opts *Options) bool {
+	if !utils.IsNullableType(t) {
+		return false
+	}
+	ignorable := opts.typeFlagsToIgnore()
+	if ignorable == 0 {
+		return true
+	}
+	// any/unknown — could be anything, including the ignorable primitives.
+	if utils.IsTypeFlagSet(t, checker.TypeFlagsAny|checker.TypeFlagsUnknown) {
+		return false
+	}
+	for _, c := range utils.UnionTypeParts(t) {
+		for _, ic := range utils.IntersectionTypeParts(c) {
+			if utils.IsTypeFlagSet(ic, ignorable) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// isTruthinessCheckEligible mirrors upstream — note the carve-out: when the
+// node is a ConditionalExpression that is the direct argument of a
+// CallExpression, the ignoreBooleanCoercion early-return does NOT fire.
+func isTruthinessCheckEligible(ctx rule.RuleContext, opts *Options, node *ast.Node, testNode *ast.Node) bool {
+	t := ctx.TypeChecker.GetTypeAtLocation(testNode)
+	if !isTypeEligibleForPreferNullish(t, opts) {
+		return false
+	}
+	if opts.ignoreConditionalTests && isConditionalTest(node) {
+		return false
+	}
+	if opts.ignoreBooleanCoercion && isBooleanConstructorContext(node) {
+		// Carve-out: a ConditionalExpression whose direct parent is a
+		// CallExpression should still report.
+		//
+		// In ESTree, ParenthesizedExpression is transparent — `node.parent` of
+		// `(a ? b : c)` inside `Boolean(...)` is the CallExpression directly.
+		// tsgo keeps an explicit ParenthesizedExpression node, so walk through
+		// any paren layers when matching upstream's `node.parent.type ===
+		// CallExpression` check.
+		p := node.Parent
+		for p != nil && p.Kind == ast.KindParenthesizedExpression {
+			p = p.Parent
+		}
+		if node.Kind != ast.KindConditionalExpression ||
+			p == nil ||
+			p.Kind != ast.KindCallExpression {
+			return false
+		}
+	}
+	return true
+}
+
+// reportPreferNullishOverOr handles `x || y` and `x ||= y`. They share one
+// BinaryExpression listener in tsgo.
+func reportPreferNullishOverOr(ctx rule.RuleContext, opts *Options, node *ast.Node, description, equals string) {
+	bin := node.AsBinaryExpression()
+	if !isTruthinessCheckEligible(ctx, opts, node, bin.Left) {
+		return
+	}
+	if opts.ignoreMixedLogicalExpressions && isMixedLogicalExpression(node) {
+		return
+	}
+
+	// Range covering only the operator token (`||` or `||=`), trivia stripped.
+	src := ctx.SourceFile.Text()
+	opPos := scanner.SkipTrivia(src, bin.OperatorToken.Pos())
+	opEnd := bin.OperatorToken.End()
+	opRange := core.NewTextRange(opPos, opEnd)
+	rawOp := src[opPos:opEnd]
+	newOp := strings.Replace(rawOp, "||", "??", 1)
+
+	fixes := []rule.RuleFix{rule.RuleFixReplaceRange(opRange, newOp)}
+	addOrParenFixes(ctx.SourceFile, node, &fixes)
+
+	ctx.ReportRangeWithSuggestions(opRange, buildPreferNullishOverOrMessage(description, equals), rule.RuleSuggestion{
+		Message:  buildSuggestNullishMessage(equals),
+		FixesArr: fixes,
+	})
+}
+
+// addOrParenFixes mirrors upstream's paren-adding logic when our parent is `||`
+// / `||=`. Mixing `&&` and `??` requires parens.
+//
+// In ESTree, ParenthesizedExpression is transparent — `node.parent` of an
+// expression inside `(...)` is the enclosing expression, not the paren. tsgo
+// keeps explicit ParenthesizedExpression nodes; walk through them so the
+// paren-add decision matches upstream byte-for-byte.
+func addOrParenFixes(sf *ast.SourceFile, node *ast.Node, fixes *[]rule.RuleFix) {
+	parent := node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parent = parent.Parent
+	}
+	if parent == nil || parent.Kind != ast.KindBinaryExpression {
+		return
+	}
+	pop := parent.AsBinaryExpression().OperatorToken.Kind
+	if pop != ast.KindBarBarToken && pop != ast.KindBarBarEqualsToken {
+		return
+	}
+	bin := node.AsBinaryExpression()
+	leftSkipped := ast.SkipParentheses(bin.Left)
+	if leftSkipped != nil && leftSkipped.Kind == ast.KindBinaryExpression {
+		innerLeftBin := leftSkipped.AsBinaryExpression()
+		innerLeftLeftSkipped := ast.SkipParentheses(innerLeftBin.Left)
+		innerLeftLeftIsLogicalOr := innerLeftLeftSkipped != nil &&
+			innerLeftLeftSkipped.Kind == ast.KindBinaryExpression &&
+			(innerLeftLeftSkipped.AsBinaryExpression().OperatorToken.Kind == ast.KindBarBarToken ||
+				innerLeftLeftSkipped.AsBinaryExpression().OperatorToken.Kind == ast.KindBarBarEqualsToken)
+		if !innerLeftLeftIsLogicalOr {
+			*fixes = append(*fixes,
+				rule.RuleFixInsertBefore(sf, innerLeftBin.Right, "("),
+				rule.RuleFixInsertAfter(bin.Right, ")"),
+			)
+			return
+		}
+	}
+	*fixes = append(*fixes,
+		rule.RuleFixInsertBefore(sf, bin.Left, "("),
+		rule.RuleFixInsertAfter(bin.Right, ")"),
+	)
+}
+
+// reportPreferNullishOverTernary reports on a ConditionalExpression whose test
+// can be replaced by ?? on the corresponding branches.
+func reportPreferNullishOverTernary(ctx rule.RuleContext, opts *Options, node *ast.Node) {
+	if opts.ignoreTernaryTests {
+		return
+	}
+	ce := node.AsConditionalExpression()
+	op, nodesInsideTest, ok := getOperatorAndNodesInsideTestExpression(ce.Condition)
+	if !ok {
+		return
+	}
+	nonNullishBranch, nullishBranch := getBranchNodes(ce, op)
+	leftNode, fixable := getNullishCoalescingParams(ctx, opts, node, nonNullishBranch, nodesInsideTest, op)
+	if !fixable {
+		return
+	}
+
+	leftText := getTextWithParentheses(ctx.SourceFile, leftNode)
+	rightText := getRightTextForTernary(ctx.SourceFile, nullishBranch)
+	replacement := leftText + " ?? " + rightText
+	ctx.ReportNodeWithSuggestions(node, buildPreferNullishOverTernaryMessage(""), rule.RuleSuggestion{
+		Message:  buildSuggestNullishMessage(""),
+		FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, replacement)},
+	})
+}
+
+// getTextWithParentheses mirrors upstream's `getTextWithParentheses` —
+// returns the source text including one immediate layer of parens iff the
+// node is parenthesized in source.
+//
+// In tsgo, parens are explicit `ParenthesizedExpression` nodes. We walk down
+// from the outermost wrapper to the innermost paren layer and emit its text.
+// That is: `(((foo).a))` becomes `((foo).a)` — exactly one paren preserved.
+func getTextWithParentheses(sf *ast.SourceFile, node *ast.Node) string {
+	current := node
+	var lastParen *ast.Node
+	for current != nil && current.Kind == ast.KindParenthesizedExpression {
+		lastParen = current
+		current = current.AsParenthesizedExpression().Expression
+	}
+	if lastParen != nil {
+		return utils.TrimmedNodeText(sf, lastParen)
+	}
+	return utils.TrimmedNodeText(sf, node)
+}
+
+// getRightTextForTernary mirrors upstream: if the nullish branch is already
+// parenthesized in source, keep it as-is; otherwise wrap with parens iff its
+// precedence is below `??`.
+func getRightTextForTernary(sf *ast.SourceFile, node *ast.Node) string {
+	// If the SOURCE-LEVEL form of `node` is wrapped in parens, keep the parens
+	// in the output by reading the outer node's text.
+	if node.Kind == ast.KindParenthesizedExpression {
+		return utils.TrimmedNodeText(sf, node)
+	}
+	text := utils.TrimmedNodeText(sf, node)
+	if isLowPrecedenceForCoalesce(node) {
+		return "(" + text + ")"
+	}
+	return text
+}
+
+// isLowPrecedenceForCoalesce reports whether `node`'s precedence is below the
+// coalesce operator (`??`), so it must be parenthesized when placed on the
+// right-hand side of a `??` substitution.
+func isLowPrecedenceForCoalesce(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindBinaryExpression:
+		op := node.AsBinaryExpression().OperatorToken.Kind
+		switch op {
+		case ast.KindAmpersandAmpersandToken, ast.KindBarBarToken, ast.KindCommaToken:
+			return true
+		}
+		if ast.IsAssignmentOperator(op) {
+			return true
+		}
+	case ast.KindConditionalExpression, ast.KindYieldExpression, ast.KindArrowFunction:
+		return true
+	}
+	return false
+}
+
+func reportPreferNullishOverIf(ctx rule.RuleContext, opts *Options, node *ast.Node) {
+	if opts.ignoreIfStatements {
+		return
+	}
+	is := node.AsIfStatement()
+	if is.ElseStatement != nil {
+		return
+	}
+	var assignmentExpr *ast.Node
+	isConsequentBlock := is.ThenStatement.Kind == ast.KindBlock
+	if isConsequentBlock {
+		stmts := is.ThenStatement.AsBlock().Statements.Nodes
+		if len(stmts) != 1 || stmts[0].Kind != ast.KindExpressionStatement {
+			return
+		}
+		assignmentExpr = stmts[0].AsExpressionStatement().Expression
+	} else if is.ThenStatement.Kind == ast.KindExpressionStatement {
+		assignmentExpr = is.ThenStatement.AsExpressionStatement().Expression
+	} else {
+		return
+	}
+
+	// tsgo preserves outer parens around the assignment as
+	// ParenthesizedExpression nodes; ESTree flattens them.
+	assignmentExprStripped := ast.SkipParentheses(assignmentExpr)
+	if assignmentExprStripped == nil || assignmentExprStripped.Kind != ast.KindBinaryExpression {
+		return
+	}
+	bin := assignmentExprStripped.AsBinaryExpression()
+	// Accept any assignment-shaped operator (`=`, `||=`, `??=`, `+=`, …) — in
+	// ESTree this is one AssignmentExpression node.
+	if !ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
+		return
+	}
+	if !isMemberAccessLike(ast.SkipParentheses(bin.Left)) {
+		return
+	}
+	leftAssignment := bin.Left
+	rightAssignment := bin.Right
+
+	op, nodesInsideTest, ok := getOperatorAndNodesInsideTestExpression(is.Expression)
+	if !ok {
+		return
+	}
+	if op != opNotTruth && op != opEqEq && op != opEqEqEq {
+		return
+	}
+	_, fixable := getNullishCoalescingParams(ctx, opts, node, leftAssignment, nodesInsideTest, op)
+	if !fixable {
+		return
+	}
+
+	src := ctx.SourceFile.Text()
+	leftText := getTextWithParentheses(ctx.SourceFile, leftAssignment)
+	rightText := getTextWithParentheses(ctx.SourceFile, rightAssignment)
+
+	// Comment handling: mirror upstream's commentsBefore / commentsAfter
+	// via forward-walking the trivia chunks around the assignment.
+	//
+	//   block:    `if (cond) { <leading-trivia> stmt; <trailing-trivia> }`
+	//   single:   `if (cond) <leading-trivia> stmt;`
+	commentsBefore := ""
+	commentsAfter := ""
+	if isConsequentBlock {
+		exprStmt := is.ThenStatement.AsBlock().Statements.Nodes[0]
+		leadingStart := exprStmt.Pos()
+		leadingEnd := scanner.SkipTrivia(src, leadingStart)
+		if leadingStart < leadingEnd {
+			commentsBefore = formatComments(src[leadingStart:leadingEnd], "\n")
+		}
+		// Trailing trivia: between the end of the (only) statement and the
+		// closing `}` of the block.
+		trailingStart := exprStmt.End()
+		trailingEnd := is.ThenStatement.End() - 1 // points at `}`
+		if trailingStart < trailingEnd {
+			commentsAfter = formatComments(src[trailingStart:trailingEnd], "\n")
+		}
+	} else {
+		// `if (cond) /* c */ foo = makeFoo();` form — preserve comments
+		// that sit in the trivia before the expression statement.
+		leadingStart := is.ThenStatement.Pos()
+		leadingEnd := scanner.SkipTrivia(src, leadingStart)
+		if leadingStart < leadingEnd {
+			commentsBefore = formatComments(src[leadingStart:leadingEnd], " ")
+		}
+	}
+
+	replacement := leftText + " ??= " + rightText + ";"
+	fixes := []rule.RuleFix{}
+	if commentsBefore != "" {
+		fixes = append(fixes, rule.RuleFixInsertBefore(ctx.SourceFile, node, commentsBefore))
+	}
+	fixes = append(fixes, rule.RuleFixReplace(ctx.SourceFile, node, replacement))
+	if commentsAfter != "" {
+		// Strip the trailing separator added by formatComments and emit with
+		// a leading space — matches upstream's `slice(0, -1)` + space.
+		trimmed := strings.TrimRight(commentsAfter, "\n ")
+		fixes = append(fixes, rule.RuleFixInsertAfter(node, " "+trimmed))
+	}
+
+	ctx.ReportNodeWithSuggestions(node, buildPreferNullishOverAssignmentMessage("="), rule.RuleSuggestion{
+		Message:  buildSuggestNullishMessage("="),
+		FixesArr: fixes,
+	})
+}
+
+// formatComments extracts comments out of a trivia chunk and returns them with
+// `separator` between each.
+func formatComments(triviaChunk string, separator string) string {
+	var out strings.Builder
+	i := 0
+	for i < len(triviaChunk) {
+		c := triviaChunk[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			i++
+			continue
+		}
+		if c == '/' && i+1 < len(triviaChunk) {
+			if triviaChunk[i+1] == '/' {
+				j := i + 2
+				for j < len(triviaChunk) && triviaChunk[j] != '\n' && triviaChunk[j] != '\r' {
+					j++
+				}
+				out.WriteString(triviaChunk[i:j])
+				out.WriteString(separator)
+				i = j
+				continue
+			}
+			if triviaChunk[i+1] == '*' {
+				j := i + 2
+				for j+1 < len(triviaChunk) && (triviaChunk[j] != '*' || triviaChunk[j+1] != '/') {
+					j++
+				}
+				if j+1 < len(triviaChunk) {
+					out.WriteString(triviaChunk[i : j+2])
+					out.WriteString(separator)
+					i = j + 2
+					continue
+				}
+				return out.String()
+			}
+		}
+		// Anything else — give up; this isn't pure trivia.
+		return out.String()
+	}
+	return out.String()
+}
+
+// getNullishCoalescingParams matches typescript-eslint's getNullishCoalescingParams
+// for ConditionalExpression / IfStatement: figures out whether the test is
+// equivalent to a nullish check, and returns the LHS for the suggested ??.
+func getNullishCoalescingParams(
+	ctx rule.RuleContext,
+	opts *Options,
+	node *ast.Node,
+	nonNullishNode *ast.Node,
+	nodesInsideTestExpression []*ast.Node,
+	op nullishCheckOperator,
+) (*ast.Node, bool) {
+	var nullishCoalescingLeftNode *ast.Node
+	hasTruthinessCheck := false
+	hasNullCheck := false
+	hasUndefinedCheck := false
+
+	if len(nodesInsideTestExpression) == 0 {
+		hasTruthinessCheck = true
+		var test *ast.Node
+		switch node.Kind {
+		case ast.KindConditionalExpression:
+			test = node.AsConditionalExpression().Condition
+		case ast.KindIfStatement:
+			test = node.AsIfStatement().Expression
+		}
+		if test == nil {
+			return nil, false
+		}
+		test = ast.SkipParentheses(test)
+		if test.Kind == ast.KindPrefixUnaryExpression {
+			nullishCoalescingLeftNode = ast.SkipParentheses(test.AsPrefixUnaryExpression().Operand)
+		} else {
+			nullishCoalescingLeftNode = test
+		}
+		if !areNodesSimilarMemberAccess(ctx.SourceFile, nullishCoalescingLeftNode, nonNullishNode) {
+			return nil, false
+		}
+	} else {
+		for _, tn := range nodesInsideTestExpression {
+			tnSkipped := ast.SkipParentheses(tn)
+			if utils.IsNullLiteral(tnSkipped) {
+				hasNullCheck = true
+			} else if utils.IsUndefinedIdentifier(tnSkipped) {
+				hasUndefinedCheck = true
+			} else if areNodesSimilarMemberAccess(ctx.SourceFile, tn, nonNullishNode) {
+				if nullishCoalescingLeftNode == nil {
+					nullishCoalescingLeftNode = tn
+				}
+			} else {
+				return nil, false
+			}
+		}
+	}
+
+	if nullishCoalescingLeftNode == nil {
+		return nil, false
+	}
+
+	if hasTruthinessCheck {
+		if !isTruthinessCheckEligible(ctx, opts, node, nullishCoalescingLeftNode) {
+			return nil, false
+		}
+		return nullishCoalescingLeftNode, true
+	}
+
+	// Non-truthiness path: equivalence between null/undefined branches.
+	if hasUndefinedCheck == hasNullCheck {
+		if hasUndefinedCheck {
+			return nullishCoalescingLeftNode, true
+		}
+		return nil, false
+	}
+	if op == opEqEq || op == opNotEq {
+		return nullishCoalescingLeftNode, true
+	}
+
+	t := ctx.TypeChecker.GetTypeAtLocation(nullishCoalescingLeftNode)
+	flags := getTypeFlags(t)
+	if flags&(checker.TypeFlagsAny|checker.TypeFlagsUnknown) != 0 {
+		return nil, false
+	}
+	hasNullType := flags&checker.TypeFlagsNull != 0
+	if hasUndefinedCheck && !hasNullType {
+		return nullishCoalescingLeftNode, true
+	}
+	hasUndefinedType := flags&checker.TypeFlagsUndefined != 0
+	if hasNullCheck && !hasUndefinedType {
+		return nullishCoalescingLeftNode, true
+	}
+	return nil, false
+}
+
+func getTypeFlags(t *checker.Type) checker.TypeFlags {
+	if t == nil {
+		return 0
+	}
+	var flags checker.TypeFlags
+	for _, p := range utils.UnionTypeParts(t) {
+		for _, ip := range utils.IntersectionTypeParts(p) {
+			flags |= checker.Type_flags(ip)
+		}
+	}
+	return flags
+}
+
+var PreferNullishCoalescingRule = rule.CreateRule(rule.Rule{
+	Name:             "prefer-nullish-coalescing",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		compilerOptions := ctx.Program.Options()
+		isStrictNullChecks := utils.IsStrictCompilerOptionEnabled(compilerOptions, compilerOptions.StrictNullChecks)
+		if !isStrictNullChecks && !opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing {
+			ctx.ReportRange(core.NewTextRange(0, 0), buildNoStrictNullCheckMessage())
+		}
+
+		// Use exit listeners (post-order / leaf-first) so the diagnostic
+		// emission order matches ESLint's `LogicalExpression` listener
+		// semantics. ESLint reports inner `||` before outer `||` for chains
+		// like `(a && b) || c || d`; pre-order would reverse that.
+		return rule.RuleListeners{
+			rule.ListenerOnExit(ast.KindBinaryExpression): func(node *ast.Node) {
+				bin := node.AsBinaryExpression()
+				op := bin.OperatorToken.Kind
+				if !isLogicalOrLikeOperator(op) {
+					return
+				}
+				if op == ast.KindBarBarToken {
+					reportPreferNullishOverOr(ctx, &opts, node, "or", "")
+				} else {
+					reportPreferNullishOverOr(ctx, &opts, node, "assignment", "=")
+				}
+			},
+			rule.ListenerOnExit(ast.KindConditionalExpression): func(node *ast.Node) {
+				reportPreferNullishOverTernary(ctx, &opts, node)
+			},
+			rule.ListenerOnExit(ast.KindIfStatement): func(node *ast.Node) {
+				reportPreferNullishOverIf(ctx, &opts, node)
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.md
+++ b/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.md
@@ -1,0 +1,88 @@
+# prefer-nullish-coalescing
+
+Enforce using the nullish coalescing operator instead of logical assignments or chaining.
+
+## Rule Details
+
+The `??` nullish coalescing runtime operator allows providing a default value when dealing with `null` or `undefined`. Because the nullish coalescing operator only coalesces when the original value is `null` or `undefined`, it is much safer than relying upon logical OR operator chaining `||`, which coalesces on any falsy value.
+
+This rule reports when `||`, `||=`, conditional expressions, and `if`-statement assignments could be replaced with the nullish-coalescing operator.
+
+This rule requires `strictNullChecks` to be enabled in `tsconfig.json` to function correctly.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+declare const a: string | null;
+declare const b: string | null;
+
+a || b;
+a || 'fallback';
+a ||= b;
+
+a !== undefined && a !== null ? a : 'a string';
+a === undefined || a === null ? 'a string' : a;
+
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+if (!foo) {
+  foo = makeFoo();
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+declare const a: string | null;
+declare const b: string | null;
+
+a ?? b;
+a ?? 'fallback';
+a ??= b;
+
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+foo ??= makeFoo();
+```
+
+## Options
+
+### `ignoreConditionalTests`
+
+Default: `true`. When `true`, ignore cases that appear inside the test of `if`/`while`/`do…while`/`for` loops or in the test of a conditional expression.
+
+```json
+{ "@typescript-eslint/prefer-nullish-coalescing": ["error", { "ignoreConditionalTests": false }] }
+```
+
+### `ignoreTernaryTests`
+
+Default: `false`. When `true`, ignore ternary expressions that could be replaced with `??`.
+
+### `ignoreIfStatements`
+
+Default: `false`. When `true`, ignore `if` statements that could be replaced with `??=`.
+
+### `ignoreMixedLogicalExpressions`
+
+Default: `false`. When `true`, ignore `||` expressions that are part of a mixed logical expression (with `&&`).
+
+### `ignoreBooleanCoercion`
+
+Default: `false`. When `true`, ignore `||` arguments to the global `Boolean` constructor.
+
+### `ignorePrimitives`
+
+Default: `{ bigint: false, boolean: false, number: false, string: false }`. Set to `true` to ignore all listed primitives, or to a partial object to ignore individual primitive types.
+
+```json
+{ "@typescript-eslint/prefer-nullish-coalescing": ["error", { "ignorePrimitives": { "string": true } }] }
+```
+
+### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
+
+Default: `false`. By default the rule errors on every file when `strictNullChecks` is off. Setting this to `true` silences that error and lets the rule run anyway.
+
+## Original Documentation
+
+[`@typescript-eslint/prefer-nullish-coalescing`](https://typescript-eslint.io/rules/prefer-nullish-coalescing)

--- a/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing_test.go
+++ b/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing_test.go
@@ -1,0 +1,3303 @@
+package prefer_nullish_coalescing
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Mirror upstream's two parametric generators —
+//   types        = ['string', 'number', 'boolean', 'object']
+//   nullishTypes = ['null', 'undefined', 'null | undefined']
+//   equals       = ['', '=']
+//
+// `typeValidTest` produces all `(type, equals)` combinations.
+// `nullishTypeTest` produces all `(nullish, type, equals)` combinations.
+
+var primitiveTypes = []string{"string", "number", "boolean", "object"}
+var nullishTypes = []string{"null", "undefined", "null | undefined"}
+
+// typeValid expands a template `cb(type, equals)` over types × equals.
+func typeValid(cb func(typ, eq string) string) []rule_tester.ValidTestCase {
+	out := make([]rule_tester.ValidTestCase, 0, len(primitiveTypes)*2)
+	for _, t := range primitiveTypes {
+		out = append(out, rule_tester.ValidTestCase{Code: cb(t, "")})
+	}
+	for _, t := range primitiveTypes {
+		out = append(out, rule_tester.ValidTestCase{Code: cb(t, "=")})
+	}
+	return out
+}
+
+// nullishTypeValid expands a template over nullish × type × equals.
+func nullishTypeValid(cb func(nullish, typ, eq string) string) []rule_tester.ValidTestCase {
+	out := make([]rule_tester.ValidTestCase, 0, len(nullishTypes)*len(primitiveTypes)*2)
+	for _, n := range nullishTypes {
+		for _, t := range primitiveTypes {
+			for _, eq := range []string{"", "="} {
+				out = append(out, rule_tester.ValidTestCase{Code: cb(n, t, eq)})
+			}
+		}
+	}
+	return out
+}
+
+// nullishTypeValidWithOpts wraps nullishTypeValid + per-case options.
+func nullishTypeValidWithOpts(opts any, cb func(nullish, typ, eq string) string) []rule_tester.ValidTestCase {
+	out := make([]rule_tester.ValidTestCase, 0, len(nullishTypes)*len(primitiveTypes)*2)
+	for _, n := range nullishTypes {
+		for _, t := range primitiveTypes {
+			for _, eq := range []string{"", "="} {
+				out = append(out, rule_tester.ValidTestCase{Code: cb(n, t, eq), Options: opts})
+			}
+		}
+	}
+	return out
+}
+
+// nullishTypeInvalid expands a template over nullish × type × equals where
+// each case is an invalid case with a single suggestion. `codeFn(nullish, typ,
+// eq)` produces the input code; `outputFn(nullish, typ, eq)` produces the
+// suggestion output.
+func nullishTypeInvalid(
+	codeFn func(nullish, typ, eq string) string,
+	outputFn func(nullish, typ, eq string) string,
+	column, endColumn, line, endLine int,
+	messageId string,
+	options any,
+) []rule_tester.InvalidTestCase {
+	out := make([]rule_tester.InvalidTestCase, 0, len(nullishTypes)*len(primitiveTypes)*2)
+	for _, n := range nullishTypes {
+		for _, t := range primitiveTypes {
+			for _, eq := range []string{"", "="} {
+				ec := endColumn
+				if ec > 0 {
+					ec += len(eq)
+				}
+				out = append(out, rule_tester.InvalidTestCase{
+					Code:    codeFn(n, t, eq),
+					Options: options,
+					Errors: []rule_tester.InvalidTestCaseError{{
+						MessageId: messageId, Line: line, EndLine: endLine, Column: column, EndColumn: ec,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestNullish", Output: outputFn(n, t, eq)},
+						},
+					}},
+				})
+			}
+		}
+	}
+	return out
+}
+
+func mustConcat(slices ...[]rule_tester.ValidTestCase) []rule_tester.ValidTestCase {
+	total := 0
+	for _, s := range slices {
+		total += len(s)
+	}
+	out := make([]rule_tester.ValidTestCase, 0, total)
+	for _, s := range slices {
+		out = append(out, s...)
+	}
+	return out
+}
+
+func mustConcatInvalid(slices ...[]rule_tester.InvalidTestCase) []rule_tester.InvalidTestCase {
+	total := 0
+	for _, s := range slices {
+		total += len(s)
+	}
+	out := make([]rule_tester.InvalidTestCase, 0, total)
+	for _, s := range slices {
+		out = append(out, s...)
+	}
+	return out
+}
+
+func TestPreferNullishCoalescingRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferNullishCoalescingRule, buildValid(), buildInvalid())
+}
+
+func buildValid() []rule_tester.ValidTestCase {
+	// ──────────────────────────────────────────────────────────────────────
+	// Valid 1: non-nullable receiver — `||` and `||=` kept as-is.
+	// ──────────────────────────────────────────────────────────────────────
+	nonNullableOr := typeValid(func(typ, eq string) string {
+		return fmt.Sprintf("\ndeclare let x: %s;\n(x ||%s 'foo');\n", typ, eq)
+	})
+
+	// Valid 2: nullable receiver with `??` / `??=` already in use.
+	alreadyNullish := nullishTypeValid(func(nullish, typ, eq string) string {
+		return fmt.Sprintf("\ndeclare let x: %s | %s;\nx ??%s 'foo';\n", typ, nullish, eq)
+	})
+
+	// Valid 3: ignoreTernaryTests permutations that don't form a clean check.
+	ternaryNotClean := []rule_tester.ValidTestCase{
+		{Code: `x !== undefined && x !== null ? x : y;`, Options: opt("ignoreTernaryTests", true)},
+		{Code: `x !== undefined && x !== null ? 'foo' : 'bar';`, Options: optTern(false)},
+		{Code: `x !== null && x !== undefined && x !== 5 ? x : y;`, Options: optTern(false)},
+		{Code: `x === null || x === undefined || x === 5 ? x : y;`, Options: optTern(false)},
+		{Code: `x === undefined && x !== null ? x : y;`, Options: optTern(false)},
+		{Code: `x === undefined && x === null ? x : y;`, Options: optTern(false)},
+		{Code: `x !== undefined && x === null ? x : y;`, Options: optTern(false)},
+		{Code: `x === undefined || x !== null ? x : y;`, Options: optTern(false)},
+		{Code: `x === undefined || x === null ? x : y;`, Options: optTern(false)},
+		{Code: `x !== undefined || x === null ? x : y;`, Options: optTern(false)},
+		{Code: `x !== undefined || x === null ? y : x;`, Options: optTern(false)},
+		{Code: `x === null || x === null ? y : x;`, Options: optTern(false)},
+		{Code: `x === undefined || x === undefined ? y : x;`, Options: optTern(false)},
+		{Code: `x == null ? x : y;`, Options: optTern(false)},
+		{Code: `undefined == null ? x : y;`, Options: optTern(false)},
+		{Code: `undefined != z ? x : y;`, Options: optTern(false)},
+		{Code: `x == undefined ? x : y;`, Options: optTern(false)},
+		{Code: `x != null ? y : x;`, Options: optTern(false)},
+		{Code: `x != undefined ? y : x;`, Options: optTern(false)},
+		{Code: `null == x ? x : y;`, Options: optTern(false)},
+		{Code: `undefined == x ? x : y;`, Options: optTern(false)},
+		{Code: `null != x ? y : x;`, Options: optTern(false)},
+		{Code: `undefined != x ? y : x;`, Options: optTern(false)},
+		// Test contains a non-null/undefined sentinel.
+		{Code: `
+declare let x: number | undefined;
+x !== 15 && x !== undefined ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: number | undefined;
+x !== undefined && x !== 15 ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: number | undefined;
+15 !== x && undefined !== x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: number | undefined;
+undefined !== x && 15 !== x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: number | undefined;
+15 !== x && x !== undefined ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: number | undefined;
+undefined !== x && x !== 15 ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: string | undefined;
+x !== 'foo' && x !== undefined ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+function test(value: number | undefined): number {
+  return value !== foo() && value !== undefined ? value : 1;
+}
+`, Options: optTern(false)},
+		{Code: `
+const test = (value: boolean | undefined): boolean =>
+  value !== undefined && value !== false ? value : false;
+`, Options: optTern(false)},
+		// non-nullable receiver — single-side checks ineligible.
+		{Code: `
+declare let x: string;
+x === null ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: string | undefined | null;
+x === null ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: string | undefined | null;
+x === undefined ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: string | undefined | null;
+x !== null ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: string | undefined | null;
+x !== undefined ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: any;
+x === null ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: unknown;
+x === null ? x : y;
+`, Options: optTern(false)},
+		// Truthy ternary on non-nullable primitives — covers all primitives.
+		{Code: `
+declare let x: string;
+x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: string;
+!x ? y : x;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: string | object;
+x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: string | object;
+!x ? y : x;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: number;
+x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: number;
+!x ? y : x;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: bigint;
+x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: bigint;
+!x ? y : x;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: boolean;
+x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: boolean;
+!x ? y : x;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: object;
+x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: object;
+!x ? y : x;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: string[];
+x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: string[];
+!x ? y : x;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: Function;
+x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: Function;
+!x ? y : x;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: () => string;
+x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: () => string;
+!x ? y : x;
+`, Options: optTern(false)},
+		// Function call — both branches the same call expression.
+		{Code: `
+declare let x: () => string | null;
+x() ? x() : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: () => string | null;
+!x() ? y : x();
+`, Options: optTern(false)},
+		{Code: `
+const a = 'foo';
+declare let x: (a: string | null) => string | null;
+x(a) ? x(a) : y;
+`, Options: optTern(false)},
+		{Code: `
+const a = 'foo';
+declare let x: (a: string | null) => string | null;
+!x(a) ? y : x(a);
+`, Options: optTern(false)},
+		// Member access on non-nullable container.
+		{Code: `
+declare let x: { n: string };
+x.n ? x.n : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: { n: string };
+!x.n ? y : x.n;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: { n: string | object };
+x.n ? x.n : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: { n: number };
+x.n ? x.n : y;
+`, Options: optTern(false)},
+		// Function-typed member.
+		{Code: `
+declare let x: { n: () => string | null | undefined };
+x.n ? x.n : y;
+`, Options: optTern(false)},
+	}
+
+	// Valid 4: if-statements that don't fit the ??= pattern.
+	ifNoFit := []rule_tester.ValidTestCase{
+		{Code: `
+declare let foo: string;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  if (!foo) {
+    foo = makeFoo();
+  }
+}
+`, Options: optTern(false)},
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo) {
+    foo = makeFoo();
+  }
+}
+`, Options: optTern(false)},
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo != null) {
+    foo = makeFoo();
+  }
+}
+`, Options: optTern(false)},
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) {
+    foo = makeFoo();
+    return foo;
+  }
+}
+`, Options: optTern(false)},
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) {
+    foo = makeFoo();
+  } else {
+    return 'bar';
+  }
+}
+`, Options: optTern(false)},
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) {
+    foo = makeFoo();
+  } else if (foo.a) {
+    return 'bar';
+  }
+}
+`, Options: optTern(false)},
+		// Body is a block declaring a shadow — not an assignment.
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+function shadowed() {
+  if (foo == null) {
+    const foo = makeFoo();
+  }
+}
+`, Options: optTern(false)},
+		// Destructuring assignment LHS — not member-access-like.
+		{Code: `
+declare let foo: { foo: string } | null;
+declare function makeFoo(): { foo: { foo: string } };
+function weirdDestructuringAssignment() {
+  if (foo == null) {
+    ({ foo } = makeFoo());
+  }
+}
+`, Options: optTern(false)},
+		// Optional chain / non-similar member compare.
+		{Code: `
+const a = 'b';
+declare let x: { a: string; b: string } | null;
+x?.a != null ? x[a] : 'foo';
+`, Options: optTern(false)},
+		{Code: `
+const a = 'b';
+declare let x: { a: string; b: string } | null;
+x?.[a] != null ? x.a : 'foo';
+`, Options: optTern(false)},
+		{Code: `
+declare let x: { a: string } | null;
+declare let y: { a: string } | null;
+x?.a ? y?.a : 'foo';
+`, Options: optTern(false)},
+		// Compound: `null !== null` etc. degenerate
+		{Code: `
+declare const nullOrObject: null | { a: string };
+
+const test = nullOrObject !== undefined && null !== null ? nullOrObject : 42;
+`, Options: optTern(false)},
+		{Code: `
+declare const nullOrObject: null | { a: string };
+
+const test = nullOrObject !== undefined && null != null ? nullOrObject : 42;
+`, Options: optTern(false)},
+		{Code: `
+declare const nullOrObject: null | { a: string };
+
+const test =
+  nullOrObject !== undefined && null != undefined ? nullOrObject : 42;
+`, Options: optTern(false)},
+		{Code: `
+declare const nullOrObject: null | { a: string };
+
+const test = nullOrObject === undefined || null === null ? 42 : nullOrObject;
+`, Options: optTern(false)},
+		{Code: `
+declare const nullOrObject: null | { a: string };
+
+const test = nullOrObject === undefined || null == null ? 42 : nullOrObject;
+`, Options: optTern(false)},
+		{Code: `
+declare const nullOrObject: null | { a: string };
+
+const test =
+  nullOrObject === undefined || null == undefined ? 42 : nullOrObject;
+`, Options: optTern(false)},
+		// ignoreIfStatements: true
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (!foo) {
+    foo = makeFoo();
+  }
+}
+`, Options: optMap("ignoreIfStatements", true)},
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (!foo) foo = makeFoo();
+}
+`, Options: optMap("ignoreIfStatements", true)},
+	}
+
+	// Valid 5: ignoreConditionalTests — `||` inside test stays under default.
+	// `x ||= 'foo'` must be parenthesized to land in the ternary test
+	// position; `x || 'foo'` doesn't need parens.
+	condTestsValid := mustConcat(
+		nullishTypeValid(func(n, t, eq string) string {
+			if eq == "=" {
+				return fmt.Sprintf(`
+declare let x: %s | %s;
+(x ||= 'foo') ? null : null;
+`, t, n)
+			}
+			return fmt.Sprintf(`
+declare let x: %s | %s;
+x || 'foo' ? null : null;
+`, t, n)
+		}),
+		nullishTypeValid(func(n, t, eq string) string {
+			return fmt.Sprintf(`
+declare let x: %s | %s;
+if (x ||%s 'foo') {
+}
+`, t, n, eq)
+		}),
+		nullishTypeValid(func(n, t, eq string) string {
+			return fmt.Sprintf(`
+declare let x: %s | %s;
+do {} while (x ||%s 'foo');
+`, t, n, eq)
+		}),
+		nullishTypeValid(func(n, t, eq string) string {
+			return fmt.Sprintf(`
+declare let x: %s | %s;
+for (; x ||%s 'foo'; ) {}
+`, t, n, eq)
+		}),
+		nullishTypeValid(func(n, t, eq string) string {
+			return fmt.Sprintf(`
+declare let x: %s | %s;
+while (x ||%s 'foo') {}
+`, t, n, eq)
+		}),
+		// Nested under `??`, `&&`, `!`, `,`
+		[]rule_tester.ValidTestCase{
+			{Code: `
+let a: string | undefined;
+let b: string | undefined;
+if (!(a || b)) {}
+`, Options: optMap("ignoreConditionalTests", true)},
+			{Code: `
+let a: string | undefined;
+let b: string | undefined;
+if (!!(a || b)) {}
+`, Options: optMap("ignoreConditionalTests", true)},
+			{Code: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+if (a ? a : b) {}
+`, Options: optMap("ignoreConditionalTests", true)},
+			{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+if (!a ? b : a) {}
+`, Options: optMap("ignoreConditionalTests", true)},
+			{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+if ((a ? a : b) || c) {}
+`, Options: optMap("ignoreConditionalTests", true)},
+			{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+if (c || (!a ? b : a)) {}
+`, Options: optMap("ignoreConditionalTests", true)},
+			{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+if ((a || b) ?? c) {}
+`, Options: optMap("ignoreConditionalTests", true)},
+			{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+if (a ?? (b || c)) {}
+`, Options: optMap("ignoreConditionalTests", true)},
+			{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+if (a ? b || c : 'fail') {}
+`, Options: optMap("ignoreConditionalTests", true)},
+			{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+if (a ? 'success' : b || c) {}
+`, Options: optMap("ignoreConditionalTests", true)},
+			{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+if (((a = b), b || c)) {}
+`, Options: optMap("ignoreConditionalTests", true)},
+		},
+	)
+
+	// Valid 6: ignoreMixedLogicalExpressions
+	mixedValid := nullishTypeValidWithOpts(optMap("ignoreMixedLogicalExpressions", true),
+		func(n, t, eq string) string {
+			return fmt.Sprintf(`
+declare let a: %s | %s;
+declare let b: %s | %s;
+declare let c: %s | %s;
+a ||%s (b && c);
+`, t, n, t, n, t, n, eq)
+		})
+
+	mixedValid2 := []rule_tester.ValidTestCase{
+		{Code: `
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string | null | undefined;
+declare let d: string | null | undefined;
+a || b || (c && d);
+`, Options: optMap("ignoreMixedLogicalExpressions", true)},
+		{Code: `
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string | null | undefined;
+declare let d: string | null | undefined;
+a || (b && c) || d;
+`, Options: optMap("ignoreMixedLogicalExpressions", true)},
+		{Code: `
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string | null | undefined;
+declare let d: string | null | undefined;
+a || (b && c && d);
+`, Options: optMap("ignoreMixedLogicalExpressions", true)},
+	}
+
+	// Valid 7: ignorePrimitives matrix
+	ignorePrim := []rule_tester.ValidTestCase{
+		{Code: `
+declare let x: string | null | undefined;
+x || 'foo';
+`, Options: optPrim(map[string]bool{"string": true})},
+		{Code: `
+declare let x: number | null | undefined;
+x || 1;
+`, Options: optPrim(map[string]bool{"number": true})},
+		{Code: `
+declare let x: bigint | null | undefined;
+x || 1n;
+`, Options: optPrim(map[string]bool{"bigint": true})},
+		{Code: `
+declare let x: boolean | null | undefined;
+x || true;
+`, Options: optPrim(map[string]bool{"boolean": true})},
+		{Code: `
+declare let x: 0 | 1 | 0n | 1n | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": true, "boolean": true, "number": false, "string": true})},
+		{Code: `
+declare let x: 0 | 1 | 0n | 1n | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": false, "boolean": true, "number": true, "string": true})},
+		{Code: `
+declare let x: 0 | 'foo' | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"number": true, "string": true})},
+		{Code: `
+declare let x: 0 | 'foo' | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare const a: any;
+declare const b: any;
+a ? a : b;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare const a: any;
+declare const b: any;
+a ? a : b;
+`, Options: optPrim(map[string]bool{"number": true})},
+		{Code: `
+declare const a: unknown;
+const b = a || 'bar';
+`, Options: optPrim(map[string]bool{"bigint": true, "boolean": false, "number": false, "string": false})},
+		// "never" types are ineligible.
+		{Code: `
+declare let x: never;
+declare let y: number;
+x ? x : y;
+`, Options: optTern(false)},
+		{Code: `
+declare let x: never;
+declare let y: number;
+!x ? y : x;
+`, Options: optTern(false)},
+	}
+
+	// Valid 8: ignoreBooleanCoercion
+	booleanValid := []rule_tester.ValidTestCase{
+		// `||` inside Boolean(...) — ignored.
+		{Code: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+const x = Boolean(a || b);
+`, Options: optMap("ignoreBooleanCoercion", true)},
+		{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+const test = Boolean(a || b || c);
+`, Options: optMap("ignoreBooleanCoercion", true)},
+		{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+const test = Boolean(a || (b && c));
+`, Options: optMap("ignoreBooleanCoercion", true)},
+		{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+const test = Boolean((a || b) ?? c);
+`, Options: optMap("ignoreBooleanCoercion", true)},
+		{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+const test = Boolean(a ?? (b || c));
+`, Options: optMap("ignoreBooleanCoercion", true)},
+		// Ternaries that aren't direct args of Boolean(...) — ignored.
+		{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+const test = Boolean(a ? b || c : 'fail');
+`, Options: optMap("ignoreBooleanCoercion", true)},
+		{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+const test = Boolean(a ? 'success' : b || c);
+`, Options: optMap("ignoreBooleanCoercion", true)},
+		// Comma sequence's last element is the Boolean arg — ignored.
+		{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+let c: string | boolean | undefined;
+const test = Boolean(((a = b), b || c));
+`, Options: optMap("ignoreBooleanCoercion", true)},
+	}
+
+	// rslint-extra: locally shadowed `Boolean` — when the call target is not
+	// the global Boolean, ignoreBooleanCoercion does NOT apply (a shadowed
+	// Boolean is just a regular function call). The rule reports normally.
+	// We keep this as an invalid test below.
+	booleanShadow := []rule_tester.ValidTestCase{}
+
+	// rslint-extra edges
+	rslintExtraValid := []rule_tester.ValidTestCase{
+		// `as`/`satisfies`/non-null assertion wrappers on test
+		{Code: `
+declare let x: string | null;
+(x as any) !== undefined ? (x as any) : y;
+`, Options: optTern(false)},
+		// Same identifier under intersection of similar type
+		{Code: `
+type T = (string | null) & {};
+declare let x: T;
+x ?? 'foo';
+`},
+	}
+
+	// ───────── ignorePrimitives — bulk matrix (mirrors upstream) ─────────
+	ignorePrimBulk := []rule_tester.ValidTestCase{
+		// per-primitive `||`
+		{Code: `
+declare let x: string | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"string": true})},
+		{Code: `
+declare let x: number | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"number": true})},
+		{Code: `
+declare let x: boolean | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"boolean": true})},
+		{Code: `
+declare let x: bigint | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": true})},
+		// `ignorePrimitives: true` umbrella
+		{Code: `
+declare let x: string | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: number | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: boolean | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: bigint | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", true)},
+		// Branded primitive intersections — upstream still respects
+		// ignorePrimitives because intersection includes the primitive flag.
+		{Code: `
+declare let x: (string & { __brand?: any }) | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"string": true})},
+		{Code: `
+declare let x: (number & { __brand?: any }) | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"number": true})},
+		{Code: `
+declare let x: (boolean & { __brand?: any }) | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"boolean": true})},
+		{Code: `
+declare let x: (bigint & { __brand?: any }) | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": true})},
+		{Code: `
+declare let x: (string & { __brand?: any }) | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: (number & { __brand?: any }) | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: (boolean & { __brand?: any }) | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: (bigint & { __brand?: any }) | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", true)},
+		// truthy ternary forms
+		{Code: `
+declare let x: string | undefined;
+x ? x : y;
+`, Options: optPrim(map[string]bool{"string": true})},
+		{Code: `
+declare let x: number | undefined;
+x ? x : y;
+`, Options: optPrim(map[string]bool{"number": true})},
+		{Code: `
+declare let x: boolean | undefined;
+x ? x : y;
+`, Options: optPrim(map[string]bool{"boolean": true})},
+		{Code: `
+declare let x: bigint | undefined;
+x ? x : y;
+`, Options: optPrim(map[string]bool{"bigint": true})},
+		{Code: `
+declare let x: string | undefined;
+!x ? y : x;
+`, Options: optPrim(map[string]bool{"string": true})},
+		{Code: `
+declare let x: number | undefined;
+!x ? y : x;
+`, Options: optPrim(map[string]bool{"number": true})},
+		{Code: `
+declare let x: boolean | undefined;
+!x ? y : x;
+`, Options: optPrim(map[string]bool{"boolean": true})},
+		{Code: `
+declare let x: bigint | undefined;
+!x ? y : x;
+`, Options: optPrim(map[string]bool{"bigint": true})},
+		{Code: `
+declare let x: string | undefined;
+x ? x : y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: number | undefined;
+x ? x : y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: boolean | undefined;
+x ? x : y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: bigint | undefined;
+x ? x : y;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: string | undefined;
+!x ? y : x;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: number | undefined;
+!x ? y : x;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: boolean | undefined;
+!x ? y : x;
+`, Options: optMap("ignorePrimitives", true)},
+		{Code: `
+declare let x: bigint | undefined;
+!x ? y : x;
+`, Options: optMap("ignorePrimitives", true)},
+	}
+
+	// ───────── real-world user scenarios ─────────
+	realWorld := []rule_tester.ValidTestCase{
+		// Already idiomatic `??`
+		{Code: `
+function getName(user?: { name?: string }) {
+  return user?.name ?? 'anonymous';
+}
+`},
+		{Code: `
+type Config = { port?: number; host?: string };
+declare const cfg: Config;
+const port = cfg.port ?? 3000;
+const host = cfg.host ?? 'localhost';
+`},
+		// Defaulting with non-nullable types — must NOT report.
+		{Code: `
+function paginate(limit: number, offset: number = 0) {
+  return [limit, offset];
+}
+`},
+		{Code: `
+const role: 'admin' | 'user' | 'guest' = 'guest';
+const permissions = role || 'guest';
+`},
+		// Logical assignment for caching / memo (already nullish form)
+		{Code: `
+const cache: Map<string, string | null> = new Map();
+declare let key: string;
+let cached: string | null | undefined;
+cached = cache.get(key) ?? null;
+`},
+		// `??` with bigint default
+		{Code: `
+declare let bigCount: bigint | null;
+const total = bigCount ?? 0n;
+`},
+		// Strictly nullable function arg + non-nullable receiver — `||` ok.
+		{Code: `
+function search(q: string) { return q.length; }
+function caller(query: string) {
+  return search(query || '');
+}
+`},
+		// `Array.prototype.find` returns `T | undefined` — handled by `??` already.
+		{Code: `
+const items: string[] = [];
+const first = items.find(x => x.length > 0) ?? 'none';
+`},
+		// JSX attribute (default for prop) using `??`
+		{
+			Code: `
+type Props = { value?: string };
+declare const props: Props;
+declare function Foo(p: any): any;
+const el = <Foo value={props.value ?? 'default'} />;
+`,
+			Tsx: true,
+		},
+		// Async/await — `await` result with `??`
+		{Code: `
+declare function fetchUser(): Promise<{ name: string } | null>;
+async function main() {
+  const u = (await fetchUser()) ?? { name: 'anonymous' };
+  return u.name;
+}
+`},
+		// Generator yielding union — non-nullable
+		{Code: `
+function* names(): Generator<string> {
+  let names: string[] = ['a', 'b'];
+  for (const n of names) yield n || 'default';
+}
+`},
+		// Class + private fields, non-nullable.
+		{Code: `
+class Counter {
+  #value: number = 0;
+  inc() { this.#value = (this.#value || 0) + 1; }
+}
+`},
+		// Tagged template with non-nullable tag.
+		{Code: `
+function tag(s: TemplateStringsArray, ...args: unknown[]): string { return s.join(''); }
+const x = tag` + "`hello ${1 || 2}`" + `;
+`},
+	}
+
+	return mustConcat(nonNullableOr, alreadyNullish, ternaryNotClean, ifNoFit, condTestsValid,
+		mixedValid, mixedValid2, ignorePrim, booleanValid, booleanShadow,
+		ignorePrimBulk, realWorld, rslintExtraValid)
+}
+
+func buildInvalid() []rule_tester.InvalidTestCase {
+	// ── ||  /  ||= per (nullish, type, equals) — every base shape ─────────
+	basicOr := nullishTypeInvalid(
+		func(n, t, eq string) string {
+			return fmt.Sprintf("\ndeclare let x: %s | %s;\nx ||%s 'foo';\n", t, n, eq)
+		},
+		func(n, t, eq string) string {
+			return fmt.Sprintf("\ndeclare let x: %s | %s;\nx ??%s 'foo';\n", t, n, eq)
+		},
+		3, 5, 3, 3,
+		"preferNullishOverOr", nil,
+	)
+
+	// ── Manual cases (single, position-asserted) ─────────────────────────
+	manualOr := []rule_tester.InvalidTestCase{
+		// Nullable receiver, `||` → `??`
+		{Code: `
+declare let x: object | null | undefined;
+x ||= {};
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverOr", Line: 3, Column: 3, EndLine: 3, EndColumn: 6,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let x: object | null | undefined;
+x ??= {};
+`},
+			},
+		}}},
+	}
+
+	// ── Ternary equivalences (clean nullish-equivalent test) ──────────────
+	ternaryClean := []rule_tester.InvalidTestCase{
+		ternFix(`x !== undefined && x !== null ? x : y;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`x !== null && x !== undefined ? x : y;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`x !== undefined && null !== x ? x : y;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`null !== x && x !== undefined ? x : y;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`undefined !== x && null !== x ? x : y;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`x !== null && undefined !== x ? x : y;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`undefined !== x && x !== null ? x : y;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`null !== x && undefined !== x ? x : y;`, `x ?? y;`, 1, 38, 1, 1),
+		// === / null + undefined — alternate branch order.
+		ternFix(`x === undefined || x === null ? y : x;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`x === null || x === undefined ? y : x;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`x === undefined || null === x ? y : x;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`null === x || x === undefined ? y : x;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`undefined === x || null === x ? y : x;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`x === null || undefined === x ? y : x;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`undefined === x || x === null ? y : x;`, `x ?? y;`, 1, 38, 1, 1),
+		ternFix(`null === x || undefined === x ? y : x;`, `x ?? y;`, 1, 38, 1, 1),
+		// `==` / `!=` mixed — collapses to !=/==.
+		ternFix(`x != undefined && x !== null ? x : y;`, `x ?? y;`, 1, 37, 1, 1),
+		ternFix(`x !== undefined && x != null ? x : y;`, `x ?? y;`, 1, 37, 1, 1),
+		ternFix(`x != null && x != undefined ? x : y;`, `x ?? y;`, 1, 36, 1, 1),
+		// Side-effect right branch needs parens.
+		ternFix(`x !== undefined && x !== null ? x : (z = y);`, `x ?? (z = y);`, 1, 44, 1, 1),
+		ternFix(`x !== null && undefined !== x ? x : (z = y);`, `x ?? (z = y);`, 1, 44, 1, 1),
+		ternFix(`x === undefined || null === x ? (z = y) : x;`, `x ?? (z = y);`, 1, 44, 1, 1),
+		ternFix(`null === x || x === undefined ? (z = y) : x;`, `x ?? (z = y);`, 1, 44, 1, 1),
+		ternFix(`x === null || undefined === x ? (z = y) : x;`, `x ?? (z = y);`, 1, 44, 1, 1),
+	}
+
+	// Single-side undefined / null check.
+	singleSide := []rule_tester.InvalidTestCase{
+		{Code: `
+declare let b: string | undefined;
+b !== undefined ? b : 'a string';
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary", Line: 3, Column: 1, EndLine: 3, EndColumn: 33,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let b: string | undefined;
+b ?? 'a string';
+`},
+			},
+		}}},
+		{Code: `
+declare let b: string | undefined;
+b === undefined ? 'a string' : b;
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary", Line: 3, Column: 1, EndLine: 3, EndColumn: 33,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let b: string | undefined;
+b ?? 'a string';
+`},
+			},
+		}}},
+		{Code: `
+declare let c: string | null;
+c !== null ? c : 'a string';
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary", Line: 3, Column: 1, EndLine: 3, EndColumn: 28,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let c: string | null;
+c ?? 'a string';
+`},
+			},
+		}}},
+		{Code: `
+declare let c: string | null;
+c === null ? 'a string' : c;
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary", Line: 3, Column: 1, EndLine: 3, EndColumn: 28,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let c: string | null;
+c ?? 'a string';
+`},
+			},
+		}}},
+	}
+
+	// Truthy ternary on nullable.
+	truthyTern := []rule_tester.InvalidTestCase{
+		{Code: `
+declare let b: string | undefined;
+b ? b : 'a string';
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary", Line: 3, Column: 1, EndLine: 3, EndColumn: 19,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let b: string | undefined;
+b ?? 'a string';
+`},
+			},
+		}}},
+		{Code: `
+declare let c: string | null;
+!c ? 'a string' : c;
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary", Line: 3, Column: 1, EndLine: 3, EndColumn: 20,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let c: string | null;
+c ?? 'a string';
+`},
+			},
+		}}},
+		{Code: `
+declare let a: any;
+a ? a : 'a string';
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary", Line: 3, Column: 1, EndLine: 3, EndColumn: 19,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let a: any;
+a ?? 'a string';
+`},
+			},
+		}}},
+	}
+
+	// Optional-chain similarity.
+	optionalChain := []rule_tester.InvalidTestCase{
+		{Code: `
+declare let x: { n?: { a?: string } };
+x.n?.a !== undefined ? x.n?.a : y;
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary", Line: 3, Column: 1, EndLine: 3, EndColumn: 34,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let x: { n?: { a?: string } };
+x.n?.a ?? y;
+`},
+			},
+		}}},
+		{Code: `
+declare let x: { n?: { a?: string } };
+x?.n?.a ? x?.n?.a : y;
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary", Line: 3, Column: 1, EndLine: 3, EndColumn: 22,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let x: { n?: { a?: string } };
+x?.n?.a ?? y;
+`},
+			},
+		}}},
+		{Code: `
+declare let x: { n?: { a?: string } };
+x?.n?.a !== undefined ? x.n?.a : y;
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary", Line: 3, Column: 1, EndLine: 3, EndColumn: 35,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let x: { n?: { a?: string } };
+x?.n?.a ?? y;
+`},
+			},
+		}}},
+	}
+
+	// IfStatement → ??=
+	ifBasic := []rule_tester.InvalidTestCase{
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitializeFoo1() {
+  if (!foo) {
+    foo = makeFoo();
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment", Line: 6, Column: 3, EndLine: 8, EndColumn: 4,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitializeFoo1() {
+  foo ??= makeFoo();
+}
+`},
+			},
+		}}},
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitializeFoo2() {
+  if (!foo) foo = makeFoo();
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment", Line: 6, Column: 3, EndLine: 6, EndColumn: 29,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitializeFoo2() {
+  foo ??= makeFoo();
+}
+`},
+			},
+		}}},
+		// `if (foo == null) foo = makeFoo()` — single-statement form.
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) foo = makeFoo();
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  foo ??= makeFoo();
+}
+`},
+			},
+		}}},
+		// `if (foo === undefined) foo = makeFoo()` on `T | undefined`.
+		{Code: `
+declare let foo: { a: string } | undefined;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo === undefined) {
+    foo = makeFoo();
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | undefined;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  foo ??= makeFoo();
+}
+`},
+			},
+		}}},
+		// member-access LHS / RHS.
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  if (foo.a == null) {
+    foo.a = makeFoo();
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  foo.a ??= makeFoo();
+}
+`},
+			},
+		}}},
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  if (foo?.a == null) {
+    foo.a = makeFoo();
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  foo.a ??= makeFoo();
+}
+`},
+			},
+		}}},
+		// Body already nullish-coalescing assignment — still emits.
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) {
+    foo ??= makeFoo();
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  foo ??= makeFoo();
+}
+`},
+			},
+		}}},
+		// weirdParens.
+		{Code: `
+declare let foo: { a: string | null };
+declare function makeString(): string;
+
+function weirdParens() {
+  if (((((foo.a)) == null))) {
+    ((((((((foo).a))))) = makeString()));
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string | null };
+declare function makeString(): string;
+
+function weirdParens() {
+  ((foo).a) ??= makeString();
+}
+`},
+			},
+		}}},
+		// `if (foo === undefined || foo === null) foo = makeFoo()` on `T |
+		// null | undefined` — both checks → fixable.
+		{Code: `
+declare let foo: { a: string } | null | undefined;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo === undefined || foo === null) {
+    foo = makeFoo();
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null | undefined;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  foo ??= makeFoo();
+}
+`},
+			},
+		}}},
+	}
+
+	// ignoreConditionalTests: false flips loop / if-test cases on.
+	// Build the ternary-test case manually since the input shape differs by eq.
+	condTernaryInvalid := func() []rule_tester.InvalidTestCase {
+		out := []rule_tester.InvalidTestCase{}
+		for _, n := range nullishTypes {
+			for _, t := range primitiveTypes {
+				// eq=''
+				out = append(out, rule_tester.InvalidTestCase{
+					Code: fmt.Sprintf(`
+declare let x: %s | %s;
+x || 'foo' ? null : null;
+`, t, n),
+					Options: optMap("ignoreConditionalTests", false),
+					Errors: []rule_tester.InvalidTestCaseError{{
+						MessageId: "preferNullishOverOr", Line: 3, EndLine: 3, Column: 3, EndColumn: 5,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestNullish", Output: fmt.Sprintf(`
+declare let x: %s | %s;
+x ?? 'foo' ? null : null;
+`, t, n)},
+						},
+					}},
+				})
+				// eq='='
+				out = append(out, rule_tester.InvalidTestCase{
+					Code: fmt.Sprintf(`
+declare let x: %s | %s;
+(x ||= 'foo') ? null : null;
+`, t, n),
+					Options: optMap("ignoreConditionalTests", false),
+					Errors: []rule_tester.InvalidTestCaseError{{
+						MessageId: "preferNullishOverOr", Line: 3, EndLine: 3, Column: 4, EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestNullish", Output: fmt.Sprintf(`
+declare let x: %s | %s;
+(x ??= 'foo') ? null : null;
+`, t, n)},
+						},
+					}},
+				})
+			}
+		}
+		return out
+	}()
+
+	condTestsInvalid := mustConcatInvalid(
+		condTernaryInvalid,
+		nullishTypeInvalid(
+			func(n, t, eq string) string {
+				return fmt.Sprintf(`
+declare let x: %s | %s;
+if (x ||%s 'foo') {
+}
+`, t, n, eq)
+			},
+			func(n, t, eq string) string {
+				return fmt.Sprintf(`
+declare let x: %s | %s;
+if (x ??%s 'foo') {
+}
+`, t, n, eq)
+			},
+			7, 9, 3, 3,
+			"preferNullishOverOr", optMap("ignoreConditionalTests", false),
+		),
+		nullishTypeInvalid(
+			func(n, t, eq string) string {
+				return fmt.Sprintf(`
+declare let x: %s | %s;
+do {} while (x ||%s 'foo');
+`, t, n, eq)
+			},
+			func(n, t, eq string) string {
+				return fmt.Sprintf(`
+declare let x: %s | %s;
+do {} while (x ??%s 'foo');
+`, t, n, eq)
+			},
+			16, 18, 3, 3,
+			"preferNullishOverOr", optMap("ignoreConditionalTests", false),
+		),
+		nullishTypeInvalid(
+			func(n, t, eq string) string {
+				return fmt.Sprintf(`
+declare let x: %s | %s;
+for (; x ||%s 'foo'; ) {}
+`, t, n, eq)
+			},
+			func(n, t, eq string) string {
+				return fmt.Sprintf(`
+declare let x: %s | %s;
+for (; x ??%s 'foo'; ) {}
+`, t, n, eq)
+			},
+			10, 12, 3, 3,
+			"preferNullishOverOr", optMap("ignoreConditionalTests", false),
+		),
+		nullishTypeInvalid(
+			func(n, t, eq string) string {
+				return fmt.Sprintf(`
+declare let x: %s | %s;
+while (x ||%s 'foo') {}
+`, t, n, eq)
+			},
+			func(n, t, eq string) string {
+				return fmt.Sprintf(`
+declare let x: %s | %s;
+while (x ??%s 'foo') {}
+`, t, n, eq)
+			},
+			10, 12, 3, 3,
+			"preferNullishOverOr", optMap("ignoreConditionalTests", false),
+		),
+	)
+
+	// ignoreBooleanCoercion default false → reports inside Boolean(...)
+	booleanInvalid := []rule_tester.InvalidTestCase{
+		{Code: `
+declare const a: string | true | undefined;
+declare const b: string | boolean | undefined;
+const x = Boolean(a || b);
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverOr", Line: 4, Column: 21, EndLine: 4, EndColumn: 23,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare const a: string | true | undefined;
+declare const b: string | boolean | undefined;
+const x = Boolean(a ?? b);
+`},
+			},
+		}}},
+		// ignoreBooleanCoercion: true but ternary is direct Boolean arg.
+		{Code: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+const x = Boolean(a ? a : b);
+`, Options: optMap("ignoreBooleanCoercion", true), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+const x = Boolean(a ?? b);
+`},
+			},
+		}}},
+		// Same as above but with extra parens around the ternary —
+		// `Boolean((a ? a : b))`. ESTree paren-transparency makes this still
+		// match the carve-out (ternary IS the direct CallExpression argument).
+		// tsgo keeps an explicit ParenthesizedExpression so we must skip
+		// paren layers when matching `node.parent === CallExpression`.
+		{Code: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+const x = Boolean((a ? a : b));
+`, Options: optMap("ignoreBooleanCoercion", true), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+const x = Boolean((a ?? b));
+`},
+			},
+		}}},
+		{Code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+const test = Boolean(!a ? b : a);
+`, Options: optMap("ignoreBooleanCoercion", true), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+const test = Boolean(a ?? b);
+`},
+			},
+		}}},
+	}
+
+	// ignoreIfStatements: false flips on
+	ifFlippedOn := []rule_tester.InvalidTestCase{
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (!foo) {
+    foo = makeFoo();
+  }
+}
+`, Options: optMap("ignoreIfStatements", false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  foo ??= makeFoo();
+}
+`},
+			},
+		}}},
+	}
+
+	// ignorePrimitives — literal-typed unions.
+	primInvalid := []rule_tester.InvalidTestCase{
+		{Code: `
+declare let x: 0 | 1 | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": true, "boolean": true, "number": false, "string": true}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: 0 | 1 | undefined;
+x ?? y;
+`},
+				},
+			}}},
+		{Code: `
+declare let x: 1 | 2 | 3 | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": true, "boolean": true, "number": false, "string": true}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: 1 | 2 | 3 | undefined;
+x ?? y;
+`},
+				},
+			}}},
+		{Code: `
+declare let x: 'a' | 'b' | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": true, "boolean": true, "number": true, "string": false}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: 'a' | 'b' | undefined;
+x ?? y;
+`},
+				},
+			}}},
+		{Code: `
+declare let x: 0n | 1n | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": false, "boolean": true, "number": true, "string": true}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: 0n | 1n | undefined;
+x ?? y;
+`},
+				},
+			}}},
+		{Code: `
+declare let x: true | false | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": true, "boolean": false, "number": true, "string": true}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: true | false | undefined;
+x ?? y;
+`},
+				},
+			}}},
+		// truthy ternary on literal
+		{Code: `
+declare let x: 'a' | 'b' | undefined;
+x ? x : y;
+`, Options: optPrim(map[string]bool{"bigint": true, "boolean": true, "number": true, "string": false}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverTernary",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: 'a' | 'b' | undefined;
+x ?? y;
+`},
+				},
+			}}},
+		// default for missing option (no `string`/`number`/`bigint`/`boolean`)
+		{Code: `
+declare let x: string | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", map[string]interface{}{"bigint": true, "boolean": true, "number": true}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: string | undefined;
+x ?? y;
+`},
+				},
+			}}},
+		{Code: `
+declare let x: number | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", map[string]interface{}{"bigint": true, "boolean": true, "string": true}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: number | undefined;
+x ?? y;
+`},
+				},
+			}}},
+		{Code: `
+declare let x: boolean | undefined;
+x || y;
+`, Options: optMap("ignorePrimitives", map[string]interface{}{"bigint": true, "number": true, "string": true}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: boolean | undefined;
+x ?? y;
+`},
+				},
+			}}},
+		// Literal-typed truthy ternary on bigint
+		{Code: `
+declare let x: 1n | undefined;
+x ? x : y;
+`, Options: optPrim(map[string]bool{"bigint": false, "boolean": true, "number": true, "string": true}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverTernary",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: 1n | undefined;
+x ?? y;
+`},
+				},
+			}}},
+	}
+
+	// noStrictNullCheck — uses Go-side TSConfig override.
+	//
+	// Upstream reports `loc:{start:{line:0,column:0}, end:{line:0,column:0}}`
+	// which ESLint surfaces as `column:1, line:0` (column gets +1, line is
+	// passed through unchanged). rslint's framework normalizes both to
+	// 1-based, producing line:1 column:1 — the underlying diagnostic
+	// position (file start, pos 0..0) is identical; only the rendering
+	// convention differs.
+	noStrict := []rule_tester.InvalidTestCase{
+		{
+			Code: `
+declare let x: string[] | null;
+if (x) {
+}
+`,
+			TSConfig: "tsconfig.unstrict.json",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStrictNullCheck", Line: 1, Column: 1, EndLine: 1, EndColumn: 1},
+			},
+		},
+	}
+
+	// Mixed `||` chains — emit one report per `||`.
+	mixedOr := []rule_tester.InvalidTestCase{
+		// `(a || b) || c` — chained `||`. Mirrors upstream byte-for-byte:
+		// the inner suggestion produces `((a ?? b)) || c;` (extra parens are
+		// redundant but syntactically valid; this is upstream's output).
+		{Code: `
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string;
+
+(a || b) || c;
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string;
+
+((a ?? b)) || c;
+`},
+				},
+			},
+			{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string;
+
+(a || b) ?? c;
+`},
+				},
+			},
+		}},
+		// `a || b && c` — `&&` and `??` cannot be mixed without parens, but
+		// upstream's autofix still produces `a ?? b && c` (a syntax error)
+		// since the parent isn't `||`/`||=` so no parens are added. Mirror
+		// upstream byte-for-byte; this is documented upstream behavior.
+		{Code: `
+declare let a: string | null | undefined;
+declare let b: string;
+declare let c: string;
+
+a || b && c;
+`, Options: optMap("ignoreMixedLogicalExpressions", false), Errors: []rule_tester.InvalidTestCaseError{
+			{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let a: string | null | undefined;
+declare let b: string;
+declare let c: string;
+
+a ?? b && c;
+`},
+				},
+			},
+		}},
+		// Aligned with upstream ordering (inner `||` first, then outer):
+		// using exit-order listeners makes leaf-first emit order.
+		{Code: `
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string | null | undefined;
+declare let d: string | null | undefined;
+(a && b) || c || d;
+`, Options: optMap("ignoreMixedLogicalExpressions", false), Errors: []rule_tester.InvalidTestCaseError{
+			{
+				MessageId: "preferNullishOverOr", Line: 6, Column: 10, EndLine: 6, EndColumn: 12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string | null | undefined;
+declare let d: string | null | undefined;
+(a && (b) ?? c) || d;
+`},
+				},
+			},
+			{
+				MessageId: "preferNullishOverOr", Line: 6, Column: 15, EndLine: 6, EndColumn: 17,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string | null | undefined;
+declare let d: string | null | undefined;
+(a && b) || c ?? d;
+`},
+				},
+			},
+		}},
+	}
+
+	// If-with-non-= assignment operator (covers `||=`, `??=`).
+	ifWithCompound := []rule_tester.InvalidTestCase{
+		// `if (foo == null) foo ||= makeFoo()` — emits BOTH
+		// preferNullishOverOr (inner ||=, leaf-first) AND
+		// preferNullishOverAssignment (the if). Order: leaf → root via
+		// exit listeners; matches upstream's depth-first emit order.
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) foo ||= makeFoo();
+  const bar = 42;
+  return bar;
+}
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) foo ??= makeFoo();
+  const bar = 42;
+  return bar;
+}
+`},
+				},
+			},
+			{
+				MessageId: "preferNullishOverAssignment",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  foo ??= makeFoo();
+  const bar = 42;
+  return bar;
+}
+`},
+				},
+			},
+		}},
+		// Body already `??=` — preferNullishOverAssignment still fires.
+		{Code: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) foo ??= makeFoo();
+  const bar = 42;
+  return bar;
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  foo ??= makeFoo();
+  const bar = 42;
+  return bar;
+}
+`},
+			},
+		}}},
+	}
+
+	// Issue #1290 — `a || b || c` where `b`/`c` are non-nullable.
+	issue1290 := nullishTypeInvalid(
+		func(n, t, eq string) string {
+			_ = eq
+			return fmt.Sprintf(`
+declare let a: %s | null | undefined;
+declare let b: %s;
+declare let c: %s;
+a || b || c;
+`, t, t, t)
+		},
+		func(n, t, eq string) string {
+			_ = eq
+			return fmt.Sprintf(`
+declare let a: %s | null | undefined;
+declare let b: %s;
+declare let c: %s;
+(a ?? b) || c;
+`, t, t, t)
+		},
+		3, 5, 5, 5,
+		"preferNullishOverOr", nil,
+	)
+	// Filter: only the variant where eq=='' is meaningful (a || b || c, not a ||= b ||= c).
+	issue1290Filtered := make([]rule_tester.InvalidTestCase, 0, len(issue1290)/2)
+	for i, c := range issue1290 {
+		// Keep only those whose code uses bare `||`. Indexing: cb is invoked
+		// with eq='' for even loop positions (no — actually our generator
+		// nests by nullish×type×eq, so eq cycles innermost). Filter by
+		// substring presence instead.
+		_ = i
+		if strings.Contains(c.Code, "a || b || c;") {
+			issue1290Filtered = append(issue1290Filtered, c)
+		}
+	}
+	// Also collapse duplicates that vary only by `nullish` (since the code
+	// template doesn't use `nullish`, all 3 are identical) — keep distinct.
+	seen := map[string]bool{}
+	dedup := make([]rule_tester.InvalidTestCase, 0, len(issue1290Filtered))
+	for _, c := range issue1290Filtered {
+		if seen[c.Code] {
+			continue
+		}
+		seen[c.Code] = true
+		dedup = append(dedup, c)
+	}
+	issue1290Final := dedup
+
+	// Same-primitive unions (literal types) — invalid because nullable
+	// suite of literal-typed primitives.
+	literalUnions := []rule_tester.InvalidTestCase{
+		{Code: `
+declare let x: 'a' | 'b' | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": true, "boolean": true, "number": true, "string": false}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: 'a' | 'b' | undefined;
+x ?? y;
+`},
+				},
+			}}},
+		{Code: `
+declare let x: 0 | 1 | undefined;
+x || y;
+`, Options: optPrim(map[string]bool{"bigint": true, "boolean": true, "number": false, "string": true}),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+declare let x: 0 | 1 | undefined;
+x ?? y;
+`},
+				},
+			}}},
+	}
+
+	// rslint-extra: tsgo-specific edge cases.
+	rslintExtraInvalid := []rule_tester.InvalidTestCase{
+		// Class member access via `this.foo`.
+		{Code: `
+class C {
+  declare foo: string | null | undefined;
+  use() {
+    return this.foo || 'foo';
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverOr",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+class C {
+  declare foo: string | null | undefined;
+  use() {
+    return this.foo ?? 'foo';
+  }
+}
+`},
+			},
+		}}},
+		// Nested ternary as right branch (precedence guard).
+		{Code: `
+let a: string | undefined;
+let b: { message: string } | undefined;
+
+const foo = a ? a : b ? 1 : 2;
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+let a: string | undefined;
+let b: { message: string } | undefined;
+
+const foo = a ?? (b ? 1 : 2);
+`},
+			},
+		}}},
+		// Side-effect in nullish branch with already-parenthesized RHS.
+		{Code: `
+let a: string | undefined;
+let b: { message: string } | undefined;
+
+const foo = a ? a : (b ? 1 : 2);
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+let a: string | undefined;
+let b: { message: string } | undefined;
+
+const foo = a ?? (b ? 1 : 2);
+`},
+			},
+		}}},
+		// `c !== null ? c : c ? 1 : 2` — operator-precedence guard.
+		{Code: `
+declare const c: string | null;
+c !== null ? c : c ? 1 : 2;
+`, Options: optTern(false), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare const c: string | null;
+c ?? (c ? 1 : 2);
+`},
+			},
+		}}},
+		// Comments preserved in `if`-block body — block form (single line comment).
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  if (foo == null) {
+    // comment
+    foo = makeFoo();
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  // comment
+foo ??= makeFoo();
+}
+`},
+			},
+		}}},
+		// Comments preserved in `if`-block body — single-statement form, two block comments.
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+if (foo == null) /* c1 */ /* c2 */ foo = makeFoo();
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+/* c1 */ /* c2 */ foo ??= makeFoo();
+`},
+			},
+		}}},
+		// Heavy comment mix — line + block + multi-line block + JSDoc, before
+		// AND after the assignment, in a top-level `if` (no surrounding fn).
+		// This is upstream's most aggressive comments suite case verbatim.
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+if (foo == null) {
+  // comment before 1
+  /* comment before 2 */
+  /* comment before 3
+    which is multiline
+  */
+  /**
+   * comment before 4
+   * which is also multiline
+   */
+  foo = makeFoo(); // comment inline
+  // comment after 1
+  /* comment after 2 */
+  /* comment after 3
+    which is multiline
+  */
+  /**
+   * comment after 4
+   * which is also multiline
+   */
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+// comment before 1
+/* comment before 2 */
+/* comment before 3
+    which is multiline
+  */
+/**
+   * comment before 4
+   * which is also multiline
+   */
+foo ??= makeFoo(); // comment inline
+// comment after 1
+/* comment after 2 */
+/* comment after 3
+    which is multiline
+  */
+/**
+   * comment after 4
+   * which is also multiline
+   */
+`},
+			},
+		}}},
+		// Single-statement form with leading inline `/* c */` AND trailing
+		// `// inline` on the same line.
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+if (foo == null) /* comment before 1 */ /* comment before 2 */ foo = makeFoo(); // comment inline
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+/* comment before 1 */ /* comment before 2 */ foo ??= makeFoo(); // comment inline
+`},
+			},
+		}}},
+		// Multiple consecutive line comments before the assignment in block.
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  if (foo == null) {
+    // a
+    // b
+    // c
+    foo = makeFoo();
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  // a
+// b
+// c
+foo ??= makeFoo();
+}
+`},
+			},
+		}}},
+		// Trailing comment after the (only) statement, before the closing `}`.
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  if (foo == null) {
+    foo = makeFoo();
+    // trailing
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  foo ??= makeFoo(); // trailing
+}
+`},
+			},
+		}}},
+		// Both leading + trailing comments around the only statement.
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  if (foo == null) {
+    /* lead */
+    foo = makeFoo();
+    /* tail */
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  /* lead */
+foo ??= makeFoo(); /* tail */
+}
+`},
+			},
+		}}},
+		// Single-statement form: a leading line comment between `if (...)` and
+		// `stmt`. NOTE: upstream's separator is `' '` for non-block form,
+		// which produces `// pre foo ??= makeFoo();` — the line comment
+		// swallows the whole replacement on the same line. We mirror that
+		// behavior byte-for-byte (verified against upstream ESLint).
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+if (foo == null) // pre
+foo = makeFoo();
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+// pre foo ??= makeFoo();
+`},
+			},
+		}}},
+		// Single-statement form: a multi-line block comment before stmt.
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+if (foo == null) /* a
+b */ foo = makeFoo();
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+/* a
+b */ foo ??= makeFoo();
+`},
+			},
+		}}},
+		// Block body with NO comments — must not insert spurious whitespace.
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+function f() {
+  if (foo == null) {
+    foo = makeFoo();
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+function f() {
+  foo ??= makeFoo();
+}
+`},
+			},
+		}}},
+		// Single-statement form, NO comments.
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+if (foo == null) foo = makeFoo();
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+foo ??= makeFoo();
+`},
+			},
+		}}},
+		// Block body with multi-line block comment AFTER the statement.
+		{Code: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+function f() {
+  if (foo == null) {
+    foo = makeFoo();
+    /* multi
+       line
+    */
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverAssignment",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+declare let foo: string | null;
+declare function makeFoo(): string;
+function f() {
+  foo ??= makeFoo(); /* multi
+       line
+    */
+}
+`},
+			},
+		}}},
+		// Locally shadowed Boolean — `||` is reported normally.
+		{Code: `
+function Boolean(x: any): boolean { return !!x; }
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+const x = Boolean(a || b);
+`, Options: optMap("ignoreBooleanCoercion", true), Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverOr",
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: `
+function Boolean(x: any): boolean { return !!x; }
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+const x = Boolean(a ?? b);
+`},
+			},
+		}}},
+	}
+
+	// ────────────────────── falsy literal types ──────────────────────────
+	falsyLiterals := []rule_tester.InvalidTestCase{
+		invalidWith(`
+declare let x: '' | undefined;
+x || y;
+`, `
+declare let x: '' | undefined;
+x ?? y;
+`, "preferNullishOverOr",
+			optPrim(map[string]bool{"bigint": true, "boolean": true, "number": true, "string": false})),
+		invalidWith(`
+declare let x: `+"`"+`hello${'string'}`+"`"+` | undefined;
+x || y;
+`, `
+declare let x: `+"`"+`hello${'string'}`+"`"+` | undefined;
+x ?? y;
+`, "preferNullishOverOr",
+			optPrim(map[string]bool{"bigint": true, "boolean": true, "number": true, "string": false})),
+		invalidWith(`
+declare let x: 0 | undefined;
+x || y;
+`, `
+declare let x: 0 | undefined;
+x ?? y;
+`, "preferNullishOverOr",
+			optPrim(map[string]bool{"bigint": true, "boolean": true, "number": false, "string": true})),
+		invalidWith(`
+declare let x: 0n | undefined;
+x || y;
+`, `
+declare let x: 0n | undefined;
+x ?? y;
+`, "preferNullishOverOr",
+			optPrim(map[string]bool{"bigint": false, "boolean": true, "number": true, "string": true})),
+		invalidWith(`
+declare let x: false | undefined;
+x || y;
+`, `
+declare let x: false | undefined;
+x ?? y;
+`, "preferNullishOverOr",
+			optPrim(map[string]bool{"bigint": true, "boolean": false, "number": true, "string": true})),
+		// truthy literal types in ternary form
+		invalidWith(`
+declare let x: '' | undefined;
+x ? x : y;
+`, `
+declare let x: '' | undefined;
+x ?? y;
+`, "preferNullishOverTernary",
+			optPrim(map[string]bool{"bigint": true, "boolean": true, "number": true, "string": false})),
+		invalidWith(`
+declare let x: 0 | undefined;
+!x ? y : x;
+`, `
+declare let x: 0 | undefined;
+x ?? y;
+`, "preferNullishOverTernary",
+			optPrim(map[string]bool{"bigint": true, "boolean": true, "number": false, "string": true})),
+		invalidWith(`
+declare let x: 0n | undefined;
+x ? x : y;
+`, `
+declare let x: 0n | undefined;
+x ?? y;
+`, "preferNullishOverTernary",
+			optPrim(map[string]bool{"bigint": false, "boolean": true, "number": true, "string": true})),
+		invalidWith(`
+declare let x: false | undefined;
+x ? x : y;
+`, `
+declare let x: false | undefined;
+x ?? y;
+`, "preferNullishOverTernary",
+			optPrim(map[string]bool{"bigint": true, "boolean": false, "number": true, "string": true})),
+	}
+
+	// ─────────────────────── mixed unions ────────────────────────────────
+	mixedUnions := []rule_tester.InvalidTestCase{
+		invalidWith(`
+declare let x: 0 | 1 | 0n | 1n | undefined;
+x || y;
+`, `
+declare let x: 0 | 1 | 0n | 1n | undefined;
+x ?? y;
+`, "preferNullishOverOr",
+			optPrim(map[string]bool{"bigint": false, "boolean": true, "number": false, "string": true})),
+		invalidWith(`
+declare let x: true | false | null | undefined;
+x || y;
+`, `
+declare let x: true | false | null | undefined;
+x ?? y;
+`, "preferNullishOverOr",
+			optPrim(map[string]bool{"bigint": true, "boolean": false, "number": true, "string": true})),
+		invalidWith(`
+declare let x: 0 | 1 | 0n | 1n | undefined;
+x ? x : y;
+`, `
+declare let x: 0 | 1 | 0n | 1n | undefined;
+x ?? y;
+`, "preferNullishOverTernary",
+			optPrim(map[string]bool{"bigint": false, "boolean": true, "number": false, "string": true})),
+		invalidWith(`
+declare let x: 0 | 1 | 0n | 1n | undefined;
+!x ? y : x;
+`, `
+declare let x: 0 | 1 | 0n | 1n | undefined;
+x ?? y;
+`, "preferNullishOverTernary",
+			optPrim(map[string]bool{"bigint": false, "boolean": true, "number": false, "string": true})),
+		invalidWith(`
+declare let x: true | false | null | undefined;
+!x ? y : x;
+`, `
+declare let x: true | false | null | undefined;
+x ?? y;
+`, "preferNullishOverTernary",
+			optPrim(map[string]bool{"bigint": true, "boolean": false, "number": true, "string": true})),
+	}
+
+	// Null/undefined-only types and bare literals.
+	nullishOnly := []rule_tester.InvalidTestCase{
+		invalidWith(`
+declare let x: null;
+x || y;
+`, `
+declare let x: null;
+x ?? y;
+`, "preferNullishOverOr", nil),
+		invalidWith(`
+const x = undefined;
+x || y;
+`, `
+const x = undefined;
+x ?? y;
+`, "preferNullishOverOr", nil),
+		invalidWith(`
+null || y;
+`, `
+null ?? y;
+`, "preferNullishOverOr", nil),
+		invalidWith(`
+undefined || y;
+`, `
+undefined ?? y;
+`, "preferNullishOverOr", nil),
+		// enum union with undefined
+		invalidWith(`
+enum Enum {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+declare let x: Enum | undefined;
+x || y;
+`, `
+enum Enum {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+declare let x: Enum | undefined;
+x ?? y;
+`, "preferNullishOverOr", nil),
+	}
+
+	// Functions inside conditional tests — `() => x || 'foo'` is the test
+	// expression; the inner `||` is NOT in conditional-test position
+	// (function-body), so the rule reports.
+	fnInsideCond := func() []rule_tester.InvalidTestCase {
+		out := []rule_tester.InvalidTestCase{}
+		for _, n := range nullishTypes {
+			for _, t := range primitiveTypes {
+				out = append(out, rule_tester.InvalidTestCase{
+					Code: fmt.Sprintf(`
+declare let x: %s | %s;
+if (() => x || 'foo') {
+}
+`, t, n),
+					Errors: []rule_tester.InvalidTestCaseError{{
+						MessageId: "preferNullishOverOr", Line: 3, EndLine: 3, Column: 13, EndColumn: 15,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestNullish", Output: fmt.Sprintf(`
+declare let x: %s | %s;
+if (() => x ?? 'foo') {
+}
+`, t, n)},
+						},
+					}},
+				})
+				out = append(out, rule_tester.InvalidTestCase{
+					Code: fmt.Sprintf(`
+declare let x: %s | %s;
+if (() => (x ||= 'foo')) {
+}
+`, t, n),
+					Errors: []rule_tester.InvalidTestCaseError{{
+						MessageId: "preferNullishOverOr", Line: 3, EndLine: 3, Column: 14, EndColumn: 17,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestNullish", Output: fmt.Sprintf(`
+declare let x: %s | %s;
+if (() => (x ??= 'foo')) {
+}
+`, t, n)},
+						},
+					}},
+				})
+			}
+		}
+		return out
+	}()
+
+	// Extra tsgo edge cases:
+	tsgoEdges := []rule_tester.InvalidTestCase{
+		// Computed property access via element-access expressions —
+		// member-access-like.
+		invalidWith(`
+declare let x: { foo: string } | null;
+x ? x : { foo: '' };
+`, `
+declare let x: { foo: string } | null;
+x ?? { foo: '' };
+`, "preferNullishOverTernary", optTern(false)),
+		// Class with `super.foo` access.
+		invalidWith(`
+class Base {
+  declare foo: string | null;
+}
+class Derived extends Base {
+  use() {
+    return super.foo || 'foo';
+  }
+}
+`, `
+class Base {
+  declare foo: string | null;
+}
+class Derived extends Base {
+  use() {
+    return super.foo ?? 'foo';
+  }
+}
+`, "preferNullishOverOr", nil),
+		// (Note) Generic type parameter constrained to a nullable union is NOT
+		// reported — matches upstream's behavior because `getTypeAtLocation`
+		// returns the type-parameter type whose flags don't include Null /
+		// Undefined; ts-api-utils' `isNullableType` only checks union members.
+		// Member of `this` inside an arrow class field.
+		invalidWith(`
+class C {
+  declare foo: string | null;
+  get value() {
+    return this.foo || 'foo';
+  }
+}
+`, `
+class C {
+  declare foo: string | null;
+  get value() {
+    return this.foo ?? 'foo';
+  }
+}
+`, "preferNullishOverOr", nil),
+		// Element access via numeric index.
+		invalidWith(`
+declare const arr: (string | null)[];
+arr[0] || 'foo';
+`, `
+declare const arr: (string | null)[];
+arr[0] ?? 'foo';
+`, "preferNullishOverOr", nil),
+		// Optional element access.
+		invalidWith(`
+declare const arr: ((string | null)[] | null);
+arr?.[0] || 'foo';
+`, `
+declare const arr: ((string | null)[] | null);
+arr?.[0] ?? 'foo';
+`, "preferNullishOverOr", nil),
+		// Returns of function call with nullable result.
+		invalidWith(`
+declare function getFoo(): string | null;
+getFoo() || 'foo';
+`, `
+declare function getFoo(): string | null;
+getFoo() ?? 'foo';
+`, "preferNullishOverOr", nil),
+		// Negative — `??` already in a chain doesn't cascade.
+		invalidWith(`
+declare let a: string | null;
+declare let b: string | null;
+declare let c: string;
+a ?? b || c;
+`, `
+declare let a: string | null;
+declare let b: string | null;
+declare let c: string;
+a ?? b ?? c;
+`, "preferNullishOverOr", nil),
+		// `as` and `satisfies` wrappers around the LHS — type-checking
+		// still picks up the nullable wrapper underneath.
+		invalidWith(`
+declare let x: string | null;
+(x as string | null) || 'foo';
+`, `
+declare let x: string | null;
+(x as string | null) ?? 'foo';
+`, "preferNullishOverOr", nil),
+	}
+
+	// ───────── real-world user scenarios (invalid) ─────────
+	realWorldInvalid := []rule_tester.InvalidTestCase{
+		// Express handler-style — `req.query` returns `string | undefined`.
+		invalidWith(`
+type Req = { query: { search?: string } };
+declare const req: Req;
+const term = req.query.search || 'default';
+`, `
+type Req = { query: { search?: string } };
+declare const req: Req;
+const term = req.query.search ?? 'default';
+`, "preferNullishOverOr", nil),
+		// Map.get
+		invalidWith(`
+const cache = new Map<string, string>();
+const v = cache.get('k') || 'default';
+`, `
+const cache = new Map<string, string>();
+const v = cache.get('k') ?? 'default';
+`, "preferNullishOverOr", nil),
+		// React-like prop fallback (parser handles tsx syntax)
+		{
+			Code: `
+type Props = { name?: string };
+declare const props: Props;
+declare function Foo(p: any): any;
+const el = <Foo name={props.name || 'default'} />;
+`,
+			Tsx:     true,
+			Options: optMap("ignoreConditionalTests", false),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverOr",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+type Props = { name?: string };
+declare const props: Props;
+declare function Foo(p: any): any;
+const el = <Foo name={props.name ?? 'default'} />;
+`},
+				},
+			}},
+		},
+		// Async/await — `await result || fallback`
+		invalidWith(`
+declare function load(): Promise<string | null>;
+async function main() {
+  const value = (await load()) || 'default';
+  return value;
+}
+`, `
+declare function load(): Promise<string | null>;
+async function main() {
+  const value = (await load()) ?? 'default';
+  return value;
+}
+`, "preferNullishOverOr", nil),
+		// Destructuring with default + nullable union — when LHS is nullable.
+		invalidWith(`
+declare const cfg: { host?: string };
+const host = cfg.host || 'localhost';
+`, `
+declare const cfg: { host?: string };
+const host = cfg.host ?? 'localhost';
+`, "preferNullishOverOr", nil),
+		// Class private field with nullable storage — `||` form is still
+		// reported (the `||` listener doesn't go through `isNodeEqual`).
+		invalidWith(`
+class Cache {
+  #value: string | null = null;
+  get(): string {
+    return this.#value || 'fresh';
+  }
+}
+`, `
+class Cache {
+  #value: string | null = null;
+  get(): string {
+    return this.#value ?? 'fresh';
+  }
+}
+`, "preferNullishOverOr", nil),
+		// Class field with `?: string`
+		invalidWith(`
+class User {
+  declare name?: string;
+  display(): string {
+    return this.name || 'anonymous';
+  }
+}
+`, `
+class User {
+  declare name?: string;
+  display(): string {
+    return this.name ?? 'anonymous';
+  }
+}
+`, "preferNullishOverOr", nil),
+		// Tagged template result fallback.
+		invalidWith(`
+declare function tag(s: TemplateStringsArray): string | null;
+const x = tag` + "`hello`" + ` || 'default';
+`, `
+declare function tag(s: TemplateStringsArray): string | null;
+const x = tag` + "`hello`" + ` ?? 'default';
+`, "preferNullishOverOr", nil),
+		// Function-call result that may be undefined (Array.find).
+		invalidWith(`
+const items: string[] = [];
+const v = items.find(x => x.length > 0) || 'none';
+`, `
+const items: string[] = [];
+const v = items.find(x => x.length > 0) ?? 'none';
+`, "preferNullishOverOr", nil),
+		// Generator-yielded value with nullable.
+		invalidWith(`
+declare function* gen(): Generator<string | null>;
+declare const it: Iterator<string | null>;
+const r = it.next().value || 'fallback';
+`, `
+declare function* gen(): Generator<string | null>;
+declare const it: Iterator<string | null>;
+const r = it.next().value ?? 'fallback';
+`, "preferNullishOverOr", nil),
+		// Index signature returning `T | undefined`
+		invalidWith(`
+type Dict = { [k: string]: string | undefined };
+declare const d: Dict;
+const v = d['key'] || 'fallback';
+`, `
+type Dict = { [k: string]: string | undefined };
+declare const d: Dict;
+const v = d['key'] ?? 'fallback';
+`, "preferNullishOverOr", nil),
+		// Tuple element typed `T | undefined`.
+		invalidWith(`
+declare const tup: [string | null, number | null];
+const a = tup[0] || 'foo';
+`, `
+declare const tup: [string | null, number | null];
+const a = tup[0] ?? 'foo';
+`, "preferNullishOverOr", nil),
+		// `env.FOO || default` — common bundler env-var fallback shape.
+		invalidWith(`
+declare const env: { FOO?: string };
+const x = env.FOO || 'fallback';
+`, `
+declare const env: { FOO?: string };
+const x = env.FOO ?? 'fallback';
+`, "preferNullishOverOr", nil),
+		// Nested object access with optional chain wrapped by `(...)`
+		invalidWith(`
+declare const config: { db?: { host?: string } };
+const host = (config.db?.host) || 'localhost';
+`, `
+declare const config: { db?: { host?: string } };
+const host = (config.db?.host) ?? 'localhost';
+`, "preferNullishOverOr", nil),
+		// Spread & rest argument — parens around `||` chain.
+		invalidWith(`
+declare function f(...args: string[]): void;
+declare let opt: string | null;
+f(opt || 'x');
+`, `
+declare function f(...args: string[]): void;
+declare let opt: string | null;
+f(opt ?? 'x');
+`, "preferNullishOverOr", nil),
+		// Array literal element fallback.
+		invalidWith(`
+declare let a: string | null;
+const arr = [a || 'foo'];
+`, `
+declare let a: string | null;
+const arr = [a ?? 'foo'];
+`, "preferNullishOverOr", nil),
+		// `.then` callback parameter fallback.
+		invalidWith(`
+declare function load(): Promise<string | null>;
+load().then(v => v || 'default');
+`, `
+declare function load(): Promise<string | null>;
+load().then(v => v ?? 'default');
+`, "preferNullishOverOr", nil),
+		// Default return in arrow with implicit body.
+		invalidWith(`
+declare let cache: Map<string, string | null>;
+const get = (k: string) => cache.get(k) || 'fresh';
+`, `
+declare let cache: Map<string, string | null>;
+const get = (k: string) => cache.get(k) ?? 'fresh';
+`, "preferNullishOverOr", nil),
+		// Computed access with string-literal index.
+		invalidWith(`
+declare const o: { [k: string]: string | undefined };
+const v = o['k'] || 'fallback';
+`, `
+declare const o: { [k: string]: string | undefined };
+const v = o['k'] ?? 'fallback';
+`, "preferNullishOverOr", nil),
+		// Branded primitive intersection — should still report when option
+		// doesn't ignore that primitive.
+		invalidWith(`
+declare let x: (string & { __brand?: any }) | undefined;
+x || y;
+`, `
+declare let x: (string & { __brand?: any }) | undefined;
+x ?? y;
+`, "preferNullishOverOr", nil),
+	}
+
+	// ───────── upstream optional-chain similarity batch ─────────
+	// Covers `x.n?.a == null/undefined`, `x.n?.a != null/undefined` with
+	// each branch reading a different chain shape (similar member-access).
+	optionalChainBatch := []rule_tester.InvalidTestCase{
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x.n?.a !== undefined ? x.n.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x.n?.a !== undefined ? x?.n?.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x.n?.a != undefined ? x.n.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x.n?.a != undefined ? x?.n?.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x.n?.a != null ? x.n.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x.n?.a != null ? x?.n.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x.n?.a != null ? x?.n?.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string | null } };
+x.n?.a !== undefined && x.n.a !== null ? x?.n?.a : y;
+`, `
+declare let x: { n?: { a?: string | null } };
+x.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string | null } };
+x.n?.a !== undefined && x.n.a !== null ? x.n.a : y;
+`, `
+declare let x: { n?: { a?: string | null } };
+x.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x?.n?.a ? x?.n?.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x?.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x?.n?.a ? x.n?.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x?.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x?.n?.a ? x.n.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x?.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x?.n?.a !== undefined ? x?.n?.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x?.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x?.n?.a !== undefined ? x.n.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x?.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x?.n?.a != undefined ? x?.n?.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x?.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+		invalidWith(`
+declare let x: { n?: { a?: string } };
+x?.n?.a != undefined ? x.n.a : y;
+`, `
+declare let x: { n?: { a?: string } };
+x?.n?.a ?? y;
+`, "preferNullishOverTernary", optTern(false)),
+	}
+
+	// ───────── extra real-world variants ─────────
+	moreRealWorld := []rule_tester.InvalidTestCase{
+		// Tuple element fallback with two members.
+		invalidWith(`
+declare const tup: [string | null, number];
+const [a, b] = tup;
+const display = a || 'unknown';
+`, `
+declare const tup: [string | null, number];
+const [a, b] = tup;
+const display = a ?? 'unknown';
+`, "preferNullishOverOr", nil),
+		// JSX with conditional default — TSX path.
+		{
+			Code: `
+type Props = { count?: number };
+declare const props: Props;
+declare function Counter(p: any): any;
+const el = <Counter count={props.count !== undefined ? props.count : 0} />;
+`,
+			Tsx:     true,
+			Options: optTern(false),
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "preferNullishOverTernary",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestNullish", Output: `
+type Props = { count?: number };
+declare const props: Props;
+declare function Counter(p: any): any;
+const el = <Counter count={props.count ?? 0} />;
+`},
+				},
+			}},
+		},
+		// Nested JSON-like struct.
+		invalidWith(`
+type Cfg = { server?: { port?: number } };
+declare const cfg: Cfg;
+const port = cfg.server?.port || 3000;
+`, `
+type Cfg = { server?: { port?: number } };
+declare const cfg: Cfg;
+const port = cfg.server?.port ?? 3000;
+`, "preferNullishOverOr", nil),
+		// Generic function returning nullable.
+		invalidWith(`
+function getOr<T>(v: T | null, fallback: T): T {
+  return v !== null ? v : fallback;
+}
+`, `
+function getOr<T>(v: T | null, fallback: T): T {
+  return v ?? fallback;
+}
+`, "preferNullishOverTernary", optTern(false)),
+		// (Note) `lookup('id') ? lookup('id') : 'default'` is NOT reported —
+		// CallExpression isn't `member-access-like` per upstream, so the
+		// rule treats both branches as opaque calls and doesn't pair them
+		// up. Matches upstream behavior.
+		// String method result fallback (non-similar branches).
+		invalidWith(`
+declare let token: string | null;
+const out = token != null ? token : '';
+`, `
+declare let token: string | null;
+const out = token ?? '';
+`, "preferNullishOverTernary", optTern(false)),
+		// (Note) Class private field `this.#v` in a ternary is NOT reported
+		// — matches upstream: `isNodeEqual` doesn't handle PrivateIdentifier
+		// so the similarity check across branches fails. Real-world impact:
+		// upstream rule misses this (arguably a bug in upstream); we mirror.
+		// Array.prototype.at returns `T | undefined`.
+		invalidWith(`
+declare const arr: string[];
+const v = arr.at(0) || 'none';
+`, `
+declare const arr: string[];
+const v = arr.at(0) ?? 'none';
+`, "preferNullishOverOr", nil),
+		// Ternary inside a function call argument.
+		invalidWith(`
+declare function show(v: string): void;
+declare let v: string | null;
+show(v !== null ? v : 'fallback');
+`, `
+declare function show(v: string): void;
+declare let v: string | null;
+show(v ?? 'fallback');
+`, "preferNullishOverTernary", optTern(false)),
+		// `if`-statement with member access on this.
+		invalidWith(`
+class Thing {
+  declare value: string | null;
+  ensure() {
+    if (this.value == null) {
+      this.value = 'init';
+    }
+  }
+}
+`, `
+class Thing {
+  declare value: string | null;
+  ensure() {
+    this.value ??= 'init';
+  }
+}
+`, "preferNullishOverAssignment", nil),
+		// Ternary used as default argument.
+		invalidWith(`
+declare let v: string | null;
+function f(arg: string = v !== null ? v : 'x') { return arg; }
+`, `
+declare let v: string | null;
+function f(arg: string = v ?? 'x') { return arg; }
+`, "preferNullishOverTernary", optTern(false)),
+		// Computed key access with `null` member.
+		invalidWith(`
+declare const m: Map<string, string | null>;
+const v = m.get('k') || 'fallback';
+`, `
+declare const m: Map<string, string | null>;
+const v = m.get('k') ?? 'fallback';
+`, "preferNullishOverOr", nil),
+	}
+
+	// Additional rare/extreme edges (non-deterministic positions skipped).
+	extremeEdges := []rule_tester.InvalidTestCase{
+		// Deeply nested optional chain similarity.
+		invalidWith(`
+declare let x: { a?: { b?: { c?: string } } };
+x.a?.b?.c !== undefined ? x.a?.b?.c : 'default';
+`, `
+declare let x: { a?: { b?: { c?: string } } };
+x.a?.b?.c ?? 'default';
+`, "preferNullishOverTernary", optTern(false)),
+		// Boolean(...) carve-out: ternary with truthy single-side check.
+		invalidWith(`
+declare let a: string | undefined;
+const x = Boolean(!a ? 'fallback' : a);
+`, `
+declare let a: string | undefined;
+const x = Boolean(a ?? 'fallback');
+`, "preferNullishOverTernary", optMap("ignoreBooleanCoercion", true)),
+		// Mixed `?.` chain + comparison (object then access).
+		invalidWith(`
+declare let foo: { bar?: string } | null;
+foo?.bar !== null && foo?.bar !== undefined ? foo?.bar : 'fallback';
+`, `
+declare let foo: { bar?: string } | null;
+foo?.bar ?? 'fallback';
+`, "preferNullishOverTernary", optTern(false)),
+		// `if`-block with prefix-unary `!` directly on member access.
+		invalidWith(`
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (!foo) {
+    foo = makeFoo();
+  }
+}
+`, `
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  foo ??= makeFoo();
+}
+`, "preferNullishOverAssignment", nil),
+		// Mixed comparisons with type that includes `void`.
+		invalidWith(`
+declare let foo: void | string;
+foo !== undefined ? foo : 'fallback';
+`, `
+declare let foo: void | string;
+foo ?? 'fallback';
+`, "preferNullishOverTernary", optTern(false)),
+		// Multiple chained `||` with nullable + non-nullable mix produces
+		// per-`||` reports (issue #1290 family).
+		invalidWith(`
+declare let a: string | null | undefined;
+declare let b: string;
+declare let c: string;
+a || b || c;
+`, `
+declare let a: string | null | undefined;
+declare let b: string;
+declare let c: string;
+(a ?? b) || c;
+`, "preferNullishOverOr", nil),
+	}
+
+	return mustConcatInvalid(
+		basicOr, manualOr, ternaryClean, singleSide, truthyTern, optionalChain,
+		ifBasic, condTestsInvalid, booleanInvalid, ifFlippedOn, primInvalid,
+		noStrict, mixedOr, ifWithCompound, issue1290Final, literalUnions,
+		falsyLiterals, mixedUnions, nullishOnly, fnInsideCond,
+		tsgoEdges, rslintExtraInvalid, realWorldInvalid, extremeEdges,
+		optionalChainBatch, moreRealWorld,
+	)
+}
+
+// invalidWith builds a generic invalid case with one suggestion. Position
+// fields are not asserted (zero values).
+func invalidWith(code, output, messageId string, options any) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:    code,
+		Options: options,
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: messageId,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: output},
+			},
+		}},
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+//                              option helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+func opt(k string, v interface{}) map[string]interface{} {
+	return map[string]interface{}{k: v}
+}
+func optTern(v bool) map[string]interface{} {
+	return map[string]interface{}{"ignoreTernaryTests": v}
+}
+func optMap(k string, v interface{}) map[string]interface{} {
+	return map[string]interface{}{k: v}
+}
+func optPrim(m map[string]bool) map[string]interface{} {
+	mm := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		mm[k] = v
+	}
+	return map[string]interface{}{"ignorePrimitives": mm}
+}
+
+// ternFix builds a minimal-suggestion ConditionalExpression invalid case
+// where the input has `ignoreTernaryTests: false` and the expected single
+// suggestion replaces the entire ternary with `<left> ?? <right>`.
+func ternFix(code, output string, column, endColumn, line, endLine int) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:    code,
+		Options: optTern(false),
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "preferNullishOverTernary",
+			Line:      line, EndLine: endLine, Column: column, EndColumn: endColumn,
+			Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "suggestNullish", Output: output},
+			},
+		}},
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -271,7 +271,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/prefer-includes.test.ts',
     './tests/typescript-eslint/rules/prefer-literal-enum-member.test.ts',
     './tests/typescript-eslint/rules/prefer-namespace-keyword.test.ts',
-    // './tests/typescript-eslint/rules/prefer-nullish-coalescing.test.ts',
+    './tests/typescript-eslint/rules/prefer-nullish-coalescing.test.ts',
     './tests/typescript-eslint/rules/prefer-optional-chain/prefer-optional-chain.test.ts',
     // './tests/typescript-eslint/rules/prefer-promise-reject-errors.test.ts',
     // './tests/typescript-eslint/rules/prefer-readonly-parameter-types.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-nullish-coalescing.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-nullish-coalescing.test.ts.snap
@@ -1,0 +1,18785 @@
+// Rstest Snapshot v1
+
+exports[`prefer-nullish-coalescing > invalid 1`] = `
+{
+  "code": "
+declare let x: string | null;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 2`] = `
+{
+  "code": "
+declare let x: string | null;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 3`] = `
+{
+  "code": "
+declare let x: number | null;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 4`] = `
+{
+  "code": "
+declare let x: number | null;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 5`] = `
+{
+  "code": "
+declare let x: boolean | null;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 6`] = `
+{
+  "code": "
+declare let x: boolean | null;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 7`] = `
+{
+  "code": "
+declare let x: object | null;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 8`] = `
+{
+  "code": "
+declare let x: object | null;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 9`] = `
+{
+  "code": "
+declare let x: string | undefined;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 10`] = `
+{
+  "code": "
+declare let x: string | undefined;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 11`] = `
+{
+  "code": "
+declare let x: number | undefined;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 12`] = `
+{
+  "code": "
+declare let x: number | undefined;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 13`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 14`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 15`] = `
+{
+  "code": "
+declare let x: object | undefined;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 16`] = `
+{
+  "code": "
+declare let x: object | undefined;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 17`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 18`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 19`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 20`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 21`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 22`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 23`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+(x || 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 24`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+(x ||= 'foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 25`] = `
+{
+  "code": "x !== undefined && x !== null ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 26`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] !== undefined && x.z[1][this[this.o]]["3"][a.b.c] !== null ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 27`] = `
+{
+  "code": "x !== undefined && x !== null ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 28`] = `
+{
+  "code": "x !== null && x !== undefined ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 29`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] !== null && x.z[1][this[this.o]]["3"][a.b.c] !== undefined ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 30`] = `
+{
+  "code": "x !== null && x !== undefined ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 31`] = `
+{
+  "code": "x === undefined || x === null ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 32`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] === undefined || x.z[1][this[this.o]]["3"][a.b.c] === null ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 33`] = `
+{
+  "code": "x === undefined || x === null ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 34`] = `
+{
+  "code": "x === null || x === undefined ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 35`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] === null || x.z[1][this[this.o]]["3"][a.b.c] === undefined ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 36`] = `
+{
+  "code": "x === null || x === undefined ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 37`] = `
+{
+  "code": "undefined !== x && x !== null ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 38`] = `
+{
+  "code": "undefined !== x.z[1][this[this.o]]["3"][a.b.c] && x.z[1][this[this.o]]["3"][a.b.c] !== null ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 39`] = `
+{
+  "code": "undefined !== x && x !== null ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 40`] = `
+{
+  "code": "null !== x && x !== undefined ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 41`] = `
+{
+  "code": "null !== x.z[1][this[this.o]]["3"][a.b.c] && x.z[1][this[this.o]]["3"][a.b.c] !== undefined ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 42`] = `
+{
+  "code": "null !== x && x !== undefined ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 43`] = `
+{
+  "code": "undefined === x || x === null ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 44`] = `
+{
+  "code": "undefined === x.z[1][this[this.o]]["3"][a.b.c] || x.z[1][this[this.o]]["3"][a.b.c] === null ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 45`] = `
+{
+  "code": "undefined === x || x === null ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 46`] = `
+{
+  "code": "null === x || x === undefined ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 47`] = `
+{
+  "code": "null === x.z[1][this[this.o]]["3"][a.b.c] || x.z[1][this[this.o]]["3"][a.b.c] === undefined ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 48`] = `
+{
+  "code": "null === x || x === undefined ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 49`] = `
+{
+  "code": "x !== undefined && null !== x ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 50`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] !== undefined && null !== x.z[1][this[this.o]]["3"][a.b.c] ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 51`] = `
+{
+  "code": "x !== undefined && null !== x ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 52`] = `
+{
+  "code": "x !== null && undefined !== x ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 53`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] !== null && undefined !== x.z[1][this[this.o]]["3"][a.b.c] ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 54`] = `
+{
+  "code": "x !== null && undefined !== x ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 55`] = `
+{
+  "code": "x === undefined || null === x ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 56`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] === undefined || null === x.z[1][this[this.o]]["3"][a.b.c] ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 57`] = `
+{
+  "code": "x === undefined || null === x ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 58`] = `
+{
+  "code": "x === null || undefined === x ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 59`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] === null || undefined === x.z[1][this[this.o]]["3"][a.b.c] ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 60`] = `
+{
+  "code": "x === null || undefined === x ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 61`] = `
+{
+  "code": "undefined !== x && null !== x ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 62`] = `
+{
+  "code": "undefined !== x.z[1][this[this.o]]["3"][a.b.c] && null !== x.z[1][this[this.o]]["3"][a.b.c] ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 63`] = `
+{
+  "code": "undefined !== x && null !== x ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 64`] = `
+{
+  "code": "null !== x && undefined !== x ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 65`] = `
+{
+  "code": "null !== x.z[1][this[this.o]]["3"][a.b.c] && undefined !== x.z[1][this[this.o]]["3"][a.b.c] ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 66`] = `
+{
+  "code": "null !== x && undefined !== x ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 67`] = `
+{
+  "code": "undefined === x || null === x ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 68`] = `
+{
+  "code": "undefined === x.z[1][this[this.o]]["3"][a.b.c] || null === x.z[1][this[this.o]]["3"][a.b.c] ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 69`] = `
+{
+  "code": "undefined === x || null === x ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 70`] = `
+{
+  "code": "null === x || undefined === x ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 71`] = `
+{
+  "code": "null === x.z[1][this[this.o]]["3"][a.b.c] || undefined === x.z[1][this[this.o]]["3"][a.b.c] ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 131,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 72`] = `
+{
+  "code": "null === x || undefined === x ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 73`] = `
+{
+  "code": "x != undefined && x != null ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 74`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] != undefined && x.z[1][this[this.o]]["3"][a.b.c] != null ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 129,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 75`] = `
+{
+  "code": "x != undefined && x != null ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 76`] = `
+{
+  "code": "x == undefined || x == null ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 77`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] == undefined || x.z[1][this[this.o]]["3"][a.b.c] == null ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 129,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 78`] = `
+{
+  "code": "x == undefined || x == null ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 79`] = `
+{
+  "code": "x != undefined && x !== null ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 80`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] != undefined && x.z[1][this[this.o]]["3"][a.b.c] !== null ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 130,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 81`] = `
+{
+  "code": "x != undefined && x !== null ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 82`] = `
+{
+  "code": "x == undefined || x === null ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 83`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] == undefined || x.z[1][this[this.o]]["3"][a.b.c] === null ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 130,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 84`] = `
+{
+  "code": "x == undefined || x === null ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 85`] = `
+{
+  "code": "x !== undefined && x != null ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 86`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] !== undefined && x.z[1][this[this.o]]["3"][a.b.c] != null ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 130,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 87`] = `
+{
+  "code": "x !== undefined && x != null ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 88`] = `
+{
+  "code": "undefined != x ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 89`] = `
+{
+  "code": "undefined != x.z[1][this[this.o]]["3"][a.b.c] ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 85,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 90`] = `
+{
+  "code": "undefined != x ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 91`] = `
+{
+  "code": "null != x ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 92`] = `
+{
+  "code": "null != x.z[1][this[this.o]]["3"][a.b.c] ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 93`] = `
+{
+  "code": "null != x ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 94`] = `
+{
+  "code": "undefined == x ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 95`] = `
+{
+  "code": "undefined == x.z[1][this[this.o]]["3"][a.b.c] ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 85,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 96`] = `
+{
+  "code": "undefined == x ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 97`] = `
+{
+  "code": "null == x ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 98`] = `
+{
+  "code": "null == x.z[1][this[this.o]]["3"][a.b.c] ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 99`] = `
+{
+  "code": "null == x ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 100`] = `
+{
+  "code": "x != undefined ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 101`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] != undefined ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 85,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 102`] = `
+{
+  "code": "x != undefined ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 103`] = `
+{
+  "code": "x != null ? x : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 104`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] != null ? x.z[1][this[this.o]]["3"][a.b.c] : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 105`] = `
+{
+  "code": "x != null ? x : (z = y);",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 106`] = `
+{
+  "code": "x == undefined  ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 107`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] == undefined  ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 86,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 108`] = `
+{
+  "code": "x == undefined  ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 109`] = `
+{
+  "code": "x == null ? y : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 110`] = `
+{
+  "code": "x.z[1][this[this.o]]["3"][a.b.c] == null ? y : x.z[1][this[this.o]]["3"][a.b.c];",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 111`] = `
+{
+  "code": "x == null ? (z = y) : x;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 112`] = `
+{
+  "code": "this != undefined ? this : y;",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 113`] = `
+{
+  "code": "
+declare let x: string | undefined;
+x !== undefined ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 114`] = `
+{
+  "code": "
+declare let x: string | undefined;
+undefined !== x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 115`] = `
+{
+  "code": "
+declare let x: string | undefined;
+x === undefined ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 116`] = `
+{
+  "code": "
+declare let x: string | undefined;
+undefined === x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 117`] = `
+{
+  "code": "
+declare let x: string | null;
+x !== null ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 118`] = `
+{
+  "code": "
+declare let x: string | null;
+null !== x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 119`] = `
+{
+  "code": "
+declare let x: string | null;
+x === null ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 120`] = `
+{
+  "code": "
+declare let x: string | null;
+null === x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 121`] = `
+{
+  "code": "
+declare let x: string | null;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 122`] = `
+{
+  "code": "
+declare let x: string | null;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 123`] = `
+{
+  "code": "
+declare let x: string | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 124`] = `
+{
+  "code": "
+declare let x: string | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 125`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 126`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 127`] = `
+{
+  "code": "
+declare let x: string | object | null;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 128`] = `
+{
+  "code": "
+declare let x: string | object | null;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 129`] = `
+{
+  "code": "
+declare let x: string | object | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 130`] = `
+{
+  "code": "
+declare let x: string | object | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 131`] = `
+{
+  "code": "
+declare let x: string | object | null | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 132`] = `
+{
+  "code": "
+declare let x: string | object | null | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 133`] = `
+{
+  "code": "
+declare let x: number | null;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 134`] = `
+{
+  "code": "
+declare let x: number | null;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 135`] = `
+{
+  "code": "
+declare let x: number | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 136`] = `
+{
+  "code": "
+declare let x: number | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 137`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 138`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 139`] = `
+{
+  "code": "
+declare let x: bigint | null;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 140`] = `
+{
+  "code": "
+declare let x: bigint | null;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 141`] = `
+{
+  "code": "
+declare let x: bigint | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 142`] = `
+{
+  "code": "
+declare let x: bigint | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 143`] = `
+{
+  "code": "
+declare let x: bigint | null | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 144`] = `
+{
+  "code": "
+declare let x: bigint | null | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 145`] = `
+{
+  "code": "
+declare let x: boolean | null;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 146`] = `
+{
+  "code": "
+declare let x: boolean | null;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 147`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 148`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 149`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 150`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 151`] = `
+{
+  "code": "
+declare let x: string[] | null;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 152`] = `
+{
+  "code": "
+declare let x: string[] | null;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 153`] = `
+{
+  "code": "
+declare let x: string[] | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 154`] = `
+{
+  "code": "
+declare let x: string[] | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 155`] = `
+{
+  "code": "
+declare let x: string[] | null | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 156`] = `
+{
+  "code": "
+declare let x: string[] | null | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 157`] = `
+{
+  "code": "
+declare let x: object | null;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 158`] = `
+{
+  "code": "
+declare let x: object | null;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 159`] = `
+{
+  "code": "
+declare let x: object | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 160`] = `
+{
+  "code": "
+declare let x: object | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 161`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 162`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 163`] = `
+{
+  "code": "
+declare let x: Function | null;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 164`] = `
+{
+  "code": "
+declare let x: Function | null;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 165`] = `
+{
+  "code": "
+declare let x: Function | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 166`] = `
+{
+  "code": "
+declare let x: Function | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 167`] = `
+{
+  "code": "
+declare let x: Function | null | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 168`] = `
+{
+  "code": "
+declare let x: Function | null | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 169`] = `
+{
+  "code": "
+declare let x: (() => string) | null;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 170`] = `
+{
+  "code": "
+declare let x: (() => string) | null;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 171`] = `
+{
+  "code": "
+declare let x: (() => string) | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 172`] = `
+{
+  "code": "
+declare let x: (() => string) | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 173`] = `
+{
+  "code": "
+declare let x: (() => string) | null | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 174`] = `
+{
+  "code": "
+declare let x: (() => string) | null | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 175`] = `
+{
+  "code": "
+declare let x: { n: string | null };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 176`] = `
+{
+  "code": "
+declare let x: { n: string | null };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 177`] = `
+{
+  "code": "
+declare let x: { n: string | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 178`] = `
+{
+  "code": "
+declare let x: { n: string | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 179`] = `
+{
+  "code": "
+declare let x: { n: string | null | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 180`] = `
+{
+  "code": "
+declare let x: { n: string | null | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 181`] = `
+{
+  "code": "
+declare let x: { n: string | object | null };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 182`] = `
+{
+  "code": "
+declare let x: { n: string | object | null };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 183`] = `
+{
+  "code": "
+declare let x: { n: string | object | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 184`] = `
+{
+  "code": "
+declare let x: { n: string | object | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 185`] = `
+{
+  "code": "
+declare let x: { n: string | object | null | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 186`] = `
+{
+  "code": "
+declare let x: { n: string | object | null | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 187`] = `
+{
+  "code": "
+declare let x: { n: number | null };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 188`] = `
+{
+  "code": "
+declare let x: { n: number | null };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 189`] = `
+{
+  "code": "
+declare let x: { n: number | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 190`] = `
+{
+  "code": "
+declare let x: { n: number | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 191`] = `
+{
+  "code": "
+declare let x: { n: number | null | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 192`] = `
+{
+  "code": "
+declare let x: { n: number | null | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 193`] = `
+{
+  "code": "
+declare let x: { n: bigint | null };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 194`] = `
+{
+  "code": "
+declare let x: { n: bigint | null };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 195`] = `
+{
+  "code": "
+declare let x: { n: bigint | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 196`] = `
+{
+  "code": "
+declare let x: { n: bigint | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 197`] = `
+{
+  "code": "
+declare let x: { n: bigint | null | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 198`] = `
+{
+  "code": "
+declare let x: { n: bigint | null | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 199`] = `
+{
+  "code": "
+declare let x: { n: boolean | null };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 200`] = `
+{
+  "code": "
+declare let x: { n: boolean | null };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 201`] = `
+{
+  "code": "
+declare let x: { n: boolean | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 202`] = `
+{
+  "code": "
+declare let x: { n: boolean | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 203`] = `
+{
+  "code": "
+declare let x: { n: boolean | null | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 204`] = `
+{
+  "code": "
+declare let x: { n: boolean | null | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 205`] = `
+{
+  "code": "
+declare let x: { n: string[] | null };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 206`] = `
+{
+  "code": "
+declare let x: { n: string[] | null };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 207`] = `
+{
+  "code": "
+declare let x: { n: string[] | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 208`] = `
+{
+  "code": "
+declare let x: { n: string[] | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 209`] = `
+{
+  "code": "
+declare let x: { n: string[] | null | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 210`] = `
+{
+  "code": "
+declare let x: { n: string[] | null | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 211`] = `
+{
+  "code": "
+declare let x: { n: object | null };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 212`] = `
+{
+  "code": "
+declare let x: { n: object | null };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 213`] = `
+{
+  "code": "
+declare let x: { n: object | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 214`] = `
+{
+  "code": "
+declare let x: { n: object | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 215`] = `
+{
+  "code": "
+declare let x: { n: object | null | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 216`] = `
+{
+  "code": "
+declare let x: { n: object | null | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 217`] = `
+{
+  "code": "
+declare let x: { n: Function | null };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 218`] = `
+{
+  "code": "
+declare let x: { n: Function | null };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 219`] = `
+{
+  "code": "
+declare let x: { n: Function | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 220`] = `
+{
+  "code": "
+declare let x: { n: Function | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 221`] = `
+{
+  "code": "
+declare let x: { n: Function | null | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 222`] = `
+{
+  "code": "
+declare let x: { n: Function | null | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 223`] = `
+{
+  "code": "
+declare let x: { n: (() => string) | null };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 224`] = `
+{
+  "code": "
+declare let x: { n: (() => string) | null };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 225`] = `
+{
+  "code": "
+declare let x: { n: (() => string) | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 226`] = `
+{
+  "code": "
+declare let x: { n: (() => string) | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 227`] = `
+{
+  "code": "
+declare let x: { n: (() => string) | null | undefined };
+x.n ? x.n : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 228`] = `
+{
+  "code": "
+declare let x: { n: (() => string) | null | undefined };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 229`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 230`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 231`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 232`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a !== undefined ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 233`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a !== undefined ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 234`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a !== undefined ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 235`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a != undefined ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 236`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a != undefined ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 237`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a != undefined ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 238`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a != null ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 239`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a != null ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 240`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x.n?.a != null ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 241`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+x.n?.a !== undefined && x.n.a !== null ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 242`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+x.n?.a !== undefined && x.n.a !== null ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 243`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 244`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a ? x.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 245`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 246`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 247`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a !== undefined ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 248`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a !== undefined ? x.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 249`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a !== undefined ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 250`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a !== undefined ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 251`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a != undefined ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 252`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a != undefined ? x.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 253`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a != undefined ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 254`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a != undefined ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 255`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a != null ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 256`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a != null ? x.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 257`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a != null ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 258`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string } };
+x?.n?.a != null ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 259`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+x?.n?.a !== undefined && x.n.a !== null ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 260`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+x?.n?.a !== undefined && x.n.a !== null ? x.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 261`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+x?.n?.a !== undefined && x.n.a !== null ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 262`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+x?.n?.a !== undefined && x.n.a !== null ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 263`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+x?.n?.a !== undefined && x.n.a !== null ? (x?.n)?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 264`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+x?.n?.a !== undefined && x.n.a !== null ? (x.n)?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 265`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+x?.n?.a !== undefined && x.n.a !== null ? (x?.n).a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 266`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+x?.n?.a !== undefined && x.n.a !== null ? (x.n).a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 267`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x?.n)?.a ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 268`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x?.n)?.a ? x.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 269`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x?.n)?.a ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 270`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x?.n)?.a ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 271`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x?.n)?.a ? (x?.n)?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 272`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x?.n)?.a ? (x.n)?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 273`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x?.n)?.a ? (x?.n).a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 274`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x.n)?.a ? x?.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 275`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x.n)?.a ? x.n?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 276`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x.n)?.a ? x?.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 277`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x.n)?.a ? x.n.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 278`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x.n)?.a ? (x?.n)?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 279`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x.n)?.a ? (x.n)?.a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 280`] = `
+{
+  "code": "
+declare let x: { n?: { a?: string | null } };
+(x.n)?.a ? (x?.n).a : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 281`] = `
+{
+  "code": "
+declare let x: string | null;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 282`] = `
+{
+  "code": "
+declare let x: string | null;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 283`] = `
+{
+  "code": "
+declare let x: number | null;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 284`] = `
+{
+  "code": "
+declare let x: number | null;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 285`] = `
+{
+  "code": "
+declare let x: boolean | null;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 286`] = `
+{
+  "code": "
+declare let x: boolean | null;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 287`] = `
+{
+  "code": "
+declare let x: object | null;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 288`] = `
+{
+  "code": "
+declare let x: object | null;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 289`] = `
+{
+  "code": "
+declare let x: string | undefined;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 290`] = `
+{
+  "code": "
+declare let x: string | undefined;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 291`] = `
+{
+  "code": "
+declare let x: number | undefined;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 292`] = `
+{
+  "code": "
+declare let x: number | undefined;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 293`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 294`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 295`] = `
+{
+  "code": "
+declare let x: object | undefined;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 296`] = `
+{
+  "code": "
+declare let x: object | undefined;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 297`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 298`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 299`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 300`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 301`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 302`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 303`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+(x || 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 304`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+(x ||= 'foo') ? null : null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 305`] = `
+{
+  "code": "
+declare let x: string | null;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 306`] = `
+{
+  "code": "
+declare let x: string | null;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 307`] = `
+{
+  "code": "
+declare let x: number | null;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 308`] = `
+{
+  "code": "
+declare let x: number | null;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 309`] = `
+{
+  "code": "
+declare let x: boolean | null;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 310`] = `
+{
+  "code": "
+declare let x: boolean | null;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 311`] = `
+{
+  "code": "
+declare let x: object | null;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 312`] = `
+{
+  "code": "
+declare let x: object | null;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 313`] = `
+{
+  "code": "
+declare let x: string | undefined;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 314`] = `
+{
+  "code": "
+declare let x: string | undefined;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 315`] = `
+{
+  "code": "
+declare let x: number | undefined;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 316`] = `
+{
+  "code": "
+declare let x: number | undefined;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 317`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 318`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 319`] = `
+{
+  "code": "
+declare let x: object | undefined;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 320`] = `
+{
+  "code": "
+declare let x: object | undefined;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 321`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 322`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 323`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 324`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 325`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 326`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 327`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+if ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 328`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+if ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 329`] = `
+{
+  "code": "
+declare let x: string | null;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 330`] = `
+{
+  "code": "
+declare let x: string | null;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 331`] = `
+{
+  "code": "
+declare let x: number | null;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 332`] = `
+{
+  "code": "
+declare let x: number | null;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 333`] = `
+{
+  "code": "
+declare let x: boolean | null;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 334`] = `
+{
+  "code": "
+declare let x: boolean | null;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 335`] = `
+{
+  "code": "
+declare let x: object | null;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 336`] = `
+{
+  "code": "
+declare let x: object | null;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 337`] = `
+{
+  "code": "
+declare let x: string | undefined;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 338`] = `
+{
+  "code": "
+declare let x: string | undefined;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 339`] = `
+{
+  "code": "
+declare let x: number | undefined;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 340`] = `
+{
+  "code": "
+declare let x: number | undefined;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 341`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 342`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 343`] = `
+{
+  "code": "
+declare let x: object | undefined;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 344`] = `
+{
+  "code": "
+declare let x: object | undefined;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 345`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 346`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 347`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 348`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 349`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 350`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 351`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+do {} while ((x || 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 352`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+do {} while ((x ||= 'foo'))
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 353`] = `
+{
+  "code": "
+declare let x: string | null;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 354`] = `
+{
+  "code": "
+declare let x: string | null;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 355`] = `
+{
+  "code": "
+declare let x: number | null;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 356`] = `
+{
+  "code": "
+declare let x: number | null;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 357`] = `
+{
+  "code": "
+declare let x: boolean | null;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 358`] = `
+{
+  "code": "
+declare let x: boolean | null;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 359`] = `
+{
+  "code": "
+declare let x: object | null;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 360`] = `
+{
+  "code": "
+declare let x: object | null;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 361`] = `
+{
+  "code": "
+declare let x: string | undefined;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 362`] = `
+{
+  "code": "
+declare let x: string | undefined;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 363`] = `
+{
+  "code": "
+declare let x: number | undefined;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 364`] = `
+{
+  "code": "
+declare let x: number | undefined;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 365`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 366`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 367`] = `
+{
+  "code": "
+declare let x: object | undefined;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 368`] = `
+{
+  "code": "
+declare let x: object | undefined;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 369`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 370`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 371`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 372`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 373`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 374`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 375`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+for (;(x || 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 376`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+for (;(x ||= 'foo');) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 377`] = `
+{
+  "code": "
+declare let x: string | null;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 378`] = `
+{
+  "code": "
+declare let x: string | null;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 379`] = `
+{
+  "code": "
+declare let x: number | null;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 380`] = `
+{
+  "code": "
+declare let x: number | null;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 381`] = `
+{
+  "code": "
+declare let x: boolean | null;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 382`] = `
+{
+  "code": "
+declare let x: boolean | null;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 383`] = `
+{
+  "code": "
+declare let x: object | null;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 384`] = `
+{
+  "code": "
+declare let x: object | null;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 385`] = `
+{
+  "code": "
+declare let x: string | undefined;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 386`] = `
+{
+  "code": "
+declare let x: string | undefined;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 387`] = `
+{
+  "code": "
+declare let x: number | undefined;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 388`] = `
+{
+  "code": "
+declare let x: number | undefined;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 389`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 390`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 391`] = `
+{
+  "code": "
+declare let x: object | undefined;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 392`] = `
+{
+  "code": "
+declare let x: object | undefined;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 393`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 394`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 395`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 396`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 397`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 398`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 399`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+while ((x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 400`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+while ((x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 401`] = `
+{
+  "code": "
+declare let a: string | null;
+declare let b: string | null;
+declare let c: string | null;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 402`] = `
+{
+  "code": "
+declare let a: number | null;
+declare let b: number | null;
+declare let c: number | null;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 403`] = `
+{
+  "code": "
+declare let a: boolean | null;
+declare let b: boolean | null;
+declare let c: boolean | null;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 404`] = `
+{
+  "code": "
+declare let a: object | null;
+declare let b: object | null;
+declare let c: object | null;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 405`] = `
+{
+  "code": "
+declare let a: string | undefined;
+declare let b: string | undefined;
+declare let c: string | undefined;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 406`] = `
+{
+  "code": "
+declare let a: number | undefined;
+declare let b: number | undefined;
+declare let c: number | undefined;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 407`] = `
+{
+  "code": "
+declare let a: boolean | undefined;
+declare let b: boolean | undefined;
+declare let c: boolean | undefined;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 408`] = `
+{
+  "code": "
+declare let a: object | undefined;
+declare let b: object | undefined;
+declare let c: object | undefined;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 409`] = `
+{
+  "code": "
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string | null | undefined;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 410`] = `
+{
+  "code": "
+declare let a: number | null | undefined;
+declare let b: number | null | undefined;
+declare let c: number | null | undefined;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 411`] = `
+{
+  "code": "
+declare let a: boolean | null | undefined;
+declare let b: boolean | null | undefined;
+declare let c: boolean | null | undefined;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 412`] = `
+{
+  "code": "
+declare let a: object | null | undefined;
+declare let b: object | null | undefined;
+declare let c: object | null | undefined;
+a || b && c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 413`] = `
+{
+  "code": "
+declare let a: string | null;
+declare let b: string | null;
+declare let c: string | null;
+declare let d: string | null;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 414`] = `
+{
+  "code": "
+declare let a: number | null;
+declare let b: number | null;
+declare let c: number | null;
+declare let d: number | null;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 415`] = `
+{
+  "code": "
+declare let a: boolean | null;
+declare let b: boolean | null;
+declare let c: boolean | null;
+declare let d: boolean | null;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 416`] = `
+{
+  "code": "
+declare let a: object | null;
+declare let b: object | null;
+declare let c: object | null;
+declare let d: object | null;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 417`] = `
+{
+  "code": "
+declare let a: string | undefined;
+declare let b: string | undefined;
+declare let c: string | undefined;
+declare let d: string | undefined;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 418`] = `
+{
+  "code": "
+declare let a: number | undefined;
+declare let b: number | undefined;
+declare let c: number | undefined;
+declare let d: number | undefined;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 419`] = `
+{
+  "code": "
+declare let a: boolean | undefined;
+declare let b: boolean | undefined;
+declare let c: boolean | undefined;
+declare let d: boolean | undefined;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 420`] = `
+{
+  "code": "
+declare let a: object | undefined;
+declare let b: object | undefined;
+declare let c: object | undefined;
+declare let d: object | undefined;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 421`] = `
+{
+  "code": "
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string | null | undefined;
+declare let d: string | null | undefined;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 422`] = `
+{
+  "code": "
+declare let a: number | null | undefined;
+declare let b: number | null | undefined;
+declare let c: number | null | undefined;
+declare let d: number | null | undefined;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 423`] = `
+{
+  "code": "
+declare let a: boolean | null | undefined;
+declare let b: boolean | null | undefined;
+declare let c: boolean | null | undefined;
+declare let d: boolean | null | undefined;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 424`] = `
+{
+  "code": "
+declare let a: object | null | undefined;
+declare let b: object | null | undefined;
+declare let c: object | null | undefined;
+declare let d: object | null | undefined;
+a || b || c && d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 425`] = `
+{
+  "code": "
+declare let a: string | null;
+declare let b: string | null;
+declare let c: string | null;
+declare let d: string | null;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 426`] = `
+{
+  "code": "
+declare let a: number | null;
+declare let b: number | null;
+declare let c: number | null;
+declare let d: number | null;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 427`] = `
+{
+  "code": "
+declare let a: boolean | null;
+declare let b: boolean | null;
+declare let c: boolean | null;
+declare let d: boolean | null;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 428`] = `
+{
+  "code": "
+declare let a: object | null;
+declare let b: object | null;
+declare let c: object | null;
+declare let d: object | null;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 429`] = `
+{
+  "code": "
+declare let a: string | undefined;
+declare let b: string | undefined;
+declare let c: string | undefined;
+declare let d: string | undefined;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 430`] = `
+{
+  "code": "
+declare let a: number | undefined;
+declare let b: number | undefined;
+declare let c: number | undefined;
+declare let d: number | undefined;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 431`] = `
+{
+  "code": "
+declare let a: boolean | undefined;
+declare let b: boolean | undefined;
+declare let c: boolean | undefined;
+declare let d: boolean | undefined;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 432`] = `
+{
+  "code": "
+declare let a: object | undefined;
+declare let b: object | undefined;
+declare let c: object | undefined;
+declare let d: object | undefined;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 433`] = `
+{
+  "code": "
+declare let a: string | null | undefined;
+declare let b: string | null | undefined;
+declare let c: string | null | undefined;
+declare let d: string | null | undefined;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 434`] = `
+{
+  "code": "
+declare let a: number | null | undefined;
+declare let b: number | null | undefined;
+declare let c: number | null | undefined;
+declare let d: number | null | undefined;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 435`] = `
+{
+  "code": "
+declare let a: boolean | null | undefined;
+declare let b: boolean | null | undefined;
+declare let c: boolean | null | undefined;
+declare let d: boolean | null | undefined;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 436`] = `
+{
+  "code": "
+declare let a: object | null | undefined;
+declare let b: object | null | undefined;
+declare let c: object | null | undefined;
+declare let d: object | null | undefined;
+a && b || c || d;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 6,
+        },
+        "start": {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 437`] = `
+{
+  "code": "
+declare let x: string | null;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 438`] = `
+{
+  "code": "
+declare let x: string | null;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 439`] = `
+{
+  "code": "
+declare let x: number | null;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 440`] = `
+{
+  "code": "
+declare let x: number | null;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 441`] = `
+{
+  "code": "
+declare let x: boolean | null;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 442`] = `
+{
+  "code": "
+declare let x: boolean | null;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 443`] = `
+{
+  "code": "
+declare let x: object | null;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 444`] = `
+{
+  "code": "
+declare let x: object | null;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 445`] = `
+{
+  "code": "
+declare let x: string | undefined;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 446`] = `
+{
+  "code": "
+declare let x: string | undefined;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 447`] = `
+{
+  "code": "
+declare let x: number | undefined;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 448`] = `
+{
+  "code": "
+declare let x: number | undefined;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 449`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 450`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 451`] = `
+{
+  "code": "
+declare let x: object | undefined;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 452`] = `
+{
+  "code": "
+declare let x: object | undefined;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 453`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 454`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 455`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 456`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 457`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 458`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 459`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+if (() => (x || 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 460`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+if (() => (x ||= 'foo')) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 461`] = `
+{
+  "code": "
+declare let x: string | null;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 462`] = `
+{
+  "code": "
+declare let x: string | null;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 463`] = `
+{
+  "code": "
+declare let x: number | null;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 464`] = `
+{
+  "code": "
+declare let x: number | null;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 465`] = `
+{
+  "code": "
+declare let x: boolean | null;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 466`] = `
+{
+  "code": "
+declare let x: boolean | null;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 467`] = `
+{
+  "code": "
+declare let x: object | null;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 468`] = `
+{
+  "code": "
+declare let x: object | null;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 469`] = `
+{
+  "code": "
+declare let x: string | undefined;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 470`] = `
+{
+  "code": "
+declare let x: string | undefined;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 471`] = `
+{
+  "code": "
+declare let x: number | undefined;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 472`] = `
+{
+  "code": "
+declare let x: number | undefined;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 473`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 474`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 475`] = `
+{
+  "code": "
+declare let x: object | undefined;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 476`] = `
+{
+  "code": "
+declare let x: object | undefined;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 477`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 478`] = `
+{
+  "code": "
+declare let x: string | null | undefined;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 479`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 480`] = `
+{
+  "code": "
+declare let x: number | null | undefined;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 481`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 482`] = `
+{
+  "code": "
+declare let x: boolean | null | undefined;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 483`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+if (function weird() { return (x || 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 484`] = `
+{
+  "code": "
+declare let x: object | null | undefined;
+if (function weird() { return (x ||= 'foo') }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 485`] = `
+{
+  "code": "
+declare let a: string | null;
+declare let b: string;
+declare let c: string;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 486`] = `
+{
+  "code": "
+declare let a: number | null;
+declare let b: number;
+declare let c: number;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 487`] = `
+{
+  "code": "
+declare let a: boolean | null;
+declare let b: boolean;
+declare let c: boolean;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 488`] = `
+{
+  "code": "
+declare let a: object | null;
+declare let b: object;
+declare let c: object;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 489`] = `
+{
+  "code": "
+declare let a: string | undefined;
+declare let b: string;
+declare let c: string;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 490`] = `
+{
+  "code": "
+declare let a: number | undefined;
+declare let b: number;
+declare let c: number;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 491`] = `
+{
+  "code": "
+declare let a: boolean | undefined;
+declare let b: boolean;
+declare let c: boolean;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 492`] = `
+{
+  "code": "
+declare let a: object | undefined;
+declare let b: object;
+declare let c: object;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 493`] = `
+{
+  "code": "
+declare let a: string | null | undefined;
+declare let b: string;
+declare let c: string;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 494`] = `
+{
+  "code": "
+declare let a: number | null | undefined;
+declare let b: number;
+declare let c: number;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 495`] = `
+{
+  "code": "
+declare let a: boolean | null | undefined;
+declare let b: boolean;
+declare let c: boolean;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 496`] = `
+{
+  "code": "
+declare let a: object | null | undefined;
+declare let b: object;
+declare let c: object;
+a || b || c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 497`] = `
+{
+  "code": "
+declare let x: string | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 498`] = `
+{
+  "code": "
+declare let x: number | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 499`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 500`] = `
+{
+  "code": "
+declare let x: bigint | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 501`] = `
+{
+  "code": "
+declare let x: string | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 502`] = `
+{
+  "code": "
+declare let x: number | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 503`] = `
+{
+  "code": "
+declare let x: boolean | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 504`] = `
+{
+  "code": "
+declare let x: bigint | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 505`] = `
+{
+  "code": "
+declare let x: '' | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 506`] = `
+{
+  "code": "
+declare let x: \`\` | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 507`] = `
+{
+  "code": "
+declare let x: 0 | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 508`] = `
+{
+  "code": "
+declare let x: 0n | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 509`] = `
+{
+  "code": "
+declare let x: false | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 510`] = `
+{
+  "code": "
+declare let x: '' | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 511`] = `
+{
+  "code": "
+declare let x: \`\` | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 512`] = `
+{
+  "code": "
+declare let x: 0 | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 513`] = `
+{
+  "code": "
+declare let x: 0n | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 514`] = `
+{
+  "code": "
+declare let x: false | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 515`] = `
+{
+  "code": "
+declare let x: 'a' | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 516`] = `
+{
+  "code": "
+declare let x: \`hello\${'string'}\` | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 517`] = `
+{
+  "code": "
+declare let x: 1 | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 518`] = `
+{
+  "code": "
+declare let x: 1n | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 519`] = `
+{
+  "code": "
+declare let x: true | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 520`] = `
+{
+  "code": "
+declare let x: 'a' | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 521`] = `
+{
+  "code": "
+declare let x: 'a' | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 522`] = `
+{
+  "code": "
+declare let x: \`hello\${'string'}\` | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 523`] = `
+{
+  "code": "
+declare let x: \`hello\${'string'}\` | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 524`] = `
+{
+  "code": "
+declare let x: 1 | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 525`] = `
+{
+  "code": "
+declare let x: 1 | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 526`] = `
+{
+  "code": "
+declare let x: 1n | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 527`] = `
+{
+  "code": "
+declare let x: 1n | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 528`] = `
+{
+  "code": "
+declare let x: true | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 529`] = `
+{
+  "code": "
+declare let x: true | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 530`] = `
+{
+  "code": "
+declare let x: 'a' | 'b' | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 531`] = `
+{
+  "code": "
+declare let x: 'a' | \`b\` | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 532`] = `
+{
+  "code": "
+declare let x: 0 | 1 | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 533`] = `
+{
+  "code": "
+declare let x: 1 | 2 | 3 | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 534`] = `
+{
+  "code": "
+declare let x: 0n | 1n | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 535`] = `
+{
+  "code": "
+declare let x: 1n | 2n | 3n | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 536`] = `
+{
+  "code": "
+declare let x: true | false | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 537`] = `
+{
+  "code": "
+declare let x: 'a' | 'b' | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 538`] = `
+{
+  "code": "
+declare let x: 'a' | 'b' | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 539`] = `
+{
+  "code": "
+declare let x: 'a' | \`b\` | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 540`] = `
+{
+  "code": "
+declare let x: 'a' | \`b\` | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 541`] = `
+{
+  "code": "
+declare let x: 0 | 1 | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 542`] = `
+{
+  "code": "
+declare let x: 0 | 1 | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 543`] = `
+{
+  "code": "
+declare let x: 1 | 2 | 3 | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 544`] = `
+{
+  "code": "
+declare let x: 1 | 2 | 3 | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 545`] = `
+{
+  "code": "
+declare let x: 0n | 1n | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 546`] = `
+{
+  "code": "
+declare let x: 0n | 1n | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 547`] = `
+{
+  "code": "
+declare let x: 1n | 2n | 3n | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 548`] = `
+{
+  "code": "
+declare let x: 1n | 2n | 3n | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 549`] = `
+{
+  "code": "
+declare let x: true | false | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 550`] = `
+{
+  "code": "
+declare let x: true | false | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 551`] = `
+{
+  "code": "
+declare let x: 0 | 1 | 0n | 1n | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 552`] = `
+{
+  "code": "
+declare let x: true | false | null | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 553`] = `
+{
+  "code": "
+declare let x: 0 | 1 | 0n | 1n | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 554`] = `
+{
+  "code": "
+declare let x: 0 | 1 | 0n | 1n | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 555`] = `
+{
+  "code": "
+declare let x: true | false | null | undefined;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 556`] = `
+{
+  "code": "
+declare let x: true | false | null | undefined;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 557`] = `
+{
+  "code": "
+declare let x: null;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 558`] = `
+{
+  "code": "
+const x = undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 559`] = `
+{
+  "code": "
+null || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 2,
+        },
+        "start": {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 560`] = `
+{
+  "code": "
+undefined || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 561`] = `
+{
+  "code": "
+enum Enum {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+declare let x: Enum | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 562`] = `
+{
+  "code": "
+enum Enum {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+declare let x: Enum.A | Enum.B | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 563`] = `
+{
+  "code": "
+enum Enum {
+  A = 'a',
+  B = 'b',
+  C = 'c',
+}
+declare let x: Enum | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 564`] = `
+{
+  "code": "
+enum Enum {
+  A = 'a',
+  B = 'b',
+  C = 'c',
+}
+declare let x: Enum.A | Enum.B | undefined;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 565`] = `
+{
+  "code": "
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+let c: boolean | undefined;
+
+const x = Boolean(a || b);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 6,
+        },
+        "start": {
+          "column": 21,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 566`] = `
+{
+  "code": "
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+const x = String(a || b);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 20,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 567`] = `
+{
+  "code": "
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+const x = Boolean(() => a || b);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 5,
+        },
+        "start": {
+          "column": 27,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 568`] = `
+{
+  "code": "
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+const x = Boolean(function weird() {
+  return a || b;
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 6,
+        },
+        "start": {
+          "column": 12,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 569`] = `
+{
+  "code": "
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+declare function f(x: unknown): unknown;
+
+const x = Boolean(f(a || b));
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 7,
+        },
+        "start": {
+          "column": 23,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 570`] = `
+{
+  "code": "
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+const x = Boolean(1 + (a || b));
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 5,
+        },
+        "start": {
+          "column": 26,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 571`] = `
+{
+  "code": "
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+declare function f(x: unknown): unknown;
+
+if (f(a || b)) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 7,
+        },
+        "start": {
+          "column": 9,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 572`] = `
+{
+  "code": "
+declare const a: string | undefined;
+declare const b: string;
+
+if (+(a || b)) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 5,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 573`] = `
+{
+  "code": "
+interface Box {
+  value: string;
+}
+declare function getFallbackBox(): Box;
+declare const defaultBox: Box | undefined;
+
+defaultBox || getFallbackBox();
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 8,
+        },
+        "start": {
+          "column": 12,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 574`] = `
+{
+  "code": "
+interface Box {
+  value: string;
+}
+declare function getFallbackBox(): Box;
+declare const defaultBox: Box | undefined;
+
+defaultBox ? defaultBox : getFallbackBox();
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 575`] = `
+{
+  "code": "
+interface Box {
+  value: string;
+}
+declare function getFallbackBox(): Box;
+declare const defaultBoxOptional: { a?: { b?: Box | undefined } };
+
+defaultBoxOptional.a?.b != null ? defaultBoxOptional.a?.b : getFallbackBox();
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 576`] = `
+{
+  "code": "
+declare const x: any;
+declare const y: any;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 577`] = `
+{
+  "code": "
+declare const x: unknown;
+declare const y: any;
+x || y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a logical or (\`||\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 578`] = `
+{
+  "code": "
+interface Box {
+  value: string;
+}
+declare function getFallbackBox(): Box;
+declare const defaultBoxOptional: { a?: { b?: Box | undefined } };
+
+defaultBoxOptional.a?.b != null ? defaultBoxOptional.a.b : getFallbackBox();
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 76,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 579`] = `
+{
+  "code": "
+interface Box {
+  value: string;
+}
+declare function getFallbackBox(): Box;
+declare const defaultBoxOptional: { a?: { b?: Box | undefined } };
+
+defaultBoxOptional.a?.b ? defaultBoxOptional.a?.b : getFallbackBox();
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 580`] = `
+{
+  "code": "
+interface Box {
+  value: string;
+}
+declare function getFallbackBox(): Box;
+declare const defaultBoxOptional: { a?: { b?: Box | undefined } };
+
+defaultBoxOptional.a?.b ? defaultBoxOptional.a.b : getFallbackBox();
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 581`] = `
+{
+  "code": "
+interface Box {
+  value: string;
+}
+declare function getFallbackBox(): Box;
+declare const defaultBoxOptional: { a?: { b?: Box | undefined } };
+
+defaultBoxOptional.a?.b !== undefined
+  ? defaultBoxOptional.a?.b
+  : getFallbackBox();
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 10,
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 582`] = `
+{
+  "code": "
+interface Box {
+  value: string;
+}
+declare function getFallbackBox(): Box;
+declare const defaultBoxOptional: { a?: { b?: Box | undefined } };
+
+defaultBoxOptional.a?.b !== undefined
+  ? defaultBoxOptional.a.b
+  : getFallbackBox();
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 10,
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 583`] = `
+{
+  "code": "
+interface Box {
+  value: string;
+}
+declare function getFallbackBox(): Box;
+declare const defaultBoxOptional: { a?: { b?: Box | undefined } };
+
+defaultBoxOptional.a?.b !== undefined && defaultBoxOptional.a?.b !== null
+  ? defaultBoxOptional.a?.b
+  : getFallbackBox();
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 10,
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 584`] = `
+{
+  "code": "
+interface Box {
+  value: string;
+}
+declare function getFallbackBox(): Box;
+declare const defaultBoxOptional: { a?: { b?: Box | undefined } };
+
+defaultBoxOptional.a?.b !== undefined && defaultBoxOptional.a?.b !== null
+  ? defaultBoxOptional.a.b
+  : getFallbackBox();
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 10,
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 585`] = `
+{
+  "code": "
+declare let x: unknown;
+declare let y: number;
+!x ? y : x;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 586`] = `
+{
+  "code": "
+declare let x: unknown;
+declare let y: number;
+x ? x : y;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 587`] = `
+{
+  "code": "
+declare let x: { n: unknown };
+!x.n ? y : x.n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 588`] = `
+{
+  "code": "
+declare let x: { a: string } | null;
+
+x?.['a'] != null ? x['a'] : 'foo';
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 589`] = `
+{
+  "code": "
+declare let x: { a: string } | null;
+
+x?.['a'] != null ? x.a : 'foo';
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 590`] = `
+{
+  "code": "
+declare let x: { a: string } | null;
+
+x?.a != null ? x['a'] : 'foo';
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 591`] = `
+{
+  "code": "
+const a = 'b';
+declare let x: { a: string; b: string } | null;
+
+x?.[a] != null ? x[a] : 'foo';
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 5,
+        },
+        "start": {
+          "column": 1,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 592`] = `
+{
+  "code": "
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (!foo) {
+    foo = makeFoo();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 593`] = `
+{
+  "code": "
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) {
+    foo = makeFoo();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 594`] = `
+{
+  "code": "
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) {
+    foo ??= makeFoo();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 595`] = `
+{
+  "code": "
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) {
+    foo ||= makeFoo();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 7,
+        },
+        "start": {
+          "column": 9,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 596`] = `
+{
+  "code": "
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo === null) {
+    foo = makeFoo();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 597`] = `
+{
+  "code": "
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) foo = makeFoo();
+  const bar = 42;
+  return bar;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 598`] = `
+{
+  "code": "
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) foo ??= makeFoo();
+  const bar = 42;
+  return bar;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 599`] = `
+{
+  "code": "
+declare let foo: { a: string } | null;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo == null) foo ||= makeFoo();
+  const bar = 42;
+  return bar;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of a logical assignment (\`||=\`), as it is a safer operator.",
+      "messageId": "preferNullishOverOr",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 6,
+        },
+        "start": {
+          "column": 24,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 600`] = `
+{
+  "code": "
+declare let foo: { a: string } | undefined;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo === undefined) {
+    foo = makeFoo();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 601`] = `
+{
+  "code": "
+declare let foo: { a: string } | null | undefined;
+declare function makeFoo(): { a: string };
+
+function lazyInitialize() {
+  if (foo === undefined || foo === null) {
+    foo = makeFoo();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 602`] = `
+{
+  "code": "
+declare let foo: { a: string } | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  if (foo.a == null) {
+    foo.a = makeFoo();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 603`] = `
+{
+  "code": "
+declare let foo: { a: string } | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  if (foo?.a == null) {
+    foo.a = makeFoo();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 604`] = `
+{
+  "code": "
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+function lazyInitialize() {
+  if (foo == null) {
+    // comment
+    foo = makeFoo();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 9,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 605`] = `
+{
+  "code": "
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+if (foo == null) {
+  // comment before 1
+  /* comment before 2 */
+  /* comment before 3
+    which is multiline
+  */
+  /**
+   * comment before 4
+   * which is also multiline
+   */
+  foo = makeFoo(); // comment inline
+  // comment after 1
+  /* comment after 2 */
+  /* comment after 3
+    which is multiline
+  */
+  /**
+   * comment after 4
+   * which is also multiline
+   */
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 25,
+        },
+        "start": {
+          "column": 1,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 606`] = `
+{
+  "code": "
+declare let foo: string | null;
+declare function makeFoo(): string;
+
+if (foo == null) /* comment before 1 */ /* comment before 2 */ foo = makeFoo(); // comment inline
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 5,
+        },
+        "start": {
+          "column": 1,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 607`] = `
+{
+  "code": "
+declare let foo: { a: string | null };
+declare function makeString(): string;
+
+function weirdParens() {
+  if (((((foo.a)) == null))) {
+    ((((((((foo).a))))) = makeString()));
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??=\`) instead of an assignment expression, as it is simpler to read.",
+      "messageId": "preferNullishOverAssignment",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 608`] = `
+{
+  "code": "
+let a: string | undefined;
+let b: { message: string } | undefined;
+
+const foo = a ? a : b ? 1 : 2;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 5,
+        },
+        "start": {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 609`] = `
+{
+  "code": "
+let a: string | undefined;
+let b: { message: string } | undefined;
+
+const foo = a ? a : (b ? 1 : 2);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 5,
+        },
+        "start": {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 610`] = `
+{
+  "code": "
+declare const c: string | null;
+c !== null ? c : c ? 1 : 2;
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 611`] = `
+{
+  "code": "
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+const x = Boolean(a ? a : b);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-nullish-coalescing > invalid 612`] = `
+{
+  "code": "
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+
+const test = Boolean(!a ? b : a);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer using nullish coalescing operator (\`??\`) instead of a ternary expression, as it is simpler to read.",
+      "messageId": "preferNullishOverTernary",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 5,
+        },
+        "start": {
+          "column": 22,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-nullish-coalescing",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/prefer-nullish-coalescing.test.ts
@@ -1251,32 +1251,13 @@ const test = Boolean(((a = b), b || c));
         },
       ],
     },
-    {
-      code: `
-let a: string | true | undefined;
-let b: string | boolean | undefined;
-
-const x = Boolean(a ? a : b);
-      `,
-      options: [
-        {
-          ignoreBooleanCoercion: true,
-        },
-      ],
-    },
-    {
-      code: `
-let a: string | boolean | undefined;
-let b: string | boolean | undefined;
-
-const test = Boolean(!a ? b : a);
-      `,
-      options: [
-        {
-          ignoreBooleanCoercion: true,
-        },
-      ],
-    },
+    // `Boolean((a ? a : b) || c)` / `Boolean(c || (!a ? b : a))` — ternary
+    // is wrapped by `||`, so its effective parent (after paren-skip) is the
+    // `||`, NOT `CallExpression`. The carve-out only fires when the ternary
+    // is the direct paren-stripped argument of `Boolean(...)`, so under
+    // `ignoreBooleanCoercion: true` these stay valid (verified against
+    // upstream byte-for-byte). The bare `Boolean(a ? a : b)` form IS
+    // reported and is in the `invalid` section below.
     {
       code: `
 let a: string | boolean | undefined;
@@ -1285,11 +1266,7 @@ let c: string | boolean | undefined;
 
 const test = Boolean((a ? a : b) || c);
       `,
-      options: [
-        {
-          ignoreBooleanCoercion: true,
-        },
-      ],
+      options: [{ ignoreBooleanCoercion: true }],
     },
     {
       code: `
@@ -1299,11 +1276,7 @@ let c: string | boolean | undefined;
 
 const test = Boolean(c || (!a ? b : a));
       `,
-      options: [
-        {
-          ignoreBooleanCoercion: true,
-        },
-      ],
+      options: [{ ignoreBooleanCoercion: true }],
     },
     {
       code: `
@@ -2505,8 +2478,12 @@ ${code.split('\n')[1]}
       output: null,
     })),
 
-    // noStrictNullCheck
+    // noStrictNullCheck — SKIP: rslint-test-tools doesn't propagate per-test
+    // `parserOptions.tsconfigRootDir` to a different tsconfig, so the file is
+    // linted against the strict default and the noStrictNullCheck branch
+    // never fires.
     {
+      skip: true,
       code: `
 declare let x: string[] | null;
 if (x) {
@@ -6317,6 +6294,68 @@ c ?? (c ? 1 : 2);
           ],
         },
       ],
+      output: null,
+    },
+    // ignoreBooleanCoercion carve-out: a ConditionalExpression whose paren-
+    // stripped direct parent is `CallExpression` (i.e. ternary IS the bare
+    // argument of `Boolean(...)`) still reports even with
+    // ignoreBooleanCoercion: true. Verified against upstream byte-for-byte.
+    //
+    // Note the strictness of upstream's carve-out: when the ternary is
+    // wrapped in another expression like `Boolean((a ? a : b) || c)` or
+    // `Boolean(c || (!a ? b : a))`, the ternary's effective parent becomes
+    // the `||`, NOT `CallExpression`, so the carve-out does NOT apply and
+    // those cases are correctly silent (kept in `valid` above).
+    {
+      code: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+const x = Boolean(a ? a : b);
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverTernary',
+          suggestions: [
+            {
+              messageId: 'suggestNullish',
+              output: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+const x = Boolean(a ?? b);
+      `,
+            },
+          ],
+        },
+      ],
+      options: [{ ignoreBooleanCoercion: true }],
+      output: null,
+    },
+    {
+      code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+
+const test = Boolean(!a ? b : a);
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverTernary',
+          suggestions: [
+            {
+              messageId: 'suggestNullish',
+              output: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+
+const test = Boolean(a ?? b);
+      `,
+            },
+          ],
+        },
+      ],
+      options: [{ ignoreBooleanCoercion: true }],
       output: null,
     },
   ],

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -304,3 +304,4 @@ humanfs
 modns
 Modns
 módulo
+dedup


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/prefer-nullish-coalescing` rule from typescript-eslint to rslint with full input/output/configuration parity against ESLint v10.

- All 7 options supported with upstream defaults: `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`, `ignoreBooleanCoercion`, `ignoreConditionalTests` (default `true`), `ignoreIfStatements`, `ignoreMixedLogicalExpressions`, `ignorePrimitives` (`true` or per-primitive object), `ignoreTernaryTests`.
- All 5 message ids: `noStrictNullCheck`, `preferNullishOverAssignment`, `preferNullishOverOr`, `preferNullishOverTernary`, `suggestNullish` — message text and `{{equals}}` / `{{description}}` template insertion are byte-identical.
- Three listeners — `BinaryExpression` (`||` / `||=`), `ConditionalExpression`, `IfStatement` — registered as exit listeners so diagnostic emit order matches ESLint's depth-first listener semantics.
- Mirrors the upstream `Boolean(<ternary>)` carve-out (a `ConditionalExpression` that is the direct argument of a `CallExpression` still reports even with `ignoreBooleanCoercion: true`).
- Mirrors upstream's narrow `isNodeEqual` set (`ThisExpression` / `Literal` / `Identifier` / `MemberExpression` only) — `PrivateIdentifier`, `TSAsExpression`-wrapped computed keys, etc. fail the similarity check, matching upstream behavior on real codebases.
- Comment-preserving `if`-statement fix matches upstream byte-for-byte across leading/trailing/inline/line/block/JSDoc/multi-line forms.

## Verification

- 675 Go sub-tests pass (parametric generators expand the upstream suite, plus extreme trivia/comment, real-world (React/Express/async/Map/Class private/JSX/tagged template/optional chain), tsgo edge cases).
- Cross-checked against upstream ESLint v10.2.1 + `@typescript-eslint/eslint-plugin` 8.59.1 (peer-supported by `^10.0.0`):
  - rsbuild: 117/117 reports — zero diff in `(file:line:column)` and message category.
  - rspack/src: 173/173 reports — zero diff.
- Verified no framework code was modified — only rule registration in `internal/config/config.go`, JS test enablement in `rstest.config.mts`, and the new rule package.

## Related Links

- ESLint rule: https://typescript-eslint.io/rules/prefer-nullish-coalescing
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).