### PR TITLE
feat: port rule import/default

### DIFF
--- a/internal/plugins/import/all.go
+++ b/internal/plugins/import/all.go
@@ -1,6 +1,7 @@
 package import_plugin
 
 import (
+	default_rule "github.com/web-infra-dev/rslint/internal/plugins/import/rules/default"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/first"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/newline_after_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_duplicates"
@@ -12,6 +13,7 @@ import (
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
+		default_rule.DefaultRule,
 		first.FirstRule,
 		newline_after_import.NewlineAfterImportRule,
 		no_duplicates.NoDuplicatesRule,

--- a/internal/plugins/import/fixtures/default_files/broken-trampoline.ts
+++ b/internal/plugins/import/fixtures/default_files/broken-trampoline.ts
@@ -1,0 +1,1 @@
+export { default } from './named-exports';

--- a/internal/plugins/import/fixtures/default_files/circular-a.ts
+++ b/internal/plugins/import/fixtures/default_files/circular-a.ts
@@ -1,0 +1,3 @@
+// Circular: a re-exports default from b, b re-exports default from a.
+// Without a real default anywhere in the cycle, the alias chain bottoms out.
+export { default } from './circular-b';

--- a/internal/plugins/import/fixtures/default_files/circular-b.ts
+++ b/internal/plugins/import/fixtures/default_files/circular-b.ts
@@ -1,0 +1,1 @@
+export { default } from './circular-a';

--- a/internal/plugins/import/fixtures/default_files/cjs-module-exports.cjs
+++ b/internal/plugins/import/fixtures/default_files/cjs-module-exports.cjs
@@ -1,0 +1,5 @@
+// CJS-style `module.exports = X` — TypeScript treats this as `export = X`,
+// which under esModuleInterop becomes the synthesized default.
+module.exports = function cjsDefault() {
+  return 'cjs';
+};

--- a/internal/plugins/import/fixtures/default_files/cjs-named-exports.cjs
+++ b/internal/plugins/import/fixtures/default_files/cjs-named-exports.cjs
@@ -1,0 +1,4 @@
+// Named-only CJS exports (no `module.exports = X`). Without esModuleInterop's
+// synthesized namespace-as-default this has no default to import.
+exports.a = 1;
+exports.b = 2;

--- a/internal/plugins/import/fixtures/default_files/common.ts
+++ b/internal/plugins/import/fixtures/default_files/common.ts
@@ -1,0 +1,3 @@
+// Mirrors upstream's `./common` fixture: a file with a single default export.
+const common = 'common';
+export default common;

--- a/internal/plugins/import/fixtures/default_files/data.json
+++ b/internal/plugins/import/fixtures/default_files/data.json
@@ -1,0 +1,4 @@
+{
+  "value": 1,
+  "name": "data"
+}

--- a/internal/plugins/import/fixtures/default_files/decl-no-default.d.ts
+++ b/internal/plugins/import/fixtures/default_files/decl-no-default.d.ts
@@ -1,0 +1,2 @@
+export declare const named: number;
+export declare type Foo = string;

--- a/internal/plugins/import/fixtures/default_files/decl-with-default.d.ts
+++ b/internal/plugins/import/fixtures/default_files/decl-with-default.d.ts
@@ -1,0 +1,2 @@
+declare const value: { x: number };
+export default value;

--- a/internal/plugins/import/fixtures/default_files/deep-trampoline.ts
+++ b/internal/plugins/import/fixtures/default_files/deep-trampoline.ts
@@ -1,0 +1,1 @@
+export { default } from './trampoline';

--- a/internal/plugins/import/fixtures/default_files/default-class.ts
+++ b/internal/plugins/import/fixtures/default_files/default-class.ts
@@ -1,0 +1,5 @@
+export default class Foo {
+  bar() {
+    return 1;
+  }
+}

--- a/internal/plugins/import/fixtures/default_files/default-export-anonymous-class.ts
+++ b/internal/plugins/import/fixtures/default_files/default-export-anonymous-class.ts
@@ -1,0 +1,5 @@
+export default class {
+  m() {
+    return 1;
+  }
+}

--- a/internal/plugins/import/fixtures/default_files/default-export-anonymous-fn.ts
+++ b/internal/plugins/import/fixtures/default_files/default-export-anonymous-fn.ts
@@ -1,0 +1,3 @@
+export default function () {
+  return 1;
+}

--- a/internal/plugins/import/fixtures/default_files/default-export-arrow.ts
+++ b/internal/plugins/import/fixtures/default_files/default-export-arrow.ts
@@ -1,0 +1,1 @@
+export default () => 42;

--- a/internal/plugins/import/fixtures/default_files/default-export-async.ts
+++ b/internal/plugins/import/fixtures/default_files/default-export-async.ts
@@ -1,0 +1,3 @@
+export default async function asyncDefault() {
+  return 1;
+}

--- a/internal/plugins/import/fixtures/default_files/default-export-generator.ts
+++ b/internal/plugins/import/fixtures/default_files/default-export-generator.ts
@@ -1,0 +1,3 @@
+export default function* gen() {
+  yield 1;
+}

--- a/internal/plugins/import/fixtures/default_files/default-export-literal.ts
+++ b/internal/plugins/import/fixtures/default_files/default-export-literal.ts
@@ -1,0 +1,1 @@
+export default 42;

--- a/internal/plugins/import/fixtures/default_files/default-export.ts
+++ b/internal/plugins/import/fixtures/default_files/default-export.ts
@@ -1,0 +1,3 @@
+export default function () {
+  return 42;
+}

--- a/internal/plugins/import/fixtures/default_files/default-null.ts
+++ b/internal/plugins/import/fixtures/default_files/default-null.ts
@@ -1,0 +1,1 @@
+export default null;

--- a/internal/plugins/import/fixtures/default_files/default-undefined.ts
+++ b/internal/plugins/import/fixtures/default_files/default-undefined.ts
@@ -1,0 +1,3 @@
+// Default export whose value is `undefined`. The rule should still treat it
+// as having a default — upstream checks the *export entry*, not the value.
+export default undefined;

--- a/internal/plugins/import/fixtures/default_files/empty-dir/sibling.ts
+++ b/internal/plugins/import/fixtures/default_files/empty-dir/sibling.ts
@@ -1,0 +1,3 @@
+// Sibling so the directory is non-empty but lacks an index entrypoint.
+// `import X from "./empty-dir"` should fail to resolve (no index).
+export const unrelated = 1;

--- a/internal/plugins/import/fixtures/default_files/empty-module.ts
+++ b/internal/plugins/import/fixtures/default_files/empty-module.ts
@@ -1,0 +1,2 @@
+// Real file, no statements — has neither default nor named exports.
+export {};

--- a/internal/plugins/import/fixtures/default_files/index-folder-no-default/index.ts
+++ b/internal/plugins/import/fixtures/default_files/index-folder-no-default/index.ts
@@ -1,0 +1,2 @@
+export const a = 1;
+export const b = 2;

--- a/internal/plugins/import/fixtures/default_files/index-folder/index.ts
+++ b/internal/plugins/import/fixtures/default_files/index-folder/index.ts
@@ -1,0 +1,3 @@
+export default function indexDefault() {
+  return 'indexed';
+}

--- a/internal/plugins/import/fixtures/default_files/jsx/App.tsx
+++ b/internal/plugins/import/fixtures/default_files/jsx/App.tsx
@@ -1,0 +1,5 @@
+export default class App {
+  render() {
+    return null as any;
+  }
+}

--- a/internal/plugins/import/fixtures/default_files/jsx/MyCoolComponent.tsx
+++ b/internal/plugins/import/fixtures/default_files/jsx/MyCoolComponent.tsx
@@ -1,0 +1,3 @@
+export default function MyCoolComponent() {
+  return <div />;
+}

--- a/internal/plugins/import/fixtures/default_files/local-rename-default.ts
+++ b/internal/plugins/import/fixtures/default_files/local-rename-default.ts
@@ -1,0 +1,5 @@
+// `export { foo as default }` — TS records `default` as an alias to `foo`.
+function foo() {
+  return 'foo';
+}
+export { foo as default };

--- a/internal/plugins/import/fixtures/default_files/mixed-exports.ts
+++ b/internal/plugins/import/fixtures/default_files/mixed-exports.ts
@@ -1,0 +1,4 @@
+export default function () {
+  return 1;
+}
+export const named = 2;

--- a/internal/plugins/import/fixtures/default_files/mjs-default.mjs
+++ b/internal/plugins/import/fixtures/default_files/mjs-default.mjs
@@ -1,0 +1,3 @@
+export default function mjsDefault() {
+  return 'mjs';
+}

--- a/internal/plugins/import/fixtures/default_files/mjs-named-only.mjs
+++ b/internal/plugins/import/fixtures/default_files/mjs-named-only.mjs
@@ -1,0 +1,2 @@
+export const a = 1;
+export const b = 2;

--- a/internal/plugins/import/fixtures/default_files/named-default-export.ts
+++ b/internal/plugins/import/fixtures/default_files/named-default-export.ts
@@ -1,0 +1,3 @@
+export default function foo() {
+  return 1;
+}

--- a/internal/plugins/import/fixtures/default_files/named-default-via-rename.ts
+++ b/internal/plugins/import/fixtures/default_files/named-default-via-rename.ts
@@ -1,0 +1,2 @@
+// Re-exports `bar` under the name `default` from a no-default source.
+export { c as default } from './named-exports';

--- a/internal/plugins/import/fixtures/default_files/named-exports.ts
+++ b/internal/plugins/import/fixtures/default_files/named-exports.ts
@@ -1,0 +1,5 @@
+export const a = 1;
+export const b = 2;
+export function c() {
+  return 3;
+}

--- a/internal/plugins/import/fixtures/default_files/parent-default.ts
+++ b/internal/plugins/import/fixtures/default_files/parent-default.ts
@@ -1,0 +1,4 @@
+// Used to verify parent-relative import paths (`../`) resolve correctly.
+export default function parent() {
+  return 'parent';
+}

--- a/internal/plugins/import/fixtures/default_files/re-export.ts
+++ b/internal/plugins/import/fixtures/default_files/re-export.ts
@@ -1,0 +1,1 @@
+export * from './named-exports';

--- a/internal/plugins/import/fixtures/default_files/redux.ts
+++ b/internal/plugins/import/fixtures/default_files/redux.ts
@@ -1,0 +1,7 @@
+declare function connect<T>(component: T): T;
+
+const App = function () {
+  return 1;
+};
+
+export default connect(App);

--- a/internal/plugins/import/fixtures/default_files/syntax-broken-no-default.ts
+++ b/internal/plugins/import/fixtures/default_files/syntax-broken-no-default.ts
@@ -1,0 +1,4 @@
+// Intentional syntax errors — no default export. Rule must not crash; should
+// either skip silently (module symbol unresolvable) or report cleanly.
+let = 1;
+export const named = 1;

--- a/internal/plugins/import/fixtures/default_files/syntax-broken-with-default.ts
+++ b/internal/plugins/import/fixtures/default_files/syntax-broken-with-default.ts
@@ -1,0 +1,7 @@
+// Intentional syntax errors — `let =` is malformed — but a default export
+// is still parseable on its own line. Rule must not crash and must observe
+// the default if TS can still bind it.
+let = 1;
+export default function brokenDefault() {
+  return 1;
+}

--- a/internal/plugins/import/fixtures/default_files/trampoline.ts
+++ b/internal/plugins/import/fixtures/default_files/trampoline.ts
@@ -1,0 +1,1 @@
+export { default } from './default-export';

--- a/internal/plugins/import/fixtures/default_files/type-only-exports.ts
+++ b/internal/plugins/import/fixtures/default_files/type-only-exports.ts
@@ -1,0 +1,5 @@
+// Only TypeScript type-space exports, no runtime values.
+export interface IFace {
+  x: number;
+}
+export type Alias = string;

--- a/internal/plugins/import/fixtures/default_files/typescript-default.ts
+++ b/internal/plugins/import/fixtures/default_files/typescript-default.ts
@@ -1,0 +1,2 @@
+const foobar = { bar: 1 };
+export default foobar;

--- a/internal/plugins/import/fixtures/default_files/typescript-export-as-default-namespace.ts
+++ b/internal/plugins/import/fixtures/default_files/typescript-export-as-default-namespace.ts
@@ -1,0 +1,7 @@
+// `export = namespace` — under esModuleInterop, the namespace becomes the
+// synthesized default. Under no-interop tsconfig, no default is available.
+namespace Foo {
+  export const a = 1;
+  export const b = 2;
+}
+export = Foo;

--- a/internal/plugins/import/fixtures/default_files/typescript-export-assign-default-namespace.ts
+++ b/internal/plugins/import/fixtures/default_files/typescript-export-assign-default-namespace.ts
@@ -1,0 +1,7 @@
+// `export = namespace` form — esModuleInterop synthesizes the default.
+namespace MyNS {
+  export const a = 1;
+  export const b = 2;
+}
+
+export = MyNS;

--- a/internal/plugins/import/fixtures/default_files/typescript-export-assign-default-reexport.ts
+++ b/internal/plugins/import/fixtures/default_files/typescript-export-assign-default-reexport.ts
@@ -1,0 +1,3 @@
+// `export =` proxying another module that uses `export default`.
+import inner from './typescript-default';
+export = inner;

--- a/internal/plugins/import/fixtures/default_files/typescript-export-assign-default.ts
+++ b/internal/plugins/import/fixtures/default_files/typescript-export-assign-default.ts
@@ -1,0 +1,6 @@
+declare const foo: {
+  (): number;
+  bar: string;
+};
+
+export = foo;

--- a/internal/plugins/import/fixtures/default_files/typescript-export-assign-function.ts
+++ b/internal/plugins/import/fixtures/default_files/typescript-export-assign-function.ts
@@ -1,0 +1,6 @@
+// `export = function` — under esModuleInterop the function is the default.
+function fn(): number {
+  return 1;
+}
+
+export = fn;

--- a/internal/plugins/import/fixtures/default_files/typescript-export-assign-mixed.ts
+++ b/internal/plugins/import/fixtures/default_files/typescript-export-assign-mixed.ts
@@ -1,0 +1,9 @@
+// `export = function-with-namespace-merge` — function callable + members.
+function fn(): number {
+  return 1;
+}
+namespace fn {
+  export const bar: string = 'bar';
+}
+
+export = fn;

--- a/internal/plugins/import/fixtures/default_files/typescript-export-assign-property.ts
+++ b/internal/plugins/import/fixtures/default_files/typescript-export-assign-property.ts
@@ -1,0 +1,7 @@
+// `export =` of a property-bearing object.
+const root = {
+  name: 'root',
+  child: { value: 1 },
+};
+
+export = root;

--- a/internal/plugins/import/fixtures/default_files/typescript.ts
+++ b/internal/plugins/import/fixtures/default_files/typescript.ts
@@ -1,0 +1,3 @@
+// Mirrors upstream's `./typescript` fixture: only named exports, no default.
+export const ts = 1;
+export type Foo = string;

--- a/internal/plugins/import/fixtures/tsconfig.allow-js.json
+++ b/internal/plugins/import/fixtures/tsconfig.allow-js.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"]
+  }
+}

--- a/internal/plugins/import/fixtures/tsconfig.no-interop.json
+++ b/internal/plugins/import/fixtures/tsconfig.no-interop.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"]
+  }
+}

--- a/internal/plugins/import/fixtures/tsconfig.with-json.json
+++ b/internal/plugins/import/fixtures/tsconfig.with-json.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"]
+  }
+}

--- a/internal/plugins/import/rules/default/default.go
+++ b/internal/plugins/import/rules/default/default.go
@@ -1,0 +1,260 @@
+package default_rule
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// defaultIgnorePatterns mirrors upstream eslint-plugin-import's
+// ExportMapBuilder fallback when `settings["import/ignore"]` is unset.
+// These match file shapes the upstream tool refuses to parse for an
+// export map (CoffeeScript, ESLint config files, native bindings, JSON, …).
+// rslint's TypeChecker can resolve some of these (e.g. `.json` with
+// resolveJsonModule), but matching the upstream contract is what users
+// configuring `import/ignore` expect.
+var defaultIgnorePatterns = []string{
+	`\.coffee$`,
+	`\.eslintrc(\.[a-z]+)?$`,
+	`\.(es6|exs|json|node)$`,
+}
+
+// See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/default.js
+var DefaultRule = rule.Rule{
+	Name: "import/default",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		if ctx.TypeChecker == nil {
+			return rule.RuleListeners{}
+		}
+		// Reuse the plugin-shared module visitor so module-specifier extraction
+		// stays consistent across import rules. ExportNamedDeclaration is in
+		// the visitor's listener set; the upstream rule's
+		// `ExportDefaultSpecifier` branch (Babel-only `export X from "..."`)
+		// is unreachable through the TS parser, so the export-side check is a
+		// no-op here.
+		return utils.VisitModules(func(source *ast.StringLiteralLike, node *ast.Node) {
+			checkDefault(ctx, source, node)
+		}, utils.VisitModulesOptions{
+			ESModule: true,
+		})
+	},
+}
+
+// checkDefault reports when an `import X from "..."` requests a default that
+// the resolved module does not actually expose.
+func checkDefault(ctx rule.RuleContext, source *ast.StringLiteralLike, node *ast.Node) {
+	defaultName := getDefaultSpecifier(node)
+	if defaultName == nil {
+		return
+	}
+
+	// Match upstream's "core / non-analyzable modules always have a default"
+	// allowance: anything we cannot resolve to a project source file is
+	// skipped so synthetic / declaration-only modules don't false-positive.
+	resolvedPath, ok := utils.Resolve(source, ctx)
+	if !ok || resolvedPath == "" {
+		return
+	}
+
+	// `settings["import/ignore"]` — array of regex patterns (or upstream's
+	// default list) tested against the resolved path. A match marks the
+	// module as un-analyzable, mirroring `ExportMapBuilder.get(...) === null`.
+	if isIgnoredPath(ctx, resolvedPath) {
+		return
+	}
+
+	// External-library imports (node_modules, ambient @types) — when the user
+	// has NOT overridden `import/ignore`, we keep the upstream-equivalent
+	// "core modules always have a default" allowance. Once the user opts into
+	// custom `import/ignore`, this fallback steps aside so they get full
+	// control.
+	if !hasExplicitIgnoreSetting(ctx) {
+		if module := ctx.Program.GetResolvedModuleFromModuleSpecifier(ctx.SourceFile, source); module != nil && module.IsExternalLibraryImport {
+			return
+		}
+	}
+
+	moduleSymbol := ctx.TypeChecker.GetSymbolAtLocation(source)
+	if moduleSymbol == nil {
+		return
+	}
+
+	if moduleHasDefaultExport(ctx, moduleSymbol) {
+		return
+	}
+
+	ctx.ReportNode(defaultName, rule.RuleMessage{
+		Id:          "default",
+		Description: fmt.Sprintf("No default export found in imported module \"%s\".", source.AsStringLiteral().Text),
+	})
+}
+
+// hasExplicitIgnoreSetting reports whether the user has set
+// `settings["import/ignore"]` to a non-nil value. An empty array is honoured
+// as "do not ignore anything" — once the user takes control, we don't layer
+// our own fallback. A `null` value is treated as absent (matches JSON-null
+// semantics: the key is present in serialized settings but carries no value).
+func hasExplicitIgnoreSetting(ctx rule.RuleContext) bool {
+	if ctx.Settings == nil {
+		return false
+	}
+	v, ok := ctx.Settings["import/ignore"]
+	if !ok {
+		return false
+	}
+	return v != nil
+}
+
+// isIgnoredPath returns true when the resolved path matches any of the
+// configured ignore patterns. Mirrors upstream eslint-plugin-import's
+// `ExportMapBuilder.exportMap()` which tests patterns against the resolved
+// file path, NOT the source value as written in the import statement.
+//
+// When `import/ignore` is unset, upstream's default list is applied. Note
+// that several of those defaults (`\.coffee$`, `\.(es6|exs|node)$`,
+// `\.eslintrc...`) are effectively inert in rslint because TypeScript's
+// resolver itself refuses to load those extensions — the rule's
+// "resolve fails → skip" branch fires before the ignore check ever runs.
+// `\.json$` is the one default that bites under `resolveJsonModule: true`.
+func isIgnoredPath(ctx rule.RuleContext, resolvedPath string) bool {
+	patterns := getIgnorePatterns(ctx)
+	if len(patterns) == 0 {
+		return false
+	}
+	for _, p := range patterns {
+		if p == nil {
+			continue
+		}
+		if p.MatchString(resolvedPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// getIgnorePatterns reads `settings["import/ignore"]` as `[]string`, falling
+// back to upstream's default list when unset or null. Invalid patterns are
+// skipped silently to match upstream's behaviour of dropping malformed regexes.
+func getIgnorePatterns(ctx rule.RuleContext) []*regexp.Regexp {
+	raw := defaultIgnorePatterns
+	if ctx.Settings != nil {
+		if v, ok := ctx.Settings["import/ignore"]; ok && v != nil {
+			parsed, applied := coerceStringSlice(v)
+			if applied {
+				raw = parsed
+			}
+		}
+	}
+	out := make([]*regexp.Regexp, 0, len(raw))
+	for _, p := range raw {
+		if re, err := regexp.Compile(p); err == nil {
+			out = append(out, re)
+		}
+	}
+	return out
+}
+
+// coerceStringSlice accepts the JSON shapes ESLint settings can deliver:
+// `[]interface{}` of strings, `[]string`, or a single string. Returns the
+// extracted patterns and whether any value (even an empty array) was found.
+func coerceStringSlice(v any) ([]string, bool) {
+	switch raw := v.(type) {
+	case []string:
+		return raw, true
+	case []interface{}:
+		out := make([]string, 0, len(raw))
+		for _, item := range raw {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out, true
+	case string:
+		return []string{raw}, true
+	}
+	return nil, false
+}
+
+// getDefaultSpecifier returns the binding node carrying a default import — the
+// place to anchor diagnostics — or nil when the construct does not introduce
+// one. Mirrors upstream's `specifiers.find(s => s.type === 'ImportDefaultSpecifier')`.
+//
+// Returns nil for: bare imports, named-only imports, namespace imports,
+// dynamic `import("...")`, plain `require("...")`, and `export ... from "..."`
+// re-exports.
+func getDefaultSpecifier(node *ast.Node) *ast.Node {
+	if node.Kind != ast.KindImportDeclaration && node.Kind != ast.KindJSImportDeclaration {
+		return nil
+	}
+	decl := node.AsImportDeclaration()
+	if decl == nil || decl.ImportClause == nil {
+		return nil
+	}
+	clause := decl.ImportClause.AsImportClause()
+	if clause == nil {
+		return nil
+	}
+	return clause.Name()
+}
+
+// moduleHasDefaultExport reports whether the resolved module exposes a default
+// export. We accept either:
+//   - `default`  — ES `export default X`
+//   - `export=`  — TS-only `export = X`, but only counted as default when the
+//     program enables esModuleInterop or allowSyntheticDefaultImports. Without
+//     either, `import X from "..."` against a CJS-shaped module is a
+//     compile-time error in TypeScript and upstream eslint-plugin-import
+//     reports it as missing default.
+//
+// Each candidate entry is followed through SkipAlias because re-exports such
+// as `export { default } from "./other"` register a `default` entry on the
+// re-exporting module's own export table even when the source module lacks a
+// default — SkipAlias collapses the chain to the unknown symbol in that case,
+// matching upstream's broken-trampoline semantics.
+func moduleHasDefaultExport(ctx rule.RuleContext, moduleSymbol *ast.Symbol) bool {
+	if findResolvedExport(ctx, moduleSymbol, ast.InternalSymbolNameDefault) {
+		return true
+	}
+	if !canSynthesizeDefaultFromExportEquals(ctx) {
+		return false
+	}
+	return findResolvedExport(ctx, moduleSymbol, ast.InternalSymbolNameExportEquals)
+}
+
+// canSynthesizeDefaultFromExportEquals returns true when the program's
+// compiler options permit treating `export = X` as a default import target.
+// TypeScript turns either `esModuleInterop: true` or
+// `allowSyntheticDefaultImports: true` into "you can `import X from` a CJS
+// module"; without either, the default specifier doesn't bind.
+func canSynthesizeDefaultFromExportEquals(ctx rule.RuleContext) bool {
+	opts := ctx.Program.Options()
+	if opts == nil {
+		return true // defensive: behave as before when options are unavailable
+	}
+	return opts.ESModuleInterop.IsTrue() || opts.AllowSyntheticDefaultImports.IsTrue()
+}
+
+func findResolvedExport(ctx rule.RuleContext, moduleSymbol *ast.Symbol, name string) bool {
+	if moduleSymbol == nil || moduleSymbol.Exports == nil {
+		return false
+	}
+	entry, ok := moduleSymbol.Exports[name]
+	if !ok || entry == nil {
+		return false
+	}
+	if !isAliasSymbol(entry) {
+		return true
+	}
+	resolved := ctx.TypeChecker.SkipAlias(entry)
+	if resolved == nil {
+		return false
+	}
+	return !ctx.TypeChecker.IsUnknownSymbol(resolved)
+}
+
+func isAliasSymbol(symbol *ast.Symbol) bool {
+	return symbol.Flags&ast.SymbolFlagsAlias != 0
+}

--- a/internal/plugins/import/rules/default/default.md
+++ b/internal/plugins/import/rules/default/default.md
@@ -1,0 +1,111 @@
+# import/default
+
+## Rule Details
+
+If a default import is requested, this rule reports when the imported module has no default export.
+
+```javascript
+// ./named-exports.ts only has named exports
+import foo from "./named-exports";  // ✘ No default export found...
+```
+
+```javascript
+// ./default-export.ts has a default export
+import foo from "./default-export";  // ✓
+import bar from "./default-export";  // ✓ renaming is fine
+import bar, { baz } from "./default-export";  // ✓ default + named
+```
+
+The rule does not apply to imports without a default specifier:
+
+```javascript
+import { foo } from "./named-exports";  // ✓
+import * as ns from "./named-exports";  // ✓
+import "./named-exports";              // ✓
+```
+
+`export { default as X } from "./mod"` is a normal named-export form and is not flagged by this rule.
+
+## Configuration
+
+This rule has no per-rule options.
+
+It honours `settings["import/ignore"]` — an array of regex strings tested against each resolved file path. A match marks the module as un-analyzable and skips the check. When unset, the rule skips imports that resolve to `.coffee`, `.eslintrc` (and friends), `.es6`, `.exs`, `.json`, or `.node` files.
+
+## Differences from ESLint
+
+### Imports inside `node_modules`
+
+```javascript
+import _ from "lodash";       // ✓ skipped
+import crypto from "crypto";  // ✓ skipped
+```
+
+rslint silently skips any import resolved into `node_modules`. ESLint skips only Node built-ins. Set `settings["import/ignore"]` to any value (including `[]`) to take over — once set, `node_modules` paths are no longer auto-skipped.
+
+### `import X = require("./mod")`
+
+```typescript
+import x = require("./named-exports");  // ✓ never flagged
+```
+
+This TypeScript syntax is never reported, even when the target has no default export. Use `import x from "./mod"` if you want the check.
+
+### Babel-only re-export forms
+
+```javascript
+export bar from "./mod";              // syntax error — won't parse
+export bar, { foo } from "./mod";     // syntax error — won't parse
+export bar, * as ns from "./mod";     // syntax error — won't parse
+```
+
+These forms don't parse under rslint, so they're never reported.
+
+### Files with parse errors
+
+When you `import foo from "./broken"` and `./broken` has parse errors:
+
+- ESLint reports `Parse errors in imported module './broken': <error> (line:col)` on the import statement.
+- rslint stays silent if the parser can recover a default; otherwise reports the regular `No default export found in imported module "./broken".` Parse errors themselves come through separately, not through this rule.
+
+### `import/ignore` pattern matching
+
+```javascript
+// settings: { "import/ignore": ["named-exports"] }
+import baz from "./default-files/named-exports";  // ✓ skipped
+```
+
+Patterns match the **resolved file path**, not the source string as written. `"./named-exports"` won't match — write `"named-exports"` instead.
+
+### `export = X` requires `esModuleInterop` or `allowSyntheticDefaultImports`
+
+```typescript
+// some.ts: export = function () {}
+
+// tsconfig has esModuleInterop: true
+import fn from "./some";  // ✓
+
+// tsconfig has neither
+import fn from "./some";  // ✘ No default export found...
+```
+
+### Settings ignored by rslint
+
+The following ESLint settings have no effect under rslint and are silently accepted:
+
+- `settings["import/parsers"]`
+- `settings["import/resolver"]`
+- `settings["import/extensions"]`
+- `settings["import/cache"]`
+
+### Diagnostic message
+
+Identical to ESLint: `No default export found in imported module "<path>".` (`messageId: "default"`).
+
+### Case-sensitive paths
+
+Whether `import Foo from "./named-exports"` (mismatched case) resolves depends on the host filesystem. Same as ESLint.
+
+## Original Documentation
+
+- [import/default](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md)

--- a/internal/plugins/import/rules/default/default_test.go
+++ b/internal/plugins/import/rules/default/default_test.go
@@ -1,0 +1,653 @@
+package default_rule_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	default_rule "github.com/web-infra-dev/rslint/internal/plugins/import/rules/default"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Mirrors the upstream eslint-plugin-import default rule test suite (every
+// case that survives the TypeScript parser) plus rslint-specific edge cases
+// and real-world user scenarios. Layout follows
+// https://github.com/import-js/eslint-plugin-import/blob/main/tests/src/rules/default.js
+// so future audits can diff top-to-bottom.
+func TestDefaultRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&default_rule.DefaultRule,
+		[]rule_tester.ValidTestCase{
+			// =====================================================
+			// Upstream `valid` (top section)
+			// =====================================================
+
+			// `import "./malformed.js"` — no default specifier, rule doesn't apply.
+			// SKIP: upstream uses an actual malformed JS file for parse-error
+			// coverage; rslint relies on the TS checker for parse diagnostics.
+			// Equivalent here: bare-import without default specifier never fires.
+			{Code: `import "./default_files/named-exports";`, FileName: "file.ts"},
+
+			{Code: `import foo from "./default_files/empty-folder";`, FileName: "file.ts"},
+			{Code: `import { c } from "./default_files/default-export";`, FileName: "file.ts"},
+			{Code: `import foo from "./default_files/default-export";`, FileName: "file.ts"},
+			{Code: `import foo from "./default_files/mixed-exports";`, FileName: "file.ts"},
+			{Code: `import bar from "./default_files/default-export";`, FileName: "file.ts"},
+			{Code: `import CoolClass from "./default_files/default-class";`, FileName: "file.ts"},
+			{Code: `import bar, { named } from "./default_files/mixed-exports";`, FileName: "file.ts"},
+
+			// core modules always have a default
+			{Code: `import crypto from "crypto";`, FileName: "file.ts"},
+
+			{Code: `import common from "./default_files/common";`, FileName: "file.ts"},
+
+			// ---- ES7 / Babel-parser-only export forms ----
+			// `export bar from "./bar"` — Babel-only `ExportDefaultSpecifier`.
+			// SKIP: not parseable by TypeScript (proposal that never landed).
+			{Code: `export { default as bar } from "./default_files/default-export";`, FileName: "file.ts"},
+			// `export bar, { foo } from "./bar"` — same as above, Babel-only.
+			// SKIP: same reason.
+			{Code: `export { default as bar, named } from "./default_files/mixed-exports";`, FileName: "file.ts"},
+			// `export bar, * as names from "./bar"` — Babel-only.
+			// SKIP: same reason.
+
+			// ---- Sanity / regression cases from upstream ----
+			{Code: `export { a } from "./default_files/named-exports";`, FileName: "file.ts"},
+			// #54: import of named-default-export
+			{Code: `import foo from "./default_files/named-default-export";`, FileName: "file.ts"},
+			// #94: redux-style `export default connect(App)`
+			{Code: `import connectedApp from "./default_files/redux";`, FileName: "file.ts"},
+			// trampoline (`export { default } from`) chain that resolves
+			{Code: `import twofer from "./default_files/trampoline";`, FileName: "file.ts"},
+			// Locks in a deeper alias chain than upstream covers.
+			{Code: `import threefer from "./default_files/deep-trampoline";`, FileName: "file.ts"},
+
+			// ---- ES2022 arbitrary module-namespace identifier ----
+			// `export { "default" as bar } from`
+			{Code: `export { "default" as bar } from "./default_files/default-export";`, FileName: "file.ts"},
+
+			// ---- JSX (TSX in our tree) ----
+			{Code: `import MyCoolComponent from "./default_files/jsx/MyCoolComponent";`, FileName: "file.tsx", Tsx: true},
+			{Code: `import App from "./default_files/jsx/App";`, FileName: "file.tsx", Tsx: true},
+
+			// ---- #545: more ES7 cases ----
+			// `import bar from './default-export-from.js'`,
+			// `import bar from './default-export-from-named.js'`,
+			// `import bar from './default-export-from-ignored.js' (settings)`,
+			// `export bar from './default-export-from-ignored.js' (settings)`.
+			// SKIP: Babel-old parser; standard re-export forms with `default as`
+			// keyword are covered above.
+
+			// =====================================================
+			// Upstream `valid` (TypeScript section)
+			// =====================================================
+			{Code: `import foobar from "./default_files/typescript-default";`, FileName: "file.ts"},
+			{Code: `import foobar from "./default_files/typescript-export-assign-default";`, FileName: "file.ts"},
+			{Code: `import foobar from "./default_files/typescript-export-assign-function";`, FileName: "file.ts"},
+			{Code: `import foobar from "./default_files/typescript-export-assign-mixed";`, FileName: "file.ts"},
+			{Code: `import foobar from "./default_files/typescript-export-assign-default-reexport";`, FileName: "file.ts"},
+			{Code: `import React from "./default_files/typescript-export-assign-default-namespace";`, FileName: "file.ts"},
+			// `./typescript-export-react-test-renderer` and `./typescript-extended-config`
+			// SKIP: those upstream cases require a multi-tsconfig setup
+			// (parserOptions.tsconfigRootDir override). The behaviour they lock
+			// in — `export = X` resolved through a sibling tsconfig — is already
+			// covered by `typescript-export-assign-default-reexport`.
+			{Code: `import foobar from "./default_files/typescript-export-assign-property";`, FileName: "file.ts"},
+
+			// =====================================================
+			// rslint-specific: anonymous default export shapes
+			// =====================================================
+			{Code: `import fn from "./default_files/default-export-anonymous-fn";`, FileName: "file.ts"},
+			{Code: `import C from "./default_files/default-export-anonymous-class";`, FileName: "file.ts"},
+			{Code: `import a from "./default_files/default-export-arrow";`, FileName: "file.ts"},
+			{Code: `import L from "./default_files/default-export-literal";`, FileName: "file.ts"},
+			{Code: `import asyncFn from "./default_files/default-export-async";`, FileName: "file.ts"},
+			{Code: `import gen from "./default_files/default-export-generator";`, FileName: "file.ts"},
+
+			// =====================================================
+			// rslint-specific: alias / rename forms
+			// =====================================================
+			// `function foo(){}; export { foo as default }` — local rename to default.
+			{Code: `import foo from "./default_files/local-rename-default";`, FileName: "file.ts"},
+			// Re-exports a named binding under the name `default`. The source
+			// binding exists, so the alias chain resolves cleanly.
+			{Code: `import x from "./default_files/named-default-via-rename";`, FileName: "file.ts"},
+			// `import { default as bar }` — explicit named-default access (not a default specifier).
+			{Code: `import { default as bar } from "./default_files/default-export";`, FileName: "file.ts"},
+			// `import foo, { default as bar }` — default specifier AND explicit named-default; rule
+			// only checks the default specifier, both refer to the same export.
+			{Code: `import foo, { default as bar } from "./default_files/default-export";`, FileName: "file.ts"},
+
+			// =====================================================
+			// rslint-specific: import shape variations
+			// =====================================================
+			{Code: `import * as ns from "./default_files/named-exports";`, FileName: "file.ts"},
+			{Code: `import type Foo from "./default_files/default-export";`, FileName: "file.ts"},
+			{Code: `import foo, * as ns from "./default_files/default-export";`, FileName: "file.ts"},
+			// import attribute `with { type }` — module specifier still resolves.
+			{Code: `import foo from "./default_files/default-export" with { type: "module" };`, FileName: "file.ts"},
+			// Explicit `.ts` extension.
+			{Code: `import foo from "./default_files/default-export.ts";`, FileName: "file.ts"},
+			// Folder import resolved through index.ts.
+			{Code: `import idx from "./default_files/index-folder";`, FileName: "file.ts"},
+			// Same import twice — rule must still pass each independently.
+			{Code: `import a from "./default_files/default-export"; import b from "./default_files/default-export";`, FileName: "file.ts"},
+
+			// =====================================================
+			// rslint-specific: graceful skips
+			// =====================================================
+			// Unresolved relative path — module symbol absent, skip without false-positive.
+			{Code: `import foo from "./default_files/non-existent";`, FileName: "file.ts"},
+			// Re-export `default` without rename — not a default specifier on the export side.
+			{Code: `export { default } from "./default_files/default-export";`, FileName: "file.ts"},
+			// Dynamic import — not a default specifier; rule never fires.
+			{Code: `const m = import("./default_files/named-exports");`, FileName: "file.ts"},
+			// Plain `require()` call — same.
+			{Code: `const m = require("./default_files/named-exports");`, FileName: "file.ts"},
+			// `import x = require()` — TS-only equivalent. SKIP: rule scope
+			// matches upstream (ImportDeclaration only); this form is not flagged.
+			{Code: `import m = require("./default_files/named-exports");`, FileName: "file.ts"},
+
+			// =====================================================
+			// rslint-specific: tsconfig-driven semantics
+			// =====================================================
+			// JSON default import (resolveJsonModule + esModuleInterop).
+			{
+				Code:     `import data from "./default_files/data.json";`,
+				FileName: "file.ts",
+				TSConfig: "tsconfig.with-json.json",
+			},
+			// `export = X` under interop ON — passes (already covered, but
+			// pair-locked here against the no-interop invalid case below to
+			// make the contract explicit).
+			{
+				Code:     `import fn from "./default_files/typescript-export-assign-function";`,
+				FileName: "file.ts",
+			},
+
+			// =====================================================
+			// rslint-specific: parse-error robustness
+			// =====================================================
+			// Module with a parse error but a recoverable default export — TS
+			// recovers binding-wise, default is observable, rule passes.
+			{Code: `import x from "./default_files/syntax-broken-with-default";`, FileName: "file.ts"},
+
+			// =====================================================
+			// rslint-specific: `settings["import/ignore"]` — match upstream contract
+			// =====================================================
+			// Default ignore list contains `\.(es6|exs|json|node)$` — JSON
+			// imports are silently treated as un-analyzable, even when the
+			// resolver could see them.
+			{
+				Code:     `import data from "./default_files/data.json";`,
+				FileName: "file.ts",
+				TSConfig: "tsconfig.with-json.json",
+			},
+			// Custom ignore: explicit pattern matches the source path → skip.
+			{
+				Code:     `import baz from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Settings: map[string]interface{}{
+					"import/ignore": []interface{}{"named-exports"},
+				},
+			},
+			// Empty ignore list → user takes control. Previously skipped
+			// `node_modules` paths now get checked too. This is a real,
+			// resolvable .ts file with a default — must still pass.
+			{
+				Code:     `import foo from "./default_files/default-export";`,
+				FileName: "file.ts",
+				Settings: map[string]interface{}{
+					"import/ignore": []interface{}{},
+				},
+			},
+			// Pattern mode: single string accepted (upstream tolerates this).
+			{
+				Code:     `import baz from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Settings: map[string]interface{}{
+					"import/ignore": "named-exports",
+				},
+			},
+			// Invalid regex in patterns is silently dropped (defensive parse).
+			{
+				Code:     `import foo from "./default_files/default-export";`,
+				FileName: "file.ts",
+				Settings: map[string]interface{}{
+					"import/ignore": []interface{}{"(((", "default-export"},
+				},
+			},
+			// `null` value (JSON null serialized into settings) — treated as
+			// "absent" (consistent with the un-set branch). Default
+			// external-library + default ignore list both apply.
+			{
+				Code:     `import crypto from "crypto";`,
+				FileName: "file.ts",
+				Settings: map[string]interface{}{
+					"import/ignore": nil,
+				},
+			},
+
+			// =====================================================
+			// rslint-specific: parent-relative path resolution
+			// =====================================================
+			// `../` traversal — file lives in `default_files/nested/`, imports
+			// from `default_files/parent-default.ts`.
+			{
+				Code:     `import p from "../parent-default";`,
+				FileName: "default_files/nested/test.ts",
+			},
+
+			// =====================================================
+			// rslint-specific: declaration-file (`.d.ts`) import sources
+			// =====================================================
+			{Code: `import v from "./default_files/decl-with-default";`, FileName: "file.ts"},
+
+			// =====================================================
+			// rslint-specific: `.mjs` source with `export default X`
+			// =====================================================
+			{
+				Code:     `import x from "./default_files/mjs-default.mjs";`,
+				FileName: "file.ts",
+				TSConfig: "tsconfig.allow-js.json",
+			},
+			// `.cjs` source with `module.exports = X` — TS reads it as
+			// `export = X`, synthesized default under esModuleInterop.
+			{
+				Code:     `import x from "./default_files/cjs-module-exports.cjs";`,
+				FileName: "file.ts",
+				TSConfig: "tsconfig.allow-js.json",
+			},
+
+			// =====================================================
+			// rslint-specific: import attributes — `with` form
+			// =====================================================
+			// SKIP: `assert { type: ... }` is now a TypeScript hard error
+			// ("Import assertions have been replaced by import attributes.
+			// Use 'with' instead of 'assert'."). The TS parser refuses to
+			// produce an AST for it, so the rule cannot be exercised on this
+			// shape. The supported `with` form is covered above.
+
+			// =====================================================
+			// rslint-specific: default value variants (export entry exists)
+			// =====================================================
+			// `export default undefined` — entry exists, value is undefined.
+			{Code: `import x from "./default_files/default-undefined";`, FileName: "file.ts"},
+			// `export default null`.
+			{Code: `import x from "./default_files/default-null";`, FileName: "file.ts"},
+
+			// =====================================================
+			// rslint-specific: import binding name = reserved-ish word
+			// =====================================================
+			// `default` cannot be used as a binding identifier in strict module
+			// code, but `await`-like reserved words can. Lock in that the rule
+			// extracts the binding regardless of identifier choice.
+			{Code: `import yield_ from "./default_files/default-export";`, FileName: "file.ts"},
+			{Code: `import async_ from "./default_files/default-export";`, FileName: "file.ts"},
+
+			// =====================================================
+			// rslint-specific: module options ignored
+			// =====================================================
+			// Upstream `schema: []` — the rule accepts no options. Passing one
+			// must not change behaviour (a no-default module still reports;
+			// a default-bearing module still passes). Both shapes covered.
+			{Code: `import foo from "./default_files/default-export";`, FileName: "file.ts", Options: map[string]interface{}{"someOpt": true}},
+			{Code: `import foo from "./default_files/default-export";`, FileName: "file.ts", Options: []interface{}{"warn", map[string]interface{}{"x": 1}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// =====================================================
+			// Upstream `invalid` (top section)
+			// =====================================================
+			// `import Foo from './jsx/FooES7.js'` — parse-error case.
+			// SKIP: rslint surfaces parse errors via the type-check pipeline,
+			// not this rule.
+
+			// `import baz from "./named-exports"` — main case
+			{
+				Code:     `import baz from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/named-exports".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 11,
+				}},
+			},
+
+			// `export baz from "./named-exports"`,
+			// `export baz, { bar } from "./named-exports"`,
+			// `export baz, * as names from "./named-exports"`.
+			// SKIP: Babel-only `ExportDefaultSpecifier` syntax.
+
+			// `import twofer from "./broken-trampoline"` — re-exports default
+			// from a no-default module.
+			{
+				Code:     `import twofer from "./default_files/broken-trampoline";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/broken-trampoline".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 14,
+				}},
+			},
+
+			// #328: `export *` does not include default.
+			{
+				Code:     `import barDefault from "./default_files/re-export";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/re-export".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 18,
+				}},
+			},
+
+			// =====================================================
+			// Upstream `invalid` (TypeScript section)
+			// =====================================================
+			// `import foobar from "./typescript"` — only named exports.
+			{
+				Code:     `import foobar from "./default_files/typescript";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/typescript".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 14,
+				}},
+			},
+			// `typescript-export-as-default-namespace` — namespace-only file
+			// without `export = X`. SKIP: upstream's failing case relies on a
+			// distinct tsconfig with no compiler options; under our tsconfig
+			// (esModuleInterop: true) the namespace case is covered by the
+			// passing variant `typescript-export-assign-default-namespace`.
+			// The plain `typescript.ts` case above already locks in the core
+			// "named exports only" failure mode.
+
+			// =====================================================
+			// rslint-specific: combined import shapes
+			// =====================================================
+			{
+				Code:     `import baz, { a } from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/named-exports".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 11,
+				}},
+			},
+			{
+				Code:     `import baz, * as ns from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/named-exports".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 11,
+				}},
+			},
+			{
+				Code:     `import type Baz from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/named-exports".`,
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 16,
+				}},
+			},
+
+			// =====================================================
+			// rslint-specific: folder / index resolution
+			// =====================================================
+			// Folder import resolves to index.ts that lacks default.
+			{
+				Code:     `import idx from "./default_files/index-folder-no-default";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/index-folder-no-default".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 11,
+				}},
+			},
+
+			// =====================================================
+			// rslint-specific: alias chain that bottoms out
+			// =====================================================
+			// Pure cycle — `circular-a` re-exports `default` from `circular-b`,
+			// which re-exports it back. SkipAlias must terminate at unknown.
+			{
+				Code:     `import x from "./default_files/circular-a";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/circular-a".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 9,
+				}},
+			},
+
+			// =====================================================
+			// rslint-specific: type-only / empty modules
+			// =====================================================
+			// File only exports types — value-space default doesn't exist.
+			{
+				Code:     `import T from "./default_files/type-only-exports";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/type-only-exports".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 9,
+				}},
+			},
+			// File explicitly exports nothing (`export {};`) — no default.
+			{
+				Code:     `import x from "./default_files/empty-module";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/empty-module".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 9,
+				}},
+			},
+
+			// =====================================================
+			// rslint-specific: schema-empty contract
+			// =====================================================
+			// Upstream `schema: []` — passing options must not silence the
+			// diagnostic. Both option shapes (bare object / array-wrapped).
+			{
+				Code:     `import baz from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Options:  map[string]interface{}{"unknown": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/named-exports".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 11,
+				}},
+			},
+			{
+				Code:     `import baz from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Options:  []interface{}{"warn", map[string]interface{}{"unknown": true}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/named-exports".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 11,
+				}},
+			},
+
+			// =====================================================
+			// rslint-specific: `settings["import/ignore"]` — non-matching patterns
+			// =====================================================
+			// Patterns that don't match still allow the rule to fire normally.
+			{
+				Code:     `import baz from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Settings: map[string]interface{}{
+					"import/ignore": []interface{}{`\.coffee$`, `\.flow$`},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/named-exports".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 11,
+				}},
+			},
+			// Empty ignore list disables the default external-library skip —
+			// `import/ignore: []` plus a real no-default project file still
+			// reports.
+			{
+				Code:     `import baz from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Settings: map[string]interface{}{
+					"import/ignore": []interface{}{},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/named-exports".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 11,
+				}},
+			},
+			// `import/ignore` matches the resolved file path, NOT the source
+			// string as written. A pattern that hits only the source ("./")
+			// must not skip — the resolved file is still a regular `.ts` file
+			// missing a default. Locks in upstream contract on path matching.
+			{
+				Code:     `import baz from "./default_files/named-exports";`,
+				FileName: "file.ts",
+				Settings: map[string]interface{}{
+					"import/ignore": []interface{}{`^\./default_files/named-exports$`},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/named-exports".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 11,
+				}},
+			},
+			// SKIP: locking in "explicit `import/ignore` bypasses the
+			// external-library fallback" against an actual node_modules path
+			// is unreliable — different @types/node versions register
+			// different default-export shapes for `crypto` (declaration
+			// merging across submodules can synthesize defaults). The
+			// behaviour is locked indirectly by the empty-array case above
+			// (`import/ignore: []` vs project file with no default reports).
+
+			// =====================================================
+			// rslint-specific: declaration-file with no default
+			// =====================================================
+			// `.d.ts` containing only ambient named exports / types.
+			{
+				Code:     `import x from "./default_files/decl-no-default";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/decl-no-default".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 9,
+				}},
+			},
+
+			// =====================================================
+			// rslint-specific: parent-relative path with no default
+			// =====================================================
+			{
+				Code:     `import x from "../named-exports";`,
+				FileName: "default_files/nested/test.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "../named-exports".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 9,
+				}},
+			},
+
+			// =====================================================
+			// rslint-specific: `.mjs` / `.cjs` with no default
+			// =====================================================
+			// `.mjs` with only named exports.
+			{
+				Code:     `import x from "./default_files/mjs-named-only.mjs";`,
+				FileName: "file.ts",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/mjs-named-only.mjs".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 9,
+				}},
+			},
+			// `.cjs` with `exports.foo = X` style (no `module.exports = X`).
+			// TS sees named exports only — no default / no `export=`.
+			{
+				Code:     `import x from "./default_files/cjs-named-exports.cjs";`,
+				FileName: "file.ts",
+				TSConfig: "tsconfig.allow-js.json",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/cjs-named-exports.cjs".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 9,
+				}},
+			},
+
+			// =====================================================
+			// rslint-specific: parse-error robustness
+			// =====================================================
+			// Module with parse errors AND no default — rule must still report
+			// without crashing.
+			{
+				Code:     `import x from "./default_files/syntax-broken-no-default";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/syntax-broken-no-default".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 9,
+				}},
+			},
+
+			// =====================================================
+			// rslint-specific: tsconfig-driven semantics
+			// =====================================================
+			// `export = X` under no-interop tsconfig — TS forbids
+			// `import X from` of a CJS module, upstream rule flags it.
+			{
+				Code:     `import Foo from "./default_files/typescript-export-as-default-namespace";`,
+				FileName: "file.ts",
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/typescript-export-as-default-namespace".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 11,
+				}},
+			},
+			// Same `export = function` file — invalid under no-interop.
+			{
+				Code:     `import fn from "./default_files/typescript-export-assign-function";`,
+				FileName: "file.ts",
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "default",
+					Message:   `No default export found in imported module "./default_files/typescript-export-assign-function".`,
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 10,
+				}},
+			},
+
+			// =====================================================
+			// rslint-specific: multiple defaults missing in one file
+			// =====================================================
+			// Each ImportDeclaration with a default specifier reports
+			// independently; locks in that the listener doesn't bail after
+			// the first hit.
+			{
+				Code: `import a from "./default_files/named-exports";
+import b from "./default_files/re-export";`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "default",
+						Message:   `No default export found in imported module "./default_files/named-exports".`,
+						Line:      1, Column: 8, EndLine: 1, EndColumn: 9,
+					},
+					{
+						MessageId: "default",
+						Message:   `No default export found in imported module "./default_files/re-export".`,
+						Line:      2, Column: 8, EndLine: 2, EndColumn: 9,
+					},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -76,6 +76,7 @@ export default defineConfig({
     './tests/eslint/rules/no-useless-computed-key.test.ts',
     './tests/eslint/rules/no-useless-concat.test.ts',
     // eslint-plugin-import
+    './tests/eslint-plugin-import/rules/default.test.ts',
     './tests/eslint-plugin-import/rules/first.test.ts',
     './tests/eslint-plugin-import/rules/newline-after-import.test.ts',
     './tests/eslint-plugin-import/rules/no-duplicates.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.default-allow-js.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.default-allow-js.json
@@ -1,0 +1,14 @@
+[
+  {
+    "language": "javascript",
+    "files": [],
+    "languageOptions": {
+      "parserOptions": {
+        "projectService": false,
+        "project": ["./tsconfig.default-allow-js.json"]
+      }
+    },
+    "rules": {},
+    "plugins": ["eslint-plugin-import"]
+  }
+]

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.default-ignore-empty.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.default-ignore-empty.json
@@ -1,0 +1,17 @@
+[
+  {
+    "language": "javascript",
+    "files": [],
+    "languageOptions": {
+      "parserOptions": {
+        "projectService": false,
+        "project": ["./tsconfig.virtual.json"]
+      }
+    },
+    "settings": {
+      "import/ignore": []
+    },
+    "rules": {},
+    "plugins": ["eslint-plugin-import"]
+  }
+]

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.default-ignore-named.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.default-ignore-named.json
@@ -1,0 +1,17 @@
+[
+  {
+    "language": "javascript",
+    "files": [],
+    "languageOptions": {
+      "parserOptions": {
+        "projectService": false,
+        "project": ["./tsconfig.virtual.json"]
+      }
+    },
+    "settings": {
+      "import/ignore": ["named-exports"]
+    },
+    "rules": {},
+    "plugins": ["eslint-plugin-import"]
+  }
+]

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.default-isolated.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.default-isolated.json
@@ -1,0 +1,14 @@
+[
+  {
+    "language": "javascript",
+    "files": [],
+    "languageOptions": {
+      "parserOptions": {
+        "projectService": false,
+        "project": ["./tsconfig.default-isolated.json"]
+      }
+    },
+    "rules": {},
+    "plugins": ["eslint-plugin-import"]
+  }
+]

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.default-no-interop.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.default-no-interop.json
@@ -1,0 +1,14 @@
+[
+  {
+    "language": "javascript",
+    "files": [],
+    "languageOptions": {
+      "parserOptions": {
+        "projectService": false,
+        "project": ["./tsconfig.default-no-interop.json"]
+      }
+    },
+    "rules": {},
+    "plugins": ["eslint-plugin-import"]
+  }
+]

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rule-tester.ts
@@ -45,6 +45,12 @@ interface TestCaseError {
 // Port from https://github.com/eslint/eslint/blob/34f0723e2d0faf8ac8dc95ec56e6d181bd6b67f2/lib/rule-tester/rule-tester.js#L1145
 
 export class RuleTester {
+  private readonly configRelPath: string;
+
+  constructor(options: { config?: string } = {}) {
+    this.configRelPath = options.config ?? './rslint.json';
+  }
+
   run(
     ruleName: string,
     rule: never,
@@ -54,9 +60,10 @@ export class RuleTester {
     },
   ) {
     ruleName = 'import/' + ruleName;
+    const configRelPath = this.configRelPath;
     describe(ruleName, () => {
       const cwd = process.cwd();
-      const config = path.resolve(import.meta.dirname, './rslint.json');
+      const config = path.resolve(import.meta.dirname, configRelPath);
 
       // test whether case has only
       let hasOnly =

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rules/default.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rules/default.test.ts
@@ -1,0 +1,450 @@
+import { test } from '../utils.js';
+
+import { RuleTester } from '../rule-tester.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('default', null as never, {
+  valid: [
+    // ===== Upstream valid (top section) =====
+    // SKIP: `import "./malformed.js"` (parse-error fixture). Equivalent
+    // bare-import-without-default is covered below.
+    test({ code: 'import "./default-files/named-exports";' }),
+    test({ code: 'import foo from "./default-files/empty-folder";' }),
+    test({ code: 'import { c } from "./default-files/default-export";' }),
+    test({ code: 'import foo from "./default-files/default-export";' }),
+    test({ code: 'import foo from "./default-files/mixed-exports";' }),
+    test({ code: 'import bar from "./default-files/default-export";' }),
+    test({ code: 'import CoolClass from "./default-files/default-class";' }),
+    test({
+      code: 'import bar, { named } from "./default-files/mixed-exports";',
+    }),
+    // core modules always have a default
+    test({ code: 'import crypto from "crypto";' }),
+    test({ code: 'import common from "./default-files/common";' }),
+
+    // ES7 / Babel-only export forms not parseable by TS — SKIP: not parseable
+    // by TS (`export bar from`, `export bar, { foo } from`, `export bar, * as
+    // names from`).
+    test({
+      code: 'export { default as bar } from "./default-files/default-export";',
+    }),
+    test({
+      code: 'export { default as bar, named } from "./default-files/mixed-exports";',
+    }),
+
+    // sanity / regression
+    test({ code: 'export { a } from "./default-files/named-exports";' }),
+    // #54: import of named-default-export
+    test({ code: 'import foo from "./default-files/named-default-export";' }),
+    // #94: redux-style `export default connect(App)`
+    test({ code: 'import connectedApp from "./default-files/redux";' }),
+    // trampoline that resolves
+    test({ code: 'import twofer from "./default-files/trampoline";' }),
+    // deeper alias chain (rslint extension)
+    test({ code: 'import threefer from "./default-files/deep-trampoline";' }),
+
+    // ES2022 arbitrary module-namespace identifier
+    test({
+      code: 'export { "default" as bar } from "./default-files/default-export";',
+    }),
+
+    // JSX (TSX)
+    test({
+      code: 'import MyCoolComponent from "./default-files/jsx/MyCoolComponent";',
+    }),
+    test({ code: 'import App from "./default-files/jsx/App";' }),
+
+    // SKIP: #545 Babel-old-only cases (`./default-export-from.js`, etc.).
+
+    // ===== Upstream valid (TypeScript section) =====
+    test({ code: 'import foobar from "./default-files/typescript-default";' }),
+    test({
+      code: 'import foobar from "./default-files/typescript-export-assign-default";',
+    }),
+    test({
+      code: 'import foobar from "./default-files/typescript-export-assign-function";',
+    }),
+    test({
+      code: 'import foobar from "./default-files/typescript-export-assign-mixed";',
+    }),
+    test({
+      code: 'import foobar from "./default-files/typescript-export-assign-default-reexport";',
+    }),
+    test({
+      code: 'import React from "./default-files/typescript-export-assign-default-namespace";',
+    }),
+    // SKIP: `./typescript-export-react-test-renderer` and
+    // `./typescript-extended-config` need parserOptions.tsconfigRootDir override.
+    test({
+      code: 'import foobar from "./default-files/typescript-export-assign-property";',
+    }),
+
+    // ===== rslint-specific: anonymous default shapes =====
+    test({
+      code: 'import fn from "./default-files/default-export-anonymous-fn";',
+    }),
+    test({
+      code: 'import C from "./default-files/default-export-anonymous-class";',
+    }),
+    test({ code: 'import a from "./default-files/default-export-arrow";' }),
+    test({ code: 'import L from "./default-files/default-export-literal";' }),
+    test({
+      code: 'import asyncFn from "./default-files/default-export-async";',
+    }),
+    test({
+      code: 'import gen from "./default-files/default-export-generator";',
+    }),
+
+    // ===== rslint-specific: alias / rename forms =====
+    test({ code: 'import foo from "./default-files/local-rename-default";' }),
+    test({ code: 'import x from "./default-files/named-default-via-rename";' }),
+    test({
+      code: 'import { default as bar } from "./default-files/default-export";',
+    }),
+    test({
+      code: 'import foo, { default as bar } from "./default-files/default-export";',
+    }),
+
+    // ===== rslint-specific: import-shape variations =====
+    test({ code: 'import * as ns from "./default-files/named-exports";' }),
+    test({ code: 'import type Foo from "./default-files/default-export";' }),
+    test({
+      code: 'import foo, * as ns from "./default-files/default-export";',
+    }),
+    test({
+      code: 'import foo from "./default-files/default-export" with { type: "module" };',
+    }),
+    test({ code: 'import foo from "./default-files/default-export.ts";' }),
+    test({ code: 'import idx from "./default-files/index-folder";' }),
+    test({
+      code: 'import a from "./default-files/default-export"; import b from "./default-files/default-export";',
+    }),
+
+    // ===== rslint-specific: graceful skips =====
+    test({ code: 'import foo from "./default-files/non-existent";' }),
+    test({ code: 'export { default } from "./default-files/default-export";' }),
+    test({ code: 'const m = import("./default-files/named-exports");' }),
+    test({ code: 'const m = require("./default-files/named-exports");' }),
+    test({ code: 'import m = require("./default-files/named-exports");' }),
+
+    // ===== rslint-specific: parse-error robustness =====
+    // Source has a parse error; default still bound — rule passes.
+    test({
+      code: 'import x from "./default-files/syntax-broken-with-default";',
+    }),
+
+    // ===== rslint-specific: declaration-file (`.d.ts`) source =====
+    test({ code: 'import v from "./default-files/decl-with-default";' }),
+
+    // (settings-driven cases live in dedicated isolated configs below.)
+
+    // ===== rslint-specific: default value variants =====
+    test({ code: 'import x from "./default-files/default-undefined";' }),
+    test({ code: 'import x from "./default-files/default-null";' }),
+
+    // ===== rslint-specific: binding identifier variations =====
+    test({ code: 'import yield_ from "./default-files/default-export";' }),
+    test({ code: 'import async_ from "./default-files/default-export";' }),
+
+    // ===== rslint-specific: schema-empty contract =====
+    // upstream `schema: []` — options must be ignored
+    test({
+      code: 'import foo from "./default-files/default-export";',
+      options: [{ someOpt: true }],
+    }),
+  ],
+  invalid: [
+    // ===== Upstream invalid (top section) =====
+    // SKIP: parse-errors-in-imported-module case (delegated to type-check).
+
+    test({
+      code: 'import baz from "./default-files/named-exports";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/named-exports".',
+        },
+      ],
+    }),
+    // SKIP: ES7 babel-only `export baz from`, `export baz, { bar } from`,
+    // `export baz, * as names from` cases.
+
+    test({
+      code: 'import twofer from "./default-files/broken-trampoline";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/broken-trampoline".',
+        },
+      ],
+    }),
+    // #328
+    test({
+      code: 'import barDefault from "./default-files/re-export";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/re-export".',
+        },
+      ],
+    }),
+
+    // ===== Upstream invalid (TypeScript section) =====
+    test({
+      code: 'import foobar from "./default-files/typescript";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/typescript".',
+        },
+      ],
+    }),
+    // SKIP: `typescript-export-as-default-namespace` invalid variant requires
+    // a separate no-compiler-options tsconfig; covered indirectly above.
+
+    // ===== rslint-specific: combined import shapes =====
+    test({
+      code: 'import baz, { a } from "./default-files/named-exports";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/named-exports".',
+        },
+      ],
+    }),
+    test({
+      code: 'import baz, * as ns from "./default-files/named-exports";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/named-exports".',
+        },
+      ],
+    }),
+    test({
+      code: 'import type Baz from "./default-files/named-exports";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/named-exports".',
+        },
+      ],
+    }),
+
+    // ===== rslint-specific: folder / index resolution =====
+    test({
+      code: 'import idx from "./default-files/index-folder-no-default";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/index-folder-no-default".',
+        },
+      ],
+    }),
+
+    // ===== rslint-specific: cycle that bottoms out =====
+    test({
+      code: 'import x from "./default-files/circular-a";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/circular-a".',
+        },
+      ],
+    }),
+
+    // ===== rslint-specific: type-only / empty modules =====
+    test({
+      code: 'import T from "./default-files/type-only-exports";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/type-only-exports".',
+        },
+      ],
+    }),
+    test({
+      code: 'import x from "./default-files/empty-module";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/empty-module".',
+        },
+      ],
+    }),
+
+    // ===== rslint-specific: schema-empty contract =====
+    test({
+      code: 'import baz from "./default-files/named-exports";',
+      options: [{ unknown: true }],
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/named-exports".',
+        },
+      ],
+    }),
+
+    // ===== rslint-specific: parse-error robustness (no default) =====
+    test({
+      code: 'import x from "./default-files/syntax-broken-no-default";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/syntax-broken-no-default".',
+        },
+      ],
+    }),
+
+    // ===== rslint-specific: declaration file with no default =====
+    test({
+      code: 'import x from "./default-files/decl-no-default";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/decl-no-default".',
+        },
+      ],
+    }),
+
+    // (settings-driven invalid cases live in dedicated isolated configs below.)
+
+    // ===== rslint-specific: two missing defaults in one file =====
+    test({
+      code: 'import a from "./default-files/named-exports";\nimport b from "./default-files/re-export";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/named-exports".',
+        },
+        {
+          message:
+            'No default export found in imported module "./default-files/re-export".',
+        },
+      ],
+    }),
+  ],
+});
+
+// =====================================================
+// Isolated config: resolveJsonModule + esModuleInterop
+// (own rslint.default-isolated.json + own tsconfig — does not pollute the
+// shared import-plugin config used by other rules' tests)
+// =====================================================
+const jsonRuleTester = new RuleTester({
+  config: './rslint.default-isolated.json',
+});
+
+jsonRuleTester.run('default', null as never, {
+  valid: [test({ code: 'import data from "./default-files/data.json";' })],
+  invalid: [],
+});
+
+// =====================================================
+// Isolated config: no esModuleInterop / no allowSyntheticDefaultImports
+// `export = X` is no longer accepted as a default import target.
+// =====================================================
+const noInteropRuleTester = new RuleTester({
+  config: './rslint.default-no-interop.json',
+});
+
+noInteropRuleTester.run('default', null as never, {
+  valid: [
+    // ES `export default X` still works without interop.
+    test({ code: 'import foo from "./default-files/default-export";' }),
+  ],
+  invalid: [
+    test({
+      code: 'import fn from "./default-files/typescript-export-assign-function";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/typescript-export-assign-function".',
+        },
+      ],
+    }),
+    test({
+      code: 'import Foo from "./default-files/typescript-export-as-default-namespace";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/typescript-export-as-default-namespace".',
+        },
+      ],
+    }),
+  ],
+});
+
+// =====================================================
+// Isolated config: settings["import/ignore"] = ["named-exports"]
+// Pattern matches the source path → rule skips even though the resolved
+// module has no default.
+// =====================================================
+const ignoreNamedRuleTester = new RuleTester({
+  config: './rslint.default-ignore-named.json',
+});
+
+ignoreNamedRuleTester.run('default', null as never, {
+  valid: [test({ code: 'import baz from "./default-files/named-exports";' })],
+  invalid: [],
+});
+
+// =====================================================
+// Isolated config: settings["import/ignore"] = []
+// User explicitly opts out of every default skip — local files with no
+// default must still report.
+// =====================================================
+const ignoreEmptyRuleTester = new RuleTester({
+  config: './rslint.default-ignore-empty.json',
+});
+
+ignoreEmptyRuleTester.run('default', null as never, {
+  valid: [test({ code: 'import foo from "./default-files/default-export";' })],
+  invalid: [
+    test({
+      code: 'import baz from "./default-files/named-exports";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/named-exports".',
+        },
+      ],
+    }),
+  ],
+});
+
+// =====================================================
+// Isolated config: allowJs + esModuleInterop
+// `.mjs` / `.cjs` source files become resolvable.
+// =====================================================
+const allowJsRuleTester = new RuleTester({
+  config: './rslint.default-allow-js.json',
+});
+
+allowJsRuleTester.run('default', null as never, {
+  valid: [
+    test({ code: 'import x from "./default-files/mjs-default.mjs";' }),
+    test({ code: 'import x from "./default-files/cjs-module-exports.cjs";' }),
+  ],
+  invalid: [
+    test({
+      code: 'import x from "./default-files/mjs-named-only.mjs";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/mjs-named-only.mjs".',
+        },
+      ],
+    }),
+    test({
+      code: 'import x from "./default-files/cjs-named-exports.cjs";',
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./default-files/cjs-named-exports.cjs".',
+        },
+      ],
+    }),
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/broken-trampoline.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/broken-trampoline.ts
@@ -1,0 +1,1 @@
+export { default } from './named-exports';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/circular-a.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/circular-a.ts
@@ -1,0 +1,3 @@
+// Circular: a re-exports default from b, b re-exports default from a.
+// Without a real default anywhere in the cycle, the alias chain bottoms out.
+export { default } from './circular-b';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/circular-b.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/circular-b.ts
@@ -1,0 +1,1 @@
+export { default } from './circular-a';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/cjs-module-exports.cjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/cjs-module-exports.cjs
@@ -1,0 +1,5 @@
+// CJS-style `module.exports = X` — TypeScript treats this as `export = X`,
+// which under esModuleInterop becomes the synthesized default.
+module.exports = function cjsDefault() {
+  return 'cjs';
+};

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/cjs-named-exports.cjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/cjs-named-exports.cjs
@@ -1,0 +1,4 @@
+// Named-only CJS exports (no `module.exports = X`). Without esModuleInterop's
+// synthesized namespace-as-default this has no default to import.
+exports.a = 1;
+exports.b = 2;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/common.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/common.ts
@@ -1,0 +1,3 @@
+// Mirrors upstream's `./common` fixture: a file with a single default export.
+const common = 'common';
+export default common;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/data.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/data.json
@@ -1,0 +1,4 @@
+{
+  "value": 1,
+  "name": "data"
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/decl-no-default.d.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/decl-no-default.d.ts
@@ -1,0 +1,2 @@
+export declare const named: number;
+export declare type Foo = string;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/decl-with-default.d.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/decl-with-default.d.ts
@@ -1,0 +1,2 @@
+declare const value: { x: number };
+export default value;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/deep-trampoline.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/deep-trampoline.ts
@@ -1,0 +1,1 @@
+export { default } from './trampoline';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-class.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-class.ts
@@ -1,0 +1,5 @@
+export default class Foo {
+  bar() {
+    return 1;
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-anonymous-class.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-anonymous-class.ts
@@ -1,0 +1,5 @@
+export default class {
+  m() {
+    return 1;
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-anonymous-fn.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-anonymous-fn.ts
@@ -1,0 +1,3 @@
+export default function () {
+  return 1;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-arrow.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-arrow.ts
@@ -1,0 +1,1 @@
+export default () => 42;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-async.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-async.ts
@@ -1,0 +1,3 @@
+export default async function asyncDefault() {
+  return 1;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-generator.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-generator.ts
@@ -1,0 +1,3 @@
+export default function* gen() {
+  yield 1;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-literal.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export-literal.ts
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-export.ts
@@ -1,0 +1,3 @@
+export default function () {
+  return 42;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-null.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-null.ts
@@ -1,0 +1,1 @@
+export default null;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-undefined.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/default-undefined.ts
@@ -1,0 +1,3 @@
+// Default export whose value is `undefined`. The rule should still treat it
+// as having a default — upstream checks the *export entry*, not the value.
+export default undefined;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/empty-dir/sibling.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/empty-dir/sibling.ts
@@ -1,0 +1,3 @@
+// Sibling so the directory is non-empty but lacks an index entrypoint.
+// `import X from "./empty-dir"` should fail to resolve (no index).
+export const unrelated = 1;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/empty-module.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/empty-module.ts
@@ -1,0 +1,2 @@
+// Real file, no statements — has neither default nor named exports.
+export {};

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/index-folder-no-default/index.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/index-folder-no-default/index.ts
@@ -1,0 +1,2 @@
+export const a = 1;
+export const b = 2;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/index-folder/index.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/index-folder/index.ts
@@ -1,0 +1,3 @@
+export default function indexDefault() {
+  return 'indexed';
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/jsx/App.tsx
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/jsx/App.tsx
@@ -1,0 +1,5 @@
+export default class App {
+  render() {
+    return null as any;
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/jsx/MyCoolComponent.tsx
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/jsx/MyCoolComponent.tsx
@@ -1,0 +1,3 @@
+export default function MyCoolComponent() {
+  return <div />;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/local-rename-default.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/local-rename-default.ts
@@ -1,0 +1,5 @@
+// `export { foo as default }` — TS records `default` as an alias to `foo`.
+function foo() {
+  return 'foo';
+}
+export { foo as default };

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/mixed-exports.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/mixed-exports.ts
@@ -1,0 +1,4 @@
+export default function () {
+  return 1;
+}
+export const named = 2;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/mjs-default.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/mjs-default.mjs
@@ -1,0 +1,3 @@
+export default function mjsDefault() {
+  return 'mjs';
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/mjs-named-only.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/mjs-named-only.mjs
@@ -1,0 +1,2 @@
+export const a = 1;
+export const b = 2;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/named-default-export.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/named-default-export.ts
@@ -1,0 +1,3 @@
+export default function foo() {
+  return 1;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/named-default-via-rename.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/named-default-via-rename.ts
@@ -1,0 +1,2 @@
+// Re-exports `bar` under the name `default` from a no-default source.
+export { c as default } from './named-exports';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/named-exports.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/named-exports.ts
@@ -1,0 +1,5 @@
+export const a = 1;
+export const b = 2;
+export function c() {
+  return 3;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/parent-default.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/parent-default.ts
@@ -1,0 +1,4 @@
+// Used to verify parent-relative import paths (`../`) resolve correctly.
+export default function parent() {
+  return 'parent';
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/re-export.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/re-export.ts
@@ -1,0 +1,1 @@
+export * from './named-exports';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/redux.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/redux.ts
@@ -1,0 +1,7 @@
+declare function connect<T>(component: T): T;
+
+const App = function () {
+  return 1;
+};
+
+export default connect(App);

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/syntax-broken-no-default.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/syntax-broken-no-default.ts
@@ -1,0 +1,4 @@
+// Intentional syntax errors — no default export. Rule must not crash; should
+// either skip silently (module symbol unresolvable) or report cleanly.
+let = 1;
+export const named = 1;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/syntax-broken-with-default.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/syntax-broken-with-default.ts
@@ -1,0 +1,7 @@
+// Intentional syntax errors — `let =` is malformed — but a default export
+// is still parseable on its own line. Rule must not crash and must observe
+// the default if TS can still bind it.
+let = 1;
+export default function brokenDefault() {
+  return 1;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/trampoline.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/trampoline.ts
@@ -1,0 +1,1 @@
+export { default } from './default-export';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/type-only-exports.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/type-only-exports.ts
@@ -1,0 +1,5 @@
+// Only TypeScript type-space exports, no runtime values.
+export interface IFace {
+  x: number;
+}
+export type Alias = string;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-default.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-default.ts
@@ -1,0 +1,2 @@
+const foobar = { bar: 1 };
+export default foobar;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-as-default-namespace.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-as-default-namespace.ts
@@ -1,0 +1,5 @@
+export const a = 1;
+export const b = 2;
+export namespace nested {
+  export const c = 3;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-default-namespace.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-default-namespace.ts
@@ -1,0 +1,7 @@
+// `export = namespace` form — esModuleInterop synthesizes the default.
+namespace MyNS {
+  export const a = 1;
+  export const b = 2;
+}
+
+export = MyNS;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-default-reexport.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-default-reexport.ts
@@ -1,0 +1,3 @@
+// `export =` proxying another module that uses `export default`.
+import inner from './typescript-default';
+export = inner;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-default.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-default.ts
@@ -1,0 +1,6 @@
+declare const foo: {
+  (): number;
+  bar: string;
+};
+
+export = foo;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-function.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-function.ts
@@ -1,0 +1,6 @@
+// `export = function` — under esModuleInterop the function is the default.
+function fn(): number {
+  return 1;
+}
+
+export = fn;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-mixed.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-mixed.ts
@@ -1,0 +1,9 @@
+// `export = function-with-namespace-merge` — function callable + members.
+function fn(): number {
+  return 1;
+}
+namespace fn {
+  export const bar: string = 'bar';
+}
+
+export = fn;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-property.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript-export-assign-property.ts
@@ -1,0 +1,7 @@
+// `export =` of a property-bearing object.
+const root = {
+  name: 'root',
+  child: { value: 1 },
+};
+
+export = root;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/src/default-files/typescript.ts
@@ -1,0 +1,3 @@
+// Mirrors upstream's `./typescript` fixture: only named exports, no default.
+export const ts = 1;
+export type Foo = string;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/tsconfig.default-allow-js.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/tsconfig.default-allow-js.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "experimentalDecorators": true
+  },
+  "include": ["src/virtual.tsx", "src/virtual.ts"]
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/tsconfig.default-isolated.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/tsconfig.default-isolated.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "experimentalDecorators": true
+  },
+  "include": ["src/virtual.tsx", "src/virtual.ts"]
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/tsconfig.default-no-interop.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/tsconfig.default-no-interop.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "experimentalDecorators": true
+  },
+  "include": ["src/virtual.tsx", "src/virtual.ts"]
+}

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -329,3 +329,5 @@ neighbour
 metacharacters
 CHARCLASS
 CLASSSET
+threefer
+twofer


### PR DESCRIPTION
## Summary

Port the `import/default` rule from `eslint-plugin-import` to rslint.

The rule reports when a default import is requested but the imported module has no default export. Implementation honours `settings["import/ignore"]` (with upstream's default pattern list as fallback) and respects `esModuleInterop` / `allowSyntheticDefaultImports` for `export = X` semantics.

## Related Links

- ESLint rule: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md
- Source code: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/default.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).