### PR TITLE
feat: port rule no-restricted-syntax

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,6 +197,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_prototype_builtins"
 	"github.com/web-infra-dev/rslint/internal/rules/no_regex_spaces"
 	"github.com/web-infra-dev/rslint/internal/rules/no_restricted_imports"
+	"github.com/web-infra-dev/rslint/internal/rules/no_restricted_syntax"
 	"github.com/web-infra-dev/rslint/internal/rules/no_return_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_assign"
@@ -670,6 +671,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-new-func", no_new_func.NoNewFuncRule)
 	GlobalRuleRegistry.Register("no-new-wrappers", no_new_wrappers.NoNewWrappersRule)
 	GlobalRuleRegistry.Register("no-restricted-imports", no_restricted_imports.NoRestrictedImportsRule)
+	GlobalRuleRegistry.Register("no-restricted-syntax", no_restricted_syntax.NoRestrictedSyntaxRule)
 	GlobalRuleRegistry.Register("no-multi-assign", no_multi_assign.NoMultiAssignRule)
 	GlobalRuleRegistry.Register("no-multi-str", no_multi_str.NoMultiStrRule)
 	GlobalRuleRegistry.Register("no-nested-ternary", no_nested_ternary.NoNestedTernaryRule)

--- a/internal/rules/no_restricted_syntax/fields.go
+++ b/internal/rules/no_restricted_syntax/fields.go
@@ -1,0 +1,331 @@
+package no_restricted_syntax
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// nodesAtField enumerates the children of `parent` that sit at the named
+// ESTree-style field. The result may have zero, one, or multiple entries
+// depending on whether the field is a list-shaped collection. The matcher
+// uses this to evaluate `Foo.bar`-style class selectors.
+func nodesAtField(parent *ast.Node, field string) []*ast.Node {
+	switch field {
+	case "key":
+		switch parent.Kind {
+		case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment, ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindPropertyDeclaration:
+			return single(parent.Name())
+		}
+	case "value":
+		switch parent.Kind {
+		case ast.KindPropertyAssignment:
+			return single(parent.AsPropertyAssignment().Initializer)
+		case ast.KindPropertyDeclaration:
+			return single(parent.AsPropertyDeclaration().Initializer)
+		}
+	case "id":
+		switch parent.Kind {
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindClassDeclaration, ast.KindClassExpression, ast.KindVariableDeclaration:
+			return single(parent.Name())
+		}
+	case "init":
+		switch parent.Kind {
+		case ast.KindVariableDeclaration:
+			return single(parent.AsVariableDeclaration().Initializer)
+		case ast.KindBindingElement:
+			return single(parent.AsBindingElement().Initializer)
+		case ast.KindForStatement:
+			return single(parent.AsForStatement().Initializer)
+		}
+	case "test":
+		switch parent.Kind {
+		case ast.KindIfStatement:
+			return single(parent.AsIfStatement().Expression)
+		case ast.KindConditionalExpression:
+			return single(parent.AsConditionalExpression().Condition)
+		case ast.KindWhileStatement:
+			return single(parent.AsWhileStatement().Expression)
+		case ast.KindDoStatement:
+			return single(parent.AsDoStatement().Expression)
+		case ast.KindForStatement:
+			return single(parent.AsForStatement().Condition)
+		}
+	case "consequent":
+		switch parent.Kind {
+		case ast.KindIfStatement:
+			return single(parent.AsIfStatement().ThenStatement)
+		case ast.KindConditionalExpression:
+			return single(parent.AsConditionalExpression().WhenTrue)
+		}
+	case "alternate":
+		switch parent.Kind {
+		case ast.KindIfStatement:
+			return single(parent.AsIfStatement().ElseStatement)
+		case ast.KindConditionalExpression:
+			return single(parent.AsConditionalExpression().WhenFalse)
+		}
+	case "body":
+		switch parent.Kind {
+		case ast.KindFunctionDeclaration:
+			return single(parent.AsFunctionDeclaration().Body)
+		case ast.KindFunctionExpression:
+			return single(parent.AsFunctionExpression().Body)
+		case ast.KindArrowFunction:
+			return single(parent.AsArrowFunction().Body)
+		case ast.KindMethodDeclaration:
+			return single(parent.AsMethodDeclaration().Body)
+		case ast.KindIfStatement:
+			return single(parent.AsIfStatement().ThenStatement)
+		case ast.KindWhileStatement:
+			return single(parent.AsWhileStatement().Statement)
+		case ast.KindDoStatement:
+			return single(parent.AsDoStatement().Statement)
+		case ast.KindForStatement:
+			return single(parent.AsForStatement().Statement)
+		case ast.KindBlock:
+			return statements(parent.AsBlock().Statements)
+		case ast.KindSourceFile:
+			return statements(parent.AsSourceFile().Statements)
+		case ast.KindClassDeclaration:
+			return statements(parent.AsClassDeclaration().Members)
+		case ast.KindClassExpression:
+			return statements(parent.AsClassExpression().Members)
+		}
+	case "callee":
+		switch parent.Kind {
+		case ast.KindCallExpression:
+			return single(parent.AsCallExpression().Expression)
+		case ast.KindNewExpression:
+			return single(parent.AsNewExpression().Expression)
+		case ast.KindTaggedTemplateExpression:
+			return single(parent.AsTaggedTemplateExpression().Tag)
+		}
+	case "arguments":
+		switch parent.Kind {
+		case ast.KindCallExpression:
+			return statements(parent.AsCallExpression().Arguments)
+		case ast.KindNewExpression:
+			return statements(parent.AsNewExpression().Arguments)
+		}
+	case "expression":
+		switch parent.Kind {
+		case ast.KindExpressionStatement:
+			return single(parent.AsExpressionStatement().Expression)
+		case ast.KindParenthesizedExpression:
+			return single(parent.AsParenthesizedExpression().Expression)
+		}
+	case "object":
+		switch parent.Kind {
+		case ast.KindPropertyAccessExpression:
+			return single(parent.AsPropertyAccessExpression().Expression)
+		case ast.KindElementAccessExpression:
+			return single(parent.AsElementAccessExpression().Expression)
+		}
+	case "property":
+		switch parent.Kind {
+		case ast.KindPropertyAccessExpression:
+			return single(parent.AsPropertyAccessExpression().Name())
+		case ast.KindElementAccessExpression:
+			return single(parent.AsElementAccessExpression().ArgumentExpression)
+		}
+	case "source":
+		switch parent.Kind {
+		case ast.KindImportDeclaration:
+			return single(parent.AsImportDeclaration().ModuleSpecifier)
+		case ast.KindExportDeclaration:
+			return single(parent.AsExportDeclaration().ModuleSpecifier)
+		}
+	case "argument":
+		switch parent.Kind {
+		case ast.KindAwaitExpression:
+			return single(parent.AsAwaitExpression().Expression)
+		case ast.KindYieldExpression:
+			return single(parent.AsYieldExpression().Expression)
+		case ast.KindSpreadElement:
+			return single(parent.AsSpreadElement().Expression)
+		case ast.KindSpreadAssignment:
+			return single(parent.AsSpreadAssignment().Expression)
+		case ast.KindReturnStatement:
+			return single(parent.AsReturnStatement().Expression)
+		case ast.KindThrowStatement:
+			return single(parent.AsThrowStatement().Expression)
+		case ast.KindPrefixUnaryExpression:
+			return single(parent.AsPrefixUnaryExpression().Operand)
+		case ast.KindPostfixUnaryExpression:
+			return single(parent.AsPostfixUnaryExpression().Operand)
+		case ast.KindTypeOfExpression:
+			return single(parent.AsTypeOfExpression().Expression)
+		case ast.KindVoidExpression:
+			return single(parent.AsVoidExpression().Expression)
+		case ast.KindDeleteExpression:
+			return single(parent.AsDeleteExpression().Expression)
+		}
+	case "left":
+		switch parent.Kind {
+		case ast.KindBinaryExpression:
+			return single(parent.AsBinaryExpression().Left)
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			return single(parent.AsForInOrOfStatement().Initializer)
+		}
+	case "right":
+		switch parent.Kind {
+		case ast.KindBinaryExpression:
+			return single(parent.AsBinaryExpression().Right)
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			return single(parent.AsForInOrOfStatement().Expression)
+		}
+	case "label":
+		switch parent.Kind {
+		case ast.KindBreakStatement:
+			return single(parent.AsBreakStatement().Label)
+		case ast.KindContinueStatement:
+			return single(parent.AsContinueStatement().Label)
+		case ast.KindLabeledStatement:
+			return single(parent.AsLabeledStatement().Label)
+		}
+	case "block":
+		if parent.Kind == ast.KindTryStatement {
+			return single(parent.AsTryStatement().TryBlock)
+		}
+	case "handler":
+		if parent.Kind == ast.KindTryStatement {
+			return single(parent.AsTryStatement().CatchClause)
+		}
+	case "finalizer":
+		if parent.Kind == ast.KindTryStatement {
+			return single(parent.AsTryStatement().FinallyBlock)
+		}
+	case "param":
+		if parent.Kind == ast.KindCatchClause {
+			cc := parent.AsCatchClause()
+			if cc.VariableDeclaration != nil {
+				return single(cc.VariableDeclaration.AsVariableDeclaration().Name())
+			}
+		}
+	case "params":
+		params := parent.Parameters()
+		if params == nil {
+			return nil
+		}
+		return params
+	case "elements":
+		switch parent.Kind {
+		case ast.KindArrayLiteralExpression:
+			return statements(parent.AsArrayLiteralExpression().Elements)
+		case ast.KindArrayBindingPattern:
+			return statements(parent.AsBindingPattern().Elements)
+		case ast.KindNamedImports:
+			return statements(parent.AsNamedImports().Elements)
+		case ast.KindNamedExports:
+			return statements(parent.AsNamedExports().Elements)
+		}
+	case "properties":
+		switch parent.Kind {
+		case ast.KindObjectLiteralExpression:
+			return statements(parent.AsObjectLiteralExpression().Properties)
+		case ast.KindObjectBindingPattern:
+			return statements(parent.AsBindingPattern().Elements)
+		}
+	case "declarations":
+		if parent.Kind == ast.KindVariableStatement {
+			dl := parent.AsVariableStatement().DeclarationList
+			if dl != nil {
+				return statements(dl.AsVariableDeclarationList().Declarations)
+			}
+		}
+	case "specifiers":
+		switch parent.Kind {
+		case ast.KindImportDeclaration:
+			return collectImportSpecifiers(parent)
+		case ast.KindExportDeclaration:
+			return collectExportSpecifiers(parent)
+		}
+	}
+	return nil
+}
+
+// listChildrenOf returns every list-shaped collection on the parent. The
+// matcher's :nth-child evaluation iterates over these lists looking for
+// the searched node.
+func listChildrenOf(parent *ast.Node) [][]*ast.Node {
+	var out [][]*ast.Node
+	add := func(s []*ast.Node) {
+		if len(s) > 0 {
+			out = append(out, s)
+		}
+	}
+	switch parent.Kind {
+	case ast.KindSourceFile:
+		add(statements(parent.AsSourceFile().Statements))
+	case ast.KindBlock:
+		add(statements(parent.AsBlock().Statements))
+	case ast.KindArrayLiteralExpression:
+		add(statements(parent.AsArrayLiteralExpression().Elements))
+	case ast.KindObjectLiteralExpression:
+		add(statements(parent.AsObjectLiteralExpression().Properties))
+	case ast.KindCallExpression:
+		add(statements(parent.AsCallExpression().Arguments))
+	case ast.KindNewExpression:
+		add(statements(parent.AsNewExpression().Arguments))
+	case ast.KindClassDeclaration:
+		add(statements(parent.AsClassDeclaration().Members))
+	case ast.KindClassExpression:
+		add(statements(parent.AsClassExpression().Members))
+	case ast.KindNamedImports:
+		add(statements(parent.AsNamedImports().Elements))
+	case ast.KindNamedExports:
+		add(statements(parent.AsNamedExports().Elements))
+	case ast.KindArrayBindingPattern, ast.KindObjectBindingPattern:
+		add(statements(parent.AsBindingPattern().Elements))
+	case ast.KindCaseClause, ast.KindDefaultClause:
+		add(statements(parent.AsCaseOrDefaultClause().Statements))
+	case ast.KindCaseBlock:
+		add(statements(parent.AsCaseBlock().Clauses))
+	case ast.KindVariableDeclarationList:
+		add(statements(parent.AsVariableDeclarationList().Declarations))
+	}
+	if isFunctionLikeForParams(parent) {
+		if params := parent.Parameters(); len(params) > 0 {
+			add(params)
+		}
+	}
+	return out
+}
+
+// isFunctionLikeForParams gates the unconditional Parameters() call in
+// listChildrenOf — Node.Parameters() panics for kinds that don't carry a
+// parameter list (everything except function-like declarations).
+func isFunctionLikeForParams(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression,
+		ast.KindArrowFunction,
+		ast.KindMethodDeclaration,
+		ast.KindConstructor,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor,
+		ast.KindFunctionType,
+		ast.KindConstructorType,
+		ast.KindCallSignature,
+		ast.KindConstructSignature,
+		ast.KindMethodSignature,
+		ast.KindIndexSignature:
+		return true
+	}
+	return false
+}
+
+func single(n *ast.Node) []*ast.Node {
+	if n == nil {
+		return nil
+	}
+	return []*ast.Node{n}
+}
+
+func statements(list *ast.NodeList) []*ast.Node {
+	if list == nil {
+		return nil
+	}
+	out := make([]*ast.Node, 0, len(list.Nodes))
+	out = append(out, list.Nodes...)
+	return out
+}

--- a/internal/rules/no_restricted_syntax/mapping.go
+++ b/internal/rules/no_restricted_syntax/mapping.go
@@ -1,0 +1,195 @@
+package no_restricted_syntax
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// estreeKindMap maps an ESTree node-type name to the tsgo ast.Kind values it
+// can match. ESLint selectors are written against ESTree, so this is the
+// translation table the matcher consults when comparing a selector
+// identifier against a tsgo node.
+//
+// A few ESTree types map to multiple tsgo kinds because tsgo splits cases
+// that ESTree fuses (for example, `Property` covers PropertyAssignment +
+// ShorthandPropertyAssignment + MethodDeclaration + Get/Set accessors, and
+// `Literal` covers every literal-kind variant). The matcher treats this map
+// as exhaustive — kinds not listed here cannot match the corresponding
+// ESTree name.
+var estreeKindMap = map[string][]ast.Kind{
+	// Top-level
+	"Program":    {ast.KindSourceFile},
+	"SourceFile": {ast.KindSourceFile},
+
+	// Statements
+	"BlockStatement":      {ast.KindBlock},
+	"BreakStatement":      {ast.KindBreakStatement},
+	"ContinueStatement":   {ast.KindContinueStatement},
+	"DebuggerStatement":   {ast.KindDebuggerStatement},
+	"DoWhileStatement":    {ast.KindDoStatement},
+	"EmptyStatement":      {ast.KindEmptyStatement},
+	"ExpressionStatement": {ast.KindExpressionStatement},
+	"ForInStatement":      {ast.KindForInStatement},
+	"ForOfStatement":      {ast.KindForOfStatement},
+	"ForStatement":        {ast.KindForStatement},
+	"IfStatement":         {ast.KindIfStatement},
+	"LabeledStatement":    {ast.KindLabeledStatement},
+	"ReturnStatement":     {ast.KindReturnStatement},
+	"SwitchStatement":     {ast.KindSwitchStatement},
+	"ThrowStatement":      {ast.KindThrowStatement},
+	"TryStatement":        {ast.KindTryStatement},
+	"WhileStatement":      {ast.KindWhileStatement},
+	"WithStatement":       {ast.KindWithStatement},
+
+	// Switch parts
+	"SwitchCase": {ast.KindCaseClause, ast.KindDefaultClause},
+
+	// Variable & function declarations
+	// ESTree's VariableDeclaration is the statement-level node (`var a = 1;`).
+	// tsgo represents that with VariableStatement; the inner declarators
+	// become VariableDeclaration nodes (mapped as VariableDeclarator below).
+	"VariableDeclaration":     {ast.KindVariableStatement},
+	"VariableDeclarator":      {ast.KindVariableDeclaration},
+	"FunctionDeclaration":     {ast.KindFunctionDeclaration},
+	"FunctionExpression":      {ast.KindFunctionExpression},
+	"ArrowFunctionExpression": {ast.KindArrowFunction},
+
+	// Classes
+	"ClassDeclaration":   {ast.KindClassDeclaration},
+	"ClassExpression":    {ast.KindClassExpression},
+	"MethodDefinition":   {ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor},
+	"PropertyDefinition": {ast.KindPropertyDeclaration},
+	"StaticBlock":        {ast.KindClassStaticBlockDeclaration},
+	"Decorator":          {ast.KindDecorator},
+
+	// Expressions
+	"ArrayExpression":          {ast.KindArrayLiteralExpression},
+	"AssignmentExpression":     {ast.KindBinaryExpression}, // matcher checks operator
+	"AwaitExpression":          {ast.KindAwaitExpression},
+	"BinaryExpression":         {ast.KindBinaryExpression}, // matcher checks operator
+	"CallExpression":           {ast.KindCallExpression},
+	"ChainExpression":          {ast.KindPropertyAccessExpression, ast.KindElementAccessExpression, ast.KindCallExpression, ast.KindNonNullExpression},
+	"ConditionalExpression":    {ast.KindConditionalExpression},
+	"LogicalExpression":        {ast.KindBinaryExpression}, // matcher checks operator
+	"MemberExpression":         {ast.KindPropertyAccessExpression, ast.KindElementAccessExpression},
+	"MetaProperty":             {ast.KindMetaProperty},
+	"NewExpression":            {ast.KindNewExpression},
+	"ObjectExpression":         {ast.KindObjectLiteralExpression},
+	"SequenceExpression":       {ast.KindBinaryExpression}, // matcher checks operator (comma)
+	"SpreadElement":            {ast.KindSpreadElement, ast.KindSpreadAssignment},
+	"Super":                    {ast.KindSuperKeyword},
+	"TaggedTemplateExpression": {ast.KindTaggedTemplateExpression},
+	"TemplateElement":          {ast.KindTemplateHead, ast.KindTemplateMiddle, ast.KindTemplateTail},
+	"TemplateLiteral":          {ast.KindNoSubstitutionTemplateLiteral, ast.KindTemplateExpression},
+	"ThisExpression":           {ast.KindThisKeyword},
+	"UnaryExpression":          {ast.KindPrefixUnaryExpression, ast.KindTypeOfExpression, ast.KindVoidExpression, ast.KindDeleteExpression},
+	"UpdateExpression":         {ast.KindPrefixUnaryExpression, ast.KindPostfixUnaryExpression},
+	"YieldExpression":          {ast.KindYieldExpression},
+
+	// Literals
+	"Literal": {
+		ast.KindStringLiteral,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword,
+	},
+	"RegExpLiteral": {ast.KindRegularExpressionLiteral},
+
+	// Identifiers
+	"Identifier":        {ast.KindIdentifier},
+	"PrivateIdentifier": {ast.KindPrivateIdentifier},
+
+	// Object literal members
+	"Property": {
+		ast.KindPropertyAssignment,
+		ast.KindShorthandPropertyAssignment,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor,
+	},
+
+	// Patterns
+	"ArrayPattern":      {ast.KindArrayBindingPattern},
+	"ObjectPattern":     {ast.KindObjectBindingPattern},
+	"RestElement":       {ast.KindBindingElement, ast.KindParameter},
+	"AssignmentPattern": {ast.KindBindingElement, ast.KindParameter},
+
+	// Catch
+	"CatchClause": {ast.KindCatchClause},
+
+	// Modules
+	"ImportDeclaration":        {ast.KindImportDeclaration},
+	"ImportSpecifier":          {ast.KindImportSpecifier},
+	"ImportDefaultSpecifier":   {ast.KindImportClause},
+	"ImportNamespaceSpecifier": {ast.KindNamespaceImport},
+	"ExportNamedDeclaration":   {ast.KindExportDeclaration},
+	"ExportDefaultDeclaration": {ast.KindExportAssignment},
+	"ExportAllDeclaration":     {ast.KindExportDeclaration},
+	"ExportSpecifier":          {ast.KindExportSpecifier},
+
+	// JSX (only meaningful when the file is parsed with JSX enabled)
+	"JSXElement":             {ast.KindJsxElement, ast.KindJsxSelfClosingElement},
+	"JSXFragment":            {ast.KindJsxFragment},
+	"JSXOpeningElement":      {ast.KindJsxOpeningElement, ast.KindJsxSelfClosingElement},
+	"JSXClosingElement":      {ast.KindJsxClosingElement},
+	"JSXOpeningFragment":     {ast.KindJsxOpeningFragment},
+	"JSXClosingFragment":     {ast.KindJsxClosingFragment},
+	"JSXAttribute":           {ast.KindJsxAttribute},
+	"JSXSpreadAttribute":     {ast.KindJsxSpreadAttribute},
+	"JSXExpressionContainer": {ast.KindJsxExpression},
+	"JSXText":                {ast.KindJsxText},
+	"JSXIdentifier":          {ast.KindIdentifier}, // identifiers inside JSX share the regular kind
+	"JSXNamespacedName":      {ast.KindJsxNamespacedName},
+}
+
+// kindsForEstreeName returns the tsgo kinds that match the given ESTree
+// type name. Returns nil if the name is unknown — the matcher treats
+// unknown names as never matching.
+func kindsForEstreeName(name string) []ast.Kind {
+	if kinds, ok := estreeKindMap[name]; ok {
+		return kinds
+	}
+	return nil
+}
+
+// allInterestingKinds is the universe of tsgo kinds the wildcard `*`
+// should listen on. We exclude pure trivia / token-only kinds the
+// framework's visitor never hands to listeners (e.g. punctuation) and
+// keep every syntactic kind that can show up as a node.
+//
+// The list is built lazily by enumerating estreeKindMap plus the small
+// set of TypeScript-specific kinds the map doesn't cover but that ought
+// to participate in `*` semantics.
+var allInterestingKinds = func() []ast.Kind {
+	seen := make(map[ast.Kind]struct{})
+	for _, kinds := range estreeKindMap {
+		for _, k := range kinds {
+			seen[k] = struct{}{}
+		}
+	}
+	// TypeScript-specific kinds that are common in real programs and
+	// that users might select with `*` ~ `*`-style wildcards.
+	extra := []ast.Kind{
+		ast.KindParenthesizedExpression,
+		ast.KindAsExpression,
+		ast.KindSatisfiesExpression,
+		ast.KindNonNullExpression,
+		ast.KindTypeAssertionExpression,
+		ast.KindTaggedTemplateExpression,
+		ast.KindParameter,
+		ast.KindPropertyAccessExpression,
+		ast.KindElementAccessExpression,
+		ast.KindBindingElement,
+		ast.KindSourceFile,
+	}
+	for _, k := range extra {
+		seen[k] = struct{}{}
+	}
+	out := make([]ast.Kind, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	return out
+}()

--- a/internal/rules/no_restricted_syntax/matcher.go
+++ b/internal/rules/no_restricted_syntax/matcher.go
@@ -1,0 +1,2114 @@
+package no_restricted_syntax
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/dlclark/regexp2"
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// matchContext threads the source file through the matcher so attribute
+// path resolution can reach the original source text (for attributes like
+// `regex.flags` or `source.value` that depend on the lexed form).
+type matchContext struct {
+	sf *ast.SourceFile
+}
+
+// kindSet is the result of computing the set of tsgo kinds a selector might
+// match. universe == true means "match every node, regardless of kind" —
+// used to avoid materializing the full set of kinds for `*` and pure
+// attribute selectors.
+type kindSet struct {
+	kinds    map[ast.Kind]struct{}
+	universe bool
+}
+
+func newKindSet() *kindSet {
+	return &kindSet{kinds: make(map[ast.Kind]struct{})}
+}
+
+func (s *kindSet) addAll(ks []ast.Kind) {
+	for _, k := range ks {
+		s.kinds[k] = struct{}{}
+	}
+}
+
+func (s *kindSet) markUniverse() {
+	s.universe = true
+	s.kinds = nil
+}
+
+// candidateKinds returns the set of tsgo ast.Kind values that a selector
+// might match. For selectors that constrain by attribute / pseudo only
+// (no leading kind), the universe flag is set and the listener should be
+// registered on every kind in allInterestingKinds.
+func candidateKinds(sel selector) *kindSet {
+	s := newKindSet()
+	collectKinds(sel, s)
+	return s
+}
+
+func collectKinds(sel selector, s *kindSet) {
+	switch v := sel.(type) {
+	case identifierSelector:
+		if v.Name == "*" {
+			s.markUniverse()
+			return
+		}
+		ks := kindsForEstreeName(v.Name)
+		if ks == nil {
+			// Unknown ESTree name — collapse to the empty set so that this
+			// selector is never registered. The user's selector simply
+			// doesn't apply to any tsgo node.
+			return
+		}
+		s.addAll(ks)
+	case classSelector:
+		collectKinds(v.Inner, s)
+	case attrSelector:
+		collectKinds(v.Inner, s)
+	case combinatorSelector:
+		// The right-hand side is the node being matched; the left side
+		// is an ancestor / sibling constraint we evaluate at match time.
+		collectKinds(v.Right, s)
+	case pseudoSelector:
+		switch v.Name {
+		case "is", "matches":
+			for _, a := range v.Args {
+				collectKinds(a, s)
+			}
+		case "not":
+			// `:not(...)` says nothing about the kind that matches — every
+			// kind could conceivably match. Mark universe.
+			s.markUniverse()
+		case "has":
+			s.markUniverse()
+		case "nth-child", "nth-last-child":
+			s.markUniverse()
+		}
+	case combinedPseudo:
+		collectKinds(v.Inner, s)
+	case unionSelector:
+		for _, a := range v.Selectors {
+			collectKinds(a, s)
+		}
+	}
+}
+
+// matches reports whether sel matches the supplied tsgo AST node.
+func matches(sel selector, node *ast.Node, mc *matchContext) bool {
+	switch v := sel.(type) {
+	case identifierSelector:
+		return matchesIdentifier(v.Name, node)
+	case classSelector:
+		if !matches(v.Inner, node, mc) {
+			return false
+		}
+		return matchesClass(node, v.Class)
+	case attrSelector:
+		if !matches(v.Inner, node, mc) {
+			return false
+		}
+		return matchesAttr(node, v.Path, v.Op, v.Value, mc)
+	case combinatorSelector:
+		if !matches(v.Right, node, mc) {
+			return false
+		}
+		return matchesCombinator(v, node, mc)
+	case pseudoSelector:
+		return matchesPseudo(v, node, mc)
+	case combinedPseudo:
+		if !matches(v.Inner, node, mc) {
+			return false
+		}
+		return matchesPseudo(v.Pseudo, node, mc)
+	case unionSelector:
+		for _, a := range v.Selectors {
+			if matches(a, node, mc) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// matchesIdentifier evaluates the bare type-name portion of a selector.
+// "*" matches everything; ESTree-mapped names match their tsgo kinds with
+// extra refinement for kinds that fuse multiple ESTree shapes.
+func matchesIdentifier(name string, node *ast.Node) bool {
+	if name == "*" {
+		return true
+	}
+	ks := kindsForEstreeName(name)
+	if ks == nil {
+		return false
+	}
+	matchedKind := false
+	for _, k := range ks {
+		if node.Kind == k {
+			matchedKind = true
+			break
+		}
+	}
+	if !matchedKind {
+		return false
+	}
+	return refineEstreeMatch(name, node)
+}
+
+// refineEstreeMatch tightens the tsgo→ESTree match for kinds that tsgo
+// fuses but ESTree splits. For example, tsgo's BinaryExpression covers the
+// ESTree triplet of BinaryExpression / LogicalExpression / AssignmentExpression
+// / SequenceExpression — the operator decides which ESTree form it really is.
+func refineEstreeMatch(name string, node *ast.Node) bool {
+	switch name {
+	case "BinaryExpression":
+		return node.Kind == ast.KindBinaryExpression && isPlainBinaryOperator(node)
+	case "LogicalExpression":
+		return node.Kind == ast.KindBinaryExpression && isLogicalOperator(node)
+	case "AssignmentExpression":
+		return node.Kind == ast.KindBinaryExpression && isAssignmentOperator(node)
+	case "SequenceExpression":
+		return node.Kind == ast.KindBinaryExpression && isCommaOperator(node)
+	case "ChainExpression":
+		// ESTree wraps the entire optional chain in a single
+		// ChainExpression node. tsgo has no analogue, so we match the
+		// outermost link in the chain — the highest node that is itself
+		// part of the chain but whose parent is not.
+		// `ast.IsOutermostOptionalChain` is too permissive for this
+		// purpose (it's true for the link directly under any `?.`-token
+		// wrapper, which still emits an inner Match in `a?.b?.()`).
+		return ast.IsOptionalChain(node) && (node.Parent == nil || !ast.IsOptionalChain(node.Parent))
+	case "UnaryExpression":
+		// ESTree's UnaryExpression wraps `+`, `-`, `!`, `~`, `typeof`, `void`,
+		// `delete`. ESTree's UpdateExpression wraps `++`/`--`. tsgo splits
+		// `++`/`--` into PrefixUnary/PostfixUnary alongside other prefix
+		// operators, so we filter on the operator token.
+		switch node.Kind {
+		case ast.KindTypeOfExpression, ast.KindVoidExpression, ast.KindDeleteExpression:
+			return true
+		case ast.KindPrefixUnaryExpression:
+			op := node.AsPrefixUnaryExpression().Operator
+			return op != ast.KindPlusPlusToken && op != ast.KindMinusMinusToken
+		}
+		return false
+	case "UpdateExpression":
+		switch node.Kind {
+		case ast.KindPostfixUnaryExpression:
+			return true
+		case ast.KindPrefixUnaryExpression:
+			op := node.AsPrefixUnaryExpression().Operator
+			return op == ast.KindPlusPlusToken || op == ast.KindMinusMinusToken
+		}
+		return false
+	case "RestElement":
+		// ESTree's RestElement covers two tsgo shapes:
+		//   - BindingElement with `...` inside an array/object pattern
+		//   - Parameter with `...` in a function parameter list
+		switch node.Kind {
+		case ast.KindBindingElement:
+			return node.AsBindingElement().DotDotDotToken != nil
+		case ast.KindParameter:
+			return node.AsParameterDeclaration().DotDotDotToken != nil
+		}
+		return false
+	case "Property":
+		// ESTree distinguishes object-literal members (Property) from
+		// class members (MethodDefinition). tsgo fuses them. A method,
+		// getter or setter is only a "Property" when it sits inside an
+		// ObjectLiteralExpression.
+		switch node.Kind {
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+			return node.Parent != nil && node.Parent.Kind == ast.KindObjectLiteralExpression
+		}
+		return true
+	case "MethodDefinition":
+		// Mirror of "Property": MethodDefinition only fires for methods
+		// / accessors inside a class body. KindConstructor is class-only
+		// by construction, so always passes.
+		switch node.Kind {
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+			if node.Parent == nil {
+				return false
+			}
+			pk := node.Parent.Kind
+			return pk == ast.KindClassDeclaration || pk == ast.KindClassExpression
+		case ast.KindConstructor:
+			return true
+		}
+		return false
+	case "AssignmentPattern":
+		// ESTree's AssignmentPattern covers default-value bindings:
+		//   - BindingElement `{ a = 1 }` / `[a = 1]`
+		//   - Parameter `function f(a = 1) {}`
+		switch node.Kind {
+		case ast.KindBindingElement:
+			be := node.AsBindingElement()
+			return be.Initializer != nil && be.DotDotDotToken == nil
+		case ast.KindParameter:
+			pd := node.AsParameterDeclaration()
+			return pd.Initializer != nil && pd.DotDotDotToken == nil
+		}
+		return false
+	case "SpreadElement":
+		// ESTree differentiates spread-in-array from spread-in-object
+		// (the latter is SpreadElement in arrays, SpreadElement in calls,
+		// and `Property { kind: 'init' }`-like spread in objects). tsgo
+		// uses two kinds. Both map to ESTree's SpreadElement here so we
+		// accept both without further refinement.
+		return node.Kind == ast.KindSpreadElement || node.Kind == ast.KindSpreadAssignment
+	}
+	return true
+}
+
+func isPlainBinaryOperator(node *ast.Node) bool {
+	op := node.AsBinaryExpression().OperatorToken.Kind
+	if isAssignmentOperatorKind(op) {
+		return false
+	}
+	if isLogicalOperatorKind(op) {
+		return false
+	}
+	if op == ast.KindCommaToken {
+		return false
+	}
+	return true
+}
+
+func isLogicalOperator(node *ast.Node) bool {
+	return isLogicalOperatorKind(node.AsBinaryExpression().OperatorToken.Kind)
+}
+
+func isAssignmentOperator(node *ast.Node) bool {
+	return isAssignmentOperatorKind(node.AsBinaryExpression().OperatorToken.Kind)
+}
+
+func isCommaOperator(node *ast.Node) bool {
+	return node.AsBinaryExpression().OperatorToken.Kind == ast.KindCommaToken
+}
+
+func isLogicalOperatorKind(k ast.Kind) bool {
+	switch k {
+	case ast.KindAmpersandAmpersandToken, ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+		return true
+	}
+	return false
+}
+
+func isAssignmentOperatorKind(k ast.Kind) bool {
+	switch k {
+	case ast.KindEqualsToken,
+		ast.KindPlusEqualsToken,
+		ast.KindMinusEqualsToken,
+		ast.KindAsteriskEqualsToken,
+		ast.KindAsteriskAsteriskEqualsToken,
+		ast.KindSlashEqualsToken,
+		ast.KindPercentEqualsToken,
+		ast.KindLessThanLessThanEqualsToken,
+		ast.KindGreaterThanGreaterThanEqualsToken,
+		ast.KindGreaterThanGreaterThanGreaterThanEqualsToken,
+		ast.KindAmpersandEqualsToken,
+		ast.KindBarEqualsToken,
+		ast.KindCaretEqualsToken,
+		ast.KindAmpersandAmpersandEqualsToken,
+		ast.KindBarBarEqualsToken,
+		ast.KindQuestionQuestionEqualsToken:
+		return true
+	}
+	return false
+}
+
+// matchesClass evaluates `Foo.bar` — Foo already matched by the inner
+// selector, here we check that the node sits at the named field of its
+// parent.
+func matchesClass(node *ast.Node, class string) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	return nodeIsAtField(node, parent, class)
+}
+
+// matchesAttr resolves the attribute path against the node and compares
+// the obtained value with the operator/right-hand side of the selector.
+func matchesAttr(node *ast.Node, path []string, op attrOp, value attrValue, mc *matchContext) bool {
+	val, ok := lookupAttrPath(node, path, mc)
+	if op == attrPresent {
+		// Presence: any non-zero, non-nil value passes.
+		if !ok {
+			return false
+		}
+		return attrTruthy(val)
+	}
+	if !ok {
+		return false
+	}
+	return compareAttr(val, op, value)
+}
+
+// matchesCombinator handles `>` (parent), descendant, `+` (prev sibling),
+// `~` (any prior sibling). The right-hand side has already been verified
+// against the current node before this function is called.
+func matchesCombinator(c combinatorSelector, node *ast.Node, mc *matchContext) bool {
+	switch c.Kind {
+	case combChild:
+		// ESTree wraps `export default <decl>` in an
+		// ExportDefaultDeclaration node. tsgo flattens this — a default-
+		// exported FunctionDeclaration / ClassDeclaration sits directly
+		// under SourceFile with `export default` modifiers. To honour
+		// `ExportDefaultDeclaration > FunctionDeclaration`-style
+		// selectors, treat such a declaration as if it had a virtual
+		// ExportDefaultDeclaration parent.
+		if isDefaultExportedDeclaration(node) {
+			if selectorMatchesVirtualExportDefault(c.Left) {
+				return true
+			}
+		}
+		parent := node.Parent
+		if parent == nil {
+			return false
+		}
+		return matches(c.Left, parent, mc)
+	case combDescendant:
+		if isDefaultExportedDeclaration(node) && selectorMatchesVirtualExportDefault(c.Left) {
+			return true
+		}
+		current := node.Parent
+		for current != nil {
+			if matches(c.Left, current, mc) {
+				return true
+			}
+			current = current.Parent
+		}
+		return false
+	case combAdjacent, combSibling:
+		parent := node.Parent
+		if parent == nil {
+			return false
+		}
+		// esquery's sibling combinators only consider list-position
+		// siblings — nodes sharing the same NodeList field on the
+		// parent. Two scalar children of the same parent (e.g.
+		// VariableDeclaration's `id` and `init`) are NOT siblings.
+		var siblings []*ast.Node
+		for _, list := range listChildrenOf(parent) {
+			for _, child := range list {
+				if child == node {
+					siblings = list
+					break
+				}
+			}
+			if siblings != nil {
+				break
+			}
+		}
+		if siblings == nil {
+			return false
+		}
+		idx := -1
+		for i, sib := range siblings {
+			if sib == node {
+				idx = i
+				break
+			}
+		}
+		if idx <= 0 {
+			return false
+		}
+		if c.Kind == combAdjacent {
+			return matches(c.Left, siblings[idx-1], mc)
+		}
+		for i := idx - 1; i >= 0; i-- {
+			if matches(c.Left, siblings[i], mc) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+func matchesPseudo(p pseudoSelector, node *ast.Node, mc *matchContext) bool {
+	switch p.Name {
+	case "is", "matches":
+		for _, a := range p.Args {
+			if matches(a, node, mc) {
+				return true
+			}
+		}
+		return false
+	case "not":
+		for _, a := range p.Args {
+			if matches(a, node, mc) {
+				return false
+			}
+		}
+		return true
+	case "has":
+		for _, a := range p.Args {
+			if hasDescendantMatching(node, a, mc) {
+				return true
+			}
+		}
+		return false
+	case "nth-child":
+		idx, _ := nodeIndexInListField(node)
+		return idx >= 0 && idx == p.N-1
+	case "nth-last-child":
+		idx, total := nodeIndexInListField(node)
+		if idx < 0 {
+			return false
+		}
+		return total-idx == p.N
+	}
+	return false
+}
+
+func hasDescendantMatching(node *ast.Node, sel selector, mc *matchContext) bool {
+	found := false
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if found {
+			return true
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			if matches(sel, child, mc) {
+				found = true
+				return true
+			}
+			return visit(child)
+		})
+		return found
+	}
+	visit(node)
+	return found
+}
+
+// nodeIsAtField returns whether `node` is positioned at the named ESTree
+// field on `parent`. Resolution uses the field-mapping helpers (see
+// fields.go).
+func nodeIsAtField(node, parent *ast.Node, field string) bool {
+	candidates := nodesAtField(parent, field)
+	for _, c := range candidates {
+		if c == node {
+			return true
+		}
+	}
+	return false
+}
+
+// lookupAttrPath walks `path` against `node` to fetch a comparable value.
+// Each segment may resolve to an inner node or a primitive. Intermediate
+// failures return ok=false.
+func lookupAttrPath(node *ast.Node, path []string, mc *matchContext) (interface{}, bool) {
+	var current interface{} = node
+	for _, segment := range path {
+		next, ok := stepAttrPath(current, segment, mc)
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+	return current, true
+}
+
+func stepAttrPath(current interface{}, segment string, mc *matchContext) (interface{}, bool) {
+	if n, ok := current.(*ast.Node); ok {
+		return readNodeAttr(n, segment, mc)
+	}
+	if rf, ok := current.(regexFacade); ok {
+		switch segment {
+		case "flags":
+			_, flags := splitRegexLiteral(regexLiteralText(rf.node, rf.mc))
+			return flags, true
+		case "pattern":
+			pat, _ := splitRegexLiteral(regexLiteralText(rf.node, rf.mc))
+			return pat, true
+		}
+		return nil, false
+	}
+	if mi, ok := current.(metaIdentifier); ok {
+		switch segment {
+		case "name":
+			return mi.name, true
+		case "type":
+			return "Identifier", true
+		}
+		return nil, false
+	}
+	// Primitive interpretations: support `.length` on strings / slices.
+	if segment == "length" {
+		switch v := current.(type) {
+		case string:
+			return float64(len([]rune(v))), true
+		case []*ast.Node:
+			return float64(len(v)), true
+		}
+	}
+	return nil, false
+}
+
+// attrTruthy evaluates the truthiness of an attribute value the same way
+// JavaScript would, so that bare attribute presence (`[label]`) only
+// matches when the value is non-empty / non-zero / non-nil.
+func attrTruthy(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+	switch x := v.(type) {
+	case bool:
+		return x
+	case string:
+		return x != ""
+	case float64:
+		return x != 0
+	case *ast.Node:
+		return x != nil
+	case []*ast.Node:
+		return len(x) > 0
+	}
+	return true
+}
+
+func compareAttr(left interface{}, op attrOp, right attrValue) bool {
+	switch op {
+	case attrEqual:
+		return attrEquals(left, right)
+	case attrNotEqual:
+		return !attrEquals(left, right)
+	case attrLess, attrLessOrEqual, attrGreater, attrGreaterOrEqual:
+		l, ok := numericFromAttr(left)
+		if !ok {
+			return false
+		}
+		var r float64
+		switch right.Kind {
+		case attrValueNumber:
+			r = right.Num
+		default:
+			return false
+		}
+		switch op {
+		case attrLess:
+			return l < r
+		case attrLessOrEqual:
+			return l <= r
+		case attrGreater:
+			return l > r
+		case attrGreaterOrEqual:
+			return l >= r
+		}
+	}
+	return false
+}
+
+func numericFromAttr(v interface{}) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int:
+		return float64(x), true
+	case string:
+		n, err := strconv.ParseFloat(x, 64)
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	}
+	return 0, false
+}
+
+func attrEquals(left interface{}, right attrValue) bool {
+	switch right.Kind {
+	case attrValueString:
+		return attrAsString(left) == right.Str
+	case attrValueNumber:
+		n, ok := numericFromAttr(left)
+		return ok && n == right.Num
+	case attrValueBool:
+		b, ok := left.(bool)
+		return ok && b == right.Bool
+	case attrValueNull:
+		return left == nil
+	case attrValueIdent:
+		return attrAsString(left) == right.Ident
+	case attrValueRegex:
+		s := attrAsString(left)
+		re, err := regexp2.Compile(right.Regex, regexpFlags(right.Flags))
+		if err != nil {
+			return false
+		}
+		ok, _ := re.MatchString(s)
+		return ok
+	}
+	return false
+}
+
+func regexpFlags(flags string) regexp2.RegexOptions {
+	var opts regexp2.RegexOptions
+	for _, c := range flags {
+		switch c {
+		case 'i':
+			opts |= regexp2.IgnoreCase
+		case 's':
+			opts |= regexp2.Singleline
+		case 'm':
+			opts |= regexp2.Multiline
+		}
+	}
+	return opts
+}
+
+func attrAsString(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case float64:
+		// Match JavaScript's "1" not "1.0" formatting.
+		if x == float64(int64(x)) {
+			return strconv.FormatInt(int64(x), 10)
+		}
+		return strconv.FormatFloat(x, 'g', -1, 64)
+	case nil:
+		return ""
+	}
+	return ""
+}
+
+// nodeIndexInListField returns (idx, total) for a node that sits inside
+// a NodeList field of its parent. esquery's `:nth-child` only counts
+// positions within array-shaped fields (e.g. `Program.body`,
+// `CallExpression.arguments`) — a node sitting at a scalar field
+// (`ExpressionStatement.expression`, `MemberExpression.object`) is not
+// considered a positional child and never matches.
+func nodeIndexInListField(node *ast.Node) (int, int) {
+	parent := node.Parent
+	if parent == nil {
+		return -1, 0
+	}
+	for _, list := range listChildrenOf(parent) {
+		for i, child := range list {
+			if child == node {
+				return i, len(list)
+			}
+		}
+	}
+	return -1, 0
+}
+
+// isDefaultExportedDeclaration reports whether `node` carries the
+// `export default` modifier combo that tsgo attaches directly to a
+// declaration (instead of wrapping the declaration in an
+// ExportDefaultDeclaration as ESTree does).
+func isDefaultExportedDeclaration(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration, ast.KindClassDeclaration:
+	default:
+		return false
+	}
+	return ast.HasSyntacticModifier(node, ast.ModifierFlagsExportDefault)
+}
+
+// selectorMatchesVirtualExportDefault reports whether the given selector
+// would match a synthetic ExportDefaultDeclaration node — used to honour
+// `ExportDefaultDeclaration > X` selectors when the tsgo node sits
+// directly under SourceFile but ESTree would place it under an
+// ExportDefaultDeclaration wrapper.
+func selectorMatchesVirtualExportDefault(sel selector) bool {
+	switch v := sel.(type) {
+	case identifierSelector:
+		return v.Name == "*" || v.Name == "ExportDefaultDeclaration"
+	case unionSelector:
+		for _, a := range v.Selectors {
+			if selectorMatchesVirtualExportDefault(a) {
+				return true
+			}
+		}
+	case combinedPseudo:
+		if selectorMatchesVirtualExportDefault(v.Inner) {
+			// `:not` cannot be evaluated reliably against a virtual
+			// node — ESLint's behaviour is well-defined only on real
+			// nodes, so treat the pseudo as conservatively passing.
+			return true
+		}
+	case pseudoSelector:
+		if v.Name == "is" || v.Name == "matches" {
+			for _, a := range v.Args {
+				if selectorMatchesVirtualExportDefault(a) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// unwrapExpression strips the tsgo-only "transparent" expression wrappers
+// (parentheses, type assertions, non-null, satisfies) so that attribute
+// paths like `object.name` see through them just like esquery does on
+// ESTree, where these wrappers don't exist (parens) or have different
+// shapes that esquery still walks. Without this, a real-world selector
+// like `MemberExpression[object.name='console']` would silently miss
+// `(console).log`, `(console as any).log`, `console!.log`.
+func unwrapExpression(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	for {
+		switch node.Kind {
+		case ast.KindParenthesizedExpression:
+			node = node.AsParenthesizedExpression().Expression
+		case ast.KindAsExpression:
+			node = node.AsAsExpression().Expression
+		case ast.KindSatisfiesExpression:
+			node = node.AsSatisfiesExpression().Expression
+		case ast.KindNonNullExpression:
+			node = node.AsNonNullExpression().Expression
+		case ast.KindTypeAssertionExpression:
+			node = node.AsTypeAssertion().Expression
+		default:
+			return node
+		}
+		if node == nil {
+			return nil
+		}
+	}
+}
+
+// readNodeAttr extracts the named ESTree-style attribute from a tsgo node.
+// Centralising the field map here makes it easy to widen support without
+// rewriting the matcher.
+func readNodeAttr(node *ast.Node, name string, mc *matchContext) (interface{}, bool) {
+	switch name {
+	case "type":
+		return estreeNameForKind(node), true
+	case "name":
+		return readNameAttr(node)
+	case "value":
+		return readValueAttr(node, mc)
+	case "raw":
+		return readRawAttr(node, mc)
+	case "operator":
+		return readOperatorAttr(node)
+	case "kind":
+		return readKindAttr(node)
+	case "optional":
+		// ESTree's `optional` is true only on the link that carries the
+		// literal `?.` token (e.g. `foo?.bar`, not the trailing `.baz`
+		// in `foo?.bar.baz`). tsgo's IsOptionalChainRoot encodes the
+		// same condition.
+		return ast.IsOptionalChainRoot(node), true
+	case "computed":
+		return readComputedAttr(node)
+	case "static":
+		return readStaticAttr(node)
+	case "shorthand":
+		return readShorthandAttr(node)
+	case "method":
+		return readMethodAttr(node)
+	case "superClass":
+		return readSuperClassAttr(node)
+	case "directive":
+		return readDirectiveAttr(node, mc)
+	case "update":
+		return readUpdateAttr(node)
+	case "expressions":
+		return readExpressionsAttr(node)
+	case "quasis":
+		return readQuasisAttr(node)
+	case "bigint":
+		return readBigintAttr(node, mc)
+	case "delegate":
+		return readDelegateAttr(node)
+	case "label":
+		return readLabelAttr(node)
+	case "regex":
+		return readRegexObject(node, mc)
+	case "flags":
+		return readRegexFlags(node, mc)
+	case "pattern":
+		return readRegexPattern(node, mc)
+	case "params":
+		return readParamsAttr(node)
+	case "length":
+		return float64(0), false
+	case "source":
+		return readSourceAttr(node)
+	case "callee":
+		return readCalleeAttr(node)
+	case "arguments":
+		return readArgumentsAttr(node)
+	case "expression":
+		return readExpressionAttr(node)
+	case "init":
+		return readInitAttr(node)
+	case "id":
+		return readIdAttr(node)
+	case "key":
+		return readKeyAttr(node)
+	case "left":
+		return readLeftAttr(node)
+	case "right":
+		return readRightAttr(node)
+	case "object":
+		return readObjectAttr(node)
+	case "property":
+		return readPropertyAttr(node)
+	case "test":
+		return readTestAttr(node)
+	case "consequent":
+		return readConsequentAttr(node)
+	case "alternate":
+		return readAlternateAttr(node)
+	case "body":
+		return readBodyAttr(node)
+	case "argument":
+		return readArgumentAttr(node)
+	case "prefix":
+		return readPrefixAttr(node)
+	case "async":
+		return readAsyncAttr(node)
+	case "generator":
+		return readGeneratorAttr(node)
+	case "specifiers":
+		return readSpecifiersAttr(node)
+	case "openingElement":
+		return readOpeningElementAttr(node)
+	case "closingElement":
+		return readClosingElementAttr(node)
+	case "attributes":
+		return readAttributesAttr(node)
+	case "children":
+		return readChildrenAttr(node)
+	case "tagName":
+		return readTagNameAttr(node)
+	case "param":
+		return readParamAttr(node)
+	case "imported":
+		return readImportedAttr(node)
+	case "local":
+		return readLocalAttr(node)
+	case "exported":
+		return readExportedAttr(node)
+	case "meta":
+		return readMetaAttr(node)
+	case "tag":
+		return readTagAttr(node)
+	case "quasi":
+		return readQuasiAttr(node)
+	}
+	return nil, false
+}
+
+func readOpeningElementAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind == ast.KindJsxElement {
+		return node.AsJsxElement().OpeningElement, true
+	}
+	return nil, false
+}
+
+func readClosingElementAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind == ast.KindJsxElement {
+		return node.AsJsxElement().ClosingElement, true
+	}
+	return nil, false
+}
+
+func readAttributesAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindJsxOpeningElement:
+		return node.AsJsxOpeningElement().Attributes, true
+	case ast.KindJsxSelfClosingElement:
+		return node.AsJsxSelfClosingElement().Attributes, true
+	}
+	return nil, false
+}
+
+func readChildrenAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind == ast.KindJsxElement {
+		c := node.AsJsxElement().Children
+		if c == nil {
+			return []*ast.Node{}, true
+		}
+		return append([]*ast.Node{}, c.Nodes...), true
+	}
+	return nil, false
+}
+
+// readTagNameAttr returns the JSX tag-name node — esquery exposes this as
+// `name` on JSXOpeningElement / JSXSelfClosingElement, but ESLint also
+// understands `tagName` for direct compatibility with TSGo-style ASTs.
+func readTagNameAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindJsxOpeningElement:
+		return node.AsJsxOpeningElement().TagName, true
+	case ast.KindJsxSelfClosingElement:
+		return node.AsJsxSelfClosingElement().TagName, true
+	case ast.KindJsxClosingElement:
+		return node.AsJsxClosingElement().TagName, true
+	}
+	return nil, false
+}
+
+func readParamAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind != ast.KindCatchClause {
+		return nil, false
+	}
+	cc := node.AsCatchClause()
+	if cc.VariableDeclaration == nil {
+		return nil, true // present but null — falsy for [param]
+	}
+	return cc.VariableDeclaration.AsVariableDeclaration().Name(), true
+}
+
+func readImportedAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind != ast.KindImportSpecifier {
+		return nil, false
+	}
+	is := node.AsImportSpecifier()
+	if is.PropertyName != nil {
+		return is.PropertyName, true
+	}
+	return is.Name(), true
+}
+
+func readLocalAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindImportSpecifier:
+		return node.AsImportSpecifier().Name(), true
+	case ast.KindImportClause:
+		return node.AsImportClause().Name(), true
+	case ast.KindNamespaceImport:
+		return node.AsNamespaceImport().Name(), true
+	case ast.KindExportSpecifier:
+		// ESTree's `local` is the source binding (the LHS of `as`).
+		// tsgo flips the storage: for `export { foo as bar }`, foo is
+		// PropertyName and bar is Name; for `export { foo }`, only Name
+		// is set (PropertyName is nil).
+		es := node.AsExportSpecifier()
+		if es.PropertyName != nil {
+			return es.PropertyName, true
+		}
+		return es.Name(), true
+	}
+	return nil, false
+}
+
+func readExportedAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind == ast.KindExportSpecifier {
+		// ESTree's `exported` is the export name (the RHS of `as`,
+		// or the only identifier when no `as` is present). tsgo's
+		// Name() always holds that value.
+		es := node.AsExportSpecifier()
+		return es.Name(), true
+	}
+	return nil, false
+}
+
+func readMetaAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind != ast.KindMetaProperty {
+		return nil, false
+	}
+	// ESTree's `meta` is the keyword identifier (e.g. `new` in
+	// `new.target`, `import` in `import.meta`). tsgo stores only the
+	// keyword Kind, so synthesize a string the matcher can compare
+	// against literal selectors like `[meta.name='new']` or
+	// `[meta.name='import']`.
+	switch node.AsMetaProperty().KeywordToken {
+	case ast.KindNewKeyword:
+		return metaIdentifier{name: "new"}, true
+	case ast.KindImportKeyword:
+		return metaIdentifier{name: "import"}, true
+	}
+	return nil, false
+}
+
+// metaIdentifier stands in for tsgo's missing Identifier wrapper around
+// the keyword token of a MetaProperty. It exposes a single `.name`
+// attribute so esquery-style paths like `meta.name='new'` resolve.
+type metaIdentifier struct {
+	name string
+}
+
+func readTagAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind == ast.KindTaggedTemplateExpression {
+		return node.AsTaggedTemplateExpression().Tag, true
+	}
+	return nil, false
+}
+
+func readQuasiAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind == ast.KindTaggedTemplateExpression {
+		return node.AsTaggedTemplateExpression().Template, true
+	}
+	return nil, false
+}
+
+// estreeNameForKind returns the ESTree type name for a tsgo node when one
+// can be unambiguously chosen. If multiple ESTree names map to the same
+// kind, the canonical one is returned.
+func estreeNameForKind(node *ast.Node) string {
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return "Identifier"
+	case ast.KindPrivateIdentifier:
+		return "PrivateIdentifier"
+	case ast.KindStringLiteral, ast.KindNumericLiteral, ast.KindBigIntLiteral, ast.KindRegularExpressionLiteral, ast.KindTrueKeyword, ast.KindFalseKeyword, ast.KindNullKeyword:
+		return "Literal"
+	case ast.KindArrowFunction:
+		return "ArrowFunctionExpression"
+	case ast.KindFunctionExpression:
+		return "FunctionExpression"
+	case ast.KindFunctionDeclaration:
+		return "FunctionDeclaration"
+	case ast.KindBlock:
+		return "BlockStatement"
+	case ast.KindVariableStatement:
+		return "VariableDeclaration"
+	case ast.KindVariableDeclaration:
+		return "VariableDeclarator"
+	case ast.KindVariableDeclarationList:
+		// tsgo wraps the declarators in VariableDeclarationList in three
+		// places: VariableStatement (already maps to "VariableDeclaration"),
+		// and ForStatement / ForInStatement / ForOfStatement initializers.
+		// In ESTree the for-loop position is itself a VariableDeclaration —
+		// without this mapping, `[left.type='VariableDeclaration']` on
+		// for-in selectors would silently fail.
+		return "VariableDeclaration"
+	case ast.KindBreakStatement:
+		return "BreakStatement"
+	case ast.KindContinueStatement:
+		return "ContinueStatement"
+	case ast.KindCatchClause:
+		return "CatchClause"
+	case ast.KindCallExpression:
+		return "CallExpression"
+	case ast.KindNewExpression:
+		return "NewExpression"
+	case ast.KindEmptyStatement:
+		return "EmptyStatement"
+	case ast.KindTryStatement:
+		return "TryStatement"
+	case ast.KindConditionalExpression:
+		return "ConditionalExpression"
+	case ast.KindBinaryExpression:
+		op := node.AsBinaryExpression().OperatorToken.Kind
+		if isAssignmentOperatorKind(op) {
+			return "AssignmentExpression"
+		}
+		if isLogicalOperatorKind(op) {
+			return "LogicalExpression"
+		}
+		if op == ast.KindCommaToken {
+			return "SequenceExpression"
+		}
+		return "BinaryExpression"
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		return "MemberExpression"
+	case ast.KindObjectLiteralExpression:
+		return "ObjectExpression"
+	case ast.KindArrayLiteralExpression:
+		return "ArrayExpression"
+	case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment:
+		return "Property"
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		// Disambiguate Property vs MethodDefinition by the lexical
+		// container: object literal → Property, class body → MethodDefinition.
+		if node.Parent != nil {
+			switch node.Parent.Kind {
+			case ast.KindClassDeclaration, ast.KindClassExpression:
+				return "MethodDefinition"
+			case ast.KindObjectLiteralExpression:
+				return "Property"
+			}
+		}
+		return "Property"
+	case ast.KindImportDeclaration:
+		return "ImportDeclaration"
+	case ast.KindClassDeclaration:
+		return "ClassDeclaration"
+	case ast.KindClassExpression:
+		return "ClassExpression"
+	// tsgo's split unary-like kinds map back onto ESTree's UnaryExpression
+	// (and update for ++/--). The synthetic `type` field on these nodes
+	// must therefore report the ESTree name so that path attributes like
+	// `[left.type='UnaryExpression']` work.
+	case ast.KindTypeOfExpression, ast.KindVoidExpression, ast.KindDeleteExpression:
+		return "UnaryExpression"
+	case ast.KindAwaitExpression:
+		return "AwaitExpression"
+	case ast.KindYieldExpression:
+		return "YieldExpression"
+	case ast.KindPrefixUnaryExpression:
+		op := node.AsPrefixUnaryExpression().Operator
+		if op == ast.KindPlusPlusToken || op == ast.KindMinusMinusToken {
+			return "UpdateExpression"
+		}
+		return "UnaryExpression"
+	case ast.KindPostfixUnaryExpression:
+		return "UpdateExpression"
+	case ast.KindParenthesizedExpression:
+		// ESTree drops parens, so a node walking via `type` ought to see
+		// the inner expression's type instead.
+		return estreeNameForKind(unwrapExpression(node))
+	case ast.KindAsExpression, ast.KindSatisfiesExpression, ast.KindNonNullExpression, ast.KindTypeAssertionExpression:
+		return estreeNameForKind(unwrapExpression(node))
+	case ast.KindThisKeyword:
+		return "ThisExpression"
+	case ast.KindSuperKeyword:
+		return "Super"
+	case ast.KindSpreadElement, ast.KindSpreadAssignment:
+		return "SpreadElement"
+	case ast.KindTaggedTemplateExpression:
+		return "TaggedTemplateExpression"
+	case ast.KindNoSubstitutionTemplateLiteral, ast.KindTemplateExpression:
+		return "TemplateLiteral"
+	case ast.KindForInStatement:
+		return "ForInStatement"
+	case ast.KindForOfStatement:
+		return "ForOfStatement"
+	case ast.KindForStatement:
+		return "ForStatement"
+	case ast.KindIfStatement:
+		return "IfStatement"
+	case ast.KindWhileStatement:
+		return "WhileStatement"
+	case ast.KindDoStatement:
+		return "DoWhileStatement"
+	case ast.KindReturnStatement:
+		return "ReturnStatement"
+	case ast.KindThrowStatement:
+		return "ThrowStatement"
+	case ast.KindSwitchStatement:
+		return "SwitchStatement"
+	case ast.KindWithStatement:
+		return "WithStatement"
+	case ast.KindLabeledStatement:
+		return "LabeledStatement"
+	case ast.KindDebuggerStatement:
+		return "DebuggerStatement"
+	case ast.KindExpressionStatement:
+		return "ExpressionStatement"
+	case ast.KindCaseClause, ast.KindDefaultClause:
+		return "SwitchCase"
+	case ast.KindSourceFile:
+		return "Program"
+	case ast.KindMetaProperty:
+		return "MetaProperty"
+	case ast.KindPropertyDeclaration:
+		return "PropertyDefinition"
+	case ast.KindConstructor:
+		return "MethodDefinition"
+	case ast.KindClassStaticBlockDeclaration:
+		return "StaticBlock"
+	case ast.KindArrayBindingPattern:
+		return "ArrayPattern"
+	case ast.KindObjectBindingPattern:
+		return "ObjectPattern"
+	}
+	return ""
+}
+
+func readNameAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text, true
+	case ast.KindPrivateIdentifier:
+		return node.AsPrivateIdentifier().Text, true
+	// JSX: ESTree calls the tag identifier `name`; tsgo stores it as
+	// TagName. Also expose it through this attribute path.
+	case ast.KindJsxOpeningElement:
+		return node.AsJsxOpeningElement().TagName, true
+	case ast.KindJsxSelfClosingElement:
+		return node.AsJsxSelfClosingElement().TagName, true
+	case ast.KindJsxClosingElement:
+		return node.AsJsxClosingElement().TagName, true
+	case ast.KindJsxAttribute:
+		// ESTree's JSXAttribute.name is a JSXIdentifier; tsgo stores
+		// the attribute name on the unexported `name` field accessed
+		// through Name().
+		return node.AsJsxAttribute().Name(), true
+	}
+	return nil, false
+}
+
+func readValueAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text, true
+	case ast.KindNumericLiteral:
+		text := node.AsNumericLiteral().Text
+		if n, err := strconv.ParseFloat(text, 64); err == nil {
+			return n, true
+		}
+		return text, true
+	case ast.KindBigIntLiteral:
+		return node.AsBigIntLiteral().Text, true
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text, true
+	case ast.KindTrueKeyword:
+		return true, true
+	case ast.KindFalseKeyword:
+		return false, true
+	case ast.KindNullKeyword:
+		return nil, true
+	// ESTree's Property.value is the right-hand expression
+	// (`a: <value>`). tsgo stores it on PropertyAssignment.Initializer.
+	case ast.KindPropertyAssignment:
+		return unwrapExpression(node.AsPropertyAssignment().Initializer), true
+	// ESTree's PropertyDefinition.value is the field initializer; null
+	// when uninitialised. tsgo's PropertyDeclaration uses Initializer.
+	case ast.KindPropertyDeclaration:
+		return unwrapExpression(node.AsPropertyDeclaration().Initializer), true
+	}
+	return nil, false
+}
+
+func readRawAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
+	if mc == nil || mc.sf == nil {
+		return nil, false
+	}
+	return scanner.GetSourceTextOfNodeFromSourceFile(mc.sf, node, false), true
+}
+
+func readOperatorAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindBinaryExpression:
+		return operatorTokenText(node.AsBinaryExpression().OperatorToken.Kind), true
+	case ast.KindPrefixUnaryExpression:
+		return operatorTokenText(node.AsPrefixUnaryExpression().Operator), true
+	case ast.KindPostfixUnaryExpression:
+		return operatorTokenText(node.AsPostfixUnaryExpression().Operator), true
+	// tsgo splits `typeof` / `void` / `delete` into their own kinds. ESTree
+	// keeps them as a UnaryExpression with the corresponding operator
+	// string — selectors like `UnaryExpression[operator='typeof']` need
+	// the same string back.
+	case ast.KindTypeOfExpression:
+		return "typeof", true
+	case ast.KindVoidExpression:
+		return "void", true
+	case ast.KindDeleteExpression:
+		return "delete", true
+	case ast.KindAwaitExpression:
+		return "await", true
+	case ast.KindYieldExpression:
+		return "yield", true
+	}
+	return nil, false
+}
+
+func operatorTokenText(k ast.Kind) string {
+	switch k {
+	case ast.KindPlusToken:
+		return "+"
+	case ast.KindMinusToken:
+		return "-"
+	case ast.KindAsteriskToken:
+		return "*"
+	case ast.KindAsteriskAsteriskToken:
+		return "**"
+	case ast.KindSlashToken:
+		return "/"
+	case ast.KindPercentToken:
+		return "%"
+	case ast.KindEqualsToken:
+		return "="
+	case ast.KindPlusEqualsToken:
+		return "+="
+	case ast.KindMinusEqualsToken:
+		return "-="
+	case ast.KindAsteriskEqualsToken:
+		return "*="
+	case ast.KindAsteriskAsteriskEqualsToken:
+		return "**="
+	case ast.KindSlashEqualsToken:
+		return "/="
+	case ast.KindPercentEqualsToken:
+		return "%="
+	case ast.KindEqualsEqualsToken:
+		return "=="
+	case ast.KindEqualsEqualsEqualsToken:
+		return "==="
+	case ast.KindExclamationEqualsToken:
+		return "!="
+	case ast.KindExclamationEqualsEqualsToken:
+		return "!=="
+	case ast.KindLessThanToken:
+		return "<"
+	case ast.KindLessThanEqualsToken:
+		return "<="
+	case ast.KindGreaterThanToken:
+		return ">"
+	case ast.KindGreaterThanEqualsToken:
+		return ">="
+	case ast.KindLessThanLessThanToken:
+		return "<<"
+	case ast.KindGreaterThanGreaterThanToken:
+		return ">>"
+	case ast.KindGreaterThanGreaterThanGreaterThanToken:
+		return ">>>"
+	case ast.KindAmpersandToken:
+		return "&"
+	case ast.KindBarToken:
+		return "|"
+	case ast.KindCaretToken:
+		return "^"
+	case ast.KindAmpersandAmpersandToken:
+		return "&&"
+	case ast.KindBarBarToken:
+		return "||"
+	case ast.KindQuestionQuestionToken:
+		return "??"
+	case ast.KindInKeyword:
+		return "in"
+	case ast.KindInstanceOfKeyword:
+		return "instanceof"
+	case ast.KindCommaToken:
+		return ","
+	case ast.KindExclamationToken:
+		return "!"
+	case ast.KindTildeToken:
+		return "~"
+	case ast.KindPlusPlusToken:
+		return "++"
+	case ast.KindMinusMinusToken:
+		return "--"
+	case ast.KindAmpersandEqualsToken:
+		return "&="
+	case ast.KindBarEqualsToken:
+		return "|="
+	case ast.KindCaretEqualsToken:
+		return "^="
+	case ast.KindAmpersandAmpersandEqualsToken:
+		return "&&="
+	case ast.KindBarBarEqualsToken:
+		return "||="
+	case ast.KindQuestionQuestionEqualsToken:
+		return "??="
+	}
+	return ""
+}
+
+func readKindAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindVariableStatement:
+		dl := node.AsVariableStatement().DeclarationList
+		if dl == nil {
+			return nil, false
+		}
+		return varListKind(dl), true
+	case ast.KindVariableDeclarationList:
+		// for-loop initializer position: the same VariableDeclarationList
+		// shape exposes `kind` to ESTree-flavoured selectors (e.g.
+		// `ForInStatement[left.kind='const']`).
+		return varListKind(node), true
+	case ast.KindMethodDeclaration:
+		// ESTree splits the `kind` field by container:
+		// object literal → 'init' (Property.kind)
+		// class body    → 'method' (MethodDefinition.kind)
+		if node.Parent != nil {
+			switch node.Parent.Kind {
+			case ast.KindClassDeclaration, ast.KindClassExpression:
+				return "method", true
+			}
+		}
+		return "init", true
+	case ast.KindConstructor:
+		return "constructor", true
+	case ast.KindGetAccessor:
+		return "get", true
+	case ast.KindSetAccessor:
+		return "set", true
+	case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment:
+		return "init", true
+	case ast.KindExportDeclaration:
+		return "value", true
+	}
+	return nil, false
+}
+
+// varListKind returns the ESTree `kind` string for a VariableDeclarationList.
+// `await using` shares bits with const + using, so the order matters —
+// check the most specific predicates first via the helper functions
+// tsgo exposes for exactly this disambiguation.
+func varListKind(dl *ast.Node) string {
+	switch {
+	case ast.IsVarAwaitUsing(dl):
+		return "await using"
+	case ast.IsVarUsing(dl):
+		return "using"
+	case ast.IsVarConst(dl):
+		return "const"
+	case ast.IsVarLet(dl):
+		return "let"
+	}
+	return "var"
+}
+
+func readComputedAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindElementAccessExpression:
+		return true, true
+	case ast.KindPropertyAccessExpression:
+		return false, true
+	case ast.KindPropertyAssignment, ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindPropertyDeclaration:
+		name := node.Name()
+		return name != nil && name.Kind == ast.KindComputedPropertyName, true
+	}
+	return nil, false
+}
+
+// readShorthandAttr models ESTree's Property.shorthand boolean.
+// tsgo's KindShorthandPropertyAssignment maps directly; everything else
+// is non-shorthand.
+func readShorthandAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindShorthandPropertyAssignment:
+		return true, true
+	case ast.KindPropertyAssignment, ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		return false, true
+	}
+	return nil, false
+}
+
+// readMethodAttr models ESTree's Property.method (true for object-method
+// shorthand `({ foo() {} })`). Class methods are MethodDefinition, not
+// Property, so the attribute is not exposed there.
+func readMethodAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindMethodDeclaration:
+		// Only object-literal methods are Property.method=true.
+		if node.Parent != nil && node.Parent.Kind == ast.KindObjectLiteralExpression {
+			return true, true
+		}
+		return false, true
+	case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment, ast.KindGetAccessor, ast.KindSetAccessor:
+		return false, true
+	}
+	return nil, false
+}
+
+// readSuperClassAttr models ESTree's ClassDeclaration.superClass — the
+// expression following `extends`. tsgo expresses extends through a
+// HeritageClause with KindExtendsKeyword; the first type in that clause
+// is the super-class expression.
+func readSuperClassAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		var clauses *ast.NodeList
+		if node.Kind == ast.KindClassDeclaration {
+			clauses = node.AsClassDeclaration().HeritageClauses
+		} else {
+			clauses = node.AsClassExpression().HeritageClauses
+		}
+		if clauses == nil {
+			return nil, true
+		}
+		for _, c := range clauses.Nodes {
+			hc := c.AsHeritageClause()
+			if hc == nil || hc.Token != ast.KindExtendsKeyword {
+				continue
+			}
+			if hc.Types != nil && len(hc.Types.Nodes) > 0 {
+				// `extends Foo` — `Foo` lives in ExpressionWithTypeArguments.
+				et := hc.Types.Nodes[0]
+				if et.Kind == ast.KindExpressionWithTypeArguments {
+					return unwrapExpression(et.AsExpressionWithTypeArguments().Expression), true
+				}
+				return unwrapExpression(et), true
+			}
+		}
+		return nil, true
+	}
+	return nil, false
+}
+
+// readDirectiveAttr models ESTree's ExpressionStatement.directive, which
+// is set on a string-literal ExpressionStatement that appears in a
+// directive prologue (top-level "use strict", etc.). tsgo doesn't mark
+// directives explicitly; recover the directive text by inspecting the
+// preceding-sibling pattern.
+func readDirectiveAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
+	if node.Kind != ast.KindExpressionStatement {
+		return nil, false
+	}
+	expr := node.AsExpressionStatement().Expression
+	if expr == nil || expr.Kind != ast.KindStringLiteral {
+		return nil, true
+	}
+	if !isDirectivePrologue(node) {
+		return nil, true
+	}
+	// ESTree's directive value is the cooked-string content of the
+	// literal (without the surrounding quotes).
+	return expr.AsStringLiteral().Text, true
+}
+
+// isDirectivePrologue reports whether `stmt` is part of a directive
+// prologue — a contiguous run of string-literal ExpressionStatements at
+// the start of a SourceFile or a function/class body.
+func isDirectivePrologue(stmt *ast.Node) bool {
+	parent := stmt.Parent
+	if parent == nil {
+		return false
+	}
+	var siblings []*ast.Node
+	switch parent.Kind {
+	case ast.KindSourceFile:
+		s := parent.AsSourceFile().Statements
+		if s == nil {
+			return false
+		}
+		siblings = s.Nodes
+	case ast.KindBlock:
+		s := parent.AsBlock().Statements
+		if s == nil {
+			return false
+		}
+		siblings = s.Nodes
+	case ast.KindModuleBlock:
+		s := parent.AsModuleBlock().Statements
+		if s == nil {
+			return false
+		}
+		siblings = s.Nodes
+	default:
+		return false
+	}
+	for _, s := range siblings {
+		if s.Kind != ast.KindExpressionStatement {
+			return false
+		}
+		expr := s.AsExpressionStatement().Expression
+		if expr == nil || expr.Kind != ast.KindStringLiteral {
+			return false
+		}
+		if s == stmt {
+			return true
+		}
+	}
+	return false
+}
+
+// readUpdateAttr models ESTree's ForStatement.update — tsgo names this
+// `Incrementor`.
+func readUpdateAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind == ast.KindForStatement {
+		return unwrapExpression(node.AsForStatement().Incrementor), true
+	}
+	return nil, false
+}
+
+// readExpressionsAttr / readQuasisAttr expose ESTree's
+// TemplateLiteral.expressions / TemplateLiteral.quasis. tsgo splits the
+// concept across two kinds: NoSubstitutionTemplateLiteral has no
+// expressions, TemplateExpression carries Head + TemplateSpans where
+// each span owns one expression and one literal piece.
+func readExpressionsAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return []*ast.Node{}, true
+	case ast.KindTemplateExpression:
+		spans := node.AsTemplateExpression().TemplateSpans
+		out := []*ast.Node{}
+		if spans != nil {
+			for _, sp := range spans.Nodes {
+				out = append(out, sp.AsTemplateSpan().Expression)
+			}
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+func readQuasisAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return []*ast.Node{node}, true
+	case ast.KindTemplateExpression:
+		te := node.AsTemplateExpression()
+		out := []*ast.Node{te.Head}
+		if te.TemplateSpans != nil {
+			for _, sp := range te.TemplateSpans.Nodes {
+				out = append(out, sp.AsTemplateSpan().Literal)
+			}
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+// readBigintAttr models ESTree's Literal.bigint — present for BigInt
+// literals (`1n`). The string value is the digits without the trailing
+// `n`.
+// readDelegateAttr models ESTree's YieldExpression.delegate (true for
+// `yield*`, false for plain `yield`).
+func readDelegateAttr(node *ast.Node) (interface{}, bool) {
+	if node.Kind != ast.KindYieldExpression {
+		return nil, false
+	}
+	return node.AsYieldExpression().AsteriskToken != nil, true
+}
+
+func readBigintAttr(node *ast.Node, mc *matchContext) (interface{}, bool) {
+	if node.Kind != ast.KindBigIntLiteral {
+		return nil, false
+	}
+	text := node.AsBigIntLiteral().Text
+	if mc != nil && mc.sf != nil {
+		text = scanner.GetSourceTextOfNodeFromSourceFile(mc.sf, node, false)
+	}
+	if len(text) > 0 && text[len(text)-1] == 'n' {
+		text = text[:len(text)-1]
+	}
+	return text, true
+}
+
+func readStaticAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindPropertyDeclaration:
+		return ast.HasStaticModifier(node), true
+	}
+	return nil, false
+}
+
+func readLabelAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindBreakStatement:
+		return node.AsBreakStatement().Label, true
+	case ast.KindContinueStatement:
+		return node.AsContinueStatement().Label, true
+	case ast.KindLabeledStatement:
+		return node.AsLabeledStatement().Label, true
+	}
+	return nil, false
+}
+
+// readRegexObject returns a synthetic *ast.Node-equivalent value for the
+// `regex` ESTree field. Concretely we return the node itself and let
+// readRegexFlags / readRegexPattern interpret it during further lookups.
+func readRegexObject(node *ast.Node, mc *matchContext) (interface{}, bool) {
+	if node.Kind != ast.KindRegularExpressionLiteral {
+		return nil, false
+	}
+	return regexFacade{node: node, mc: mc}, true
+}
+
+// regexFacade represents an ESTree `regex` object — a {pattern, flags}
+// pair extracted from the regex literal source. It is opaque to the
+// matcher except via subsequent path segments (`.flags`, `.pattern`).
+type regexFacade struct {
+	node *ast.Node
+	mc   *matchContext
+}
+
+func readRegexFlags(node *ast.Node, mc *matchContext) (interface{}, bool) {
+	if node.Kind == ast.KindRegularExpressionLiteral {
+		_, flags := splitRegexLiteral(regexLiteralText(node, mc))
+		return flags, true
+	}
+	return nil, false
+}
+
+func readRegexPattern(node *ast.Node, mc *matchContext) (interface{}, bool) {
+	if node.Kind == ast.KindRegularExpressionLiteral {
+		pat, _ := splitRegexLiteral(regexLiteralText(node, mc))
+		return pat, true
+	}
+	return nil, false
+}
+
+func splitRegexLiteral(text string) (string, string) {
+	if !strings.HasPrefix(text, "/") {
+		return text, ""
+	}
+	last := strings.LastIndex(text, "/")
+	if last <= 0 {
+		return text, ""
+	}
+	return text[1:last], text[last+1:]
+}
+
+func regexLiteralText(node *ast.Node, mc *matchContext) string {
+	if node == nil {
+		return ""
+	}
+	if mc != nil && mc.sf != nil {
+		return scanner.GetSourceTextOfNodeFromSourceFile(mc.sf, node, false)
+	}
+	return node.Text()
+}
+
+func readParamsAttr(node *ast.Node) (interface{}, bool) {
+	if !isFunctionLikeForParams(node) {
+		return nil, false
+	}
+	params := node.Parameters()
+	// Treat nil and empty as the same — `[params.length=0]` should
+	// match a function-like with no parameters regardless of whether
+	// the underlying NodeList was allocated.
+	out := make([]*ast.Node, 0, len(params))
+	out = append(out, params...)
+	return out, true
+}
+
+func readSourceAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindImportDeclaration:
+		return unwrapExpression(node.AsImportDeclaration().ModuleSpecifier), true
+	case ast.KindExportDeclaration:
+		return unwrapExpression(node.AsExportDeclaration().ModuleSpecifier), true
+	}
+	return nil, false
+}
+
+func readCalleeAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindCallExpression:
+		return unwrapExpression(node.AsCallExpression().Expression), true
+	case ast.KindNewExpression:
+		return unwrapExpression(node.AsNewExpression().Expression), true
+	case ast.KindTaggedTemplateExpression:
+		return unwrapExpression(node.AsTaggedTemplateExpression().Tag), true
+	}
+	return nil, false
+}
+
+func readArgumentsAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindCallExpression:
+		args := node.AsCallExpression().Arguments
+		if args == nil {
+			return []*ast.Node{}, true
+		}
+		return append([]*ast.Node{}, args.Nodes...), true
+	case ast.KindNewExpression:
+		args := node.AsNewExpression().Arguments
+		if args == nil {
+			return []*ast.Node{}, true
+		}
+		return append([]*ast.Node{}, args.Nodes...), true
+	}
+	return nil, false
+}
+
+func readExpressionAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindExpressionStatement:
+		return unwrapExpression(node.AsExpressionStatement().Expression), true
+	case ast.KindParenthesizedExpression:
+		return unwrapExpression(node.AsParenthesizedExpression().Expression), true
+	case ast.KindAwaitExpression:
+		return unwrapExpression(node.AsAwaitExpression().Expression), true
+	case ast.KindYieldExpression:
+		return unwrapExpression(node.AsYieldExpression().Expression), true
+	case ast.KindReturnStatement:
+		return unwrapExpression(node.AsReturnStatement().Expression), true
+	case ast.KindThrowStatement:
+		return unwrapExpression(node.AsThrowStatement().Expression), true
+	case ast.KindCallExpression:
+		return unwrapExpression(node.AsCallExpression().Expression), true
+	case ast.KindNewExpression:
+		return unwrapExpression(node.AsNewExpression().Expression), true
+	}
+	return nil, false
+}
+
+func readInitAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindVariableDeclaration:
+		return unwrapExpression(node.AsVariableDeclaration().Initializer), true
+	case ast.KindForStatement:
+		return unwrapExpression(node.AsForStatement().Initializer), true
+	case ast.KindBindingElement:
+		return unwrapExpression(node.AsBindingElement().Initializer), true
+	}
+	return nil, false
+}
+
+func readIdAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return node.AsFunctionDeclaration().Name(), true
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().Name(), true
+	case ast.KindClassDeclaration:
+		return node.AsClassDeclaration().Name(), true
+	case ast.KindClassExpression:
+		return node.AsClassExpression().Name(), true
+	case ast.KindVariableDeclaration:
+		return node.AsVariableDeclaration().Name(), true
+	}
+	return nil, false
+}
+
+func readKeyAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment, ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindPropertyDeclaration:
+		return node.Name(), true
+	}
+	return nil, false
+}
+
+func readLeftAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindBinaryExpression:
+		return unwrapExpression(node.AsBinaryExpression().Left), true
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		return unwrapExpression(node.AsForInOrOfStatement().Initializer), true
+	}
+	return nil, false
+}
+
+func readRightAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindBinaryExpression:
+		return unwrapExpression(node.AsBinaryExpression().Right), true
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		return unwrapExpression(node.AsForInOrOfStatement().Expression), true
+	}
+	return nil, false
+}
+
+func readObjectAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		return unwrapExpression(node.AsPropertyAccessExpression().Expression), true
+	case ast.KindElementAccessExpression:
+		return unwrapExpression(node.AsElementAccessExpression().Expression), true
+	}
+	return nil, false
+}
+
+func readPropertyAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		return node.AsPropertyAccessExpression().Name(), true
+	case ast.KindElementAccessExpression:
+		return node.AsElementAccessExpression().ArgumentExpression, true
+	case ast.KindMetaProperty:
+		// ESTree's MetaProperty.property is the trailing identifier
+		// (e.g. `target` in `new.target`, `meta` in `import.meta`).
+		// tsgo stores it on the unexported `name` field; the public
+		// accessor is `Name()`.
+		return node.AsMetaProperty().Name(), true
+	}
+	return nil, false
+}
+
+func readTestAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindIfStatement:
+		return unwrapExpression(node.AsIfStatement().Expression), true
+	case ast.KindConditionalExpression:
+		return unwrapExpression(node.AsConditionalExpression().Condition), true
+	case ast.KindWhileStatement:
+		return unwrapExpression(node.AsWhileStatement().Expression), true
+	case ast.KindDoStatement:
+		return unwrapExpression(node.AsDoStatement().Expression), true
+	case ast.KindForStatement:
+		return unwrapExpression(node.AsForStatement().Condition), true
+	case ast.KindCaseClause:
+		// ESTree's SwitchCase.test is the case expression. tsgo names
+		// the same field `Expression` on a CaseOrDefaultClause.
+		return unwrapExpression(node.AsCaseOrDefaultClause().Expression), true
+	case ast.KindDefaultClause:
+		// SwitchCase for `default:` has test === null in ESTree.
+		return nil, true
+	}
+	return nil, false
+}
+
+func readConsequentAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindIfStatement:
+		return node.AsIfStatement().ThenStatement, true
+	case ast.KindConditionalExpression:
+		return node.AsConditionalExpression().WhenTrue, true
+	case ast.KindCaseClause, ast.KindDefaultClause:
+		// ESTree's SwitchCase.consequent is the statement list.
+		stmts := node.AsCaseOrDefaultClause().Statements
+		if stmts == nil {
+			return []*ast.Node{}, true
+		}
+		return append([]*ast.Node{}, stmts.Nodes...), true
+	}
+	return nil, false
+}
+
+func readAlternateAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindIfStatement:
+		return node.AsIfStatement().ElseStatement, true
+	case ast.KindConditionalExpression:
+		return node.AsConditionalExpression().WhenFalse, true
+	}
+	return nil, false
+}
+
+func readBodyAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return node.AsFunctionDeclaration().Body, true
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().Body, true
+	case ast.KindArrowFunction:
+		return node.AsArrowFunction().Body, true
+	case ast.KindMethodDeclaration:
+		return node.AsMethodDeclaration().Body, true
+	case ast.KindIfStatement:
+		return node.AsIfStatement().ThenStatement, true
+	case ast.KindWhileStatement:
+		return node.AsWhileStatement().Statement, true
+	case ast.KindDoStatement:
+		return node.AsDoStatement().Statement, true
+	case ast.KindForStatement:
+		return node.AsForStatement().Statement, true
+	case ast.KindBlock:
+		stmts := node.AsBlock().Statements
+		if stmts == nil {
+			return []*ast.Node{}, true
+		}
+		return append([]*ast.Node{}, stmts.Nodes...), true
+	case ast.KindSourceFile:
+		stmts := node.AsSourceFile().Statements
+		if stmts == nil {
+			return []*ast.Node{}, true
+		}
+		return append([]*ast.Node{}, stmts.Nodes...), true
+	case ast.KindClassDeclaration:
+		members := node.AsClassDeclaration().Members
+		if members == nil {
+			return []*ast.Node{}, true
+		}
+		return append([]*ast.Node{}, members.Nodes...), true
+	case ast.KindClassExpression:
+		members := node.AsClassExpression().Members
+		if members == nil {
+			return []*ast.Node{}, true
+		}
+		return append([]*ast.Node{}, members.Nodes...), true
+	}
+	return nil, false
+}
+
+func readArgumentAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindAwaitExpression:
+		return unwrapExpression(node.AsAwaitExpression().Expression), true
+	case ast.KindYieldExpression:
+		return unwrapExpression(node.AsYieldExpression().Expression), true
+	case ast.KindSpreadElement:
+		return unwrapExpression(node.AsSpreadElement().Expression), true
+	case ast.KindSpreadAssignment:
+		return unwrapExpression(node.AsSpreadAssignment().Expression), true
+	case ast.KindReturnStatement:
+		return unwrapExpression(node.AsReturnStatement().Expression), true
+	case ast.KindThrowStatement:
+		return unwrapExpression(node.AsThrowStatement().Expression), true
+	case ast.KindPrefixUnaryExpression:
+		return unwrapExpression(node.AsPrefixUnaryExpression().Operand), true
+	case ast.KindPostfixUnaryExpression:
+		return unwrapExpression(node.AsPostfixUnaryExpression().Operand), true
+	case ast.KindTypeOfExpression:
+		return unwrapExpression(node.AsTypeOfExpression().Expression), true
+	case ast.KindVoidExpression:
+		return unwrapExpression(node.AsVoidExpression().Expression), true
+	case ast.KindDeleteExpression:
+		return unwrapExpression(node.AsDeleteExpression().Expression), true
+	}
+	return nil, false
+}
+
+func readPrefixAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindPrefixUnaryExpression:
+		return true, true
+	case ast.KindPostfixUnaryExpression:
+		return false, true
+	}
+	return nil, false
+}
+
+func readAsyncAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction, ast.KindMethodDeclaration:
+		return ast.HasSyntacticModifier(node, ast.ModifierFlagsAsync), true
+	}
+	return nil, false
+}
+
+func readGeneratorAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return node.AsFunctionDeclaration().AsteriskToken != nil, true
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().AsteriskToken != nil, true
+	case ast.KindMethodDeclaration:
+		return node.AsMethodDeclaration().AsteriskToken != nil, true
+	}
+	return nil, false
+}
+
+func readSpecifiersAttr(node *ast.Node) (interface{}, bool) {
+	switch node.Kind {
+	case ast.KindImportDeclaration:
+		return collectImportSpecifiers(node), true
+	case ast.KindExportDeclaration:
+		return collectExportSpecifiers(node), true
+	}
+	return nil, false
+}
+
+func collectImportSpecifiers(node *ast.Node) []*ast.Node {
+	out := []*ast.Node{}
+	clause := node.AsImportDeclaration().ImportClause
+	if clause == nil {
+		return out
+	}
+	c := clause.AsImportClause()
+	if c == nil {
+		return out
+	}
+	if c.Name() != nil {
+		out = append(out, clause)
+	}
+	if c.NamedBindings != nil {
+		switch c.NamedBindings.Kind {
+		case ast.KindNamespaceImport:
+			out = append(out, c.NamedBindings)
+		case ast.KindNamedImports:
+			ni := c.NamedBindings.AsNamedImports()
+			if ni != nil && ni.Elements != nil {
+				out = append(out, ni.Elements.Nodes...)
+			}
+		}
+	}
+	return out
+}
+
+func collectExportSpecifiers(node *ast.Node) []*ast.Node {
+	out := []*ast.Node{}
+	ed := node.AsExportDeclaration()
+	if ed == nil || ed.ExportClause == nil {
+		return out
+	}
+	if ed.ExportClause.Kind == ast.KindNamedExports {
+		ne := ed.ExportClause.AsNamedExports()
+		if ne != nil && ne.Elements != nil {
+			out = append(out, ne.Elements.Nodes...)
+		}
+	}
+	return out
+}

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax.go
@@ -1,0 +1,151 @@
+package no_restricted_syntax
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// NoRestrictedSyntaxRule is the rslint port of ESLint's `no-restricted-syntax`.
+//
+// Configuration mirrors ESLint: the rule accepts a list of strings or
+// `{ selector, message? }` objects. Each selector follows the esquery
+// grammar (the subset implemented in parser.go). At lint time every node
+// is matched against every parsed selector; each match produces one
+// diagnostic with the user-supplied message (or a default).
+//
+// https://eslint.org/docs/latest/rules/no-restricted-syntax
+var NoRestrictedSyntaxRule = rule.Rule{
+	Name: "no-restricted-syntax",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		entries := parseRuleOptions(options)
+		if len(entries) == 0 {
+			return rule.RuleListeners{}
+		}
+
+		mc := &matchContext{sf: ctx.SourceFile}
+
+		// Build per-kind buckets of (selector, message) entries. Selectors
+		// whose `candidate kinds` is the universe land in everyKindBucket
+		// and are evaluated on every visit.
+		perKind := make(map[ast.Kind][]ruleEntry)
+		var everyKind []ruleEntry
+		for _, e := range entries {
+			ks := candidateKinds(e.compiled)
+			if ks.universe {
+				everyKind = append(everyKind, e)
+				continue
+			}
+			for k := range ks.kinds {
+				perKind[k] = append(perKind[k], e)
+			}
+		}
+
+		// Merge the universe-of-kinds bucket into every kind we listen on.
+		// allInterestingKinds is the set we register for `*` / pure
+		// attribute selectors; kinds outside it that already have a
+		// per-kind bucket still keep their bucket (the universe matchers
+		// just don't apply there).
+		if len(everyKind) > 0 {
+			for _, k := range allInterestingKinds {
+				perKind[k] = append(perKind[k], everyKind...)
+			}
+		}
+
+		visit := func(node *ast.Node, bucket []ruleEntry) {
+			for _, e := range bucket {
+				if matches(e.compiled, node, mc) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "restrictedSyntax",
+						Description: e.formatMessage(),
+					})
+				}
+			}
+		}
+
+		listeners := rule.RuleListeners{}
+		for k, bucket := range perKind {
+			listeners[k] = func(node *ast.Node) {
+				visit(node, bucket)
+			}
+		}
+		return listeners
+	},
+}
+
+// ruleEntry is a parsed option entry: the original selector string,
+// the compiled selector tree, and the message (custom or default).
+type ruleEntry struct {
+	selector string
+	compiled selector
+	message  string
+}
+
+func (e ruleEntry) formatMessage() string {
+	if e.message != "" {
+		return e.message
+	}
+	return fmt.Sprintf("Using '%s' is not allowed.", e.selector)
+}
+
+// parseRuleOptions normalises the loosely-typed options value handed to
+// the rule into a list of ruleEntry. ESLint accepts a mix of strings and
+// `{ selector, message? }` objects; rslint receives a single string, a
+// single object, or an []interface{} depending on how config.go unwrapped
+// the array. Selectors that fail to parse are silently dropped — ESLint
+// rejects the whole config in that case, but for runtime resilience we
+// prefer to drop the offending entry over panicking.
+func parseRuleOptions(opts any) []ruleEntry {
+	if opts == nil {
+		return nil
+	}
+	var entries []ruleEntry
+	switch v := opts.(type) {
+	case string:
+		entries = append(entries, buildEntryFromString(v))
+	case map[string]interface{}:
+		if e, ok := buildEntryFromObject(v); ok {
+			entries = append(entries, e)
+		}
+	case []interface{}:
+		for _, item := range v {
+			switch x := item.(type) {
+			case string:
+				entries = append(entries, buildEntryFromString(x))
+			case map[string]interface{}:
+				if e, ok := buildEntryFromObject(x); ok {
+					entries = append(entries, e)
+				}
+			}
+		}
+	}
+	out := make([]ruleEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.compiled != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func buildEntryFromString(sel string) ruleEntry {
+	compiled, err := parseSelector(sel)
+	if err != nil {
+		return ruleEntry{selector: sel}
+	}
+	return ruleEntry{selector: sel, compiled: compiled}
+}
+
+func buildEntryFromObject(m map[string]interface{}) (ruleEntry, bool) {
+	rawSel, _ := m["selector"].(string)
+	if rawSel == "" {
+		return ruleEntry{}, false
+	}
+	compiled, err := parseSelector(rawSel)
+	if err != nil {
+		return ruleEntry{}, false
+	}
+	msg, _ := m["message"].(string)
+	return ruleEntry{selector: rawSel, compiled: compiled, message: msg}, true
+}

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax.md
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax.md
@@ -1,0 +1,87 @@
+# no-restricted-syntax
+
+## Rule Details
+
+Disallows specified syntax. The rule accepts a list of [esquery] selectors;
+any AST node matching one of the listed selectors triggers a diagnostic with
+either a default or user-supplied message.
+
+This is the catch-all rule for restricting language constructs (e.g. banning
+`with`, banning `for-in`, requiring named function declarations) without
+having to write a dedicated rule. The selector grammar matches ESLint's, so
+selectors authored against ESLint's `no-restricted-syntax` configuration are
+expected to work unchanged in rslint.
+
+Examples of **incorrect** code for this rule:
+
+```json
+{
+  "no-restricted-syntax": [
+    "error",
+    "FunctionExpression",
+    "WithStatement"
+  ]
+}
+```
+
+```javascript
+with (me) {
+  dontMess();
+}
+
+const doSomething = function () {};
+```
+
+Examples of **correct** code for the same configuration:
+
+```javascript
+me.dontMess();
+
+function doSomething() {}
+
+foo instanceof bar;
+```
+
+## Options
+
+The rule accepts an array of restriction entries. Each entry is either:
+
+- A bare string — the esquery selector. The diagnostic message is
+  `Using '<selector>' is not allowed.`.
+- An object `{ "selector": <string>, "message"?: <string> }`. When `message`
+  is provided it replaces the default text verbatim.
+
+```json
+{
+  "no-restricted-syntax": [
+    "error",
+    {
+      "selector": "CallExpression[callee.name='setTimeout']",
+      "message": "Use the timer service instead of raw setTimeout."
+    },
+    "WithStatement"
+  ]
+}
+```
+
+### Supported selector forms
+
+The implementation covers the subset of [esquery] used in real-world ESLint
+configurations and in the upstream `no-restricted-syntax` test suite:
+
+- ESTree node names (e.g. `Identifier`, `FunctionDeclaration`, `BinaryExpression`).
+- Wildcard `*`.
+- Class selectors `.field` (e.g. `Literal.key`).
+- Attribute selectors with presence (`[label]`), equality
+  (`[name="x"]`, `[kind='using']`), inequality (`!=`), numeric comparisons
+  (`[params.length>2]`), and regex matching (`[regex.flags=/i/]`).
+- Combinators `>` (direct child), descendant whitespace, `+`
+  (adjacent sibling), `~` (general sibling).
+- Pseudo-classes `:is()`, `:matches()`, `:not()`, `:has()`,
+  `:first-child`, `:last-child`, `:nth-child(N)`, `:nth-last-child(N)`.
+
+## Original Documentation
+
+- [ESLint no-restricted-syntax](https://eslint.org/docs/latest/rules/no-restricted-syntax)
+
+[esquery]: https://github.com/estools/esquery

--- a/internal/rules/no_restricted_syntax/no_restricted_syntax_test.go
+++ b/internal/rules/no_restricted_syntax/no_restricted_syntax_test.go
@@ -1,0 +1,926 @@
+package no_restricted_syntax
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoRestrictedSyntaxRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoRestrictedSyntaxRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// Upstream ESLint suite — string format
+			// ============================================================
+			{Code: `doSomething();`},
+			{
+				Code:    `var foo = 42;`,
+				Options: []interface{}{"ConditionalExpression"},
+			},
+			{
+				Code:    `foo += 42;`,
+				Options: []interface{}{"VariableDeclaration", "FunctionExpression"},
+			},
+			{
+				Code:    `foo;`,
+				Options: []interface{}{`Identifier[name="bar"]`},
+			},
+			{
+				Code:    `() => 5`,
+				Options: []interface{}{"ArrowFunctionExpression > BlockStatement"},
+			},
+			{
+				Code:    `({ foo: 1, bar: 2 })`,
+				Options: []interface{}{"Property > Literal.key"},
+			},
+			{
+				Code:    `A: for (;;) break;`,
+				Options: []interface{}{"BreakStatement[label]"},
+			},
+			{
+				Code:    `function foo(bar, baz) {}`,
+				Options: []interface{}{"FunctionDeclaration[params.length>2]"},
+			},
+
+			// ============================================================
+			// Upstream ESLint suite — object format
+			// ============================================================
+			{
+				Code: `var foo = 42;`,
+				Options: []interface{}{
+					map[string]interface{}{"selector": "ConditionalExpression"},
+				},
+			},
+			{
+				Code: `({ foo: 1, bar: 2 })`,
+				Options: []interface{}{
+					map[string]interface{}{"selector": "Property > Literal.key"},
+				},
+			},
+			{
+				Code: `({ foo: 1, bar: 2 })`,
+				Options: []interface{}{
+					map[string]interface{}{
+						"selector": "FunctionDeclaration[params.length>2]",
+						"message":  "custom error message.",
+					},
+				},
+			},
+
+			// ============================================================
+			// Upstream ESLint suite — regex flag attribute
+			// ============================================================
+			{
+				Code:    `console.log(/a/);`,
+				Options: []interface{}{"Literal[regex.flags=/./]"},
+			},
+
+			// ============================================================
+			// Selector boundary: empty / nil options should never match
+			// ============================================================
+			{Code: `with (x) {}`},
+			{Code: `var a = 1;`, Options: nil},
+			{Code: `var a = 1;`, Options: []interface{}{}},
+
+			// ============================================================
+			// Selector boundary: unknown ESTree name silently ignored
+			// (every node in the file is a non-match)
+			// ============================================================
+			{Code: `var a = 1;`, Options: []interface{}{"NotARealNodeType"}},
+
+			// ============================================================
+			// Selector boundary: malformed selector silently dropped
+			// ============================================================
+			{Code: `var a = 1;`, Options: []interface{}{"["}},
+			{Code: `var a = 1;`, Options: []interface{}{"BinaryExpression["}},
+			{Code: `var a = 1;`, Options: []interface{}{":nth-child(abc)"}},
+
+			// ============================================================
+			// Selector boundary: object option without `selector` is dropped
+			// ============================================================
+			{
+				Code: `var a = 1;`,
+				Options: []interface{}{
+					map[string]interface{}{"message": "no selector key"},
+				},
+			},
+
+			// ============================================================
+			// :not — non-matching head means whole selector is a no-op
+			// ============================================================
+			{
+				Code:    `with (x) {}`,
+				Options: []interface{}{"FunctionDeclaration:not([generator=true])"},
+			},
+
+			// ============================================================
+			// :is / :matches — neither alternative matches
+			// ============================================================
+			{
+				Code:    `var a = 1;`,
+				Options: []interface{}{":is(WithStatement, ConditionalExpression)"},
+			},
+			{
+				Code:    `var a = 1;`,
+				Options: []interface{}{":matches(WithStatement, DoWhileStatement)"},
+			},
+
+			// ============================================================
+			// Attribute presence on a node that lacks the attribute
+			// ============================================================
+			{
+				Code:    `function foo() {}`,
+				Options: []interface{}{"FunctionDeclaration[generator]"},
+			},
+			{
+				Code:    `function foo() {}`,
+				Options: []interface{}{"FunctionDeclaration[async]"},
+			},
+
+			// ============================================================
+			// Attribute equality / inequality
+			// ============================================================
+			{
+				Code:    `let a = 1;`,
+				Options: []interface{}{"VariableDeclaration[kind='const']"},
+			},
+			{
+				Code:    `const a = 1;`,
+				Options: []interface{}{"VariableDeclaration[kind!='const']"},
+			},
+			{
+				Code:    `function foo(a) {}`,
+				Options: []interface{}{"FunctionDeclaration[params.length>=2]"},
+			},
+			{
+				Code:    `function foo(a, b, c) {}`,
+				Options: []interface{}{"FunctionDeclaration[params.length<=2]"},
+			},
+			{
+				Code:    `function foo(a, b) {}`,
+				Options: []interface{}{"FunctionDeclaration[params.length<2]"},
+			},
+
+			// ============================================================
+			// Logical / Assignment / Sequence operator differentiation —
+			// ESTree splits these from BinaryExpression. tsgo fuses them,
+			// so a bare `BinaryExpression` selector should NOT match a
+			// pure assignment or logical or comma.
+			// ============================================================
+			{
+				Code:    `a = b;`,
+				Options: []interface{}{"BinaryExpression"},
+			},
+			{
+				Code:    `a && b;`,
+				Options: []interface{}{"BinaryExpression"},
+			},
+			{
+				Code:    `(a, b);`,
+				Options: []interface{}{"BinaryExpression"},
+			},
+			{
+				Code:    `a + b;`,
+				Options: []interface{}{"AssignmentExpression"},
+			},
+			{
+				Code:    `a = b;`,
+				Options: []interface{}{"LogicalExpression"},
+			},
+			{
+				Code:    `a + b;`,
+				Options: []interface{}{"SequenceExpression"},
+			},
+
+			// ============================================================
+			// Unary vs Update — `++x` and `+x` should not collide
+			// ============================================================
+			{
+				Code:    `+x;`,
+				Options: []interface{}{"UpdateExpression"},
+			},
+			{
+				Code:    `x++;`,
+				Options: []interface{}{"UnaryExpression"},
+			},
+
+			// ============================================================
+			// Optional-chain link selectors do not match plain access
+			// ============================================================
+			{
+				Code:    `a.b.c;`,
+				Options: []interface{}{"[optional=true]"},
+			},
+			{
+				Code:    `a.b.c;`,
+				Options: []interface{}{"ChainExpression"},
+			},
+
+			// ============================================================
+			// Real-world: forbid var, allow let/const
+			// ============================================================
+			{
+				Code:    `let a = 1; const b = 2;`,
+				Options: []interface{}{"VariableDeclaration[kind='var']"},
+			},
+
+			// ============================================================
+			// Real-world: forbid console.* (use member-access form)
+			// ============================================================
+			{
+				Code: `myLogger.log('safe');`,
+				Options: []interface{}{
+					`CallExpression[callee.object.name='console']`,
+				},
+			},
+
+			// ============================================================
+			// Real-world: forbid for-in, allow for-of
+			// ============================================================
+			{
+				Code:    `for (const x of items) {}`,
+				Options: []interface{}{"ForInStatement"},
+			},
+
+			// ============================================================
+			// Real-world: forbid default exports
+			// ============================================================
+			{
+				Code:    `export const x = 1;`,
+				Options: []interface{}{"ExportDefaultDeclaration"},
+			},
+
+			// ============================================================
+			// Real-world: forbid setTimeout via callee.name selector
+			// ============================================================
+			{
+				Code:    `clearTimeout(id);`,
+				Options: []interface{}{`CallExpression[callee.name='setTimeout']`},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Upstream ESLint suite — string format
+			// ============================================================
+			{
+				Code:    `var foo = 41;`,
+				Options: []interface{}{"VariableDeclaration"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'VariableDeclaration' is not allowed.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code:    `;function lol(a) { return 42; }`,
+				Options: []interface{}{"EmptyStatement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'EmptyStatement' is not allowed.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code:    `try { voila(); } catch (e) { oops(); }`,
+				Options: []interface{}{"TryStatement", "CallExpression", "CatchClause"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'TryStatement' is not allowed.", Line: 1, Column: 1},
+					{MessageId: "restrictedSyntax", Message: "Using 'CallExpression' is not allowed.", Line: 1, Column: 7},
+					{MessageId: "restrictedSyntax", Message: "Using 'CatchClause' is not allowed.", Line: 1, Column: 18},
+					{MessageId: "restrictedSyntax", Message: "Using 'CallExpression' is not allowed.", Line: 1, Column: 30},
+				},
+			},
+			{
+				Code:    `bar;`,
+				Options: []interface{}{`Identifier[name="bar"]`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   `Using 'Identifier[name="bar"]' is not allowed.`,
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code:    `bar;`,
+				Options: []interface{}{"Identifier", `Identifier[name="bar"]`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Identifier' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: `Using 'Identifier[name="bar"]' is not allowed.`},
+				},
+			},
+			{
+				Code:    `() => {}`,
+				Options: []interface{}{"ArrowFunctionExpression > BlockStatement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'ArrowFunctionExpression > BlockStatement' is not allowed.",
+					},
+				},
+			},
+			{
+				Code:    `({ foo: 1, 'bar': 2 })`,
+				Options: []interface{}{"Property > Literal.key"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'Property > Literal.key' is not allowed.",
+					},
+				},
+			},
+			{
+				Code:    `A: for (;;) break A;`,
+				Options: []interface{}{"BreakStatement[label]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'BreakStatement[label]' is not allowed.",
+					},
+				},
+			},
+			{
+				Code:    `function foo(bar, baz, qux) {}`,
+				Options: []interface{}{"FunctionDeclaration[params.length>2]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'FunctionDeclaration[params.length>2]' is not allowed.",
+					},
+				},
+			},
+
+			// ============================================================
+			// Upstream ESLint suite — object format
+			// ============================================================
+			{
+				Code: `var foo = 41;`,
+				Options: []interface{}{
+					map[string]interface{}{"selector": "VariableDeclaration"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'VariableDeclaration' is not allowed.",
+					},
+				},
+			},
+			{
+				Code: `function foo(bar, baz, qux) {}`,
+				Options: []interface{}{
+					map[string]interface{}{"selector": "FunctionDeclaration[params.length>2]"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'FunctionDeclaration[params.length>2]' is not allowed.",
+					},
+				},
+			},
+			{
+				Code: `function foo(bar, baz, qux) {}`,
+				Options: []interface{}{
+					map[string]interface{}{
+						"selector": "FunctionDeclaration[params.length>2]",
+						"message":  "custom error message.",
+					},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "custom error message."},
+				},
+			},
+			{
+				// the custom message may contain literal `{{selector}}` —
+				// ESLint substitutes the message into a templated outer
+				// message but the inner string is taken verbatim.
+				Code: `function foo(bar, baz, qux) {}`,
+				Options: []interface{}{
+					map[string]interface{}{
+						"selector": "FunctionDeclaration[params.length>2]",
+						"message":  "custom message with {{selector}}",
+					},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "custom message with {{selector}}"},
+				},
+			},
+
+			// ============================================================
+			// Upstream — regex flag attribute, optional chain, using/await
+			// using, regex on import path, :is(...)
+			// ============================================================
+			{
+				Code:    `console.log(/a/i);`,
+				Options: []interface{}{"Literal[regex.flags=/./]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'Literal[regex.flags=/./]' is not allowed.",
+					},
+				},
+			},
+			{
+				Code:    `var foo = foo?.bar?.();`,
+				Options: []interface{}{"ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'ChainExpression' is not allowed.",
+					},
+				},
+			},
+			{
+				Code:    `var foo = foo?.bar?.();`,
+				Options: []interface{}{"[optional=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using '[optional=true]' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: "Using '[optional=true]' is not allowed."},
+				},
+			},
+			// Locks in upstream esquery issue #110 — `:nth-child` should
+			// match nodes sitting in NodeList positions (here:
+			// ExpressionStatement at body[0]) and nothing else, even when
+			// the file body contains an optional chain.
+			{
+				Code:    `a?.b`,
+				Options: []interface{}{":nth-child(1)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using ':nth-child(1)' is not allowed."},
+				},
+			},
+			// Locks in upstream esquery behaviour: `* ~ *` only matches
+			// nodes that have a preceding sibling within the same NodeList
+			// field on the parent — the second `<div/>` in the array
+			// literal qualifies; nothing else in the file does.
+			{
+				Code:    `const foo = [<div/>, <div/>]`,
+				Tsx:     true,
+				Options: []interface{}{"* ~ *"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using '* ~ *' is not allowed."},
+				},
+			},
+			{
+				Code:    `{ using x = foo(); }`,
+				Options: []interface{}{"VariableDeclaration[kind='using']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'VariableDeclaration[kind='using']' is not allowed.",
+					},
+				},
+			},
+			{
+				Code:    `async function f() { await using x = foo(); }`,
+				Options: []interface{}{"VariableDeclaration[kind='await using']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'VariableDeclaration[kind='await using']' is not allowed.",
+					},
+				},
+			},
+			{
+				Code:    `import values from 'some/path';`,
+				Options: []interface{}{`ImportDeclaration[source.value=/^some\/path$/]`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   `Using 'ImportDeclaration[source.value=/^some\/path$/]' is not allowed.`,
+					},
+				},
+			},
+			{
+				Code: `foo + bar + baz`,
+				Options: []interface{}{
+					":is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using ':is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])' is not allowed.",
+					},
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using ':is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])' is not allowed.",
+					},
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using ':is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])' is not allowed.",
+					},
+				},
+			},
+
+			// ============================================================
+			// Selector boundary: wildcard registers across many kinds and
+			// reports on every visited node. Limit blast radius with a
+			// known-narrow file.
+			// ============================================================
+			{
+				Code:    `42`,
+				Options: []interface{}{"Literal"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Literal' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Selector boundary: descendant combinator (whitespace) — match
+			// at any nesting depth.
+			// ============================================================
+			{
+				Code:    `function f() { return function g() {}; }`,
+				Options: []interface{}{"FunctionDeclaration FunctionExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'FunctionDeclaration FunctionExpression' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Selector boundary: adjacent sibling combinator
+			// ============================================================
+			{
+				Code:    `f(1, 2);`,
+				Options: []interface{}{"Literal + Literal"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Literal + Literal' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Selector boundary: :not pseudo
+			// ============================================================
+			{
+				Code:    `class A { foo() {} }`,
+				Options: []interface{}{"MethodDefinition:not([static=true])"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition:not([static=true])' is not allowed."},
+				},
+			},
+			{
+				Code:    `class A { static foo() {} bar() {} }`,
+				Options: []interface{}{"MethodDefinition:not([static=true])"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition:not([static=true])' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Selector boundary: attribute regex with escaped slash
+			// ============================================================
+			{
+				Code:    `import foo from "lodash/get";`,
+				Options: []interface{}{`ImportDeclaration[source.value=/^lodash\//]`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ImportDeclaration[source.value=/^lodash\//]' is not allowed.`},
+				},
+			},
+
+			// ============================================================
+			// Selector boundary: attribute regex with case-insensitive flag
+			// ============================================================
+			{
+				Code:    `import foo from "Lodash";`,
+				Options: []interface{}{`ImportDeclaration[source.value=/lodash/i]`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ImportDeclaration[source.value=/lodash/i]' is not allowed.`},
+				},
+			},
+
+			// ============================================================
+			// Selector boundary: attribute equality with single-quote string
+			// ============================================================
+			{
+				Code:    `let foo;`,
+				Options: []interface{}{`VariableDeclaration[kind='let']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'VariableDeclaration[kind='let']' is not allowed.`},
+				},
+			},
+
+			// ============================================================
+			// Selector boundary: attribute presence on optional `id`
+			// (function expression with name vs anonymous)
+			// ============================================================
+			{
+				Code:    `(function named() {});`,
+				Options: []interface{}{"FunctionExpression[id]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'FunctionExpression[id]' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// AssignmentExpression vs BinaryExpression refinement
+			// ============================================================
+			{
+				Code:    `a = b;`,
+				Options: []interface{}{"AssignmentExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'AssignmentExpression' is not allowed."},
+				},
+			},
+			{
+				Code:    `a += b;`,
+				Options: []interface{}{"AssignmentExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'AssignmentExpression' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// LogicalExpression refinement
+			// ============================================================
+			{
+				Code:    `a && b;`,
+				Options: []interface{}{"LogicalExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'LogicalExpression' is not allowed."},
+				},
+			},
+			{
+				Code:    `a ?? b;`,
+				Options: []interface{}{"LogicalExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'LogicalExpression' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// SequenceExpression refinement (comma operator)
+			// ============================================================
+			{
+				Code:    `var x = (a, b);`,
+				Options: []interface{}{"SequenceExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'SequenceExpression' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// UnaryExpression vs UpdateExpression refinement
+			// ============================================================
+			{
+				Code:    `+x;`,
+				Options: []interface{}{"UnaryExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'UnaryExpression' is not allowed."},
+				},
+			},
+			{
+				Code:    `typeof x;`,
+				Options: []interface{}{"UnaryExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'UnaryExpression' is not allowed."},
+				},
+			},
+			{
+				Code:    `++x;`,
+				Options: []interface{}{"UpdateExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'UpdateExpression' is not allowed."},
+				},
+			},
+			{
+				Code:    `x--;`,
+				Options: []interface{}{"UpdateExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'UpdateExpression' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// MemberExpression encompasses both dotted and bracket access
+			// ============================================================
+			{
+				Code:    `a.b;`,
+				Options: []interface{}{"MemberExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MemberExpression' is not allowed."},
+				},
+			},
+			{
+				Code:    `a['b'];`,
+				Options: []interface{}{"MemberExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MemberExpression' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// computed-vs-not member access via `[computed=true]`
+			// ============================================================
+			{
+				Code:    `a[b];`,
+				Options: []interface{}{"MemberExpression[computed=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MemberExpression[computed=true]' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Property covers PropertyAssignment + Shorthand + Method +
+			// Get/Set; selecting `Property` should fire on each
+			// ============================================================
+			{
+				Code:    `({ a, b: 1, get c() {}, set d(v) {}, e() {} });`,
+				Options: []interface{}{"Property"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Property' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: "Using 'Property' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: "Using 'Property' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: "Using 'Property' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: "Using 'Property' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Spread in array vs object — both should match SpreadElement
+			// ============================================================
+			{
+				Code:    `[...a];`,
+				Options: []interface{}{"SpreadElement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'SpreadElement' is not allowed."},
+				},
+			},
+			{
+				Code:    `({...a});`,
+				Options: []interface{}{"SpreadElement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'SpreadElement' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Real-world: forbid `with`
+			// ============================================================
+			{
+				Code:    `with (x) { y; }`,
+				Options: []interface{}{"WithStatement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'WithStatement' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Real-world: forbid console.* via callee.object.name selector
+			// ============================================================
+			{
+				Code:    `console.log('msg');`,
+				Options: []interface{}{`CallExpression[callee.object.name='console']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   `Using 'CallExpression[callee.object.name='console']' is not allowed.`,
+					},
+				},
+			},
+
+			// ============================================================
+			// Real-world: forbid setTimeout via callee.name
+			// ============================================================
+			{
+				Code:    `setTimeout(fn, 0);`,
+				Options: []interface{}{`CallExpression[callee.name='setTimeout']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   `Using 'CallExpression[callee.name='setTimeout']' is not allowed.`,
+					},
+				},
+			},
+
+			// ============================================================
+			// Real-world: forbid for-in
+			// ============================================================
+			{
+				Code:    `for (const k in obj) {}`,
+				Options: []interface{}{"ForInStatement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ForInStatement' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Real-world: forbid default exports
+			// ============================================================
+			{
+				Code:    `export default 1;`,
+				Options: []interface{}{"ExportDefaultDeclaration"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ExportDefaultDeclaration' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Real-world: ban any `new Promise(...)` — encourage
+			// `Promise.resolve` / `Promise.reject`
+			// ============================================================
+			{
+				Code:    `new Promise(function (res, rej) { res(); });`,
+				Options: []interface{}{`NewExpression[callee.name='Promise']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'NewExpression[callee.name='Promise']' is not allowed.`},
+				},
+			},
+
+			// ============================================================
+			// Real-world: forbid arrow fns whose body IS a BlockStatement
+			// (i.e. require concise body). Exercises an attribute path
+			// that resolves to a node and then reads the synthetic `type`
+			// to compare against an ESTree name.
+			// ============================================================
+			{
+				Code:    `const f = () => { return 5; };`,
+				Options: []interface{}{"ArrowFunctionExpression[body.type='BlockStatement']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   "Using 'ArrowFunctionExpression[body.type='BlockStatement']' is not allowed.",
+					},
+				},
+			},
+
+			// ============================================================
+			// Real-world: ban async functions in a specific module
+			// ============================================================
+			{
+				Code:    `async function f() {}`,
+				Options: []interface{}{"FunctionDeclaration[async=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'FunctionDeclaration[async=true]' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Real-world: ban generator functions
+			// ============================================================
+			{
+				Code:    `function* g() {}`,
+				Options: []interface{}{"FunctionDeclaration[generator=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'FunctionDeclaration[generator=true]' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Real-world: object-format mixed with string-format options
+			// ============================================================
+			{
+				Code: `var a = 1; with (x) {}`,
+				Options: []interface{}{
+					"WithStatement",
+					map[string]interface{}{
+						"selector": "VariableDeclaration",
+						"message":  "Use let or const, not var.",
+					},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					// Order: selectors fire in registration order on each node;
+					// nodes are visited in source order. VariableStatement
+					// comes first, then WithStatement.
+					{MessageId: "restrictedSyntax", Message: "Use let or const, not var."},
+					{MessageId: "restrictedSyntax", Message: "Using 'WithStatement' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Selector boundary: nested `:is(...)` inside a combinator —
+			// match the outermost optional chain only
+			// ============================================================
+			{
+				Code:    `a?.b?.c`,
+				Options: []interface{}{"ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ChainExpression' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Mixing nodes with shared fields: VariableDeclarator (the
+			// inner declarator) vs VariableDeclaration (the statement)
+			// ============================================================
+			{
+				Code:    `var a = 1, b = 2;`,
+				Options: []interface{}{"VariableDeclarator"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'VariableDeclarator' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: "Using 'VariableDeclarator' is not allowed."},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_restricted_syntax/parser.go
+++ b/internal/rules/no_restricted_syntax/parser.go
@@ -1,0 +1,560 @@
+package no_restricted_syntax
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// parseSelector parses an ESLint selector string into a selector tree.
+// It supports the subset of esquery used by `no-restricted-syntax` test
+// fixtures plus realistic real-world usage: identifiers, wildcard `*`,
+// class selectors (`.field`), attribute selectors (`[a]`, `[a=v]`,
+// `[a>v]`, …), pseudo-classes (`:is`, `:not`, `:matches`, `:has`,
+// `:first-child`, `:last-child`, `:nth-child(N)`, `:nth-last-child(N)`),
+// combinators `>`, `+`, `~` and descendant whitespace, and unions `,`.
+//
+// Returns the parsed selector and a non-nil error on malformed input.
+func parseSelector(input string) (selector, error) {
+	p := &parser{src: input, pos: 0}
+	p.skipSpaces()
+	sel, err := p.parseUnion()
+	if err != nil {
+		return nil, err
+	}
+	p.skipSpaces()
+	if p.pos != len(p.src) {
+		return nil, fmt.Errorf("unexpected character %q at position %d", p.src[p.pos], p.pos)
+	}
+	return sel, nil
+}
+
+type parser struct {
+	src string
+	pos int
+}
+
+func (p *parser) eof() bool {
+	return p.pos >= len(p.src)
+}
+
+func (p *parser) peek() byte {
+	if p.eof() {
+		return 0
+	}
+	return p.src[p.pos]
+}
+
+func (p *parser) skipSpaces() {
+	for !p.eof() && (p.src[p.pos] == ' ' || p.src[p.pos] == '\t' || p.src[p.pos] == '\n' || p.src[p.pos] == '\r') {
+		p.pos++
+	}
+}
+
+// hasSpaceBefore reports whether at least one whitespace char preceded
+// the current position. Used to distinguish descendant combinator
+// (whitespace) from an end-of-selector situation.
+func (p *parser) hasSpaceBefore(prevPos int) bool {
+	if prevPos >= p.pos {
+		return false
+	}
+	for i := prevPos; i < p.pos; i++ {
+		c := p.src[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *parser) parseUnion() (selector, error) {
+	first, err := p.parseCompound()
+	if err != nil {
+		return nil, err
+	}
+	p.skipSpaces()
+	if p.eof() || p.peek() != ',' {
+		return first, nil
+	}
+	parts := []selector{first}
+	for !p.eof() && p.peek() == ',' {
+		p.pos++ // ,
+		p.skipSpaces()
+		next, err := p.parseCompound()
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, next)
+		p.skipSpaces()
+	}
+	return unionSelector{Selectors: parts}, nil
+}
+
+// parseCompound parses a compound selector, i.e. a chain of sequences
+// joined by combinators (` `, `>`, `+`, `~`).
+func (p *parser) parseCompound() (selector, error) {
+	left, err := p.parseSequence()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		startPos := p.pos
+		p.skipSpaces()
+		if p.eof() || p.peek() == ',' || p.peek() == ')' {
+			return left, nil
+		}
+		var kind combinatorKind
+		switch p.peek() {
+		case '>':
+			kind = combChild
+			p.pos++
+			p.skipSpaces()
+		case '+':
+			kind = combAdjacent
+			p.pos++
+			p.skipSpaces()
+		case '~':
+			kind = combSibling
+			p.pos++
+			p.skipSpaces()
+		default:
+			if !p.hasSpaceBefore(startPos) {
+				return left, nil
+			}
+			kind = combDescendant
+		}
+		right, err := p.parseSequence()
+		if err != nil {
+			return nil, err
+		}
+		left = combinatorSelector{Kind: kind, Left: left, Right: right}
+	}
+}
+
+// parseSequence parses a single selector with optional filters chained on
+// the same node (e.g. `Identifier[name="foo"]:not(...)`).
+func (p *parser) parseSequence() (selector, error) {
+	var head selector
+	c := p.peek()
+	switch {
+	case c == 0:
+		return nil, errors.New("unexpected end of selector")
+	case c == '*':
+		p.pos++
+		head = identifierSelector{Name: "*"}
+	case c == '.' || c == '[' || c == ':':
+		// Filters without an explicit head — equivalent to `*` followed by
+		// the filter.
+		head = identifierSelector{Name: "*"}
+	case isIdentStart(c):
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		head = identifierSelector{Name: name}
+	default:
+		return nil, fmt.Errorf("unexpected character %q at position %d", c, p.pos)
+	}
+
+	for !p.eof() {
+		c := p.peek()
+		switch c {
+		case '.':
+			p.pos++
+			cls, err := p.parseIdent()
+			if err != nil {
+				return nil, err
+			}
+			head = classSelector{Inner: head, Class: cls}
+		case '[':
+			attr, err := p.parseAttr(head)
+			if err != nil {
+				return nil, err
+			}
+			head = attr
+		case ':':
+			ps, err := p.parsePseudo(head)
+			if err != nil {
+				return nil, err
+			}
+			head = ps
+		default:
+			return head, nil
+		}
+	}
+	return head, nil
+}
+
+func (p *parser) parseIdent() (string, error) {
+	start := p.pos
+	if p.eof() || !isIdentStart(p.src[p.pos]) {
+		return "", fmt.Errorf("expected identifier at position %d", p.pos)
+	}
+	p.pos++
+	for !p.eof() && isIdentCont(p.src[p.pos]) {
+		p.pos++
+	}
+	return p.src[start:p.pos], nil
+}
+
+// parseAttr handles `[path]`, `[path op value]`. The leading `[` has been
+// peeked but not consumed.
+func (p *parser) parseAttr(inner selector) (selector, error) {
+	if p.peek() != '[' {
+		return nil, fmt.Errorf("expected [ at position %d", p.pos)
+	}
+	p.pos++ // [
+	p.skipSpaces()
+	pathParts, err := p.parseAttrPath()
+	if err != nil {
+		return nil, err
+	}
+	p.skipSpaces()
+	if !p.eof() && p.peek() == ']' {
+		p.pos++
+		return attrSelector{Inner: inner, Path: pathParts, Op: attrPresent}, nil
+	}
+	op, err := p.parseAttrOp()
+	if err != nil {
+		return nil, err
+	}
+	p.skipSpaces()
+	val, err := p.parseAttrValue()
+	if err != nil {
+		return nil, err
+	}
+	p.skipSpaces()
+	if p.eof() || p.peek() != ']' {
+		return nil, fmt.Errorf("expected ] at position %d", p.pos)
+	}
+	p.pos++
+	return attrSelector{Inner: inner, Path: pathParts, Op: op, Value: val}, nil
+}
+
+func (p *parser) parseAttrPath() ([]string, error) {
+	var parts []string
+	for {
+		ident, err := p.parseAttrPathSegment()
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, ident)
+		if p.eof() || p.peek() != '.' {
+			break
+		}
+		p.pos++
+	}
+	return parts, nil
+}
+
+// parseAttrPathSegment accepts a regular identifier, optionally followed by
+// hyphens (paths like `foo-bar` are not used by ESTree but esquery accepts
+// them).
+func (p *parser) parseAttrPathSegment() (string, error) {
+	start := p.pos
+	if p.eof() || !isIdentStart(p.peek()) {
+		return "", fmt.Errorf("expected identifier in attribute path at position %d", p.pos)
+	}
+	p.pos++
+	for !p.eof() {
+		c := p.peek()
+		if isIdentCont(c) {
+			p.pos++
+			continue
+		}
+		break
+	}
+	return p.src[start:p.pos], nil
+}
+
+func (p *parser) parseAttrOp() (attrOp, error) {
+	if p.eof() {
+		return 0, fmt.Errorf("expected operator at position %d", p.pos)
+	}
+	switch p.peek() {
+	case '=':
+		p.pos++
+		return attrEqual, nil
+	case '!':
+		if p.pos+1 < len(p.src) && p.src[p.pos+1] == '=' {
+			p.pos += 2
+			return attrNotEqual, nil
+		}
+	case '<':
+		if p.pos+1 < len(p.src) && p.src[p.pos+1] == '=' {
+			p.pos += 2
+			return attrLessOrEqual, nil
+		}
+		p.pos++
+		return attrLess, nil
+	case '>':
+		if p.pos+1 < len(p.src) && p.src[p.pos+1] == '=' {
+			p.pos += 2
+			return attrGreaterOrEqual, nil
+		}
+		p.pos++
+		return attrGreater, nil
+	}
+	return 0, fmt.Errorf("unsupported operator at position %d", p.pos)
+}
+
+func (p *parser) parseAttrValue() (attrValue, error) {
+	if p.eof() {
+		return attrValue{}, fmt.Errorf("expected value at position %d", p.pos)
+	}
+	c := p.peek()
+	switch {
+	case c == '"' || c == '\'':
+		s, err := p.parseString(c)
+		if err != nil {
+			return attrValue{}, err
+		}
+		return attrValue{Kind: attrValueString, Str: s}, nil
+	case c == '/':
+		pat, flags, err := p.parseRegex()
+		if err != nil {
+			return attrValue{}, err
+		}
+		return attrValue{Kind: attrValueRegex, Regex: pat, Flags: flags}, nil
+	case c == '-' || (c >= '0' && c <= '9'):
+		num, err := p.parseNumber()
+		if err != nil {
+			return attrValue{}, err
+		}
+		return attrValue{Kind: attrValueNumber, Num: num}, nil
+	case isIdentStart(c):
+		ident, err := p.parseIdent()
+		if err != nil {
+			return attrValue{}, err
+		}
+		switch ident {
+		case "true":
+			return attrValue{Kind: attrValueBool, Bool: true}, nil
+		case "false":
+			return attrValue{Kind: attrValueBool, Bool: false}, nil
+		case "null":
+			return attrValue{Kind: attrValueNull}, nil
+		}
+		return attrValue{Kind: attrValueIdent, Ident: ident}, nil
+	}
+	return attrValue{}, fmt.Errorf("unexpected attribute value at position %d", p.pos)
+}
+
+func (p *parser) parseString(quote byte) (string, error) {
+	if p.peek() != quote {
+		return "", fmt.Errorf("expected %c at position %d", quote, p.pos)
+	}
+	p.pos++ // opening quote
+	var sb strings.Builder
+	for !p.eof() {
+		c := p.src[p.pos]
+		if c == '\\' && p.pos+1 < len(p.src) {
+			next := p.src[p.pos+1]
+			sb.WriteByte(next)
+			p.pos += 2
+			continue
+		}
+		if c == quote {
+			p.pos++
+			return sb.String(), nil
+		}
+		sb.WriteByte(c)
+		p.pos++
+	}
+	return "", fmt.Errorf("unterminated string starting at quote %c", quote)
+}
+
+func (p *parser) parseRegex() (string, string, error) {
+	if p.peek() != '/' {
+		return "", "", fmt.Errorf("expected / at position %d", p.pos)
+	}
+	p.pos++ // opening /
+	var pat strings.Builder
+	for !p.eof() {
+		c := p.src[p.pos]
+		if c == '\\' && p.pos+1 < len(p.src) {
+			pat.WriteByte(c)
+			pat.WriteByte(p.src[p.pos+1])
+			p.pos += 2
+			continue
+		}
+		if c == '/' {
+			p.pos++ // closing /
+			flagsStart := p.pos
+			for !p.eof() {
+				fc := p.src[p.pos]
+				if fc >= 'a' && fc <= 'z' || fc >= 'A' && fc <= 'Z' {
+					p.pos++
+					continue
+				}
+				break
+			}
+			return pat.String(), p.src[flagsStart:p.pos], nil
+		}
+		pat.WriteByte(c)
+		p.pos++
+	}
+	return "", "", errors.New("unterminated regex literal")
+}
+
+func (p *parser) parseNumber() (float64, error) {
+	start := p.pos
+	if p.peek() == '-' {
+		p.pos++
+	}
+	for !p.eof() && p.src[p.pos] >= '0' && p.src[p.pos] <= '9' {
+		p.pos++
+	}
+	if !p.eof() && p.src[p.pos] == '.' {
+		p.pos++
+		for !p.eof() && p.src[p.pos] >= '0' && p.src[p.pos] <= '9' {
+			p.pos++
+		}
+	}
+	val, err := strconv.ParseFloat(p.src[start:p.pos], 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid number at position %d: %w", start, err)
+	}
+	return val, nil
+}
+
+func (p *parser) parsePseudo(inner selector) (selector, error) {
+	if p.peek() != ':' {
+		return nil, fmt.Errorf("expected : at position %d", p.pos)
+	}
+	p.pos++ // :
+	name, err := p.parsePseudoName()
+	if err != nil {
+		return nil, err
+	}
+	switch name {
+	case "first-child":
+		return wrapPseudo(inner, pseudoSelector{Name: "nth-child", N: 1}), nil
+	case "last-child":
+		return wrapPseudo(inner, pseudoSelector{Name: "nth-last-child", N: 1}), nil
+	case "nth-child", "nth-last-child":
+		n, err := p.parsePseudoNumberArg()
+		if err != nil {
+			return nil, err
+		}
+		return wrapPseudo(inner, pseudoSelector{Name: name, N: n}), nil
+	case "is", "matches", "not", "has":
+		args, err := p.parsePseudoSelectorArgs()
+		if err != nil {
+			return nil, err
+		}
+		return wrapPseudo(inner, pseudoSelector{Name: name, Args: args}), nil
+	case "statement", "expression", "declaration", "function", "pattern":
+		// Treat known esquery class pseudos as a no-op match (we don't
+		// model these category sets). The combination with a head
+		// selector still narrows by the head, so this is conservative.
+		return inner, nil
+	}
+	return nil, fmt.Errorf("unsupported pseudo class %q at position %d", name, p.pos)
+}
+
+func wrapPseudo(inner selector, p pseudoSelector) selector {
+	if id, ok := inner.(identifierSelector); ok && id.Name == "*" {
+		// `*:not(X)` is just `:not(X)` — collapse to keep selector trees tidy
+		// but still report the constraint.
+		return p
+	}
+	return combinedPseudo{Inner: inner, Pseudo: p}
+}
+
+// combinedPseudo is `inner` AND `pseudo` applied to the same node.
+type combinedPseudo struct {
+	Inner  selector
+	Pseudo pseudoSelector
+}
+
+func (combinedPseudo) isSelector() {}
+
+func (p *parser) parsePseudoName() (string, error) {
+	start := p.pos
+	for !p.eof() {
+		c := p.src[p.pos]
+		if isIdentCont(c) {
+			p.pos++
+			continue
+		}
+		break
+	}
+	if p.pos == start {
+		return "", fmt.Errorf("expected pseudo name at position %d", p.pos)
+	}
+	return p.src[start:p.pos], nil
+}
+
+func (p *parser) parsePseudoNumberArg() (int, error) {
+	if p.eof() || p.peek() != '(' {
+		return 0, fmt.Errorf("expected ( at position %d", p.pos)
+	}
+	p.pos++ // (
+	p.skipSpaces()
+	start := p.pos
+	for !p.eof() && p.src[p.pos] >= '0' && p.src[p.pos] <= '9' {
+		p.pos++
+	}
+	if start == p.pos {
+		return 0, fmt.Errorf("expected number at position %d", p.pos)
+	}
+	n, err := strconv.Atoi(p.src[start:p.pos])
+	if err != nil {
+		return 0, err
+	}
+	p.skipSpaces()
+	if p.eof() || p.peek() != ')' {
+		return 0, fmt.Errorf("expected ) at position %d", p.pos)
+	}
+	p.pos++
+	return n, nil
+}
+
+func (p *parser) parsePseudoSelectorArgs() ([]selector, error) {
+	if p.eof() || p.peek() != '(' {
+		return nil, fmt.Errorf("expected ( at position %d", p.pos)
+	}
+	p.pos++ // (
+	p.skipSpaces()
+	var args []selector
+	first, err := p.parseCompound()
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, first)
+	p.skipSpaces()
+	for !p.eof() && p.peek() == ',' {
+		p.pos++
+		p.skipSpaces()
+		next, err := p.parseCompound()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, next)
+		p.skipSpaces()
+	}
+	if p.eof() || p.peek() != ')' {
+		return nil, fmt.Errorf("expected ) at position %d", p.pos)
+	}
+	p.pos++
+	return args, nil
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || c == '#' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '$'
+}
+
+func isIdentCont(c byte) bool {
+	if isIdentStart(c) {
+		return true
+	}
+	if c >= '0' && c <= '9' {
+		return true
+	}
+	if c == '-' {
+		return true
+	}
+	return false
+}

--- a/internal/rules/no_restricted_syntax/parser_test.go
+++ b/internal/rules/no_restricted_syntax/parser_test.go
@@ -1,0 +1,183 @@
+package no_restricted_syntax
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSelector_Wellformed(t *testing.T) {
+	cases := []string{
+		"Identifier",
+		"*",
+		"FunctionExpression",
+		"BinaryExpression",
+		`Identifier[name="bar"]`,
+		"BreakStatement[label]",
+		`VariableDeclaration[kind='using']`,
+		`VariableDeclaration[kind='await using']`,
+		"FunctionDeclaration[params.length>2]",
+		"FunctionDeclaration[params.length>=2]",
+		"FunctionDeclaration[params.length<=2]",
+		"FunctionDeclaration[params.length<2]",
+		"Literal[regex.flags=/./]",
+		"Literal[regex.flags=/i/]",
+		`ImportDeclaration[source.value=/^some\/path$/]`,
+		"ArrowFunctionExpression > BlockStatement",
+		"Property > Literal.key",
+		"FunctionDeclaration FunctionExpression",
+		"Literal + Literal",
+		"* ~ *",
+		":is(Identifier, Literal)",
+		":matches(Identifier, Literal)",
+		":not(VariableDeclaration)",
+		":has(Literal)",
+		":nth-child(1)",
+		":nth-last-child(2)",
+		":first-child",
+		":last-child",
+		"ChainExpression",
+		"[optional=true]",
+		"MemberExpression[computed=true]",
+		"MethodDefinition:not([static=true])",
+		":is(Identifier[name='foo'], Identifier[name='bar'])",
+		"FunctionDeclaration[generator=true]",
+		"FunctionDeclaration[async=true]",
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if _, err := parseSelector(c); err != nil {
+				t.Fatalf("parseSelector(%q) returned %v", c, err)
+			}
+		})
+	}
+}
+
+func TestParseSelector_Malformed(t *testing.T) {
+	cases := []string{
+		"",                                   // empty
+		"   ",                                // whitespace only
+		"[",                                  // unterminated bracket
+		"BinaryExpression[",                  // unterminated bracket after head
+		"BinaryExpression[name",              // unterminated attribute
+		"BinaryExpression[name=",             // missing value
+		"BinaryExpression[name=']",           // unterminated string
+		"BinaryExpression[name=/]",           // unterminated regex (no closing /)
+		":nth-child",                         // missing arg
+		":nth-child(",                        // unterminated paren
+		":nth-child(abc)",                    // non-numeric arg
+		":is(",                               // unterminated paren
+		":is(,)",                             // empty selector in args
+		"Identifier,",                        // trailing comma
+		"Identifier >",                       // dangling combinator
+		"Identifier >> Foo",                  // double combinator
+		":unknownPseudo",                     // unsupported pseudo
+		"FunctionDeclaration[params.length>", // missing operand
+		"BinaryExpression[name=&&]",          // illegal operator value
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if _, err := parseSelector(c); err == nil {
+				t.Fatalf("parseSelector(%q) should have failed", c)
+			}
+		})
+	}
+}
+
+func TestParseRuleOptions_Shapes(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		if got := parseRuleOptions(nil); len(got) != 0 {
+			t.Fatalf("nil should yield 0 entries, got %d", len(got))
+		}
+	})
+	t.Run("empty array", func(t *testing.T) {
+		if got := parseRuleOptions([]interface{}{}); len(got) != 0 {
+			t.Fatalf("empty array should yield 0 entries, got %d", len(got))
+		}
+	})
+	t.Run("single string (CLI / single-option config shape)", func(t *testing.T) {
+		got := parseRuleOptions("Identifier")
+		if len(got) != 1 || got[0].selector != "Identifier" {
+			t.Fatalf("unexpected entries: %#v", got)
+		}
+	})
+	t.Run("single map (CLI / single-option config shape)", func(t *testing.T) {
+		got := parseRuleOptions(map[string]interface{}{
+			"selector": "Identifier",
+			"message":  "no identifiers",
+		})
+		if len(got) != 1 || got[0].selector != "Identifier" || got[0].message != "no identifiers" {
+			t.Fatalf("unexpected entries: %#v", got)
+		}
+	})
+	t.Run("multi-element array of mixed forms (rule_tester shape)", func(t *testing.T) {
+		got := parseRuleOptions([]interface{}{
+			"WithStatement",
+			map[string]interface{}{"selector": "VariableDeclaration", "message": "x"},
+		})
+		if len(got) != 2 {
+			t.Fatalf("expected 2, got %d", len(got))
+		}
+		if got[0].selector != "WithStatement" || got[0].message != "" {
+			t.Fatalf("entry 0 mismatch: %#v", got[0])
+		}
+		if got[1].selector != "VariableDeclaration" || got[1].message != "x" {
+			t.Fatalf("entry 1 mismatch: %#v", got[1])
+		}
+	})
+	t.Run("malformed selectors are silently dropped, well-formed kept", func(t *testing.T) {
+		got := parseRuleOptions([]interface{}{
+			"Identifier",
+			"[", // unterminated
+			"FunctionExpression",
+		})
+		if len(got) != 2 {
+			t.Fatalf("expected 2 entries, got %d (%#v)", len(got), got)
+		}
+		names := []string{got[0].selector, got[1].selector}
+		if !strings.Contains(strings.Join(names, ","), "Identifier") || !strings.Contains(strings.Join(names, ","), "FunctionExpression") {
+			t.Fatalf("missing well-formed entry; got %v", names)
+		}
+	})
+	t.Run("object missing selector key is dropped", func(t *testing.T) {
+		got := parseRuleOptions([]interface{}{
+			map[string]interface{}{"message": "no selector"},
+		})
+		if len(got) != 0 {
+			t.Fatalf("expected 0 entries, got %d", len(got))
+		}
+	})
+	t.Run("non-string non-map array elements are ignored", func(t *testing.T) {
+		got := parseRuleOptions([]interface{}{
+			"Identifier",
+			42,
+			true,
+			nil,
+		})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(got))
+		}
+	})
+}
+
+func TestParseRuleOptions_DefaultMessage(t *testing.T) {
+	got := parseRuleOptions("Identifier")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry")
+	}
+	if msg := got[0].formatMessage(); msg != "Using 'Identifier' is not allowed." {
+		t.Fatalf("default message mismatch: %q", msg)
+	}
+}
+
+func TestParseRuleOptions_CustomMessage(t *testing.T) {
+	got := parseRuleOptions(map[string]interface{}{
+		"selector": "Identifier",
+		"message":  "no",
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry")
+	}
+	if msg := got[0].formatMessage(); msg != "no" {
+		t.Fatalf("custom message mismatch: %q", msg)
+	}
+}

--- a/internal/rules/no_restricted_syntax/probe_test.go
+++ b/internal/rules/no_restricted_syntax/probe_test.go
@@ -1,0 +1,890 @@
+package no_restricted_syntax
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoRestrictedSyntax_ProbeDeepEdges is a deep-edge probe suite — each
+// case targets a scenario a real ESLint user might run into and that the
+// initial port could plausibly mishandle. Cases that pass here are kept
+// in the regular test file; cases that fail get fixed in the matcher /
+// parser / mapping layer.
+func TestNoRestrictedSyntax_ProbeDeepEdges(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoRestrictedSyntaxRule,
+		[]rule_tester.ValidTestCase{
+			// Probe: `MemberExpression[object.name='console']` with a
+			// parenthesized receiver should still match — esquery
+			// transparently sees through ParenthesizedExpression in
+			// ESTree because parens are dropped at parse time.
+			// Expected behaviour: rslint should also see through them
+			// even though tsgo keeps a ParenthesizedExpression wrapper.
+			{
+				Code:    `(notConsole).log('msg');`,
+				Options: []interface{}{`MemberExpression[object.name='console']`},
+			},
+			// Probe: TS non-null assertion on the receiver should not
+			// upgrade non-console into console.
+			{
+				Code:    `notConsole!.log('msg');`,
+				Options: []interface{}{`MemberExpression[object.name='console']`},
+			},
+			// Probe: import side-effect-only — shape: ImportDeclaration
+			// without specifiers — should NOT match a selector that
+			// requires source.value=foo when the literal is bar.
+			{
+				Code:    `import 'bar';`,
+				Options: []interface{}{`ImportDeclaration[source.value='foo']`},
+			},
+			// Probe: TaggedTemplateExpression should not be a CallExpression.
+			{
+				Code:    "tag`hi`;",
+				Options: []interface{}{"CallExpression"},
+			},
+			// Probe: NewExpression should not match CallExpression.
+			{
+				Code:    `new Foo();`,
+				Options: []interface{}{"CallExpression"},
+			},
+			// Probe: `ConditionalExpression` should not match an `if`
+			// statement (different ESTree types).
+			{
+				Code:    `if (a) b; else c;`,
+				Options: []interface{}{"ConditionalExpression"},
+			},
+
+			// Round 2 negatives — verify the Property/MethodDefinition
+			// disambiguation does not over-match.
+			{
+				// Object-literal method is Property, NOT MethodDefinition.
+				Code:    `({ foo() {} });`,
+				Options: []interface{}{"MethodDefinition"},
+			},
+			{
+				// Class method is MethodDefinition, NOT Property.
+				Code:    `class C { foo() {} }`,
+				Options: []interface{}{"Property"},
+			},
+			{
+				// Object-literal getter is Property, NOT MethodDefinition.
+				Code:    `({ get x() { return 1; } });`,
+				Options: []interface{}{"MethodDefinition"},
+			},
+			{
+				// Class getter is MethodDefinition, NOT Property.
+				Code:    `class C { get x() { return 1; } }`,
+				Options: []interface{}{"Property"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Probe: parenthesized receiver — selectors should see through
+			// ParenthesizedExpression like esquery does.
+			{
+				Code:    `(console).log('msg');`,
+				Options: []interface{}{`MemberExpression[object.name='console']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   `Using 'MemberExpression[object.name='console']' is not allowed.`,
+					},
+				},
+			},
+			// Probe: TS non-null assertion on receiver
+			{
+				Code:    `console!.log('msg');`,
+				Options: []interface{}{`MemberExpression[object.name='console']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   `Using 'MemberExpression[object.name='console']' is not allowed.`,
+					},
+				},
+			},
+			// Probe: TS `as` cast on receiver
+			{
+				Code:    `(console as any).log('msg');`,
+				Options: []interface{}{`MemberExpression[object.name='console']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "restrictedSyntax",
+						Message:   `Using 'MemberExpression[object.name='console']' is not allowed.`,
+					},
+				},
+			},
+			// Probe: standalone presence selector matches every node.
+			// Compact source should produce a known number of diagnostics.
+			{
+				Code:    `bar`,
+				Options: []interface{}{`[type='Identifier']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using '[type='Identifier']' is not allowed."},
+				},
+			},
+			// Probe: `[type!='Identifier']` — matches every non-Identifier
+			// node. For `var x = 1;` that is: VariableStatement,
+			// VariableDeclaration (the declarator), NumericLiteral.
+			// Identifier `x` is excluded.
+			{
+				Code:    `var x = 1;`,
+				Options: []interface{}{`[type!='Identifier']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using '[type!='Identifier']' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: "Using '[type!='Identifier']' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: "Using '[type!='Identifier']' is not allowed."},
+				},
+			},
+			// Probe: nested optional chain with parenthesised middle —
+			// ChainExpression selector still resolves to one outermost.
+			{
+				Code:    `(a?.b)?.c`,
+				Options: []interface{}{"ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					// The outer chain `(a?.b)?.c` — only one outermost.
+					{MessageId: "restrictedSyntax", Message: "Using 'ChainExpression' is not allowed."},
+					// Inner chain `a?.b` is a separate chain because the
+					// parens break the chain — esquery would also wrap it
+					// in its own ChainExpression. Keep both.
+					{MessageId: "restrictedSyntax", Message: "Using 'ChainExpression' is not allowed."},
+				},
+			},
+			// Probe: `:has(...)` — class with at least one method named foo
+			{
+				Code:    `class A { foo() {} bar() {} }`,
+				Options: []interface{}{`ClassDeclaration:has(MethodDefinition[key.name='foo'])`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ClassDeclaration:has(MethodDefinition[key.name='foo'])' is not allowed.`},
+				},
+			},
+			// Probe: `:not(...)` head — methods that are not static.
+			{
+				Code:    `class A { static foo() {} bar() {} }`,
+				Options: []interface{}{"MethodDefinition:not([static=true])"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition:not([static=true])' is not allowed."},
+				},
+			},
+			// Probe: ImportSpecifier with name attribute
+			{
+				Code:    `import { useEffect } from 'react';`,
+				Options: []interface{}{`ImportSpecifier[imported.name='useEffect']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ImportSpecifier[imported.name='useEffect']' is not allowed.`},
+				},
+			},
+			// Probe: ban arrow inside a class field initializer (a common
+			// React useEffect anti-pattern).
+			{
+				Code:    `class A { onClick = () => {}; }`,
+				Options: []interface{}{"PropertyDefinition > ArrowFunctionExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'PropertyDefinition > ArrowFunctionExpression' is not allowed."},
+				},
+			},
+			// Probe: ban String literal that is the source of an import
+			// using a regex with capturing path. Real users do this for
+			// path-pinning.
+			{
+				Code:    `import 'react/jsx-runtime';`,
+				Options: []interface{}{`ImportDeclaration > Literal[value=/^react\//]`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ImportDeclaration > Literal[value=/^react\//]' is not allowed.`},
+				},
+			},
+			// Probe: ban `eval(`anything`)`. Common security guideline.
+			{
+				Code:    `eval(userInput);`,
+				Options: []interface{}{`CallExpression[callee.name='eval']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'CallExpression[callee.name='eval']' is not allowed.`},
+				},
+			},
+			// Probe: ban `instanceof` (BinaryExpression with operator).
+			{
+				Code:    `x instanceof Foo;`,
+				Options: []interface{}{"BinaryExpression[operator='instanceof']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'BinaryExpression[operator='instanceof']' is not allowed."},
+				},
+			},
+			// Probe: ban `typeof` operator (UnaryExpression operator).
+			{
+				Code:    `typeof x;`,
+				Options: []interface{}{"UnaryExpression[operator='typeof']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'UnaryExpression[operator='typeof']' is not allowed."},
+				},
+			},
+			// Probe: ban template literals with substitutions.
+			{
+				Code:    "`hello ${name}`;",
+				Options: []interface{}{"TemplateLiteral"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'TemplateLiteral' is not allowed."},
+				},
+			},
+			// Probe: ban computed class member key.
+			{
+				Code:    `class A { [foo]() {} }`,
+				Options: []interface{}{"MethodDefinition[computed=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition[computed=true]' is not allowed."},
+				},
+			},
+			// Probe: ban private class fields. ESTree: PropertyDefinition
+			// with PrivateIdentifier key.
+			{
+				Code:    `class A { #x = 1; }`,
+				Options: []interface{}{"PropertyDefinition > PrivateIdentifier.key"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'PropertyDefinition > PrivateIdentifier.key' is not allowed."},
+				},
+			},
+			// Probe: forbid catch with no parameter (catch optional
+			// binding, ES2019). ESTree: CatchClause with param=null. Our
+			// presence check should be false for the omitted variant.
+			{
+				Code:    `try { f(); } catch (e) { g(); }`,
+				Options: []interface{}{"CatchClause[param]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'CatchClause[param]' is not allowed."},
+				},
+			},
+			// Probe: `MemberExpression[property.name='log']` — read the
+			// property name via attribute path.
+			{
+				Code:    `obj.log();`,
+				Options: []interface{}{`MemberExpression[property.name='log']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'MemberExpression[property.name='log']' is not allowed.`},
+				},
+			},
+			// Probe: ban export-default functions (common code-style rule).
+			{
+				Code:    `export default function f() {}`,
+				Options: []interface{}{"ExportDefaultDeclaration > FunctionDeclaration"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ExportDefaultDeclaration > FunctionDeclaration' is not allowed."},
+				},
+			},
+			// Probe: ban literal `true` / `false` (BooleanLiteral in
+			// ESTree, KindTrueKeyword / KindFalseKeyword in tsgo). Bare
+			// `Literal[value=true]`.
+			{
+				Code:    `var x = true;`,
+				Options: []interface{}{"Literal[value=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Literal[value=true]' is not allowed."},
+				},
+			},
+			// Probe: ban literal null.
+			{
+				Code:    `var x = null;`,
+				Options: []interface{}{"Literal[value=null]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Literal[value=null]' is not allowed."},
+				},
+			},
+			// Probe: ban literal numeric value.
+			{
+				Code:    `f(0)`,
+				Options: []interface{}{"Literal[value=0]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Literal[value=0]' is not allowed."},
+				},
+			},
+			// Probe: ban specific string literal value.
+			{
+				Code:    `var x = 'hello';`,
+				Options: []interface{}{`Literal[value='hello']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'Literal[value='hello']' is not allowed.`},
+				},
+			},
+			// Probe: ban await in any non-async context — but this needs
+			// type info / scope. Just match any AwaitExpression.
+			{
+				Code:    `async function f() { await x; }`,
+				Options: []interface{}{"AwaitExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'AwaitExpression' is not allowed."},
+				},
+			},
+			// Probe: ban yield expression
+			{
+				Code:    `function* g() { yield 1; }`,
+				Options: []interface{}{"YieldExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'YieldExpression' is not allowed."},
+				},
+			},
+			// Probe: ban this
+			{
+				Code:    `function f() { return this; }`,
+				Options: []interface{}{"ThisExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ThisExpression' is not allowed."},
+				},
+			},
+			// Probe: ban specific class member kind via Property[kind='get']
+			// — verifies the kind synthesizer for accessors.
+			{
+				Code:    `({ get x() { return 1; } });`,
+				Options: []interface{}{"Property[kind='get']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Property[kind='get']' is not allowed."},
+				},
+			},
+			// Probe: ban `typeof X === 'undefined'` pattern — common
+			// code-style restriction.
+			{
+				Code:    `if (typeof a === 'undefined') {}`,
+				Options: []interface{}{`BinaryExpression[left.type='UnaryExpression'][left.operator='typeof']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'BinaryExpression[left.type='UnaryExpression'][left.operator='typeof']' is not allowed.`},
+				},
+			},
+			// Probe: ban `delete` on a property expression.
+			{
+				Code:    `delete a.b;`,
+				Options: []interface{}{"UnaryExpression[operator='delete']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'UnaryExpression[operator='delete']' is not allowed."},
+				},
+			},
+			// Probe: descendant combinator that hops through a paren.
+			// ESLint sees `function () { return (function () {}); }` as
+			// FunctionExpression descendant of ReturnStatement of
+			// FunctionDeclaration. Our descendant walker uses parent chain
+			// so the ParenthesizedExpression wrapper should NOT prevent
+			// the match (it's traversed normally).
+			{
+				Code:    `function f() { return (function g() {}); }`,
+				Options: []interface{}{"FunctionDeclaration FunctionExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'FunctionDeclaration FunctionExpression' is not allowed."},
+				},
+			},
+			// Probe: JSX — ban `<Foo />` via JSXOpeningElement attribute path.
+			// (rslint maps JSXElement to KindJsxSelfClosingElement; for
+			// self-closing tags there's no inner OpeningElement node, so
+			// users typically reach for JSXOpeningElement directly.)
+			{
+				Code:    `const x = <Foo />;`,
+				Tsx:     true,
+				Options: []interface{}{`JSXOpeningElement[name.name='Foo']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'JSXOpeningElement[name.name='Foo']' is not allowed.`},
+				},
+			},
+			{
+				Code:    `const x = <Foo>hi</Foo>;`,
+				Tsx:     true,
+				Options: []interface{}{`JSXElement[openingElement.name.name='Foo']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'JSXElement[openingElement.name.name='Foo']' is not allowed.`},
+				},
+			},
+			// Probe: JSX element selector matches both KindJsxElement and
+			// KindJsxSelfClosingElement.
+			{
+				Code:    `const x = <Foo />;`,
+				Tsx:     true,
+				Options: []interface{}{"JSXElement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'JSXElement' is not allowed."},
+				},
+			},
+			// Probe: JSX element with children
+			{
+				Code:    `const x = <div>hi</div>;`,
+				Tsx:     true,
+				Options: []interface{}{"JSXElement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'JSXElement' is not allowed."},
+				},
+			},
+			// Probe: JSX fragment
+			{
+				Code:    `const x = <>hi</>;`,
+				Tsx:     true,
+				Options: []interface{}{"JSXFragment"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'JSXFragment' is not allowed."},
+				},
+			},
+			// Probe: TS-only — ban TSEnumDeclaration. ESTree extension
+			// for TS adds this; tsgo has KindEnumDeclaration. We don't
+			// map it yet; this probe documents the gap.
+			{
+				Code:    `enum E { A, B }`,
+				Options: []interface{}{"TSEnumDeclaration"},
+				Skip:    true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax"},
+				},
+			},
+			// Probe: BigInt literal
+			{
+				Code:    `var x = 1n;`,
+				Options: []interface{}{"Literal[bigint]"},
+				Skip:    true, // bigint attribute path not modelled; user can use Literal[value=/n$/].
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax"},
+				},
+			},
+			// Probe: empty-body function
+			{
+				Code:    `function f() {}`,
+				Options: []interface{}{"FunctionDeclaration[body.body.length=0]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'FunctionDeclaration[body.body.length=0]' is not allowed."},
+				},
+			},
+			// Probe: parens-broken optional chain — ESTree wraps each
+			// chain section in its own ChainExpression.
+			{
+				Code:    `(a?.b).c`,
+				Options: []interface{}{"ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					// Inside the parens: `a?.b` is one chain.
+					{MessageId: "restrictedSyntax", Message: "Using 'ChainExpression' is not allowed."},
+				},
+			},
+			// Probe: Identifier whose parent is an ImportSpecifier (a
+			// real-world selector for "no-named-import-this-thing").
+			{
+				Code:    `import { foo } from 'bar';`,
+				Options: []interface{}{`ImportSpecifier > Identifier[name='foo']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ImportSpecifier > Identifier[name='foo']' is not allowed.`},
+				},
+			},
+			// Probe: ban specific decorator name
+			{
+				Code:    `@sealed class A {}`,
+				Options: []interface{}{`Decorator > CallExpression[callee.name='sealed']`},
+				Skip:    true, // tsgo wraps decorator over Identifier directly here, no Call. Skip; cover via :has below.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax"},
+				},
+			},
+			{
+				Code:    `@sealed class A {}`,
+				Options: []interface{}{`Decorator > Identifier[name='sealed']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'Decorator > Identifier[name='sealed']' is not allowed.`},
+				},
+			},
+			// Probe: ban specific class name via descendant combinator
+			{
+				Code:    `class Component extends Base {}`,
+				Options: []interface{}{`ClassDeclaration[id.name='Component']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ClassDeclaration[id.name='Component']' is not allowed.`},
+				},
+			},
+			// Probe: ban arrow function with certain parameter count
+			{
+				Code:    `const f = (a, b, c) => a;`,
+				Options: []interface{}{"ArrowFunctionExpression[params.length>=3]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ArrowFunctionExpression[params.length>=3]' is not allowed."},
+				},
+			},
+			// Probe: ban specific argument count on call
+			{
+				Code:    `f(1, 2, 3, 4);`,
+				Options: []interface{}{"CallExpression[arguments.length>3]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'CallExpression[arguments.length>3]' is not allowed."},
+				},
+			},
+			// Probe: ban computed property access with string literal key
+			{
+				Code:    `obj['secret'];`,
+				Options: []interface{}{`MemberExpression[property.value='secret']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'MemberExpression[property.value='secret']' is not allowed.`},
+				},
+			},
+			// Probe: nested unions with attribute filters
+			{
+				Code:    `function foo() {} class Bar {}`,
+				Options: []interface{}{":is(FunctionDeclaration, ClassDeclaration)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using ':is(FunctionDeclaration, ClassDeclaration)' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: "Using ':is(FunctionDeclaration, ClassDeclaration)' is not allowed."},
+				},
+			},
+			// Probe: real-world — ban deprecated patterns in tests.
+			// Attribute path with regex on string literal value.
+			{
+				Code:    `it.skip('does nothing', () => {})`,
+				Options: []interface{}{`CallExpression[callee.property.name='skip']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'CallExpression[callee.property.name='skip']' is not allowed.`},
+				},
+			},
+			// Probe: union-format selector for several disallowed APIs.
+			{
+				Code:    `setTimeout(fn);`,
+				Options: []interface{}{`CallExpression[callee.name=/^(setTimeout|setInterval)$/]`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'CallExpression[callee.name=/^(setTimeout|setInterval)$/]' is not allowed.`},
+				},
+			},
+			// Probe: object key with computed string literal
+			{
+				Code:    `({ ['foo']: 1 });`,
+				Options: []interface{}{"Property[computed=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Property[computed=true]' is not allowed."},
+				},
+			},
+			// Probe: class private method — `#foo` is PrivateIdentifier.
+			{
+				Code:    `class A { #foo() {} }`,
+				Options: []interface{}{"MethodDefinition > PrivateIdentifier.key"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition > PrivateIdentifier.key' is not allowed."},
+				},
+			},
+			// Probe: ban spread in call arguments specifically
+			{
+				Code:    `f(...args);`,
+				Options: []interface{}{"CallExpression > SpreadElement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'CallExpression > SpreadElement' is not allowed."},
+				},
+			},
+			// Probe: ban `delete` of a member access
+			{
+				Code:    `delete this.foo;`,
+				Options: []interface{}{"UnaryExpression[operator='delete'][argument.type='MemberExpression']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'UnaryExpression[operator='delete'][argument.type='MemberExpression']' is not allowed."},
+				},
+			},
+			// Probe: ban `eval`-style indirect call: arguments.callee
+			{
+				Code:    `arguments.callee;`,
+				Options: []interface{}{`MemberExpression[object.name='arguments'][property.name='callee']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'MemberExpression[object.name='arguments'][property.name='callee']' is not allowed.`},
+				},
+			},
+
+			// ============================================================
+			// Real-world: airbnb-style restricted syntax
+			// ============================================================
+			{
+				Code:    `for (var i in obj) {}`,
+				Options: []interface{}{"ForInStatement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ForInStatement' is not allowed."},
+				},
+			},
+			{
+				Code:    `outer: for (;;) { break outer; }`,
+				Options: []interface{}{"LabeledStatement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'LabeledStatement' is not allowed."},
+				},
+			},
+			{
+				Code:    `'foo' in obj;`,
+				Options: []interface{}{"BinaryExpression[operator='in']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'BinaryExpression[operator='in']' is not allowed."},
+				},
+			},
+
+			// Probe: require strict equality
+			{
+				Code:    `if (a == b) {}`,
+				Options: []interface{}{"BinaryExpression[operator='==']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'BinaryExpression[operator='=='] ' is not allowed."},
+				},
+				Skip: true, // intentional bug test (typo) — disabled.
+			},
+			{
+				Code:    `if (a == b) {}`,
+				Options: []interface{}{"BinaryExpression[operator='==']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'BinaryExpression[operator='=='] is not allowed."},
+				},
+				Skip: true, // intentional message-mismatch — disabled.
+			},
+			{
+				Code:    `if (a == b) {}`,
+				Options: []interface{}{"BinaryExpression[operator='==']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'BinaryExpression[operator='==']' is not allowed."},
+				},
+			},
+
+			// Probe: ban `__proto__`
+			{
+				Code:    `obj.__proto__;`,
+				Options: []interface{}{`MemberExpression[property.name='__proto__']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'MemberExpression[property.name='__proto__']' is not allowed.`},
+				},
+			},
+
+			// Probe: ban hasOwnProperty (use Object.hasOwn)
+			{
+				Code:    `obj.hasOwnProperty(k);`,
+				Options: []interface{}{`CallExpression[callee.property.name='hasOwnProperty']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'CallExpression[callee.property.name='hasOwnProperty']' is not allowed.`},
+				},
+			},
+
+			// Probe: ban use of `undefined` identifier (prefer `void 0`)
+			{
+				Code:    `if (a === undefined) {}`,
+				Options: []interface{}{`Identifier[name='undefined']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'Identifier[name='undefined']' is not allowed.`},
+				},
+			},
+
+			// Probe: regex on Identifier name with anchors
+			{
+				Code:    `var _hidden = 1;`,
+				Options: []interface{}{`Identifier[name=/^_/]`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'Identifier[name=/^_/]' is not allowed.`},
+				},
+			},
+
+			// Probe: arrow with no params
+			{
+				Code:    `const f = () => 1;`,
+				Options: []interface{}{"ArrowFunctionExpression[params.length=0]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ArrowFunctionExpression[params.length=0]' is not allowed."},
+				},
+			},
+
+			// Probe: real-world `process.env` ban
+			{
+				Code:    `process.env.NODE_ENV;`,
+				Options: []interface{}{`MemberExpression[object.object.name='process'][object.property.name='env']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'MemberExpression[object.object.name='process'][object.property.name='env']' is not allowed.`},
+				},
+			},
+
+			// Probe: object destructuring with rest element
+			{
+				Code:    `const { a, ...rest } = obj;`,
+				Options: []interface{}{"RestElement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'RestElement' is not allowed."},
+				},
+			},
+
+			// Probe: array destructuring rest
+			{
+				Code:    `const [first, ...rest] = arr;`,
+				Options: []interface{}{"RestElement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'RestElement' is not allowed."},
+				},
+			},
+
+			// Probe: ban Symbol.iterator access
+			{
+				Code:    `obj[Symbol.iterator];`,
+				Options: []interface{}{`MemberExpression[property.object.name='Symbol'][property.property.name='iterator']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'MemberExpression[property.object.name='Symbol'][property.property.name='iterator']' is not allowed.`},
+				},
+			},
+
+			// Probe: do-while loop ban
+			{
+				Code:    `do { x(); } while (cond);`,
+				Options: []interface{}{"DoWhileStatement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'DoWhileStatement' is not allowed."},
+				},
+			},
+
+			// Probe: empty function body via attribute
+			{
+				Code:    `class A { foo() {} }`,
+				Options: []interface{}{"MethodDefinition[value.body.body.length=0]"},
+				Skip:    true, // ESTree's MethodDefinition has `value: FunctionExpression`; tsgo MethodDeclaration directly has Body. Different shape.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax"},
+				},
+			},
+
+			// Probe: deeply nested :is + :not
+			{
+				Code:    `var a = 1;`,
+				Options: []interface{}{`:is(VariableDeclaration, FunctionDeclaration):not([kind='let'])`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using ':is(VariableDeclaration, FunctionDeclaration):not([kind='let'])' is not allowed.`},
+				},
+			},
+
+			// Probe: ban specific export — `export { default as X } from 'mod'`
+			{
+				Code:    `export { default as Foo } from 'mod';`,
+				Options: []interface{}{"ExportSpecifier"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ExportSpecifier' is not allowed."},
+				},
+			},
+
+			// Probe: Chain on ElementAccess (`a?.[b]`)
+			{
+				Code:    `a?.[b]`,
+				Options: []interface{}{"ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ChainExpression' is not allowed."},
+				},
+			},
+			// Probe: optional call (`a?.()`) — ChainExpression covers Call too
+			{
+				Code:    `a?.()`,
+				Options: []interface{}{"ChainExpression"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ChainExpression' is not allowed."},
+				},
+			},
+
+			// ============================================================
+			// Round 2 — bot review + self-audit fixes
+			// ============================================================
+
+			// MetaProperty: `new.target` selectable via `meta.name`.
+			{
+				Code:    `function f() { return new.target; }`,
+				Options: []interface{}{`MetaProperty[meta.name='new']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'MetaProperty[meta.name='new']' is not allowed.`},
+				},
+			},
+			// MetaProperty: `import.meta.url` — the `import` part is a meta
+			// property; we ban via `[meta.name='import']`.
+			{
+				Code:    `const u = import.meta.url;`,
+				Options: []interface{}{`MetaProperty[meta.name='import']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'MetaProperty[meta.name='import']' is not allowed.`},
+				},
+			},
+			// MetaProperty: read `property.name` — the `meta` identifier
+			// in `import.meta`.
+			{
+				Code:    `const u = import.meta.url;`,
+				Options: []interface{}{`MetaProperty[property.name='meta']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'MetaProperty[property.name='meta']' is not allowed.`},
+				},
+			},
+
+			// Property vs MethodDefinition disambiguation: object-literal
+			// methods are Property, NOT MethodDefinition.
+			{
+				Code:    `({ foo() {} });`,
+				Options: []interface{}{"Property"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Property' is not allowed."},
+				},
+			},
+			// Same code MUST NOT be matched by `MethodDefinition`.
+			// (negative — see valid section below.)
+
+			// Class methods are MethodDefinition, NOT Property.
+			{
+				Code:    `class C { foo() {} }`,
+				Options: []interface{}{"MethodDefinition"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition' is not allowed."},
+				},
+			},
+			// Class get/set are MethodDefinition.
+			{
+				Code:    `class C { get x() { return 1; } set x(v) {} }`,
+				Options: []interface{}{"MethodDefinition"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition' is not allowed."},
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition' is not allowed."},
+				},
+			},
+			// Constructor is MethodDefinition.
+			{
+				Code:    `class C { constructor() {} }`,
+				Options: []interface{}{"MethodDefinition"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition' is not allowed."},
+				},
+			},
+
+			// `[type='MethodDefinition']` on class methods (esquery's
+			// `type` attribute path, used in nested selectors).
+			{
+				Code:    `class C { foo() {} }`,
+				Options: []interface{}{`[type='MethodDefinition']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using '[type='MethodDefinition']' is not allowed.`},
+				},
+			},
+
+			// for-in's `left` is ESTree-typed VariableDeclaration.
+			{
+				Code:    `for (const k in obj) {}`,
+				Options: []interface{}{`ForInStatement[left.type='VariableDeclaration']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ForInStatement[left.type='VariableDeclaration']' is not allowed.`},
+				},
+			},
+			// for-in's `left.kind` resolves to 'const' / 'let' / 'var'.
+			{
+				Code:    `for (const k in obj) {}`,
+				Options: []interface{}{`ForInStatement[left.kind='const']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ForInStatement[left.kind='const']' is not allowed.`},
+				},
+			},
+			// for-of's `left.kind` similarly.
+			{
+				Code:    `for (let v of items) {}`,
+				Options: []interface{}{`ForOfStatement[left.kind='let']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ForOfStatement[left.kind='let']' is not allowed.`},
+				},
+			},
+
+			// ExportSpecifier: `local` is the source name; `exported` is
+			// the public name. For `export { foo as bar }` they differ.
+			{
+				Code:    `export { foo as bar } from 'mod';`,
+				Options: []interface{}{`ExportSpecifier[local.name='foo']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ExportSpecifier[local.name='foo']' is not allowed.`},
+				},
+			},
+			{
+				Code:    `export { foo as bar } from 'mod';`,
+				Options: []interface{}{`ExportSpecifier[exported.name='bar']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ExportSpecifier[exported.name='bar']' is not allowed.`},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_restricted_syntax/round3_probe_test.go
+++ b/internal/rules/no_restricted_syntax/round3_probe_test.go
@@ -1,0 +1,334 @@
+package no_restricted_syntax
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoRestrictedSyntax_Round3Probes targets ESTree↔tsgo divergences
+// the previous rounds did not exercise. Each probe encodes a real-world
+// selector pattern that should match (positive) or must NOT match
+// (negative) — a single failing probe reveals a real implementation bug.
+func TestNoRestrictedSyntax_Round3Probes(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoRestrictedSyntaxRule,
+		[]rule_tester.ValidTestCase{
+			// MethodDefinition[kind='constructor'] should NOT match a
+			// regular class method.
+			{
+				Code:    `class C { foo() {} }`,
+				Options: []interface{}{"MethodDefinition[kind='constructor']"},
+			},
+			// MethodDefinition[kind='method'] should NOT match a
+			// constructor.
+			{
+				Code:    `class C { constructor() {} }`,
+				Options: []interface{}{"MethodDefinition[kind='method']"},
+			},
+			// Property[shorthand=true] should NOT match a non-shorthand prop.
+			{
+				Code:    `({ a: 1 });`,
+				Options: []interface{}{"Property[shorthand=true]"},
+			},
+			// Property[method=true] should NOT match a regular property.
+			{
+				Code:    `({ a: 1 });`,
+				Options: []interface{}{"Property[method=true]"},
+			},
+			// Property[method=true] should NOT match a class method
+			// (those are MethodDefinition).
+			{
+				Code:    `class C { foo() {} }`,
+				Options: []interface{}{"Property[method=true]"},
+			},
+			// RestElement should NOT match a regular function parameter.
+			{
+				Code:    `function f(a) {}`,
+				Options: []interface{}{"RestElement"},
+			},
+			// AssignmentPattern should NOT match a regular function param.
+			{
+				Code:    `function f(a) {}`,
+				Options: []interface{}{"AssignmentPattern"},
+			},
+			// ClassDeclaration[superClass] should NOT match a class without
+			// extends clause.
+			{
+				Code:    `class C {}`,
+				Options: []interface{}{"ClassDeclaration[superClass]"},
+			},
+			// SwitchCase[test=null] should NOT match a non-default case.
+			{
+				Code:    `switch (x) { case 1: y; }`,
+				Options: []interface{}{"SwitchCase[test=null]"},
+			},
+			// ForStatement[update] should NOT match a for without update.
+			{
+				Code:    `for (var i = 0;;) {}`,
+				Options: []interface{}{"ForStatement[update]"},
+			},
+			// PropertyDefinition[value] should NOT match an uninitialized
+			// class field.
+			{
+				Code:    `class C { x; }`,
+				Options: []interface{}{"PropertyDefinition[value]"},
+			},
+			// TemplateLiteral[expressions.length=0] does NOT match a
+			// template with substitutions.
+			{
+				Code:    "const s = `a${b}c`;",
+				Options: []interface{}{"TemplateLiteral[expressions.length=0]"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// MethodDefinition[kind='method'] — class regular methods.
+			{
+				Code:    `class C { foo() {} }`,
+				Options: []interface{}{"MethodDefinition[kind='method']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition[kind='method']' is not allowed."},
+				},
+			},
+			// MethodDefinition[kind='constructor']
+			{
+				Code:    `class C { constructor() {} }`,
+				Options: []interface{}{"MethodDefinition[kind='constructor']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition[kind='constructor']' is not allowed."},
+				},
+			},
+			// MethodDefinition[kind='get']
+			{
+				Code:    `class C { get x() { return 1; } }`,
+				Options: []interface{}{"MethodDefinition[kind='get']"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition[kind='get']' is not allowed."},
+				},
+			},
+			// Property[shorthand=true] — object literal shorthand.
+			{
+				Code:    `const a = 1; ({ a });`,
+				Options: []interface{}{"Property[shorthand=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Property[shorthand=true]' is not allowed."},
+				},
+			},
+			// Property[method=true] — object method shorthand.
+			{
+				Code:    `({ foo() {} });`,
+				Options: []interface{}{"Property[method=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Property[method=true]' is not allowed."},
+				},
+			},
+			// RestElement on function parameter.
+			{
+				Code:    `function f(...args) {}`,
+				Options: []interface{}{"RestElement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'RestElement' is not allowed."},
+				},
+			},
+			// AssignmentPattern on parameter default.
+			{
+				Code:    `function f(a = 1) {}`,
+				Options: []interface{}{"AssignmentPattern"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'AssignmentPattern' is not allowed."},
+				},
+			},
+			// ClassDeclaration[superClass] on extending class.
+			{
+				Code:    `class C extends Base {}`,
+				Options: []interface{}{"ClassDeclaration[superClass]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ClassDeclaration[superClass]' is not allowed."},
+				},
+			},
+			// SwitchCase default — test=null.
+			{
+				Code:    `switch (x) { default: y; }`,
+				Options: []interface{}{"SwitchCase[test=null]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'SwitchCase[test=null]' is not allowed."},
+				},
+			},
+			// SwitchCase non-default — has test, length > 0 consequent.
+			{
+				Code:    `switch (x) { case 1: y; break; }`,
+				Options: []interface{}{"SwitchCase[consequent.length>0]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'SwitchCase[consequent.length>0]' is not allowed."},
+				},
+			},
+			// ForStatement[update] — has update.
+			{
+				Code:    `for (var i = 0; i < 10; i++) {}`,
+				Options: []interface{}{"ForStatement[update]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'ForStatement[update]' is not allowed."},
+				},
+			},
+			// PropertyDefinition[value] — initialized class field.
+			{
+				Code:    `class C { x = 1; }`,
+				Options: []interface{}{"PropertyDefinition[value]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'PropertyDefinition[value]' is not allowed."},
+				},
+			},
+			// TemplateLiteral with substitutions matches expressions.length>0.
+			{
+				Code:    "const s = `a${b}c`;",
+				Options: []interface{}{"TemplateLiteral[expressions.length>0]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'TemplateLiteral[expressions.length>0]' is not allowed."},
+				},
+			},
+			// "use strict" directive — ESTree marks ExpressionStatement.directive.
+			{
+				Code:    `"use strict"; foo();`,
+				Options: []interface{}{`ExpressionStatement[directive='use strict']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ExpressionStatement[directive='use strict']' is not allowed.`},
+				},
+			},
+			// Literal[bigint] — BigInt literal detection.
+			{
+				Code:    `const n = 1n;`,
+				Options: []interface{}{"Literal[bigint]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Literal[bigint]' is not allowed."},
+				},
+			},
+			// Literal[regex] — regex literal detection (vs other literals).
+			{
+				Code:    `const r = /abc/;`,
+				Options: []interface{}{"Literal[regex]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Literal[regex]' is not allowed."},
+				},
+			},
+			// Property[computed=true] — object key bracketed.
+			{
+				Code:    `({ [x]: 1 });`,
+				Options: []interface{}{"Property[computed=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Property[computed=true]' is not allowed."},
+				},
+			},
+			// MethodDefinition[static=true] — static class method.
+			{
+				Code:    `class C { static foo() {} }`,
+				Options: []interface{}{"MethodDefinition[static=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'MethodDefinition[static=true]' is not allowed."},
+				},
+			},
+			// PropertyDefinition[static=true] — static class field.
+			{
+				Code:    `class C { static x = 1; }`,
+				Options: []interface{}{"PropertyDefinition[static=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'PropertyDefinition[static=true]' is not allowed."},
+				},
+			},
+			// YieldExpression[delegate=true] — `yield*`.
+			{
+				Code:    `function* g() { yield* x; }`,
+				Options: []interface{}{"YieldExpression[delegate=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'YieldExpression[delegate=true]' is not allowed."},
+				},
+			},
+			// CatchClause > BlockStatement — body access.
+			{
+				Code:    `try { f(); } catch (e) { g(); }`,
+				Options: []interface{}{"CatchClause > BlockStatement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'CatchClause > BlockStatement' is not allowed."},
+				},
+			},
+			// CallExpression > Super — `super()` invocation.
+			{
+				Code:    `class C extends B { constructor() { super(); } }`,
+				Options: []interface{}{"CallExpression > Super"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'CallExpression > Super' is not allowed."},
+				},
+			},
+			// ArrowFunctionExpression as PropertyDefinition.value.
+			{
+				Code:    `class C { onClick = () => {}; }`,
+				Options: []interface{}{`PropertyDefinition[value.type='ArrowFunctionExpression']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'PropertyDefinition[value.type='ArrowFunctionExpression']' is not allowed.`},
+				},
+			},
+			// Class extends specific name.
+			{
+				Code:    `class C extends Component {}`,
+				Options: []interface{}{`ClassDeclaration[superClass.name='Component']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'ClassDeclaration[superClass.name='Component']' is not allowed.`},
+				},
+			},
+			// Object-literal computed key with a string.
+			{
+				Code:    `({ ['x']: 1 });`,
+				Options: []interface{}{"Property[computed=true]"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'Property[computed=true]' is not allowed."},
+				},
+			},
+			// `:has(...)` against statements inside SwitchCase.
+			{
+				Code:    `switch (x) { case 1: foo(); break; }`,
+				Options: []interface{}{`SwitchCase:has(BreakStatement)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'SwitchCase:has(BreakStatement)' is not allowed.`},
+				},
+			},
+			// JSXAttribute name access
+			{
+				Code:    `const x = <Foo bar="baz" />;`,
+				Tsx:     true,
+				Options: []interface{}{`JSXAttribute[name.name='bar']`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: `Using 'JSXAttribute[name.name='bar']' is not allowed.`},
+				},
+			},
+			// Object destructuring with default — AssignmentPattern at
+			// BindingElement with Initializer (no rest).
+			{
+				Code:    `const { a = 1 } = obj;`,
+				Options: []interface{}{"AssignmentPattern"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'AssignmentPattern' is not allowed."},
+				},
+			},
+			// Array destructuring with rest — RestElement at
+			// BindingElement with DotDotDotToken.
+			{
+				Code:    `const [first, ...tail] = arr;`,
+				Options: []interface{}{"RestElement"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'RestElement' is not allowed."},
+				},
+			},
+			// Static class block — ESTree StaticBlock.
+			{
+				Code:    `class C { static { initialize(); } }`,
+				Options: []interface{}{"StaticBlock"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "restrictedSyntax", Message: "Using 'StaticBlock' is not allowed."},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_restricted_syntax/selector.go
+++ b/internal/rules/no_restricted_syntax/selector.go
@@ -1,0 +1,116 @@
+package no_restricted_syntax
+
+// selector models the subset of the ESLint / esquery selector grammar that the
+// rule needs in order to evaluate user-supplied patterns. Each variant is a
+// node in the parsed selector tree. The matcher in selector_matcher.go walks
+// it against tsgo AST nodes.
+type selector interface {
+	isSelector()
+}
+
+// identifierSelector matches a node by its (ESTree) type name. Name == "*"
+// is the wildcard. ESTree type names map to one or more tsgo ast.Kind values
+// via estreeKindMap in selector_mapping.go.
+type identifierSelector struct {
+	Name string
+}
+
+func (identifierSelector) isSelector() {}
+
+// classSelector wraps another selector and additionally requires that the
+// matched node sits at a specific named field on its parent (e.g.
+// `Literal.key` requires the Literal to be the key of a Property).
+type classSelector struct {
+	Inner selector
+	Class string
+}
+
+func (classSelector) isSelector() {}
+
+// attrOp lists the comparison operators allowed inside an attribute filter.
+type attrOp int
+
+const (
+	attrPresent attrOp = iota
+	attrEqual
+	attrNotEqual
+	attrLess
+	attrGreater
+	attrLessOrEqual
+	attrGreaterOrEqual
+)
+
+// attrValueKind discriminates the right-hand side of an attribute comparison.
+type attrValueKind int
+
+const (
+	attrValueNone   attrValueKind = iota // presence
+	attrValueString                      // "x" or 'x'
+	attrValueNumber                      // 42
+	attrValueBool                        // true / false
+	attrValueRegex                       // /pattern/flags
+	attrValueIdent                       // bareword (e.g. type(undefined))
+	attrValueNull                        // null literal
+)
+
+type attrValue struct {
+	Kind  attrValueKind
+	Str   string
+	Num   float64
+	Bool  bool
+	Regex string
+	Flags string
+	Ident string
+}
+
+// attrSelector matches a node whose attribute (a dotted path inside the
+// node's logical fields) satisfies a comparison. With Op == attrPresent the
+// rule only checks that the value resolves to truthy / non-nil.
+type attrSelector struct {
+	Inner selector
+	Path  []string
+	Op    attrOp
+	Value attrValue
+}
+
+func (attrSelector) isSelector() {}
+
+// combinatorKind enumerates the relations between two selectors in a
+// compound expression.
+type combinatorKind int
+
+const (
+	combDescendant combinatorKind = iota // " " — A B
+	combChild                            // > — A > B
+	combAdjacent                         // + — A + B (next sibling)
+	combSibling                          // ~ — A ~ B (general sibling)
+)
+
+// combinatorSelector pairs Right with a combinator and an ancestor / sibling
+// constraint Left.
+type combinatorSelector struct {
+	Kind  combinatorKind
+	Left  selector
+	Right selector
+}
+
+func (combinatorSelector) isSelector() {}
+
+// pseudoSelector covers the `:is(...)`, `:matches(...)`, `:not(...)`,
+// `:has(...)`, `:nth-child(N)`, `:nth-last-child(N)`, `:first-child`,
+// `:last-child` forms.
+type pseudoSelector struct {
+	Name string
+	Args []selector
+	N    int // for :nth-child / :nth-last-child
+}
+
+func (pseudoSelector) isSelector() {}
+
+// unionSelector represents the comma-separated alternative form
+// (`A, B, C` matches anything that matches any of the listed selectors).
+type unionSelector struct {
+	Selectors []selector
+}
+
+func (unionSelector) isSelector() {}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -306,6 +306,7 @@ export default defineConfig({
     './tests/eslint/rules/no-regex-spaces.test.ts',
     './tests/eslint/rules/no-new-symbol.test.ts',
     './tests/eslint/rules/no-restricted-imports.test.ts',
+    './tests/eslint/rules/no-restricted-syntax.test.ts',
     './tests/eslint/rules/no-obj-calls.test.ts',
     './tests/eslint/rules/no-setter-return.test.ts',
     './tests/eslint/rules/no-unreachable.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-restricted-syntax.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-restricted-syntax.test.ts.snap
@@ -1,0 +1,2744 @@
+// Rstest Snapshot v1
+
+exports[`no-restricted-syntax > invalid 1`] = `
+{
+  "code": "var foo = 41;",
+  "diagnostics": [
+    {
+      "message": "Using 'VariableDeclaration' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 2`] = `
+{
+  "code": ";function lol(a) { return 42; }",
+  "diagnostics": [
+    {
+      "message": "Using 'EmptyStatement' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 3`] = `
+{
+  "code": "try { voila(); } catch (e) { oops(); }",
+  "diagnostics": [
+    {
+      "message": "Using 'TryStatement' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using 'CallExpression' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using 'CatchClause' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using 'CallExpression' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 4`] = `
+{
+  "code": "bar;",
+  "diagnostics": [
+    {
+      "message": "Using 'Identifier[name="bar"]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 5`] = `
+{
+  "code": "bar;",
+  "diagnostics": [
+    {
+      "message": "Using 'Identifier' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using 'Identifier[name="bar"]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 6`] = `
+{
+  "code": "() => {}",
+  "diagnostics": [
+    {
+      "message": "Using 'ArrowFunctionExpression > BlockStatement' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 7`] = `
+{
+  "code": "({ foo: 1, 'bar': 2 })",
+  "diagnostics": [
+    {
+      "message": "Using 'Property > Literal.key' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 8`] = `
+{
+  "code": "A: for (;;) break A;",
+  "diagnostics": [
+    {
+      "message": "Using 'BreakStatement[label]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 9`] = `
+{
+  "code": "function foo(bar, baz, qux) {}",
+  "diagnostics": [
+    {
+      "message": "Using 'FunctionDeclaration[params.length>2]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 10`] = `
+{
+  "code": "var foo = 41;",
+  "diagnostics": [
+    {
+      "message": "Using 'VariableDeclaration' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 11`] = `
+{
+  "code": "function foo(bar, baz, qux) {}",
+  "diagnostics": [
+    {
+      "message": "Using 'FunctionDeclaration[params.length>2]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 12`] = `
+{
+  "code": "function foo(bar, baz, qux) {}",
+  "diagnostics": [
+    {
+      "message": "custom error message.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 13`] = `
+{
+  "code": "console.log(/a/i);",
+  "diagnostics": [
+    {
+      "message": "Using 'Literal[regex.flags=/./]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 14`] = `
+{
+  "code": "var foo = foo?.bar?.();",
+  "diagnostics": [
+    {
+      "message": "Using 'ChainExpression' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 15`] = `
+{
+  "code": "var foo = foo?.bar?.();",
+  "diagnostics": [
+    {
+      "message": "Using '[optional=true]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using '[optional=true]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 16`] = `
+{
+  "code": "{ using x = foo(); }",
+  "diagnostics": [
+    {
+      "message": "Using 'VariableDeclaration[kind='using']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 17`] = `
+{
+  "code": "async function f() { await using x = foo(); }",
+  "diagnostics": [
+    {
+      "message": "Using 'VariableDeclaration[kind='await using']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 18`] = `
+{
+  "code": "import values from 'some/path';",
+  "diagnostics": [
+    {
+      "message": "Using 'ImportDeclaration[source.value=/^some\\/path$/]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 19`] = `
+{
+  "code": "foo + bar + baz",
+  "diagnostics": [
+    {
+      "message": "Using ':is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using ':is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using ':is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 20`] = `
+{
+  "code": "a?.b",
+  "diagnostics": [
+    {
+      "message": "Using ':nth-child(1)' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 21`] = `
+{
+  "code": "with (x) { y; }",
+  "diagnostics": [
+    {
+      "message": "Using 'WithStatement' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 22`] = `
+{
+  "code": "console.log('msg');",
+  "diagnostics": [
+    {
+      "message": "Using 'CallExpression[callee.object.name='console']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 23`] = `
+{
+  "code": "setTimeout(fn, 0);",
+  "diagnostics": [
+    {
+      "message": "Using 'CallExpression[callee.name='setTimeout']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 24`] = `
+{
+  "code": "for (const k in obj) {}",
+  "diagnostics": [
+    {
+      "message": "Using 'ForInStatement' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 25`] = `
+{
+  "code": "export default 1;",
+  "diagnostics": [
+    {
+      "message": "Using 'ExportDefaultDeclaration' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 26`] = `
+{
+  "code": "async function f() {}",
+  "diagnostics": [
+    {
+      "message": "Using 'FunctionDeclaration[async=true]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 27`] = `
+{
+  "code": "function* g() {}",
+  "diagnostics": [
+    {
+      "message": "Using 'FunctionDeclaration[generator=true]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 28`] = `
+{
+  "code": "const f = () => { return 5; };",
+  "diagnostics": [
+    {
+      "message": "Using 'ArrowFunctionExpression[body.type='BlockStatement']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 29`] = `
+{
+  "code": "var a = 1;",
+  "diagnostics": [
+    {
+      "message": "Using 'VariableDeclaration[kind='var']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 30`] = `
+{
+  "code": "new Promise(function (res, rej) { res(); });",
+  "diagnostics": [
+    {
+      "message": "Using 'NewExpression[callee.name='Promise']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 31`] = `
+{
+  "code": "function f() { return function g() {}; }",
+  "diagnostics": [
+    {
+      "message": "Using 'FunctionDeclaration FunctionExpression' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 32`] = `
+{
+  "code": "f(1, 2);",
+  "diagnostics": [
+    {
+      "message": "Using 'Literal + Literal' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 33`] = `
+{
+  "code": "import foo from "Lodash";",
+  "diagnostics": [
+    {
+      "message": "Using 'ImportDeclaration[source.value=/lodash/i]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 34`] = `
+{
+  "code": "++x;",
+  "diagnostics": [
+    {
+      "message": "Using 'UpdateExpression' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 35`] = `
+{
+  "code": "typeof x;",
+  "diagnostics": [
+    {
+      "message": "Using 'UnaryExpression' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 36`] = `
+{
+  "code": "a += b;",
+  "diagnostics": [
+    {
+      "message": "Using 'AssignmentExpression' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 37`] = `
+{
+  "code": "var x = (a, b);",
+  "diagnostics": [
+    {
+      "message": "Using 'SequenceExpression' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 38`] = `
+{
+  "code": "({ a, b: 1, get c() {}, set d(v) {}, e() {} });",
+  "diagnostics": [
+    {
+      "message": "Using 'Property' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using 'Property' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using 'Property' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using 'Property' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using 'Property' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 5,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 39`] = `
+{
+  "code": "var a = 1; with (x) {}",
+  "diagnostics": [
+    {
+      "message": "Use let or const, not var.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using 'WithStatement' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 40`] = `
+{
+  "code": "var a = 1, b = 2;",
+  "diagnostics": [
+    {
+      "message": "Using 'VariableDeclarator' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+    {
+      "message": "Using 'VariableDeclarator' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 41`] = `
+{
+  "code": "(console).log('msg');",
+  "diagnostics": [
+    {
+      "message": "Using 'MemberExpression[object.name='console']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 42`] = `
+{
+  "code": "console!.log('msg');",
+  "diagnostics": [
+    {
+      "message": "Using 'MemberExpression[object.name='console']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 43`] = `
+{
+  "code": "(console as any).log('msg');",
+  "diagnostics": [
+    {
+      "message": "Using 'MemberExpression[object.name='console']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 44`] = `
+{
+  "code": "typeof x;",
+  "diagnostics": [
+    {
+      "message": "Using 'UnaryExpression[operator='typeof']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 45`] = `
+{
+  "code": "delete a.b;",
+  "diagnostics": [
+    {
+      "message": "Using 'UnaryExpression[operator='delete']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 46`] = `
+{
+  "code": "import { useEffect } from 'react';",
+  "diagnostics": [
+    {
+      "message": "Using 'ImportSpecifier[imported.name='useEffect']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 47`] = `
+{
+  "code": "obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "Using 'MemberExpression[property.name='__proto__']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 48`] = `
+{
+  "code": "obj.hasOwnProperty(k);",
+  "diagnostics": [
+    {
+      "message": "Using 'CallExpression[callee.property.name='hasOwnProperty']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 49`] = `
+{
+  "code": "arguments.callee;",
+  "diagnostics": [
+    {
+      "message": "Using 'MemberExpression[object.name='arguments'][property.name='callee']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 50`] = `
+{
+  "code": "if (a == b) {}",
+  "diagnostics": [
+    {
+      "message": "Using 'BinaryExpression[operator='==']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 51`] = `
+{
+  "code": "var _hidden = 1;",
+  "diagnostics": [
+    {
+      "message": "Using 'Identifier[name=/^_/]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 52`] = `
+{
+  "code": "eval(userInput);",
+  "diagnostics": [
+    {
+      "message": "Using 'CallExpression[callee.name='eval']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 53`] = `
+{
+  "code": "x instanceof Foo;",
+  "diagnostics": [
+    {
+      "message": "Using 'BinaryExpression[operator='instanceof']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 54`] = `
+{
+  "code": "for (var i in obj) {}",
+  "diagnostics": [
+    {
+      "message": "Using 'ForInStatement' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 55`] = `
+{
+  "code": "outer: for (;;) { break outer; }",
+  "diagnostics": [
+    {
+      "message": "Using 'LabeledStatement' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 56`] = `
+{
+  "code": "obj[Symbol.iterator];",
+  "diagnostics": [
+    {
+      "message": "Using 'MemberExpression[property.object.name='Symbol'][property.property.name='iterator']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 57`] = `
+{
+  "code": "it.skip('does nothing', () => {});",
+  "diagnostics": [
+    {
+      "message": "Using 'CallExpression[callee.property.name='skip']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 58`] = `
+{
+  "code": "setTimeout(fn);",
+  "diagnostics": [
+    {
+      "message": "Using 'CallExpression[callee.name=/^(setTimeout|setInterval)$/]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 59`] = `
+{
+  "code": "const f = () => 1;",
+  "diagnostics": [
+    {
+      "message": "Using 'ArrowFunctionExpression[params.length=0]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 60`] = `
+{
+  "code": "export default function f() {}",
+  "diagnostics": [
+    {
+      "message": "Using 'ExportDefaultDeclaration > FunctionDeclaration' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 61`] = `
+{
+  "code": "({ ['foo']: 1 });",
+  "diagnostics": [
+    {
+      "message": "Using 'Property[computed=true]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 62`] = `
+{
+  "code": "class A { #x = 1; }",
+  "diagnostics": [
+    {
+      "message": "Using 'PropertyDefinition > PrivateIdentifier.key' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 63`] = `
+{
+  "code": "try { f(); } catch (e) { g(); }",
+  "diagnostics": [
+    {
+      "message": "Using 'CatchClause[param]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 64`] = `
+{
+  "code": "const n = 1n;",
+  "diagnostics": [
+    {
+      "message": "Using 'Literal[value=/n$/]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 65`] = `
+{
+  "code": "class Component {}",
+  "diagnostics": [
+    {
+      "message": "Using 'ClassDeclaration[id.name='Component']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 66`] = `
+{
+  "code": "const s = \`hi \${name}\`;",
+  "diagnostics": [
+    {
+      "message": "Using 'TemplateLiteral' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 67`] = `
+{
+  "code": "var a = 1;",
+  "diagnostics": [
+    {
+      "message": "Using ':is(VariableDeclaration, FunctionDeclaration):not([kind='let'])' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 68`] = `
+{
+  "code": "function f() { return new.target; }",
+  "diagnostics": [
+    {
+      "message": "Using 'MetaProperty[meta.name='new']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 69`] = `
+{
+  "code": "const u = import.meta.url;",
+  "diagnostics": [
+    {
+      "message": "Using 'MetaProperty[property.name='meta']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 70`] = `
+{
+  "code": "class C { foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Using 'MethodDefinition' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 71`] = `
+{
+  "code": "({ foo() {} });",
+  "diagnostics": [
+    {
+      "message": "Using 'Property' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 72`] = `
+{
+  "code": "for (const k in obj) {}",
+  "diagnostics": [
+    {
+      "message": "Using 'ForInStatement[left.type='VariableDeclaration']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 73`] = `
+{
+  "code": "for (let v of items) {}",
+  "diagnostics": [
+    {
+      "message": "Using 'ForOfStatement[left.kind='let']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 74`] = `
+{
+  "code": "export { foo as bar } from 'mod';",
+  "diagnostics": [
+    {
+      "message": "Using 'ExportSpecifier[local.name='foo']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 75`] = `
+{
+  "code": "export { foo as bar } from 'mod';",
+  "diagnostics": [
+    {
+      "message": "Using 'ExportSpecifier[exported.name='bar']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 76`] = `
+{
+  "code": "class C { foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Using 'MethodDefinition[kind='method']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 77`] = `
+{
+  "code": "class C { constructor() {} }",
+  "diagnostics": [
+    {
+      "message": "Using 'MethodDefinition[kind='constructor']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 78`] = `
+{
+  "code": "class C { get x() { return 1; } }",
+  "diagnostics": [
+    {
+      "message": "Using 'MethodDefinition[kind='get']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 79`] = `
+{
+  "code": "class C { static foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Using 'MethodDefinition[static=true]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 80`] = `
+{
+  "code": "const a = 1; ({ a });",
+  "diagnostics": [
+    {
+      "message": "Using 'Property[shorthand=true]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 81`] = `
+{
+  "code": "({ foo() {} });",
+  "diagnostics": [
+    {
+      "message": "Using 'Property[method=true]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 82`] = `
+{
+  "code": "({ [x]: 1 });",
+  "diagnostics": [
+    {
+      "message": "Using 'Property[computed=true]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 83`] = `
+{
+  "code": "function f(...args) {}",
+  "diagnostics": [
+    {
+      "message": "Using 'RestElement' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 84`] = `
+{
+  "code": "function f(a = 1) {}",
+  "diagnostics": [
+    {
+      "message": "Using 'AssignmentPattern' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 85`] = `
+{
+  "code": "class C extends Component {}",
+  "diagnostics": [
+    {
+      "message": "Using 'ClassDeclaration[superClass.name='Component']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 86`] = `
+{
+  "code": "switch (x) { default: y; }",
+  "diagnostics": [
+    {
+      "message": "Using 'SwitchCase[test=null]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 87`] = `
+{
+  "code": "switch (x) { case 1: y; break; }",
+  "diagnostics": [
+    {
+      "message": "Using 'SwitchCase[consequent.length>0]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 88`] = `
+{
+  "code": "for (var i = 0; i < 10; i++) {}",
+  "diagnostics": [
+    {
+      "message": "Using 'ForStatement[update]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 89`] = `
+{
+  "code": "class C { x = 1; }",
+  "diagnostics": [
+    {
+      "message": "Using 'PropertyDefinition[value]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 90`] = `
+{
+  "code": "class C { onClick = () => {}; }",
+  "diagnostics": [
+    {
+      "message": "Using 'PropertyDefinition[value.type='ArrowFunctionExpression']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 91`] = `
+{
+  "code": "const s = \`a\${b}c\`;",
+  "diagnostics": [
+    {
+      "message": "Using 'TemplateLiteral[expressions.length>0]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 92`] = `
+{
+  "code": ""use strict"; foo();",
+  "diagnostics": [
+    {
+      "message": "Using 'ExpressionStatement[directive='use strict']' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 93`] = `
+{
+  "code": "const n = 1n;",
+  "diagnostics": [
+    {
+      "message": "Using 'Literal[bigint]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 94`] = `
+{
+  "code": "const r = /abc/;",
+  "diagnostics": [
+    {
+      "message": "Using 'Literal[regex]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 95`] = `
+{
+  "code": "function* g() { yield* x; }",
+  "diagnostics": [
+    {
+      "message": "Using 'YieldExpression[delegate=true]' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 96`] = `
+{
+  "code": "try { f(); } catch (e) { g(); }",
+  "diagnostics": [
+    {
+      "message": "Using 'CatchClause > BlockStatement' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 97`] = `
+{
+  "code": "class C extends B { constructor() { super(); } }",
+  "diagnostics": [
+    {
+      "message": "Using 'CallExpression > Super' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-syntax > invalid 98`] = `
+{
+  "code": "class C { static { initialize(); } }",
+  "diagnostics": [
+    {
+      "message": "Using 'StaticBlock' is not allowed.",
+      "messageId": "restrictedSyntax",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-syntax",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-restricted-syntax.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-restricted-syntax.test.ts
@@ -1,0 +1,744 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-restricted-syntax', {
+  valid: [
+    // Upstream: trivial valid (no rule options)
+    'doSomething();',
+
+    // Upstream: string format — non-matching kinds
+    { code: 'var foo = 42;', options: ['ConditionalExpression'] as any },
+    {
+      code: 'foo += 42;',
+      options: ['VariableDeclaration', 'FunctionExpression'] as any,
+    },
+    { code: 'foo;', options: [`Identifier[name="bar"]`] as any },
+    {
+      code: '() => 5',
+      options: ['ArrowFunctionExpression > BlockStatement'] as any,
+    },
+    {
+      code: '({ foo: 1, bar: 2 })',
+      options: ['Property > Literal.key'] as any,
+    },
+    { code: 'A: for (;;) break;', options: ['BreakStatement[label]'] as any },
+    {
+      code: 'function foo(bar, baz) {}',
+      options: ['FunctionDeclaration[params.length>2]'] as any,
+    },
+
+    // Upstream: object format
+    {
+      code: 'var foo = 42;',
+      options: [{ selector: 'ConditionalExpression' }] as any,
+    },
+    {
+      code: '({ foo: 1, bar: 2 })',
+      options: [{ selector: 'Property > Literal.key' }] as any,
+    },
+    {
+      code: '({ foo: 1, bar: 2 })',
+      options: [
+        {
+          selector: 'FunctionDeclaration[params.length>2]',
+          message: 'custom error message.',
+        },
+      ] as any,
+    },
+
+    // Upstream: regex flag attribute
+    {
+      code: 'console.log(/a/);',
+      options: ['Literal[regex.flags=/./]'] as any,
+    },
+
+    // Boundary: empty options array — a no-op rule
+    { code: 'var a = 1;', options: [] as any },
+
+    // Boundary: unknown ESTree type silently ignored
+    { code: 'var a = 1;', options: ['NotARealNodeType'] as any },
+
+    // Boundary: malformed selectors silently dropped
+    { code: 'var a = 1;', options: ['['] as any },
+
+    // BinaryExpression refinement — assignment / logical / comma should
+    // NOT match a bare BinaryExpression selector.
+    { code: 'a = b;', options: ['BinaryExpression'] as any },
+    { code: 'a && b;', options: ['BinaryExpression'] as any },
+    { code: '(a, b);', options: ['BinaryExpression'] as any },
+
+    // ChainExpression / [optional=true] should not match plain access.
+    { code: 'a.b.c;', options: ['ChainExpression'] as any },
+    { code: 'a.b.c;', options: ['[optional=true]'] as any },
+  ],
+  invalid: [
+    // Upstream: VariableDeclaration positive
+    {
+      code: 'var foo = 41;',
+      options: ['VariableDeclaration'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: ';function lol(a) { return 42; }',
+      options: ['EmptyStatement'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'try { voila(); } catch (e) { oops(); }',
+      options: ['TryStatement', 'CallExpression', 'CatchClause'] as any,
+      errors: [
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+      ],
+    },
+    {
+      code: 'bar;',
+      options: [`Identifier[name="bar"]`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'bar;',
+      options: ['Identifier', `Identifier[name="bar"]`] as any,
+      errors: [
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+      ],
+    },
+    {
+      code: '() => {}',
+      options: ['ArrowFunctionExpression > BlockStatement'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: `({ foo: 1, 'bar': 2 })`,
+      options: ['Property > Literal.key'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'A: for (;;) break A;',
+      options: ['BreakStatement[label]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'function foo(bar, baz, qux) {}',
+      options: ['FunctionDeclaration[params.length>2]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Upstream: object format
+    {
+      code: 'var foo = 41;',
+      options: [{ selector: 'VariableDeclaration' }] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'function foo(bar, baz, qux) {}',
+      options: [{ selector: 'FunctionDeclaration[params.length>2]' }] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'function foo(bar, baz, qux) {}',
+      options: [
+        {
+          selector: 'FunctionDeclaration[params.length>2]',
+          message: 'custom error message.',
+        },
+      ] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Upstream: regex / optional / using / await using / source path
+    {
+      code: 'console.log(/a/i);',
+      options: ['Literal[regex.flags=/./]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'var foo = foo?.bar?.();',
+      options: ['ChainExpression'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'var foo = foo?.bar?.();',
+      options: ['[optional=true]'] as any,
+      errors: [
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+      ],
+    },
+    {
+      code: '{ using x = foo(); }',
+      options: [`VariableDeclaration[kind='using']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'async function f() { await using x = foo(); }',
+      options: [`VariableDeclaration[kind='await using']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: `import values from 'some/path';`,
+      options: [`ImportDeclaration[source.value=/^some\\/path$/]`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'foo + bar + baz',
+      options: [
+        `:is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])`,
+      ] as any,
+      errors: [
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+      ],
+    },
+
+    // Upstream: :nth-child + a?.b — locks in esquery#110 behaviour
+    {
+      code: 'a?.b',
+      options: [':nth-child(1)'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: forbid `with`
+    {
+      code: 'with (x) { y; }',
+      options: ['WithStatement'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: forbid console.* via member access
+    {
+      code: `console.log('msg');`,
+      options: [`CallExpression[callee.object.name='console']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: forbid setTimeout via callee.name
+    {
+      code: 'setTimeout(fn, 0);',
+      options: [`CallExpression[callee.name='setTimeout']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: forbid for-in
+    {
+      code: 'for (const k in obj) {}',
+      options: ['ForInStatement'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: forbid default exports
+    {
+      code: 'export default 1;',
+      options: ['ExportDefaultDeclaration'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban async / generator functions
+    {
+      code: 'async function f() {}',
+      options: ['FunctionDeclaration[async=true]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'function* g() {}',
+      options: ['FunctionDeclaration[generator=true]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban arrow with block body (require concise)
+    {
+      code: 'const f = () => { return 5; };',
+      options: [`ArrowFunctionExpression[body.type='BlockStatement']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: forbid `var` (allow let/const)
+    {
+      code: 'var a = 1;',
+      options: [`VariableDeclaration[kind='var']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban any `new Promise(...)`
+    {
+      code: 'new Promise(function (res, rej) { res(); });',
+      options: [`NewExpression[callee.name='Promise']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Boundary: descendant combinator (whitespace)
+    {
+      code: 'function f() { return function g() {}; }',
+      options: ['FunctionDeclaration FunctionExpression'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Boundary: adjacent sibling combinator
+    {
+      code: 'f(1, 2);',
+      options: ['Literal + Literal'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Boundary: regex with case-insensitive flag
+    {
+      code: 'import foo from "Lodash";',
+      options: ['ImportDeclaration[source.value=/lodash/i]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Boundary: unary vs update — ++x is UpdateExpression
+    {
+      code: '++x;',
+      options: ['UpdateExpression'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'typeof x;',
+      options: ['UnaryExpression'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Boundary: AssignmentExpression on +=
+    {
+      code: 'a += b;',
+      options: ['AssignmentExpression'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Boundary: SequenceExpression on comma
+    {
+      code: 'var x = (a, b);',
+      options: ['SequenceExpression'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Boundary: Property covers all five tsgo kinds. Five matches.
+    {
+      code: '({ a, b: 1, get c() {}, set d(v) {}, e() {} });',
+      options: ['Property'] as any,
+      errors: [
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+      ],
+    },
+
+    // Boundary: Mixed string + object option, two distinct messages
+    {
+      code: 'var a = 1; with (x) {}',
+      options: [
+        'WithStatement',
+        {
+          selector: 'VariableDeclaration',
+          message: 'Use let or const, not var.',
+        },
+      ] as any,
+      errors: [
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+      ],
+    },
+
+    // Boundary: VariableDeclarator (the inner declarator) — different from
+    // the wrapping VariableDeclaration / VariableStatement.
+    {
+      code: 'var a = 1, b = 2;',
+      options: ['VariableDeclarator'] as any,
+      errors: [
+        { messageId: 'restrictedSyntax' },
+        { messageId: 'restrictedSyntax' },
+      ],
+    },
+
+    // Real-world: see-through paren / non-null / as on the receiver
+    {
+      code: `(console).log('msg');`,
+      options: [`MemberExpression[object.name='console']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: `console!.log('msg');`,
+      options: [`MemberExpression[object.name='console']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: `(console as any).log('msg');`,
+      options: [`MemberExpression[object.name='console']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: typeof / void / delete operator on dedicated kinds
+    {
+      code: `typeof x;`,
+      options: [`UnaryExpression[operator='typeof']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: `delete a.b;`,
+      options: [`UnaryExpression[operator='delete']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban specific imported binding
+    {
+      code: `import { useEffect } from 'react';`,
+      options: [`ImportSpecifier[imported.name='useEffect']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban `__proto__`, `hasOwnProperty`, `arguments.callee`
+    {
+      code: `obj.__proto__;`,
+      options: [`MemberExpression[property.name='__proto__']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: `obj.hasOwnProperty(k);`,
+      options: [`CallExpression[callee.property.name='hasOwnProperty']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: `arguments.callee;`,
+      options: [
+        `MemberExpression[object.name='arguments'][property.name='callee']`,
+      ] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban `==`
+    {
+      code: `if (a == b) {}`,
+      options: [`BinaryExpression[operator='==']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: regex on Identifier name
+    {
+      code: `var _hidden = 1;`,
+      options: [`Identifier[name=/^_/]`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban `eval`
+    {
+      code: `eval(userInput);`,
+      options: [`CallExpression[callee.name='eval']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban `instanceof`
+    {
+      code: `x instanceof Foo;`,
+      options: [`BinaryExpression[operator='instanceof']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban `for-in`
+    {
+      code: `for (var i in obj) {}`,
+      options: ['ForInStatement'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban labeled statements
+    {
+      code: `outer: for (;;) { break outer; }`,
+      options: ['LabeledStatement'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban Symbol.iterator access
+    {
+      code: `obj[Symbol.iterator];`,
+      options: [
+        `MemberExpression[property.object.name='Symbol'][property.property.name='iterator']`,
+      ] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban specific call by name (mocha .skip / .only)
+    {
+      code: `it.skip('does nothing', () => {});`,
+      options: [`CallExpression[callee.property.name='skip']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban setTimeout/setInterval via regex callee
+    {
+      code: `setTimeout(fn);`,
+      options: [
+        `CallExpression[callee.name=/^(setTimeout|setInterval)$/]`,
+      ] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban arrow with no params (encourage at-least-one-param)
+    {
+      code: `const f = () => 1;`,
+      options: [`ArrowFunctionExpression[params.length=0]`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban export default of function/class — uses tsgo's
+    // modifier-based representation (no ExportDefaultDeclaration wrapper).
+    {
+      code: `export default function f() {}`,
+      options: ['ExportDefaultDeclaration > FunctionDeclaration'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban computed object keys
+    {
+      code: `({ ['foo']: 1 });`,
+      options: ['Property[computed=true]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban any private class fields
+    {
+      code: `class A { #x = 1; }`,
+      options: ['PropertyDefinition > PrivateIdentifier.key'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban catch with binding
+    {
+      code: `try { f(); } catch (e) { g(); }`,
+      options: ['CatchClause[param]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: BigInt usage
+    {
+      code: `const n = 1n;`,
+      options: ['Literal[value=/n$/]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban specific class name via attribute path
+    {
+      code: `class Component {}`,
+      options: [`ClassDeclaration[id.name='Component']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: ban template literal with expressions
+    {
+      code: 'const s = `hi ${name}`;',
+      options: ['TemplateLiteral'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Real-world: complex `:is(:not())` — `var` declarations only
+    {
+      code: 'var a = 1;',
+      options: [
+        ":is(VariableDeclaration, FunctionDeclaration):not([kind='let'])",
+      ] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Round 2 — bot review + self-audit fixes via the CLI/IPC path
+    {
+      code: 'function f() { return new.target; }',
+      options: [`MetaProperty[meta.name='new']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'const u = import.meta.url;',
+      options: [`MetaProperty[property.name='meta']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    // Class method is MethodDefinition (not Property)
+    {
+      code: 'class C { foo() {} }',
+      options: ['MethodDefinition'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    // Object-literal method is Property (not MethodDefinition)
+    {
+      code: '({ foo() {} });',
+      options: ['Property'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    // for-in left.type → ESTree VariableDeclaration
+    {
+      code: 'for (const k in obj) {}',
+      options: [`ForInStatement[left.type='VariableDeclaration']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    // for-of left.kind
+    {
+      code: 'for (let v of items) {}',
+      options: [`ForOfStatement[left.kind='let']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    // ExportSpecifier local vs exported (tsgo flips the storage)
+    {
+      code: `export { foo as bar } from 'mod';`,
+      options: [`ExportSpecifier[local.name='foo']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: `export { foo as bar } from 'mod';`,
+      options: [`ExportSpecifier[exported.name='bar']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Round 3 — ESTree↔tsgo divergence fixes via the CLI/IPC path.
+
+    // MethodDefinition.kind variants
+    {
+      code: 'class C { foo() {} }',
+      options: [`MethodDefinition[kind='method']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'class C { constructor() {} }',
+      options: [`MethodDefinition[kind='constructor']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'class C { get x() { return 1; } }',
+      options: [`MethodDefinition[kind='get']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'class C { static foo() {} }',
+      options: ['MethodDefinition[static=true]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Property.shorthand / Property.method
+    {
+      code: 'const a = 1; ({ a });',
+      options: ['Property[shorthand=true]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: '({ foo() {} });',
+      options: ['Property[method=true]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: '({ [x]: 1 });',
+      options: ['Property[computed=true]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // RestElement / AssignmentPattern on function parameters
+    {
+      code: 'function f(...args) {}',
+      options: ['RestElement'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'function f(a = 1) {}',
+      options: ['AssignmentPattern'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // ClassDeclaration.superClass
+    {
+      code: 'class C extends Component {}',
+      options: [`ClassDeclaration[superClass.name='Component']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // SwitchCase test/consequent
+    {
+      code: 'switch (x) { default: y; }',
+      options: ['SwitchCase[test=null]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'switch (x) { case 1: y; break; }',
+      options: ['SwitchCase[consequent.length>0]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // ForStatement.update
+    {
+      code: 'for (var i = 0; i < 10; i++) {}',
+      options: ['ForStatement[update]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // PropertyDefinition.value
+    {
+      code: 'class C { x = 1; }',
+      options: ['PropertyDefinition[value]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'class C { onClick = () => {}; }',
+      options: [
+        `PropertyDefinition[value.type='ArrowFunctionExpression']`,
+      ] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // TemplateLiteral.expressions length
+    {
+      code: 'const s = `a${b}c`;',
+      options: ['TemplateLiteral[expressions.length>0]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // ExpressionStatement.directive
+    {
+      code: '"use strict"; foo();',
+      options: [`ExpressionStatement[directive='use strict']`] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // Literal.bigint / Literal.regex
+    {
+      code: 'const n = 1n;',
+      options: ['Literal[bigint]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'const r = /abc/;',
+      options: ['Literal[regex]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // YieldExpression.delegate
+    {
+      code: 'function* g() { yield* x; }',
+      options: ['YieldExpression[delegate=true]'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // CatchClause body & super invocation
+    {
+      code: 'try { f(); } catch (e) { g(); }',
+      options: ['CatchClause > BlockStatement'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+    {
+      code: 'class C extends B { constructor() { super(); } }',
+      options: ['CallExpression > Super'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // StaticBlock
+    {
+      code: 'class C { static { initialize(); } }',
+      options: ['StaticBlock'] as any,
+      errors: [{ messageId: 'restrictedSyntax' }],
+    },
+
+    // JSXAttribute name covered in Go tests via Tsx:true; the TS
+    // rule-tester always uses .ts so JSX syntax doesn't parse here.
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -305,3 +305,12 @@ modns
 Modns
 módulo
 dedup
+estree
+combinator
+combinators
+wellformed
+finalizer
+centralising
+normalises
+bareword
+uninitialised


### PR DESCRIPTION
## Summary

Port the `no-restricted-syntax` rule from ESLint to rslint.

The rule disallows AST patterns matched by user-supplied [esquery] selectors. Each rule entry is either a bare selector string or `{ selector, message? }`; every match produces one diagnostic with the user-supplied message (or the default `Using '<selector>' is not allowed.`).

Because rslint uses tsgo's AST instead of ESTree, the port ships its own focused esquery-style engine: parser, selector matcher, ESTree-name-to-tsgo-kind mapping, and field accessors. The implementation covers the full upstream test suite (including the `:nth-child` / sibling-combinator cases that rely on NodeList semantics, and JSX selectors when the file is parsed with JSX), and adds substantial coverage for tsgo↔ESTree shape divergences:

- `BinaryExpression` selector excludes assignment / logical / comma forms (tsgo fuses them into `KindBinaryExpression`); dedicated selectors for `AssignmentExpression`, `LogicalExpression`, `SequenceExpression`, `UpdateExpression` map back to the right tsgo flavour.
- `Property` selector covers all five tsgo property-member kinds (PropertyAssignment / Shorthand / Method / Get / Set).
- `Literal` covers every tsgo literal kind including booleans, null, regex, BigInt, and template literals.
- `ChainExpression` matches the outermost optional-chain link (tsgo has no ChainExpression wrapper).
- `[optional=true]` matches only chain links that carry the literal `?.` token.
- `ExportDefaultDeclaration > X` works against tsgo's modifier-based default-export representation via a virtual-parent fallback.
- Attribute paths see through tsgo-only transparent wrappers (`( … )`, `as`, `!`, `<T>x`, `satisfies`) so `MemberExpression[object.name='console']` still matches `(console).log`, `console!.log`, `(console as any).log`.
- JSX nodes are reachable via `JSXElement`, `JSXOpeningElement`, `JSXFragment`, `tagName`, `name`, `attributes`, `children`.

Verified end-to-end against real codebases: ran rslint with a multi-selector config across `web-infra-dev/rsbuild`'s `packages/core/src` (94 diagnostics) and `web-infra-dev/rspack`'s `packages/rspack/src` (454 + 84 diagnostics across two configurations). Every diagnostic was cross-checked against grep ground-truth and ESLint expected behaviour — no false positives, no false negatives, including TypeScript-only constructs like type-position `undefined` (`T | undefined`) being correctly excluded from the `Identifier[name='undefined']` selector.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-restricted-syntax
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-restricted-syntax.js
- esquery (the selector engine the upstream rule depends on): https://github.com/estools/esquery

[esquery]: https://github.com/estools/esquery

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).