### PR TITLE
feat: port rule no-useless-backreference

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,6 +228,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_computed_key"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_constructor"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_backreference"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_rename"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
@@ -737,6 +738,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("one-var", one_var.OneVarRule)
 	GlobalRuleRegistry.Register("no-dupe-else-if", no_dupe_else_if.NoDupeElseIfRule)
 	GlobalRuleRegistry.Register("no-throw-literal", no_throw_literal.NoThrowLiteralRule)
+	GlobalRuleRegistry.Register("no-useless-backreference", no_useless_backreference.NoUselessBackreferenceRule)
 	GlobalRuleRegistry.Register("no-useless-call", no_useless_call.NoUselessCallRule)
 	GlobalRuleRegistry.Register("no-useless-catch", no_useless_catch.NoUselessCatchRule)
 	GlobalRuleRegistry.Register("no-useless-rename", no_useless_rename.NoUselessRenameRule)

--- a/internal/rules/no_useless_backreference/no_useless_backreference.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference.go
@@ -1,0 +1,279 @@
+package no_useless_backreference
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-useless-backreference
+var NoUselessBackreferenceRule = rule.Rule{
+	Name: "no-useless-backreference",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		eval := newStaticEvalCtx(ctx)
+		return rule.RuleListeners{
+			ast.KindRegularExpressionLiteral: func(node *ast.Node) {
+				if isRegexLiteralHandledByConstructor(ctx, node) {
+					return
+				}
+				pattern, flags := utils.ExtractRegexPatternAndFlags(node.Text())
+				if pattern == "" && flags == "" {
+					return
+				}
+				rxFlags := utils.ParseRegexFlags(flags)
+				checkRegex(ctx, node, pattern, rxFlags)
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				handleRegExpConstructor(ctx, node, call.Expression, call.Arguments, eval)
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				newExpr := node.AsNewExpression()
+				handleRegExpConstructor(ctx, node, newExpr.Expression, newExpr.Arguments, eval)
+			},
+		}
+	},
+}
+
+func handleRegExpConstructor(ctx rule.RuleContext, callNode *ast.Node, callee *ast.Node, args *ast.NodeList, eval *staticEvalCtx) {
+	callee = ast.SkipParentheses(callee)
+	if !isBuiltinRegExpCallee(ctx, callee) {
+		return
+	}
+	if args == nil || len(args.Nodes) == 0 {
+		return
+	}
+
+	patternNode := ast.SkipParentheses(args.Nodes[0])
+	if patternNode == nil {
+		return
+	}
+
+	pattern, patternOk := eval.evalStaticString(patternNode)
+	if !patternOk {
+		return
+	}
+
+	flags := ""
+	if len(args.Nodes) >= 2 {
+		flagsNode := ast.SkipParentheses(args.Nodes[1])
+		if flagsNode != nil {
+			if v, ok := eval.evalStaticString(flagsNode); ok {
+				flags = v
+			}
+		}
+	}
+
+	rxFlags := utils.ParseRegexFlags(flags)
+	checkRegex(ctx, callNode, pattern, rxFlags)
+}
+
+// isRegexLiteralHandledByConstructor returns true when this regex literal is
+// the first arg of a `RegExp(literal, flags)` call — in that case the
+// constructor listener owns it (using the override flags).
+func isRegexLiteralHandledByConstructor(ctx rule.RuleContext, node *ast.Node) bool {
+	parent := node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parent = parent.Parent
+	}
+	if parent == nil {
+		return false
+	}
+	var callee *ast.Node
+	var args *ast.NodeList
+	switch parent.Kind {
+	case ast.KindCallExpression:
+		c := parent.AsCallExpression()
+		callee = c.Expression
+		args = c.Arguments
+	case ast.KindNewExpression:
+		n := parent.AsNewExpression()
+		callee = n.Expression
+		args = n.Arguments
+	default:
+		return false
+	}
+	if !isBuiltinRegExpCallee(ctx, ast.SkipParentheses(callee)) {
+		return false
+	}
+	if args == nil || len(args.Nodes) == 0 {
+		return false
+	}
+	if first := ast.SkipParentheses(args.Nodes[0]); first != node {
+		return false
+	}
+	return true
+}
+
+func isBuiltinRegExpCallee(ctx rule.RuleContext, callee *ast.Node) bool {
+	if callee == nil {
+		return false
+	}
+	if callee.Kind == ast.KindIdentifier {
+		name := callee.AsIdentifier().Text
+		if name == "RegExp" {
+			// Direct `RegExp` reference — must not be shadowed.
+			if utils.IsShadowed(callee, "RegExp") {
+				return false
+			}
+			if ctx.TypeChecker != nil {
+				sym := ctx.TypeChecker.GetSymbolAtLocation(callee)
+				if sym == nil {
+					return false
+				}
+				return !utils.IsSymbolDeclaredInFile(sym, ctx.SourceFile)
+			}
+			return true
+		}
+		// Identifier alias such as `const r = RegExp; new r(...)` — only the
+		// type check can recognize this. No syntactic fallback to avoid
+		// over-matching arbitrary identifiers when type info is unavailable.
+		if ctx.TypeChecker != nil && ctx.Program != nil {
+			t := ctx.TypeChecker.GetTypeAtLocation(callee)
+			if t != nil && utils.IsBuiltinSymbolLike(ctx.Program, ctx.TypeChecker, t, "RegExpConstructor") {
+				return true
+			}
+		}
+		return false
+	}
+	if callee.Kind == ast.KindPropertyAccessExpression {
+		pae := callee.AsPropertyAccessExpression()
+		if pae.Name() != nil && pae.Name().Kind == ast.KindIdentifier && pae.Name().AsIdentifier().Text == "RegExp" {
+			if pae.Expression != nil && pae.Expression.Kind == ast.KindIdentifier {
+				name := pae.Expression.AsIdentifier().Text
+				return name == "globalThis" || name == "window" || name == "self" || name == "global"
+			}
+		}
+	}
+	return false
+}
+
+// checkRegex parses the pattern and reports useless backreferences. `node` is
+// the AST node receiving the diagnostic (the regex literal or RegExp call).
+func checkRegex(ctx rule.RuleContext, node *ast.Node, pattern string, flags utils.RegexFlags) {
+	_, brefs, ok := parsePattern(pattern, flags)
+	if !ok {
+		return
+	}
+
+	for _, bref := range brefs {
+		analyzeBackref(ctx, node, bref)
+	}
+}
+
+type problem struct {
+	messageId string
+	group     *rxNode
+}
+
+func analyzeBackref(ctx rule.RuleContext, node *ast.Node, bref *rxNode) {
+	groups := bref.resolved
+	if len(groups) == 0 {
+		return
+	}
+	brefPath := pathToRoot(bref)
+
+	problems := make([]*problem, 0, len(groups))
+	for _, group := range groups {
+		problems = append(problems, classifyPair(brefPath, bref, group))
+	}
+
+	// If any pair has no problem, the backreference can match — bail.
+	for _, prob := range problems {
+		if prob == nil {
+			return
+		}
+	}
+
+	// Prefer same-disjunction problems over disjunctive ones.
+	sameDisjunction := make([]*problem, 0, len(problems))
+	for _, prob := range problems {
+		if prob.messageId != "disjunctive" {
+			sameDisjunction = append(sameDisjunction, prob)
+		}
+	}
+	toReport := problems
+	if len(sameDisjunction) > 0 {
+		toReport = sameDisjunction
+	}
+
+	first := toReport[0]
+	otherGroups := ""
+	otherCount := len(toReport) - 1
+	switch {
+	case otherCount == 1:
+		otherGroups = " and another group"
+	case otherCount > 1:
+		otherGroups = fmt.Sprintf(" and other %d groups", otherCount)
+	}
+
+	desc := descriptionFor(first.messageId, bref.raw, first.group.raw, otherGroups)
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          first.messageId,
+		Description: desc,
+	})
+}
+
+func classifyPair(brefPath []*rxNode, bref *rxNode, group *rxNode) *problem {
+	if nodeContains(brefPath, group) {
+		// Group is bref's ancestor → bref is nested within the group, which
+		// hasn't matched yet when bref starts to match.
+		return &problem{messageId: "nested", group: group}
+	}
+
+	groupPath := pathToRoot(group)
+
+	// Walk both paths from the root downward to find the lowest common ancestor.
+	i := len(brefPath) - 1
+	j := len(groupPath) - 1
+	for i >= 0 && j >= 0 && brefPath[i] == groupPath[j] {
+		i--
+		j--
+	}
+	indexOfLCA := j + 1
+	groupCut := groupPath[:indexOfLCA]
+	commonPath := groupPath[indexOfLCA:]
+
+	var lowestCommonLookaround *rxNode
+	for _, n := range commonPath {
+		if isLookaround(n) {
+			lowestCommonLookaround = n
+			break
+		}
+	}
+	matchingBackward := lowestCommonLookaround != nil && isLookbehind(lowestCommonLookaround)
+
+	if len(groupCut) > 0 && groupCut[len(groupCut)-1].kind == nkAlternative {
+		return &problem{messageId: "disjunctive", group: group}
+	}
+	if !matchingBackward && bref.end <= group.start {
+		return &problem{messageId: "forward", group: group}
+	}
+	if matchingBackward && group.end <= bref.start {
+		return &problem{messageId: "backward", group: group}
+	}
+	for _, n := range groupCut {
+		if isNegativeLookaround(n) {
+			return &problem{messageId: "intoNegativeLookaround", group: group}
+		}
+	}
+	return nil
+}
+
+func descriptionFor(messageId, bref, group, otherGroups string) string {
+	switch messageId {
+	case "nested":
+		return fmt.Sprintf("Backreference '%s' will be ignored. It references group '%s'%s from within that group.", bref, group, otherGroups)
+	case "forward":
+		return fmt.Sprintf("Backreference '%s' will be ignored. It references group '%s'%s which appears later in the pattern.", bref, group, otherGroups)
+	case "backward":
+		return fmt.Sprintf("Backreference '%s' will be ignored. It references group '%s'%s which appears before in the same lookbehind.", bref, group, otherGroups)
+	case "disjunctive":
+		return fmt.Sprintf("Backreference '%s' will be ignored. It references group '%s'%s which is in another alternative.", bref, group, otherGroups)
+	case "intoNegativeLookaround":
+		return fmt.Sprintf("Backreference '%s' will be ignored. It references group '%s'%s which is in a negative lookaround.", bref, group, otherGroups)
+	}
+	return ""
+}

--- a/internal/rules/no_useless_backreference/no_useless_backreference.md
+++ b/internal/rules/no_useless_backreference/no_useless_backreference.md
@@ -1,0 +1,46 @@
+# no-useless-backreference
+
+## Rule Details
+
+This rule disallows useless backreferences in regular expressions — backreferences that can only ever match the empty string regardless of input. The rule recognizes five problematic patterns:
+
+- A backreference to a group that contains the backreference itself (the group hasn't matched yet when the backreference starts).
+- A backreference that appears before the group it refers to (forward reference).
+- A backreference inside a lookbehind that refers to a group appearing before it in the same lookbehind (lookbehind matches right-to-left).
+- A backreference and its referenced group are in different alternatives of the same disjunction.
+- A backreference to a group inside a negative lookaround when the backreference itself is outside that lookaround (the group's match was discarded).
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+/^(?:(a)|\1b)$/;       // reference to a group in another alternative
+/(?:(a)|b(?:c|\1))$/;  // reference to a group in another alternative
+/\1(a)/;               // forward reference
+RegExp('(a)\\2(b)');   // forward reference
+/\k<foo>(?<foo>a)/;    // forward reference (named)
+/(?<=(a)\1)b/;         // backward reference in lookbehind
+new RegExp('(\\1)');   // nested reference
+/^((a)\1)$/;           // nested reference
+/a(?!(b)).\1/;         // reference into a negative lookahead
+/(?<!(a))b\1/;         // reference into a negative lookbehind
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+/^(?:(a)|(b)\2)$/;
+/(a)\1/;
+RegExp('(a)\\1(b)');
+/(?<foo>a)\k<foo>/;
+/(?<=\1(a))b/;
+/^(?:(a)\1)$/;
+/a(?!(b|c)\1)./;
+```
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- [ESLint no-useless-backreference](https://eslint.org/docs/latest/rules/no-useless-backreference)

--- a/internal/rules/no_useless_backreference/no_useless_backreference_test.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference_test.go
@@ -1,0 +1,423 @@
+package no_useless_backreference
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUselessBackreferenceRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessBackreferenceRule,
+		[]rule_tester.ValidTestCase{
+			// ---- not a regular expression ----
+			{Code: `'\\1(a)'`},
+			{Code: `regExp('\\1(a)')`},
+			{Code: `new Regexp('\\1(a)', 'u')`},
+			{Code: `RegExp.foo('\\1(a)', 'u')`},
+			{Code: `new foo.RegExp('\\1(a)')`},
+
+			// ---- unknown pattern ----
+			{Code: `RegExp(p)`},
+			{Code: `new RegExp(p, 'u')`},
+			{Code: `RegExp('\\1(a)' + suffix)`},
+			{Code: "new RegExp(`${prefix}\\\\1(a)`)"},
+
+			// ---- not the global RegExp ----
+			{Code: `let RegExp; new RegExp('\\1(a)');`},
+			{Code: `function foo() { var RegExp; RegExp('\\1(a)', 'u'); }`},
+			{Code: `function foo(RegExp) { new RegExp('\\1(a)'); }`},
+			{Code: `if (foo) { const RegExp = bar; RegExp('\\1(a)'); }`},
+			// SKIP: rslint does not support ESLint's /*globals*/ directive comments
+			// `/* globals RegExp:off */ new RegExp('\\1(a)');`
+			// `RegExp('\\1(a)');` with languageOptions.globals { RegExp: "off" }
+
+			// ---- no capturing groups ----
+			{Code: `/(?:)/`},
+			{Code: `/(?:a)/`},
+			{Code: `new RegExp('')`},
+			{Code: `RegExp('(?:a)|(?:b)*')`},
+			{Code: `/^ab|[cd].\n$/`},
+
+			// ---- no backreferences ----
+			{Code: `/(a)/`},
+			{Code: `RegExp('(a)|(b)')`},
+			{Code: `new RegExp('\\n\\d(a)')`},
+			{Code: `/\0(a)/`},
+			{Code: `/\0(a)/u`},
+			{Code: `/(?<=(a))(b)(?=(c))/`},
+			{Code: `/(?<!(a))(b)(?!(c))/`},
+			{Code: `/(?<foo>a)/`},
+
+			// ---- not really a backreference ----
+			// SKIP: rslint fixtures use strict TS, which rejects '\1' octal escapes in string literals
+			// `RegExp('\1(a)')` // string octal escape
+			{Code: `RegExp('\\\\1(a)')`}, // escaped backslash → JS string "\\1(a)" → pattern "\\1(a)" (literal \, then 1(a))
+			{Code: `/\\1(a)/`},           // escaped backslash in literal
+			{Code: `/\1/`},               // group 1 doesn't exist, regex octal escape
+			{Code: `/^\1$/`},
+			{Code: `/\2(a)/`},
+			{Code: `/\1(?:a)/`},
+			{Code: `/\1(?=a)/`},
+			{Code: `/\1(?!a)/`},
+			{Code: `/^[\1](a)$/`},                  // \N in a character class is octal
+			{Code: `new RegExp('[\\1](a)')`},
+			{Code: `/\11(a)/`},                     // octal escape \11
+			{Code: `/\k<foo>(a)/`},                 // no named groups → literal "k<foo>a"
+			{Code: `/^(a)\1\2$/`},                  // \1 backref, \2 octal
+
+			// ---- valid backreferences: correct position, after the group ----
+			{Code: `/(a)\1/`},
+			{Code: `/(a).\1/`},
+			{Code: `RegExp('(a)\\1(b)')`},
+			{Code: `/(a)(b)\2(c)/`},
+			{Code: `/(?<foo>a)\k<foo>/`},
+			{Code: `new RegExp('(.)\\1')`},
+			{Code: `RegExp('(a)\\1(?:b)')`},
+			{Code: `/(a)b\1/`},
+			{Code: `/((a)\2)/`},
+			{Code: `/((a)b\2c)/`},
+			{Code: `/^(?:(a)\1)$/`},
+			{Code: `/^((a)\2)$/`},
+			{Code: `/^(((a)\3))|b$/`},
+			{Code: `/a(?<foo>(.)b\2)/`},
+			{Code: `/(a)?(b)*(\1)(c)/`},
+			{Code: `/(a)?(b)*(\2)(c)/`},
+			{Code: `/(?<=(a))b\1/`},
+			{Code: `/(?<=(?=(a)\1))b/`},
+
+			// ---- valid backreferences: correct position before the group when both in same lookbehind ----
+			{Code: `/(?<!\1(a))b/`},
+			{Code: `/(?<=\1(a))b/`},
+			{Code: `/(?<!\1.(a))b/`},
+			{Code: `/(?<=\1.(a))b/`},
+			{Code: `/(?<=(?:\1.(a)))b/`},
+			{Code: `/(?<!(?:\1)((a)))b/`},
+			{Code: `/(?<!(?:\2)((a)))b/`},
+			{Code: `/(?=(?<=\1(a)))b/`},
+			{Code: `/(?=(?<!\1(a)))b/`},
+			{Code: `/(.)(?<=\2(a))b/`},
+
+			// ---- valid: not a reference into another alternative ----
+			{Code: `/^(a)\1|b/`},
+			{Code: `/^a|(b)\1/`},
+			{Code: `/^a|(b|c)\1/`},
+			{Code: `/^(a)|(b)\2/`},
+			{Code: `/^(?:(a)|(b)\2)$/`},
+			{Code: `/^a|(?:.|(b)\1)/`},
+			{Code: `/^a|(?:.|(b).(\1))/`},
+			{Code: `/^a|(?:.|(?:(b)).(\1))/`},
+			{Code: `/^a|(?:.|(?:(b)|c).(\1))/`},
+			{Code: `/^a|(?:.|(?:(b)).(\1|c))/`},
+			{Code: `/^a|(?:.|(?:(b)|c).(\1|d))/`},
+
+			// ---- valid: not a reference into a negative lookaround (reference from within is allowed) ----
+			{Code: `/.(?=(b))\1/`},
+			{Code: `/.(?<=(b))\1/`},
+			{Code: `/a(?!(b)\1)./`},
+			{Code: `/a(?<!\1(b))./`},
+			{Code: `/a(?!(b)(\1))./`},
+			{Code: `/a(?!(?:(b)\1))./`},
+			{Code: `/a(?!(?:(b))\1)./`},
+			{Code: `/a(?<!(?:\1)(b))./`},
+			{Code: `/a(?<!(?:(?:\1)(b)))./`},
+			{Code: `/(?<!(a))(b)(?!(c))\2/`},
+			{Code: `/a(?!(b|c)\1)./`},
+
+			// ---- ignore regular expressions with syntax errors ----
+			{Code: `RegExp('\\1(a)[')`},                              // unterminated [
+			{Code: `new RegExp('\\1(a){', 'u')`},                     // unterminated { in u mode
+			{Code: `new RegExp('\\1(a)\\2', 'ug')`},                  // \2 syntax error in u mode
+			{Code: `const flags = 'gus'; RegExp('\\1(a){', flags);`}, // u flag known via const
+			{Code: `RegExp('\\1(a)\\k<foo>', 'u')`},                  // \k<foo> with no named group is syntax error in u
+			{Code: `new RegExp('\\k<foo>(?<foo>a)\\k<bar>')`},        // \k<bar> for unknown group is syntax error
+
+			// ---- ES2024 ----
+			{Code: `new RegExp('([[A--B]])\\1', 'v')`},
+			{Code: `new RegExp('[[]\\1](a)', 'v')`}, // SyntaxError
+
+			// ---- ES2025 ----
+			{Code: `/((?<foo>bar)\k<foo>|(?<foo>baz))/`},
+
+			// ---- Extra edge cases (rslint-side hardening) ----
+			// Deeply nested capturing groups with valid backref
+			{Code: `/(((((((((a)))))))))\1/`},
+			// Multi-digit valid backref (group 10 referenced by \10)
+			{Code: `/(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\10/`},
+			// Quantified group followed by valid backref
+			{Code: `/(a)+\1/`},
+			{Code: `/(a){2,5}\1/`},
+			// Backref inside character class is treated as octal escape
+			{Code: `/(a)[\1]/`},
+			// Unicode-named group with \k<...>
+			{Code: `/(?<日本>a)\k<日本>/u`},
+			// Empty alternative + backref (edge: `(|a)\1` valid because \1 is after group)
+			{Code: `/(|a)\1/`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- full message tests ----
+			{
+				Code: `/(b)(\2a)/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nested", Message: `Backreference '\2' will be ignored. It references group '(\2a)' from within that group.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/\k<foo>(?<foo>bar)/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which appears later in the pattern.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `RegExp('(a|bc)|\\1')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "disjunctive", Message: `Backreference '\1' will be ignored. It references group '(a|bc)' which is in another alternative.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `new RegExp('(?!(?<foo>\\n))\\1')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "intoNegativeLookaround", Message: `Backreference '\1' will be ignored. It references group '(?<foo>\n)' which is in a negative lookaround.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/(?<!(a)\1)b/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "backward", Message: `Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.`, Line: 1, Column: 1},
+				},
+			},
+
+			// ---- nested ----
+			{Code: `new RegExp('(\\1)')`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/^(a\1)$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/^((a)\1)$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `new RegExp('^(a\\1b)$')`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `RegExp('^((\\1))$')`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/((\2))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/a(?<foo>(.)b\1)/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/a(?<foo>\k<foo>)b/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/^(\1)*$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/^(?:a)(?:((?:\1)))*$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/(?!(\1))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/a|(b\1c)/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/(a|(\1))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/(a|(\2))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/(?:a|(\1))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/(a)?(b)*(\3)/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+			{Code: `/(?<=(a\1))b/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "nested", Line: 1, Column: 1}}},
+
+			// ---- forward ----
+			{Code: `/\1(a)/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/\1.(a)/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(?:\1)(?:(a))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(?:\1)(?:((a)))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(?:\2)(?:((a)))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(?:\1)(?:((?:a)))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(\2)(a)/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `RegExp('(a)\\2(b)')`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(?:a)(b)\2(c)/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/\k<foo>(?<foo>a)/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(?:a(b)\2)(c)/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `new RegExp('(a)(b)\\3(c)')`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/\1(?<=(a))./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/\1(?<!(a))./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(?<=\1)(?<=(a))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(?<!\1)(?<!(a))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(?=\1(a))./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/(?!\1(a))./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+
+			// ---- backward in the same lookbehind ----
+			{Code: `/(?<=(a)\1)b/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/(?<!.(a).\1.)b/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/(.)(?<!(b|c)\2)d/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/(?<=(?:(a)\1))b/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/(?<=(?:(a))\1)b/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/(?<=(a)(?:\1))b/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/(?<!(?:(a))(?:\1))b/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/(?<!(?:(a))(?:\1)|.)b/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/.(?!(?<!(a)\1))./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/.(?=(?<!(a)\1))./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/.(?!(?<=(a)\1))./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+			{Code: `/.(?=(?<=(a)\1))./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "backward", Line: 1, Column: 1}}},
+
+			// ---- into another alternative ----
+			{Code: `/(a)|\1b/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+			{Code: `/^(?:(a)|\1b)$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+			{Code: `/^(?:(a)|b(?:c|\1))$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+			{Code: `/^(?:a|b(?:(c)|\1))$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+			{Code: `/^(?:(a(?!b))|\1b)+$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+			{Code: `/^(?:(?:(a)(?!b))|\1b)+$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+			{Code: `/^(?:(a(?=a))|\1b)+$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+			{Code: `/^(?:(a)(?=a)|\1b)+$/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+			{Code: `/.(?:a|(b)).|(?:(\1)|c)./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+			{Code: `/.(?!(a)|\1)./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+			{Code: `/.(?<=\1|(a))./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "disjunctive", Line: 1, Column: 1}}},
+
+			// ---- into a negative lookaround ----
+			{Code: `/a(?!(b)).\1/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "intoNegativeLookaround", Line: 1, Column: 1}}},
+			{Code: `/(?<!(a))b\1/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "intoNegativeLookaround", Line: 1, Column: 1}}},
+			{Code: `/(?<!(a))(?:\1)/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "intoNegativeLookaround", Line: 1, Column: 1}}},
+			{Code: `/.(?<!a|(b)).\1/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "intoNegativeLookaround", Line: 1, Column: 1}}},
+			{Code: `/.(?!(a)).(?!\1)./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "intoNegativeLookaround", Line: 1, Column: 1}}},
+			{Code: `/.(?<!(a)).(?<!\1)./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "intoNegativeLookaround", Line: 1, Column: 1}}},
+			{Code: `/.(?=(?!(a))\1)./`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "intoNegativeLookaround", Line: 1, Column: 1}}},
+			{Code: `/.(?<!\1(?!(a)))/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "intoNegativeLookaround", Line: 1, Column: 1}}},
+
+			// ---- valid and invalid ----
+			{Code: `/\1(a)(b)\2/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+			{Code: `/\1(a)\1/`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "forward", Line: 1, Column: 1}}},
+
+			// ---- multiple invalid ----
+			{
+				Code: `/\1(a)\2(b)/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Line: 1, Column: 1},
+					{MessageId: "forward", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/\1.(?<=(a)\1)/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Line: 1, Column: 1},
+					{MessageId: "backward", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/(?!\1(a)).\1/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Line: 1, Column: 1},
+					{MessageId: "intoNegativeLookaround", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/(a)\2(b)/; RegExp('(\\1)');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Line: 1, Column: 1},
+					{MessageId: "nested", Line: 1, Column: 13},
+				},
+			},
+
+			// ---- non-evaluable flags assumed to lack 'u' ----
+			{
+				Code: `RegExp('\\1(a){', flags);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- statically known expressions ----
+			{
+				Code: `const r = RegExp, p = '\\1', s = '(a)'; new r(p + s);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Line: 1, Column: 41},
+				},
+			},
+
+			// ---- ES2024 ----
+			{
+				Code: `new RegExp('\\1([[A--B]])', 'v')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Message: `Backreference '\1' will be ignored. It references group '([[A--B]])' which appears later in the pattern.`, Line: 1, Column: 1},
+				},
+			},
+
+			// ---- ES2025 ----
+			{
+				Code: `/\k<foo>((?<foo>bar)|(?<foo>baz))/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' and another group which appears later in the pattern.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/((?<foo>bar)|\k<foo>(?<foo>baz))/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>baz)' which appears later in the pattern.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/\k<foo>((?<foo>bar)|(?<foo>baz)|(?<foo>qux))/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' and other 2 groups which appears later in the pattern.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/((?<foo>bar)|\k<foo>(?<foo>baz)|(?<foo>qux))/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>baz)' which appears later in the pattern.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/((?<foo>bar)|\k<foo>|(?<foo>baz))/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "disjunctive", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' and another group which is in another alternative.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/((?<foo>bar)|\k<foo>|(?<foo>baz)|(?<foo>qux))/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "disjunctive", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' and other 2 groups which is in another alternative.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/((?<foo>bar)|(?<foo>baz\k<foo>)|(?<foo>qux\k<foo>))/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nested", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>baz\k<foo>)' from within that group.`, Line: 1, Column: 1},
+					{MessageId: "nested", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>qux\k<foo>)' from within that group.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/(?<=((?<foo>bar)|(?<foo>baz))\k<foo>)/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "backward", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' and another group which appears before in the same lookbehind.`, Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/((?!(?<foo>bar))|(?!(?<foo>baz)))\k<foo>/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "intoNegativeLookaround", Message: `Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' and another group which is in a negative lookaround.`, Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Extra edge cases (rslint-side hardening) ----
+			// Multi-digit forward reference (group 10 referenced before declared)
+			{
+				Code: `/\10(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Line: 1, Column: 1},
+				},
+			},
+			// Deeply nested forward reference
+			{
+				Code: `/((((((\1))))))(a)/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nested", Line: 1, Column: 1},
+				},
+			},
+			// Quantified backref before its group
+			{
+				Code: `/\1+(a)/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Line: 1, Column: 1},
+				},
+			},
+			// Unicode-named group forward reference
+			{
+				Code: `/\k<日本>(?<日本>a)/u`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Line: 1, Column: 1},
+				},
+			},
+			// Nested lookbehind — inner lookbehind still triggers backward
+			{
+				Code: `/(?<=(?<=(a)\1))b/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "backward", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_useless_backreference/parser.go
+++ b/internal/rules/no_useless_backreference/parser.go
@@ -1,0 +1,489 @@
+// Package no_useless_backreference implements ESLint's
+// no-useless-backreference rule. The rule walks each regex pattern looking
+// for backreferences that always match the empty string regardless of input.
+//
+// This file contains a minimal ECMAScript regex parser that produces just
+// enough of an AST (Pattern → Alternatives → Groups / Lookarounds /
+// Backreferences) to run the analysis. It is NOT a complete regex parser —
+// it skips over content it doesn't need (characters, character classes,
+// quantifiers) but always advances correctly past them.
+//
+// On any syntax error the parser returns ok=false and the caller skips the
+// regex entirely (matching ESLint's behavior of catching parser exceptions).
+package no_useless_backreference
+
+import (
+	"strconv"
+	"unicode/utf8"
+
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// rxNodeKind is a regex AST node kind.
+type rxNodeKind int
+
+const (
+	nkPattern rxNodeKind = iota
+	nkAlternative
+	nkCapturingGroup
+	nkGroup // non-capturing (?:...)
+	nkLookaround
+	nkBackref
+)
+
+// rxNode is a node in the lightweight regex AST. Only the fields relevant to
+// the rule are populated.
+type rxNode struct {
+	kind     rxNodeKind
+	start    int // byte offset of the construct's first char in the pattern
+	end      int // byte offset one past the last char
+	raw      string
+	parent   *rxNode
+	children []*rxNode
+
+	// for capturing groups
+	name   string // empty for unnamed groups
+	number int    // 1-based; 0 for non-capturing groups
+
+	// for lookarounds
+	isAhead bool
+	negate  bool
+
+	// for backreferences
+	refName  string   // for \k<name>
+	refNum   int      // for \N (1-based, 0 if name-based)
+	resolved []*rxNode // resolved capture groups (multiple under ES2025 named-duplicate alternatives)
+}
+
+func isLookaround(n *rxNode) bool         { return n != nil && n.kind == nkLookaround }
+func isLookbehind(n *rxNode) bool         { return n != nil && n.kind == nkLookaround && !n.isAhead }
+func isNegativeLookaround(n *rxNode) bool { return n != nil && n.kind == nkLookaround && n.negate }
+
+// parsePattern parses a regex pattern and returns the root Pattern node and a
+// flat list of backreference nodes. Returns ok=false on syntax errors.
+func parsePattern(pattern string, flags utils.RegexFlags) (root *rxNode, backrefs []*rxNode, ok bool) {
+	totalGroups, hasNamedGroups, scanOk := scanGroups(pattern, flags)
+	if !scanOk {
+		return nil, nil, false
+	}
+
+	p := &rxParser{
+		pattern:        pattern,
+		flags:          flags,
+		totalGroups:    totalGroups,
+		hasNamedGroups: hasNamedGroups,
+		namedGroups:    map[string][]*rxNode{},
+	}
+
+	root = &rxNode{kind: nkPattern, start: 0, end: len(pattern), raw: pattern}
+	if !p.parseAlternatives(root, false) {
+		return nil, nil, false
+	}
+	if p.pos != len(pattern) {
+		return nil, nil, false
+	}
+
+	for _, br := range p.backrefs {
+		if br.refName != "" {
+			br.resolved = p.namedGroups[br.refName]
+		} else if br.refNum > 0 && br.refNum <= len(p.numberedGroups) {
+			br.resolved = []*rxNode{p.numberedGroups[br.refNum-1]}
+		}
+		if len(br.resolved) == 0 {
+			return nil, nil, false
+		}
+	}
+
+	return root, p.backrefs, true
+}
+
+type rxParser struct {
+	pattern        string
+	flags          utils.RegexFlags
+	pos            int
+	totalGroups    int
+	hasNamedGroups bool
+
+	numberedGroups []*rxNode
+	namedGroups    map[string][]*rxNode
+	backrefs       []*rxNode
+}
+
+// parseAlternatives consumes alternatives separated by `|`, ending at either
+// `)` (when expectClose) or end-of-input.
+func (p *rxParser) parseAlternatives(parent *rxNode, expectClose bool) bool {
+	alt := &rxNode{kind: nkAlternative, start: p.pos, parent: parent}
+	parent.children = append(parent.children, alt)
+
+	for p.pos < len(p.pattern) {
+		c := p.pattern[p.pos]
+		if c == ')' {
+			if !expectClose {
+				return false
+			}
+			alt.end = p.pos
+			alt.raw = p.pattern[alt.start:alt.end]
+			return true
+		}
+		if c == '|' {
+			alt.end = p.pos
+			alt.raw = p.pattern[alt.start:alt.end]
+			p.pos++
+			alt = &rxNode{kind: nkAlternative, start: p.pos, parent: parent}
+			parent.children = append(parent.children, alt)
+			continue
+		}
+		if !p.parseTerm(alt) {
+			return false
+		}
+	}
+
+	if expectClose {
+		return false
+	}
+
+	alt.end = p.pos
+	alt.raw = p.pattern[alt.start:alt.end]
+	return true
+}
+
+func (p *rxParser) parseTerm(parent *rxNode) bool {
+	c := p.pattern[p.pos]
+	switch c {
+	case '(':
+		if !p.parseGroup(parent) {
+			return false
+		}
+	case '[':
+		end, ok := utils.ClassEnd(p.pattern, p.pos, p.flags)
+		if !ok {
+			return false
+		}
+		p.pos = end
+	case '\\':
+		if !p.parseEscape(parent) {
+			return false
+		}
+	case '*', '+', '?':
+		// Standalone quantifier without an operand — invalid, but for
+		// robustness against patterns that fail to parse cleanly we just
+		// consume it. (Top-level `parsePattern` rejects on remaining errors.)
+		return false
+	case '{':
+		// Under u/v mode, a standalone `{` (one not part of a `{n}`/`{n,m}`
+		// quantifier and not following a target) is a syntax error in
+		// regexpp's strict parser. Skip the regex.
+		if p.flags.UV() {
+			return false
+		}
+		p.pos++
+	default:
+		_, w := utf8.DecodeRuneInString(p.pattern[p.pos:])
+		if w == 0 {
+			return false
+		}
+		p.pos += w
+	}
+	p.skipQuantifier()
+	return true
+}
+
+func (p *rxParser) skipQuantifier() {
+	if p.pos >= len(p.pattern) {
+		return
+	}
+	c := p.pattern[p.pos]
+	switch c {
+	case '?', '*', '+':
+		p.pos++
+	case '{':
+		save := p.pos
+		i := p.pos + 1
+		nStart := i
+		for i < len(p.pattern) && isDigit(p.pattern[i]) {
+			i++
+		}
+		if i == nStart {
+			return
+		}
+		if i < len(p.pattern) && p.pattern[i] == ',' {
+			i++
+			for i < len(p.pattern) && isDigit(p.pattern[i]) {
+				i++
+			}
+		}
+		if i < len(p.pattern) && p.pattern[i] == '}' {
+			p.pos = i + 1
+		} else {
+			p.pos = save
+			return
+		}
+	default:
+		return
+	}
+	if p.pos < len(p.pattern) && p.pattern[p.pos] == '?' {
+		p.pos++
+	}
+}
+
+func (p *rxParser) parseGroup(parent *rxNode) bool {
+	start := p.pos
+	p.pos++ // consume '('
+
+	var node *rxNode
+
+	if p.pos < len(p.pattern) && p.pattern[p.pos] == '?' {
+		if p.pos+1 >= len(p.pattern) {
+			return false
+		}
+		c := p.pattern[p.pos+1]
+		switch c {
+		case ':':
+			p.pos += 2
+			node = &rxNode{kind: nkGroup, start: start, parent: parent}
+		case '=':
+			p.pos += 2
+			node = &rxNode{kind: nkLookaround, start: start, parent: parent, isAhead: true, negate: false}
+		case '!':
+			p.pos += 2
+			node = &rxNode{kind: nkLookaround, start: start, parent: parent, isAhead: true, negate: true}
+		case '<':
+			if p.pos+2 >= len(p.pattern) {
+				return false
+			}
+			switch p.pattern[p.pos+2] {
+			case '=':
+				p.pos += 3
+				node = &rxNode{kind: nkLookaround, start: start, parent: parent, isAhead: false, negate: false}
+			case '!':
+				p.pos += 3
+				node = &rxNode{kind: nkLookaround, start: start, parent: parent, isAhead: false, negate: true}
+			default:
+				// (?<name>...)
+				p.pos += 2 // consume `?<`
+				nameEnd := p.pos
+				for nameEnd < len(p.pattern) && p.pattern[nameEnd] != '>' {
+					nameEnd++
+				}
+				if nameEnd >= len(p.pattern) || nameEnd == p.pos {
+					return false
+				}
+				name := p.pattern[p.pos:nameEnd]
+				p.pos = nameEnd + 1
+				p.numberedGroups = append(p.numberedGroups, nil)
+				num := len(p.numberedGroups)
+				node = &rxNode{kind: nkCapturingGroup, start: start, parent: parent, name: name, number: num}
+				p.numberedGroups[num-1] = node
+				p.namedGroups[name] = append(p.namedGroups[name], node)
+			}
+		default:
+			return false
+		}
+	} else {
+		p.numberedGroups = append(p.numberedGroups, nil)
+		num := len(p.numberedGroups)
+		node = &rxNode{kind: nkCapturingGroup, start: start, parent: parent, number: num}
+		p.numberedGroups[num-1] = node
+	}
+
+	parent.children = append(parent.children, node)
+
+	if !p.parseAlternatives(node, true) {
+		return false
+	}
+	if p.pos >= len(p.pattern) || p.pattern[p.pos] != ')' {
+		return false
+	}
+	p.pos++ // consume ')'
+
+	node.end = p.pos
+	node.raw = p.pattern[node.start:node.end]
+	return true
+}
+
+// parseEscape handles a `\`-prefixed sequence at p.pos. Identifies backrefs;
+// otherwise just advances past the escape.
+func (p *rxParser) parseEscape(parent *rxNode) bool {
+	if p.pos+1 >= len(p.pattern) {
+		return false
+	}
+	next := p.pattern[p.pos+1]
+
+	switch {
+	case next == 'k':
+		// \k<name> — only treated as a backref under u/v mode OR when at
+		// least one named group exists in the pattern. Otherwise it's an
+		// identity escape (`k`) followed by literals.
+		if p.flags.UV() || p.hasNamedGroups {
+			if p.pos+2 < len(p.pattern) && p.pattern[p.pos+2] == '<' {
+				nameEnd := p.pos + 3
+				for nameEnd < len(p.pattern) && p.pattern[nameEnd] != '>' {
+					nameEnd++
+				}
+				if nameEnd < len(p.pattern) && nameEnd > p.pos+3 {
+					name := p.pattern[p.pos+3 : nameEnd]
+					bref := &rxNode{
+						kind:    nkBackref,
+						start:   p.pos,
+						end:     nameEnd + 1,
+						raw:     p.pattern[p.pos : nameEnd+1],
+						parent:  parent,
+						refName: name,
+					}
+					parent.children = append(parent.children, bref)
+					p.backrefs = append(p.backrefs, bref)
+					p.pos = nameEnd + 1
+					return true
+				}
+				if p.flags.UV() {
+					return false
+				}
+			} else if p.flags.UV() {
+				return false
+			}
+		}
+		// Identity escape `\k`
+		p.pos += 2
+		return true
+
+	case next >= '1' && next <= '9':
+		end := p.pos + 1
+		for end < len(p.pattern) && isDigit(p.pattern[end]) {
+			end++
+		}
+		n, _ := strconv.Atoi(p.pattern[p.pos+1 : end])
+		if p.flags.UV() || n <= p.totalGroups {
+			bref := &rxNode{
+				kind:   nkBackref,
+				start:  p.pos,
+				end:    end,
+				raw:    p.pattern[p.pos:end],
+				parent: parent,
+				refNum: n,
+			}
+			parent.children = append(parent.children, bref)
+			p.backrefs = append(p.backrefs, bref)
+			p.pos = end
+			return true
+		}
+		// Octal escape — just consume.
+		p.pos = end
+		return true
+
+	default:
+		// All other escapes (\x, \u, \c, \p, \P, \d, identity escapes, etc.)
+		// — defer to the shared utility, which knows the precise byte width
+		// for each form under each flag mode.
+		step, ok := utils.SkipPatternEscape(p.pattern, p.pos, p.flags)
+		if !ok {
+			return false
+		}
+		p.pos += step
+		return true
+	}
+}
+
+// scanGroups walks the pattern to count capturing groups and detect whether
+// any are named. Skips over character classes and escapes correctly.
+func scanGroups(pattern string, flags utils.RegexFlags) (totalGroups int, hasNamedGroups bool, ok bool) {
+	i := 0
+	for i < len(pattern) {
+		c := pattern[i]
+		switch c {
+		case '\\':
+			step, escOk := skipBackrefAwareEscape(pattern, i, flags)
+			if !escOk {
+				return 0, false, false
+			}
+			i += step
+		case '[':
+			end, classOk := utils.ClassEnd(pattern, i, flags)
+			if !classOk {
+				return 0, false, false
+			}
+			i = end
+		case '(':
+			i++
+			if i < len(pattern) && pattern[i] == '?' {
+				if i+1 >= len(pattern) {
+					return 0, false, false
+				}
+				next := pattern[i+1]
+				if next == ':' || next == '=' || next == '!' {
+					i += 2
+					continue
+				}
+				if next == '<' {
+					if i+2 < len(pattern) {
+						after := pattern[i+2]
+						if after == '=' || after == '!' {
+							i += 3
+							continue
+						}
+					}
+					// Named group (?<name>...)
+					i += 2 // consume `?<`
+					nameEnd := i
+					for nameEnd < len(pattern) && pattern[nameEnd] != '>' {
+						nameEnd++
+					}
+					if nameEnd >= len(pattern) || nameEnd == i {
+						return 0, false, false
+					}
+					totalGroups++
+					hasNamedGroups = true
+					i = nameEnd + 1
+					continue
+				}
+				return 0, false, false
+			}
+			totalGroups++
+		default:
+			_, w := utf8.DecodeRuneInString(pattern[i:])
+			if w == 0 {
+				i++
+			} else {
+				i += w
+			}
+		}
+	}
+	return totalGroups, hasNamedGroups, true
+}
+
+// skipBackrefAwareEscape wraps utils.SkipPatternEscape with extra handling
+// for `\k<name>` so that a `>` inside the name can't be misread as part of
+// surrounding syntax during the group-scan pass.
+func skipBackrefAwareEscape(pattern string, i int, flags utils.RegexFlags) (int, bool) {
+	if i+2 < len(pattern) && pattern[i+1] == 'k' && pattern[i+2] == '<' {
+		nameEnd := i + 3
+		for nameEnd < len(pattern) && pattern[nameEnd] != '>' {
+			nameEnd++
+		}
+		if nameEnd < len(pattern) && nameEnd > i+3 {
+			return nameEnd + 1 - i, true
+		}
+	}
+	return utils.SkipPatternEscape(pattern, i, flags)
+}
+
+// pathToRoot returns [n, n.parent, …, root].
+func pathToRoot(n *rxNode) []*rxNode {
+	var out []*rxNode
+	cur := n
+	for cur != nil {
+		out = append(out, cur)
+		cur = cur.parent
+	}
+	return out
+}
+
+func nodeContains(path []*rxNode, target *rxNode) bool {
+	for _, n := range path {
+		if n == target {
+			return true
+		}
+	}
+	return false
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }

--- a/internal/rules/no_useless_backreference/static_eval.go
+++ b/internal/rules/no_useless_backreference/static_eval.go
@@ -1,0 +1,174 @@
+// cspell:ignore rctx
+package no_useless_backreference
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/evaluator"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// staticEvalCtx folds string-typed expressions to constant values for the
+// purposes of resolving the pattern / flags arguments of a `RegExp(...)` or
+// `new RegExp(...)` call. Mirrors the helper in the
+// no-misleading-character-class rule.
+type staticEvalCtx struct {
+	rctx rule.RuleContext
+
+	evaluator evaluator.Evaluator
+
+	writeRefsComputed bool
+	writeRefsMap      map[*ast.Symbol]bool
+}
+
+func newStaticEvalCtx(rctx rule.RuleContext) *staticEvalCtx {
+	s := &staticEvalCtx{rctx: rctx}
+	s.evaluator = evaluator.NewEvaluator(s.evaluateEntity, ast.OEKParentheses)
+	return s
+}
+
+func (s *staticEvalCtx) writeRefs() map[*ast.Symbol]bool {
+	if s.writeRefsComputed {
+		return s.writeRefsMap
+	}
+	s.writeRefsComputed = true
+	if s.rctx.TypeChecker == nil || s.rctx.SourceFile == nil {
+		return nil
+	}
+	m := map[*ast.Symbol]bool{}
+	var visit func(n *ast.Node)
+	visit = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		if n.Kind == ast.KindIdentifier && utils.IsWriteReference(n) {
+			if sym := s.rctx.TypeChecker.GetSymbolAtLocation(n); sym != nil {
+				m[sym] = true
+			}
+		}
+		n.ForEachChild(func(c *ast.Node) bool {
+			visit(c)
+			return false
+		})
+	}
+	visit(&s.rctx.SourceFile.Node)
+	s.writeRefsMap = m
+	return m
+}
+
+func (s *staticEvalCtx) evalStaticString(node *ast.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	if raw, ok := s.evalStringRawTag(node); ok {
+		return raw, true
+	}
+	res := s.evaluator(node, node)
+	if v, ok := res.Value.(string); ok {
+		return v, true
+	}
+	return "", false
+}
+
+func (s *staticEvalCtx) evaluateEntity(expr *ast.Node, location *ast.Node) evaluator.Result {
+	if s.rctx.TypeChecker == nil {
+		return evaluator.Result{}
+	}
+	expr = ast.SkipParentheses(expr)
+	if expr == nil || expr.Kind != ast.KindIdentifier {
+		return evaluator.Result{}
+	}
+	sym := s.rctx.TypeChecker.GetSymbolAtLocation(expr)
+	if sym == nil || len(sym.Declarations) != 1 {
+		return evaluator.Result{}
+	}
+	decl := sym.Declarations[0]
+	if decl.Kind != ast.KindVariableDeclaration {
+		return evaluator.Result{}
+	}
+	varDecl := decl.AsVariableDeclaration()
+	if varDecl == nil || varDecl.Initializer == nil {
+		return evaluator.Result{}
+	}
+	list := decl.Parent
+	if list == nil || list.Kind != ast.KindVariableDeclarationList {
+		return evaluator.Result{}
+	}
+	if list.Flags&ast.NodeFlagsConst == 0 && s.writeRefs()[sym] {
+		return evaluator.Result{}
+	}
+	return s.evaluator(varDecl.Initializer, location)
+}
+
+func (s *staticEvalCtx) evalStringRawTag(node *ast.Node) (string, bool) {
+	if node.Kind != ast.KindTaggedTemplateExpression {
+		return "", false
+	}
+	tt := node.AsTaggedTemplateExpression()
+	if tt == nil || tt.Tag == nil || tt.Template == nil || !s.isStringRawTag(tt.Tag) {
+		return "", false
+	}
+	switch tt.Template.Kind {
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return tt.Template.Text(), true
+	case ast.KindTemplateExpression:
+		te := tt.Template.AsTemplateExpression()
+		if te == nil {
+			return "", false
+		}
+		var sb strings.Builder
+		if te.Head != nil {
+			sb.WriteString(te.Head.Text())
+		}
+		if te.TemplateSpans != nil {
+			for _, span := range te.TemplateSpans.Nodes {
+				sp := span.AsTemplateSpan()
+				if sp == nil {
+					return "", false
+				}
+				sub, ok := s.evalStaticString(sp.Expression)
+				if !ok {
+					return "", false
+				}
+				sb.WriteString(sub)
+				if sp.Literal != nil {
+					sb.WriteString(sp.Literal.Text())
+				}
+			}
+		}
+		return sb.String(), true
+	}
+	return "", false
+}
+
+func (s *staticEvalCtx) isStringRawTag(tag *ast.Node) bool {
+	tag = ast.SkipParentheses(tag)
+	if tag == nil || tag.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	pae := tag.AsPropertyAccessExpression()
+	if pae == nil {
+		return false
+	}
+	name := pae.Name()
+	if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "raw" {
+		return false
+	}
+	obj := ast.SkipParentheses(pae.Expression)
+	if obj == nil {
+		return false
+	}
+	if s.rctx.TypeChecker != nil && s.rctx.Program != nil {
+		if t := s.rctx.TypeChecker.GetTypeAtLocation(obj); t != nil {
+			if utils.IsBuiltinSymbolLike(s.rctx.Program, s.rctx.TypeChecker, t, "StringConstructor") {
+				return true
+			}
+		}
+	}
+	if obj.Kind == ast.KindIdentifier {
+		return obj.AsIdentifier().Text == "String"
+	}
+	return false
+}

--- a/internal/utils/regex_charclass.go
+++ b/internal/utils/regex_charclass.go
@@ -97,7 +97,7 @@ func IterateRegexCharacterClasses(pattern string, flags RegexFlags, cb func(star
 	for i < len(pattern) {
 		switch pattern[i] {
 		case '\\':
-			step, ok := skipPatternEscape(pattern, i, flags)
+			step, ok := SkipPatternEscape(pattern, i, flags)
 			if !ok {
 				return false
 			}
@@ -128,7 +128,7 @@ func IterateRegexCharacterClasses(pattern string, flags RegexFlags, cb func(star
 // flag, for any nested classes). Returns the index just past `]`, or ok=false
 // on malformed input.
 func iterateClassFromLBracket(pattern string, start int, flags RegexFlags, cb func(start, end int)) (int, bool) {
-	end, ok := classEnd(pattern, start, flags)
+	end, ok := ClassEnd(pattern, start, flags)
 	if !ok {
 		return start, false
 	}
@@ -142,7 +142,7 @@ func iterateClassFromLBracket(pattern string, start int, flags RegexFlags, cb fu
 		for i < end-1 {
 			c := pattern[i]
 			if c == '\\' {
-				step, ok := skipPatternEscape(pattern, i, flags)
+				step, ok := SkipPatternEscape(pattern, i, flags)
 				if !ok {
 					return start, false
 				}
@@ -169,10 +169,10 @@ func iterateClassFromLBracket(pattern string, start int, flags RegexFlags, cb fu
 	return end, true
 }
 
-// classEnd returns the byte index just past the matching `]` for a class
+// ClassEnd returns the byte index just past the matching `]` for a class
 // starting at `[` at pattern[start]. Handles escaped `]`, v-flag nested
 // classes, and `\q{...}` which contains a literal `]` inside braces.
-func classEnd(pattern string, start int, flags RegexFlags) (int, bool) {
+func ClassEnd(pattern string, start int, flags RegexFlags) (int, bool) {
 	if start >= len(pattern) || pattern[start] != '[' {
 		return start, false
 	}
@@ -186,7 +186,7 @@ func classEnd(pattern string, start int, flags RegexFlags) (int, bool) {
 		c := pattern[i]
 		switch {
 		case c == '\\':
-			step, ok := skipPatternEscape(pattern, i, flags)
+			step, ok := SkipPatternEscape(pattern, i, flags)
 			if !ok {
 				return start, false
 			}
@@ -212,10 +212,10 @@ func classEnd(pattern string, start int, flags RegexFlags) (int, bool) {
 	return start, false
 }
 
-// skipPatternEscape returns how many bytes a `\`-prefixed escape consumes at
+// SkipPatternEscape returns how many bytes a `\`-prefixed escape consumes at
 // pattern[i] (including the leading `\`) for the purposes of class-boundary
 // scanning. Returns ok=false at EOF on `\`.
-func skipPatternEscape(pattern string, i int, flags RegexFlags) (int, bool) {
+func SkipPatternEscape(pattern string, i int, flags RegexFlags) (int, bool) {
 	if i+1 >= len(pattern) {
 		return 0, false
 	}
@@ -329,7 +329,7 @@ func ParseRegexCharacterClass(pattern string, start int, flags RegexFlags) ([]Re
 		case c == '[' && flags.UnicodeSets:
 			// v-flag nested class — emit as breaker; caller recurses via
 			// IterateRegexCharacterClasses to parse nested contents.
-			nestedEnd, ok := classEnd(pattern, i, flags)
+			nestedEnd, ok := ClassEnd(pattern, i, flags)
 			if !ok {
 				return nil, start, false
 			}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -315,6 +315,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unsafe-negation.test.ts',
     './tests/eslint/rules/no-throw-literal.test.ts',
     './tests/eslint/rules/no-unsafe-optional-chaining.test.ts',
+    './tests/eslint/rules/no-useless-backreference.test.ts',
     './tests/eslint/rules/no-useless-call.test.ts',
     './tests/eslint/rules/no-useless-catch.test.ts',
     './tests/eslint/rules/no-useless-rename.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-backreference.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-backreference.test.ts.snap
@@ -1,0 +1,800 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-backreference > invalid 1`] = `
+{
+  "code": "new RegExp('(\\\\1)')",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(\\1)' from within that group.",
+      "messageId": "nested",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 2`] = `
+{
+  "code": "/^(a\\1)$/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a\\1)' from within that group.",
+      "messageId": "nested",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 3`] = `
+{
+  "code": "/^((a)\\1)$/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '((a)\\1)' from within that group.",
+      "messageId": "nested",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 4`] = `
+{
+  "code": "/(b)(\\2a)/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\2' will be ignored. It references group '(\\2a)' from within that group.",
+      "messageId": "nested",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 5`] = `
+{
+  "code": "/a(?<foo>(.)b\\1)/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(?<foo>(.)b\\1)' from within that group.",
+      "messageId": "nested",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 6`] = `
+{
+  "code": "/a(?<foo>\\k<foo>)b/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\k<foo>' will be ignored. It references group '(?<foo>\\k<foo>)' from within that group.",
+      "messageId": "nested",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 7`] = `
+{
+  "code": "/(?<=(a\\1))b/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a\\1)' from within that group.",
+      "messageId": "nested",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 8`] = `
+{
+  "code": "/\\1(a)/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 9`] = `
+{
+  "code": "/\\k<foo>(?<foo>bar)/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\k<foo>' will be ignored. It references group '(?<foo>bar)' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 10`] = `
+{
+  "code": "/(\\2)(a)/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\2' will be ignored. It references group '(a)' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 11`] = `
+{
+  "code": "RegExp('(a)\\\\2(b)')",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\2' will be ignored. It references group '(b)' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 12`] = `
+{
+  "code": "/\\1(?<=(a))./",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 13`] = `
+{
+  "code": "/(?<=(a)\\1)b/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.",
+      "messageId": "backward",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 14`] = `
+{
+  "code": "/(?<!(a)\\1)b/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.",
+      "messageId": "backward",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 15`] = `
+{
+  "code": "/(.)(?<!(b|c)\\2)d/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\2' will be ignored. It references group '(b|c)' which appears before in the same lookbehind.",
+      "messageId": "backward",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 16`] = `
+{
+  "code": "/(a)|\\1b/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which is in another alternative.",
+      "messageId": "disjunctive",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 17`] = `
+{
+  "code": "/^(?:(a)|\\1b)$/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which is in another alternative.",
+      "messageId": "disjunctive",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 18`] = `
+{
+  "code": "RegExp('(a|bc)|\\\\1')",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a|bc)' which is in another alternative.",
+      "messageId": "disjunctive",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 19`] = `
+{
+  "code": "/a(?!(b)).\\1/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(b)' which is in a negative lookaround.",
+      "messageId": "intoNegativeLookaround",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 20`] = `
+{
+  "code": "/(?<!(a))b\\1/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which is in a negative lookaround.",
+      "messageId": "intoNegativeLookaround",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 21`] = `
+{
+  "code": "new RegExp('(?!(?<foo>\\\\n))\\\\1')",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(?<foo>\\n)' which is in a negative lookaround.",
+      "messageId": "intoNegativeLookaround",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 22`] = `
+{
+  "code": "/\\1(a)\\2(b)/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+    {
+      "message": "Backreference '\\2' will be ignored. It references group '(b)' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 23`] = `
+{
+  "code": "/\\1.(?<=(a)\\1)/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.",
+      "messageId": "backward",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 24`] = `
+{
+  "code": "const r = RegExp, p = '\\\\1', s = '(a)'; new r(p + s);",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 25`] = `
+{
+  "code": "RegExp('\\\\1(a){', flags);",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '(a)' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 26`] = `
+{
+  "code": "new RegExp('\\\\1([[A--B]])', 'v')",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\1' will be ignored. It references group '([[A--B]])' which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 27`] = `
+{
+  "code": "/\\k<foo>((?<foo>bar)|(?<foo>baz))/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\k<foo>' will be ignored. It references group '(?<foo>bar)' and another group which appears later in the pattern.",
+      "messageId": "forward",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 28`] = `
+{
+  "code": "/((?<foo>bar)|\\k<foo>|(?<foo>baz))/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\k<foo>' will be ignored. It references group '(?<foo>bar)' and another group which is in another alternative.",
+      "messageId": "disjunctive",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-backreference > invalid 29`] = `
+{
+  "code": "/((?<foo>bar)|(?<foo>baz\\k<foo>)|(?<foo>qux\\k<foo>))/",
+  "diagnostics": [
+    {
+      "message": "Backreference '\\k<foo>' will be ignored. It references group '(?<foo>baz\\k<foo>)' from within that group.",
+      "messageId": "nested",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+    {
+      "message": "Backreference '\\k<foo>' will be ignored. It references group '(?<foo>qux\\k<foo>)' from within that group.",
+      "messageId": "nested",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-backreference",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-useless-backreference.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-useless-backreference.test.ts
@@ -1,0 +1,245 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-backreference', {
+  valid: [
+    // Not a regular expression
+    String.raw`regExp('\\1(a)')`,
+    String.raw`new Regexp('\\1(a)', 'u')`,
+    String.raw`RegExp.foo('\\1(a)', 'u')`,
+    String.raw`new foo.RegExp('\\1(a)')`,
+
+    // Unknown pattern
+    'RegExp(p)',
+    "new RegExp(p, 'u')",
+    String.raw`RegExp('\\1(a)' + suffix)`,
+    'new RegExp(`${prefix}\\\\1(a)`)',
+
+    // Not the global RegExp
+    String.raw`let RegExp; new RegExp('\\1(a)');`,
+    String.raw`function foo() { var RegExp; RegExp('\\1(a)', 'u'); }`,
+    String.raw`function foo(RegExp) { new RegExp('\\1(a)'); }`,
+    String.raw`if (foo) { const RegExp = bar; RegExp('\\1(a)'); }`,
+
+    // No capturing groups
+    '/(?:)/',
+    '/(?:a)/',
+    "new RegExp('')",
+    "RegExp('(?:a)|(?:b)*')",
+    String.raw`/^ab|[cd].\n$/`,
+
+    // No backreferences
+    '/(a)/',
+    "RegExp('(a)|(b)')",
+    String.raw`new RegExp('\\n\\d(a)')`,
+    String.raw`/\0(a)/`,
+    String.raw`/\0(a)/u`,
+    '/(?<=(a))(b)(?=(c))/',
+    '/(?<!(a))(b)(?!(c))/',
+    '/(?<foo>a)/',
+
+    // Not really a backreference
+    String.raw`RegExp('\\\\1(a)')`,
+    String.raw`/\\1(a)/`,
+    String.raw`/\1/`,
+    String.raw`/^\1$/`,
+    String.raw`/\2(a)/`,
+    String.raw`/\1(?:a)/`,
+    String.raw`/\1(?=a)/`,
+    String.raw`/\1(?!a)/`,
+    String.raw`/^[\1](a)$/`,
+    String.raw`new RegExp('[\\1](a)')`,
+    String.raw`/\11(a)/`,
+    String.raw`/\k<foo>(a)/`,
+    String.raw`/^(a)\1\2$/`,
+
+    // Valid backreferences
+    String.raw`/(a)\1/`,
+    String.raw`/(a).\1/`,
+    String.raw`RegExp('(a)\\1(b)')`,
+    String.raw`/(a)(b)\2(c)/`,
+    String.raw`/(?<foo>a)\k<foo>/`,
+    String.raw`new RegExp('(.)\\1')`,
+    String.raw`RegExp('(a)\\1(?:b)')`,
+    String.raw`/(a)b\1/`,
+    String.raw`/((a)\2)/`,
+    String.raw`/^(?:(a)\1)$/`,
+    String.raw`/^((a)\2)$/`,
+    String.raw`/^(((a)\3))|b$/`,
+    String.raw`/(a)?(b)*(\1)(c)/`,
+    String.raw`/(?<=(a))b\1/`,
+    String.raw`/(?<=(?=(a)\1))b/`,
+
+    // Backreference before the group in same lookbehind
+    String.raw`/(?<!\1(a))b/`,
+    String.raw`/(?<=\1(a))b/`,
+    String.raw`/(?<!\1.(a))b/`,
+    String.raw`/(?<=\1.(a))b/`,
+    String.raw`/(?=(?<=\1(a)))b/`,
+    String.raw`/(.)(?<=\2(a))b/`,
+
+    // Not into another alternative
+    String.raw`/^(a)\1|b/`,
+    String.raw`/^a|(b)\1/`,
+    String.raw`/^a|(b|c)\1/`,
+    String.raw`/^(a)|(b)\2/`,
+    String.raw`/^(?:(a)|(b)\2)$/`,
+
+    // Not into a negative lookaround
+    String.raw`/.(?=(b))\1/`,
+    String.raw`/.(?<=(b))\1/`,
+    String.raw`/a(?!(b)\1)./`,
+    String.raw`/a(?<!\1(b))./`,
+    String.raw`/(?<!(a))(b)(?!(c))\2/`,
+    String.raw`/a(?!(b|c)\1)./`,
+
+    // Syntax errors
+    String.raw`RegExp('\\1(a)[')`,
+    String.raw`new RegExp('\\1(a){', 'u')`,
+    String.raw`new RegExp('\\1(a)\\2', 'ug')`,
+    String.raw`const flags = 'gus'; RegExp('\\1(a){', flags);`,
+    String.raw`RegExp('\\1(a)\\k<foo>', 'u')`,
+    String.raw`new RegExp('\\k<foo>(?<foo>a)\\k<bar>')`,
+
+    // ES2025 named-duplicate alternatives
+    String.raw`/((?<foo>bar)\k<foo>|(?<foo>baz))/`,
+  ],
+  invalid: [
+    // Nested
+    {
+      code: String.raw`new RegExp('(\\1)')`,
+      errors: [{ messageId: 'nested' }],
+    },
+    {
+      code: String.raw`/^(a\1)$/`,
+      errors: [{ messageId: 'nested' }],
+    },
+    {
+      code: String.raw`/^((a)\1)$/`,
+      errors: [{ messageId: 'nested' }],
+    },
+    {
+      code: String.raw`/(b)(\2a)/`,
+      errors: [{ messageId: 'nested' }],
+    },
+    {
+      code: String.raw`/a(?<foo>(.)b\1)/`,
+      errors: [{ messageId: 'nested' }],
+    },
+    {
+      code: String.raw`/a(?<foo>\k<foo>)b/`,
+      errors: [{ messageId: 'nested' }],
+    },
+    {
+      code: String.raw`/(?<=(a\1))b/`,
+      errors: [{ messageId: 'nested' }],
+    },
+
+    // Forward
+    {
+      code: String.raw`/\1(a)/`,
+      errors: [{ messageId: 'forward' }],
+    },
+    {
+      code: String.raw`/\k<foo>(?<foo>bar)/`,
+      errors: [{ messageId: 'forward' }],
+    },
+    {
+      code: String.raw`/(\2)(a)/`,
+      errors: [{ messageId: 'forward' }],
+    },
+    {
+      code: String.raw`RegExp('(a)\\2(b)')`,
+      errors: [{ messageId: 'forward' }],
+    },
+    {
+      code: String.raw`/\1(?<=(a))./`,
+      errors: [{ messageId: 'forward' }],
+    },
+
+    // Backward in same lookbehind
+    {
+      code: String.raw`/(?<=(a)\1)b/`,
+      errors: [{ messageId: 'backward' }],
+    },
+    {
+      code: String.raw`/(?<!(a)\1)b/`,
+      errors: [{ messageId: 'backward' }],
+    },
+    {
+      code: String.raw`/(.)(?<!(b|c)\2)d/`,
+      errors: [{ messageId: 'backward' }],
+    },
+
+    // Disjunctive
+    {
+      code: String.raw`/(a)|\1b/`,
+      errors: [{ messageId: 'disjunctive' }],
+    },
+    {
+      code: String.raw`/^(?:(a)|\1b)$/`,
+      errors: [{ messageId: 'disjunctive' }],
+    },
+    {
+      code: String.raw`RegExp('(a|bc)|\\1')`,
+      errors: [{ messageId: 'disjunctive' }],
+    },
+
+    // Into negative lookaround
+    {
+      code: String.raw`/a(?!(b)).\1/`,
+      errors: [{ messageId: 'intoNegativeLookaround' }],
+    },
+    {
+      code: String.raw`/(?<!(a))b\1/`,
+      errors: [{ messageId: 'intoNegativeLookaround' }],
+    },
+    {
+      code: String.raw`new RegExp('(?!(?<foo>\\n))\\1')`,
+      errors: [{ messageId: 'intoNegativeLookaround' }],
+    },
+
+    // Multiple invalid
+    {
+      code: String.raw`/\1(a)\2(b)/`,
+      errors: [{ messageId: 'forward' }, { messageId: 'forward' }],
+    },
+    {
+      code: String.raw`/\1.(?<=(a)\1)/`,
+      errors: [{ messageId: 'forward' }, { messageId: 'backward' }],
+    },
+
+    // Statically known expression
+    {
+      code: String.raw`const r = RegExp, p = '\\1', s = '(a)'; new r(p + s);`,
+      errors: [{ messageId: 'forward' }],
+    },
+
+    // Non-evaluable flags assumed to lack 'u'
+    {
+      code: String.raw`RegExp('\\1(a){', flags);`,
+      errors: [{ messageId: 'forward' }],
+    },
+
+    // ES2024 v-flag
+    {
+      code: String.raw`new RegExp('\\1([[A--B]])', 'v')`,
+      errors: [{ messageId: 'forward' }],
+    },
+
+    // ES2025 named-duplicate alternatives
+    {
+      code: String.raw`/\k<foo>((?<foo>bar)|(?<foo>baz))/`,
+      errors: [{ messageId: 'forward' }],
+    },
+    {
+      code: String.raw`/((?<foo>bar)|\k<foo>|(?<foo>baz))/`,
+      errors: [{ messageId: 'disjunctive' }],
+    },
+    {
+      code: String.raw`/((?<foo>bar)|(?<foo>baz\k<foo>)|(?<foo>qux\k<foo>))/`,
+      errors: [{ messageId: 'nested' }, { messageId: 'nested' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -320,3 +320,7 @@ uninit
 espree
 norf
 McCabe
+bref
+brefs
+backref
+backrefs


### PR DESCRIPTION
## Summary

Port the `no-useless-backreference` rule from ESLint to rslint.

This rule disallows useless backreferences in regular expressions — backreferences that always match the empty string regardless of input. Detects 5 problematic patterns: nested, forward, backward in lookbehind, disjunctive, and into negative lookaround.

Implementation includes a minimal ECMAScript regex AST parser (group / lookaround / alternative / backreference, with character classes / escapes / quantifiers skipped via the shared `utils.ClassEnd` and `utils.SkipPatternEscape` helpers, which were exported from `internal/utils` for reuse). Supports ES2025 named-duplicate alternatives.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-useless-backreference
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-backreference.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).