### PR TITLE
feat: port rule max-params

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_implied_eval"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_inferrable_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_invalid_void_type"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/max_params"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_loop_func"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_magic_numbers"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_meaningless_void_operator"
@@ -514,6 +515,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/dot-notation", dot_notation.DotNotationRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/explicit-function-return-type", explicit_function_return_type.ExplicitFunctionReturnTypeRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/explicit-member-accessibility", explicit_member_accessibility.ExplicitMemberAccessibilityRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/max-params", max_params.MaxParamsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/member-ordering", member_ordering.MemberOrderingRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/method-signature-style", method_signature_style.MethodSignatureStyleRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/naming-convention", naming_convention.NamingConventionRule)

--- a/internal/plugins/typescript/rules/max_params/max_params.go
+++ b/internal/plugins/typescript/rules/max_params/max_params.go
@@ -1,0 +1,125 @@
+package max_params
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// MaxParamsRule enforces a maximum number of parameters in function
+// definitions. Mirrors @typescript-eslint/max-params, which extends ESLint
+// core's max-params with the `countVoidThis` option.
+//
+// https://typescript-eslint.io/rules/max-params
+var MaxParamsRule = rule.CreateRule(rule.Rule{
+	Name: "max-params",
+	Run:  run,
+})
+
+const defaultMax = 3
+
+type ruleOptions struct {
+	max           int
+	countVoidThis bool
+}
+
+func run(ctx rule.RuleContext, options any) rule.RuleListeners {
+	opts := parseOptions(options)
+
+	check := func(node *ast.Node) {
+		params := node.Parameters()
+		effective := len(params)
+		if !opts.countVoidThis && len(params) > 0 && isThisVoidParam(params[0]) {
+			effective--
+		}
+		if effective <= opts.max {
+			return
+		}
+		name := utils.UpperCaseFirstASCII(utils.GetFunctionNameWithKind(node))
+		ctx.ReportRange(
+			utils.GetFunctionHeadLoc(ctx.SourceFile, node),
+			rule.RuleMessage{
+				Id: "exceed",
+				Description: fmt.Sprintf(
+					"%s has too many parameters (%d). Maximum allowed is %d.",
+					name, effective, opts.max,
+				),
+			},
+		)
+	}
+
+	// In ESTree, FunctionExpression wraps class methods, constructors,
+	// getters, setters, and object methods (via MethodDefinition.value /
+	// Property.value). tsgo represents each as its own kind, so listen
+	// explicitly to keep parity with ESLint.
+	return rule.RuleListeners{
+		ast.KindFunctionDeclaration: check,
+		ast.KindFunctionExpression:  check,
+		ast.KindArrowFunction:       check,
+		ast.KindMethodDeclaration:   check,
+		ast.KindConstructor:         check,
+		ast.KindGetAccessor:         check,
+		ast.KindSetAccessor:         check,
+		ast.KindFunctionType:        check,
+	}
+}
+
+// isThisVoidParam reports whether `p` is a `this: void` parameter, which
+// the typescript-eslint rule strips from the parameter list before counting
+// (unless `countVoidThis: true`).
+func isThisVoidParam(p *ast.Node) bool {
+	if !ast.IsThisParameter(p) {
+		return false
+	}
+	t := p.Type()
+	return t != nil && t.Kind == ast.KindVoidKeyword
+}
+
+// parseOptions mirrors @typescript-eslint/max-params' schema: a single
+// optional object with `max`, `maximum`, and `countVoidThis`. Other shapes
+// (bare integer, integer-in-array) fall through to defaults — upstream
+// rejects them at schema validation, and rslint has no schema layer to
+// reproduce that, so we treat them as "no option" rather than guess.
+//
+// `option.maximum || option.max` follows JS truthy coercion: a present-but-
+// zero `maximum` falls through to `max`; a present-but-falsy value with no
+// fallback leaves `numParams = undefined` upstream, which makes every
+// `count > undefined` comparison false (effectively disabling the rule).
+// We model that case with MaxInt.
+func parseOptions(o any) ruleOptions {
+	out := ruleOptions{max: defaultMax}
+	m := utils.GetOptionsMap(o)
+	if m == nil {
+		return out
+	}
+	_, hasMaximum := m["maximum"]
+	_, hasMax := m["max"]
+	if hasMaximum || hasMax {
+		hasNum := false
+		if hasMaximum {
+			if n, ok := utils.CoerceInt(m["maximum"]); ok && n != 0 {
+				out.max = n
+				hasNum = true
+			}
+		}
+		if !hasNum && hasMax {
+			if n, ok := utils.CoerceInt(m["max"]); ok {
+				out.max = n
+				hasNum = true
+			}
+		}
+		if !hasNum {
+			out.max = math.MaxInt
+		}
+	}
+	if v, ok := m["countVoidThis"]; ok {
+		if b, ok := v.(bool); ok {
+			out.countVoidThis = b
+		}
+	}
+	return out
+}
+

--- a/internal/plugins/typescript/rules/max_params/max_params.md
+++ b/internal/plugins/typescript/rules/max_params/max_params.md
@@ -1,0 +1,87 @@
+# max-params
+
+Enforce a maximum number of parameters in function definitions.
+
+## Rule Details
+
+Functions that take many parameters are usually harder to read and maintain than
+functions that take fewer. This rule reports any function whose parameter list
+exceeds the configured maximum (default 3).
+
+The typescript-eslint variant adds the `countVoidThis` option for the TypeScript
+`this: void` parameter, which is a type annotation rather than a real argument.
+By default, `this: void` is excluded from the parameter count.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function foo(a, b, c, d) {}
+
+const bar = (a, b, c, d) => {};
+
+class Foo {
+  method(this: Foo, a, b, c) {}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function foo(a, b, c) {}
+
+const bar = (a, b, c) => {};
+
+class Foo {
+  method(this: void, a, b, c) {}
+}
+```
+
+## Options
+
+The rule accepts an options object:
+
+```json
+{ "@typescript-eslint/max-params": ["error", { "max": 3 }] }
+```
+
+- `max` (default `3`): the maximum number of parameters allowed.
+- `maximum`: deprecated alias for `max`.
+- `countVoidThis` (default `false`): if `true`, count a `this: void` parameter
+  toward the limit.
+
+Examples of **incorrect** code with `{ "max": 2 }`:
+
+```json
+{ "@typescript-eslint/max-params": ["error", { "max": 2 }] }
+```
+
+```javascript
+function foo(a, b, c) {}
+```
+
+Examples of **correct** code with `{ "max": 2 }`:
+
+```json
+{ "@typescript-eslint/max-params": ["error", { "max": 2 }] }
+```
+
+```javascript
+function foo(a, b) {}
+```
+
+Examples of **incorrect** code with `{ "countVoidThis": true, "max": 2 }`:
+
+```json
+{ "@typescript-eslint/max-params": ["error", { "countVoidThis": true, "max": 2 }] }
+```
+
+```javascript
+class Foo {
+  method(this: void, a, b) {}
+}
+```
+
+## Original Documentation
+
+- [`@typescript-eslint/max-params`](https://typescript-eslint.io/rules/max-params)
+- [`max-params` (ESLint core)](https://eslint.org/docs/latest/rules/max-params)

--- a/internal/plugins/typescript/rules/max_params/max_params_test.go
+++ b/internal/plugins/typescript/rules/max_params/max_params_test.go
@@ -1,0 +1,1021 @@
+package max_params
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// objectOption returns the array-wrapped single-option shape that matches
+// rule_tester / multi-element CLI configs and exercises the JSON path through
+// utils.GetOptionsMap (the typed-struct shortcut would silently bypass it).
+func objectOption(opts map[string]interface{}) []interface{} {
+	return []interface{}{opts}
+}
+
+// TestMaxParams covers four corpora:
+//
+//  1. Upstream parity (typescript-eslint) — every case from
+//     typescript-eslint/packages/eslint-plugin/tests/rules/max-params.test.ts
+//     migrated 1:1.
+//  2. Upstream parity (eslint core, TS-meaningful cases) — the upstream eslint
+//     core test cases that remain valid under the typescript-eslint schema
+//     (object-only options; no `countThis`).
+//  3. Universal edge shapes — every container kind ESLint's FunctionExpression
+//     listener implicitly covers in ESTree but tsgo splits into distinct kinds
+//     (constructor, method, getter, setter, class field arrow, object literal
+//     method, class expression method, function type literal). Each kind is
+//     exercised on both the valid and invalid side, plus modifier crosses
+//     (static / private / async / generator / async-generator / abstract /
+//     decorated).
+//  4. Real-world & boundary scenarios — `this: void` x rest params, parameter
+//     properties (constructor `public a`/`private b`/`readonly c`),
+//     overload signatures, deeply-nested function-likes, decorated methods,
+//     event-handler signatures, computed-property names, optional / default
+//     parameters (each counts as 1).
+func TestMaxParams(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&MaxParamsRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// 1. Upstream parity — typescript-eslint
+			//    packages/eslint-plugin/tests/rules/max-params.test.ts
+			// ============================================================
+			{Code: "function foo() {}"},
+			{Code: "const foo = function () {};"},
+			{Code: "const foo = () => {};"},
+			{Code: "function foo(a) {}"},
+			{Code: `
+class Foo {
+  constructor(a) {}
+}
+			`},
+			{Code: `
+class Foo {
+  method(this: void, a, b, c) {}
+}
+			`},
+			{Code: `
+class Foo {
+  method(this: Foo, a, b) {}
+}
+			`},
+			{Code: "function foo(a, b, c, d) {}", Options: objectOption(map[string]interface{}{"max": 4})},
+			{Code: "function foo(a, b, c, d) {}", Options: objectOption(map[string]interface{}{"maximum": 4})},
+			{
+				Code:    "\nclass Foo {\n  method(this: void) {}\n}\n",
+				Options: objectOption(map[string]interface{}{"max": 0}),
+			},
+			{
+				Code:    "\nclass Foo {\n  method(this: void, a) {}\n}\n",
+				Options: objectOption(map[string]interface{}{"max": 1}),
+			},
+			{
+				Code:    "\nclass Foo {\n  method(this: void, a) {}\n}\n",
+				Options: objectOption(map[string]interface{}{"countVoidThis": true, "max": 2}),
+			},
+			{
+				Code:    "function testD(this: void, a) {}",
+				Options: objectOption(map[string]interface{}{"max": 1}),
+			},
+			{
+				Code:    "function testD(this: void, a) {}",
+				Options: objectOption(map[string]interface{}{"countVoidThis": true, "max": 2}),
+			},
+			{
+				Code:    "const testE = function (this: void, a) {}",
+				Options: objectOption(map[string]interface{}{"max": 1}),
+			},
+			{
+				Code:    "const testE = function (this: void, a) {}",
+				Options: objectOption(map[string]interface{}{"countVoidThis": true, "max": 2}),
+			},
+			{
+				Code:    "\ndeclare function makeDate(m: number, d: number, y: number): Date;\n",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+			},
+			{
+				Code:    "\ntype sum = (a: number, b: number) => number;\n",
+				Options: objectOption(map[string]interface{}{"max": 2}),
+			},
+
+			// ============================================================
+			// 2. Upstream parity — eslint core valid cases
+			//    (rewritten from `[3]` to `[{max: 3}]` since the
+			//    typescript-eslint schema is object-only; integer form is
+			//    rejected upstream by schema validation.)
+			// ============================================================
+			{Code: "function test(d, e, f) {}"},
+			{Code: "var test = function(a, b, c) {};", Options: objectOption(map[string]interface{}{"max": 3})},
+			{Code: "var test = (a, b, c) => {};", Options: objectOption(map[string]interface{}{"max": 3})},
+			{Code: "var test = function test(a, b, c) {};", Options: objectOption(map[string]interface{}{"max": 3})},
+
+			// ============================================================
+			// 3. Universal edge shapes — tsgo container kinds
+			// ============================================================
+
+			// --- Default option (max=3) on every container ---
+			{Code: "function foo(a, b, c) {}"},
+			{Code: "const foo = function (a, b, c) {};"},
+			{Code: "const foo = (a, b, c) => {};"},
+			{Code: "class C { method(a, b, c) {} }"},
+			{Code: "class C { static method(a, b, c) {} }"},
+			{Code: "class C { #method(a, b, c) {} }"},
+			{Code: "class C { static #method(a, b, c) {} }"},
+			{Code: "class C { constructor(a, b, c) {} }"},
+			{Code: "class C { get x() { return 0; } }"},
+			{Code: "class C { set x(v) {} }"},
+			{Code: "class C { handler = (a, b, c) => {}; }"},
+			{Code: "var X = class { method(a, b, c) {} }"},
+			{Code: "var X = class { #m(a, b, c) {} }"},
+			{Code: "var obj = { method(a, b, c) {} }"},
+			{Code: "var obj = { get x() { return 0; } }"},
+			{Code: "var obj = { set x(v) {} }"},
+			{Code: "var obj = { ['computed'](a, b, c) {} }"},
+
+			// --- async / generator / async-generator on each form ---
+			{Code: "async function foo(a, b, c) {}"},
+			{Code: "function* foo(a, b, c) {}"},
+			{Code: "async function* foo(a, b, c) {}"},
+			{Code: "const foo = async (a, b, c) => {};"},
+			{Code: "const foo = async function (a, b, c) {};"},
+			{Code: "const foo = async function* (a, b, c) {};"},
+			{Code: "class C { async method(a, b, c) {} }"},
+			{Code: "class C { *method(a, b, c) {} }"},
+			{Code: "class C { async *method(a, b, c) {} }"},
+			{Code: "class C { static async #m(a, b, c) {} }"},
+
+			// --- Function-like types (TSFunctionType / declare) ---
+			{Code: "type F = (a: number, b: number, c: number) => void;"},
+			{Code: "declare function foo(a: number, b: number, c: number): void;"},
+
+			// --- Empty bodies / edge param shapes ---
+			{Code: "function foo() {}"},
+			{Code: "function foo(...args) {}"},
+			{Code: "function foo({a, b, c}) {}"},
+			{Code: "function foo([a, b], {c}, d) {}"},
+			{Code: "function foo(a?, b?, c?) {}"},
+			{Code: "function foo(a = 1, b = 2, c = 3) {}"},
+			{Code: "function foo(a: number, b: string, c: boolean) {}"},
+			{
+				// Generic type parameters do NOT count toward max.
+				Code: "function foo<T, U, V, W, X>(a, b, c) {}",
+			},
+
+			// --- Options shapes — exercise the JSON path ---
+			// Bare object (single-option CLI shape).
+			{
+				Code:    "function foo(a, b, c, d) {}",
+				Options: map[string]interface{}{"max": 4},
+			},
+			// Array-wrapped (multi-element / rule_tester shape).
+			{
+				Code:    "function foo(a, b, c, d) {}",
+				Options: objectOption(map[string]interface{}{"max": 4}),
+			},
+			// Empty options array → defaults to 3.
+			{Code: "function foo(a, b, c) {}", Options: []interface{}{}},
+			// Empty options object → defaults to 3.
+			{
+				Code:    "function foo(a, b, c) {}",
+				Options: objectOption(map[string]interface{}{}),
+			},
+			// Legacy `maximum` key.
+			{
+				Code:    "function foo(a, b, c, d) {}",
+				Options: map[string]interface{}{"maximum": 4},
+			},
+			// `maximum: 0` with no `max` → ESLint sets numParams=undefined,
+			// effectively disabling the rule.
+			{
+				Code:    "function foo(a, b, c, d, e, f) {}",
+				Options: objectOption(map[string]interface{}{"maximum": 0}),
+			},
+			// `maximum: 0, max: 4` → falls through to `max` per JS truthy.
+			{
+				Code:    "function foo(a, b, c, d) {}",
+				Options: objectOption(map[string]interface{}{"maximum": 0, "max": 4}),
+			},
+			// `maximum: 4, max: 2` → maximum wins (truthy).
+			{
+				Code:    "function foo(a, b, c, d) {}",
+				Options: objectOption(map[string]interface{}{"maximum": 4, "max": 2}),
+			},
+			// Bare integer / array-of-integer is REJECTED upstream by schema —
+			// rslint has no schema layer, so we treat as "no option" and fall
+			// back to defaults rather than guessing.
+			{Code: "function foo(a, b, c) {}", Options: 7},
+			{Code: "function foo(a, b, c) {}", Options: []interface{}{7}},
+
+			// --- this parameter handling ---
+			// `this` with no type annotation — never stripped (4 effective).
+			{
+				Code:    "function f(this, a, b, c) {}",
+				Options: objectOption(map[string]interface{}{"max": 4}),
+			},
+			// `this: any` — not void, not stripped (4 effective).
+			{
+				Code:    "function f(this: any, a, b, c) {}",
+				Options: objectOption(map[string]interface{}{"max": 4}),
+			},
+			// `this: Foo` — not void, not stripped (4 effective).
+			{
+				Code:    "function f(this: Foo, a, b, c) {}",
+				Options: objectOption(map[string]interface{}{"max": 4}),
+			},
+			// `this: never` — not void, not stripped (4 effective).
+			{
+				Code:    "function f(this: never, a, b, c) {}",
+				Options: objectOption(map[string]interface{}{"max": 4}),
+			},
+			// `this: unknown` — not void, not stripped (4 effective).
+			{
+				Code:    "function f(this: unknown, a, b, c) {}",
+				Options: objectOption(map[string]interface{}{"max": 4}),
+			},
+			// `this: void` with countVoidThis: true — counted (4 with -> exceed unless max bumped).
+			{
+				Code:    "function f(this: void, a, b, c) {}",
+				Options: objectOption(map[string]interface{}{"countVoidThis": true, "max": 4}),
+			},
+			// `this: void` + rest params: stripped, rest counts as 1.
+			{Code: "function f(this: void, ...args) {}"},
+			{Code: "function f(this: void, a, ...rest) {}"},
+			// `this: void` + destructuring + default: still strips this, rest count regular.
+			{Code: "function f(this: void, {a}, b = 1) {}"},
+			// First param destructuring with key 'this' — NOT a real this param.
+			{Code: "function f({ this: x }: any, a, b) {}"},
+			// Method overload signatures — each declaration has ≤ 3 params.
+			{Code: `
+class Foo {
+  method(a: number): void;
+  method(a: number, b: string): void;
+  method(...args: any[]): void {}
+}
+			`},
+
+			// --- Parameter properties (TS class constructors) ---
+			// Each parameter property counts as one param toward the limit.
+			{Code: "class C { constructor(public a: number, private b: string, readonly c: boolean) {} }"},
+
+			// --- Decorators on methods — head loc skips decorators, count is unaffected ---
+			{Code: `
+declare const dec: any;
+class C {
+  @dec
+  method(a, b, c) {}
+}
+			`},
+
+			// --- Abstract methods ---
+			{Code: `
+abstract class A {
+  abstract foo(a, b, c): void;
+}
+			`},
+
+			// --- Deeply nested function-likes — each gets its own counter ---
+			{Code: "function outer(a) { function inner() { function deep(a, b, c) {} } }"},
+			{Code: "class C { method(a, b, c) { return function inner(d, e, f) {}; } }"},
+
+			// --- Real-world: callback signatures within max=3 ---
+			{Code: "[1].forEach((value, index, array) => {});"},
+			{Code: "const handler = (req, res, next) => {};"},
+
+			// --- Object-property function expression / arrow ---
+			{Code: "var obj = { foo: function (a, b, c) {} }"},
+			{Code: "var obj = { foo: (a, b, c) => {} }"},
+			{Code: "var obj = { foo: async function (a, b, c) {} }"},
+			{Code: "var obj = { foo: function bar(a, b, c) {} }"},
+			// Numeric / string property keys
+			{Code: "var obj = { 0(a, b, c) {} }"},
+			{Code: "var obj = { 'string-key'(a, b, c) {} }"},
+
+			// --- Interface method signatures are NOT checked (upstream
+			// typescript-eslint does not listen on TSMethodSignature). ---
+			{Code: "interface I { foo(a, b, c, d, e): void }"},
+			{Code: "interface I { (a, b, c, d, e): void }"},
+			{Code: "interface I { new (a, b, c, d, e): void }"},
+			// Index signatures: only 1 param syntactically; never exceeds.
+			{Code: "interface I { [k: string]: any }"},
+
+			// --- Function type as property value of interface IS checked
+			// (it is a TSFunctionType, which IS in the listener set). ---
+			{Code: "interface I { foo: (a, b, c) => void }"},
+
+			// --- Class field initialized with function expression ---
+			{Code: "class C { foo = function (a, b, c) {}; }"},
+			{Code: "class C { foo = function bar(a, b, c) {}; }"},
+
+			// --- Constructor type / call signature appearing inside other types ---
+			// `new (...) => T` is KindConstructorType (not in listener set) ✓
+			{Code: "type Ctor = new (a, b, c, d, e) => any;"},
+
+			// --- Class with both static and instance methods ---
+			{Code: `
+class C {
+  static a(a, b, c) {}
+  b(a, b, c) {}
+  static get g() { return 0; }
+  set s(v) {}
+}
+			`},
+
+			// --- TS namespaces / declare module ---
+			{Code: `
+declare module 'x' {
+  function foo(a, b, c): void;
+  export function bar(a, b, c): void;
+}
+			`},
+		},
+
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// 1. Upstream parity — typescript-eslint invalid
+			// ============================================================
+			{
+				Code: "function foo(a, b, c, d) {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Function 'foo' has too many parameters (4). Maximum allowed is 3.",
+						Line:      1, Column: 1, EndLine: 1, EndColumn: 13,
+					},
+				},
+			},
+			{
+				Code:   "const foo = function (a, b, c, d) {};",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:   "const foo = (a, b, c, d) => {};",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:    "const foo = a => {};",
+				Options: objectOption(map[string]interface{}{"max": 0}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code: "\nclass Foo {\n  method(this: void, a, b, c, d) {}\n}\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 3, EndLine: 3, EndColumn: 9},
+				},
+			},
+			{
+				Code:    "\nclass Foo {\n  method(this: void, a) {}\n}\n",
+				Options: objectOption(map[string]interface{}{"countVoidThis": true, "max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:   "\nclass Foo {\n  method(this: Foo, a, b, c) {}\n}\n",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:    "\ndeclare function makeDate(m: number, d: number, y: number): Date;\n",
+				Options: objectOption(map[string]interface{}{"max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:    "\ntype sum = (a: number, b: number) => number;\n",
+				Options: objectOption(map[string]interface{}{"max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+
+			// ============================================================
+			// 2. Upstream parity — eslint core invalid (object-form options)
+			// ============================================================
+			{
+				Code:    "function test(a, b, c) {}",
+				Options: objectOption(map[string]interface{}{"max": 2}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Function 'test' has too many parameters (3). Maximum allowed is 2.",
+						Line:      1, Column: 1, EndLine: 1, EndColumn: 14,
+					},
+				},
+			},
+			{
+				Code: "function test(a, b, c, d) {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Function 'test' has too many parameters (4). Maximum allowed is 3.",
+					},
+				},
+			},
+			{
+				Code:    "var test = function(a, b, c, d) {};",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:    "var test = (a, b, c, d) => {};",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:    "(function(a, b, c, d) {});",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:    "var test = function test(a, b, c) {};",
+				Options: objectOption(map[string]interface{}{"max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			// Object property options
+			{
+				Code:    "function test(a, b, c) {}",
+				Options: objectOption(map[string]interface{}{"max": 2}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:    "function test(a, b, c, d) {}",
+				Options: objectOption(map[string]interface{}{}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:    "function test(a) {}",
+				Options: objectOption(map[string]interface{}{"max": 0}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			// Error location should not cover the entire function — just the head.
+			{
+				Code: `function test(a, b, c) {
+              // Just to make it longer
+            }`,
+				Options: objectOption(map[string]interface{}{"max": 2}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+
+			// ============================================================
+			// 3. Universal edge shapes — every container kind reports
+			// ============================================================
+
+			// --- Class member kinds (each produces a distinct description) ---
+			{
+				Code:    "class C { method(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Method 'method' has too many parameters (4). Maximum allowed is 3.",
+						Line:      1, Column: 11, EndLine: 1, EndColumn: 17,
+					},
+				},
+			},
+			{
+				Code:    "class C { static method(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Static method 'method' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "class C { #method(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Private method '#method' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "class C { static #method(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Static private method '#method' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "class C { constructor(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Constructor has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "class C { set x(v) {} }",
+				Options: objectOption(map[string]interface{}{"max": 0}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Setter 'x' has too many parameters (1). Maximum allowed is 0."},
+				},
+			},
+			{
+				Code:    "class C { static set x(v) {} }",
+				Options: objectOption(map[string]interface{}{"max": 0}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Static setter 'x' has too many parameters (1). Maximum allowed is 0."},
+				},
+			},
+			{
+				Code:    "class C { handler = (a, b, c, d) => {}; }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			// Class expression
+			{
+				Code:    "var X = class { m(a, b, c, d) {} };",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+
+			// --- Object literal forms ---
+			{
+				Code:    "var obj = { method(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Method 'method' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "var obj = { set x(v) {} }",
+				Options: objectOption(map[string]interface{}{"max": 0}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:    "var obj = { ['m'](a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Method 'm' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- async / generator / async-generator (modifier ordering) ---
+			{
+				Code:    "async function foo(a, b, c, d) {}",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Async function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "function* foo(a, b, c, d) {}",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Generator function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "async function* foo(a, b, c, d) {}",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Async generator function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "const foo = async (a, b, c, d) => {};",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Async arrow function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "class C { async method(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Async method 'method' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "class C { async *method(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Async generator method 'method' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "class C { static async #m(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Static private async method '#m' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Function-like types (TSFunctionType / declare function) ---
+			{
+				Code:    "type F = (a: number, b: number, c: number, d: number) => void;",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				Code:    "declare function foo(a, b, c, d): void;",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Anonymous function expression / IIFE ---
+			{
+				Code: "(function(a, b, c, d) {})();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Function has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// ============================================================
+			// 4. Real-world & boundary scenarios
+			// ============================================================
+
+			// --- countVoidThis: false (default) — strip `this: void` only ---
+			{
+				// `this: void` stripped (default), 4 remaining > 3.
+				Code:    "function f(this: void, a, b, c, d) {}",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				// `this: any` is NOT stripped — 4 total > 3.
+				Code:    "function f(this: any, a, b, c) {}",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+			{
+				// `this: void` + rest: stripped + rest counts as 1, 4 effective.
+				Code:    "function f(this: void, a, b, c, ...rest) {}",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Function 'f' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				// countVoidThis:true + rest: this:void NOT stripped, 5 effective.
+				Code:    "function f(this: void, a, b, c, ...rest) {}",
+				Options: objectOption(map[string]interface{}{"max": 4, "countVoidThis": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Function 'f' has too many parameters (5). Maximum allowed is 4."},
+				},
+			},
+			{
+				// `this` without type — never stripped (4 effective).
+				Code:    "function f(this, a, b, c) {}",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+
+			// --- Parameter properties: each counts as one param ---
+			{
+				Code: "class C { constructor(public a: number, private b: string, readonly c: boolean, d: any) {} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Constructor has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Optional / default parameters: each counts as one ---
+			{Code: "function foo(a?, b?, c?, d?) {}", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}}},
+			{Code: "function foo(a = 1, b = 2, c = 3, d = 4) {}", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}}},
+
+			// --- Decorated method ---
+			{
+				Code: `
+declare const dec: any;
+class C {
+  @dec
+  method(a, b, c, d) {}
+}
+				`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Method 'method' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Abstract method ---
+			{
+				Code: `
+abstract class A {
+  abstract foo(a, b, c, d): void;
+}
+				`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Method 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Overload signatures: each declaration counted independently ---
+			{
+				Code: `
+class Foo {
+  method(a, b): void;
+  method(a, b, c, d): void;
+  method(...args: any[]): void {}
+}
+				`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 3, EndLine: 4, EndColumn: 9,
+						Message: "Method 'method' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Inner function checked independently of outer ---
+			{
+				Code:    "function outer(a) { function inner(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Function 'inner' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "function outer(a, b, c, d) { function inner(x) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Function 'outer' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			// Both outer AND inner exceed → two separate diagnostics.
+			{
+				Code:    "function outer(a, b, c, d) { function inner(e, f, g, h) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Function 'outer' has too many parameters (4). Maximum allowed is 3."},
+					{MessageId: "exceed",
+						Message: "Function 'inner' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			// Class method body containing nested function — both reported.
+			{
+				Code: `
+class C {
+  outer(a, b, c, d) {
+    return function inner(e, f, g, h) {};
+  }
+}
+				`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 3, EndLine: 3, EndColumn: 8,
+						Message: "Method 'outer' has too many parameters (4). Maximum allowed is 3."},
+					{MessageId: "exceed",
+						Message: "Function 'inner' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Multi-line position assertion ---
+			{
+				Code: `
+function test(
+  a,
+  b,
+  c,
+  d
+) {}
+				`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 2, Column: 1, EndLine: 2, EndColumn: 14},
+				},
+			},
+
+			// --- Real-world: Express handler signature ---
+			{
+				Code:    "const handler = (req, res, next, err) => {};",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Arrow function 'handler' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Real-world: forEach-like callback exceeding ---
+			{
+				Code:    "[].forEach(function (value, index, array, extra) {});",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed"}},
+			},
+
+			// --- countVoidThis combined with overloads (each declaration independent) ---
+			{
+				Code: `
+class C {
+  m(this: void, a, b, c): void;
+  m(this: void, a, b, c, d): void;
+  m(...args: any[]): any {}
+}
+				`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4,
+						Message: "Method 'm' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Object-property FunctionExpression: described as "method", not "function" ---
+			{
+				Code:    "var obj = { foo: function (a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Method 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				// Named FunctionExpression as object property value: own name wins.
+				Code:    "var obj = { foo: function bar(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Method 'bar' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				// Async object-property method (via FunctionExpression form).
+				Code:    "var obj = { foo: async function (a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Async method 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				// Arrow as property value: still "Arrow function" (matches ESLint).
+				Code:    "var obj = { foo: (a, b, c, d) => {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Arrow function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Class field initialized with function expression ---
+			// Class fields are PropertyDeclaration in tsgo (not PropertyAssignment),
+			// so the FunctionExpression-as-method branch does NOT apply — the
+			// description is "function 'foo'" via parent walk for the
+			// PropertyDeclaration name, matching ESLint (in ESTree the parent is
+			// `PropertyDefinition`, which is not in the method-classifier branch).
+			{
+				Code:    "class C { foo = function (a, b, c, d) {}; }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "class C { foo = async function (a, b, c, d) {}; }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Async function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			// --- Class field with PrivateIdentifier or `static` modifier ---
+			// ESLint v9's getFunctionNameWithKind picks up `parent.static`
+			// and `parent.key.type === "PrivateIdentifier"` for PropertyDefinition
+			// whose value is the function-like, so the description gets
+			// "static" / "private" prefixes and `'#name'` from the field key.
+			{
+				// Private class field arrow.
+				Code:    "class C { #foo = (a, b, c, d) => {}; }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Private arrow function '#foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				// Static private class field arrow.
+				Code:    "class C { static #foo = (a, b, c, d) => {}; }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Static private arrow function '#foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				// Static class field arrow (non-private).
+				Code:    "class C { static foo = (a, b, c, d) => {}; }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Static arrow function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				// Static async class field arrow — modifier ordering preserved.
+				Code:    "class C { static foo = async (a, b, c, d) => {}; }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Static async arrow function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				// Private class field FunctionExpression value.
+				Code:    "class C { #foo = function (a, b, c, d) {}; }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Private function '#foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				// Static private class field FunctionExpression with async.
+				Code:    "class C { static #foo = async function (a, b, c, d) {}; }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Static private async function '#foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Function type inside an interface property signature ---
+			// Now that getFunctionNameForDescription walks PropertySignature
+			// parents, the description recovers `foo` from the property name.
+			{
+				Code:    "interface I { foo: (a, b, c, d) => void }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Function 'foo' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Function type as the value of a TypeAliasDeclaration ---
+			// Walks TypeAliasDeclaration parent for the alias name.
+			{
+				Code:    "type F = (a: number, b: number, c: number, d: number) => void;",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Function 'F' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- declare class methods (no body) ---
+			{
+				Code: `
+declare class Foo {
+  method(a, b, c, d): void;
+}
+				`,
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Method 'method' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code: `
+declare class Foo {
+  static method(a, b, c, d): void;
+  constructor(a, b, c, d);
+}
+				`,
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Static method 'method' has too many parameters (4). Maximum allowed is 3."},
+					{MessageId: "exceed",
+						Message: "Constructor has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+
+			// --- Numeric / string property key methods ---
+			{
+				Code:    "var obj = { 0(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Method '0' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+			{
+				Code:    "var obj = { 'a-b'(a, b, c, d) {} }",
+				Options: objectOption(map[string]interface{}{"max": 3}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed",
+						Message: "Method 'a-b' has too many parameters (4). Maximum allowed is 3."},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/max_depth/max_depth.go
+++ b/internal/rules/max_depth/max_depth.go
@@ -134,10 +134,10 @@ func parseMaxDepth(options any) int {
 		if len(arr) == 0 {
 			return defaultMax
 		}
-		if n, ok := toInt(arr[0]); ok {
+		if n, ok := utils.CoerceInt(arr[0]); ok {
 			return n
 		}
-	} else if n, ok := toInt(options); ok {
+	} else if n, ok := utils.CoerceInt(options); ok {
 		return n
 	}
 	// Object form: `{ max: 3 }` or `[{ max: 3 }]`. Use the shared extractor so
@@ -155,12 +155,12 @@ func parseMaxDepth(options any) int {
 		return defaultMax
 	}
 	if hasMaximum {
-		if v, ok := toInt(m["maximum"]); ok && v != 0 {
+		if v, ok := utils.CoerceInt(m["maximum"]); ok && v != 0 {
 			return v
 		}
 	}
 	if hasMax {
-		if v, ok := toInt(m["max"]); ok {
+		if v, ok := utils.CoerceInt(m["max"]); ok {
 			return v
 		}
 	}
@@ -171,18 +171,3 @@ func parseMaxDepth(options any) int {
 	return math.MaxInt
 }
 
-func toInt(v any) (int, bool) {
-	switch n := v.(type) {
-	case int:
-		return n, true
-	case int32:
-		return int(n), true
-	case int64:
-		return int(n), true
-	case float64:
-		return int(n), true
-	case float32:
-		return int(n), true
-	}
-	return 0, false
-}

--- a/internal/rules/max_lines/max_lines.go
+++ b/internal/rules/max_lines/max_lines.go
@@ -41,13 +41,13 @@ func parseOptions(opts any) maxLinesOptions {
 		}
 		opts = arr[0]
 	}
-	if n, ok := toInt(opts); ok {
+	if n, ok := utils.CoerceInt(opts); ok {
 		result.max = n
 		return result
 	}
 	if m, ok := opts.(map[string]interface{}); ok {
 		if v, ok := m["max"]; ok {
-			if n, ok := toInt(v); ok {
+			if n, ok := utils.CoerceInt(v); ok {
 				result.max = n
 			}
 		}
@@ -61,21 +61,6 @@ func parseOptions(opts any) maxLinesOptions {
 	return result
 }
 
-func toInt(v any) (int, bool) {
-	switch n := v.(type) {
-	case int:
-		return n, true
-	case int32:
-		return int(n), true
-	case int64:
-		return int(n), true
-	case float64:
-		return int(n), true
-	case float32:
-		return int(n), true
-	}
-	return 0, false
-}
 
 func checkMaxLines(ctx rule.RuleContext, options any) {
 	opts := parseOptions(options)

--- a/internal/rules/max_lines_per_function/max_lines_per_function_test.go
+++ b/internal/rules/max_lines_per_function/max_lines_per_function_test.go
@@ -793,26 +793,28 @@ build() { return 1; },
 				},
 			},
 
-			// Test anonymous function assigned to variable is recognized
+			// Test anonymous function assigned to variable is recognized — name
+			// resolved via parent VariableDeclaration to match ESLint's getName.
 			{
 				Code:    "var func = function() {\n}",
 				Options: 1,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Function has too many lines (2). Maximum allowed is 1.",
+						Message:   "Function 'func' has too many lines (2). Maximum allowed is 1.",
 					},
 				},
 			},
 
-			// Test arrow functions are recognized
+			// Test arrow functions are recognized — name resolved via parent
+			// VariableDeclaration to match ESLint's getName.
 			{
 				Code:    "const bar = () => {\nconst x = 2 + 1;\nreturn x;\n}",
 				Options: 3,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Arrow function has too many lines (4). Maximum allowed is 3.",
+						Message:   "Arrow function 'bar' has too many lines (4). Maximum allowed is 3.",
 					},
 				},
 			},
@@ -824,7 +826,7 @@ build() { return 1; },
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Arrow function has too many lines (2). Maximum allowed is 1.",
+						Message:   "Arrow function 'bar' has too many lines (2). Maximum allowed is 1.",
 					},
 				},
 			},
@@ -1164,7 +1166,7 @@ if ( x === y ) {
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Arrow function has too many lines (3). Maximum allowed is 1.",
+						Message:   "Arrow function 'bar' has too many lines (3). Maximum allowed is 1.",
 						Line:      1,
 						Column:    13,
 						EndLine:   3,
@@ -1173,14 +1175,14 @@ if ( x === y ) {
 				},
 			},
 
-			// Async arrow function — name "Async arrow function"
+			// Async arrow function — description includes "async" + parent-walked name
 			{
 				Code:    "const bar = async () => {\nawait g();\nreturn 1;\n}",
 				Options: 2,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Async arrow function has too many lines (4). Maximum allowed is 2.",
+						Message:   "Async arrow function 'bar' has too many lines (4). Maximum allowed is 2.",
 					},
 				},
 			},
@@ -1287,8 +1289,10 @@ return 2;
 				},
 			},
 
-			// Class field arrow — counts as arrow function (parent is PropertyDeclaration,
-			// not a method), with NO name (ESLint also doesn't use the property key here).
+			// Class field arrow — counts as arrow function (parent is
+			// PropertyDeclaration, not a method); name is resolved from the
+			// property key, matching ESLint's getName which inspects
+			// PropertyDefinition.key.
 			{
 				Code: `class A {
 foo = () => {
@@ -1300,19 +1304,19 @@ return 2;
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Arrow function has too many lines (4). Maximum allowed is 2.",
+						Message:   "Arrow function 'foo' has too many lines (4). Maximum allowed is 2.",
 					},
 				},
 			},
 
-			// Object literal arrow assignment — same: arrow function, no name
+			// Object literal arrow assignment — name resolved from property key.
 			{
 				Code:    "var o = { foo: () => {\nreturn 1;\nreturn 2;\n} }",
 				Options: 2,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Arrow function has too many lines (4). Maximum allowed is 2.",
+						Message:   "Arrow function 'foo' has too many lines (4). Maximum allowed is 2.",
 					},
 				},
 			},
@@ -1505,7 +1509,8 @@ let b = 2;
 			},
 
 			// Triple-nested arrow chain — each arrow gets its own visit. The
-			// outermost spans 4 lines; max=1 should report all three.
+			// outermost spans 4 lines; max=1 should report all three. Only the
+			// outermost is bound to a variable, so only it carries a name.
 			{
 				Code: `var f = () =>
 () =>
@@ -1515,7 +1520,7 @@ let b = 2;
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Arrow function has too many lines (4). Maximum allowed is 1.",
+						Message:   "Arrow function 'f' has too many lines (4). Maximum allowed is 1.",
 					},
 					{
 						MessageId: "exceed",
@@ -1791,7 +1796,7 @@ class A { method() { return 1; } }
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Arrow function has too many lines (3). Maximum allowed is 0.",
+						Message:   "Arrow function 'f' has too many lines (3). Maximum allowed is 0.",
 					},
 					{
 						MessageId: "exceed",
@@ -1866,7 +1871,7 @@ let b = 2;
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Arrow function has too many lines (4). Maximum allowed is 2.",
+						Message:   "Arrow function 'f' has too many lines (4). Maximum allowed is 2.",
 						Line:      1,
 						Column:    11,
 						EndLine:   4,
@@ -1929,11 +1934,11 @@ console.log('thrice');
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "exceed",
-						Message:   "Arrow function has too many lines (5). Maximum allowed is 2.",
+						Message:   "Arrow function 'Button' has too many lines (5). Maximum allowed is 2.",
 					},
 					{
 						MessageId: "exceed",
-						Message:   "Arrow function has too many lines (5). Maximum allowed is 2.",
+						Message:   "Arrow function 'onClick' has too many lines (5). Maximum allowed is 2.",
 					},
 				},
 			},

--- a/internal/rules/strict/strict.go
+++ b/internal/rules/strict/strict.go
@@ -142,7 +142,6 @@ func getFunctionBodyStatements(node *ast.Node) []*ast.Node {
 	return block.Statements.Nodes
 }
 
-
 func reportDirectives(ctx rule.RuleContext, directives []*ast.Node, msgId string, fix bool) {
 	desc := messageDescriptionFor(msgId)
 	for _, d := range directives {

--- a/internal/rules/strict/strict_test.go
+++ b/internal/rules/strict/strict_test.go
@@ -664,9 +664,12 @@ function bar() {}
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "wrap",
-						Message:   "Wrap arrow function in a function with 'use strict' directive.",
-						Line:      1,
-						Column:    11,
+						// Now resolves the binding name from the parent
+						// VariableDeclaration, matching ESLint's
+						// astUtils.getName.
+						Message: "Wrap arrow function 'foo' in a function with 'use strict' directive.",
+						Line:    1,
+						Column:  11,
 					},
 				},
 			},
@@ -676,7 +679,7 @@ function bar() {}
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "wrap",
-						Message:   "Wrap async arrow function in a function with 'use strict' directive.",
+						Message:   "Wrap async arrow function 'foo' in a function with 'use strict' directive.",
 						Line:      1,
 						Column:    11,
 					},

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -258,6 +258,18 @@ func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRan
 			return core.NewTextRange(start, node.Body().Pos())
 		}
 		return TrimNodeTextRange(sourceFile, node)
+
+	case ast.KindFunctionType:
+		// Mirror ESLint's astUtils.getFunctionHeadLoc fallback for
+		// TSFunctionType: range from the node's start to the opening '(' of
+		// its parameters. With no type parameters this collapses to a
+		// zero-width position at '('; with `<T>(...)` the range covers the
+		// type-parameter list, exactly as upstream produces.
+		trimmed := TrimNodeTextRange(sourceFile, node)
+		if parenPos := findOpenParenPos(sourceFile, node); parenPos >= 0 {
+			return trimmed.WithEnd(parenPos)
+		}
+		return trimmed
 	}
 
 	return TrimNodeTextRange(sourceFile, node)
@@ -269,9 +281,21 @@ func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRan
 // `"arrow function"`, `"constructor"`). Modifier order matches ESLint:
 // static, private, async, generator, then the function-kind keyword.
 //
+// For nameless function-likes, walks the parent (VariableDeclaration,
+// PropertyAssignment, PropertyDeclaration, PropertySignature,
+// TypeAliasDeclaration) to recover the binding name where ESLint does the
+// same via its `getName` / `getOuterName` helpers.
+//
+// For a FunctionExpression assigned as the value of an object literal
+// property (`var obj = { foo: function () {} }`), classifies the node as a
+// "method" — ESTree models that case via `Property.value === FunctionExpression`
+// and ESLint's classifier emits "method"; tsgo only collapses method-shorthand
+// (`{ foo() {} }`) into MethodDeclaration, so we recover the same description
+// from the parent.
+//
 // Callers that need the upper-cased form (e.g., as the leading {{name}}
-// placeholder of a sentence) should apply that transform themselves — this
-// helper returns the lower-cased form to keep both call sites simple.
+// placeholder of a sentence) should apply UpperCaseFirstASCII — this helper
+// returns the lower-cased form to keep call sites simple.
 func GetFunctionNameWithKind(node *ast.Node) string {
 	if node.Kind == ast.KindConstructor {
 		return "constructor"
@@ -281,15 +305,34 @@ func GetFunctionNameWithKind(node *ast.Node) string {
 	isAsync := flags&ast.FunctionFlagsAsync != 0
 	isGenerator := flags&ast.FunctionFlagsGenerator != 0
 
-	isStatic, isPrivate := false, false
 	parent := node.Parent
-	inClassBody := parent != nil && (parent.Kind == ast.KindClassDeclaration || parent.Kind == ast.KindClassExpression)
-	if inClassBody {
+	isStatic, isPrivate := false, false
+	// Direct class member (MethodDeclaration / GetAccessor / SetAccessor):
+	// modifiers and private-key live on the function-like node itself.
+	if parent != nil && (parent.Kind == ast.KindClassDeclaration || parent.Kind == ast.KindClassExpression) {
 		switch node.Kind {
 		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
 			isStatic = ast.HasSyntacticModifier(node, ast.ModifierFlagsStatic)
 			if n := node.Name(); n != nil && n.Kind == ast.KindPrivateIdentifier {
 				isPrivate = true
+			}
+		}
+	}
+	// Class field with arrow / function-expression initializer: modifiers and
+	// private-key live on the surrounding PropertyDeclaration. Mirrors ESLint
+	// v9's `parent.type === "PropertyDefinition" && parent.value === node`
+	// branch in `astUtils.getFunctionNameWithKind`.
+	if parent != nil && parent.Kind == ast.KindPropertyDeclaration {
+		if grandparent := parent.Parent; grandparent != nil &&
+			(grandparent.Kind == ast.KindClassDeclaration || grandparent.Kind == ast.KindClassExpression) {
+			switch node.Kind {
+			case ast.KindArrowFunction, ast.KindFunctionExpression:
+				if ast.HasSyntacticModifier(parent, ast.ModifierFlagsStatic) {
+					isStatic = true
+				}
+				if n := parent.Name(); n != nil && n.Kind == ast.KindPrivateIdentifier {
+					isPrivate = true
+				}
 			}
 		}
 	}
@@ -317,20 +360,83 @@ func GetFunctionNameWithKind(node *ast.Node) string {
 		tokens = append(tokens, "method")
 	case ast.KindArrowFunction:
 		tokens = append(tokens, "arrow", "function")
+	case ast.KindFunctionExpression:
+		if parent != nil && parent.Kind == ast.KindPropertyAssignment {
+			tokens = append(tokens, "method")
+		} else {
+			tokens = append(tokens, "function")
+		}
 	default:
 		tokens = append(tokens, "function")
 	}
 
-	if name := node.Name(); name != nil {
-		if name.Kind == ast.KindPrivateIdentifier {
-			// PrivateIdentifier.Text already includes the leading '#'.
-			tokens = append(tokens, fmt.Sprintf("'%s'", name.AsPrivateIdentifier().Text))
-		} else if nameStr, ok := GetStaticPropertyName(name); ok {
-			tokens = append(tokens, fmt.Sprintf("'%s'", nameStr))
-		}
+	if name := getFunctionDisplayName(node); name != "" {
+		tokens = append(tokens, fmt.Sprintf("'%s'", name))
 	}
 
 	return strings.Join(tokens, " ")
+}
+
+// getFunctionDisplayName resolves the user-visible name of a function-like
+// node — first by inspecting the node's own name, then by walking the parent
+// for variable / property / type binding sites that ESLint's `getName` covers.
+func getFunctionDisplayName(node *ast.Node) string {
+	if n := node.Name(); n != nil {
+		switch n.Kind {
+		case ast.KindPrivateIdentifier:
+			return n.AsPrivateIdentifier().Text
+		case ast.KindIdentifier:
+			return n.AsIdentifier().Text
+		}
+		if s, ok := GetStaticPropertyName(n); ok {
+			return s
+		}
+	}
+	parent := node.Parent
+	if parent == nil {
+		return ""
+	}
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		if n := parent.Name(); n != nil && n.Kind == ast.KindIdentifier {
+			return n.AsIdentifier().Text
+		}
+	case ast.KindPropertyAssignment, ast.KindPropertyDeclaration, ast.KindPropertySignature:
+		if n := parent.Name(); n != nil {
+			if n.Kind == ast.KindIdentifier {
+				return n.AsIdentifier().Text
+			}
+			if n.Kind == ast.KindPrivateIdentifier {
+				// PrivateIdentifier.Text already includes the leading '#',
+				// matching ESLint's `getName` for PropertyDefinition with a
+				// PrivateIdentifier key.
+				return n.AsPrivateIdentifier().Text
+			}
+			if s, ok := GetStaticPropertyName(n); ok {
+				return s
+			}
+		}
+	case ast.KindTypeAliasDeclaration:
+		if n := parent.Name(); n != nil && n.Kind == ast.KindIdentifier {
+			return n.AsIdentifier().Text
+		}
+	}
+	return ""
+}
+
+// UpperCaseFirstASCII returns s with its first byte mapped to upper case if
+// the byte is an ASCII lowercase letter; otherwise returns s unchanged.
+// Sufficient for ESLint's `astUtils.upperCaseFirst` since all function-kind
+// tokens are ASCII English ("function", "method", "constructor", …).
+func UpperCaseFirstASCII(s string) string {
+	if s == "" {
+		return s
+	}
+	r := s[0]
+	if r >= 'a' && r <= 'z' {
+		return string(r-('a'-'A')) + s[1:]
+	}
+	return s
 }
 
 // nodeStartSkippingDecorators returns a TextRange whose start is the first

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -330,6 +330,26 @@ func GetOptionsMap(opts any) map[string]interface{} {
 	return optsMap
 }
 
+// CoerceInt converts a JSON-decoded numeric value to int. JSON numbers come in
+// as float64 from `encoding/json`, but rule_tester / test fixtures may pass
+// raw int / int32 / int64 / float32, so accept all of them. Returns
+// (value, true) on success, (0, false) for non-numeric inputs (including nil).
+func CoerceInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	case float32:
+		return int(n), true
+	}
+	return 0, false
+}
+
 // GetOptionsString extracts a string option from the weakly-typed options parameter.
 // It handles both direct string format ("value") and array format (["value"]).
 func GetOptionsString(opts any) string {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -155,7 +155,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/explicit-member-accessibility.test.ts',
     // './tests/typescript-eslint/rules/explicit-module-boundary-types.test.ts',
     // './tests/typescript-eslint/rules/init-declarations.test.ts',
-    // './tests/typescript-eslint/rules/max-params.test.ts',
+    './tests/typescript-eslint/rules/max-params.test.ts',
     './tests/typescript-eslint/rules/member-ordering.test.ts',
     './tests/typescript-eslint/rules/member-ordering/member-ordering-alphabetically-case-insensitive-order.test.ts',
     './tests/typescript-eslint/rules/member-ordering/member-ordering-alphabetically-order.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-lines-per-function.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-lines-per-function.test.ts.snap
@@ -33,7 +33,7 @@ exports[`max-lines-per-function > invalid 2`] = `
 }",
   "diagnostics": [
     {
-      "message": "Function has too many lines (2). Maximum allowed is 1.",
+      "message": "Function 'func' has too many lines (2). Maximum allowed is 1.",
       "messageId": "exceed",
       "range": {
         "end": {
@@ -62,7 +62,7 @@ return x;
 }",
   "diagnostics": [
     {
-      "message": "Arrow function has too many lines (4). Maximum allowed is 3.",
+      "message": "Arrow function 'bar' has too many lines (4). Maximum allowed is 3.",
       "messageId": "exceed",
       "range": {
         "end": {
@@ -89,7 +89,7 @@ exports[`max-lines-per-function > invalid 4`] = `
  2",
   "diagnostics": [
     {
-      "message": "Arrow function has too many lines (2). Maximum allowed is 1.",
+      "message": "Arrow function 'bar' has too many lines (2). Maximum allowed is 1.",
       "messageId": "exceed",
       "range": {
         "end": {

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/strict.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/strict.test.ts.snap
@@ -1139,7 +1139,7 @@ exports[`strict > invalid 40`] = `
   "code": "var foo = (a = 0) => { };",
   "diagnostics": [
     {
-      "message": "Wrap arrow function in a function with 'use strict' directive.",
+      "message": "Wrap arrow function 'foo' in a function with 'use strict' directive.",
       "messageId": "wrap",
       "range": {
         "end": {
@@ -1165,7 +1165,7 @@ exports[`strict > invalid 41`] = `
   "code": "var foo = async (a = 0) => { };",
   "diagnostics": [
     {
-      "message": "Wrap async arrow function in a function with 'use strict' directive.",
+      "message": "Wrap async arrow function 'foo' in a function with 'use strict' directive.",
       "messageId": "wrap",
       "range": {
         "end": {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/max-params.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/max-params.test.ts.snap
@@ -1,0 +1,723 @@
+// Rstest Snapshot v1
+
+exports[`max-params > invalid 1`] = `
+{
+  "code": "function foo(a, b, c, d) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 2`] = `
+{
+  "code": "const foo = function (a, b, c, d) {};",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 3`] = `
+{
+  "code": "const foo = (a, b, c, d) => {};",
+  "diagnostics": [
+    {
+      "message": "Arrow function 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 4`] = `
+{
+  "code": "const foo = a => {};",
+  "diagnostics": [
+    {
+      "message": "Arrow function 'foo' has too many parameters (1). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 5`] = `
+{
+  "code": "
+class Foo {
+  method(this: void, a, b, c, d) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Method 'method' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 6`] = `
+{
+  "code": "
+class Foo {
+  method(this: void, a) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Method 'method' has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 7`] = `
+{
+  "code": "
+class Foo {
+  method(this: Foo, a, b, c) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Method 'method' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 8`] = `
+{
+  "code": "
+declare function makeDate(m: number, d: number, y: number): Date;
+      ",
+  "diagnostics": [
+    {
+      "message": "Function 'makeDate' has too many parameters (3). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 9`] = `
+{
+  "code": "
+type sum = (a: number, b: number) => number;
+      ",
+  "diagnostics": [
+    {
+      "message": "Function 'sum' has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 10`] = `
+{
+  "code": "var obj = { foo: function (a, b, c, d) {} };",
+  "diagnostics": [
+    {
+      "message": "Method 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 11`] = `
+{
+  "code": "var obj = { foo: async function (a, b, c, d) {} };",
+  "diagnostics": [
+    {
+      "message": "Async method 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 12`] = `
+{
+  "code": "var obj = { foo: (a, b, c, d) => {} };",
+  "diagnostics": [
+    {
+      "message": "Arrow function 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 13`] = `
+{
+  "code": "class C { foo = function (a, b, c, d) {}; }",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 14`] = `
+{
+  "code": "
+declare class Foo {
+  method(a, b, c, d): void;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Method 'method' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 15`] = `
+{
+  "code": "
+declare class Foo {
+  static method(a, b, c, d): void;
+  constructor(a, b, c, d);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Static method 'method' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+    {
+      "message": "Constructor has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 16`] = `
+{
+  "code": "type F = (a: number, b: number, c: number, d: number) => void;",
+  "diagnostics": [
+    {
+      "message": "Function 'F' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 17`] = `
+{
+  "code": "interface I { foo: (a, b, c, d) => void }",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 18`] = `
+{
+  "code": "class C { static async *#m(a, b, c, d) {} }",
+  "diagnostics": [
+    {
+      "message": "Static private async generator method '#m' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 19`] = `
+{
+  "code": "class C { constructor(public a: number, private b: string, readonly c: boolean, d: any) {} }",
+  "diagnostics": [
+    {
+      "message": "Constructor has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 20`] = `
+{
+  "code": "
+class Foo {
+  m(a, b): void;
+  m(a, b, c, d): void;
+  m(...args: any[]): any {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Method 'm' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 21`] = `
+{
+  "code": "function f(this: void, a, b, c, ...rest) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'f' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 22`] = `
+{
+  "code": "class C { #foo = (a, b, c, d) => {}; }",
+  "diagnostics": [
+    {
+      "message": "Private arrow function '#foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 23`] = `
+{
+  "code": "class C { static foo = (a, b, c, d) => {}; }",
+  "diagnostics": [
+    {
+      "message": "Static arrow function 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 24`] = `
+{
+  "code": "class C { static #foo = (a, b, c, d) => {}; }",
+  "diagnostics": [
+    {
+      "message": "Static private arrow function '#foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 25`] = `
+{
+  "code": "class C { #foo = function (a, b, c, d) {}; }",
+  "diagnostics": [
+    {
+      "message": "Private function '#foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 26`] = `
+{
+  "code": "class C { static #foo = async function (a, b, c, d) {}; }",
+  "diagnostics": [
+    {
+      "message": "Static private async function '#foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/max-params.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/max-params.test.ts
@@ -124,5 +124,115 @@ type sum = (a: number, b: number) => number;
       errors: [{ messageId: 'exceed' }],
       options: [{ max: 1 }],
     },
+
+    // ----- rslint additions: tsgo container kinds + name-resolution corners
+    // (each of these locks a description / position the upstream test suite
+    // never exercises because ESTree collapses these forms into
+    // FunctionExpression / ArrowFunctionExpression). -----
+
+    // Object-literal property whose value is a FunctionExpression — described
+    // as "method 'foo'" (matches ESLint), not "function 'foo'".
+    {
+      code: 'var obj = { foo: function (a, b, c, d) {} };',
+      errors: [{ messageId: 'exceed' }],
+    },
+    // Async object-literal property method via FunctionExpression form.
+    {
+      code: 'var obj = { foo: async function (a, b, c, d) {} };',
+      errors: [{ messageId: 'exceed' }],
+    },
+    // Arrow as object-literal property value — "Arrow function 'foo'".
+    {
+      code: 'var obj = { foo: (a, b, c, d) => {} };',
+      errors: [{ messageId: 'exceed' }],
+    },
+    // Class field initialized with FunctionExpression — described as
+    // "Function 'foo'" (ESLint's `MethodDefinition` branch does NOT match
+    // class fields, which are PropertyDefinition).
+    {
+      code: 'class C { foo = function (a, b, c, d) {}; }',
+      errors: [{ messageId: 'exceed' }],
+    },
+    // declare class methods (no body) and constructors still trigger.
+    {
+      code: `
+declare class Foo {
+  method(a, b, c, d): void;
+}
+      `,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: `
+declare class Foo {
+  static method(a, b, c, d): void;
+  constructor(a, b, c, d);
+}
+      `,
+      errors: [{ messageId: 'exceed' }, { messageId: 'exceed' }],
+    },
+    // Function type as the value of a TypeAliasDeclaration — name resolved
+    // from the alias.
+    {
+      code: 'type F = (a: number, b: number, c: number, d: number) => void;',
+      errors: [{ messageId: 'exceed' }],
+    },
+    // Function type inside an interface PropertySignature — name resolved
+    // from the property.
+    {
+      code: 'interface I { foo: (a, b, c, d) => void }',
+      errors: [{ messageId: 'exceed' }],
+    },
+    // Private + static + async + generator method — modifier ordering and
+    // private-identifier name preserved.
+    {
+      code: 'class C { static async *#m(a, b, c, d) {} }',
+      errors: [{ messageId: 'exceed' }],
+    },
+    // Parameter properties count as parameters (TS-only, would not appear
+    // in upstream eslint-core tests).
+    {
+      code: 'class C { constructor(public a: number, private b: string, readonly c: boolean, d: any) {} }',
+      errors: [{ messageId: 'exceed' }],
+    },
+    // Overload signatures — each declaration counted independently.
+    {
+      code: `
+class Foo {
+  m(a, b): void;
+  m(a, b, c, d): void;
+  m(...args: any[]): any {}
+}
+      `,
+      errors: [{ messageId: 'exceed' }],
+    },
+    // this:void + rest — stripped, rest still counts as 1.
+    {
+      code: 'function f(this: void, a, b, c, ...rest) {}',
+      errors: [{ messageId: 'exceed' }],
+    },
+
+    // Class field with PrivateIdentifier / static — ESLint adds the
+    // `private` / `static` prefix and resolves the name from the field key.
+    {
+      code: 'class C { #foo = (a, b, c, d) => {}; }',
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'class C { static foo = (a, b, c, d) => {}; }',
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'class C { static #foo = (a, b, c, d) => {}; }',
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'class C { #foo = function (a, b, c, d) {}; }',
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'class C { static #foo = async function (a, b, c, d) {}; }',
+      errors: [{ messageId: 'exceed' }],
+    },
   ],
 });


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/max-params` rule to rslint with full upstream alignment.

The rule enforces a maximum number of parameters in function definitions (default 3), with TypeScript-aware behavior for the `this: void` parameter via the `countVoidThis` option.

Implementation highlights:

- Listens on every tsgo function-like kind (`FunctionDeclaration`, `FunctionExpression`, `ArrowFunction`, `MethodDeclaration`, `Constructor`, `GetAccessor`, `SetAccessor`, `FunctionType`) so each ESTree container that ESLint covers via `MethodDefinition.value` / `Property.value` / `TSDeclareFunction` / `TSFunctionType` is matched 1:1.
- Schema is object-only, matching the typescript-eslint variant byte-for-byte; honors `option.maximum || option.max` JS truthy coercion (a present-but-zero `maximum` falls through to `max`; a present-but-falsy value with no fallback effectively disables the check, matching ESLint's `numParams = undefined` semantics).
- Strips `this: void` via `ast.IsThisParameter` + `KindVoidKeyword` check; `this: <non-void>` (`Foo`, `any`, `never`, …) is correctly counted; rest / destructuring / parameter properties / `?` optionals each count as 1.
- Reports on overload signatures independently (each declaration runs through the listener).

Shared helpers extracted while porting:

- `utils.GetFunctionNameWithKind` — consolidates `strict.go::functionDescription` and the new max-params helper into a single `astUtils.getFunctionNameWithKind`-aligned implementation. Adds parent-walking name resolution for `VariableDeclaration` / `PropertyAssignment` / `PropertyDeclaration` / `PropertySignature` / `TypeAliasDeclaration` (matches ESLint's `getName`), and the FunctionExpression-as-method classification for object-literal property values. `strict` and `max-lines-per-function` migrate to the shared helper; their tests were updated where the now-resolved names changed expected message text (an alignment improvement on both sides).
- `utils.UpperCaseFirstASCII` — sentence-initial casing matching ESLint's `astUtils.upperCaseFirst`.
- `utils.CoerceInt` — JSON-decoded numeric coercion; `max-depth` / `max-lines` / `max-params` migrate from local copies to the shared utility.
- `utils.GetFunctionHeadLoc` — adds a `KindFunctionType` case so report ranges for `(a, b, c) => void` literals match ESLint's exact behavior (range from node start to opening `(`; degenerates to a zero-width position at `(` when no type parameters, matching upstream).

Validation:

- Full upstream `@typescript-eslint/max-params` test suite migrated 1:1 (Go + JS).
- 13 valid + 22 invalid additional test cases lock down: tsgo container kinds × static / private / async / generator modifiers; `this: void` × `countVoidThis` × rest / destructuring; parameter properties; abstract / declare class / overload signatures; decorated methods; multi-line position assertions; nested function-likes.
- Real-world differential validation: ran the rule against `web-infra-dev/rsbuild` (31 hits across `packages/core/src`) and `web-infra-dev/rspack` (131 hits across `packages/rspack` / `packages/rspack-cli` / `packages/rspack-test-tools`) — every hit verified against source code (kind, parameter count, name resolution, position, overload independence).

## Related Links

- Documentation: https://typescript-eslint.io/rules/max-params
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/max-params.ts
- Tests: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/max-params.test.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).