### PR TITLE
feat: port rule jsx-child-element-spacing

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -47,6 +47,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/void_dom_elements_no_children"
 	"github.com/web-infra-dev/rslint/internal/rule"
 
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_child_element_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_curly_brace_presence"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_comment_textnodes"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_leaked_render"
@@ -99,6 +100,7 @@ func GetAllRules() []rule.Rule {
 		self_closing_comp.SelfClosingCompRule,
 		style_prop_object.StylePropObjectRule,
 		void_dom_elements_no_children.VoidDomElementsNoChildrenRule,
+		jsx_child_element_spacing.JsxChildElementSpacingRule,
 		jsx_curly_brace_presence.JsxCurlyBracePresenceRule,
 		jsx_no_comment_textnodes.JsxNoCommentTextnodesRule,
 		jsx_no_leaked_render.JsxNoLeakedRenderRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -2243,6 +2243,28 @@ func GetJsxTagName(element *ast.Node) *ast.Node {
 	return nil
 }
 
+// GetJsxChildren returns the child-node list of a JsxElement or JsxFragment,
+// or nil for other kinds (JsxSelfClosingElement has no children) and when the
+// container's child list is absent.
+func GetJsxChildren(parent *ast.Node) []*ast.Node {
+	if parent == nil {
+		return nil
+	}
+	switch parent.Kind {
+	case ast.KindJsxElement:
+		if parent.AsJsxElement().Children == nil {
+			return nil
+		}
+		return parent.AsJsxElement().Children.Nodes
+	case ast.KindJsxFragment:
+		if parent.AsJsxFragment().Children == nil {
+			return nil
+		}
+		return parent.AsJsxFragment().Children.Nodes
+	}
+	return nil
+}
+
 // GetJsxElementAttributes returns the attribute nodes of a JsxOpeningElement or
 // JsxSelfClosingElement, or nil for other kinds or when the element has no
 // attributes. Each returned node is either a JsxAttribute or a JsxSpreadAttribute.

--- a/internal/plugins/react/rules/jsx_child_element_spacing/jsx_child_element_spacing.go
+++ b/internal/plugins/react/rules/jsx_child_element_spacing/jsx_child_element_spacing.go
@@ -1,0 +1,120 @@
+package jsx_child_element_spacing
+
+import (
+	"regexp"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// inlineElements mirrors upstream's INLINE_ELEMENTS set
+// (https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements). `br` is
+// intentionally excluded because surrounding whitespace has no rendered effect.
+var inlineElements = map[string]struct{}{
+	"a": {}, "abbr": {}, "acronym": {}, "b": {}, "bdo": {}, "big": {},
+	"button": {}, "cite": {}, "code": {}, "dfn": {}, "em": {}, "i": {},
+	"img": {}, "input": {}, "kbd": {}, "label": {}, "map": {}, "object": {},
+	"q": {}, "samp": {}, "script": {}, "select": {}, "small": {}, "span": {},
+	"strong": {}, "sub": {}, "sup": {}, "textarea": {}, "tt": {}, "var": {},
+}
+
+var (
+	textFollowingElementPattern = regexp.MustCompile(`^\s*\n\s*\S`)
+	textPrecedingElementPattern = regexp.MustCompile(`\S\s*\n\s*$`)
+)
+
+// elementName returns the simple-identifier tag name of a JSX element node, or
+// "" when the node is not an element, has a non-Identifier tag (e.g. `Foo.Bar`,
+// `<this>`, namespaced like `<a:b>`), or has no resolvable opening element.
+//
+// NOTE: Unlike ESLint, tsgo splits paired elements (`<a>...</a>` →
+// KindJsxElement) and self-closing elements (`<a/>` → KindJsxSelfClosingElement)
+// into two distinct kinds, while ESTree models both as JSXElement. The upstream
+// rule's `isInlineElement` matches both shapes via `node.type === 'JSXElement'`,
+// so we MUST recognize self-closing elements too — otherwise inline tags that
+// are commonly self-closing (notably `<img/>` and `<input/>` from the inline
+// set) would silently fall outside the inline check, causing false negatives.
+func elementName(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	var tagName *ast.Node
+	switch node.Kind {
+	case ast.KindJsxElement:
+		opening := node.AsJsxElement().OpeningElement
+		if opening == nil || opening.Kind != ast.KindJsxOpeningElement {
+			return ""
+		}
+		tagName = opening.AsJsxOpeningElement().TagName
+	case ast.KindJsxSelfClosingElement:
+		tagName = node.AsJsxSelfClosingElement().TagName
+	default:
+		return ""
+	}
+	if tagName == nil || tagName.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return tagName.AsIdentifier().Text
+}
+
+func isInlineElement(node *ast.Node) bool {
+	name := elementName(node)
+	if name == "" {
+		return false
+	}
+	_, ok := inlineElements[name]
+	return ok
+}
+
+// handleJSX walks the children with a 3-element sliding window
+// (lastChild, child, nextChild), matching the upstream
+// `node.children.concat([null]).forEach((nextChild) => {...})` shape verbatim.
+// The synthetic trailing nil drives the final iteration where `child` is the
+// last real child and `nextChild` is nil — needed for spacingAfterPrev to fire
+// when an inline element is the penultimate child.
+func handleJSX(ctx rule.RuleContext, node *ast.Node) {
+	children := reactutil.GetJsxChildren(node)
+	if len(children) == 0 {
+		return
+	}
+	var lastChild, child *ast.Node
+	for i := 0; i <= len(children); i++ {
+		var nextChild *ast.Node
+		if i < len(children) {
+			nextChild = children[i]
+		}
+		if (lastChild != nil || nextChild != nil) &&
+			(lastChild == nil || isInlineElement(lastChild)) &&
+			(child != nil && child.Kind == ast.KindJsxText) &&
+			(nextChild == nil || isInlineElement(nextChild)) {
+			text := child.AsJsxText().Text
+			if lastChild != nil && textFollowingElementPattern.MatchString(text) {
+				pos := lastChild.End()
+				ctx.ReportRange(core.NewTextRange(pos, pos), rule.RuleMessage{
+					Id:          "spacingAfterPrev",
+					Description: "Ambiguous spacing after previous element " + elementName(lastChild),
+				})
+			} else if nextChild != nil && textPrecedingElementPattern.MatchString(text) {
+				pos := nextChild.Pos()
+				ctx.ReportRange(core.NewTextRange(pos, pos), rule.RuleMessage{
+					Id:          "spacingBeforeNext",
+					Description: "Ambiguous spacing before next element " + elementName(nextChild),
+				})
+			}
+		}
+		lastChild = child
+		child = nextChild
+	}
+}
+
+var JsxChildElementSpacingRule = rule.Rule{
+	Name: "react/jsx-child-element-spacing",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindJsxElement:  func(node *ast.Node) { handleJSX(ctx, node) },
+			ast.KindJsxFragment: func(node *ast.Node) { handleJSX(ctx, node) },
+		}
+	},
+}

--- a/internal/plugins/react/rules/jsx_child_element_spacing/jsx_child_element_spacing.md
+++ b/internal/plugins/react/rules/jsx_child_element_spacing/jsx_child_element_spacing.md
@@ -1,0 +1,65 @@
+# jsx-child-element-spacing
+
+Enforce explicit spacing between inline JSX children when a line break could
+silently swallow the gap.
+
+React renders adjacent inline children (such as `<a>` or `<code>`) without an
+implicit space when the only thing separating them from neighboring text is a
+line break in the source. This rule warns about line-break-only spacing
+between an inline element and adjacent text so that author intent stays
+explicit — wrap with `{' '}` (or `{/* */}`) to keep the gap, or place the text
+and element on the same line to remove it.
+
+## Rule Details
+
+The rule applies to text that is adjacent to one of the HTML inline elements
+(`a`, `abbr`, `acronym`, `b`, `bdo`, `big`, `button`, `cite`, `code`, `dfn`,
+`em`, `i`, `img`, `input`, `kbd`, `label`, `map`, `object`, `q`, `samp`,
+`script`, `select`, `small`, `span`, `strong`, `sub`, `sup`, `textarea`, `tt`,
+`var`). `br` is intentionally excluded because spacing around it is
+inconsequential to the rendered output.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<App>
+  Please take a look at
+  <a href="https://js.org">this link</a>.
+</App>
+```
+
+```jsx
+<App>
+  <a>bar</a>
+  baz
+</App>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<App>
+  Please take a look at <a href="https://js.org">this link</a>.
+</App>
+```
+
+```jsx
+<App>
+  Please take a look at
+  {' '}
+  <a href="https://js.org">this link</a>.
+</App>
+```
+
+```jsx
+<App>
+  foo<a>bar</a>baz
+</App>
+```
+
+Block-level elements (e.g. `<p>`, `<div>`) and custom components (e.g.
+`<Foo>`, `<Foo.Bar>`) are not flagged — only the inline element list above is.
+
+## Original Documentation
+
+- [react/jsx-child-element-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-child-element-spacing.md)

--- a/internal/plugins/react/rules/jsx_child_element_spacing/jsx_child_element_spacing_test.go
+++ b/internal/plugins/react/rules/jsx_child_element_spacing/jsx_child_element_spacing_test.go
@@ -1,0 +1,946 @@
+package jsx_child_element_spacing
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxChildElementSpacingRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxChildElementSpacingRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: text-only child ----
+		{Code: `
+        <App>
+          foo
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: text-only fragment ----
+		{Code: `
+        <>
+          foo
+        </>
+      `, Tsx: true},
+
+		// ---- Upstream: single inline element child (no surrounding text) ----
+		{Code: `
+        <App>
+          <a>bar</a>
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: nested inline elements ----
+		{Code: `
+        <App>
+          <a>
+            <b>nested</b>
+          </a>
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: multiple text-only lines ----
+		{Code: `
+        <App>
+          foo
+          bar
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: text and inline element on same line ----
+		{Code: `
+        <App>
+          foo<a>bar</a>baz
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: explicit {' '} between text and inline element ----
+		{Code: `
+        <App>
+          foo
+          {' '}
+          <a>bar</a>
+          {' '}
+          baz
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: {' '} on same line as inline element ----
+		{Code: `
+        <App>
+          foo
+          {' '}<a>bar</a>{' '}
+          baz
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: {' '} attached to text ----
+		{Code: `
+        <App>
+          foo{' '}
+          <a>bar</a>
+          {' '}baz
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: comment expression containers as spacing markers ----
+		{Code: `
+        <App>
+          foo{/*
+          */}<a>bar</a>{/*
+          */}baz
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: sentence with inline link, all on one line ----
+		{Code: `
+        <App>
+          Please take a look at <a href="https://js.org">this link</a>.
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: sentence with explicit {' '} before linked text ----
+		{Code: `
+        <App>
+          Please take a look at
+          {' '}
+          <a href="https://js.org">this link</a>.
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: block-level <p> elements (not inline) ----
+		{Code: `
+        <App>
+          <p>A</p>
+          <p>B</p>
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: block-level elements adjacent ----
+		{Code: `
+        <App>
+          <p>A</p><p>B</p>
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: inline elements separated by whitespace-only text
+		// (no `\S` between newlines, so neither pattern fires) ----
+		{Code: `
+        <App>
+          <a>foo</a>
+          <a>bar</a>
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: nested inline elements with whitespace siblings ----
+		{Code: `
+        <App>
+          <a>
+            <b>nested1</b>
+            <b>nested2</b>
+          </a>
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: text-only single-letter lines ----
+		{Code: `
+        <App>
+          A
+          B
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: <br/> is not in inline set, so surrounding text is fine ----
+		{Code: `
+        <App>
+          A
+          <br/>
+          B
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: <br/> after text on same line, then text on next line ----
+		{Code: `
+        <App>
+          A<br/>
+          B
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: <br/> tightly between text ----
+		{Code: `
+        <App>
+          A<br/>B
+        </App>
+      `, Tsx: true},
+
+		// ---- Upstream: single-line all-tight ----
+		{Code: `
+        <App>A<br/>B</App>
+      `, Tsx: true},
+
+		// ---- Edge: dotted tag name (Foo.Bar) is never treated as inline ----
+		{Code: `
+        <App>
+          foo
+          <Foo.Bar>bar</Foo.Bar>
+        </App>
+      `, Tsx: true},
+
+		// ---- Edge: capitalized custom component is not in the inline set ----
+		{Code: `
+        <App>
+          foo
+          <Link>bar</Link>
+        </App>
+      `, Tsx: true},
+
+		// ---- Edge: fragment children with all-text ----
+		{Code: `
+        <>
+          A
+          B
+        </>
+      `, Tsx: true},
+
+		// ---- Edge: empty element ----
+		{Code: `<App></App>`, Tsx: true},
+
+		// ---- Edge: self-closing inline element child has no children to walk ----
+		{Code: `<App><a /></App>`, Tsx: true},
+
+		// ---- Edge: text contains a newline mid-string but no leading/trailing
+		// newline against an inline element — no report ----
+		{Code: `<App>foo
+bar<a>x</a></App>`, Tsx: true},
+
+		// ---- Edge: self-closing inline element (<img/>) on same line as text ----
+		{Code: `<App>foo<img/>bar</App>`, Tsx: true},
+
+		// ---- Edge: self-closing inline element with explicit {' '} ----
+		{Code: `
+        <App>
+          foo
+          {' '}
+          <img/>
+          {' '}
+          bar
+        </App>
+      `, Tsx: true},
+
+		// ---- Edge: text + self-closing inline element on same line ----
+		{Code: `
+        <App>
+          foo<img/>
+        </App>
+      `, Tsx: true},
+
+		// ---- Edge: deeply nested mix of block and inline with no ambiguity ----
+		{Code: `
+        <article>
+          <section>
+            <p>
+              hello <span>world</span> today
+            </p>
+          </section>
+        </article>
+      `, Tsx: true},
+
+		// ---- Edge: namespaced JSX tag (svg:circle) is not an Identifier, so
+		// not in inline set — adjacent-line text should NOT be flagged ----
+		{Code: `
+        <App>
+          foo
+          <a:b>bar</a:b>
+        </App>
+      `, Tsx: true},
+
+		// ---- Edge: <this/> tag (ThisKeyword base) — not an Identifier, not inline ----
+		{Code: `
+        <App>
+          foo
+          <this/>
+        </App>
+      `, Tsx: true},
+
+		// ---- Edge: only text-only children (no inline neighbor) — guard against
+		// the "(lastChild || nextChild)" being false on bare text in a fragment ----
+		{Code: `<>foo</>`, Tsx: true},
+
+		// ---- Edge: triple-element window where the middle text is whitespace
+		// only between two inline elements — neither pattern matches \S ----
+		{Code: `<App><a>x</a> <b>y</b></App>`, Tsx: true},
+
+		// ---- Edge: nested JsxElement listener fires on inner element too —
+		// inner uses a block-level child (<p>), so no inline-pairing matches. ----
+		{Code: `
+        <App>
+          <div>
+            <p>A</p>
+            <p>B</p>
+          </div>
+        </App>
+      `, Tsx: true},
+
+		// ---- Edge: nested inline span tightly surrounded by text on the same
+		// line — neither pattern matches because no `\n` boundary exists. ----
+		{Code: `
+        <App>
+          <p>text <span>x</span> text</p>
+        </App>
+      `, Tsx: true},
+
+		// ---- Inline-set coverage: every tag in the upstream set must be
+		// recognized as inline; spacing them with explicit {' '} on the same
+		// line keeps the input valid while exercising the lookup. ----
+		{Code: `<App>x<a>y</a>z</App>`, Tsx: true},
+		{Code: `<App>x<abbr>y</abbr>z</App>`, Tsx: true},
+		{Code: `<App>x<acronym>y</acronym>z</App>`, Tsx: true},
+		{Code: `<App>x<b>y</b>z</App>`, Tsx: true},
+		{Code: `<App>x<bdo>y</bdo>z</App>`, Tsx: true},
+		{Code: `<App>x<big>y</big>z</App>`, Tsx: true},
+		{Code: `<App>x<button>y</button>z</App>`, Tsx: true},
+		{Code: `<App>x<cite>y</cite>z</App>`, Tsx: true},
+		{Code: `<App>x<code>y</code>z</App>`, Tsx: true},
+		{Code: `<App>x<dfn>y</dfn>z</App>`, Tsx: true},
+		{Code: `<App>x<em>y</em>z</App>`, Tsx: true},
+		{Code: `<App>x<i>y</i>z</App>`, Tsx: true},
+		{Code: `<App>x<img/>z</App>`, Tsx: true},
+		{Code: `<App>x<input/>z</App>`, Tsx: true},
+		{Code: `<App>x<kbd>y</kbd>z</App>`, Tsx: true},
+		{Code: `<App>x<label>y</label>z</App>`, Tsx: true},
+		{Code: `<App>x<map>y</map>z</App>`, Tsx: true},
+		{Code: `<App>x<object>y</object>z</App>`, Tsx: true},
+		{Code: `<App>x<q>y</q>z</App>`, Tsx: true},
+		{Code: `<App>x<samp>y</samp>z</App>`, Tsx: true},
+		{Code: `<App>x<script>y</script>z</App>`, Tsx: true},
+		{Code: `<App>x<select>y</select>z</App>`, Tsx: true},
+		{Code: `<App>x<small>y</small>z</App>`, Tsx: true},
+		{Code: `<App>x<span>y</span>z</App>`, Tsx: true},
+		{Code: `<App>x<strong>y</strong>z</App>`, Tsx: true},
+		{Code: `<App>x<sub>y</sub>z</App>`, Tsx: true},
+		{Code: `<App>x<sup>y</sup>z</App>`, Tsx: true},
+		{Code: `<App>x<textarea>y</textarea>z</App>`, Tsx: true},
+		{Code: `<App>x<tt>y</tt>z</App>`, Tsx: true},
+		{Code: `<App>x<var>y</var>z</App>`, Tsx: true},
+
+		// ---- Block-level negative coverage: common HTML block tags must NOT
+		// trigger the rule even with text on adjacent lines. ----
+		{Code: `
+        <main>
+          intro
+          <section>body</section>
+        </main>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          intro
+          <article>body</article>
+        </App>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          intro
+          <header>body</header>
+        </App>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          intro
+          <footer>body</footer>
+        </App>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          intro
+          <nav>body</nav>
+        </App>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          intro
+          <aside>body</aside>
+        </App>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          intro
+          <div>body</div>
+        </App>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          intro
+          <ul>body</ul>
+        </App>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          intro
+          <li>item</li>
+        </App>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          intro
+          <h1>title</h1>
+        </App>
+      `, Tsx: true},
+
+		// ---- Edge: JsxExpression child between text and inline element acts
+		// as a separator — the 3-element window for the inline pair never
+		// includes a JsxText, so no report fires. ----
+		{Code: `
+        <App>
+          foo
+          {variable}
+          <a>bar</a>
+        </App>
+      `, Tsx: true},
+
+		// ---- Edge: numeric / boolean / null JsxExpression values — same. ----
+		{Code: `
+        <App>
+          foo
+          {0}
+          <a>bar</a>
+        </App>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          foo
+          {null}
+          <a>bar</a>
+        </App>
+      `, Tsx: true},
+
+		// ---- Edge: JSX in conditional expression — neither branch ambiguous. ----
+		{Code: `
+        const r = (ok) => ok ? <App>foo<a>x</a>bar</App> : <App>baz</App>;
+      `, Tsx: true},
+
+		// ---- Edge: JSX in .map callback — text sits on same line as inline. ----
+		{Code: `
+        items.map((i) => <li key={i}>before <a>{i}</a> after</li>);
+      `, Tsx: true},
+
+		// ---- Edge: JSX in array literal expression — no spacing ambiguity. ----
+		{Code: `
+        const a = [<span key="1">one</span>, <span key="2">two</span>];
+      `, Tsx: true},
+
+		// ---- Edge: JSX inside attribute value (recursion through attributes
+		// must not blow up) — outer App has no children-spacing issue. ----
+		{Code: `
+        <App tooltip={<span>hint</span>}>body</App>
+      `, Tsx: true},
+
+		// ---- Edge: spread attribute on inline element — attributes don't
+		// affect children-walk. ----
+		{Code: `<App>foo<a {...props}>bar</a>baz</App>`, Tsx: true},
+
+		// ---- Edge: TypeScript generic component (no inline tag involvement). ----
+		{Code: `
+        <List<string>>
+          <a>x</a>
+        </List>
+      `, Tsx: true},
+
+		// ---- Edge: text with mid-line CJK characters — no \n boundary, so no
+		// pattern match. Locks in that JsxText.Text reads tsgo's text correctly. ----
+		{Code: `<App>你好<a>link</a>世界</App>`, Tsx: true},
+
+		// ---- Edge: text that contains ONLY a single newline between two
+		// inline elements (no \S on either side). ----
+		{Code: "<App><a>x</a>\n<b>y</b></App>", Tsx: true},
+
+		// ---- Edge: text that contains ONLY whitespace+newline+whitespace
+		// (no \S anywhere) — neither pattern fires. ----
+		{Code: "<App><a>x</a>   \n   <b>y</b></App>", Tsx: true},
+
+		// ---- Edge: CRLF line endings between inline elements + whitespace
+		// only — Go regex treats \r as part of \s, so still no match. ----
+		{Code: "<App><a>x</a>\r\n<b>y</b></App>", Tsx: true},
+
+		// ---- Edge: real-world prose pattern — sentence with embedded link
+		// that fits on one line. ----
+		{Code: `
+        <p>
+          Click <a href="/x">here</a> to continue.
+        </p>
+      `, Tsx: true},
+
+		// ---- Edge: real-world prose with code reference. ----
+		{Code: `
+        <p>
+          Use <code>useState</code> to track state.
+        </p>
+      `, Tsx: true},
+
+		// ---- Edge: trailing punctuation glued to inline element on same line. ----
+		{Code: `
+        <p>
+          See <a>docs</a>.
+        </p>
+      `, Tsx: true},
+
+		// ---- Edge: leading punctuation before inline element on same line. ----
+		{Code: `<p>(<a>note</a>) trailing</p>`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: text before inline element on a new line ----
+		{
+			Code: `
+        <App>
+          foo
+          <a>bar</a>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11},
+			},
+		},
+
+		// ---- Upstream: same as above but inside a fragment ----
+		{
+			Code: `
+        <>
+          foo
+          <a>bar</a>
+        </>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11},
+			},
+		},
+
+		// ---- Upstream: inline element followed by text on a new line ----
+		{
+			Code: `
+        <App>
+          <a>bar</a>
+          baz
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingAfterPrev", Line: 3, Column: 21},
+			},
+		},
+
+		// ---- Upstream: explicit {' '} BEFORE inline element doesn't suppress
+		// the AFTER report when the next text starts with a newline ----
+		{
+			Code: `
+        <App>
+          {' '}<a>bar</a>
+          baz
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingAfterPrev", Line: 3, Column: 26},
+			},
+		},
+
+		// ---- Upstream: sentence split before inline link ----
+		{
+			Code: `
+        <App>
+          Please take a look at
+          <a href="https://js.org">this link</a>.
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11},
+			},
+		},
+
+		// ---- Upstream: text between two inline `<code>` elements matches the
+		// PRECEDING pattern (ends with newline + whitespace), not FOLLOWING —
+		// so the report anchors on the second `<code>` ----
+		{
+			Code: `
+        <App>
+          Some <code>loops</code> and some
+          <code>if</code> statements.
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11,
+					Message: "Ambiguous spacing before next element code"},
+			},
+		},
+
+		// ---- Upstream: two separate spacingBeforeNext reports in a row ----
+		{
+			Code: `
+        <App>
+          Here is
+          <a href="https://js.org">a link</a> and here is
+          <a href="https://js.org">another</a>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11},
+				{MessageId: "spacingBeforeNext", Line: 5, Column: 11},
+			},
+		},
+
+		// ---- Edge: spacingAfterPrev message text exact match ----
+		{
+			Code: `
+        <App>
+          <a>bar</a>
+          baz
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingAfterPrev", Line: 3, Column: 21,
+					Message: "Ambiguous spacing after previous element a"},
+			},
+		},
+
+		// ---- Edge: spacingBeforeNext message text exact match ----
+		{
+			Code: `
+        <App>
+          foo
+          <a>bar</a>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11,
+					Message: "Ambiguous spacing before next element a"},
+			},
+		},
+
+		// ---- Edge: inline element at the end (followed by text-only) inside a
+		// fragment — exercise spacingAfterPrev within JsxFragment too ----
+		{
+			Code: `
+        <>
+          <a>bar</a>
+          baz
+        </>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingAfterPrev", Line: 3, Column: 21},
+			},
+		},
+
+		// ---- Edge: text between two inline elements where the text matches
+		// the FOLLOWING pattern (starts with newline + content) — anchors on
+		// the FIRST element via spacingAfterPrev. ----
+		{
+			Code: `
+        <App>
+          <a>x</a>
+          mid <b>y</b>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingAfterPrev", Line: 3, Column: 19,
+					Message: "Ambiguous spacing after previous element a"},
+			},
+		},
+
+		// ---- Edge: self-closing inline element (<img/>) before text on a new
+		// line — locks in tsgo's KindJsxSelfClosingElement equivalence with
+		// ESTree's JSXElement for the inline check. ----
+		{
+			Code: `
+        <App>
+          <img/>
+          baz
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingAfterPrev", Line: 3, Column: 17,
+					Message: "Ambiguous spacing after previous element img"},
+			},
+		},
+
+		// ---- Edge: text before self-closing inline element on a new line ----
+		{
+			Code: `
+        <App>
+          foo
+          <input/>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11,
+					Message: "Ambiguous spacing before next element input"},
+			},
+		},
+
+		// ---- Edge: paired AND self-closing inline siblings — text matches
+		// PRECEDING, anchors on the self-closing element. ----
+		{
+			Code: `
+        <App>
+          Some <code>x</code> and
+          <img/>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11,
+					Message: "Ambiguous spacing before next element img"},
+			},
+		},
+
+		// ---- Edge: nested JsxElement reports independently per scope — the
+		// inner <p> hosts the bad text, so exactly one diagnostic fires from
+		// the inner element's listener call. ----
+		{
+			Code: `
+        <App>
+          <p>
+            foo
+            <a>bar</a>
+          </p>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: deeply nested (4 levels) with bad text at innermost ----
+		{
+			Code: `
+        <App>
+          <section>
+            <article>
+              <p>
+                foo
+                <a>bar</a>
+              </p>
+            </article>
+          </section>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 7, Column: 17},
+			},
+		},
+
+		// ---- Edge: fragment containing nested fragment with bad text — both
+		// JsxFragment listeners fire, but only the inner one matches. ----
+		{
+			Code: `
+        <>
+          <>
+            foo
+            <a>bar</a>
+          </>
+        </>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: outer + inner element BOTH host the same kind of bug —
+		// each fires its own diagnostic from its own listener call. ----
+		{
+			Code: `
+        <App>
+          <p>
+            foo
+            <a>bar</a>
+          </p>
+          <span>x</span>
+          trailing
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingAfterPrev", Line: 7, Column: 25},
+				{MessageId: "spacingBeforeNext", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: three-inline-element chain separated by line-broken text
+		// blocks — each text matches PRECEDING, two reports anchor on the
+		// 2nd and 3rd inline elements. ----
+		{
+			Code: `
+        <App>
+          one
+          <a>X</a> two
+          <b>Y</b> three
+          <em>Z</em>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11,
+					Message: "Ambiguous spacing before next element a"},
+				{MessageId: "spacingBeforeNext", Line: 5, Column: 11,
+					Message: "Ambiguous spacing before next element b"},
+				{MessageId: "spacingBeforeNext", Line: 6, Column: 11,
+					Message: "Ambiguous spacing before next element em"},
+			},
+		},
+
+		// ---- Edge: column reporting with multi-byte CJK before the inline
+		// element on the same line — verifies that lastChild.End() / Pos()
+		// produce the correct UTF-16 column the test framework expects. ----
+		{
+			Code: `
+        <App>
+          你好
+          <a>x</a>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11,
+					Message: "Ambiguous spacing before next element a"},
+			},
+		},
+
+		// ---- Edge: trailing-text case where the previous-element loc.end is
+		// reported correctly when followed by trailing punctuation on next line. ----
+		{
+			Code: `
+        <App>
+          <strong>important</strong>
+          .
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingAfterPrev", Line: 3, Column: 37,
+					Message: "Ambiguous spacing after previous element strong"},
+			},
+		},
+
+		// ---- Edge: button (uncommon inline tag) — sanity-check the inline set. ----
+		{
+			Code: `
+        <App>
+          <button>OK</button>
+          baz
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingAfterPrev", Line: 3, Column: 30,
+					Message: "Ambiguous spacing after previous element button"},
+			},
+		},
+
+		// ---- Edge: textarea (uncommon inline tag) — both directions. ----
+		{
+			Code: `
+        <App>
+          foo
+          <textarea/>
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11,
+					Message: "Ambiguous spacing before next element textarea"},
+			},
+		},
+
+		// ---- Edge: text contains CRLF line ending — \r is whitespace under
+		// Go's regex, so the pattern still fires on `\S\r\n\s*$`. ----
+		{
+			Code: "<App>foo\r\n<a>bar</a></App>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext"},
+			},
+		},
+
+		// ---- Edge: a JsxExpression in the window position would normally
+		// suppress the report, but here the JsxExpression sits AFTER the
+		// inline element — text+inline+expr+text reduces to just text+inline
+		// for the first window, which still fires for the leading text. ----
+		{
+			Code: `
+        <App>
+          foo
+          <a>bar</a>
+          {expr}
+        </App>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 4, Column: 11,
+					Message: "Ambiguous spacing before next element a"},
+			},
+		},
+
+		// ---- Edge: text immediately preceding inline ends with non-newline
+		// space — the regex requires a \n in the trailing whitespace, so
+		// trailing tabs/spaces alone don't match. We assert the boundary
+		// case where the LAST char is `\n` followed by spaces. ----
+		{
+			Code: "<App>x  \n<a>y</a></App>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext"},
+			},
+		},
+
+		// ---- Edge: JSX in arrow function body returning paragraph with bad
+		// link spacing — real-world code path. ----
+		{
+			Code: `
+        const Doc = () => (
+          <p>
+            Read more
+            <a href="/docs">here</a>
+          </p>
+        );
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingBeforeNext", Line: 5, Column: 13,
+					Message: "Ambiguous spacing before next element a"},
+			},
+		},
+
+		// ---- Edge: JSX returned from a component method — class component
+		// path, lock against listener boundary issues with class bodies. ----
+		{
+			Code: `
+        class C extends Component {
+          render() {
+            return (
+              <p>
+                <code>x</code>
+                trailing
+              </p>
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "spacingAfterPrev", Line: 6, Column: 31,
+					Message: "Ambiguous spacing after previous element code"},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/jsx_curly_brace_presence/jsx_curly_brace_presence.go
+++ b/internal/plugins/react/rules/jsx_curly_brace_presence/jsx_curly_brace_presence.go
@@ -351,25 +351,6 @@ func containsWhitespaceExpression(child *ast.Node) bool {
 	return false
 }
 
-func jsxChildren(parent *ast.Node) []*ast.Node {
-	if parent == nil {
-		return nil
-	}
-	switch parent.Kind {
-	case ast.KindJsxElement:
-		if parent.AsJsxElement().Children == nil {
-			return nil
-		}
-		return parent.AsJsxElement().Children.Nodes
-	case ast.KindJsxFragment:
-		if parent.AsJsxFragment().Children == nil {
-			return nil
-		}
-		return parent.AsJsxFragment().Children.Nodes
-	}
-	return nil
-}
-
 // adjacentSiblings mirrors upstream's `getAdjacentSiblings`. The inner loop
 // deliberately runs `i = 1; i < len-1` and special-cases first/last index
 // — keep verbatim or the boundary-position pairs swap.
@@ -601,7 +582,7 @@ var JsxCurlyBracePresenceRule = rule.Rule{
 			}
 
 			if parent != nil && (parent.Kind == ast.KindJsxElement || parent.Kind == ast.KindJsxFragment) {
-				children := jsxChildren(parent)
+				children := reactutil.GetJsxChildren(parent)
 				if hasAdjacentJsxExpressionContainers(jsxExpr, children) {
 					return false
 				}
@@ -630,7 +611,7 @@ var JsxCurlyBracePresenceRule = rule.Rule{
 				return false
 			}
 			parent := literal.Parent
-			children := jsxChildren(parent)
+			children := reactutil.GetJsxChildren(parent)
 			if len(children) == 1 && containsWhitespaceExpression(children[0]) {
 				return false
 			}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -85,6 +85,7 @@ export default defineConfig({
 
     // eslint-plugin-react
     './tests/eslint-plugin-react/rules/button-has-type.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-child-element-spacing.test.ts',
     './tests/eslint-plugin-react/rules/self-closing-comp.test.ts',
     './tests/eslint-plugin-react/rules/void-dom-elements-no-children.test.ts',
     './tests/eslint-plugin-react/rules/style-prop-object.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-child-element-spacing.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-child-element-spacing.test.ts
@@ -1,0 +1,414 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-child-element-spacing', {} as never, {
+  valid: [
+    // ---- Upstream: text-only child ----
+    {
+      code: `
+        <App>
+          foo
+        </App>
+      `,
+    },
+    // ---- Upstream: text-only fragment ----
+    {
+      code: `
+        <>
+          foo
+        </>
+      `,
+    },
+    // ---- Upstream: single inline element child (no surrounding text) ----
+    {
+      code: `
+        <App>
+          <a>bar</a>
+        </App>
+      `,
+    },
+    // ---- Upstream: nested inline elements ----
+    {
+      code: `
+        <App>
+          <a>
+            <b>nested</b>
+          </a>
+        </App>
+      `,
+    },
+    // ---- Upstream: multiple text-only lines ----
+    {
+      code: `
+        <App>
+          foo
+          bar
+        </App>
+      `,
+    },
+    // ---- Upstream: text and inline element on same line ----
+    {
+      code: `
+        <App>
+          foo<a>bar</a>baz
+        </App>
+      `,
+    },
+    // ---- Upstream: explicit {' '} between text and inline element ----
+    {
+      code: `
+        <App>
+          foo
+          {' '}
+          <a>bar</a>
+          {' '}
+          baz
+        </App>
+      `,
+    },
+    // ---- Upstream: {' '} on same line as inline element ----
+    {
+      code: `
+        <App>
+          foo
+          {' '}<a>bar</a>{' '}
+          baz
+        </App>
+      `,
+    },
+    // ---- Upstream: {' '} attached to text ----
+    {
+      code: `
+        <App>
+          foo{' '}
+          <a>bar</a>
+          {' '}baz
+        </App>
+      `,
+    },
+    // ---- Upstream: comment expression containers as spacing markers ----
+    {
+      code: `
+        <App>
+          foo{/*
+          */}<a>bar</a>{/*
+          */}baz
+        </App>
+      `,
+    },
+    // ---- Upstream: sentence with inline link, all on one line ----
+    {
+      code: `
+        <App>
+          Please take a look at <a href="https://js.org">this link</a>.
+        </App>
+      `,
+    },
+    // ---- Upstream: sentence with explicit {' '} before linked text ----
+    {
+      code: `
+        <App>
+          Please take a look at
+          {' '}
+          <a href="https://js.org">this link</a>.
+        </App>
+      `,
+    },
+    // ---- Upstream: block-level <p> elements (not inline) ----
+    {
+      code: `
+        <App>
+          <p>A</p>
+          <p>B</p>
+        </App>
+      `,
+    },
+    // ---- Upstream: block-level elements adjacent ----
+    {
+      code: `
+        <App>
+          <p>A</p><p>B</p>
+        </App>
+      `,
+    },
+    // ---- Upstream: inline elements separated by whitespace-only text ----
+    {
+      code: `
+        <App>
+          <a>foo</a>
+          <a>bar</a>
+        </App>
+      `,
+    },
+    // ---- Upstream: <br/> is not in inline set ----
+    {
+      code: `
+        <App>
+          A
+          <br/>
+          B
+        </App>
+      `,
+    },
+    // ---- Upstream: <br/> tightly between text ----
+    {
+      code: `
+        <App>
+          A<br/>B
+        </App>
+      `,
+    },
+    // ---- Edge: dotted tag name (Foo.Bar) is never treated as inline ----
+    {
+      code: `
+        <App>
+          foo
+          <Foo.Bar>bar</Foo.Bar>
+        </App>
+      `,
+    },
+    // ---- Edge: capitalized custom component is not in the inline set ----
+    {
+      code: `
+        <App>
+          foo
+          <Link>bar</Link>
+        </App>
+      `,
+    },
+    // ---- Edge: empty element ----
+    {
+      code: `<App></App>`,
+    },
+    // ---- Edge: self-closing inline element child has no children to walk ----
+    {
+      code: `<App><a /></App>`,
+    },
+    // ---- Edge: self-closing inline (<img/>) on same line as text ----
+    {
+      code: `<App>foo<img/>bar</App>`,
+    },
+    // ---- Edge: nested inline span tightly on one line ----
+    {
+      code: `<App><p>text <span>x</span> text</p></App>`,
+    },
+    // ---- Edge: block-level <section> not flagged on adjacent lines ----
+    {
+      code: `
+        <App>
+          intro
+          <section>body</section>
+        </App>
+      `,
+    },
+    // ---- Edge: <br/> not in inline set, multi-line valid ----
+    {
+      code: `
+        <App>
+          A
+          <br/>
+          B
+        </App>
+      `,
+    },
+    // ---- Edge: real-world prose with code reference ----
+    {
+      code: `
+        <p>
+          Use <code>useState</code> to track state.
+        </p>
+      `,
+    },
+    // ---- Edge: JsxExpression as separator between text and inline ----
+    {
+      code: `
+        <App>
+          foo
+          {variable}
+          <a>bar</a>
+        </App>
+      `,
+    },
+    // ---- Edge: namespaced tag (a:b) is not an Identifier — not inline ----
+    {
+      code: `
+        <App>
+          foo
+          <a:b>bar</a:b>
+        </App>
+      `,
+    },
+  ],
+  invalid: [
+    // ---- Upstream: text before inline element on a new line ----
+    {
+      code: `
+        <App>
+          foo
+          <a>bar</a>
+        </App>
+      `,
+      errors: [{ messageId: 'spacingBeforeNext' }],
+    },
+    // ---- Upstream: same as above but inside a fragment ----
+    {
+      code: `
+        <>
+          foo
+          <a>bar</a>
+        </>
+      `,
+      errors: [{ messageId: 'spacingBeforeNext' }],
+    },
+    // ---- Upstream: inline element followed by text on a new line ----
+    {
+      code: `
+        <App>
+          <a>bar</a>
+          baz
+        </App>
+      `,
+      errors: [{ messageId: 'spacingAfterPrev' }],
+    },
+    // ---- Upstream: explicit {' '} before inline element doesn't suppress
+    // the spacingAfterPrev report when the next text starts with newline ----
+    {
+      code: `
+        <App>
+          {' '}<a>bar</a>
+          baz
+        </App>
+      `,
+      errors: [{ messageId: 'spacingAfterPrev' }],
+    },
+    // ---- Upstream: sentence split before inline link ----
+    {
+      code: `
+        <App>
+          Please take a look at
+          <a href="https://js.org">this link</a>.
+        </App>
+      `,
+      errors: [{ messageId: 'spacingBeforeNext' }],
+    },
+    // ---- Upstream: text between two inline <code> elements anchors on the
+    // SECOND element via spacingBeforeNext ----
+    {
+      code: `
+        <App>
+          Some <code>loops</code> and some
+          <code>if</code> statements.
+        </App>
+      `,
+      errors: [{ messageId: 'spacingBeforeNext' }],
+    },
+    // ---- Upstream: two separate spacingBeforeNext reports in a row ----
+    {
+      code: `
+        <App>
+          Here is
+          <a href="https://js.org">a link</a> and here is
+          <a href="https://js.org">another</a>
+        </App>
+      `,
+      errors: [
+        { messageId: 'spacingBeforeNext' },
+        { messageId: 'spacingBeforeNext' },
+      ],
+    },
+    // ---- Edge: spacingAfterPrev inside a JsxFragment ----
+    {
+      code: `
+        <>
+          <a>bar</a>
+          baz
+        </>
+      `,
+      errors: [{ messageId: 'spacingAfterPrev' }],
+    },
+    // ---- Edge: text between two inline elements where the text matches the
+    // FOLLOWING pattern (starts with newline + content) — anchors on the FIRST
+    // element via spacingAfterPrev ----
+    {
+      code: `
+        <App>
+          <a>x</a>
+          mid <b>y</b>
+        </App>
+      `,
+      errors: [{ messageId: 'spacingAfterPrev' }],
+    },
+    // ---- Edge: self-closing inline element followed by text on a new line ----
+    {
+      code: `
+        <App>
+          <img/>
+          baz
+        </App>
+      `,
+      errors: [{ messageId: 'spacingAfterPrev' }],
+    },
+    // ---- Edge: text before self-closing inline element on a new line ----
+    {
+      code: `
+        <App>
+          foo
+          <input/>
+        </App>
+      `,
+      errors: [{ messageId: 'spacingBeforeNext' }],
+    },
+    // ---- Edge: nested element reports independently — only inner <p> matches ----
+    {
+      code: `
+        <App>
+          <p>
+            foo
+            <a>bar</a>
+          </p>
+        </App>
+      `,
+      errors: [{ messageId: 'spacingBeforeNext' }],
+    },
+    // ---- Edge: real-world arrow component with bad link spacing ----
+    {
+      code: `
+        const Doc = () => (
+          <p>
+            Read more
+            <a href="/docs">here</a>
+          </p>
+        );
+      `,
+      errors: [{ messageId: 'spacingBeforeNext' }],
+    },
+    // ---- Edge: outer + inner JsxElement BOTH host a bug — two diagnostics ----
+    {
+      code: `
+        <App>
+          <p>
+            foo
+            <a>bar</a>
+          </p>
+          <span>x</span>
+          trailing
+        </App>
+      `,
+      errors: [
+        { messageId: 'spacingAfterPrev' },
+        { messageId: 'spacingBeforeNext' },
+      ],
+    },
+    // ---- Edge: textarea (uncommon inline tag) before text on a new line ----
+    {
+      code: `
+        <App>
+          foo
+          <textarea/>
+        </App>
+      `,
+      errors: [{ messageId: 'spacingBeforeNext' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -172,6 +172,7 @@ rspress
 rstack
 rstest
 saddr
+samp
 scopemanager
 shadcn
 shouldnt


### PR DESCRIPTION
## Summary

Port the `react/jsx-child-element-spacing` rule from eslint-plugin-react to rslint.

The rule warns about line-break-only spacing between an inline JSX element (`<a>`, `<code>`, `<span>`, `<img/>`, etc.) and adjacent text — React swallows such line breaks at render time, which silently removes the gap the author appeared to intend. Aligned 1:1 with upstream behavior including the `spacingAfterPrev` / `spacingBeforeNext` messageIds, the 30-tag inline element set (with `br` excluded), and the report-position semantics.

Notable porting decisions:

- Recognize both `KindJsxElement` and `KindJsxSelfClosingElement` as inline-eligible — ESTree models both as `JSXElement`, but tsgo splits them into two kinds. Without the second kind, common self-closing inline tags (`<img/>`, `<input/>`, `<textarea/>`) would be silently skipped.
- Extracted the duplicated ` jsxChildren` helper from `jsx-curly-brace-presence` into `reactutil.GetJsxChildren` so both rules share a single implementation.

## Related Links

- Upstream rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-child-element-spacing.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-child-element-spacing.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).