### PR TITLE
feat: port rule max-nested-callbacks

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/max_depth"
 	"github.com/web-infra-dev/rslint/internal/rules/max_lines"
 	"github.com/web-infra-dev/rslint/internal/rules/max_lines_per_function"
+	"github.com/web-infra-dev/rslint/internal/rules/max_nested_callbacks"
 	"github.com/web-infra-dev/rslint/internal/rules/no_alert"
 	"github.com/web-infra-dev/rslint/internal/rules/no_async_promise_executor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_await_in_loop"
@@ -629,6 +630,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("max-depth", max_depth.MaxDepthRule)
 	GlobalRuleRegistry.Register("max-lines", max_lines.MaxLinesRule)
 	GlobalRuleRegistry.Register("max-lines-per-function", max_lines_per_function.MaxLinesPerFunctionRule)
+	GlobalRuleRegistry.Register("max-nested-callbacks", max_nested_callbacks.MaxNestedCallbacksRule)
 	GlobalRuleRegistry.Register("no-alert", no_alert.NoAlertRule)
 	GlobalRuleRegistry.Register("no-async-promise-executor", no_async_promise_executor.NoAsyncPromiseExecutorRule)
 	GlobalRuleRegistry.Register("no-await-in-loop", no_await_in_loop.NoAwaitInLoopRule)

--- a/internal/rules/max_nested_callbacks/max_nested_callbacks.go
+++ b/internal/rules/max_nested_callbacks/max_nested_callbacks.go
@@ -1,0 +1,139 @@
+package max_nested_callbacks
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// MaxNestedCallbacksRule enforces a maximum depth of nested callbacks.
+// https://eslint.org/docs/latest/rules/max-nested-callbacks
+var MaxNestedCallbacksRule = rule.Rule{
+	Name: "max-nested-callbacks",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		threshold := parseThreshold(options)
+
+		// `callbackStack` mirrors ESLint's stack of FunctionExpression /
+		// ArrowFunctionExpression nodes that sit *directly* under a
+		// CallExpression — i.e. function-likes used as call arguments or as
+		// the callee of an immediately-invoked call. Push happens only when
+		// the (paren-flattened) parent is a CallExpression; pop fires on
+		// every function-like exit, even when the entry didn't push. The
+		// asymmetry is preserved verbatim from ESLint to keep diagnostic
+		// counts byte-for-byte identical with upstream.
+		var callbackStack []*ast.Node
+
+		check := func(node *ast.Node) {
+			// tsgo preserves ParenthesizedExpression nodes that ESTree
+			// flattens. Walk them so `(function(){})()` and `foo((fn))` are
+			// recognized as the function's "real" parent being a CallExpression.
+			parent := ast.WalkUpParenthesizedExpressions(node.Parent)
+			if parent != nil && ast.IsCallExpression(parent) {
+				callbackStack = append(callbackStack, node)
+			}
+			if len(callbackStack) > threshold {
+				ctx.ReportNode(node, buildExceedMessage(len(callbackStack), threshold))
+			}
+		}
+		pop := func(node *ast.Node) {
+			// JS Array#pop on an empty array is a no-op; bound the slice
+			// likewise so the asymmetric exit-pop can't underflow.
+			if len(callbackStack) > 0 {
+				callbackStack = callbackStack[:len(callbackStack)-1]
+			}
+		}
+
+		return rule.RuleListeners{
+			// FunctionExpression / ArrowFunction map directly to ESLint's
+			// FunctionExpression / ArrowFunctionExpression — push when the
+			// (paren-flattened) parent is a CallExpression, pop on exit.
+			ast.KindFunctionExpression:                      check,
+			rule.ListenerOnExit(ast.KindFunctionExpression): pop,
+			ast.KindArrowFunction:                           check,
+			rule.ListenerOnExit(ast.KindArrowFunction):      pop,
+
+			// In ESTree, class methods / getters / setters / constructors and
+			// object-shorthand methods are all `FunctionExpression` nodes
+			// nested inside `MethodDefinition` / `Property`. ESLint's listener
+			// therefore fires on each of them — performing both the threshold
+			// check on entry (without pushing, since parent is not a
+			// CallExpression) and the unconditional pop on exit. tsgo
+			// represents these as distinct AST kinds with no inner FE node, so
+			// we wire entry+exit on each kind to reproduce the diagnostic
+			// count exactly. The reported start position is the tsgo node
+			// itself rather than the wrapped FE — message text, messageId,
+			// num / max values, and line all match upstream; column may shift
+			// by the length of the method name and modifiers.
+			ast.KindMethodDeclaration:                      check,
+			rule.ListenerOnExit(ast.KindMethodDeclaration): pop,
+			ast.KindGetAccessor:                            check,
+			rule.ListenerOnExit(ast.KindGetAccessor):       pop,
+			ast.KindSetAccessor:                            check,
+			rule.ListenerOnExit(ast.KindSetAccessor):       pop,
+			ast.KindConstructor:                            check,
+			rule.ListenerOnExit(ast.KindConstructor):       pop,
+		}
+	},
+}
+
+func buildExceedMessage(num, threshold int) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "exceed",
+		Description: fmt.Sprintf("Too many nested callbacks (%d). Maximum allowed is %d.", num, threshold),
+	}
+}
+
+// parseThreshold resolves the configured maximum nesting depth, mirroring
+// ESLint's `option.maximum || option.max` coercion. The legacy `maximum` key
+// is honored only when truthy (matching JS coercion); otherwise `max` wins.
+// When neither key is present, the default is 10.
+func parseThreshold(options any) int {
+	const defaultMax = 10
+	if options == nil {
+		return defaultMax
+	}
+	// Number form: `3` or `[3]`.
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) == 0 {
+			return defaultMax
+		}
+		if n, ok := utils.CoerceInt(arr[0]); ok {
+			return n
+		}
+	} else if n, ok := utils.CoerceInt(options); ok {
+		return n
+	}
+	// Object form: `{ max: 3 }` or `[{ max: 3 }]`. Use the shared extractor so
+	// both the array-wrapped (rule_tester / multi-element CLI) and bare-object
+	// (single-option CLI) shapes are handled uniformly.
+	m := utils.GetOptionsMap(options)
+	if m == nil {
+		return defaultMax
+	}
+	_, hasMaximum := m["maximum"]
+	_, hasMax := m["max"]
+	if !hasMaximum && !hasMax {
+		// Matches ESLint: when neither key is present, the option object is
+		// ignored and the default is used.
+		return defaultMax
+	}
+	if hasMaximum {
+		if v, ok := utils.CoerceInt(m["maximum"]); ok && v != 0 {
+			return v
+		}
+	}
+	if hasMax {
+		if v, ok := utils.CoerceInt(m["max"]); ok {
+			return v
+		}
+	}
+	// `option.maximum` is present but coerces to 0 / non-numeric, and
+	// `option.max` is absent or non-numeric: ESLint sets `THRESHOLD = undefined`
+	// here, which makes every `length > THRESHOLD` comparison false and
+	// effectively disables the check. MaxInt produces the same observable
+	// behavior.
+	return math.MaxInt
+}

--- a/internal/rules/max_nested_callbacks/max_nested_callbacks.md
+++ b/internal/rules/max_nested_callbacks/max_nested_callbacks.md
@@ -1,0 +1,113 @@
+# max-nested-callbacks
+
+## Rule Details
+
+This rule enforces a maximum depth that callbacks can be nested to improve
+code readability. A common anti-pattern is "callback hell" — deeply nested
+callbacks that grow rightward and become hard to follow.
+
+A function expression or arrow function counts toward the nesting depth only
+when it is passed directly to a call (as a call argument or as the callee of
+an immediately-invoked call). Function-likes assigned to variables, object or
+class properties, array elements, JSX attributes, default parameter values,
+or used as `new` arguments / tagged-template arguments do not increase the
+counter.
+
+Examples of **incorrect** code for this rule with the default `{ "max": 10 }`
+option:
+
+```javascript
+foo1(function () {
+  foo2(function () {
+    foo3(function () {
+      foo4(function () {
+        foo5(function () {
+          foo6(function () {
+            foo7(function () {
+              foo8(function () {
+                foo9(function () {
+                  foo10(function () {
+                    foo11(function () {});
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});
+```
+
+Examples of **correct** code for this rule with the default `{ "max": 10 }`
+option:
+
+```javascript
+foo1(handleFoo1);
+
+function handleFoo1() {
+  foo2(handleFoo2);
+}
+
+function handleFoo2() {
+  foo3(handleFoo3);
+}
+```
+
+## Options
+
+This rule accepts a number, or an object with the following properties:
+
+- `max` (default `10`): the maximum nesting depth allowed.
+- `maximum`: deprecated alias for `max`. When both keys are present and
+  `maximum` is truthy, `maximum` wins (matching ESLint's
+  `option.maximum || option.max` coercion).
+
+### `max`
+
+Examples of **incorrect** code for this rule with `{ "max": 3 }`:
+
+```json
+{ "max-nested-callbacks": ["error", { "max": 3 }] }
+```
+
+```javascript
+foo1(function () {
+  foo2(function () {
+    foo3(function () {
+      foo4(function () {});
+    });
+  });
+});
+```
+
+Examples of **correct** code for this rule with `{ "max": 3 }`:
+
+```json
+{ "max-nested-callbacks": ["error", { "max": 3 }] }
+```
+
+```javascript
+foo1(function () {
+  foo2(function () {
+    foo3(function () {});
+  });
+});
+```
+
+Arrow functions are counted the same as function expressions:
+
+```javascript
+foo1(() => {
+  foo2(() => {
+    foo3(() => {
+      foo4(() => {});
+    });
+  });
+});
+```
+
+## Original Documentation
+
+- [https://eslint.org/docs/latest/rules/max-nested-callbacks](https://eslint.org/docs/latest/rules/max-nested-callbacks)

--- a/internal/rules/max_nested_callbacks/max_nested_callbacks_test.go
+++ b/internal/rules/max_nested_callbacks/max_nested_callbacks_test.go
@@ -1,0 +1,1114 @@
+package max_nested_callbacks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// nestFunctions returns `foo(function(){...})` nested `times` deep, matching
+// the helper of the same name in eslint/tests/lib/rules/max-nested-callbacks.js.
+func nestFunctions(times int) string {
+	const opening = "foo(function() {"
+	const closing = "});"
+	return strings.Repeat(opening, times) + strings.Repeat(closing, times)
+}
+
+// TestMaxNestedCallbacks covers two corpora:
+//
+//  1. ESLint parity — every case from eslint/tests/lib/rules/max-nested-callbacks.js
+//     migrated 1:1. Line and column are added to every invalid case (upstream
+//     omits them) so subsequent refactors can't silently shift report position.
+//  2. Additional edge cases — option-shape coverage, paren-walked parents,
+//     tsgo-specific syntax forms (TS expressions, optional chains), and
+//     lock-in tests for the asymmetric push/pop branch in the rule source.
+func TestMaxNestedCallbacks(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&MaxNestedCallbacksRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// 1. ESLint parity — mirrors tests/lib/rules/max-nested-callbacks.js
+			// ============================================================
+			{
+				Code:    "foo(function() { bar(thing, function(data) {}); });",
+				Options: 3,
+			},
+			{
+				Code:    "var foo = function() {}; bar(function(){ baz(function() { qux(foo); }) });",
+				Options: 2,
+			},
+			{
+				Code:    "fn(function(){}, function(){}, function(){});",
+				Options: 2,
+			},
+			{
+				Code:    "fn(() => {}, function(){}, function(){});",
+				Options: 2,
+			},
+			// 10 deep is exactly at the default threshold of 10 — valid.
+			{Code: nestFunctions(10)},
+
+			// object property options
+			{
+				Code:    "foo(function() { bar(thing, function(data) {}); });",
+				Options: map[string]interface{}{"max": 3},
+			},
+
+			// ============================================================
+			// 2. Additional edge cases
+			// ============================================================
+
+			// --- Default option (max=10) ---
+			// One-deep callback with default — well below the limit.
+			{
+				Code: "foo(function() { console.log('hi'); });",
+			},
+
+			// --- Options shapes — exercise the JSON path explicitly ---
+			// Number directly (not wrapped in array — bare CLI shape).
+			{Code: "foo(function() {});", Options: 1},
+			// Bare object (single-option CLI shape).
+			{
+				Code:    "foo(function() { bar(function() {}); });",
+				Options: map[string]interface{}{"max": 2},
+			},
+			// Array-wrapped object (multi-element / rule_tester shape).
+			{
+				Code:    "foo(function() { bar(function() {}); });",
+				Options: []interface{}{map[string]interface{}{"max": 2}},
+			},
+			// Empty options array → default 10.
+			{Code: nestFunctions(10), Options: []interface{}{}},
+			// Legacy `maximum` key.
+			{
+				Code:    "foo(function() { bar(function() { baz(function() {}); }); });",
+				Options: map[string]interface{}{"maximum": 3},
+			},
+
+			// --- Function-likes that are NOT direct CallExpression children
+			//     do not push, even if deeply nested ---
+			// Variable declaration value — never pushes.
+			{
+				Code:    "var a = function() { var b = function() { var c = function() { var d = function() {}; }; }; };",
+				Options: 0,
+			},
+			// Property value — never pushes.
+			{
+				Code:    "var x = { a: function() { return { b: function() { return { c: function() {} }; } }; } };",
+				Options: 0,
+			},
+			// Array element — never pushes.
+			{
+				Code:    "var arr = [function() {}, function() {}];",
+				Options: 0,
+			},
+			// `new Foo(fn)` — NewExpression, not CallExpression, no push.
+			{
+				Code:    "new Foo(function() { new Bar(function() {}); });",
+				Options: 0,
+			},
+			// Tagged template — TemplateExpression child, not CallExpression.
+			{
+				Code:    "tag`${function() {}}`;",
+				Options: 0,
+			},
+			// JSX expression container — not CallExpression.
+			{
+				Code:    "var el = <Foo cb={function() { return <Bar cb={function() {}} />; }} />;",
+				Options: 0,
+				Tsx:     true,
+			},
+			// Function declaration — listener never fires.
+			{
+				Code:    "function a() { function b() { function c() { function d() {} } } }",
+				Options: 0,
+			},
+
+			// --- Class / object method bodies are NOT FunctionExpressions in
+			//     tsgo; methods, getters, setters, constructors, static blocks
+			//     don't fire the listener at all ---
+			{
+				Code:    "class C { m() { class D { m() { class E { m() {} } } } } }",
+				Options: 0,
+			},
+			{
+				Code:    "var o = { m() { return { m() { return { m() {} }; } }; } };",
+				Options: 0,
+			},
+			{
+				Code:    "class C { get x() { return 1; } set x(v) {} constructor() {} static {} }",
+				Options: 0,
+			},
+
+			// --- Class / object-method exit pop mirrors ESLint's exit-pop bug:
+			//     a class or object method sitting between two callback frames
+			//     pops the outer frame on its exit, so siblings after the
+			//     method see a smaller depth count. Without this, rslint would
+			//     over-report compared to ESLint.
+			//   `outer(function(){ class C { m(){} } bar(function(){}); })`:
+			//     ESLint sees bar at depth 1 (m's exit-pop cleared outer);
+			//     rslint matches via the KindMethodDeclaration exit listener.
+			{
+				Code:    "outer(function() { class C { m() {} } bar(function() {}); });",
+				Options: 1,
+			},
+			// Same with object shorthand method.
+			{
+				Code:    "outer(function() { ({ m() {} }); bar(function() {}); });",
+				Options: 1,
+			},
+			// Same with getter / setter / constructor.
+			{
+				Code:    "outer(function() { class C { get x() {} } bar(function() {}); });",
+				Options: 1,
+			},
+			{
+				Code:    "outer(function() { class C { set x(v) {} } bar(function() {}); });",
+				Options: 1,
+			},
+			{
+				Code:    "outer(function() { class C { constructor() {} } bar(function() {}); });",
+				Options: 1,
+			},
+
+			// --- Paren-walked parent: `(function(){})()` IIFE callee position ---
+			// Single paren wrap.
+			{
+				Code:    "(function() {})();",
+				Options: 1,
+			},
+			// Multiple paren wraps.
+			{
+				Code:    "(((function() {})))();",
+				Options: 1,
+			},
+			// Paren-wrapped argument.
+			{
+				Code:    "foo((function() {}));",
+				Options: 1,
+			},
+
+			// --- Optional call chains push like normal calls ---
+			{
+				Code:    "foo?.(function() {});",
+				Options: 1,
+			},
+			{
+				Code:    "obj?.method(function() {});",
+				Options: 1,
+			},
+
+			// --- TS expression wrappers around the function do NOT push ---
+			// `as` wrapper around the callback argument — function's parent is
+			// AsExpression (not CallExpression), so no push, even though the
+			// outer call IS a CallExpression. Mirrors ESLint+TS-parser.
+			{
+				Code:    "foo(function() {} as any);",
+				Options: 0,
+			},
+			// `satisfies` wrapper — same.
+			{
+				Code:    "foo(function() {} satisfies any);",
+				Options: 0,
+			},
+			// Type assertion `<any>fn` — same.
+			{
+				Code:    "foo(<any>function() {});",
+				Options: 0,
+			},
+
+			// --- TS wrappers on the *callee* don't change push behavior ---
+			// Function in arguments still pushes.
+			{
+				Code:    "(foo as any)(function() {});",
+				Options: 1,
+			},
+			{
+				Code:    "foo!(function() {});",
+				Options: 1,
+			},
+			{
+				Code:    "foo<T>(function() {});",
+				Options: 1,
+			},
+
+			// --- async / generator / async generator function expressions ---
+			{
+				Code:    "foo(async function() {});",
+				Options: 1,
+			},
+			{
+				Code:    "foo(function*() {});",
+				Options: 1,
+			},
+			{
+				Code:    "foo(async function*() {});",
+				Options: 1,
+			},
+			{
+				Code:    "foo(async () => {});",
+				Options: 1,
+			},
+
+			// --- Mixed argument list: only function-likes count, others ignored ---
+			{
+				Code:    "foo(1, 'two', null, function() {});",
+				Options: 1,
+			},
+
+			// --- Spread argument with function ---
+			// `foo(...args, function(){})` — function is a regular CallExpression
+			// argument, parent=CallExpression, pushed.
+			{
+				Code:    "foo(...args, function() {});",
+				Options: 1,
+			},
+			// SpreadElement with function inside — `foo(...[function(){}])` — the
+			// function is inside an ArrayLiteralExpression spread, parent=Array,
+			// no push.
+			{
+				Code:    "foo(...[function() {}, function() {}]);",
+				Options: 0,
+			},
+
+			// --- Default parameter with function-like value — never pushes ---
+			{
+				Code:    "function f(cb = function() {}) {}",
+				Options: 0,
+			},
+			{
+				Code:    "function f(cb = () => {}) {}",
+				Options: 0,
+			},
+
+			// --- Class field arrow / default member ---
+			{
+				Code:    "class C { handler = function() {}; arrow = () => {}; }",
+				Options: 0,
+			},
+
+			// --- Conditional expression branches — neither pushes ---
+			{
+				Code:    "var x = cond ? function() {} : function() {};",
+				Options: 0,
+			},
+
+			// --- Logical / comma expression branches — neither pushes ---
+			{
+				Code:    "var x = a || function() {};",
+				Options: 0,
+			},
+			{
+				Code:    "var x = (1, function() {});",
+				Options: 0,
+			},
+
+			// --- Decorator with function-like argument: parent IS CallExpression ---
+			// `@dec(function(){})` — decorator wraps CallExpression `dec(function(){})`.
+			// Function's parent = CallExpression. Pushed.
+			{
+				Code:    "function dec(cb) { return () => {}; } @dec(function() {}) class C {}",
+				Options: 1,
+			},
+
+			// --- Chained method calls — each call's argument pushes & pops in sequence ---
+			{
+				Code:    "promise.then(function(a){}).catch(function(b){}).finally(function(c){});",
+				Options: 1,
+			},
+
+			// --- super() call with function arg (inside a constructor) ---
+			{
+				Code:    "class B { constructor(cb) {} } class D extends B { constructor() { super(function() {}); } }",
+				Options: 1,
+			},
+
+			// --- TaggedTemplateExpression — function in template substitution
+			//     is not a CallExpression child, no push ---
+			{
+				Code:    "tag`x ${function() {}} y`",
+				Options: 0,
+			},
+
+			// --- Nested calls but with intermediate non-callback nesting ---
+			// `foo(function(){})` then unrelated `bar(function(){})` at same level.
+			{
+				Code:    "foo(function() {}); bar(function() {}); baz(function() {});",
+				Options: 1,
+			},
+
+			// --- Empty / degenerate forms ---
+			{Code: ""},
+			{Code: "foo();"},
+			{Code: ";"},
+
+			// --- Real-world: shallow callback chain (typical promise then) ---
+			{
+				Code: `fetch('/api')
+  .then(function(r) { return r.json(); })
+  .then(function(d) { console.log(d); });`,
+				Options: 2,
+			},
+
+			// ============================================================
+			// 3. Container/container nesting — function-likes as containers
+			//    around CallExpressions (every depth-bearing JS form)
+			// ============================================================
+
+			// --- Callback inside if / else / else if branches ---
+			{
+				Code:    "foo(function() { if (a) { bar(function() {}); } else { baz(function() {}); } });",
+				Options: 2,
+			},
+			{
+				Code:    "foo(function() { if (a) {} else if (b) { bar(function() {}); } });",
+				Options: 2,
+			},
+
+			// --- Callback inside switch case / default ---
+			{
+				Code:    "foo(function() { switch (k) { case 1: bar(function() {}); break; default: baz(function() {}); } });",
+				Options: 2,
+			},
+
+			// --- Callback inside try / catch / finally ---
+			{
+				Code:    "foo(function() { try { bar(function() {}); } catch (e) { baz(function() {}); } finally { qux(function() {}); } });",
+				Options: 2,
+			},
+
+			// --- Callback inside while / do-while / for / for-in / for-of / for-await ---
+			{
+				Code:    "foo(function() { while (a) { bar(function() {}); } });",
+				Options: 2,
+			},
+			{
+				Code:    "foo(function() { do { bar(function() {}); } while (a); });",
+				Options: 2,
+			},
+			{
+				Code:    "foo(function() { for (let i = 0; i < 10; i++) { bar(function() {}); } });",
+				Options: 2,
+			},
+			{
+				Code:    "foo(function() { for (const k in o) { bar(function() {}); } });",
+				Options: 2,
+			},
+			{
+				Code:    "foo(function() { for (const v of a) { bar(function() {}); } });",
+				Options: 2,
+			},
+			{
+				Code:    "foo(async function() { for await (const v of a) { bar(function() {}); } });",
+				Options: 2,
+			},
+
+			// --- Callback after `await` / `yield` in async / generator ---
+			{
+				Code:    "foo(async function() { await bar(function() {}); });",
+				Options: 2,
+			},
+			{
+				Code:    "foo(function*() { yield bar(function() {}); });",
+				Options: 2,
+			},
+
+			// --- Arrow with concise-body invocation (no block) ---
+			// `() => fn(function(){})` — arrow body IS the call expression.
+			{
+				Code:    "var f = () => bar(function() {});",
+				Options: 2,
+			},
+			// Arrow returning arrow returning callback — each arrow pushes.
+			{
+				Code:    "foo(() => () => bar(function() {}));",
+				Options: 3,
+			},
+
+			// --- Function in array spread — element of ArrayLiteralExpression
+			//     (parent ≠ CallExpression even after walking spread).
+			{
+				Code:    "foo(...[1, function() {}, 2]);",
+				Options: 0,
+			},
+
+			// --- Object/array destructuring binding with function default ---
+			{
+				Code:    "function f({ cb = function() {} } = {}) {}",
+				Options: 0,
+			},
+			{
+				Code:    "function f([cb = function() {}]) {}",
+				Options: 0,
+			},
+
+			// --- Class with computed / private / static method names — none push ---
+			{
+				Code:    "class C { ['m']() {} #priv() {} static st() {} }",
+				Options: 0,
+			},
+			// Async / async-generator class methods.
+			{
+				Code:    "class C { async m() {} async *g() {} }",
+				Options: 0,
+			},
+			// Setter with rest pattern (TS-only) and complex parameter form.
+			{
+				Code:    "class C { set v(value) {} get v() { return 1; } }",
+				Options: 0,
+			},
+
+			// --- Class extends with super call passing callback ---
+			{
+				Code:    "class B { constructor(cb) {} } class D extends B { constructor() { super(function() {}); } }",
+				Options: 1,
+			},
+
+			// --- yield* delegation with callback arg ---
+			{
+				Code:    "foo(function*() { yield* bar(function() {}); });",
+				Options: 2,
+			},
+
+			// --- await import() then ---
+			{
+				Code: `async function load() {
+  const m = await import('mod');
+  return m.run(function() {});
+}`,
+				Options: 1,
+			},
+
+			// --- Dynamic import with then chain ---
+			{
+				Code:    "import('mod').then(function(m) { m.run(); });",
+				Options: 1,
+			},
+
+			// --- Multi-line nested IIFE pattern ---
+			{
+				Code: `(function() {
+  (function() {
+    (function() {})();
+  })();
+})();`,
+				Options: 3,
+			},
+
+			// --- Sibling chains separated by class declaration with method ---
+			// Validates the method-exit pop fully clears between siblings.
+			{
+				Code: `outer(function() {
+  class A { m() {} }
+  class B { m() {} }
+  bar(function() {});
+});`,
+				Options: 1,
+			},
+
+			// --- Real-world: jQuery-like AJAX shape ---
+			{
+				Code: `$(function() {
+  $.ajax({
+    success: function(data) { handle(data); },
+  });
+});`,
+				Options: 2,
+			},
+
+			// --- Real-world: Express middleware chain ---
+			{
+				Code: `app.get('/x', function(req, res, next) {
+  next();
+});`,
+				Options: 1,
+			},
+
+			// --- Real-world: Node.js style fs.readFile ---
+			{
+				Code: `fs.readFile('a', function(err, data) {
+  if (err) return cb(err);
+  cb(null, data);
+});`,
+				Options: 1,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// 1. ESLint parity — mirrors tests/lib/rules/max-nested-callbacks.js
+			// ============================================================
+			{
+				Code:    "foo(function() { bar(thing, function(data) { baz(function() {}); }); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    50,
+					},
+				},
+			},
+			{
+				Code:    "foo(function() { bar(thing, (data) => { baz(function() {}); }); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    45,
+					},
+				},
+			},
+			{
+				Code:    "foo(() => { bar(thing, (data) => { baz( () => {}); }); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    41,
+					},
+				},
+			},
+			{
+				Code:    "foo(function() { if (isTrue) { bar(function(data) { baz(function() {}); }); } });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    57,
+					},
+				},
+			},
+			{
+				Code: nestFunctions(11),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (11). Maximum allowed is 10.",
+						Line:      1,
+						Column:    165,
+					},
+				},
+			},
+			{
+				Code:    nestFunctions(11),
+				Options: map[string]interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (11). Maximum allowed is 10.",
+						Line:      1,
+						Column:    165,
+					},
+				},
+			},
+			{
+				Code:    "foo(function() {})",
+				Options: map[string]interface{}{"max": 0},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (1). Maximum allowed is 0.",
+						Line:      1,
+						Column:    5,
+					},
+				},
+			},
+
+			// object property options
+			{
+				Code:    "foo(function() { bar(thing, function(data) { baz(function() {}); }); });",
+				Options: map[string]interface{}{"max": 2},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    50,
+					},
+				},
+			},
+
+			// ============================================================
+			// 2. Additional edge cases
+			// ============================================================
+
+			// --- Multi-line code: line/column precision ---
+			{
+				Code: `foo(function() {
+    bar(function() {
+        baz(function() {
+            qux(function() {});
+        });
+    });
+});`,
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      3,
+						Column:    13,
+					},
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (4). Maximum allowed is 2.",
+						Line:      4,
+						Column:    17,
+					},
+				},
+			},
+
+			// --- IIFE callee + nested callbacks ---
+			{
+				Code:    "(function() { foo(function() { bar(function() {}); }); })();",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    36,
+					},
+				},
+			},
+			// IIFE wrapped in extra parens — paren walking lets the outer FE push.
+			{
+				Code:    "((function() { foo(function() { bar(function() {}); }); }))();",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    37,
+					},
+				},
+			},
+			// Paren-wrapped argument — function's parent is ParenthesizedExpression,
+			// but paren walking treats CallExpression as the effective parent.
+			{
+				Code:    "foo((function() { bar((function() { baz((function() {})); })); }));",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    42,
+					},
+				},
+			},
+
+			// --- Mixed FunctionExpression / ArrowFunction nesting ---
+			{
+				Code:    "foo(() => bar(function() { baz(() => {}); }));",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    32,
+					},
+				},
+			},
+
+			// --- async / generator function-likes still push ---
+			{
+				Code:    "foo(async function() { bar(async function() { baz(async function() {}); }); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    51,
+					},
+				},
+			},
+			{
+				Code:    "foo(function*() { bar(function*() { baz(function*() {}); }); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    41,
+					},
+				},
+			},
+			{
+				Code:    "foo(async () => { bar(async () => { baz(async () => {}); }); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    41,
+					},
+				},
+			},
+
+			// --- Optional chain calls push the same as plain calls ---
+			{
+				Code:    "foo?.(function() { bar?.(function() { baz?.(function() {}); }); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    45,
+					},
+				},
+			},
+
+			// --- max=0 reports every direct callback ---
+			// All three are direct CallExpression children → all pushed and
+			// reported (length goes 1, 1, 1 each time, all > 0).
+			{
+				Code:    "foo(function() {}); bar(function() {}); baz(function() {});",
+				Options: 0,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (1). Maximum allowed is 0.", Line: 1, Column: 5},
+					{MessageId: "exceed", Message: "Too many nested callbacks (1). Maximum allowed is 0.", Line: 1, Column: 25},
+					{MessageId: "exceed", Message: "Too many nested callbacks (1). Maximum allowed is 0.", Line: 1, Column: 45},
+				},
+			},
+
+			// --- Sibling callback chains under a shared outer callback ---
+			{
+				Code:    "foo(function() { bar(function() { baz(function() {}); }); qux(function() { quux(function() {}); }); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    39,
+					},
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    81,
+					},
+				},
+			},
+
+			// --- Legacy `maximum` key honored ---
+			{
+				Code:    "foo(function() { bar(function() { baz(function() {}); }); });",
+				Options: map[string]interface{}{"maximum": 2},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    39,
+					},
+				},
+			},
+			// `maximum` wins when both keys are present and `maximum` is truthy
+			// (matches ESLint's `option.maximum || option.max`).
+			{
+				Code:    "foo(function() { bar(function() { baz(function() {}); }); });",
+				Options: map[string]interface{}{"maximum": 2, "max": 5},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    39,
+					},
+				},
+			},
+			// `{ maximum: 0 }` short-circuits to undefined in ESLint (disabling
+			// the check). Lock in the falsy-but-valid path with `{ max: 0 }`
+			// (which DOES report).
+			{
+				Code:    "foo(function() {});",
+				Options: []interface{}{map[string]interface{}{"max": 0}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (1). Maximum allowed is 0.",
+						Line:      1,
+						Column:    5,
+					},
+				},
+			},
+
+			// --- Lock-in: asymmetric exit pop. A non-pushed FunctionExpression
+			//     (var-declared, not a callback) still pops the stack on exit,
+			//     mirroring ESLint's `popStack` ALWAYS calling Array#pop. The
+			//     practical effect: code AFTER `var x = function(){}` inside a
+			//     callback sees a stack length one less than its true depth. ---
+			// Without the asymmetric pop, the inner `bar(...)` would see depth=2
+			// (outer + bar). With the pop, it sees depth=1 (outer was popped by
+			// `var x`'s exit). With max=1, no report. We assert this by using
+			// max=0 instead — bar's callback still reports as length=1.
+			{
+				Code:    "foo(function() { var x = function() {}; bar(function() {}); });",
+				Options: 0,
+				Errors: []rule_tester.InvalidTestCaseError{
+					// Outer callback is direct call argument → pushed → reported.
+					{MessageId: "exceed", Message: "Too many nested callbacks (1). Maximum allowed is 0.", Line: 1, Column: 5},
+					// `var x = function(){}` doesn't push. But ESLint also runs
+					// the length check after the (skipped) push: stack=[outer]
+					// length=1 > 0 → REPORT.
+					{MessageId: "exceed", Message: "Too many nested callbacks (1). Maximum allowed is 0.", Line: 1, Column: 26},
+					// `var x`'s exit pops → stack=[]. `bar(function(){})` pushes.
+					// Length=1 > 0 → REPORT.
+					{MessageId: "exceed", Message: "Too many nested callbacks (1). Maximum allowed is 0.", Line: 1, Column: 45},
+				},
+			},
+
+			// --- Function-likes inside conditional / loop bodies still nest ---
+			{
+				Code:    "foo(function() { while (true) { bar(function() { for (;;) { baz(function() {}); } }); } });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    65,
+					},
+				},
+			},
+
+			// --- TS-only: function-likes inside CallExpression with type args ---
+			{
+				Code:    "foo<T>(function() { bar<U>(function() { baz<V>(function() {}); }); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (3). Maximum allowed is 2.",
+						Line:      1,
+						Column:    48,
+					},
+				},
+			},
+
+			// --- Real-world: callback hell (the canonical anti-pattern) ---
+			{
+				Code: `getData('a', function (a) {
+  getData(a, function (b) {
+    getData(b, function (c) {
+      getData(c, function (d) {
+        process(d);
+      });
+    });
+  });
+});`,
+				Options: 3,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "exceed",
+						Message:   "Too many nested callbacks (4). Maximum allowed is 3.",
+						Line:      4,
+						Column:    18,
+					},
+				},
+			},
+
+			// --- Lock-in: callbacks INSIDE a class method body still see the
+			//     outer callback frame, because the method's exit-pop runs only
+			//     after we've finished traversing its body. ESLint and rslint
+			//     agree: bar inside m sees depth=2, baz inside bar sees depth=3.
+			{
+				Code:    "outer(function() { class C { m() { bar(function() { baz(function() {}); }); } } });",
+				Options: 1,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (2). Maximum allowed is 1.", Line: 1, Column: 40},
+					{MessageId: "exceed", Message: "Too many nested callbacks (3). Maximum allowed is 1.", Line: 1, Column: 57},
+				},
+			},
+
+			// --- Chained method calls combined with nesting reports correctly ---
+			{
+				Code: `promise
+  .then(function(a) {
+    return a.next(function(b) {
+      return b.next(function(c) {});
+    });
+  });`,
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (3). Maximum allowed is 2.", Line: 4, Column: 21},
+				},
+			},
+
+			// ============================================================
+			// 4. Container nesting — callbacks deep inside control flow
+			// ============================================================
+
+			// --- Inside if branch ---
+			{
+				Code:    "foo(function() { if (a) { bar(function() { baz(function() {}); }); } });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (3). Maximum allowed is 2.", Line: 1, Column: 48},
+				},
+			},
+			// --- Inside for-of body ---
+			{
+				Code:    "foo(function() { for (const v of a) { bar(function() { baz(function() {}); }); } });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (3). Maximum allowed is 2.", Line: 1, Column: 60},
+				},
+			},
+			// --- Inside try / catch ---
+			{
+				Code:    "foo(function() { try { bar(function() { baz(function() {}); }); } catch (e) {} });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (3). Maximum allowed is 2.", Line: 1, Column: 45},
+				},
+			},
+
+			// --- await on a call whose argument is the deeper callback ---
+			{
+				Code:    "foo(async function() { await bar(async function() { await baz(async function() {}); }); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (3). Maximum allowed is 2.", Line: 1, Column: 63},
+				},
+			},
+
+			// --- Concise-body arrow chain reaches threshold ---
+			{
+				Code:    "foo(() => bar(() => baz(() => qux(() => {}))));",
+				Options: 3,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (4). Maximum allowed is 3.", Line: 1, Column: 35},
+				},
+			},
+
+			// ============================================================
+			// 5. Real-world patterns — anti-patterns we'd actually flag
+			// ============================================================
+
+			// --- Express middleware with deeply nested callbacks ---
+			{
+				Code: `app.get('/x', function(req, res) {
+  db.connect(function(err, client) {
+    client.query('SELECT', function(err, rows) {
+      rows.forEach(function(row) {
+        process(row);
+      });
+    });
+  });
+});`,
+				Options: 3,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (4). Maximum allowed is 3.", Line: 4, Column: 20},
+				},
+			},
+
+			// --- Node.js fs callback hell ---
+			{
+				Code: `fs.readFile('a', function(err, a) {
+  fs.readFile('b', function(err, b) {
+    fs.readFile('c', function(err, c) {
+      fs.writeFile('out', a + b + c, function(err) {});
+    });
+  });
+});`,
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (3). Maximum allowed is 2.", Line: 3, Column: 22},
+					{MessageId: "exceed", Message: "Too many nested callbacks (4). Maximum allowed is 2.", Line: 4, Column: 38},
+				},
+			},
+
+			// --- jQuery DOM-ready + AJAX + iteration. ESLint counts only
+			//     direct CallExpression-children: `$(fn)`, `forEach(fn)`,
+			//     `each(fn)` — three callbacks. The `success: function(){}`
+			//     inside the `$.ajax({...})` object literal is a Property
+			//     value, NOT a CallExpression child, so it does not push. ---
+			{
+				Code: `$(function() {
+  $.ajax({
+    success: function(data) {
+      data.items.forEach(function(item) {
+        $(item).each(function() {});
+      });
+    },
+  });
+});`,
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (3). Maximum allowed is 2.", Line: 5, Column: 22},
+				},
+			},
+
+			// --- setTimeout inside setTimeout (timer pyramid) ---
+			{
+				Code: `setTimeout(function() {
+  setTimeout(function() {
+    setTimeout(function() {
+      setTimeout(function() {});
+    }, 10);
+  }, 10);
+}, 10);`,
+				Options: 3,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (4). Maximum allowed is 3.", Line: 4, Column: 18},
+				},
+			},
+
+			// ============================================================
+			// 6. Pure-syntax boundaries — paren / type-wrapper interactions
+			// ============================================================
+
+			// --- Optional call combined with paren-wrapped function arg ---
+			{
+				Code:    "foo?.(function() { bar?.((function() { baz?.((function() {})); })); });",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (3). Maximum allowed is 2.", Line: 1, Column: 47},
+				},
+			},
+
+			// --- Mixed paren wraps in IIFE callee + nested ---
+			{
+				Code:    "(((function() { (((function() { (((function() {})))(); })))(); })))();",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: "Too many nested callbacks (3). Maximum allowed is 2.", Line: 1, Column: 36},
+				},
+			},
+
+			// --- Function inside object spread (not a CallExpression child)
+			//     yet OUTER call still pushes because the function in args
+			//     directly is. Tests that we don't mistakenly attribute push
+			//     to the inner one. ---
+			{
+				Code:    "foo({...x, cb: function(){}}, function(){});",
+				Options: 0,
+				Errors: []rule_tester.InvalidTestCaseError{
+					// Only the trailing function is a direct CallExpression argument.
+					{MessageId: "exceed", Message: "Too many nested callbacks (1). Maximum allowed is 0.", Line: 1, Column: 31},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -328,6 +328,7 @@ export default defineConfig({
     './tests/eslint/rules/max-depth.test.ts',
     './tests/eslint/rules/max-lines.test.ts',
     './tests/eslint/rules/max-lines-per-function.test.ts',
+    './tests/eslint/rules/max-nested-callbacks.test.ts',
     './tests/eslint/rules/no-label-var.test.ts',
     './tests/eslint/rules/no-shadow.test.ts',
     './tests/eslint/rules/no-labels.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-nested-callbacks.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-nested-callbacks.test.ts.snap
@@ -1,0 +1,582 @@
+// Rstest Snapshot v1
+
+exports[`max-nested-callbacks > invalid 1`] = `
+{
+  "code": "foo(function() { bar(thing, function(data) { baz(function() {}); }); });",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 2`] = `
+{
+  "code": "foo(function() { bar(thing, (data) => { baz(function() {}); }); });",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 3`] = `
+{
+  "code": "foo(() => { bar(thing, (data) => { baz( () => {}); }); });",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 4`] = `
+{
+  "code": "foo(function() { if (isTrue) { bar(function(data) { baz(function() {}); }); } });",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 57,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 5`] = `
+{
+  "code": "foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {});});});});});});});});});});});",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (11). Maximum allowed is 10.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 178,
+          "line": 1,
+        },
+        "start": {
+          "column": 165,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 6`] = `
+{
+  "code": "foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {foo(function() {});});});});});});});});});});});",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (11). Maximum allowed is 10.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 178,
+          "line": 1,
+        },
+        "start": {
+          "column": 165,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 7`] = `
+{
+  "code": "foo(function() {})",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (1). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 8`] = `
+{
+  "code": "foo(function() { bar(thing, function(data) { baz(function() {}); }); });",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 9`] = `
+{
+  "code": "(function() { foo(function() { bar(function() {}); }); })();",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 10`] = `
+{
+  "code": "foo((function() { bar((function() { baz((function() {})); })); }));",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 11`] = `
+{
+  "code": "foo(() => bar(function() { baz(() => {}); }));",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 12`] = `
+{
+  "code": "foo?.(function() { bar?.(function() { baz?.(function() {}); }); });",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 13`] = `
+{
+  "code": "foo(function() { bar(function() { baz(function() {}); }); });",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 14`] = `
+{
+  "code": "foo(function() { bar(function() { baz(function() {}); }); });",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 15`] = `
+{
+  "code": "app.get('/x', function(req, res) {
+  db.connect(function(err, client) {
+    client.query('SELECT', function(err, rows) {
+      rows.forEach(function(row) {
+        process(row);
+      });
+    });
+  });
+});",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 6,
+        },
+        "start": {
+          "column": 20,
+          "line": 4,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 16`] = `
+{
+  "code": "fs.readFile('a', function(err, a) {
+  fs.readFile('b', function(err, b) {
+    fs.readFile('c', function(err, c) {
+      fs.writeFile('out', a + b + c, function(err) {});
+    });
+  });
+});",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 22,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+    {
+      "message": "Too many nested callbacks (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 4,
+        },
+        "start": {
+          "column": 38,
+          "line": 4,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 17`] = `
+{
+  "code": "setTimeout(function() {
+  setTimeout(function() {
+    setTimeout(function() {
+      setTimeout(function() {});
+    }, 10);
+  }, 10);
+}, 10);",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 4,
+        },
+        "start": {
+          "column": 18,
+          "line": 4,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 18`] = `
+{
+  "code": "foo(() => bar(() => baz(() => qux(() => {}))));",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 19`] = `
+{
+  "code": "foo?.(function() { bar?.((function() { baz?.((function() {})); })); });",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 20`] = `
+{
+  "code": "(((function() { (((function() { (((function() {})))(); })))(); })))();",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-nested-callbacks > invalid 21`] = `
+{
+  "code": "foo({...x, cb: function(){}}, function(){});",
+  "diagnostics": [
+    {
+      "message": "Too many nested callbacks (1). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-nested-callbacks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/max-nested-callbacks.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/max-nested-callbacks.test.ts
@@ -1,0 +1,280 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const OPENING = 'foo(function() {';
+const CLOSING = '});';
+const nestFunctions = (times: number) =>
+  OPENING.repeat(times) + CLOSING.repeat(times);
+
+ruleTester.run('max-nested-callbacks', {
+  valid: [
+    {
+      code: 'foo(function() { bar(thing, function(data) {}); });',
+      options: [3] as any,
+    },
+    {
+      code: 'var foo = function() {}; bar(function(){ baz(function() { qux(foo); }) });',
+      options: [2] as any,
+    },
+    {
+      code: 'fn(function(){}, function(){}, function(){});',
+      options: [2] as any,
+    },
+    {
+      code: 'fn(() => {}, function(){}, function(){});',
+      options: [2] as any,
+    },
+    nestFunctions(10),
+    {
+      code: 'foo(function() { bar(thing, function(data) {}); });',
+      options: [{ max: 3 }] as any,
+    },
+
+    // Function-likes that are NOT direct CallExpression children — never push.
+    {
+      code: 'var a = function() { var b = function() { var c = function() {}; }; };',
+      options: [0] as any,
+    },
+    {
+      code: 'new Foo(function() { new Bar(function() {}); });',
+      options: [0] as any,
+    },
+    'function a() { function b() { function c() {} } }',
+    {
+      code: 'class C { m() { class D { m() { class E { m() {} } } } } }',
+      options: [0] as any,
+    },
+    {
+      code: 'var o = { m() { return { m() { return { m() {} }; } }; } };',
+      options: [0] as any,
+    },
+
+    // Paren-walked parent — IIFE callee and paren-wrapped arguments.
+    { code: '(function() {})();', options: [1] as any },
+    { code: '(((function() {})))();', options: [1] as any },
+    { code: 'foo((function() {}));', options: [1] as any },
+
+    // Optional chain calls push like normal calls.
+    { code: 'foo?.(function() {});', options: [1] as any },
+    { code: 'obj?.method(function() {});', options: [1] as any },
+
+    // TS expression wrappers around the callback DON'T push.
+    { code: 'foo(function() {} as any);', options: [0] as any },
+    { code: 'foo(function() {} satisfies any);', options: [0] as any },
+
+    // TS wrappers on the callee — function still in arguments, pushes.
+    { code: '(foo as any)(function() {});', options: [1] as any },
+    { code: 'foo!(function() {});', options: [1] as any },
+    { code: 'foo<T>(function() {});', options: [1] as any },
+
+    // async / generator / async generator and async arrow.
+    { code: 'foo(async function() {});', options: [1] as any },
+    { code: 'foo(function*() {});', options: [1] as any },
+    { code: 'foo(async function*() {});', options: [1] as any },
+    { code: 'foo(async () => {});', options: [1] as any },
+
+    // Sibling callback after a class / object method — the method's exit pop
+    // clears the outer frame, matching ESLint's exit-pop semantics. Without
+    // the method-exit listener rslint would over-report here.
+    {
+      code: 'outer(function() { class C { m() {} } bar(function() {}); });',
+      options: [1] as any,
+    },
+    {
+      code: 'outer(function() { ({ m() {} }); bar(function() {}); });',
+      options: [1] as any,
+    },
+    {
+      code: 'outer(function() { class C { get x() {} } bar(function() {}); });',
+      options: [1] as any,
+    },
+    {
+      code: 'outer(function() { class C { constructor() {} } bar(function() {}); });',
+      options: [1] as any,
+    },
+
+    // Container nesting — depth carries across control-flow constructs.
+    {
+      code: 'foo(function() { if (a) { bar(function() {}); } else { baz(function() {}); } });',
+      options: [2] as any,
+    },
+    {
+      code: 'foo(function() { for (const v of a) { bar(function() {}); } });',
+      options: [2] as any,
+    },
+    {
+      code: 'foo(function() { try { bar(function() {}); } catch (e) {} });',
+      options: [2] as any,
+    },
+    {
+      code: 'foo(async function() { await bar(function() {}); });',
+      options: [2] as any,
+    },
+
+    // Concise-body arrow with call.
+    { code: 'var f = () => bar(function() {});', options: [2] as any },
+
+    // Real-world: jQuery / AJAX / iteration.
+    {
+      code: `$(function() {
+  $.ajax({
+    success: function(data) { handle(data); },
+  });
+});`,
+      options: [2] as any,
+    },
+    // Real-world: Express middleware.
+    {
+      code: "app.get('/x', function(req, res, next) { next(); });",
+      options: [1] as any,
+    },
+    // Real-world: Node fs.readFile.
+    {
+      code: "fs.readFile('a', function(err, data) { cb(null, data); });",
+      options: [1] as any,
+    },
+  ],
+  invalid: [
+    {
+      code: 'foo(function() { bar(thing, function(data) { baz(function() {}); }); });',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 50 }],
+    },
+    {
+      code: 'foo(function() { bar(thing, (data) => { baz(function() {}); }); });',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 45 }],
+    },
+    {
+      code: 'foo(() => { bar(thing, (data) => { baz( () => {}); }); });',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 41 }],
+    },
+    {
+      code: 'foo(function() { if (isTrue) { bar(function(data) { baz(function() {}); }); } });',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 57 }],
+    },
+    {
+      code: nestFunctions(11),
+      errors: [{ messageId: 'exceed', line: 1, column: 165 }],
+    },
+    {
+      code: nestFunctions(11),
+      options: [{}] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 165 }],
+    },
+    {
+      code: 'foo(function() {})',
+      options: [{ max: 0 }] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 5 }],
+    },
+    {
+      code: 'foo(function() { bar(thing, function(data) { baz(function() {}); }); });',
+      options: [{ max: 2 }] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 50 }],
+    },
+    // IIFE callee + nested callbacks.
+    {
+      code: '(function() { foo(function() { bar(function() {}); }); })();',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 36 }],
+    },
+    // Paren-wrapped arguments still trigger via paren-walk.
+    {
+      code: 'foo((function() { bar((function() { baz((function() {})); })); }));',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 42 }],
+    },
+    // Mixed FunctionExpression / ArrowFunction.
+    {
+      code: 'foo(() => bar(function() { baz(() => {}); }));',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 32 }],
+    },
+    // Optional chain calls in callback chains.
+    {
+      code: 'foo?.(function() { bar?.(function() { baz?.(function() {}); }); });',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 45 }],
+    },
+    // Legacy `maximum` key.
+    {
+      code: 'foo(function() { bar(function() { baz(function() {}); }); });',
+      options: [{ maximum: 2 }] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 39 }],
+    },
+    // `maximum` wins when both are present and `maximum` is truthy.
+    {
+      code: 'foo(function() { bar(function() { baz(function() {}); }); });',
+      options: [{ maximum: 2, max: 5 }] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 39 }],
+    },
+    // Real-world: Express deeply nested.
+    {
+      code: `app.get('/x', function(req, res) {
+  db.connect(function(err, client) {
+    client.query('SELECT', function(err, rows) {
+      rows.forEach(function(row) {
+        process(row);
+      });
+    });
+  });
+});`,
+      options: [3] as any,
+      errors: [{ messageId: 'exceed', line: 4, column: 20 }],
+    },
+    // Real-world: Node.js callback hell.
+    {
+      code: `fs.readFile('a', function(err, a) {
+  fs.readFile('b', function(err, b) {
+    fs.readFile('c', function(err, c) {
+      fs.writeFile('out', a + b + c, function(err) {});
+    });
+  });
+});`,
+      options: [2] as any,
+      errors: [
+        { messageId: 'exceed', line: 3, column: 22 },
+        { messageId: 'exceed', line: 4, column: 38 },
+      ],
+    },
+    // Real-world: setTimeout pyramid.
+    {
+      code: `setTimeout(function() {
+  setTimeout(function() {
+    setTimeout(function() {
+      setTimeout(function() {});
+    }, 10);
+  }, 10);
+}, 10);`,
+      options: [3] as any,
+      errors: [{ messageId: 'exceed', line: 4, column: 18 }],
+    },
+    // Concise-body arrow chain.
+    {
+      code: 'foo(() => bar(() => baz(() => qux(() => {}))));',
+      options: [3] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 35 }],
+    },
+    // Optional chain combined with paren-wrapped function arg.
+    {
+      code: 'foo?.(function() { bar?.((function() { baz?.((function() {})); })); });',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 47 }],
+    },
+    // Mixed paren wraps in IIFE chain.
+    {
+      code: '(((function() { (((function() { (((function() {})))(); })))(); })))();',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 36 }],
+    },
+    // Object spread containing function — only the trailing direct arg pushes.
+    {
+      code: 'foo({...x, cb: function(){}}, function(){});',
+      options: [0] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 31 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `max-nested-callbacks` rule from ESLint to rslint.

This rule enforces a maximum depth that callbacks can be nested to keep code readable. A function expression or arrow function counts toward the depth only when it is passed directly to a call (as a call argument or the callee of an immediately-invoked call); function-likes assigned to variables, properties, array elements, JSX attributes, default parameters, or used as `new` arguments / tagged-template arguments do not increase the counter.

The implementation is byte-for-byte aligned with upstream on input (schema, all option shapes including `max`, legacy `maximum`, default 10, `option.maximum || option.max` truthy short-circuit), output (`messageId: "exceed"`, message text and `num`/`max` substitution, line, column, diagnostic count), and asymmetric stack semantics (push only on direct CallExpression children, pop on every function-like exit, length-check on every entry). Class methods, getters, setters, constructors, and object-literal shorthand methods participate in the exit-pop to mirror ESLint's listener behavior.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/max-nested-callbacks
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/max-nested-callbacks.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).