### PR TITLE
feat: port rule no-unexpected-multiline

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,6 +216,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_this_before_super"
 	"github.com/web-infra-dev/rslint/internal/rules/no_throw_literal"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unexpected_multiline"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef_init"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unmodified_loop_condition"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unneeded_ternary"
@@ -746,6 +747,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-prototype-builtins", no_prototype_builtins.NoPrototypeBuiltinsRule)
 	GlobalRuleRegistry.Register("require-yield", require_yield.RequireYieldRule)
 	GlobalRuleRegistry.Register("symbol-description", symbol_description.SymbolDescriptionRule)
+	GlobalRuleRegistry.Register("no-unexpected-multiline", no_unexpected_multiline.NoUnexpectedMultilineRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/no_unexpected_multiline/no_unexpected_multiline.go
+++ b/internal/rules/no_unexpected_multiline/no_unexpected_multiline.go
@@ -1,0 +1,192 @@
+package no_unexpected_multiline
+
+import (
+	"regexp"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var regexFlagMatcher = regexp.MustCompile(`^[gimsuy]+$`)
+
+var messageFunction = rule.RuleMessage{
+	Id:          "function",
+	Description: "Unexpected newline between function and ( of function call.",
+}
+var messageProperty = rule.RuleMessage{
+	Id:          "property",
+	Description: "Unexpected newline between object and [ of property access.",
+}
+var messageTaggedTemplate = rule.RuleMessage{
+	Id:          "taggedTemplate",
+	Description: "Unexpected newline between template tag and template literal.",
+}
+var messageDivision = rule.RuleMessage{
+	Id:          "division",
+	Description: "Unexpected newline between numerator and division operator.",
+}
+
+// https://eslint.org/docs/latest/rules/no-unexpected-multiline
+var NoUnexpectedMultilineRule = rule.Rule{
+	Name: "no-unexpected-multiline",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		sf := ctx.SourceFile
+		text := sf.Text()
+		lineMap := sf.ECMALineMap()
+
+		// reportTokenBreakAfter checks whether the next non-trivia token after
+		// `expr` starts on a different line than the source position of
+		// `expr.End()`. If so, it reports a diagnostic spanning that next
+		// token. Mirrors ESLint's checkForBreakAfter — tsgo's `Expression.End()`
+		// already accounts for trailing parens (parens are explicit nodes), so
+		// we don't need ESLint's `isNotClosingParenToken` filter.
+		reportTokenBreakAfter := func(expr *ast.Node, msg rule.RuleMessage) {
+			exprEnd := expr.End()
+			tokenStart := scanner.SkipTrivia(text, exprEnd)
+			if tokenStart >= len(text) {
+				return
+			}
+			exprEndLine := scanner.ComputeLineOfPosition(lineMap, exprEnd)
+			tokenLine := scanner.ComputeLineOfPosition(lineMap, tokenStart)
+			if exprEndLine == tokenLine {
+				return
+			}
+			// ESLint reports a single-character range for `[` / `(`. Don't use
+			// scanner.GetRangeOfTokenAtPosition here — for the tagged-template
+			// case it would expand to the entire `\`...\`` token, breaking
+			// parity with ESLint's `column .. column+1` location.
+			ctx.ReportRange(core.NewTextRange(tokenStart, tokenStart+1), msg)
+		}
+
+		return rule.RuleListeners{
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				// `node.optional` (ESTree) maps to IsOptionalChainRoot — only
+				// the link with the literal `?.` token, not later
+				// continuations. Without this guard, `b?.[c]` would be flagged.
+				if ast.IsOptionalChainRoot(node) {
+					return
+				}
+				expr := node.AsElementAccessExpression().Expression
+				reportTokenBreakAfter(expr, messageProperty)
+			},
+
+			ast.KindCallExpression: func(node *ast.Node) {
+				if ast.IsOptionalChainRoot(node) {
+					return
+				}
+				call := node.AsCallExpression()
+				if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+					return
+				}
+				reportTokenBreakAfter(call.Expression, messageFunction)
+			},
+
+			ast.KindTaggedTemplateExpression: func(node *ast.Node) {
+				tte := node.AsTaggedTemplateExpression()
+				template := tte.Template
+				// Position of the backtick that opens the template literal.
+				backtick := scanner.SkipTrivia(text, template.Pos())
+				if backtick >= len(text) {
+					return
+				}
+				// `template.Pos() - 1` lands on the last character of the
+				// previous sibling (Tag, or the closing `>` of TypeArguments
+				// when present). Avoids a separate token rewind.
+				prevPos := template.Pos() - 1
+				if prevPos < 0 {
+					return
+				}
+				prevLine := scanner.ComputeLineOfPosition(lineMap, prevPos)
+				backtickLine := scanner.ComputeLineOfPosition(lineMap, backtick)
+				if prevLine == backtickLine {
+					return
+				}
+				ctx.ReportRange(core.NewTextRange(backtick, backtick+1), messageTaggedTemplate)
+			},
+
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				bin := node.AsBinaryExpression()
+				if bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindSlashToken {
+					return
+				}
+				// Mirror ESLint's `BinaryExpression > BinaryExpression.left`
+				// selector. ESTree drops parens, so `(a/b)/c` matches; tsgo
+				// keeps them as explicit nodes. WalkUpParenthesizedExpressions
+				// returns the topmost paren wrapper above `node` (or `node`
+				// itself if unwrapped) — that's the entity whose direct
+				// parent the selector consults.
+				outerChild := ast.WalkUpParenthesizedExpressions(node)
+				outer := outerChild.Parent
+				if outer == nil || outer.Kind != ast.KindBinaryExpression {
+					return
+				}
+				outerBin := outer.AsBinaryExpression()
+				if outerBin.OperatorToken == nil || outerBin.OperatorToken.Kind != ast.KindSlashToken {
+					return
+				}
+				if outerBin.Left != outerChild {
+					return
+				}
+
+				// secondSlash = outer's `/`. Find the token immediately after.
+				// ESLint requires `secondSlash.range[1] === tokenAfter.range[0]`
+				// — no trivia between the slash and the flag identifier — so
+				// we don't call SkipTrivia here.
+				afterPos := outerBin.OperatorToken.End()
+				if afterPos >= len(text) {
+					return
+				}
+				identEnd, ok := scanIdentifier(text, afterPos)
+				if !ok {
+					return
+				}
+				if !regexFlagMatcher.MatchString(text[afterPos:identEnd]) {
+					return
+				}
+
+				// checkForBreakAfter(node.left): compare lines of
+				// `bin.Left.End()` (= last char of the numerator, possibly the
+				// closing `)` of a paren-wrapped left) and the first `/`
+				// (= bin.OperatorToken). Use TrimNodeTextRange so we land on
+				// the trimmed start of the slash, not its leading trivia.
+				firstSlashRange := utils.TrimNodeTextRange(sf, bin.OperatorToken)
+				leftEnd := bin.Left.End()
+				leftLine := scanner.ComputeLineOfPosition(lineMap, leftEnd)
+				slashLine := scanner.ComputeLineOfPosition(lineMap, firstSlashRange.Pos())
+				if leftLine == slashLine {
+					return
+				}
+				ctx.ReportRange(firstSlashRange, messageDivision)
+			},
+		}
+	},
+}
+
+// scanIdentifier walks the identifier starting at `pos` (if any) and returns
+// the position right after its last character. Uses the tsgo scanner's
+// Unicode-aware identifier helpers and full UTF-8 rune decoding so we agree
+// with the parser on what counts as an identifier — mirroring ESLint's
+// `tokenAfterOperator.type === "Identifier"` check by construction. Returns
+// ok=false when no identifier starts at `pos`.
+func scanIdentifier(text string, pos int) (int, bool) {
+	if pos >= len(text) {
+		return pos, false
+	}
+	startCh, size := utf8.DecodeRuneInString(text[pos:])
+	if startCh == utf8.RuneError || !scanner.IsIdentifierStart(startCh) {
+		return pos, false
+	}
+	end := pos + size
+	for end < len(text) {
+		ch, sz := utf8.DecodeRuneInString(text[end:])
+		if ch == utf8.RuneError || !scanner.IsIdentifierPart(ch) {
+			break
+		}
+		end += sz
+	}
+	return end, true
+}

--- a/internal/rules/no_unexpected_multiline/no_unexpected_multiline.md
+++ b/internal/rules/no_unexpected_multiline/no_unexpected_multiline.md
@@ -1,0 +1,47 @@
+# no-unexpected-multiline
+
+## Rule Details
+
+JavaScript inserts semicolons automatically (ASI), but only at certain positions. When a line break appears between an expression and tokens like `(`, `[`, `` ` ``, or `/`, the parser treats the next line as a continuation rather than a new statement, which often surprises the author.
+
+This rule reports four cases where a newline produces an unintended continuation:
+
+- A function call where `(` opens on the next line.
+- A computed property access where `[` opens on the next line.
+- A tagged template where the `` ` `` opens on the next line.
+- A division by a value that visually resembles a regular-expression literal (e.g. `foo / bar /gym`), where what looks like a regex is actually parsed as two divisions.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var a = b
+(x || y).doSomething()
+
+var a = b
+[a, b, c].forEach(doSomething)
+
+let x = function() {}
+`hello`
+
+foo
+/ bar /gym
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var a = b;
+(x || y).doSomething()
+
+var a = b;
+[a, b, c].forEach(doSomething)
+
+let x = function() {};
+`hello`
+
+foo / bar / gym
+```
+
+## Original Documentation
+
+- [ESLint no-unexpected-multiline](https://eslint.org/docs/latest/rules/no-unexpected-multiline)

--- a/internal/rules/no_unexpected_multiline/no_unexpected_multiline_test.go
+++ b/internal/rules/no_unexpected_multiline/no_unexpected_multiline_test.go
@@ -1,0 +1,646 @@
+package no_unexpected_multiline
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnexpectedMultilineRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnexpectedMultilineRule,
+		// Valid cases — ported from ESLint's `tests/lib/rules/no-unexpected-multiline.js`
+		[]rule_tester.ValidTestCase{
+			{Code: `(x || y).aFunction()`},
+			{Code: `[a, b, c].forEach(doSomething)`},
+			{Code: `var a = b;
+(x || y).doSomething()`},
+			{Code: `var a = b
+;(x || y).doSomething()`},
+			{Code: `var a = b
+void (x || y).doSomething()`},
+			{Code: `var a = b;
+[1, 2, 3].forEach(console.log)`},
+			{Code: `var a = b
+void [1, 2, 3].forEach(console.log)`},
+			{Code: `"abc\
+(123)"`},
+			{Code: `var a = (
+(123)
+)`},
+			{Code: `f(
+(x)
+)`},
+			{Code: `(
+function () {}
+)[1]`},
+			{Code: "let x = function() {};\n   `hello`"},
+			{Code: "let x = function() {}\nx `hello`"},
+			{Code: "String.raw `Hi\n${2+3}!`;"},
+			{Code: "x\n.y\nz `Valid Test Case`"},
+			{Code: "f(x\n)`Valid Test Case`"},
+			{Code: "x.\ny `Valid Test Case`"},
+			{Code: "(x\n)`Valid Test Case`"},
+			{Code: `
+                foo
+                / bar /2
+            `},
+			{Code: `
+                foo
+                / bar / mgy
+            `},
+			{Code: `
+                foo
+                / bar /
+                gym
+            `},
+			{Code: `
+                foo
+                / bar
+                / ygm
+            `},
+			{Code: `
+                foo
+                / bar /GYM
+            `},
+			{Code: `
+                foo
+                / bar / baz
+            `},
+			{Code: `foo /bar/g`},
+			{Code: `
+                foo
+                /denominator/
+                2
+            `},
+			{Code: `
+                foo
+                / /abc/
+            `},
+			{Code: `
+                5 / (5
+                / 5)
+            `},
+
+			// https://github.com/eslint/eslint/issues/11650 — TypeScript generic
+			// type-argument forms.
+			{Code: `
+                tag<generic>` + "`" + `
+                    multiline
+                ` + "`" + `;
+            `},
+			{Code: `
+                tag<
+                  generic
+                >` + "`" + `
+                    multiline
+                ` + "`" + `;
+            `},
+			{Code: `
+                tag<
+                  generic
+                >` + "`multiline`" + `;
+            `},
+
+			// Optional chaining — ESLint skips when the link itself carries
+			// `?.`, so all four forms are valid regardless of newlines.
+			{Code: "var a = b\n  ?.(x || y).doSomething()"},
+			{Code: "var a = b\n  ?.[a, b, c].forEach(doSomething)"},
+			{Code: "var a = b?.\n  (x || y).doSomething()"},
+			{Code: "var a = b?.\n  [a, b, c].forEach(doSomething)"},
+
+			// Class fields where ASI separates the members rather than chaining
+			// them into a single MemberExpression.
+			{Code: "class C { field1\n[field2]; }"},
+			{Code: "class C { field1\n*gen() {} }"},
+			// Arrow function initializer doesn't connect to the next member.
+			{Code: "class C { field1 = () => {}\n[field2]; }"},
+			{Code: "class C { field1 = () => {}\n*gen() {} }"},
+
+			// tsgo-specific edges (locking in behavior beyond the ESLint suite):
+			// Element access on the same line as the receiver — common case.
+			{Code: `b[c]`},
+			// Tagged template attached on the same line — common case.
+			{Code: "tag`hello`"},
+			// Optional chain continuation on a new line, but the call/access
+			// stays single-line — `?.` is on the inner link, not this one.
+			{Code: "a?.b\n.c"},
+			// Sequence-style division `(a, b) / c / d`: the inner `/` is on
+			// a sequence's right operand, not a `/` itself, so the listener
+			// shouldn't activate the regex-flag check.
+			{Code: `(a, b) / c / d`},
+			// Compound assignment `/=` — must NOT match the slash listener.
+			{Code: `let x = 1; x /= 2`},
+			// Locks in upstream "no-newline" branch: regex-flag match requires
+			// the identifier to be IMMEDIATELY after the slash (no trivia).
+			// Here there's a space, so the check must skip even though the
+			// identifier text matches `[gimsuy]+`.
+			{Code: "foo / bar / g"},
+			// Locks in identifier-only branch: numeric token after slash isn't
+			// an Identifier, so the check skips even when adjacent.
+			{Code: "foo\n/ bar /2"},
+			// Same-line division+regex-flags shouldn't trigger.
+			{Code: `foo / bar /gym`},
+			// Multi-level paren wrap above the inner division — exercises the
+			// paren-skipping ancestor walk.
+			{Code: "((foo / bar)) / 2"},
+			// `(a/b)/c` form: ESTree drops the inner parens so the selector
+			// matches, but `c` is numeric so no flag-identifier — same line
+			// also keeps it valid even if it did match.
+			{Code: `(foo / bar) / 5`},
+			// Optional-chain continuation call (outer call has no `?.`) but
+			// stays single-line.
+			{Code: "a?.b()"},
+			// TS non-null receiver, single line.
+			{Code: `b![c]`},
+			// TS `as` cast wrapper around the receiver.
+			{Code: `(b as any)[c]`},
+			// Empty-arg call on its own line — ESLint skips because the
+			// `()` form is unambiguous.
+			{Code: "b\n()"},
+			// Optional-chain element access (root) — skipped regardless of
+			// the newline before `[`.
+			{Code: "a\n?.[b]"},
+			// Chained member access where parens disambiguate but no
+			// newline is present.
+			{Code: `(x || y).aFunction()`},
+
+			// === Real-world IIFE / module patterns ===
+			// IIFE with ASI guard `;(function...)` — the rule must NOT
+			// flag this idiom because the `;` separates statements.
+			{Code: "var a = b;\n;(function() {})()"},
+			// UMD-style IIFE on its own — single statement, no newline issue.
+			{Code: "(function () {\n  return 1;\n})();"},
+			// Method chain across lines, each call is single-line — common
+			// builder pattern (`.then().catch()`).
+			{Code: "fetch(url)\n.then(r => r.json())\n.catch(handle)"},
+			// jQuery-style chain spread across lines.
+			{Code: "$(selector)\n  .find('.x')\n  .each(fn)"},
+
+			// === Real-world generic / type-argument patterns ===
+			// Generic call with type arguments — same line, common TS case.
+			{Code: "fn<string>(x)"},
+			// Generic call wrapped in parens, then property access on same line.
+			{Code: "(fn<string>(x)).y"},
+			// Multi-line type argument list followed by call args on the
+			// same line as `>` — common in styled-components style code.
+			{Code: "fn<\n  Props,\n  State\n>(x)"},
+			// Generic-typed function reference with the call args on a new
+			// line — ESLint compares the callee end (`fn`) to the next token
+			// (`<`), which is on the SAME line, so no report.
+			{Code: "fn<string>\n(x)"},
+			// Type assertion wrapping a function call as receiver, single line.
+			{Code: "(getX() as Foo).y"},
+
+			// === Numeric / regex disambiguation in the wild ===
+			// Pure regex literal at start of statement — not a division.
+			{Code: "/foo/g.test(x)"},
+			// Multiplication that visually resembles a regex pattern.
+			{Code: "a * b / c * d"},
+			// Modulo not affected by the rule.
+			{Code: "a\n% b"},
+			// `**` exponentiation, not `/`.
+			{Code: "a\n** b"},
+			// Bracket notation as a numeric index, single line.
+			{Code: "arr[0]"},
+			// Nested computed access, single line.
+			{Code: "obj['a']['b']"},
+
+			// === Template literal real-world patterns ===
+			// Multi-line template literal content — newlines INSIDE the
+			// template, not before the backtick — must NOT report.
+			{Code: "tag`first\nsecond\nthird`"},
+			// Tagged template where Tag is a generic-typed call (TS).
+			{Code: "fn<T>`x`"},
+			// Plain template literal at statement position, no tag — outside
+			// the rule's scope (no TaggedTemplateExpression).
+			{Code: "`hello`"},
+			{Code: "let x = 1;\n`hello`"},
+
+			// === Optional chaining real cases ===
+			// Optional element access continuation across lines — only the
+			// root has `?.`, but it's still on the same chain so ESLint's
+			// `optional: false` would fire... but the property access here
+			// stays single-line, so no break.
+			{Code: "a?.b[c]"},
+			// Optional call followed by template on next line — handled in
+			// invalid section (the `?.` only skips the CallExpression
+			// listener, not the TaggedTemplate listener).
+
+			// === Receiver wrappers that must not bleed past boundaries ===
+			// Class member with computed name on the SAME line as the field
+			// keyword — must not be flagged.
+			{Code: "class C { [a]; }"},
+			// Class with static block — internal newlines don't reach the
+			// rule's listeners.
+			{Code: "class C {\n  static { console.log(1); }\n}"},
+
+			// === Async / generator function bodies ===
+			// Async function with newline between body and tagged template
+			// — but the template is INSIDE the function body, not after.
+			{Code: "async function f() {\n  return tag`x`;\n}"},
+			// Generator function call with arg on same line.
+			{Code: "function* g() { yield 1; }\ng().next()"},
+
+			// === Cases that look like ASI hazards but aren't ===
+			// `return` on its own line ends the statement (ASI inserts
+			// semicolon BEFORE the next-line content).
+			{Code: "function f() {\n  return\n  (1).toString()\n}"},
+			// `throw` similarly — ASI inserts semicolon.
+			{Code: "function f() {\n  throw new Error()\n}"},
+
+			// === No leading expression — rule shouldn't fire ===
+			// Standalone array literal as expression statement.
+			{Code: "[1, 2, 3]"},
+			// Standalone parenthesized expression statement.
+			{Code: "(1 + 2)"},
+			// Standalone tagged template at statement start.
+			{Code: "tag`x`"},
+
+			// === Multi-byte / Unicode content ===
+			// Unicode identifier as receiver, then computed access on same
+			// line — must scan correctly.
+			{Code: `日本[c]`},
+			// Multi-byte content inside string before the rule's listeners
+			// fire on a separate expression.
+			{Code: "var a = '日本';\n[1].forEach(f)"},
+			// Emoji inside template literal content.
+			{Code: "tag`hi 🎉`"},
+			// Unicode identifier immediately after the second `/` — must NOT
+			// match `^[gimsuy]+$` (ASCII regex), so no division report. This
+			// stress-tests the UTF-8 decoding in scanIdentifier.
+			{Code: "foo\n/bar/日本"},
+			// Unicode identifier as numerator with division across lines —
+			// the rule's checks are byte-position based but should treat the
+			// multi-byte name as a single identifier source-text-wise.
+			{Code: "日本 /bar/g"},
+		},
+		// Invalid cases — ported from ESLint
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: "var a = b\n(x || y).doSomething()",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "var a = (a || b)\n(x || y).doSomething()",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "var a = (a || b)\n(x).doSomething()",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "var a = b\n[a, b, c].forEach(doSomething)",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "var a = b\n    (x || y).doSomething()",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 5, EndLine: 2, EndColumn: 6,
+				}},
+			},
+			{
+				Code: "var a = b\n  [a, b, c].forEach(doSomething)",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      2, Column: 3, EndLine: 2, EndColumn: 4,
+				}},
+			},
+			{
+				Code: "let x = function() {}\n `hello`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "taggedTemplate",
+					Line:      2, Column: 2, EndLine: 2, EndColumn: 3,
+				}},
+			},
+			{
+				Code: "let x = function() {}\nx\n`hello`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "taggedTemplate",
+					Line:      3, Column: 1, EndLine: 3, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "x\n.y\nz\n`Invalid Test Case`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "taggedTemplate",
+					Line:      4, Column: 1, EndLine: 4, EndColumn: 2,
+				}},
+			},
+			{
+				Code: `
+                foo
+                / bar /gym
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      3, Column: 17, EndLine: 3, EndColumn: 18,
+				}},
+			},
+			{
+				Code: `
+                foo
+                / bar /g
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      3, Column: 17, EndLine: 3, EndColumn: 18,
+				}},
+			},
+			{
+				Code: `
+                foo
+                / bar /g.test(baz)
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      3, Column: 17, EndLine: 3, EndColumn: 18,
+				}},
+			},
+			{
+				Code: `
+                foo
+                /bar/gimuygimuygimuy.test(baz)
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      3, Column: 17, EndLine: 3, EndColumn: 18,
+				}},
+			},
+			{
+				Code: `
+                foo
+                /bar/s.test(baz)
+            `,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      3, Column: 17, EndLine: 3, EndColumn: 18,
+				}},
+			},
+
+			// https://github.com/eslint/eslint/issues/11650 — TS generics with
+			// a block comment between `>` and the template.
+			{
+				Code: "const x = aaaa<\n  test\n>/*\ntest\n*/`foo`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "taggedTemplate",
+					Line:      5, Column: 3, EndLine: 5, EndColumn: 4,
+				}},
+			},
+
+			// Class fields where the parser keeps the initializer chained
+			// across the newline.
+			{
+				Code: "class C { field1 = obj\n[field2]; }",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "class C { field1 = function() {}\n[field2]; }",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+
+			// Extra coverage beyond upstream — locks in tsgo-specific shape
+			// behavior the ESLint suite doesn't exercise.
+
+			// Paren-wrapped numerator: ESTree strips parens so the inner `/`
+			// matches the selector; tsgo preserves them, so the
+			// WalkUpParenthesizedExpressions skip is required for parity.
+			// `(foo)\n/ bar /gym` — first `/` on the next line.
+			{
+				Code: "(foo)\n/ bar /gym",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Multi-line MemberExpression where the receiver itself spans
+			// lines — break is between the `)` of the receiver and `[`.
+			{
+				Code: "(a\n||b)\n[c]",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      3, Column: 1, EndLine: 3, EndColumn: 2,
+				}},
+			},
+			// TS non-null assertion in front of the computed access — break
+			// happens between `!` and `[`.
+			{
+				Code: "b!\n[c]",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// TS `as` cast as receiver of a call.
+			{
+				Code: "(b as any)\n(c)",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Tagged template where Tag is a CallExpression — both
+			// "function" and "taggedTemplate" listeners can fire, but here
+			// the call args are on the same line, so only the template
+			// break should trigger.
+			{
+				Code: "tag(x)\n`hello`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "taggedTemplate",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Template with substitutions still triggers when separated.
+			{
+				Code: "tag\n`hi${x}!`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "taggedTemplate",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Optional-chain CONTINUATION call (outer call lacks `?.`)
+			// across a line break — should still flag because ESLint's
+			// `node.optional` is false on continuations.
+			{
+				Code: "a?.b\n(c)",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Block comment between numerator and `/` should still flag —
+			// trivia doesn't change the line of the slash.
+			{
+				Code: "foo /* x */\n/ bar /g",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+
+			// === Real-world ASI traps ===
+			// Module-pattern IIFE typo: missing `;` between two var decls.
+			{
+				Code: "var a = foo\n(function () {})()",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// `const X = arr` followed by destructure-looking line — common
+			// developer mistake.
+			{
+				Code: "const x = arr\n[0]",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Return-value mistakenly continues onto next line via call.
+			{
+				Code: "function f() {\n  return getThing\n  (x)\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      3, Column: 3, EndLine: 3, EndColumn: 4,
+				}},
+			},
+
+			// === Deeply nested receivers ===
+			// PropertyAccess chain as receiver of a computed access across
+			// a line break.
+			{
+				Code: "obj.a.b.c\n[d]",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Call result as receiver of a tagged template across lines.
+			{
+				Code: "fn().g()\n`x`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "taggedTemplate",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Element access as receiver of a call across lines.
+			{
+				Code: "obj[k]\n(x)",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+
+			// === TS-only constructs as the receiver ===
+			// `satisfies` clause on the receiver of a call.
+			{
+				Code: "(x satisfies Foo)\n(y)",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// `as const` cast as receiver of an element access.
+			{
+				Code: "(arr as const)\n[0]",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// === Division flag exhaustive coverage ===
+			// All six valid regex flags (`gimsuy`) spelled out immediately
+			// after the second slash — must match `^[gimsuy]+$` and report
+			// at the FIRST slash on line 2.
+			{
+				Code: "foo\n/bar/gimsuy",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Single-flag minimal repro: first `/` on line 2 col 1.
+			{
+				Code: "x\n/y/i",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+
+			// === Optional call as Tag of a tagged template ===
+			// `fn?.(x)\n\`hello\`` — the call's `?.` opts only the
+			// CallExpression listener out; the TaggedTemplate listener still
+			// fires on the break between `)` and the backtick.
+			{
+				Code: "fn?.(x)\n`hello`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "taggedTemplate",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Tagged template after a call-with-args, all separated by
+			// newlines — only the LAST break (between `)` and backtick)
+			// triggers; the `(x)` args are immediately after `tag`.
+			{
+				Code: "tag(x)\n\n`hi`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "taggedTemplate",
+					Line:      3, Column: 1, EndLine: 3, EndColumn: 2,
+				}},
+			},
+			// Multi-line break between receiver and `[` — many blank lines
+			// in between, all should be one diagnostic at the `[`.
+			{
+				Code: "var a = b\n\n\n[c]",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      4, Column: 1, EndLine: 4, EndColumn: 2,
+				}},
+			},
+
+			// === Class field continuations beyond upstream ===
+			// Class field initializer that's a chained call across lines.
+			{
+				Code: "class C { field = obj.method()\n[k]; }",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Class field initializer is a tagged template — the field's
+			// initializer crosses into a `[k]` access.
+			{
+				Code: "class C { field = tag`x`\n[k]; }",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -341,6 +341,7 @@ export default defineConfig({
     './tests/eslint/rules/no-multi-str.test.ts',
     './tests/eslint/rules/no-nested-ternary.test.ts',
     './tests/eslint/rules/no-nonoctal-decimal-escape.test.ts',
+    './tests/eslint/rules/no-unexpected-multiline.test.ts',
     './tests/eslint/rules/object-shorthand.test.ts',
     './tests/eslint/rules/no-octal.test.ts',
     './tests/eslint/rules/no-octal-escape.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unexpected-multiline.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unexpected-multiline.test.ts.snap
@@ -1,0 +1,1019 @@
+// Rstest Snapshot v1
+
+exports[`no-unexpected-multiline > invalid 1`] = `
+{
+  "code": "var a = b
+(x || y).doSomething()",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between function and ( of function call.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 2`] = `
+{
+  "code": "var a = (a || b)
+(x || y).doSomething()",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between function and ( of function call.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 3`] = `
+{
+  "code": "var a = (a || b)
+(x).doSomething()",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between function and ( of function call.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 4`] = `
+{
+  "code": "var a = b
+[a, b, c].forEach(doSomething)",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 5`] = `
+{
+  "code": "var a = b
+    (x || y).doSomething()",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between function and ( of function call.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 6`] = `
+{
+  "code": "var a = b
+  [a, b, c].forEach(doSomething)",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 7`] = `
+{
+  "code": "let x = function() {}
+ \`hello\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between template tag and template literal.",
+      "messageId": "taggedTemplate",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 2,
+        },
+        "start": {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 8`] = `
+{
+  "code": "let x = function() {}
+x
+\`hello\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between template tag and template literal.",
+      "messageId": "taggedTemplate",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 9`] = `
+{
+  "code": "x
+.y
+z
+\`Invalid Test Case\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between template tag and template literal.",
+      "messageId": "taggedTemplate",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 10`] = `
+{
+  "code": "
+                foo
+                / bar /gym
+            ",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between numerator and division operator.",
+      "messageId": "division",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 11`] = `
+{
+  "code": "
+                foo
+                / bar /g
+            ",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between numerator and division operator.",
+      "messageId": "division",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 12`] = `
+{
+  "code": "
+                foo
+                / bar /g.test(baz)
+            ",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between numerator and division operator.",
+      "messageId": "division",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 13`] = `
+{
+  "code": "
+                foo
+                /bar/gimuygimuygimuy.test(baz)
+            ",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between numerator and division operator.",
+      "messageId": "division",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 14`] = `
+{
+  "code": "
+                foo
+                /bar/s.test(baz)
+            ",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between numerator and division operator.",
+      "messageId": "division",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 15`] = `
+{
+  "code": "const x = aaaa<
+  test
+>/*
+test
+*/\`foo\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between template tag and template literal.",
+      "messageId": "taggedTemplate",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 16`] = `
+{
+  "code": "class C { field1 = obj
+[field2]; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 17`] = `
+{
+  "code": "class C { field1 = function() {}
+[field2]; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 18`] = `
+{
+  "code": "var a = foo
+(function () {})()",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between function and ( of function call.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 19`] = `
+{
+  "code": "const x = arr
+[0]",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 20`] = `
+{
+  "code": "obj.a.b.c
+[d]",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 21`] = `
+{
+  "code": "fn().g()
+\`x\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between template tag and template literal.",
+      "messageId": "taggedTemplate",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 22`] = `
+{
+  "code": "obj[k]
+(x)",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between function and ( of function call.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 23`] = `
+{
+  "code": "b!
+[c]",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 24`] = `
+{
+  "code": "(b as any)
+(c)",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between function and ( of function call.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 25`] = `
+{
+  "code": "(x satisfies Foo)
+(y)",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between function and ( of function call.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 26`] = `
+{
+  "code": "(arr as const)
+[0]",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 27`] = `
+{
+  "code": "foo
+/bar/gimsuy",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between numerator and division operator.",
+      "messageId": "division",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 28`] = `
+{
+  "code": "x
+/y/i",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between numerator and division operator.",
+      "messageId": "division",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 29`] = `
+{
+  "code": "foo /* x */
+/ bar /g",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between numerator and division operator.",
+      "messageId": "division",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 30`] = `
+{
+  "code": "tag
+\`hi\${x}!\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between template tag and template literal.",
+      "messageId": "taggedTemplate",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 31`] = `
+{
+  "code": "tag(x)
+\`hello\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between template tag and template literal.",
+      "messageId": "taggedTemplate",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 32`] = `
+{
+  "code": "fn?.(x)
+\`hello\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between template tag and template literal.",
+      "messageId": "taggedTemplate",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 33`] = `
+{
+  "code": "a?.b
+(c)",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between function and ( of function call.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 34`] = `
+{
+  "code": "var a = b
+
+
+[c]",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 35`] = `
+{
+  "code": "tag(x)
+
+\`hi\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between template tag and template literal.",
+      "messageId": "taggedTemplate",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 36`] = `
+{
+  "code": "class C { field = obj.method()
+[k]; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unexpected-multiline > invalid 37`] = `
+{
+  "code": "class C { field = tag\`x\`
+[k]; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected newline between object and [ of property access.",
+      "messageId": "property",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unexpected-multiline",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unexpected-multiline.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unexpected-multiline.test.ts
@@ -1,0 +1,264 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unexpected-multiline', {
+  valid: [
+    '(x || y).aFunction()',
+    '[a, b, c].forEach(doSomething)',
+    'var a = b;\n(x || y).doSomething()',
+    'var a = b\n;(x || y).doSomething()',
+    'var a = b\nvoid (x || y).doSomething()',
+    'var a = b;\n[1, 2, 3].forEach(console.log)',
+    'var a = b\nvoid [1, 2, 3].forEach(console.log)',
+    '"abc\\\n(123)"',
+    'var a = (\n(123)\n)',
+    'f(\n(x)\n)',
+    '(\nfunction () {}\n)[1]',
+    'let x = function() {};\n   `hello`',
+    'let x = function() {}\nx `hello`',
+    'String.raw `Hi\n${2+3}!`;',
+    'x\n.y\nz `Valid Test Case`',
+    'f(x\n)`Valid Test Case`',
+    'x.\ny `Valid Test Case`',
+    '(x\n)`Valid Test Case`',
+    '\n                foo\n                / bar /2\n            ',
+    '\n                foo\n                / bar / mgy\n            ',
+    '\n                foo\n                / bar /\n                gym\n            ',
+    '\n                foo\n                / bar\n                / ygm\n            ',
+    '\n                foo\n                / bar /GYM\n            ',
+    '\n                foo\n                / bar / baz\n            ',
+    'foo /bar/g',
+    '\n                foo\n                /denominator/\n                2\n            ',
+    '\n                foo\n                / /abc/\n            ',
+    '\n                5 / (5\n                / 5)\n            ',
+
+    // TypeScript generic type-argument forms (issue #11650).
+    '\n                tag<generic>`\n                    multiline\n                `;\n            ',
+    '\n                tag<\n                  generic\n                >`\n                    multiline\n                `;\n            ',
+    '\n                tag<\n                  generic\n                >`multiline`;\n            ',
+
+    // Optional chaining — `?.` opts the link out of the rule.
+    'var a = b\n  ?.(x || y).doSomething()',
+    'var a = b\n  ?.[a, b, c].forEach(doSomething)',
+    'var a = b?.\n  (x || y).doSomething()',
+    'var a = b?.\n  [a, b, c].forEach(doSomething)',
+
+    // Class fields where ASI separates members.
+    'class C { field1\n[field2]; }',
+    'class C { field1\n*gen() {} }',
+    'class C { field1 = () => {}\n[field2]; }',
+    'class C { field1 = () => {}\n*gen() {} }',
+
+    // === Real-world IIFE / chain patterns ===
+    'var a = b;\n;(function() {})()',
+    '(function () {\n  return 1;\n})();',
+    'fetch(url)\n.then(r => r.json())\n.catch(handle)',
+    '$(selector)\n  .find(".x")\n  .each(fn)',
+
+    // === TS generics — same line / multi-line type args ===
+    'fn<string>(x)',
+    '(fn<string>(x)).y',
+    'fn<\n  Props,\n  State\n>(x)',
+    // ESLint treats `<` as the next token after `fn`, on the SAME line.
+    'fn<string>\n(x)',
+
+    // === Disambiguation cases ===
+    '/foo/g.test(x)',
+    'a * b / c * d',
+    'a\n% b',
+    'arr[0]',
+    "obj['a']['b']",
+    'b[c]',
+    'b![c]',
+    '(b as any)[c]',
+
+    // === Template real-world ===
+    'tag`hello`',
+    'tag`first\nsecond\nthird`',
+    'fn<T>`x`',
+    '`hello`',
+
+    // === Optional chaining variants ===
+    'a?.b\n.c',
+    'a?.b()',
+    'a\n?.[b]',
+
+    // === Operators that are NOT `/` ===
+    '(a, b) / c / d',
+    'let x = 1; x /= 2',
+    'foo / bar / g',
+    'foo\n/ bar /2',
+    '((foo / bar)) / 2',
+    '(foo / bar) / 5',
+
+    // === ASI-already-inserted statements ===
+    '[1, 2, 3]',
+    '(1 + 2)',
+    'function f() {\n  return\n  (1).toString()\n}',
+  ],
+  invalid: [
+    {
+      code: 'var a = b\n(x || y).doSomething()',
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: 'var a = (a || b)\n(x || y).doSomething()',
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: 'var a = (a || b)\n(x).doSomething()',
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: 'var a = b\n[a, b, c].forEach(doSomething)',
+      errors: [{ messageId: 'property' }],
+    },
+    {
+      code: 'var a = b\n    (x || y).doSomething()',
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: 'var a = b\n  [a, b, c].forEach(doSomething)',
+      errors: [{ messageId: 'property' }],
+    },
+    {
+      code: 'let x = function() {}\n `hello`',
+      errors: [{ messageId: 'taggedTemplate' }],
+    },
+    {
+      code: 'let x = function() {}\nx\n`hello`',
+      errors: [{ messageId: 'taggedTemplate' }],
+    },
+    {
+      code: 'x\n.y\nz\n`Invalid Test Case`',
+      errors: [{ messageId: 'taggedTemplate' }],
+    },
+    {
+      code: '\n                foo\n                / bar /gym\n            ',
+      errors: [{ messageId: 'division' }],
+    },
+    {
+      code: '\n                foo\n                / bar /g\n            ',
+      errors: [{ messageId: 'division' }],
+    },
+    {
+      code: '\n                foo\n                / bar /g.test(baz)\n            ',
+      errors: [{ messageId: 'division' }],
+    },
+    {
+      code: '\n                foo\n                /bar/gimuygimuygimuy.test(baz)\n            ',
+      errors: [{ messageId: 'division' }],
+    },
+    {
+      code: '\n                foo\n                /bar/s.test(baz)\n            ',
+      errors: [{ messageId: 'division' }],
+    },
+    {
+      code: 'const x = aaaa<\n  test\n>/*\ntest\n*/`foo`',
+      errors: [{ messageId: 'taggedTemplate' }],
+    },
+    {
+      code: 'class C { field1 = obj\n[field2]; }',
+      errors: [{ messageId: 'property' }],
+    },
+    {
+      code: 'class C { field1 = function() {}\n[field2]; }',
+      errors: [{ messageId: 'property' }],
+    },
+
+    // === Real-world ASI traps ===
+    {
+      code: 'var a = foo\n(function () {})()',
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: 'const x = arr\n[0]',
+      errors: [{ messageId: 'property' }],
+    },
+    {
+      code: 'obj.a.b.c\n[d]',
+      errors: [{ messageId: 'property' }],
+    },
+    {
+      code: 'fn().g()\n`x`',
+      errors: [{ messageId: 'taggedTemplate' }],
+    },
+    {
+      code: 'obj[k]\n(x)',
+      errors: [{ messageId: 'function' }],
+    },
+
+    // === TS-only receiver wrappers across lines ===
+    {
+      code: 'b!\n[c]',
+      errors: [{ messageId: 'property' }],
+    },
+    {
+      code: '(b as any)\n(c)',
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: '(x satisfies Foo)\n(y)',
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: '(arr as const)\n[0]',
+      errors: [{ messageId: 'property' }],
+    },
+
+    // === Division flag exhaustive ===
+    {
+      code: 'foo\n/bar/gimsuy',
+      errors: [{ messageId: 'division' }],
+    },
+    {
+      code: 'x\n/y/i',
+      errors: [{ messageId: 'division' }],
+    },
+    {
+      code: 'foo /* x */\n/ bar /g',
+      errors: [{ messageId: 'division' }],
+    },
+
+    // === Templates with substitutions / blank lines / typed tags ===
+    {
+      code: 'tag\n`hi${x}!`',
+      errors: [{ messageId: 'taggedTemplate' }],
+    },
+    {
+      code: 'tag(x)\n`hello`',
+      errors: [{ messageId: 'taggedTemplate' }],
+    },
+    {
+      code: 'fn?.(x)\n`hello`',
+      errors: [{ messageId: 'taggedTemplate' }],
+    },
+
+    // === Optional-chain CONTINUATION calls / accesses ===
+    {
+      code: 'a?.b\n(c)',
+      errors: [{ messageId: 'function' }],
+    },
+
+    // === Multi-line breaks ===
+    {
+      code: 'var a = b\n\n\n[c]',
+      errors: [{ messageId: 'property' }],
+    },
+    {
+      code: 'tag(x)\n\n`hi`',
+      errors: [{ messageId: 'taggedTemplate' }],
+    },
+
+    // === Class field continuations beyond upstream ===
+    {
+      code: 'class C { field = obj.method()\n[k]; }',
+      errors: [{ messageId: 'property' }],
+    },
+    {
+      code: 'class C { field = tag`x`\n[k]; }',
+      errors: [{ messageId: 'property' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -324,3 +324,4 @@ bref
 brefs
 backref
 backrefs
+gimuygimuygimuy


### PR DESCRIPTION
## Summary

Port the `no-unexpected-multiline` rule from ESLint to rslint.

This rule disallows confusing multiline expressions where automatic semicolon insertion (ASI) does not apply, catching four classes of newline hazards:

- Newline between a function and the `(` of its call.
- Newline between an object and the `[` of a computed property access.
- Newline between a template tag and its template literal.
- Newline between a numerator and a `/` operator that visually resembles a regex literal.

The implementation is 1:1 aligned with ESLint: same four `messageId`s (`function`, `property`, `taggedTemplate`, `division`), same single-character report range, same skip rules (`!computed || optional`, `arguments.length === 0 || optional`, etc.), same regex flag matcher (`/^[gimsuy]+$/`).

tsgo-specific implementation details:
- `ast.WalkUpParenthesizedExpressions` simulates ESTree's paren-stripping for the `BinaryExpression > BinaryExpression.left` selector in the division branch.
- `Expression.End()` already accounts for trailing parens in tsgo, so ESLint's `isNotClosingParenToken` filter is unnecessary.
- TS-only nodes (`!`, `as`, `satisfies`, `<T>`) are naturally included in `Expression.End()`, matching the typescript-eslint parser's behavior.
- `scanner.IsIdentifierStart` / `IsIdentifierPart` with full UTF-8 decoding ensures Unicode identifiers are handled the same way the parser does.

Verified on real-world codebases (rsbuild and rspack — both produced 0 false positives, with all grep-discovered ASI-shape candidates manually confirmed as legitimate code).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-unexpected-multiline
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-unexpected-multiline.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).