### PR TITLE
feat: port rule no-useless-escape

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,8 +228,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_computed_key"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
-	"github.com/web-infra-dev/rslint/internal/rules/no_useless_constructor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_backreference"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_constructor"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_escape"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_rename"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
@@ -742,6 +743,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-useless-backreference", no_useless_backreference.NoUselessBackreferenceRule)
 	GlobalRuleRegistry.Register("no-useless-call", no_useless_call.NoUselessCallRule)
 	GlobalRuleRegistry.Register("no-useless-catch", no_useless_catch.NoUselessCatchRule)
+	GlobalRuleRegistry.Register("no-useless-escape", no_useless_escape.NoUselessEscapeRule)
 	GlobalRuleRegistry.Register("no-useless-rename", no_useless_rename.NoUselessRenameRule)
 	GlobalRuleRegistry.Register("no-useless-constructor", no_useless_constructor.NoUselessConstructorRule)
 	GlobalRuleRegistry.Register("no-prototype-builtins", no_prototype_builtins.NoPrototypeBuiltinsRule)

--- a/internal/rules/no_useless_escape/no_useless_escape.go
+++ b/internal/rules/no_useless_escape/no_useless_escape.go
@@ -1,0 +1,847 @@
+// Package no_useless_escape implements ESLint's `no-useless-escape` rule.
+//
+// It scans string literals, template literals, and regular-expression literals
+// for backslash escapes whose escaped character carries no special meaning, and
+// reports each such escape with two suggestions: remove the backslash, or
+// double it (`\\X`) to embed an actual backslash.
+package no_useless_escape
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-useless-escape
+var NoUselessEscapeRule = rule.Rule{
+	Name: "no-useless-escape",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		allowed := parseAllowRegexCharacters(options)
+
+		return rule.RuleListeners{
+			ast.KindStringLiteral: func(node *ast.Node) {
+				if isInJsxLiteralContext(node) {
+					return
+				}
+				checkStringLiteral(ctx, node)
+			},
+			ast.KindNoSubstitutionTemplateLiteral: func(node *ast.Node) {
+				if isInsideTaggedTemplate(node) {
+					return
+				}
+				checkTemplateElement(ctx, node)
+			},
+			ast.KindTemplateHead: func(node *ast.Node) {
+				if isInsideTaggedTemplate(node) {
+					return
+				}
+				checkTemplateElement(ctx, node)
+			},
+			ast.KindTemplateMiddle: func(node *ast.Node) {
+				if isInsideTaggedTemplate(node) {
+					return
+				}
+				checkTemplateElement(ctx, node)
+			},
+			ast.KindTemplateTail: func(node *ast.Node) {
+				if isInsideTaggedTemplate(node) {
+					return
+				}
+				checkTemplateElement(ctx, node)
+			},
+			ast.KindRegularExpressionLiteral: func(node *ast.Node) {
+				validateRegExp(ctx, node, allowed)
+			},
+		}
+	},
+}
+
+func parseAllowRegexCharacters(options any) map[string]bool {
+	out := map[string]bool{}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return out
+	}
+	raw, ok := optsMap["allowRegexCharacters"]
+	if !ok {
+		return out
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return out
+	}
+	for _, v := range arr {
+		if s, ok := v.(string); ok {
+			out[s] = true
+		}
+	}
+	return out
+}
+
+// validStringEscape mirrors ESLint's VALID_STRING_ESCAPES — the escape
+// characters that produce a different value from their literal form, so the
+// backslash is meaningful. Single-character entries are checked via this map;
+// linebreak runes are checked separately.
+var validStringEscape = map[byte]bool{
+	'\\': true, 'n': true, 'r': true, 'v': true, 't': true,
+	'b': true, 'f': true, 'u': true, 'x': true,
+}
+
+// isLineContinuation reports whether the rune begins a LineTerminatorSequence
+// that, when preceded by `\` in a string/template, forms a line continuation.
+// ESLint's LINEBREAKS includes \n, \r, U+2028 (LINE SEPARATOR), U+2029
+// (PARAGRAPH SEPARATOR).
+func isLineContinuation(r rune) bool {
+	return r == '\n' || r == '\r' || r == 0x2028 || r == 0x2029
+}
+
+// isInJsxLiteralContext reports whether `node` is a string literal that JSX
+// passes through verbatim — JSX attribute values, plus the rare cases where
+// a string literal appears as a direct child of a JsxElement / JsxFragment
+// (legacy JSX-text-in-element shapes). JSX itself does not interpret escape
+// sequences (https://facebook.github.io/jsx/), so the `\` is part of the
+// authored text.
+func isInJsxLiteralContext(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindJsxAttribute, ast.KindJsxElement, ast.KindJsxFragment:
+		return true
+	}
+	return false
+}
+
+// isInsideTaggedTemplate reports whether the template element belongs to a
+// TaggedTemplateExpression. Tagged tags (e.g. `String.raw`, `myFn`) receive the
+// raw escape text via the `raw` array, so removing the backslash would change
+// the value the tag function sees.
+func isInsideTaggedTemplate(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindNoSubstitutionTemplateLiteral:
+		// Parent is the TaggedTemplateExpression directly when the template is
+		// the tagged form `tag`literal``.
+		return node.Parent != nil && node.Parent.Kind == ast.KindTaggedTemplateExpression
+	case ast.KindTemplateHead:
+		// Parent is TemplateExpression; grandparent is the TaggedTemplate.
+		return node.Parent != nil &&
+			node.Parent.Parent != nil &&
+			node.Parent.Parent.Kind == ast.KindTaggedTemplateExpression
+	case ast.KindTemplateMiddle, ast.KindTemplateTail:
+		// Parent is TemplateSpan; grandparent is TemplateExpression;
+		// great-grandparent is the TaggedTemplate.
+		return node.Parent != nil &&
+			node.Parent.Parent != nil &&
+			node.Parent.Parent.Parent != nil &&
+			node.Parent.Parent.Parent.Kind == ast.KindTaggedTemplateExpression
+	}
+	return false
+}
+
+// isStringLiteralDirective reports whether `node` is a string literal that
+// occupies a directive prologue position. ESLint's parser marks directives via
+// `node.directive` only at: the SourceFile / ModuleBlock head, or the head of
+// a function body (FunctionDeclaration, FunctionExpression, ArrowFunction,
+// MethodDeclaration, GetAccessor, SetAccessor, Constructor, ClassStaticBlock).
+// A plain `Block` inside `if`/`for`/`while`/etc. is NOT a directive container.
+//
+// rslint mirrors that: the parent must be an ExpressionStatement, the
+// grandparent must be one of the directive containers, AND in the Block case
+// the great-grandparent must be a function-like / class-static-block.
+func isStringLiteralDirective(sourceFile *ast.SourceFile, node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil || parent.Kind != ast.KindExpressionStatement {
+		return false
+	}
+	grandparent := parent.Parent
+	if grandparent == nil {
+		return false
+	}
+	var statements []*ast.Node
+	switch grandparent.Kind {
+	case ast.KindSourceFile:
+		statements = sourceFile.Statements.Nodes
+	case ast.KindModuleBlock:
+		statements = grandparent.AsModuleBlock().Statements.Nodes
+	case ast.KindBlock:
+		// Only function-body / class-static-block / constructor-body Blocks are
+		// directive containers. Bodies of `if` / `for` / `while` / standalone
+		// blocks etc. are not.
+		container := grandparent.Parent
+		if container == nil || !isDirectiveBlockContainer(container) {
+			return false
+		}
+		statements = grandparent.AsBlock().Statements.Nodes
+	default:
+		return false
+	}
+	for _, stmt := range statements {
+		if stmt == parent {
+			return true
+		}
+		if !ast.IsPrologueDirective(stmt) {
+			return false
+		}
+	}
+	return false
+}
+
+// isDirectiveBlockContainer reports whether a Block whose parent is `node` is
+// a function-body Block (i.e. its first statements are part of a directive
+// prologue). Mirrors the set of node kinds that carry a `body: Block` and
+// honor "use strict" / other directives in ECMAScript.
+func isDirectiveBlockContainer(node *ast.Node) bool {
+	if ast.IsFunctionLike(node) {
+		return true
+	}
+	switch node.Kind {
+	case ast.KindClassStaticBlockDeclaration:
+		return true
+	}
+	return false
+}
+
+// rawStartOf returns the source-text start offset of `node`, skipping any
+// leading trivia. For string/template/regex literals this points at the
+// opening delimiter (`'`, `"`, `` ` ``, `}`, or `/`).
+func rawStartOf(sourceFile *ast.SourceFile, node *ast.Node) int {
+	return utils.TrimNodeTextRange(sourceFile, node).Pos()
+}
+
+// rawTextOf returns the raw source text of `node` (delimiters included).
+func rawTextOf(sourceFile *ast.SourceFile, node *ast.Node) string {
+	return scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, node, false)
+}
+
+// checkStringLiteral scans a `'…'` / `"…"` literal for useless escapes.
+func checkStringLiteral(ctx rule.RuleContext, node *ast.Node) {
+	rawStart := rawStartOf(ctx.SourceFile, node)
+	raw := rawTextOf(ctx.SourceFile, node)
+	if len(raw) < 2 {
+		return
+	}
+	quote := raw[0]
+	directive := isStringLiteralDirective(ctx.SourceFile, node)
+	scanLiteralEscapes(raw, func(escapeIdx int, escapedRune rune, escapedRuneSize int) {
+		if isValidStringEscapeRune(escapedRune) {
+			return
+		}
+		if escapedRuneSize == 1 && byte(escapedRune) == quote {
+			return
+		}
+		reportEscape(ctx, rawStart, escapeIdx, escapedDisplayText(raw, escapeIdx, escapedRune, escapedRuneSize), directive, false)
+	})
+}
+
+// checkTemplateElement scans a template element (NoSubstitutionTemplateLiteral
+// or TemplateHead/Middle/Tail) for useless escapes. Template-specific cases:
+//   - `` \` `` is the quote escape and never reported.
+//   - `\$` is necessary iff followed by `{` (forms `\${` to suppress
+//     interpolation).
+//   - `\{` is necessary iff preceded by `$` (forms `$\{` to suppress
+//     interpolation; the leading `\$` would have been reported instead in the
+//     `\${` case).
+//
+// Template literals are never directives, so the suggestion message is always
+// the standard `removeEscape`.
+func checkTemplateElement(ctx rule.RuleContext, node *ast.Node) {
+	rawStart := rawStartOf(ctx.SourceFile, node)
+	raw := rawTextOf(ctx.SourceFile, node)
+	scanLiteralEscapes(raw, func(escapeIdx int, escapedRune rune, escapedRuneSize int) {
+		// `\`` is the template quote escape — always valid.
+		if escapedRune == '`' {
+			return
+		}
+		unnecessary := !isValidStringEscapeRune(escapedRune)
+
+		switch escapedRune {
+		case '$':
+			// `\$` is necessary only when followed by `{`.
+			afterIdx := escapeIdx + 1 + escapedRuneSize
+			unnecessary = afterIdx >= len(raw) || raw[afterIdx] != '{'
+		case '{':
+			// `\{` is necessary only when preceded by `$`. If preceded by `\$`,
+			// the rule reports the `\$` instead (it scans left-to-right and
+			// the `\$` is the first useless escape).
+			unnecessary = escapeIdx == 0 || raw[escapeIdx-1] != '$'
+		}
+		if !unnecessary {
+			return
+		}
+		reportEscape(ctx, rawStart, escapeIdx, escapedDisplayText(raw, escapeIdx, escapedRune, escapedRuneSize), false, false)
+	})
+}
+
+// escapedDisplayText returns the source-text bytes for the escaped character,
+// used as the `{character}` placeholder in the diagnostic message. ESLint
+// computes this as `match[0].slice(1)` over the JS source string — which for
+// astral X gives both surrogate code units (i.e. the full character). Slicing
+// the UTF-8 source bytes by `escapedRuneSize` produces the equivalent display
+// string: same rendered character, different byte-encoding. The message text
+// rendered by terminals / IDEs is identical.
+func escapedDisplayText(raw string, escapeIdx int, escapedRune rune, escapedRuneSize int) string {
+	return raw[escapeIdx+1 : escapeIdx+1+escapedRuneSize]
+}
+
+func isValidStringEscapeRune(r rune) bool {
+	if r < 128 && validStringEscape[byte(r)] {
+		return true
+	}
+	return isLineContinuation(r)
+}
+
+// scanLiteralEscapes mirrors ESLint's `/\\\D/gu`: it walks `raw` and invokes
+// `cb` for every backslash that is followed by a non-digit character. The
+// callback receives the index of the backslash, the escaped rune, and the
+// rune's UTF-8 byte width. A backslash at the end of input or directly before
+// an ASCII digit is consumed without reporting (digit-prefixed escapes are
+// hex/unicode/octal continuations, not single-character escapes).
+func scanLiteralEscapes(raw string, cb func(escapeIdx int, escapedRune rune, escapedRuneSize int)) {
+	i := 0
+	for i < len(raw) {
+		if raw[i] != '\\' {
+			i++
+			continue
+		}
+		if i+1 >= len(raw) {
+			return
+		}
+		next := raw[i+1]
+		if next >= '0' && next <= '9' {
+			i += 2
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(raw[i+1:])
+		if size == 0 {
+			return
+		}
+		cb(i, r, size)
+		// Step past the backslash and the escaped rune. ESLint's regex matches
+		// `/\\\D/g` so its loop also consumes the escaped char before
+		// continuing.
+		i += 1 + size
+	}
+}
+
+// reportEscape emits the diagnostic and the two standard suggestions.
+//
+// `startOffset` is the byte index of the backslash within the raw text;
+// `escapedText` is the source-text representation of the escaped character
+// (without the leading backslash). When `directive` is true the remove-escape
+// suggestion uses the `removeEscapeDoNotKeepSemantics` message — removing the
+// `\` from `"use\ strict"` does not preserve the directive's behavior. When
+// `disableEscapeBackslash` is true the second (`\X` → `\\X`) suggestion is
+// suppressed; this happens for v-mode escapes whose direct parent in the
+// regexpp AST is a `ClassIntersection` / `ClassSubtraction` operator.
+func reportEscape(ctx rule.RuleContext, rawStart, startOffset int, escapedText string, directive bool, disableEscapeBackslash bool) {
+	rangeStart := rawStart + startOffset
+	rangeEnd := rangeStart + 1
+	textRange := core.NewTextRange(rangeStart, rangeEnd)
+
+	suggestions := make([]rule.RuleSuggestion, 0, 2)
+	removeMsg := rule.RuleMessage{
+		Id:          "removeEscape",
+		Description: "Remove the `\\`. This maintains the current functionality.",
+	}
+	if directive {
+		removeMsg = rule.RuleMessage{
+			Id:          "removeEscapeDoNotKeepSemantics",
+			Description: "Remove the `\\` if it was inserted by mistake.",
+		}
+	}
+	suggestions = append(suggestions, rule.RuleSuggestion{
+		Message:  removeMsg,
+		FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(textRange)},
+	})
+	if !disableEscapeBackslash {
+		suggestions = append(suggestions, rule.RuleSuggestion{
+			Message: rule.RuleMessage{
+				Id:          "escapeBackslash",
+				Description: "Replace the `\\` with `\\\\` to include the actual backslash character.",
+			},
+			FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(
+				core.NewTextRange(rangeStart, rangeStart),
+				"\\",
+			)},
+		})
+	}
+	ctx.ReportRangeWithSuggestions(textRange, rule.RuleMessage{
+		Id:          "unnecessaryEscape",
+		Description: fmt.Sprintf("Unnecessary escape character: \\%s.", escapedText),
+	}, suggestions...)
+}
+
+// ----------------------------------------------------------------------------
+// Regex pattern scanner
+// ----------------------------------------------------------------------------
+
+// regexClassFrame tracks a single open `[...]` (or `[^...]`, or v-mode nested
+// class) while we walk the pattern. A frame holds enough context to answer
+// each of the rule's class-sensitive questions:
+//
+//   - is the current escape positioned at the very start of this class
+//     (relevant to `\^` and `\-`)?
+//   - is it at the end (relevant to `\-` outside v-mode)?
+//   - is the immediately enclosing class a `ClassIntersection` /
+//     `ClassSubtraction` (v-mode `--` / `&&`), which suppresses the
+//     `escapeBackslash` suggestion?
+type regexClassFrame struct {
+	start    int  // byte offset of `[`
+	end      int  // byte offset of `]` (exclusive of the bracket itself; end = index after `]`)
+	negate   bool // `[^…` form
+	hasSetOp bool // contains `--` or `&&` at THIS class's level (v-mode only)
+}
+
+// reservedDoublePunctuator mirrors REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR
+// in the ESLint source: characters that, when doubled inside a v-mode class,
+// form a reserved-syntax pair (e.g. `&&`, `++`).
+var reservedDoublePunctuator = map[byte]bool{
+	'!': true, '#': true, '$': true, '%': true, '&': true,
+	'*': true, '+': true, ',': true, '.': true, ':': true,
+	';': true, '<': true, '=': true, '>': true, '?': true,
+	'@': true, '^': true, '`': true, '~': true,
+}
+
+// regexGeneralEscape mirrors REGEX_GENERAL_ESCAPES: characters whose `\X` form
+// is meaningful in any regex position (assertions, character-class shorthands,
+// hex/unicode escape leaders, octal/backreference digits, the `]` escape).
+var regexGeneralEscape = map[byte]bool{
+	'\\': true, 'b': true, 'c': true, 'd': true, 'D': true, 'f': true,
+	'n': true, 'p': true, 'P': true, 'r': true, 's': true, 'S': true,
+	't': true, 'v': true, 'w': true, 'W': true, 'x': true, 'u': true,
+	'0': true, '1': true, '2': true, '3': true, '4': true, '5': true,
+	'6': true, '7': true, '8': true, '9': true, ']': true,
+}
+
+// regexNonClassExtra adds the characters whose `\X` is meaningful outside any
+// character class (regex metacharacters), on top of regexGeneralEscape.
+var regexNonClassExtra = map[byte]bool{
+	'^': true, '/': true, '.': true, '$': true, '*': true, '+': true,
+	'?': true, '[': true, '{': true, '}': true, '|': true, '(': true,
+	')': true, 'B': true, 'k': true,
+}
+
+// regexClassSetExtra adds the characters whose `\X` is meaningful inside a
+// v-mode character class, on top of regexGeneralEscape.
+var regexClassSetExtra = map[byte]bool{
+	'q': true, '/': true, '[': true, '{': true, '}': true,
+	'|': true, '(': true, ')': true, '-': true,
+}
+
+// regexAllowedNonClass / regexAllowedClassU / regexAllowedClassV are the three
+// resolved allow-sets (per ESLint's three context branches), pre-merged at
+// init so the hot path doesn't rebuild a map per escape.
+var (
+	regexAllowedNonClass = mergeByteSets(regexGeneralEscape, regexNonClassExtra)
+	regexAllowedClassU   = regexGeneralEscape
+	regexAllowedClassV   = mergeByteSets(regexGeneralEscape, regexClassSetExtra)
+)
+
+// validateRegExp inspects a /…/flags literal for useless escape characters.
+// It mirrors ESLint's regexpp-driven walker but operates on the raw pattern
+// text rather than a parsed AST: every check the rule cares about can be
+// answered from the byte-level position alone (immediate enclosing class,
+// negate flag, presence of `--`/`&&` in that class). The pre-scan in
+// preScanClass populates the frame metadata before we reach inner content.
+func validateRegExp(ctx rule.RuleContext, node *ast.Node, allowed map[string]bool) {
+	rawStart := rawStartOf(ctx.SourceFile, node)
+	text := rawTextOf(ctx.SourceFile, node)
+	pattern, flagsStr := utils.ExtractRegexPatternAndFlags(text)
+	if pattern == "" {
+		return
+	}
+	flags := utils.ParseRegexFlags(flagsStr)
+	patternStart := rawStart + 1 // past the opening `/`
+
+	// Match ESLint's "wrap regexpp.parsePattern in try/catch and skip on any
+	// error" semantics: if the pattern doesn't parse cleanly, we don't report
+	// — `no-invalid-regexp` will surface the syntax issue instead.
+	if !patternParses(pattern, flags) {
+		return
+	}
+
+	var stack []regexClassFrame
+	i := 0
+	for i < len(pattern) {
+		c := pattern[i]
+		switch {
+		case c == '\\':
+			advance, escapedByte, escapedSize, isSingleIdentity := readRegexEscape(pattern, i, flags, len(stack) > 0)
+			if isSingleIdentity {
+				handleRegexIdentityEscape(ctx, patternStart, pattern, i, escapedByte, escapedSize, stack, flags, allowed)
+			}
+			i += advance
+		case c == '[' && (len(stack) == 0 || flags.UnicodeSets):
+			// Open a new class frame at depth 0 always; nested `[` only nests
+			// under v-mode. In non-v mode an inner `[` is a literal character.
+			frame := preScanClass(pattern, i, flags)
+			stack = append(stack, frame)
+			i++
+			if frame.negate {
+				i++ // step past the leading `^`
+			}
+		case c == ']' && len(stack) > 0:
+			stack = stack[:len(stack)-1]
+			i++
+		case len(stack) > 0 && flags.UnicodeSets && (c == '-' || c == '&') &&
+			i+1 < len(pattern) && pattern[i+1] == c:
+			// v-mode set operator `--` / `&&` — consumed as one unit.
+			i += 2
+		default:
+			_, w := utf8.DecodeRuneInString(pattern[i:])
+			if w == 0 {
+				i++
+			} else {
+				i += w
+			}
+		}
+	}
+}
+
+// readRegexEscape classifies the `\…` token at pattern[i].
+//
+// Returns:
+//   - advance: how many bytes the token consumes (always ≥ 2).
+//   - escapedByte: the byte right after `\`. Only meaningful for single-byte
+//     identity escapes.
+//   - escapedSize: byte width of the escaped rune (1 for ASCII, ≥ 2 otherwise).
+//   - isSingleIdentity: true iff the token is a `\X` form whose value equals
+//     `X` itself (i.e. the backslash carries no meaning beyond escaping `X`).
+//     Multi-byte structural escapes (`\xHH`, `\uHHHH`, `\u{H…}`, `\p{…}`,
+//     `\q{…}`, `\k<…>`, decimal continuations) return false here so the rule
+//     never inspects them.
+func readRegexEscape(pattern string, i int, flags utils.RegexFlags, inClass bool) (advance int, escapedByte byte, escapedSize int, isSingleIdentity bool) {
+	if i+1 >= len(pattern) {
+		return 1, 0, 0, false
+	}
+	next := pattern[i+1]
+	switch next {
+	case 'x':
+		// `\xHH` — 4 bytes. Otherwise treat as identity escape of `x`.
+		if i+3 < len(pattern) && utils.IsHexDigit(pattern[i+2]) && utils.IsHexDigit(pattern[i+3]) {
+			return 4, 0, 0, false
+		}
+	case 'u':
+		// `\u{H…}` (uvMode), `\uHHHH`, otherwise identity escape of `u`.
+		if flags.UV() && i+2 < len(pattern) && pattern[i+2] == '{' {
+			if rel := strings.IndexByte(pattern[i+3:], '}'); rel >= 0 {
+				return 3 + rel + 1, 0, 0, false
+			}
+		}
+		if i+5 < len(pattern) && utils.AllHexDigits(pattern[i+2:i+6]) {
+			return 6, 0, 0, false
+		}
+	case 'p', 'P':
+		// `\p{…}` / `\P{…}` are unicode property escapes only under uvMode.
+		// In non-uvMode this is identity escape of `p` / `P`.
+		if flags.UV() && i+2 < len(pattern) && pattern[i+2] == '{' {
+			if rel := strings.IndexByte(pattern[i+3:], '}'); rel >= 0 {
+				return 3 + rel + 1, 0, 0, false
+			}
+		}
+	// `\q{…}` is intentionally NOT skipped as a unit. ESLint's regexpp parser
+	// visits Character nodes inside the q-string body (each alternative is a
+	// String containing real Character nodes), so identity escapes like `\.`
+	// inside `\q{a\.b}` MUST be flagged. We treat `\q` as an identity escape
+	// (allowed in v-mode class via regexClassSetExtra) and let the main walker
+	// scan the body bytes — `{`, `|`, alternative chars, and the closing `}`
+	// are all plain in our model. Unterminated `\q{` is rejected separately
+	// in patternParses so we never reach inconsistent state on broken input.
+	case 'k':
+		// `\k<name>` — named backreference outside class.
+		if !inClass && i+2 < len(pattern) && pattern[i+2] == '<' {
+			if rel := strings.IndexByte(pattern[i+3:], '>'); rel >= 0 {
+				return 3 + rel + 1, 0, 0, false
+			}
+		}
+	case 'c':
+		// `\cX` control escape. Only well-formed when followed by an ASCII
+		// letter; otherwise regexpp falls back to identity-escape `c` (under
+		// non-u). We treat any `\c<x>` as a structural escape — `c` itself is
+		// in regexGeneralEscape so non-letter follow-ups still won't flag.
+		if i+2 < len(pattern) {
+			return 3, 0, 0, false
+		}
+	}
+	if next >= '0' && next <= '9' {
+		// Backreference (outside class) or legacy octal — eat all consecutive
+		// digits as one structural escape.
+		j := i + 2
+		for j < len(pattern) && pattern[j] >= '0' && pattern[j] <= '9' {
+			j++
+		}
+		return j - i, 0, 0, false
+	}
+
+	// Single-character identity escape `\X`. Decode the rune to handle
+	// multi-byte X (very rare but possible in identity-escape position).
+	r, w := utf8.DecodeRuneInString(pattern[i+1:])
+	if w == 0 {
+		return 1, 0, 0, false
+	}
+	if w == 1 {
+		return 2, byte(r), 1, true
+	}
+	// Multi-byte identity escape. ESLint's set-membership checks operate on
+	// single ASCII chars; a multi-byte X is never "valid" in any of those
+	// sets, so treating it as a flagged identity is the safe path. Callers
+	// pass escapedSize so we can copy the right number of bytes for the
+	// diagnostic text.
+	return 1 + w, 0, w, true
+}
+
+// handleRegexIdentityEscape classifies a `\X` (single-codepoint identity
+// escape) and reports it when ESLint would. It encodes:
+//
+//   - Set membership: `X` against REGEX_GENERAL_ESCAPES /
+//     REGEX_NON_CHARCLASS_ESCAPES / REGEX_CLASSSET_CHARACTER_ESCAPES based on
+//     class state and uvMode.
+//   - Caret exemption: `\^` at `[`-position is meaningful even under v-mode.
+//   - Dash exemption (non-v): `\-` away from class edges is meaningful.
+//   - V-mode reserved double punctuators: `\X` is meaningful when sandwiched
+//     against a literal `X` neighbour (`\&&`, `&\&`, …) — with a small twist
+//     for `\^` adjacent to the class's negate caret.
+//   - V-mode set-operation parents: when the class containing the escape has
+//     `--` / `&&` at its top level (frame.hasSetOp), the second
+//     `escapeBackslash` suggestion is suppressed.
+func handleRegexIdentityEscape(
+	ctx rule.RuleContext,
+	patternStart int,
+	pattern string,
+	escapeIdx int,
+	escapedByte byte,
+	escapedSize int,
+	stack []regexClassFrame,
+	flags utils.RegexFlags,
+	allowed map[string]bool,
+) {
+	if escapedSize == 0 {
+		return
+	}
+	escapedText := pattern[escapeIdx+1 : escapeIdx+1+escapedSize]
+	if allowed[escapedText] {
+		return
+	}
+	// Multi-byte identity escapes never match the ASCII-keyed allow sets, so
+	// we can fast-path them straight to a flag.
+	if escapedSize > 1 {
+		reportEscape(ctx, patternStart, escapeIdx, escapedText, false, false)
+		return
+	}
+
+	inClass := len(stack) > 0
+	var allowedSet map[byte]bool
+	switch {
+	case !inClass:
+		allowedSet = regexAllowedNonClass
+	case flags.UnicodeSets:
+		allowedSet = regexAllowedClassV
+	default:
+		allowedSet = regexAllowedClassU
+	}
+	if allowedSet[escapedByte] {
+		return
+	}
+
+	disableBackslash := false
+	if inClass {
+		frame := stack[len(stack)-1]
+		// `\^` exemption: at the very first character position of the class.
+		if escapedByte == '^' {
+			if frame.start+1 == escapeIdx {
+				return
+			}
+		}
+		if !flags.UnicodeSets {
+			if escapedByte == '-' {
+				escEnd := escapeIdx + 2
+				// Outside v-mode, `\-` is meaningful in the middle of a class
+				// — only flag it when adjacent to either edge.
+				if frame.start+1 != escapeIdx && escEnd != frame.end-1 {
+					return
+				}
+			}
+		} else {
+			if reservedDoublePunctuator[escapedByte] {
+				escEnd := escapeIdx + 2
+				if escEnd < len(pattern) && pattern[escEnd] == escapedByte {
+					return
+				}
+				if escapeIdx > 0 && pattern[escapeIdx-1] == escapedByte {
+					if escapedByte != '^' {
+						return
+					}
+					if !frame.negate {
+						return
+					}
+					negateCaretIdx := frame.start + 1
+					if negateCaretIdx < escapeIdx-1 {
+						return
+					}
+					// Otherwise the prior char IS the negate caret, so the
+					// escape still looks redundant — fall through to flag.
+				}
+			}
+			if frame.hasSetOp {
+				disableBackslash = true
+			}
+		}
+	}
+
+	reportEscape(ctx, patternStart, escapeIdx, escapedText, false, disableBackslash)
+}
+
+// preScanClass walks a `[...]` opening at pattern[start] to determine its end
+// position, whether it's negated (`[^…`), and whether it contains a v-mode
+// set operator (`--` / `&&`) at its OWN nesting level (not inside a deeper
+// nested class or `\q{…}` body).
+//
+// `\q{…}` content is skipped here as a unit because we need to find the class
+// end, and a `]` literal inside `\q{a]b}` must NOT close the outer class.
+// (Outside this scanner, the main walker re-walks `\q{…}` body to flag
+// nested escapes — see readRegexEscape for the rationale.)
+func preScanClass(pattern string, start int, flags utils.RegexFlags) regexClassFrame {
+	frame := regexClassFrame{start: start, end: len(pattern)}
+	i := start + 1
+	if i < len(pattern) && pattern[i] == '^' {
+		frame.negate = true
+		i++
+	}
+	depth := 1
+	for i < len(pattern) {
+		c := pattern[i]
+		switch {
+		case c == '\\':
+			// Special case: `\q{…}` body can contain a literal `]`. Skip the
+			// whole `\q{…}` here so we don't mis-close the class.
+			if flags.UnicodeSets && i+2 < len(pattern) && pattern[i+1] == 'q' && pattern[i+2] == '{' {
+				if rel := strings.IndexByte(pattern[i+3:], '}'); rel >= 0 {
+					i += 3 + rel + 1
+					continue
+				}
+			}
+			adv, _, _, _ := readRegexEscape(pattern, i, flags, true)
+			i += adv
+		case c == '[' && flags.UnicodeSets:
+			depth++
+			i++
+		case c == ']':
+			depth--
+			i++
+			if depth == 0 {
+				frame.end = i
+				return frame
+			}
+		case flags.UnicodeSets && depth == 1 && (c == '-' || c == '&') &&
+			i+1 < len(pattern) && pattern[i+1] == c:
+			frame.hasSetOp = true
+			i += 2
+		default:
+			_, w := utf8.DecodeRuneInString(pattern[i:])
+			if w == 0 {
+				i++
+			} else {
+				i += w
+			}
+		}
+	}
+	return frame
+}
+
+// patternParses returns false for patterns that should be skipped by the rule
+// — matching ESLint's wrap-regexpp-in-try/catch behavior. We don't fully
+// validate regex syntax (that's `no-invalid-regexp`'s job), but we do reject
+// the breakage modes that would let our walker drift away from regexpp's
+// semantics:
+//
+//   - Unterminated character class (no closing `]`).
+//   - Trailing `\` with no escaped char.
+//   - v-mode `\u{H…}` / `\p{…}` / `\q{…}` / non-class `\k<…>` with no closing
+//     `}` or `>`.
+//
+// Anything else (legal-but-weird patterns) is left to the walker.
+func patternParses(pattern string, flags utils.RegexFlags) bool {
+	depth := 0
+	i := 0
+	for i < len(pattern) {
+		c := pattern[i]
+		switch c {
+		case '\\':
+			if i+1 >= len(pattern) {
+				return false
+			}
+			next := pattern[i+1]
+			// Detect unterminated structural escapes BEFORE the readRegexEscape
+			// fast path swallows them as identity escapes.
+			switch {
+			case flags.UV() && next == 'u' && i+2 < len(pattern) && pattern[i+2] == '{':
+				if strings.IndexByte(pattern[i+3:], '}') < 0 {
+					return false
+				}
+			case flags.UV() && (next == 'p' || next == 'P') && i+2 < len(pattern) && pattern[i+2] == '{':
+				if strings.IndexByte(pattern[i+3:], '}') < 0 {
+					return false
+				}
+			case flags.UnicodeSets && depth > 0 && next == 'q' && i+2 < len(pattern) && pattern[i+2] == '{':
+				rel := strings.IndexByte(pattern[i+3:], '}')
+				if rel < 0 {
+					return false
+				}
+				// Skip `\q{…}` as a unit so a `]` inside doesn't unbalance the
+				// class depth count.
+				i += 3 + rel + 1
+				continue
+			case depth == 0 && next == 'k' && i+2 < len(pattern) && pattern[i+2] == '<':
+				if strings.IndexByte(pattern[i+3:], '>') < 0 {
+					return false
+				}
+			}
+			adv, _, _, _ := readRegexEscape(pattern, i, flags, depth > 0)
+			i += adv
+		case '[':
+			// Only nest depth in v-mode (where `[[…]…]` is a class set
+			// expression). In non-v mode `[` inside a class is a literal char,
+			// not a nested class — incrementing here would consume the wrong
+			// `]` as the class closer.
+			if depth == 0 || flags.UnicodeSets {
+				depth++
+			}
+			i++
+		case ']':
+			if depth == 0 {
+				// `]` outside class — legal in regex (literal `]`).
+				i++
+				continue
+			}
+			depth--
+			i++
+		default:
+			_, w := utf8.DecodeRuneInString(pattern[i:])
+			if w == 0 {
+				i++
+			} else {
+				i += w
+			}
+		}
+	}
+	return depth == 0
+}
+
+func mergeByteSets(sets ...map[byte]bool) map[byte]bool {
+	out := make(map[byte]bool, 64)
+	for _, s := range sets {
+		for k, v := range s {
+			if v {
+				out[k] = true
+			}
+		}
+	}
+	return out
+}

--- a/internal/rules/no_useless_escape/no_useless_escape.md
+++ b/internal/rules/no_useless_escape/no_useless_escape.md
@@ -1,0 +1,91 @@
+# no-useless-escape
+
+Disallow unnecessary escape characters.
+
+Escaping non-special characters in strings, template literals, and regular expressions does not change behavior. Removing the redundant `\` keeps the code simpler and avoids confusion.
+
+```js
+let foo = "hol\a"; // > foo = "hola"
+let bar = `${foo}\!`; // > bar = "hola!"
+let baz = /\:/; // same as /:/
+```
+
+## Rule Details
+
+This rule flags escapes that can be safely removed without changing behavior.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+"\'";
+'\"';
+"\#";
+"\e";
+`\"`;
+`\"${foo}\"`;
+`\#{foo}`;
+/\!/;
+/\@/;
+/[\[]/;
+/[a-z\-]/;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+"\"";
+'\'';
+"\x12";
+"©";
+"\371";
+"xsℑ";
+`\``;
+`\${${foo}}`;
+`$\{${foo}}`;
+/\\/g;
+/\t/g;
+/\w\$\*\^\./;
+/[[]/;
+/[\]]/;
+/[a-z-]/;
+```
+
+## Options
+
+This rule has an object option:
+
+- `allowRegexCharacters` — array of characters whose `\X` form is always allowed inside regular expressions, even when the `\` would otherwise be flagged. Useful for characters like `-` where the explicit escape can prevent the pattern from drifting into a range as the class grows.
+
+### allowRegexCharacters
+
+Examples of **incorrect** code for the `{ "allowRegexCharacters": ["-"] }` option:
+
+```json
+{ "no-useless-escape": ["error", { "allowRegexCharacters": ["-"] }] }
+```
+
+```javascript
+/\!/;
+/\@/;
+/[a-z\^]/;
+```
+
+Examples of **correct** code for the `{ "allowRegexCharacters": ["-"] }` option:
+
+```json
+{ "no-useless-escape": ["error", { "allowRegexCharacters": ["-"] }] }
+```
+
+```javascript
+/[0\-]/;
+/[\-9]/;
+/a\-b/;
+```
+
+## When Not To Use It
+
+If you do not want to be notified about unnecessary escapes, you can safely disable this rule.
+
+## Original Documentation
+
+- [no-useless-escape](https://eslint.org/docs/latest/rules/no-useless-escape)

--- a/internal/rules/no_useless_escape/no_useless_escape_test.go
+++ b/internal/rules/no_useless_escape/no_useless_escape_test.go
@@ -1,0 +1,1687 @@
+package no_useless_escape
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestNoUselessEscapeRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessEscapeRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Regex: meaningful escapes outside character classes ----
+			{Code: `var foo = /\./`},
+			{Code: `var foo = /\//g`},
+			{Code: `var foo = /""/`},
+			{Code: `var foo = /''/`},
+			{Code: `var foo = /([A-Z])\t+/g`},
+			{Code: `var foo = /([A-Z])\n+/g`},
+			{Code: `var foo = /([A-Z])\v+/g`},
+			{Code: `var foo = /\D/`},
+			{Code: `var foo = /\W/`},
+			{Code: `var foo = /\w/`},
+			{Code: `var foo = /\\/g`},
+			{Code: `var foo = /\w\$\*\./`},
+			{Code: `var foo = /\^\+\./`},
+			{Code: `var foo = /\|\}\{\./`},
+			{Code: `var foo = /]\[\(\)\//`},
+
+			// ---- String literals: valid escape sequences ----
+			{Code: `var foo = "\x12"`},
+			{Code: `var foo = "©"`},
+			{Code: `var foo = "\""`},
+			{Code: `var foo = "xsℑ"`},
+			{Code: `var foo = "foo \\ bar";`},
+			{Code: `var foo = "\t";`},
+			{Code: `var foo = "foo \b bar";`},
+			{Code: `var foo = '\n';`},
+			{Code: `var foo = 'foo \r bar';`},
+			{Code: `var foo = '\v';`},
+			{Code: `var foo = '\f';`},
+			// Line continuations: \<LF>, \<CRLF>
+			{Code: "var foo = '\\\n';"},
+			{Code: "var foo = '\\\r\n';"},
+			// LineSeparator / ParagraphSeparator continuations.
+			{Code: "var foo = 'foo \\  bar'"},
+			{Code: "var foo = 'foo \\  bar'"},
+
+			// ---- Template literals: valid escape sequences ----
+			{Code: "var foo = `\\x12`"},
+			{Code: "var foo = `\\u00a9`"},
+			{Code: "var foo = `xs\\u2111`"},
+			{Code: "var foo = `foo \\\\ bar`;"},
+			{Code: "var foo = `\\t`;"},
+			{Code: "var foo = `foo \\b bar`;"},
+			{Code: "var foo = `\\n`;"},
+			{Code: "var foo = `foo \\r bar`;"},
+			{Code: "var foo = `\\v`;"},
+			{Code: "var foo = `\\f`;"},
+			{Code: "var foo = `\\\n`;"},
+			{Code: "var foo = `\\\r\n`;"},
+			{Code: "var foo = `${foo} \\x12`"},
+			{Code: "var foo = `${foo} \\u00a9`"},
+			{Code: "var foo = `${foo} xs\\u2111`"},
+			{Code: "var foo = `${foo} \\\\ ${bar}`;"},
+			{Code: "var foo = `${foo} \\b ${bar}`;"},
+			{Code: "var foo = `${foo}\\t`;"},
+			{Code: "var foo = `${foo}\\n`;"},
+			{Code: "var foo = `${foo}\\r`;"},
+			{Code: "var foo = `${foo}\\v`;"},
+			{Code: "var foo = `${foo}\\f`;"},
+			{Code: "var foo = `${foo}\\\n`;"},
+			{Code: "var foo = `${foo}\\\r\n`;"},
+			// Quote escape inside template: `\``.
+			{Code: "var foo = `\\``"},
+			{Code: "var foo = `\\`${foo}\\``"},
+			// `\$` followed by `{` and `\{` preceded by `$` are necessary.
+			{Code: "var foo = `\\${{${foo}`;"},
+			{Code: "var foo = `$\\{{${foo}`;"},
+			// Tagged template — escapes are exposed via the `raw` array.
+			{Code: "var foo = String.raw`\\.`"},
+			{Code: "var foo = myFunc`\\.`"},
+
+			// ---- Regex character classes ----
+			{Code: `var foo = /[\d]/`},
+			{Code: `var foo = /[a\-b]/`},
+			{Code: `var foo = /foo\?/`},
+			{Code: `var foo = /example\.com/`},
+			{Code: `var foo = /foo\|bar/`},
+			{Code: `var foo = /\^bar/`},
+			{Code: `var foo = /[\^bar]/`},
+			{Code: `var foo = /\(bar\)/`},
+			{Code: `var foo = /[[\]]/`}, // class containing '[' and ']'
+			{Code: `var foo = /[[]\./`},
+			{Code: `var foo = /[\]\]]/`},
+			{Code: `var foo = /\[abc]/`},
+			{Code: `var foo = /\[foo\.bar]/`},
+			{Code: `var foo = /vi/m`},
+			{Code: `var foo = /\B/`},
+
+			// ---- Special regex escapes (issue #7472) ----
+			{Code: `var foo = /\0/`},
+			{Code: `var foo = /\1/`},
+			{Code: `var foo = /(a)\1/`},
+			{Code: `var foo = /(a)\12/`},
+			{Code: `var foo = /[\0]/`},
+
+			// ---- Unicode-property and named-backreference escapes (uvMode) ----
+			{Code: `var foo = /(?<a>)\k<a>/`},
+			{Code: `var foo = /(\\?<a>)/`},
+			{Code: `var foo = /\p{ASCII}/u`},
+			{Code: `var foo = /\P{ASCII}/u`},
+			{Code: `var foo = /[\p{ASCII}]/u`},
+			{Code: `var foo = /[\P{ASCII}]/u`},
+
+			// ---- Carets ----
+			{Code: `/[^^]/`},
+			{Code: `/[^^]/u`},
+
+			// ---- ES2024 v-flag character class escapes ----
+			{Code: "/[\\q{abc}]/v"},
+			{Code: `/[\(]/v`},
+			{Code: `/[\)]/v`},
+			{Code: `/[\{]/v`},
+			{Code: `/[\]]/v`},
+			{Code: `/[\}]/v`},
+			{Code: `/[\/]/v`},
+			{Code: `/[\-]/v`},
+			{Code: `/[\|]/v`},
+			{Code: `/[\$$]/v`},
+			{Code: `/[\&&]/v`},
+			{Code: `/[\!!]/v`},
+			{Code: `/[\##]/v`},
+			{Code: `/[\%%]/v`},
+			{Code: `/[\**]/v`},
+			{Code: `/[\++]/v`},
+			{Code: `/[\,,]/v`},
+			{Code: `/[\..]/v`},
+			{Code: `/[\::]/v`},
+			{Code: `/[\;;]/v`},
+			{Code: `/[\<<]/v`},
+			{Code: `/[\==]/v`},
+			{Code: `/[\>>]/v`},
+			{Code: `/[\??]/v`},
+			{Code: `/[\@@]/v`},
+			{Code: "/[\\``]/v"},
+			{Code: `/[\~~]/v`},
+			{Code: `/[^\^^]/v`},
+			{Code: `/[_\^^]/v`},
+			{Code: `/[$\$]/v`},
+			{Code: `/[&\&]/v`},
+			{Code: `/[!\!]/v`},
+			{Code: `/[#\#]/v`},
+			{Code: `/[%\%]/v`},
+			{Code: `/[*\*]/v`},
+			{Code: `/[+\+]/v`},
+			{Code: `/[,\,]/v`},
+			{Code: `/[.\.]/v`},
+			{Code: `/[:\:]/v`},
+			{Code: `/[;\;]/v`},
+			{Code: `/[<\<]/v`},
+			{Code: `/[=\=]/v`},
+			{Code: `/[>\>]/v`},
+			{Code: `/[?\?]/v`},
+			{Code: `/[@\@]/v`},
+			{Code: "/[`\\`]/v"},
+			{Code: `/[~\~]/v`},
+			{Code: `/[^^\^]/v`},
+			{Code: `/[_^\^]/v`},
+			{Code: `/[\&&&\&]/v`},
+			{Code: `/[[\-]\-]/v`},
+			{Code: `/[\^]/v`},
+
+			// ---- Option allowRegexCharacters ----
+			{Code: `var foo = /\#/;`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"#"}}},
+			{Code: `var foo = /\;/;`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{";"}}},
+			{Code: `var foo = /\#\;/;`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"#", ";"}}},
+			{Code: `var foo = /[ab\-]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"-"}}},
+			{Code: `var foo = /[\-ab]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"-"}}},
+			{Code: `var foo = /[ab\?]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"?"}}},
+			{Code: `var foo = /[ab\.]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"."}}},
+			{Code: `var foo = /[a\|b]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"|"}}},
+			{Code: `var foo = /\-/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"-"}}},
+			{Code: `var foo = /[\-]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"-"}}},
+			{Code: `var foo = /[ab\$]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"$"}}},
+			{Code: `var foo = /[\(paren]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"("}}},
+			{Code: `var foo = /[\[]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"["}}},
+			{Code: `var foo = /[\/]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"/"}}},
+			{Code: `var foo = /[\B]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"B"}}},
+			{Code: `var foo = /[a][\-b]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"-"}}},
+			{Code: `var foo = /\-[]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"-"}}},
+			{Code: `var foo = /[a\^]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"^"}}},
+			{Code: `/[^\^]/`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"^"}}},
+			{Code: `/[^\^]/u`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"^"}}},
+			{Code: `/[\$]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"$"}}},
+			{Code: `/[\&\&]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"&"}}},
+			{Code: `/[\!!]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"!"}}},
+			{Code: `/[\##]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"#"}}},
+			{Code: `/[\%%]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"%"}}},
+			{Code: `/[\*\*]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"*"}}},
+			{Code: `/[\+\+]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"+"}}},
+			{Code: `/[\,,]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{","}}},
+			{Code: `/[\..]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"."}}},
+			{Code: `/[\:\:]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{":"}}},
+			{Code: `/[\;\;]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{";"}}},
+			{Code: `/[\<\<]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"<"}}},
+			{Code: `/[\=\=]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"="}}},
+			{Code: `/[\>\>]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{">"}}},
+			{Code: `/[\?\?]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"?"}}},
+			{Code: `/[\@\@]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"@"}}},
+			{Code: "/[\\``]/v", Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"`"}}},
+			{Code: `/[\~\~]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"~"}}},
+			{Code: `/[^\^\^]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"^"}}},
+			{Code: `/[_\^\^]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"^"}}},
+			{Code: `/[\&\&&\&]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"&"}}},
+			{Code: `/[\p{ASCII}--\.]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"."}}},
+			{Code: `/[\p{ASCII}&&\.]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"."}}},
+			{Code: `/[\.--[.&]]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"."}}},
+			{Code: `/[\.&&[.&]]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"."}}},
+			{Code: `/[\.--\.--\.]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"."}}},
+			{Code: `/[\.&&\.&&\.]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"."}}},
+			{Code: `/[[\.&]--[\.&]]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"."}}},
+			{Code: `/[[\.&]&&[\.&]]/v`, Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"."}}},
+
+			// ---- JSX attribute strings — the only JSX shape where StringLiteral
+			// is a direct AST child of a JSX-related node. These MUST not fire;
+			// other JSX-child shapes wrap StringLiteral in JsxText / JsxExpression
+			// and never reach KindJsxElement / KindJsxFragment as direct parent.
+			{Code: `var x = <foo attr="\d"/>`, Tsx: true},
+			{Code: `var x = <foo attr='\d'></foo>`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Regex outside character class ----
+			{
+				Code: `var foo = /\#/;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \#.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /#/;`},
+						{MessageId: "escapeBackslash", Output: `var foo = /\\#/;`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /\;/;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \;.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /;/;`},
+						{MessageId: "escapeBackslash", Output: `var foo = /\\;/;`},
+					},
+				}},
+			},
+
+			// ---- String literals: identity escapes that aren't valid ----
+			{
+				Code: `var foo = "\'";`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \'.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = "'";`},
+						{MessageId: "escapeBackslash", Output: `var foo = "\\'";`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = "\#/";`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \#.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = "#/";`},
+						{MessageId: "escapeBackslash", Output: `var foo = "\\#/";`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = "\a"`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \a.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = "a"`},
+						{MessageId: "escapeBackslash", Output: `var foo = "\\a"`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = "\B";`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \B.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = "B";`},
+						{MessageId: "escapeBackslash", Output: `var foo = "\\B";`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = "\@";`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \@.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = "@";`},
+						{MessageId: "escapeBackslash", Output: `var foo = "\\@";`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = "foo \a bar";`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \a.`,
+					Line:      1, Column: 16, EndLine: 1, EndColumn: 17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = "foo a bar";`},
+						{MessageId: "escapeBackslash", Output: `var foo = "foo \\a bar";`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = '\"';`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \".`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = '"';`},
+						{MessageId: "escapeBackslash", Output: `var foo = '\\"';`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = '\#';`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \#.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = '#';`},
+						{MessageId: "escapeBackslash", Output: `var foo = '\\#';`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = '\$';`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \$.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = '$';`},
+						{MessageId: "escapeBackslash", Output: `var foo = '\\$';`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = '\p';`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \p.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = 'p';`},
+						{MessageId: "escapeBackslash", Output: `var foo = '\\p';`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = '\p\a\@';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \p.`,
+						Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `var foo = 'p\a\@';`},
+							{MessageId: "escapeBackslash", Output: `var foo = '\\p\a\@';`},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \a.`,
+						Line:      1, Column: 14, EndLine: 1, EndColumn: 15,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `var foo = '\pa\@';`},
+							{MessageId: "escapeBackslash", Output: `var foo = '\p\\a\@';`},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \@.`,
+						Line:      1, Column: 16, EndLine: 1, EndColumn: 17,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `var foo = '\p\a@';`},
+							{MessageId: "escapeBackslash", Output: `var foo = '\p\a\\@';`},
+						},
+					},
+				},
+			},
+			{
+				Code: `var foo = '\` + "`" + `';`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   "Unnecessary escape character: \\`.",
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "var foo = '`';"},
+						{MessageId: "escapeBackslash", Output: "var foo = '\\\\`';"},
+					},
+				}},
+			},
+
+			// ---- Template literals: identity escapes that aren't valid ----
+			{
+				Code: "var foo = `\\\"`;",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \".`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "var foo = `\"`;"},
+						{MessageId: "escapeBackslash", Output: "var foo = `\\\\\"`;"},
+					},
+				}},
+			},
+			{
+				Code: "var foo = `\\'`;",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \'.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "var foo = `'`;"},
+						{MessageId: "escapeBackslash", Output: "var foo = `\\\\'`;"},
+					},
+				}},
+			},
+			{
+				Code: "var foo = `\\#`;",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \#.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "var foo = `#`;"},
+						{MessageId: "escapeBackslash", Output: "var foo = `\\\\#`;"},
+					},
+				}},
+			},
+			{
+				Code: "var foo = '\\`foo\\`';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   "Unnecessary escape character: \\`.",
+						Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var foo = '`foo\\`';"},
+							{MessageId: "escapeBackslash", Output: "var foo = '\\\\`foo\\`';"},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   "Unnecessary escape character: \\`.",
+						Line:      1, Column: 17, EndLine: 1, EndColumn: 18,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var foo = '\\`foo`';"},
+							{MessageId: "escapeBackslash", Output: "var foo = '\\`foo\\\\`';"},
+						},
+					},
+				},
+			},
+			{
+				Code: "var foo = `\\\"${foo}\\\"`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \".`,
+						Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var foo = `\"${foo}\\\"`;"},
+							{MessageId: "escapeBackslash", Output: "var foo = `\\\\\"${foo}\\\"`;"},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \".`,
+						Line:      1, Column: 20, EndLine: 1, EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var foo = `\\\"${foo}\"`;"},
+							{MessageId: "escapeBackslash", Output: "var foo = `\\\"${foo}\\\\\"`;"},
+						},
+					},
+				},
+			},
+			{
+				Code: "var foo = `\\'${foo}\\'`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \'.`,
+						Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var foo = `'${foo}\\'`;"},
+							{MessageId: "escapeBackslash", Output: "var foo = `\\\\'${foo}\\'`;"},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \'.`,
+						Line:      1, Column: 20, EndLine: 1, EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var foo = `\\'${foo}'`;"},
+							{MessageId: "escapeBackslash", Output: "var foo = `\\'${foo}\\\\'`;"},
+						},
+					},
+				},
+			},
+			{
+				Code: "var foo = `\\#${foo}`;",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \#.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "var foo = `#${foo}`;"},
+						{MessageId: "escapeBackslash", Output: "var foo = `\\\\#${foo}`;"},
+					},
+				}},
+			},
+			{
+				Code: `let foo = '\ ';`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   "Unnecessary escape character: \\ .",
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `let foo = ' ';`},
+						{MessageId: "escapeBackslash", Output: `let foo = '\\ ';`},
+					},
+				}},
+			},
+			{
+				Code: `let foo = /\ /;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   "Unnecessary escape character: \\ .",
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `let foo = / /;`},
+						{MessageId: "escapeBackslash", Output: `let foo = /\\ /;`},
+					},
+				}},
+			},
+			{
+				Code: "var foo = `\\$\\{{${foo}`;",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \$.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "var foo = `$\\{{${foo}`;"},
+						{MessageId: "escapeBackslash", Output: "var foo = `\\\\$\\{{${foo}`;"},
+					},
+				}},
+			},
+			{
+				Code: "var foo = `\\$a${foo}`;",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \$.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "var foo = `$a${foo}`;"},
+						{MessageId: "escapeBackslash", Output: "var foo = `\\\\$a${foo}`;"},
+					},
+				}},
+			},
+			{
+				Code: "var foo = `a\\{{${foo}`;",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \{.`,
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "var foo = `a{{${foo}`;"},
+						{MessageId: "escapeBackslash", Output: "var foo = `a\\\\{{${foo}`;"},
+					},
+				}},
+			},
+
+			// ---- Multi-line template literal: line/column track newlines ----
+			{
+				Code: "`multiline template\nliteral with useless \\escape`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \e.`,
+					Line:      2, Column: 22, EndLine: 2, EndColumn: 23,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "`multiline template\nliteral with useless escape`"},
+						{MessageId: "escapeBackslash", Output: "`multiline template\nliteral with useless \\\\escape`"},
+					},
+				}},
+			},
+			{
+				Code: "`multiline template\r\nliteral with useless \\escape`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \e.`,
+					Line:      2, Column: 22, EndLine: 2, EndColumn: 23,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "`multiline template\r\nliteral with useless escape`"},
+						{MessageId: "escapeBackslash", Output: "`multiline template\r\nliteral with useless \\\\escape`"},
+					},
+				}},
+			},
+			{
+				Code: "`template literal with line continuation \\\nand useless \\escape`",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \e.`,
+					Line:      2, Column: 13, EndLine: 2, EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "`template literal with line continuation \\\nand useless escape`"},
+						{MessageId: "escapeBackslash", Output: "`template literal with line continuation \\\nand useless \\\\escape`"},
+					},
+				}},
+			},
+
+			// ---- Regex character class ----
+			{
+				Code: `var foo = /[ab\-]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \-.`,
+					Line:      1, Column: 15, EndLine: 1, EndColumn: 16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[ab-]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[ab\\-]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[\-ab]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \-.`,
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[-ab]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[\\-ab]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[ab\?]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 15, EndLine: 1, EndColumn: 16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[ab?]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[ab\\?]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[ab\.]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 15, EndLine: 1, EndColumn: 16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[ab.]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[ab\\.]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[a\|b]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 14, EndLine: 1, EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[a|b]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[a\\|b]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /\-/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /-/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /\\-/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[\-]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[-]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[\\-]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[ab\$]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 15, EndLine: 1, EndColumn: 16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[ab$]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[ab\\$]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[\(paren]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[(paren]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[\\(paren]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[\[]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[[]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[\\[]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[\/]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[/]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[\\/]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[\B]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[B]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[\\B]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[a][\-b]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 16, EndLine: 1, EndColumn: 17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[a][-b]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[a][\\-b]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /\-[]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /-[]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /\\-[]/`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = /[a\^]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 14, EndLine: 1, EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[a^]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[a\\^]/`},
+					},
+				}},
+			},
+
+			// ---- Caret in negated class ----
+			{
+				Code: `/[^\^]/`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 4,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "/[^^]/"},
+						{MessageId: "escapeBackslash", Output: `/[^\\^]/`},
+					},
+				}},
+			},
+			{
+				Code: `/[^\^]/u`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 4,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "/[^^]/u"},
+						{MessageId: "escapeBackslash", Output: `/[^\\^]/u`},
+					},
+				}},
+			},
+
+			// ---- Directive prologue: removeEscapeDoNotKeepSemantics suggestion ----
+			{
+				Code: `"use\ strict";`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   "Unnecessary escape character: \\ .",
+					Line:      1, Column: 5, EndLine: 1, EndColumn: 6,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscapeDoNotKeepSemantics", Output: `"use strict";`},
+						{MessageId: "escapeBackslash", Output: `"use\\ strict";`},
+					},
+				}},
+			},
+			{
+				Code: `({ foo() { "foo"; "bar"; "ba\z" } })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \z.`,
+					Line:      1, Column: 29, EndLine: 1, EndColumn: 30,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscapeDoNotKeepSemantics", Output: `({ foo() { "foo"; "bar"; "baz" } })`},
+						{MessageId: "escapeBackslash", Output: `({ foo() { "foo"; "bar"; "ba\\z" } })`},
+					},
+				}},
+			},
+
+			// ---- ES2024 v-mode reserved-double-punctuator escapes ----
+			// Each leading `\X` is at the start of the class so neither neighbour
+			// nor double-punctuator exemption applies — flagged with both
+			// suggestions.
+			{
+				Code: `/[\$]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 3, EndLine: 1, EndColumn: 4,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "/[$]/v"},
+						{MessageId: "escapeBackslash", Output: `/[\\$]/v`},
+					},
+				}},
+			},
+			{
+				Code: `/[\&\&]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \&.`,
+					Line:      1, Column: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[&\&]/v`},
+						{MessageId: "escapeBackslash", Output: `/[\\&\&]/v`},
+					},
+				}},
+			},
+			{
+				Code: `/[\!\!]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[!\!]/v`},
+						{MessageId: "escapeBackslash", Output: `/[\\!\!]/v`},
+					},
+				}},
+			},
+			{
+				Code: `/[\#\#]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[#\#]/v`},
+						{MessageId: "escapeBackslash", Output: `/[\\#\#]/v`},
+					},
+				}},
+			},
+			{
+				Code: `/[\%\%]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[%\%]/v`},
+						{MessageId: "escapeBackslash", Output: `/[\\%\%]/v`},
+					},
+				}},
+			},
+			{
+				Code: `/[\*\*]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[*\*]/v`},
+						{MessageId: "escapeBackslash", Output: `/[\\*\*]/v`},
+					},
+				}},
+			},
+			{
+				Code: `/[\+\+]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[+\+]/v`},
+						{MessageId: "escapeBackslash", Output: `/[\\+\+]/v`},
+					},
+				}},
+			},
+
+			// ---- v-mode set-operation escapes: only `removeEscape`, no `escapeBackslash` ----
+			{
+				Code: `/[\p{ASCII}--\.]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \..`,
+					Line:      1, Column: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[\p{ASCII}--.]/v`},
+					},
+				}},
+			},
+			{
+				Code: `/[\p{ASCII}&&\.]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[\p{ASCII}&&.]/v`},
+					},
+				}},
+			},
+			{
+				Code: `/[\.--[.&]]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[.--[.&]]/v`},
+					},
+				}},
+			},
+			{
+				Code: `/[\.&&[.&]]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[.&&[.&]]/v`},
+					},
+				}},
+			},
+			{
+				Code: `/[\.--\.--\.]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[.--\.--\.]/v`},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[\.--.--\.]/v`},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 11,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[\.--\.--.]/v`},
+						},
+					},
+				},
+			},
+			{
+				Code: `/[\.&&\.&&\.]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[.&&\.&&\.]/v`},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[\.&&.&&\.]/v`},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 11,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[\.&&\.&&.]/v`},
+						},
+					},
+				},
+			},
+			// Nested classes — escapes are inside [.&], not directly in the
+			// outer set-operation class, so escapeBackslash IS suggested.
+			{
+				Code: `/[[\.&]--[\.&]]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 4,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[[.&]--[\.&]]/v`},
+							{MessageId: "escapeBackslash", Output: `/[[\\.&]--[\.&]]/v`},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 11,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[[\.&]--[.&]]/v`},
+							{MessageId: "escapeBackslash", Output: `/[[\.&]--[\\.&]]/v`},
+						},
+					},
+				},
+			},
+			{
+				Code: `/[[\.&]&&[\.&]]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 4,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[[.&]&&[\.&]]/v`},
+							{MessageId: "escapeBackslash", Output: `/[[\\.&]&&[\.&]]/v`},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 11,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[[\.&]&&[.&]]/v`},
+							{MessageId: "escapeBackslash", Output: `/[[\.&]&&[\\.&]]/v`},
+						},
+					},
+				},
+			},
+
+			// ---- Option allowRegexCharacters: only allows specific chars ----
+			{
+				Code:    `var foo = "\#/";`,
+				Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"#"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \#.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = "#/";`},
+						{MessageId: "escapeBackslash", Output: `var foo = "\\#/";`},
+					},
+				}},
+			},
+			{
+				Code:    `var foo = /\#\@/;`,
+				Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"#"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \@.`,
+					Line:      1, Column: 14, EndLine: 1, EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /\#@/;`},
+						{MessageId: "escapeBackslash", Output: `var foo = /\#\\@/;`},
+					},
+				}},
+			},
+			{
+				Code:    `var foo = /[a\@b]/`,
+				Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"#"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \@.`,
+					Line:      1, Column: 14, EndLine: 1, EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /[a@b]/`},
+						{MessageId: "escapeBackslash", Output: `var foo = /[a\\@b]/`},
+					},
+				}},
+			},
+			{
+				Code:    `/[\@\@]/v`,
+				Options: map[string]interface{}{"allowRegexCharacters": []interface{}{"#"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[@\@]/v`},
+						{MessageId: "escapeBackslash", Output: `/[\\@\@]/v`},
+					},
+				}},
+			},
+
+			// =================================================================
+			// rslint-specific extensions beyond the upstream test suite. The
+			// goal is to lock in tsgo / Go-port edge cases that the ESLint
+			// suite never exercises.
+			// =================================================================
+
+			// ---- Multi-span template literals: each span reports independently ----
+			{
+				Code: "var foo = `\\#${a}\\@${b}\\!`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \#.`,
+						Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var foo = `#${a}\\@${b}\\!`;"},
+							{MessageId: "escapeBackslash", Output: "var foo = `\\\\#${a}\\@${b}\\!`;"},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \@.`,
+						Line:      1, Column: 18, EndLine: 1, EndColumn: 19,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var foo = `\\#${a}@${b}\\!`;"},
+							{MessageId: "escapeBackslash", Output: "var foo = `\\#${a}\\\\@${b}\\!`;"},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \!.`,
+						Line:      1, Column: 24, EndLine: 1, EndColumn: 25,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var foo = `\\#${a}\\@${b}!`;"},
+							{MessageId: "escapeBackslash", Output: "var foo = `\\#${a}\\@${b}\\\\!`;"},
+						},
+					},
+				},
+			},
+
+			// ---- TS surface around string literals — non-null, parens, as ----
+			{
+				Code: `var foo = ("\#")!;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \#.`,
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = ("#")!;`},
+						{MessageId: "escapeBackslash", Output: `var foo = ("\\#")!;`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = "\@" as string;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \@.`,
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = "@" as string;`},
+						{MessageId: "escapeBackslash", Output: `var foo = "\\@" as string;`},
+					},
+				}},
+			},
+			{
+				Code: `var foo = "\@" satisfies string;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = "@" satisfies string;`},
+						{MessageId: "escapeBackslash", Output: `var foo = "\\@" satisfies string;`},
+					},
+				}},
+			},
+
+			// ---- String literals in real TS contexts ----
+			{
+				Code: `import foo from "./a\#";`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 21, EndLine: 1, EndColumn: 22,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `import foo from "./a#";`},
+						{MessageId: "escapeBackslash", Output: `import foo from "./a\\#";`},
+					},
+				}},
+			},
+			{
+				Code: `enum E { A = "\#" }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 15, EndLine: 1, EndColumn: 16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `enum E { A = "#" }`},
+						{MessageId: "escapeBackslash", Output: `enum E { A = "\\#" }`},
+					},
+				}},
+			},
+			{
+				Code: `type T = "\#";`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 11, EndLine: 1, EndColumn: 12,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `type T = "#";`},
+						{MessageId: "escapeBackslash", Output: `type T = "\\#";`},
+					},
+				}},
+			},
+			{
+				Code: `const obj = { ["\#"]: 1 };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 17, EndLine: 1, EndColumn: 18,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `const obj = { ["#"]: 1 };`},
+						{MessageId: "escapeBackslash", Output: `const obj = { ["\\#"]: 1 };`},
+					},
+				}},
+			},
+
+			// ---- Function-body directive prologue (use removeEscapeDoNotKeepSemantics) ----
+			{
+				Code: `function f() { "use\ strict"; return 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 20, EndLine: 1, EndColumn: 21,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscapeDoNotKeepSemantics", Output: `function f() { "use strict"; return 1; }`},
+						{MessageId: "escapeBackslash", Output: `function f() { "use\\ strict"; return 1; }`},
+					},
+				}},
+			},
+			// String literal in expression position (NOT a directive) → standard removeEscape.
+			{
+				Code: `var x = "\@"; "ba\z";`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 10, EndLine: 1, EndColumn: 11,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `var x = "@"; "ba\z";`},
+							{MessageId: "escapeBackslash", Output: `var x = "\\@"; "ba\z";`},
+						},
+					},
+					// `"ba\z";` is the second statement, NOT a prologue — uses removeEscape, not the DoNotKeepSemantics variant.
+					{
+						MessageId: "unnecessaryEscape",
+						Line:      1, Column: 18, EndLine: 1, EndColumn: 19,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `var x = "\@"; "baz";`},
+							{MessageId: "escapeBackslash", Output: `var x = "\@"; "ba\\z";`},
+						},
+					},
+				},
+			},
+
+			// ---- Surrogate-pair / multi-byte preceding the escape (column counted in UTF-16) ----
+			// 👍 occupies 2 UTF-16 code units (cols 12-13); the `\#` lands at column 14.
+			{
+				Code: "var foo = '👍\\#';",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 14, EndLine: 1, EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "var foo = '👍#';"},
+						{MessageId: "escapeBackslash", Output: "var foo = '👍\\\\#';"},
+					},
+				}},
+			},
+
+			// ---- Multi-line regex-equivalent (multi-line content via continuations / line 2 reports) ----
+			{
+				Code: "var foo = '\\\nbar\\@';",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      2, Column: 4, EndLine: 2, EndColumn: 5,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: "var foo = '\\\nbar@';"},
+						{MessageId: "escapeBackslash", Output: "var foo = '\\\nbar\\\\@';"},
+					},
+				}},
+			},
+
+			// ---- v-mode triple-nested classes — escape directly under outer set-op ----
+			// `[\.&&[a&&[b]]]` — \. is at top of outer class which has &&; no escapeBackslash.
+			{
+				Code: `/[\.&&[a&&[b]]]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 3, EndLine: 1, EndColumn: 4,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[.&&[a&&[b]]]/v`},
+					},
+				}},
+			},
+			// Escape three levels deep inside a class without set ops — has escapeBackslash.
+			{
+				Code: `/[a&&[b&&[\.]]]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 11, EndLine: 1, EndColumn: 12,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[a&&[b&&[.]]]/v`},
+						{MessageId: "escapeBackslash", Output: `/[a&&[b&&[\\.]]]/v`},
+					},
+				}},
+			},
+
+			// ---- v-mode `\^` adjacent-to-negate-caret edge ----
+			// Before-caret: `\^` IS the negate; second `^` is literal — only the
+			// inner `\^` should fire if it's after the negate but doubled with
+			// another `^` after.
+			// Already covered by /[^\^^]/v (valid) and /[^\^]/v (invalid in v).
+			// Add: nested negate class with `\^` not at start.
+			{
+				Code: `/[^a\^]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 5, EndLine: 1, EndColumn: 6,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[^a^]/v`},
+						{MessageId: "escapeBackslash", Output: `/[^a\\^]/v`},
+					},
+				}},
+			},
+
+			// ---- Multi-byte UTF-8 escapes inside string ----
+			// `\é` (multi-byte X) — flagged with the multi-byte text in the message.
+			{
+				Code: `var foo = "\é";`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   "Unnecessary escape character: \\é.",
+					Line:      1, Column: 12, EndLine: 1, EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = "é";`},
+						{MessageId: "escapeBackslash", Output: `var foo = "\\é";`},
+					},
+				}},
+			},
+
+			// ---- Multiple escapes interleaved with valid escapes in regex ----
+			{
+				Code: `var foo = /\d\@\w\#\s/;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \@.`,
+						Line:      1, Column: 14, EndLine: 1, EndColumn: 15,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `var foo = /\d@\w\#\s/;`},
+							{MessageId: "escapeBackslash", Output: `var foo = /\d\\@\w\#\s/;`},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \#.`,
+						Line:      1, Column: 18, EndLine: 1, EndColumn: 19,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `var foo = /\d\@\w#\s/;`},
+							{MessageId: "escapeBackslash", Output: `var foo = /\d\@\w\\#\s/;`},
+						},
+					},
+				},
+			},
+
+			// ---- Regex with leading/trailing valid escapes guarding an invalid one ----
+			{
+				Code: `var foo = /\b\@\b/;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 14, EndLine: 1, EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var foo = /\b@\b/;`},
+						{MessageId: "escapeBackslash", Output: `var foo = /\b\\@\b/;`},
+					},
+				}},
+			},
+
+			// ---- Directive-container precision: only function-body Blocks count ----
+			// Inside `if (true) { "ba\z"; }` — `{ }` is a plain Block, NOT a directive
+			// container. The string is a regular expression statement, so the
+			// remove-escape suggestion should be the standard `removeEscape`,
+			// NOT `removeEscapeDoNotKeepSemantics`.
+			{
+				Code: `if (true) { "ba\z"; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 16, EndLine: 1, EndColumn: 17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `if (true) { "baz"; }`},
+						{MessageId: "escapeBackslash", Output: `if (true) { "ba\\z"; }`},
+					},
+				}},
+			},
+			{
+				Code: `for (;;) { "ba\z"; break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 15, EndLine: 1, EndColumn: 16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `for (;;) { "baz"; break; }`},
+						{MessageId: "escapeBackslash", Output: `for (;;) { "ba\\z"; break; }`},
+					},
+				}},
+			},
+			// Plain Block as a statement — also NOT a directive container.
+			{
+				Code: `{ "ba\z"; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 6, EndLine: 1, EndColumn: 7,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `{ "baz"; }`},
+						{MessageId: "escapeBackslash", Output: `{ "ba\\z"; }`},
+					},
+				}},
+			},
+			// Class static block IS a directive container.
+			{
+				Code: `class C { static { "use\ strict"; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 24, EndLine: 1, EndColumn: 25,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscapeDoNotKeepSemantics", Output: `class C { static { "use strict"; } }`},
+						{MessageId: "escapeBackslash", Output: `class C { static { "use\\ strict"; } }`},
+					},
+				}},
+			},
+			// Arrow-function body IS a function body → directive container.
+			{
+				Code: `var f = () => { "use\ strict"; return 1; };`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 21, EndLine: 1, EndColumn: 22,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscapeDoNotKeepSemantics", Output: `var f = () => { "use strict"; return 1; };`},
+						{MessageId: "escapeBackslash", Output: `var f = () => { "use\\ strict"; return 1; };`},
+					},
+				}},
+			},
+
+			// ---- TSX: probe whether StringLiteral CAN appear under JsxElement /
+			// JsxFragment as direct children. If it can, our defensive skip
+			// branches matter; if it can't, they're dead code (matching upstream's
+			// defensive structural check). The cases below assert the actually
+			// reachable JSX shapes.
+
+			// JsxAttribute value (StringLiteral child of JsxAttribute) — SKIPPED.
+			// (No error expected; this case lives in the valid section above as
+			// `<div attr="\d" />`. Repeated here as documentation.)
+
+			// StringLiteral inside `{…}` — parent is JsxExpression, NOT
+			// JsxAttribute / JsxElement / JsxFragment — should be FLAGGED.
+			{
+				Code: `<foo attr={"\#"}/>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `<foo attr={"#"}/>`},
+						{MessageId: "escapeBackslash", Output: `<foo attr={"\\#"}/>`},
+					},
+				}},
+			},
+			// StringLiteral inside JsxExpression in element body — same: parent
+			// is JsxExpression. Confirms the JsxElement-direct-child case is
+			// unreachable in tsgo (StringLiteral is wrapped in JsxExpression).
+			{
+				Code: `var x = <div>{"\@"}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Line:      1, Column: 16, EndLine: 1, EndColumn: 17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `var x = <div>{"@"}</div>`},
+						{MessageId: "escapeBackslash", Output: `var x = <div>{"\\@"}</div>`},
+					},
+				}},
+			},
+
+			// ---- Non-v mode: literal `[` inside a class is NOT a nested
+			// class start; the next `]` still closes the class. Caught from a
+			// real-world rsbuild/css-loader bundled regex that we initially
+			// missed. ----
+			{
+				Code: "var p = /[ -,.\\/:-@[\\]\\^`{-~]/;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \/.`,
+						Line:      1, Column: 15, EndLine: 1, EndColumn: 16,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var p = /[ -,./:-@[\\]\\^`{-~]/;"},
+							{MessageId: "escapeBackslash", Output: "var p = /[ -,.\\\\/:-@[\\]\\^`{-~]/;"},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \^.`,
+						Line:      1, Column: 23, EndLine: 1, EndColumn: 24,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: "var p = /[ -,.\\/:-@[\\]^`{-~]/;"},
+							{MessageId: "escapeBackslash", Output: "var p = /[ -,.\\/:-@[\\]\\\\^`{-~]/;"},
+						},
+					},
+				},
+			},
+
+			// ---- v-mode `\q{…}` body: nested escapes are flagged ----
+			// `\.` inside `\q{a\.b}` is a Character node in regexpp's AST, so
+			// upstream flags it. Our walker must too.
+			{
+				Code: `/[\q{a\.b}]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unnecessaryEscape",
+					Message:   `Unnecessary escape character: \..`,
+					Line:      1, Column: 7, EndLine: 1, EndColumn: 8,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "removeEscape", Output: `/[\q{a.b}]/v`},
+						{MessageId: "escapeBackslash", Output: `/[\q{a\\.b}]/v`},
+					},
+				}},
+			},
+			// Multiple alternatives, multiple flags.
+			{
+				Code: `/[\q{\@a|\#b}]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \@.`,
+						Line:      1, Column: 6, EndLine: 1, EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[\q{@a|\#b}]/v`},
+							{MessageId: "escapeBackslash", Output: `/[\q{\\@a|\#b}]/v`},
+						},
+					},
+					{
+						MessageId: "unnecessaryEscape",
+						Message:   `Unnecessary escape character: \#.`,
+						Line:      1, Column: 10, EndLine: 1, EndColumn: 11,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "removeEscape", Output: `/[\q{\@a|#b}]/v`},
+							{MessageId: "escapeBackslash", Output: `/[\q{\@a|\\#b}]/v`},
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
+// =============================================================================
+// Hardening tests for the regex pattern parser. These cover malformed-input
+// skip behavior (matching ESLint's regexpp try/catch) and boundary conditions
+// that aren't surfaced through the rule_tester DSL because TS rejects the
+// regex at parse time. We exercise the parser as a pure function below.
+// =============================================================================
+
+func TestPatternParses(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		flagStr string
+		want    bool
+	}{
+		// Well-formed patterns — should parse.
+		{name: "empty", pattern: "", flagStr: "", want: true},
+		{name: "literal", pattern: "abc", flagStr: "", want: true},
+		{name: "simple class", pattern: "[abc]", flagStr: "", want: true},
+		{name: "negated class", pattern: "[^abc]", flagStr: "", want: true},
+		{name: "v-mode nested classes", pattern: "[[a]&&[b]]", flagStr: "v", want: true},
+		{name: "u-mode property escape", pattern: "\\p{ASCII}", flagStr: "u", want: true},
+		{name: "v-mode q-string", pattern: "[\\q{abc}]", flagStr: "v", want: true},
+		{name: "v-mode q-string with literal ]", pattern: "[\\q{a]b}c]", flagStr: "v", want: true},
+		{name: "named backreference", pattern: "(?<a>x)\\k<a>", flagStr: "", want: true},
+		{name: "literal-]-outside-class", pattern: "abc]", flagStr: "", want: true},
+
+		// Malformed — should skip.
+		{name: "unterminated class", pattern: "[abc", flagStr: "", want: false},
+		{name: "trailing backslash", pattern: "abc\\", flagStr: "", want: false},
+		{name: "unterminated u-brace under uvMode", pattern: "\\u{1F600", flagStr: "u", want: false},
+		{name: "unterminated p-brace", pattern: "\\p{ASCI", flagStr: "u", want: false},
+		{name: "unterminated q-brace", pattern: "[\\q{abc", flagStr: "v", want: false},
+		{name: "unterminated k-name", pattern: "\\k<name", flagStr: "", want: false},
+		// Note: `\u{` in non-uvMode is identity-escape `u`, NOT an error.
+		{name: "u-brace in non-uvMode is fine", pattern: "\\u{1F600}", flagStr: "", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := parseFlagsFromStr(tt.flagStr)
+			got := patternParses(tt.pattern, flags)
+			if got != tt.want {
+				t.Errorf("patternParses(%q, %q) = %v, want %v", tt.pattern, tt.flagStr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreScanClass(t *testing.T) {
+	tests := []struct {
+		name        string
+		pattern     string
+		start       int
+		flagStr     string
+		wantNegate  bool
+		wantSetOp   bool
+		wantEnd     int
+	}{
+		{name: "simple", pattern: "[abc]", start: 0, flagStr: "", wantEnd: 5},
+		{name: "negated", pattern: "[^abc]", start: 0, flagStr: "", wantNegate: true, wantEnd: 6},
+		{name: "v-mode no set op", pattern: "[abc]", start: 0, flagStr: "v", wantEnd: 5},
+		{name: "v-mode subtract", pattern: "[\\.--\\.]", start: 0, flagStr: "v", wantSetOp: true, wantEnd: 8},
+		{name: "v-mode intersect", pattern: "[a&&b]", start: 0, flagStr: "v", wantSetOp: true, wantEnd: 6},
+		// Nested set-op only counts at the OUTER class's level.
+		{name: "v-mode set-op nested only", pattern: "[a[b&&c]]", start: 0, flagStr: "v", wantEnd: 9},
+		{name: "v-mode set-op outer with nested", pattern: "[a&&[b]]", start: 0, flagStr: "v", wantSetOp: true, wantEnd: 8},
+		// Escaped `]` should not close the class early.
+		{name: "escaped ] in class", pattern: "[\\]a]", start: 0, flagStr: "", wantEnd: 5},
+		// `\q{...}` in v-mode contains a `]` literal; class shouldn't close inside.
+		{name: "q-string inside class", pattern: "[\\q{a]b}c]", start: 0, flagStr: "v", wantEnd: 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := parseFlagsFromStr(tt.flagStr)
+			frame := preScanClass(tt.pattern, tt.start, flags)
+			if frame.negate != tt.wantNegate {
+				t.Errorf("negate = %v, want %v", frame.negate, tt.wantNegate)
+			}
+			if frame.hasSetOp != tt.wantSetOp {
+				t.Errorf("hasSetOp = %v, want %v", frame.hasSetOp, tt.wantSetOp)
+			}
+			if frame.end != tt.wantEnd {
+				t.Errorf("end = %d, want %d", frame.end, tt.wantEnd)
+			}
+		})
+	}
+}
+
+func parseFlagsFromStr(s string) utils.RegexFlags {
+	return utils.ParseRegexFlags(s)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -318,6 +318,7 @@ export default defineConfig({
     './tests/eslint/rules/no-useless-backreference.test.ts',
     './tests/eslint/rules/no-useless-call.test.ts',
     './tests/eslint/rules/no-useless-catch.test.ts',
+    './tests/eslint/rules/no-useless-escape.test.ts',
     './tests/eslint/rules/no-useless-rename.test.ts',
     './tests/eslint/rules/no-useless-constructor.test.ts',
     './tests/eslint/rules/no-prototype-builtins.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-escape.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-escape.test.ts.snap
@@ -1,0 +1,1685 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-escape > invalid 1`] = `
+{
+  "code": "var foo = /\\#/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 2`] = `
+{
+  "code": "var foo = /\\;/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\;.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 3`] = `
+{
+  "code": "var foo = "\\'";",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\'.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 4`] = `
+{
+  "code": "var foo = "\\#/";",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 5`] = `
+{
+  "code": "var foo = "\\a";",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\a.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 6`] = `
+{
+  "code": "var foo = "\\B";",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\B.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 7`] = `
+{
+  "code": "var foo = "\\@";",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\@.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 8`] = `
+{
+  "code": "var foo = "foo \\a bar";",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\a.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 9`] = `
+{
+  "code": "var foo = '\\"';",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\".",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 10`] = `
+{
+  "code": "var foo = '\\#';",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 11`] = `
+{
+  "code": "var foo = '\\$';",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\$.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 12`] = `
+{
+  "code": "var foo = '\\p';",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\p.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 13`] = `
+{
+  "code": "var foo = '\\p\\a\\@';",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\p.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+    {
+      "message": "Unnecessary escape character: \\a.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+    {
+      "message": "Unnecessary escape character: \\@.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 14`] = `
+{
+  "code": "var foo = '\\\`';",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\\`.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 15`] = `
+{
+  "code": "var foo = \`\\"\`;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\".",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 16`] = `
+{
+  "code": "var foo = \`\\'\`;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\'.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 17`] = `
+{
+  "code": "var foo = \`\\#\`;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 18`] = `
+{
+  "code": "var foo = '\\\`foo\\\`';",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\\`.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+    {
+      "message": "Unnecessary escape character: \\\`.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 19`] = `
+{
+  "code": "var foo = \`\\#\${foo}\`;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 20`] = `
+{
+  "code": "var foo = \`\\$\\{{\${foo}\`;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\$.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 21`] = `
+{
+  "code": "var foo = \`\\$a\${foo}\`;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\$.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 22`] = `
+{
+  "code": "var foo = \`a\\{{\${foo}\`;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\{.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 23`] = `
+{
+  "code": "var foo = /[ab\\-]/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\-.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 24`] = `
+{
+  "code": "var foo = /[\\-ab]/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\-.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 25`] = `
+{
+  "code": "var foo = /[ab\\?]/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\?.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 26`] = `
+{
+  "code": "var foo = /[ab\\.]/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\..",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 27`] = `
+{
+  "code": "var foo = /\\-/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\-.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 28`] = `
+{
+  "code": "var foo = /[\\-]/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\-.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 29`] = `
+{
+  "code": "var foo = /[\\B]/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\B.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 30`] = `
+{
+  "code": "var foo = /[a\\^]/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\^.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 31`] = `
+{
+  "code": "/[^\\^]/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\^.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 32`] = `
+{
+  "code": ""use\\ strict";",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\ .",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 33`] = `
+{
+  "code": "/[\\$]/v;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\$.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 34`] = `
+{
+  "code": "/[\\&\\&]/v;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\&.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 35`] = `
+{
+  "code": "/[\\p{ASCII}--\\.]/v;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\..",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 36`] = `
+{
+  "code": "/[\\.--\\.--\\.]/v;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\..",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+    {
+      "message": "Unnecessary escape character: \\..",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+    {
+      "message": "Unnecessary escape character: \\..",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 37`] = `
+{
+  "code": "/[[\\.&]--[\\.&]]/v;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\..",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+    {
+      "message": "Unnecessary escape character: \\..",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 38`] = `
+{
+  "code": "var foo = /\\#\\@/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\@.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 39`] = `
+{
+  "code": "var foo = /[a\\@b]/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\@.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 40`] = `
+{
+  "code": "var foo = \`\\#\${a}\\@\${b}\\!\`;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+    {
+      "message": "Unnecessary escape character: \\@.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+    {
+      "message": "Unnecessary escape character: \\!.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 41`] = `
+{
+  "code": "var foo = ("\\#")!;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 42`] = `
+{
+  "code": "var foo = "\\@" as string;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\@.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 43`] = `
+{
+  "code": "var foo = "\\@" satisfies string;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\@.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 44`] = `
+{
+  "code": "import foo from "./a\\#";",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 45`] = `
+{
+  "code": "enum E { A = "\\#" }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 46`] = `
+{
+  "code": "type T = "\\#";",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 47`] = `
+{
+  "code": "const obj = { ["\\#"]: 1 };",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 48`] = `
+{
+  "code": "function f() { "use\\ strict"; return 1; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\ .",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 49`] = `
+{
+  "code": "/[\\.&&[a&&[b]]]/v;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\..",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 50`] = `
+{
+  "code": "/[a&&[b&&[\\.]]]/v;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\..",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 51`] = `
+{
+  "code": "/[^a\\^]/v;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\^.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 52`] = `
+{
+  "code": "var foo = "\\é";",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\é.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 53`] = `
+{
+  "code": "var foo = /\\d\\@\\w\\#\\s/;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\@.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 54`] = `
+{
+  "code": "var foo = '👍\\#';",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 55`] = `
+{
+  "code": "if (true) { "ba\\z"; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\z.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 56`] = `
+{
+  "code": "{ "ba\\z"; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\z.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 57`] = `
+{
+  "code": "class C { static { "use\\ strict"; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\ .",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 58`] = `
+{
+  "code": "/[\\q{a\\.b}]/v;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\..",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-escape > invalid 59`] = `
+{
+  "code": "/[\\q{\\@a|\\#b}]/v;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary escape character: \\@.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+    {
+      "message": "Unnecessary escape character: \\#.",
+      "messageId": "unnecessaryEscape",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-escape",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-useless-escape.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-useless-escape.test.ts
@@ -1,0 +1,421 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-escape', {
+  valid: [
+    // ---- Regex outside character classes ----
+    'var foo = /\\./;',
+    'var foo = /\\//g;',
+    'var foo = /""/;',
+    "var foo = /''/;",
+    'var foo = /\\D/;',
+    'var foo = /\\W/;',
+    'var foo = /\\w/;',
+    'var foo = /\\\\/g;',
+    'var foo = /\\w\\$\\*\\./;',
+    'var foo = /\\^\\+\\./;',
+
+    // ---- String literals: valid escape sequences ----
+    'var foo = "\\x12";',
+    'var foo = "\\u00a9";',
+    'var foo = "\\"";',
+    'var foo = "foo \\\\ bar";',
+    'var foo = "\\t";',
+    'var foo = "foo \\b bar";',
+    "var foo = '\\n';",
+    "var foo = 'foo \\r bar';",
+    "var foo = '\\v';",
+    "var foo = '\\f';",
+
+    // ---- Template literals: valid escape sequences ----
+    'var foo = `\\x12`;',
+    'var foo = `\\u00a9`;',
+    'var foo = `xs\\u2111`;',
+    'var foo = `foo \\\\ bar`;',
+    'var foo = `\\t`;',
+    'var foo = `\\n`;',
+    'var foo = `\\r`;',
+    'var foo = `\\v`;',
+    'var foo = `\\f`;',
+
+    // ---- Quote escape inside template ----
+    'var foo = `\\``;',
+    'var foo = `\\`${foo}\\``;',
+    // `\$` followed by `{` and `\{` preceded by `$` are necessary.
+    'var foo = `\\${{${foo}`;',
+    'var foo = `$\\{{${foo}`;',
+    // Tagged template — escapes are exposed via the `raw` array.
+    'var foo = String.raw`\\.`;',
+    'var foo = myFunc`\\.`;',
+
+    // ---- Regex character classes ----
+    'var foo = /[\\d]/;',
+    'var foo = /[a\\-b]/;',
+    'var foo = /foo\\?/;',
+    'var foo = /example\\.com/;',
+    'var foo = /foo\\|bar/;',
+    'var foo = /[\\^bar]/;',
+    'var foo = /\\(bar\\)/;',
+    'var foo = /[[\\]]/;',
+    'var foo = /[\\]\\]]/;',
+    'var foo = /\\[abc]/;',
+
+    // ---- Special regex escapes ----
+    'var foo = /\\0/;',
+    'var foo = /\\1/;',
+    'var foo = /(a)\\1/;',
+    'var foo = /(a)\\12/;',
+    'var foo = /[\\0]/;',
+
+    // ---- Carets ----
+    '/[^^]/;',
+    '/[^^]/u;',
+
+    // ---- v-flag character class escapes ----
+    '/[\\q{abc}]/v;',
+    '/[\\(]/v;',
+    '/[\\-]/v;',
+    '/[\\&&]/v;',
+    '/[\\&&&\\&]/v;',
+    '/[\\^]/v;',
+
+    // ---- allowRegexCharacters option ----
+    {
+      code: 'var foo = /\\#/;',
+      options: { allowRegexCharacters: ['#'] },
+    },
+    {
+      code: 'var foo = /[ab\\-]/;',
+      options: { allowRegexCharacters: ['-'] },
+    },
+    {
+      code: 'var foo = /\\-/;',
+      options: { allowRegexCharacters: ['-'] },
+    },
+  ],
+  invalid: [
+    // ---- Regex outside character class ----
+    {
+      code: 'var foo = /\\#/;',
+      errors: [
+        {
+          messageId: 'unnecessaryEscape',
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: 'var foo = /\\;/;',
+      errors: [
+        {
+          messageId: 'unnecessaryEscape',
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+    // ---- String literals: identity escapes that aren't valid ----
+    {
+      code: 'var foo = "\\\'";',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = "\\#/";',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = "\\a";',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = "\\B";',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = "\\@";',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = "foo \\a bar";',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 16 }],
+    },
+    {
+      code: "var foo = '\\\"';",
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: "var foo = '\\#';",
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: "var foo = '\\$';",
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: "var foo = '\\p';",
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: "var foo = '\\p\\a\\@';",
+      errors: [
+        { messageId: 'unnecessaryEscape', line: 1, column: 12 },
+        { messageId: 'unnecessaryEscape', line: 1, column: 14 },
+        { messageId: 'unnecessaryEscape', line: 1, column: 16 },
+      ],
+    },
+    {
+      code: "var foo = '\\`';",
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+
+    // ---- Template literals ----
+    {
+      code: 'var foo = `\\"`;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: "var foo = `\\'`;",
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = `\\#`;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: "var foo = '\\`foo\\`';",
+      errors: [
+        { messageId: 'unnecessaryEscape', line: 1, column: 12 },
+        { messageId: 'unnecessaryEscape', line: 1, column: 17 },
+      ],
+    },
+    {
+      code: 'var foo = `\\#${foo}`;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = `\\$\\{{${foo}`;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = `\\$a${foo}`;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = `a\\{{${foo}`;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 13 }],
+    },
+
+    // ---- Regex character class ----
+    {
+      code: 'var foo = /[ab\\-]/;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 15 }],
+    },
+    {
+      code: 'var foo = /[\\-ab]/;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 13 }],
+    },
+    {
+      code: 'var foo = /[ab\\?]/;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 15 }],
+    },
+    {
+      code: 'var foo = /[ab\\.]/;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 15 }],
+    },
+    {
+      code: 'var foo = /\\-/;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = /[\\-]/;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 13 }],
+    },
+    {
+      code: 'var foo = /[\\B]/;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 13 }],
+    },
+    {
+      code: 'var foo = /[a\\^]/;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 14 }],
+    },
+
+    // ---- Caret in negated class ----
+    {
+      code: '/[^\\^]/;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 4 }],
+    },
+
+    // ---- Directive prologue ----
+    {
+      code: '"use\\ strict";',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 5 }],
+    },
+
+    // ---- v-flag identity escapes ----
+    {
+      code: '/[\\$]/v;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 3 }],
+    },
+    {
+      code: '/[\\&\\&]/v;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 3 }],
+    },
+
+    // ---- v-flag set-operation escapes (no escapeBackslash suggestion) ----
+    {
+      code: '/[\\p{ASCII}--\\.]/v;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 14 }],
+    },
+    {
+      code: '/[\\.--\\.--\\.]/v;',
+      errors: [
+        { messageId: 'unnecessaryEscape', line: 1, column: 3 },
+        { messageId: 'unnecessaryEscape', line: 1, column: 7 },
+        { messageId: 'unnecessaryEscape', line: 1, column: 11 },
+      ],
+    },
+    {
+      code: '/[[\\.&]--[\\.&]]/v;',
+      errors: [
+        { messageId: 'unnecessaryEscape', line: 1, column: 4 },
+        { messageId: 'unnecessaryEscape', line: 1, column: 11 },
+      ],
+    },
+
+    // ---- allowRegexCharacters: only allows specific chars ----
+    {
+      code: 'var foo = /\\#\\@/;',
+      options: { allowRegexCharacters: ['#'] },
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 14 }],
+    },
+    {
+      code: 'var foo = /[a\\@b]/;',
+      options: { allowRegexCharacters: ['#'] },
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 14 }],
+    },
+
+    // ---- rslint-specific extensions (tsgo / Go-port edge cases) ----
+
+    // ---- Multi-span template literals: each span reports independently ----
+    {
+      code: 'var foo = `\\#${a}\\@${b}\\!`;',
+      errors: [
+        { messageId: 'unnecessaryEscape', line: 1, column: 12 },
+        { messageId: 'unnecessaryEscape', line: 1, column: 18 },
+        { messageId: 'unnecessaryEscape', line: 1, column: 24 },
+      ],
+    },
+
+    // ---- TS surface around string literals — non-null, parens, as, satisfies ----
+    {
+      code: 'var foo = ("\\#")!;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 13 }],
+    },
+    {
+      code: 'var foo = "\\@" as string;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+    {
+      code: 'var foo = "\\@" satisfies string;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+
+    // ---- String literals in real TS contexts ----
+    {
+      code: 'import foo from "./a\\#";',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 21 }],
+    },
+    {
+      code: 'enum E { A = "\\#" }',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 15 }],
+    },
+    {
+      code: 'type T = "\\#";',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 11 }],
+    },
+    {
+      code: 'const obj = { ["\\#"]: 1 };',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 17 }],
+    },
+
+    // ---- Function-body directive prologue ----
+    {
+      code: 'function f() { "use\\ strict"; return 1; }',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 20 }],
+    },
+
+    // ---- v-mode triple-nested classes ----
+    // Outer class has `&&` set-op → escape directly under it has no escapeBackslash.
+    {
+      code: '/[\\.&&[a&&[b]]]/v;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 3 }],
+    },
+    // Innermost class has no set-ops → escape gets escapeBackslash.
+    {
+      code: '/[a&&[b&&[\\.]]]/v;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 11 }],
+    },
+
+    // ---- v-mode `\^` not at class start in negated class ----
+    {
+      code: '/[^a\\^]/v;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 5 }],
+    },
+
+    // ---- Multi-byte UTF-8 escape ----
+    {
+      code: 'var foo = "\\é";',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 12 }],
+    },
+
+    // ---- Multiple escapes interleaved with valid escapes in regex ----
+    {
+      code: 'var foo = /\\d\\@\\w\\#\\s/;',
+      errors: [
+        { messageId: 'unnecessaryEscape', line: 1, column: 14 },
+        { messageId: 'unnecessaryEscape', line: 1, column: 18 },
+      ],
+    },
+
+    // ---- Surrogate-pair preceding the escape (UTF-16 column counting) ----
+    // 👍 occupies cols 12-13; \# lands at col 14.
+    {
+      code: "var foo = '👍\\#';",
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 14 }],
+    },
+
+    // ---- Directive-container precision: only function-body Blocks ----
+    {
+      code: 'if (true) { "ba\\z"; }',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 16 }],
+    },
+    {
+      code: '{ "ba\\z"; }',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 6 }],
+    },
+    // Class static block IS a directive container.
+    {
+      code: 'class C { static { "use\\ strict"; } }',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 24 }],
+    },
+
+    // ---- v-mode \q{...} body: nested escapes are flagged ----
+    {
+      code: '/[\\q{a\\.b}]/v;',
+      errors: [{ messageId: 'unnecessaryEscape', line: 1, column: 7 }],
+    },
+    {
+      code: '/[\\q{\\@a|\\#b}]/v;',
+      errors: [
+        { messageId: 'unnecessaryEscape', line: 1, column: 6 },
+        { messageId: 'unnecessaryEscape', line: 1, column: 10 },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -325,3 +325,7 @@ brefs
 backref
 backrefs
 gimuygimuygimuy
+neighbour
+metacharacters
+CHARCLASS
+CLASSSET


### PR DESCRIPTION
## Summary

Port the `no-useless-escape` rule from ESLint to rslint.

The rule flags backslash escapes whose escaped character carries no special meaning, in string literals, template literals, and regular-expression literals. It supports the `allowRegexCharacters` option, three message IDs (`unnecessaryEscape`, `removeEscape` / `removeEscapeDoNotKeepSemantics`, `escapeBackslash`), and full v-mode (ES2024) regex character-class semantics including reserved double punctuators and set operations.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-useless-escape
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-escape.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).