### PR TITLE
feat: port rule forbid-component-props

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -2,6 +2,7 @@ package react_plugin
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/button_has_type"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_component_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_boolean_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_closing_tag_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_equals_spacing"
@@ -19,7 +20,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_access_state_in_setstate"
-	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_component_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_children_prop"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger_with_children"
@@ -58,6 +58,7 @@ import (
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		button_has_type.ButtonHasTypeRule,
+		forbid_component_props.ForbidComponentPropsRule,
 		jsx_boolean_value.JsxBooleanValueRule,
 		jsx_closing_tag_location.JsxClosingTagLocationRule,
 		jsx_equals_spacing.JsxEqualsSpacingRule,
@@ -75,7 +76,6 @@ func GetAllRules() []rule.Rule {
 		jsx_uses_vars.JsxUsesVarsRule,
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
 		no_access_state_in_setstate.NoAccessStateInSetstateRule,
-		forbid_component_props.ForbidComponentPropsRule,
 		no_children_prop.NoChildrenPropRule,
 		no_danger.NoDangerRule,
 		no_danger_with_children.NoDangerWithChildrenRule,

--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -19,6 +19,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_access_state_in_setstate"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_component_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_children_prop"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger_with_children"
@@ -74,6 +75,7 @@ func GetAllRules() []rule.Rule {
 		jsx_uses_vars.JsxUsesVarsRule,
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
 		no_access_state_in_setstate.NoAccessStateInSetstateRule,
+		forbid_component_props.ForbidComponentPropsRule,
 		no_children_prop.NoChildrenPropRule,
 		no_danger.NoDangerRule,
 		no_danger_with_children.NoDangerWithChildrenRule,

--- a/internal/plugins/react/rules/forbid_component_props/forbid_component_props.go
+++ b/internal/plugins/react/rules/forbid_component_props/forbid_component_props.go
@@ -1,0 +1,321 @@
+package forbid_component_props
+
+import (
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const msgPropIsForbidden = `Prop "{{prop}}" is forbidden on Components`
+
+// forbidEntry mirrors a single value of upstream's `forbid` Map. The raw key
+// is the literal `propName` (or `propNamePattern`) the user supplied — pattern
+// entries are matched via minimatch against the JSX attribute name; non-pattern
+// entries are looked up by exact string equality first.
+type forbidEntry struct {
+	key                 string
+	isPattern           bool
+	allowList           []string
+	allowPatternList    []string
+	disallowList        []string
+	disallowPatternList []string
+	message             string
+}
+
+type forbidConfig struct {
+	byKey   map[string]*forbidEntry
+	ordered []*forbidEntry
+}
+
+func parseOptions(options any) *forbidConfig {
+	cfg := &forbidConfig{byKey: map[string]*forbidEntry{}}
+
+	var forbidList []interface{}
+	if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+		if raw, ok := optsMap["forbid"].([]interface{}); ok {
+			forbidList = raw
+		}
+	}
+	// Upstream falls back to DEFAULTS = ['className', 'style'] when `forbid`
+	// is absent. An explicit empty array (`forbid: []`) keeps an empty list,
+	// matching upstream behavior.
+	if forbidList == nil {
+		forbidList = []interface{}{"className", "style"}
+	}
+
+	for _, raw := range forbidList {
+		switch v := raw.(type) {
+		case string:
+			if v == "" {
+				continue
+			}
+			cfg.set(v, &forbidEntry{key: v})
+		case map[string]interface{}:
+			propName, _ := v["propName"].(string)
+			propPattern, _ := v["propNamePattern"].(string)
+			key := propName
+			if key == "" {
+				key = propPattern
+			}
+			if key == "" {
+				continue
+			}
+			e := &forbidEntry{key: key, isPattern: propPattern != ""}
+			if l, ok := v["allowedFor"].([]interface{}); ok {
+				e.allowList = stringSlice(l)
+			}
+			if l, ok := v["allowedForPatterns"].([]interface{}); ok {
+				e.allowPatternList = stringSlice(l)
+			}
+			if l, ok := v["disallowedFor"].([]interface{}); ok {
+				e.disallowList = stringSlice(l)
+			}
+			if l, ok := v["disallowedForPatterns"].([]interface{}); ok {
+				e.disallowPatternList = stringSlice(l)
+			}
+			if msg, ok := v["message"].(string); ok && msg != "" {
+				e.message = msg
+			}
+			cfg.set(key, e)
+		}
+	}
+	return cfg
+}
+
+// set mirrors `Map.prototype.set`: re-setting an existing key replaces the
+// value but preserves the original insertion position. Pattern iteration in
+// `getPropOptions` walks `ordered` so the order is observable.
+func (c *forbidConfig) set(key string, e *forbidEntry) {
+	if _, exists := c.byKey[key]; exists {
+		for i, prev := range c.ordered {
+			if prev.key == key {
+				c.ordered[i] = e
+				break
+			}
+		}
+	} else {
+		c.ordered = append(c.ordered, e)
+	}
+	c.byKey[key] = e
+}
+
+func stringSlice(raw []interface{}) []string {
+	out := make([]string, 0, len(raw))
+	for _, x := range raw {
+		if s, ok := x.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// getPropOptions mirrors upstream `getPropOptions`: direct string-key lookup
+// wins; otherwise the first pattern entry whose key matches the prop wins.
+func (c *forbidConfig) getPropOptions(prop string) *forbidEntry {
+	if e, ok := c.byKey[prop]; ok {
+		return e
+	}
+	for _, e := range c.ordered {
+		if !e.isPattern {
+			continue
+		}
+		if reactutil.MatchGlob(prop, e.key) {
+			return e
+		}
+	}
+	return nil
+}
+
+// isForbidden mirrors upstream `isForbidden`. The disallow path takes
+// precedence when at least one disallow list is configured; otherwise the
+// allow path applies.
+func (c *forbidConfig) isForbidden(prop, tag string) (forbidden bool, opts *forbidEntry) {
+	opts = c.getPropOptions(prop)
+	if opts == nil {
+		return false, nil
+	}
+
+	hasDisallowOptions := len(opts.disallowList) > 0 || len(opts.disallowPatternList) > 0
+
+	var tagForbidden bool
+	if hasDisallowOptions {
+		tagForbidden = slices.Contains(opts.disallowList, tag)
+		if !tagForbidden {
+			for _, p := range opts.disallowPatternList {
+				if reactutil.MatchGlob(tag, p) {
+					tagForbidden = true
+					break
+				}
+			}
+		}
+	} else {
+		if slices.Contains(opts.allowList, tag) {
+			tagForbidden = false
+		} else if len(opts.allowPatternList) == 0 {
+			tagForbidden = true
+		} else {
+			tagForbidden = true
+			for _, p := range opts.allowPatternList {
+				if reactutil.MatchGlob(tag, p) {
+					tagForbidden = false
+					break
+				}
+			}
+		}
+	}
+
+	// Upstream: `typeof tagName === 'undefined' || isTagForbidden`. tag == ""
+	// in the Go port stands in for the upstream undefined case (an unknown /
+	// unrepresentable tag shape) — treat it as forbidden.
+	return tag == "" || tagForbidden, opts
+}
+
+// tagShape carries the data the rule needs out of a JSX tag-name node: the
+// `tag` string (matched against allow/disallow lists), the `componentName`
+// string (used for the DOM check), and `skipDomCheck` to mirror upstream's
+// quirk that namespaced tags bypass the lowercase-rejection branch.
+type tagShape struct {
+	tag           string
+	componentName string
+	skipDomCheck  bool
+}
+
+// getTagShape mirrors upstream's tag/componentName extraction:
+//
+//	const tag = parentName.name || `${parentName.object.name}.${parentName.property.name}`;
+//	const componentName = parentName.name || parentName.property.name;
+//
+// Two upstream behaviors are mirrored exactly so allow/disallow lists match
+// byte-for-byte:
+//
+//  1. Member expressions deeper than two segments (`<Foo.Bar.Baz />`) produce
+//     the literal string `"undefined.Baz"` because `parentName.object.name` is
+//     undefined when `object` is itself a member expression.
+//  2. JSX namespaced names (`<fbt:param />`) — upstream's `tag` becomes a
+//     JSXIdentifier object (truthy but not a string), so allow/disallow
+//     `indexOf` never matches and `componentName[0]` is undefined, which
+//     bypasses the lowercase-rejection branch. We model this with a synthetic
+//     tag string that allow/disallow lists can still match (more useful for
+//     real configs) and `skipDomCheck = true` so namespaced lowercase tags
+//     are NOT silently dropped as DOM intrinsics.
+func getTagShape(tagName *ast.Node) (tagShape, bool) {
+	if tagName == nil {
+		return tagShape{}, false
+	}
+	switch tagName.Kind {
+	case ast.KindIdentifier:
+		id := tagName.AsIdentifier()
+		if id == nil {
+			return tagShape{}, false
+		}
+		text := id.Text
+		return tagShape{tag: text, componentName: text}, true
+	case ast.KindThisKeyword:
+		// Bare `<this>` is not legal JSX; defensive branch only.
+		return tagShape{tag: "this", componentName: "this"}, true
+	case ast.KindPropertyAccessExpression:
+		pa := tagName.AsPropertyAccessExpression()
+		if pa == nil || pa.Expression == nil {
+			return tagShape{}, false
+		}
+		propName := pa.Name()
+		if propName == nil || propName.Kind != ast.KindIdentifier {
+			return tagShape{}, false
+		}
+		propText := propName.AsIdentifier().Text
+		var baseText string
+		switch pa.Expression.Kind {
+		case ast.KindIdentifier:
+			baseText = pa.Expression.AsIdentifier().Text
+		case ast.KindThisKeyword:
+			baseText = "this"
+		default:
+			// Mirror upstream's `${undefined}.<prop>` for chains deeper than
+			// two segments (e.g. `<Foo.Bar.Baz />`).
+			baseText = "undefined"
+		}
+		return tagShape{tag: baseText + "." + propText, componentName: propText}, true
+	case ast.KindJsxNamespacedName:
+		ns := tagName.AsJsxNamespacedName()
+		if ns == nil || ns.Namespace == nil || ns.Name() == nil {
+			return tagShape{}, false
+		}
+		if ns.Namespace.Kind != ast.KindIdentifier || ns.Name().Kind != ast.KindIdentifier {
+			return tagShape{}, false
+		}
+		nsText := ns.Namespace.AsIdentifier().Text
+		nameText := ns.Name().AsIdentifier().Text
+		return tagShape{
+			tag:           nsText + ":" + nameText,
+			componentName: nameText,
+			// Mirror upstream: namespaced names bypass the DOM lowercase-skip
+			// path entirely, so `<fbt:param>` is treated as a Component.
+			skipDomCheck: true,
+		}, true
+	}
+	return tagShape{}, false
+}
+
+// isLowercaseStart mirrors upstream's
+// `componentName[0] !== componentName[0].toUpperCase()` test: returns true iff
+// the first rune is a cased letter in its lowercase form. Digits, `_`, `$`,
+// and uppercase letters all return false (the rule then continues, matching
+// upstream).
+func isLowercaseStart(s string) bool {
+	if s == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(s)
+	return unicode.ToLower(r) == r && unicode.ToUpper(r) != r
+}
+
+var ForbidComponentPropsRule = rule.Rule{
+	Name: "react/forbid-component-props",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		cfg := parseOptions(options)
+		return rule.RuleListeners{
+			ast.KindJsxAttribute: func(node *ast.Node) {
+				parent := reactutil.GetJsxParentElement(node)
+				if parent == nil {
+					return
+				}
+				tagName := reactutil.GetJsxTagName(parent)
+				if tagName == nil {
+					return
+				}
+				shape, ok := getTagShape(tagName)
+				if !ok {
+					return
+				}
+				if !shape.skipDomCheck && isLowercaseStart(shape.componentName) {
+					return
+				}
+				prop := reactutil.GetJsxPropName(node)
+				if prop == "" {
+					return
+				}
+				forbidden, opts := cfg.isForbidden(prop, shape.tag)
+				if !forbidden {
+					return
+				}
+				if opts != nil && opts.message != "" {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Description: opts.message,
+					})
+					return
+				}
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "propIsForbidden",
+					Description: strings.ReplaceAll(msgPropIsForbidden, "{{prop}}", prop),
+					Data:        map[string]string{"prop": prop},
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/forbid_component_props/forbid_component_props.go
+++ b/internal/plugins/react/rules/forbid_component_props/forbid_component_props.go
@@ -91,6 +91,10 @@ func parseOptions(options any) *forbidConfig {
 // set mirrors `Map.prototype.set`: re-setting an existing key replaces the
 // value but preserves the original insertion position. Pattern iteration in
 // `getPropOptions` walks `ordered` so the order is observable.
+//
+// The replace path scans `ordered` linearly (O(n)). `forbid` configs are
+// expected to be small (typically ≤10 entries in real configs), so a linear
+// scan is preferred over carrying a parallel index map purely for replace.
 func (c *forbidConfig) set(key string, e *forbidEntry) {
 	if _, exists := c.byKey[key]; exists {
 		for i, prev := range c.ordered {
@@ -191,6 +195,20 @@ type tagShape struct {
 //	const tag = parentName.name || `${parentName.object.name}.${parentName.property.name}`;
 //	const componentName = parentName.name || parentName.property.name;
 //
+// JSX tag-name grammar (tsgo `parseJsxElementName`, parser.go:4948) restricts
+// the receiver to one of:
+//   - `Identifier`            — `<Foo>`
+//   - `ThisKeyword`           — `<this>` / `<this.X>`
+//   - `JsxNamespacedName`     — `<ns:Name>`
+//   - `PropertyAccessExpression` whose own `.Expression` is recursively one
+//     of the above — `<Foo.Bar>`, `<Foo.Bar.Baz>`
+//
+// Expression wrappers like `(X)`, `X as T`, `X!`, `X satisfies T`, `<T>x` are
+// REJECTED by the parser at JSX-tag-name position (they're parsed as ordinary
+// expressions only outside of JSX tag names). Therefore no `SkipParentheses`
+// / `SkipExpressionWrappers` pass is needed when walking `pa.Expression` — a
+// wrapper kind is unreachable here.
+//
 // Two upstream behaviors are mirrored exactly so allow/disallow lists match
 // byte-for-byte:
 //
@@ -236,8 +254,12 @@ func getTagShape(tagName *ast.Node) (tagShape, bool) {
 		case ast.KindThisKeyword:
 			baseText = "this"
 		default:
-			// Mirror upstream's `${undefined}.<prop>` for chains deeper than
-			// two segments (e.g. `<Foo.Bar.Baz />`).
+			// Per the grammar note above, the only remaining shape here is
+			// `pa.Expression` being itself a `PropertyAccessExpression` —
+			// i.e. chains deeper than two segments (`<Foo.Bar.Baz />`).
+			// Upstream produces `"undefined.<prop>"` for that case because
+			// `parentName.object.name` is undefined when `object` is itself
+			// a member expression; mirror it byte-for-byte.
 			baseText = "undefined"
 		}
 		return tagShape{tag: baseText + "." + propText, componentName: propText}, true

--- a/internal/plugins/react/rules/forbid_component_props/forbid_component_props.md
+++ b/internal/plugins/react/rules/forbid_component_props/forbid_component_props.md
@@ -1,0 +1,83 @@
+# forbid-component-props
+
+By default this rule prevents passing of [props that add lots of complexity](https://medium.com/brigade-engineering/don-t-pass-css-classes-between-components-e9f7ab192785) (`className`, `style`) to Components. This rule only applies to Components (e.g. `<Foo />`) and not DOM nodes (e.g. `<div />`). The list of forbidden props can be customized with the `forbid` option.
+
+## Rule Details
+
+This rule checks all JSX elements and verifies that no forbidden props are used on Components. This rule is off by default.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<Hello className='foo' />
+```
+
+```jsx
+<Hello style={{color: 'red'}} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<Hello name='Joe' />
+```
+
+```jsx
+<div className='foo' />
+```
+
+```jsx
+<div style={{color: 'red'}} />
+```
+
+## Rule Options
+
+```json
+{ "react/forbid-component-props": ["error", { "forbid": ["className", "style"] }] }
+```
+
+### `forbid`
+
+An array specifying the names of props that are forbidden. The default value of this option is `['className', 'style']`. Each array element can either be a string with the property name, or an object specifying the property name (or glob string), an optional custom message, and a component allowlist:
+
+```json
+{ "react/forbid-component-props": ["error", { "forbid": [{ "propName": "someProp", "allowedFor": ["SomeComponent", "AnotherComponent"], "message": "Avoid using someProp except SomeComponent and AnotherComponent" }] }] }
+```
+
+Use `disallowedFor` as an exclusion list to warn on props for specific components. `disallowedFor` must have at least one item.
+
+```json
+{ "react/forbid-component-props": ["error", { "forbid": [{ "propName": "someProp", "disallowedFor": ["SomeComponent", "AnotherComponent"], "message": "Avoid using someProp for SomeComponent and AnotherComponent" }] }] }
+```
+
+For `propNamePattern` glob string patterns:
+
+```json
+{ "react/forbid-component-props": ["error", { "forbid": [{ "propNamePattern": "**-**", "allowedFor": ["div"], "message": "Avoid using kebab-case except div" }] }] }
+```
+
+```json
+{ "react/forbid-component-props": ["error", { "forbid": [{ "propNamePattern": "**-**", "allowedForPatterns": ["*Component"], "message": "Avoid using kebab-case except components that match the `*Component` pattern" }] }] }
+```
+
+Use `allowedForPatterns` for glob string patterns:
+
+```json
+{ "react/forbid-component-props": ["error", { "forbid": [{ "propName": "someProp", "allowedForPatterns": ["*Component"], "message": "Avoid using `someProp` except components that match the `*Component` pattern" }] }] }
+```
+
+Use `disallowedForPatterns` for glob string patterns:
+
+```json
+{ "react/forbid-component-props": ["error", { "forbid": [{ "propName": "someProp", "disallowedForPatterns": ["*Component"], "message": "Avoid using `someProp` for components that match the `*Component` pattern" }] }] }
+```
+
+Combine several properties to cover more cases:
+
+```json
+{ "react/forbid-component-props": ["error", { "forbid": [{ "propName": "someProp", "allowedFor": ["div"], "allowedForPatterns": ["*Component"], "message": "Avoid using `someProp` except `div` and components that match the `*Component` pattern" }] }] }
+```
+
+## Original Documentation
+
+- [eslint-plugin-react/forbid-component-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md)

--- a/internal/plugins/react/rules/forbid_component_props/forbid_component_props_test.go
+++ b/internal/plugins/react/rules/forbid_component_props/forbid_component_props_test.go
@@ -308,6 +308,15 @@ func TestForbidComponentPropsRule(t *testing.T) {
 		// ---- Additional edge cases (Dimension 4 universal edge shapes) ----
 		// `<Foo.bar>` — rightmost lowercase, treated as DOM. tag = "Foo.bar".
 		{Code: `<Foo.bar className="x" />;`, Tsx: true},
+		// Bare `<this />` — KindThisKeyword tag; `componentName = "this"` is
+		// lowercase, so the DOM-skip path fires and the prop is not checked
+		// (matches upstream where `parentName.name === "this"` and
+		// `"this"[0] === "t"` is lowercase).
+		{Code: `<this bar="x" />;`, Tsx: true},
+		// Bare `<this className="x" />` — same DOM-skip path. Even though
+		// `className` is in default forbid, the lowercase componentName
+		// short-circuits the rule.
+		{Code: `<this className="x" />;`, Tsx: true},
 		// `<a.B>` — rightmost uppercase, NOT DOM. tag = "a.B"; allowedFor
 		// matches by exact string.
 		{

--- a/internal/plugins/react/rules/forbid_component_props/forbid_component_props_test.go
+++ b/internal/plugins/react/rules/forbid_component_props/forbid_component_props_test.go
@@ -1,0 +1,1241 @@
+package forbid_component_props
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestForbidComponentPropsRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ForbidComponentPropsRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		// DOM intrinsic element with default forbid (className, style).
+		{
+			Code: `
+        var First = createReactClass({
+          render: function() {
+            return <div className="foo" />;
+          }
+        });
+      `,
+			Tsx: true,
+		},
+		// DOM intrinsic with explicit forbid omitting className.
+		{
+			Code: `
+        var First = createReactClass({
+          render: function() {
+            return <div style={{color: "red"}} />;
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"style"}},
+		},
+		// Component with non-forbidden prop.
+		{
+			Code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo bar="baz" />;
+          }
+        });
+      `,
+			Tsx: true,
+		},
+		// Component with className when only style is forbidden.
+		{
+			Code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"style"}},
+		},
+		// Multiple non-matching forbid entries.
+		{
+			Code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"style", "foo"}},
+		},
+		// `<this.Foo>` with default forbid: prop "bar" not in forbid → no report.
+		{
+			Code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <this.Foo bar="baz" />;
+          }
+        });
+      `,
+			Tsx: true,
+		},
+		// `<this.foo>` (lowercase rightmost) — treated as DOM by upstream's
+		// componentName check, so the className prop is not checked.
+		{
+			Code: `
+        class First extends createReactClass {
+          render() {
+            return <this.foo className="bar" />;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"style"}},
+		},
+		// JSX spread on `<this.Foo>` — no JSXAttribute to check (spread is
+		// JsxSpreadAttribute) so default forbid doesn't apply.
+		{
+			Code: `
+        const First = (props) => (
+          <this.Foo {...props} />
+        );
+      `,
+			Tsx: true,
+		},
+		// allowedFor matches: ReactModal allowed for className.
+		{
+			Code: `
+        const item = (<ReactModal className="foo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":   "className",
+					"allowedFor": []interface{}{"ReactModal"},
+				},
+			}},
+		},
+		// allowedFor matches a member-expression tag literally.
+		{
+			Code: `
+        const item = (<MyLayout.Content className="customFoo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":   "className",
+					"allowedFor": []interface{}{"MyLayout.Content"},
+				},
+			}},
+		},
+		// allowedFor matches "this.<X>".
+		{
+			Code: `
+        const item = (<this.ReactModal className="foo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":   "className",
+					"allowedFor": []interface{}{"this.ReactModal"},
+				},
+			}},
+		},
+		// disallowedFor doesn't match Foo, so className stays allowed.
+		{
+			Code: `
+        const item = (<Foo className="foo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":      "className",
+					"disallowedFor": []interface{}{"ReactModal"},
+				},
+			}},
+		},
+		// JSX namespaced name (`<fbt:param>`) — `name` and `number` aren't
+		// in default forbid, so no report. This locks in the namespaced-tag
+		// path of the listener.
+		{
+			Code: `
+        <fbt:param name="Total number of files" number={true} />
+      `,
+			Tsx: true,
+		},
+		// Combined disallowedFor across two entries; matched tag is excluded.
+		{
+			Code: `
+        const item = (
+          <Foo className="bar">
+            <ReactModal style={{color: "red"}} />
+          </Foo>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":      "className",
+					"disallowedFor": []interface{}{"OtherModal", "ReactModal"},
+				},
+				map[string]interface{}{
+					"propName":      "style",
+					"disallowedFor": []interface{}{"Foo"},
+				},
+			}},
+		},
+		// disallowedFor on one entry plus allowedFor on the other.
+		{
+			Code: `
+        const item = (
+          <Foo className="bar">
+            <ReactModal style={{color: "red"}} />
+          </Foo>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":      "className",
+					"disallowedFor": []interface{}{"OtherModal", "ReactModal"},
+				},
+				map[string]interface{}{
+					"propName":   "style",
+					"allowedFor": []interface{}{"ReactModal"},
+				},
+			}},
+		},
+		// disallowedFor entry doesn't match `this.ReactModal` (different tag).
+		{
+			Code: `
+        const item = (<this.ReactModal className="foo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":      "className",
+					"disallowedFor": []interface{}{"ReactModal"},
+				},
+			}},
+		},
+		// propNamePattern with allowedFor on a DOM intrinsic — `<div>` is DOM
+		// and skipped before the pattern check runs.
+		{
+			Code: `
+        const MyComponent = () => (
+          <div aria-label="welcome" />
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propNamePattern": "**-**",
+					"allowedFor":      []interface{}{"div"},
+				},
+			}},
+		},
+		// allowedForPatterns: glob matches across several Components.
+		{
+			Code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <UIButton className="size-lg" />
+          </Root>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":           "className",
+					"allowedForPatterns": []interface{}{"*Icon", "*Svg", "UI*"},
+				},
+			}},
+		},
+		// allowedFor + allowedForPatterns combined: legacy explicit name plus pattern.
+		{
+			Code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <UIButton className="size-lg" />
+            <ButtonLegacy className="size-lg" />
+          </Root>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":           "className",
+					"allowedFor":         []interface{}{"ButtonLegacy"},
+					"allowedForPatterns": []interface{}{"*Icon", "*Svg", "UI*"},
+				},
+			}},
+		},
+		// disallowedFor + disallowedForPatterns: tags not matching either are allowed.
+		{
+			Code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <UIButton className="size-lg" />
+          </Root>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":              "className",
+					"disallowedFor":         []interface{}{"Modal"},
+					"disallowedForPatterns": []interface{}{"*Legacy", "Shared*"},
+				},
+			}},
+		},
+
+		// ---- Additional edge cases (Dimension 4 universal edge shapes) ----
+		// `<Foo.bar>` — rightmost lowercase, treated as DOM. tag = "Foo.bar".
+		{Code: `<Foo.bar className="x" />;`, Tsx: true},
+		// `<a.B>` — rightmost uppercase, NOT DOM. tag = "a.B"; allowedFor
+		// matches by exact string.
+		{
+			Code: `const x = (<a.B className="x" />);`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":   "className",
+					"allowedFor": []interface{}{"a.B"},
+				},
+			}},
+		},
+		// Empty forbid list: nothing is forbidden, even className/style.
+		{
+			Code:    `<Foo className="x" style={{}} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{}},
+		},
+		// Spread attributes are not JsxAttributes — never reported.
+		{
+			Code: `<Foo {...props} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{"propName": "className"},
+			}},
+		},
+		// Spread + named attribute coexisting: spread is ignored, named is checked.
+		{
+			Code: `<Foo {...props} bar="x" />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{"propName": "className"},
+			}},
+		},
+		// Boolean shorthand prop: `<Foo disabled />` — initializer absent. The
+		// listener still receives the JsxAttribute and can match by name.
+		{Code: `<Foo bar />;`, Tsx: true},
+		// JSX Fragment containing Components: each Component is checked
+		// independently; tags inside fragments are not affected by parent shape.
+		{
+			Code: `<><Foo bar="x" /><Bar baz="y" /></>;`,
+			Tsx:  true,
+		},
+		// Empty string entries in forbid are skipped; a real entry alongside still applies.
+		{
+			Code:    `<Foo other="x" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"", "className"}},
+		},
+		// `forbid` not an array (schema-violating): falls back to defaults
+		// `['className', 'style']`. Here `other` isn't in defaults → valid.
+		{
+			Code:    `<Foo other="x" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": "className"},
+		},
+		// Nested Components: outer/inner DOM and outer/inner Components mixed.
+		// `<a>` and `<span>` are DOM — their props aren't checked even if forbidden.
+		{
+			Code: `
+        <a className="outer">
+          <Foo bar="ok">
+            <span className="ok" />
+          </Foo>
+        </a>
+      `,
+			Tsx: true,
+		},
+		// Custom message with empty string falls back to default messageId
+		// path — mirrors the truthy check in upstream `customMessage || ...`.
+		{
+			Code: `<MyComp other="x" />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName": "className",
+					"message":  "",
+				},
+			}},
+		},
+		// Non-string forbid entries (numbers, nulls, nested arrays) are ignored.
+		// Defaults are NOT re-applied because `forbid` is present (a non-nil
+		// array). Nothing is forbidden.
+		{
+			Code:    `<Foo className="x" style={{}} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{42, nil, []interface{}{"className"}}},
+		},
+
+		// ---- TS-specific syntax & wrappers (Dimension 1) ----
+		// TS generic on a component tag: `<Foo<T>>` — tagName is still
+		// Identifier "Foo"; type arguments don't affect tag string.
+		{
+			Code: `function W<T>() { return <Foo<T> bar="x" />; }`,
+			Tsx:  true,
+		},
+		// TS non-null on the JSX child expression doesn't affect the
+		// JSXAttribute listener.
+		{
+			Code: `const F: any = null; <a>{F!}</a>;`,
+			Tsx:  true,
+		},
+		// TS `as` cast inside a JSX expression initializer — value side, not
+		// inspected by the rule. Tag is DOM (`a`).
+		{
+			Code: `<a href={("/x" as string)} />;`,
+			Tsx:  true,
+		},
+
+		// ---- Whitespace & comment robustness (Dimension 4) ----
+		// Tag name immediately followed by self-close: `<Foo/>` (no space).
+		{Code: `<Foo bar="x"/>;`, Tsx: true},
+		// Multi-line attribute on a Component: only the prop name matters.
+		{
+			Code: `
+        <Foo
+          bar="multi-line"
+        />
+      `,
+			Tsx: true,
+		},
+		// Block comment between tag and attribute — should not break parsing.
+		{
+			Code: `<Foo /* hi */ bar="x" />;`,
+			Tsx:  true,
+		},
+
+		// ---- Defaults & options edge shapes ----
+		// `null` options → defaults apply but bar is not in defaults.
+		{Code: `<Foo bar="x" />;`, Tsx: true, Options: nil},
+		// Options array shape `[opts]` — exercises GetOptionsMap unwrap path.
+		{
+			Code:    `<Foo bar="x" />;`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"forbid": []interface{}{"className"}}},
+		},
+		// Options object shape `opts` — single-option CLI path.
+		{
+			Code:    `<Foo bar="x" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"className"}},
+		},
+		// Object entry with neither propName nor propNamePattern is silently
+		// skipped (upstream produces an entry keyed by undefined). Bar is
+		// then unrestricted.
+		{
+			Code: `<Foo bar="x" />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{"allowedFor": []interface{}{"X"}},
+			}},
+		},
+		// `allowedFor` non-array (schema-violating) is silently ignored —
+		// fall back to "no allow list, no allow patterns" → defaults forbid
+		// applies. Here `bar` isn't forbidden so still valid.
+		{
+			Code: `<Foo bar="x" />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{"propName": "className", "allowedFor": "ReactModal"},
+			}},
+		},
+
+		// ---- Real-world allow patterns (designed for typical app configs) ----
+		// 1) Strict whitelist: only `Theme.*` may use `style`.
+		{
+			Code: `<Theme.Box style={{padding: 8}} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":           "style",
+					"allowedForPatterns": []interface{}{"Theme.*"},
+				},
+			}},
+		},
+		// 2) Mixed glob — both `Card`-suffixed and `Modal`-suffixed allowed.
+		{
+			Code: `
+        <UserCard className="foo" />;
+        <UserModal className="bar" />;
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":           "className",
+					"allowedForPatterns": []interface{}{"*Card", "*Modal"},
+				},
+			}},
+		},
+		// 3) Combined disallow + custom message — none of the listed
+		// components present; quietly valid.
+		{
+			Code: `<HappyButton onClick={() => {}} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":              "onClick",
+					"disallowedFor":         []interface{}{"DangerousButton"},
+					"disallowedForPatterns": []interface{}{"Legacy*"},
+					"message":               "Use IconButton#onPress",
+				},
+			}},
+		},
+		// 4) Multiple unrelated forbid entries; matched-rule routing.
+		{
+			Code: `<Foo onClick={() => {}} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{"propName": "className"},
+				map[string]interface{}{"propName": "style"},
+				map[string]interface{}{"propName": "onClick", "allowedFor": []interface{}{"Foo"}},
+			}},
+		},
+		// 5) JSX inside `key={...}` expression is checked separately as a
+		// nested element — the inner `<Inner>` renders inside an attribute
+		// expression, but its own props are still checked.
+		{
+			Code: `<div data-x={(<Inner bar="x" />)} />;`,
+			Tsx:  true,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		// Default forbid catches className on a Component.
+		{
+			Code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 5, Column: 25},
+			},
+		},
+		// Default forbid catches style on a Component.
+		{
+			Code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo style={{color: "red"}} />;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 5, Column: 25},
+			},
+		},
+		// Explicit string forbid list catches className.
+		{
+			Code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"className", "style"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 5, Column: 25},
+			},
+		},
+		// Explicit string forbid list catches style.
+		{
+			Code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo style={{color: "red"}} />;
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"className", "style"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 5, Column: 25},
+			},
+		},
+		// disallowedFor matches the Component tag.
+		{
+			Code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo style={{color: "red"}} />;
+          }
+        });
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":      "style",
+					"disallowedFor": []interface{}{"Foo"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 5, Column: 25},
+			},
+		},
+		// allowedFor not matching → forbidden.
+		{
+			Code: `
+        const item = (<Foo className="foo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":   "className",
+					"allowedFor": []interface{}{"ReactModal"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 2, Column: 28},
+			},
+		},
+		// `<this.ReactModal>` with allowedFor matching only `ReactModal` — tag
+		// is "this.ReactModal", not in allowList, forbidden.
+		{
+			Code: `
+        const item = (<this.ReactModal className="foo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":   "className",
+					"allowedFor": []interface{}{"ReactModal"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 2, Column: 40},
+			},
+		},
+		// `<this.ReactModal>` with disallowedFor including the dotted name.
+		{
+			Code: `
+        const item = (<this.ReactModal className="foo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":      "className",
+					"disallowedFor": []interface{}{"this.ReactModal"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 2, Column: 40},
+			},
+		},
+		// disallowedFor exact match on a single-name Component.
+		{
+			Code: `
+        const item = (<ReactModal className="foo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":      "className",
+					"disallowedFor": []interface{}{"ReactModal"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 2, Column: 35},
+			},
+		},
+		// disallowedFor on a member-expression tag.
+		{
+			Code: `
+        const item = (<MyLayout.Content className="customFoo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":      "className",
+					"disallowedFor": []interface{}{"MyLayout.Content"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 2, Column: 41},
+			},
+		},
+		// Custom message replaces the default; no messageId is emitted.
+		{
+			Code: `
+        const item = (<Foo className="foo" />);
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName": "className",
+					"message":  "Please use ourCoolClassName instead of ClassName",
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "Please use ourCoolClassName instead of ClassName", Line: 2, Column: 28},
+			},
+		},
+		// Multiple custom messages, in source order across nested elements.
+		{
+			Code: `
+        const item = () => (
+          <Foo className="foo">
+            <Bar option="high" />
+          </Foo>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName": "className",
+					"message":  "Please use ourCoolClassName instead of ClassName",
+				},
+				map[string]interface{}{
+					"propName": "option",
+					"message":  "Avoid using option",
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "Please use ourCoolClassName instead of ClassName", Line: 3, Column: 16},
+				{Message: "Avoid using option", Line: 4, Column: 18},
+			},
+		},
+		// Mix of default-message and custom-message entries.
+		{
+			Code: `
+        const item = () => (
+          <Foo className="foo">
+            <Bar option="high" />
+          </Foo>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{"propName": "className"},
+				map[string]interface{}{
+					"propName": "option",
+					"message":  "Avoid using option",
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 3, Column: 16},
+				{Message: "Avoid using option", Line: 4, Column: 18},
+			},
+		},
+		// propNamePattern matches a kebab-case prop on a Component.
+		{
+			Code: `
+        const MyComponent = () => (
+          <Foo kebab-case-prop={123} />
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{"propNamePattern": "**-**"},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 3, Column: 16},
+			},
+		},
+		// propNamePattern + custom message.
+		{
+			Code: `
+        const MyComponent = () => (
+          <Foo kebab-case-prop={123} />
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propNamePattern": "**-**",
+					"message":         "Avoid using kebab-case",
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "Avoid using kebab-case", Line: 3, Column: 16},
+			},
+		},
+		// propNamePattern + allowedFor: DOM intrinsic skipped, Component flagged.
+		{
+			Code: `
+        const MyComponent = () => (
+          <div>
+            <div aria-label="Hello World" />
+            <Foo kebab-case-prop={123} />
+          </div>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propNamePattern": "**-**",
+					"allowedFor":      []interface{}{"div"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 5, Column: 18},
+			},
+		},
+		// propNamePattern + disallowedFor: DOM intrinsics skipped (h1, div).
+		{
+			Code: `
+        const MyComponent = () => (
+          <div>
+            <div aria-label="Hello World" />
+            <h1 data-id="my-heading" />
+            <Foo kebab-case-prop={123} />
+          </div>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propNamePattern": "**-**",
+					"disallowedFor":   []interface{}{"Foo"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 6, Column: 18},
+			},
+		},
+		// allowedForPatterns + custom message.
+		{
+			Code: `
+        const rootElement = () => (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+          </Root>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":           "className",
+					"message":            "className available only for icons",
+					"allowedForPatterns": []interface{}{"*Icon"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "className available only for icons", Line: 5, Column: 22},
+			},
+		},
+		// Two separate entries, each with allowedForPatterns + custom message.
+		{
+			Code: `
+        const rootElement = () => (
+          <Root>
+            <UICard style={{backgroundColor: black}}/>
+            <SomeIcon className="size-lg" />
+            <SomeSvg className="size-lg" style={{fill: currentColor}} />
+          </Root>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":           "className",
+					"message":            "className available only for icons",
+					"allowedForPatterns": []interface{}{"*Icon"},
+				},
+				map[string]interface{}{
+					"propName":           "style",
+					"message":            "style available only for SVGs",
+					"allowedForPatterns": []interface{}{"*Svg"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "style available only for SVGs", Line: 4, Column: 21},
+				{Message: "className available only for icons", Line: 6, Column: 22},
+			},
+		},
+		// disallowedFor + disallowedForPatterns combined; multi-component flagging.
+		{
+			Code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <ButtonLegacy className="size-lg" />
+          </Root>
+        );
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":              "className",
+					"disallowedFor":         []interface{}{"SomeSvg"},
+					"disallowedForPatterns": []interface{}{"UI*", "*Icon"},
+					"message":               "Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns",
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns", Line: 4, Column: 23},
+				{Message: "Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns", Line: 5, Column: 26},
+				{Message: "Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns", Line: 6, Column: 22},
+				{Message: "Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns", Line: 7, Column: 21},
+			},
+		},
+
+		// ---- Additional lock-in cases ----
+		// `<Foo.Bar.Baz>` deep-nested member access: upstream produces
+		// "undefined.Baz" as the tag string. Our port mirrors that quirk so
+		// allow/disallow lists match upstream byte-for-byte. This locks in
+		// the behavior — a future refactor that walks the chain cleanly
+		// would change the resulting tag string and should explicitly
+		// flip this test.
+		{
+			Code: `<Foo.Bar.Baz className="x" />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":      "className",
+					"disallowedFor": []interface{}{"undefined.Baz"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 14},
+			},
+		},
+		// Options passed as bare object (single-option CLI shape) — exercises
+		// `utils.GetOptionsMap`'s array-vs-map handling.
+		{
+			Code:    `<Foo style={{}} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"style"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 6},
+			},
+		},
+		// JSX namespaced name with a forbidden prop. Upstream: namespaced
+		// tags bypass the `componentName[0]` lowercase check (because
+		// componentName is a JSXIdentifier object, not a string). We mirror
+		// that — `<fbt:param>` is treated as a Component, so `className` is
+		// reported. Locks in the namespaced-tag path of the listener.
+		{
+			Code: `<fbt:param className="x" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 12},
+			},
+		},
+		// Same namespaced tag with explicit allowedFor matching `ns:name`.
+		// Confirms our synthetic tag-string format `"fbt:param"` is what
+		// users would naturally write in their config.
+		{
+			Code: `<fbt:Foo style={{a: 1}} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":   "style",
+					"allowedFor": []interface{}{"fbt:notFoo"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 10},
+			},
+		},
+		// Multi-level Component nesting: every JsxAttribute on a Component
+		// is checked, regardless of how deeply nested. DOM `<div>` is skipped.
+		{
+			Code: `
+        const tree = (
+          <Outer className="o1">
+            <div className="d1">
+              <Inner className="i1">
+                <Leaf className="l1" />
+              </Inner>
+            </div>
+          </Outer>
+        );
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 3, Column: 18},
+				{MessageId: "propIsForbidden", Line: 5, Column: 22},
+				{MessageId: "propIsForbidden", Line: 6, Column: 23},
+			},
+		},
+		// Multiple JsxAttributes on the same Component, mixed with spread:
+		// each forbidden named attr is reported independently.
+		{
+			Code: `<Foo {...rest} className="x" style={{}} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 16},
+				{MessageId: "propIsForbidden", Line: 1, Column: 30},
+			},
+		},
+		// Direct propName lookup wins over a propNamePattern that would also
+		// match — locks in upstream `forbid.get(prop) || patternMatch` order.
+		// Pattern entry has a custom message; direct entry has none, so the
+		// reported message is the default.
+		{
+			Code: `<Foo className="x" />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propNamePattern": "*Name",
+					"message":         "Pattern wins (should NOT see this)",
+				},
+				map[string]interface{}{"propName": "className"},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 6},
+			},
+		},
+		// Same prop hits TWO pattern entries; first-matched-in-insertion-order
+		// wins (upstream `Array.find`). The first entry has a custom message.
+		{
+			Code: `<Foo data-id="x" />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propNamePattern": "data-*",
+					"message":         "First pattern",
+				},
+				map[string]interface{}{
+					"propNamePattern": "*-id",
+					"message":         "Second pattern (should NOT see this)",
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "First pattern", Line: 1, Column: 6},
+			},
+		},
+		// JSX expression initializer (no string literal): the rule only looks
+		// at the attribute name, never the value, so this is reported.
+		{
+			Code: `<Foo style={someStyle} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 6},
+			},
+		},
+		// `<Foo.Bar>` 2-segment member with disallowedFor — locks in the
+		// canonical `"Foo.Bar"` tag string.
+		{
+			Code: `<Foo.Bar style={{}} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":      "style",
+					"disallowedFor": []interface{}{"Foo.Bar"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 10},
+			},
+		},
+
+		// ---- Reporting position robustness (Go-vs-ESLint ECMA columns) ----
+		// JSXOpening (`<Foo>`) variant — the listener fires on the attribute
+		// inside the opening element, not on the closing tag.
+		{
+			Code: `<Foo className="x">child text</Foo>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 6},
+			},
+		},
+		// Indented multi-line attribute — column counts from line start of
+		// the JsxAttribute, not the opening tag.
+		{
+			Code: `
+        <Foo
+          className="x"
+        />;
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 3, Column: 11},
+			},
+		},
+		// Tab-indented attribute — UTF-16 column counting (rule_tester uses
+		// ECMA spec line/column, tabs count as 1).
+		{
+			Code: "<Foo\n\tclassName=\"x\"\n/>;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 2, Column: 2},
+			},
+		},
+		// Multi-byte (CJK) child content — column on the attribute line is
+		// not affected by the multi-byte payload elsewhere in the file.
+		{
+			Code: `
+        const t = "中文";
+        <Foo className={t} />;
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 3, Column: 14},
+			},
+		},
+
+		// ---- TS-specific syntax on the Component side ----
+		// TS generic on a Component tag combined with forbidden prop.
+		{
+			Code: `function W<T>() { return <Foo<T> className="x" />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 34},
+			},
+		},
+		// JSX expression value with TS `as` cast — the rule still flags
+		// the attribute by name.
+		{
+			Code: `<Foo style={({} as React.CSSProperties)} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 6},
+			},
+		},
+		// JSX expression value with TS non-null `!` — same.
+		{
+			Code: `const s: any = null; <Foo style={s!} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 27},
+			},
+		},
+
+		// ---- Real-world configurations ----
+		// Design-system enforcement: forbid `className` everywhere except
+		// utility primitives matching `Box`/`Stack`/`Inline`.
+		{
+			Code: `
+        <Card className="bad" />;
+        <Box className="ok" />;
+        <Stack className="ok" />;
+        <Inline className="ok" />;
+        <CustomThing className="bad" />;
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propName":           "className",
+					"allowedForPatterns": []interface{}{"Box", "Stack", "Inline"},
+					"message":            "Use design-system primitives for className.",
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "Use design-system primitives for className.", Line: 2, Column: 15},
+				{Message: "Use design-system primitives for className.", Line: 6, Column: 22},
+			},
+		},
+		// `data-*` ban on Components but allowed on `<TestHarness>`.
+		{
+			Code: `
+        <TestHarness data-x="ok" />;
+        <Widget data-y="bad" />;
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{
+				map[string]interface{}{
+					"propNamePattern": "data-*",
+					"allowedFor":      []interface{}{"TestHarness"},
+				},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 3, Column: 17},
+			},
+		},
+		// Many siblings, alternating Component vs DOM, single forbid rule;
+		// only Component children are reported.
+		{
+			Code: `
+        <Group>
+          <Foo className="a" />
+          <span className="b" />
+          <Bar className="c" />
+          <i className="d" />
+          <Baz className="e" />
+        </Group>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 3, Column: 16},
+				{MessageId: "propIsForbidden", Line: 5, Column: 16},
+				{MessageId: "propIsForbidden", Line: 7, Column: 16},
+			},
+		},
+		// JSX child elements (`<Foo>` containing nested children incl. another
+		// Component with the same forbidden prop).
+		{
+			Code: `
+        <Foo className="outer">
+          <Bar className="inner" />
+        </Foo>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 2, Column: 14},
+				{MessageId: "propIsForbidden", Line: 3, Column: 16},
+			},
+		},
+		// Component inside a parent attribute expression: rule fires on
+		// `<Inner className=...>` even though it's nested in a JSX expression.
+		{
+			Code: `<div data-x={(<Inner className="x" />)} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 22},
+			},
+		},
+		// Conditional rendering with both branches producing Components.
+		{
+			Code: `const cond = true; const x = cond ? <Foo style={{}} /> : <Bar style={{}} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 42},
+				{MessageId: "propIsForbidden", Line: 1, Column: 63},
+			},
+		},
+		// Mapping over a list — JSX inside an arrow body still triggers.
+		{
+			Code: `const xs: any[] = []; xs.map(x => <Item key={x} className="row" />);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propIsForbidden", Line: 1, Column: 49},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -85,6 +85,7 @@ export default defineConfig({
 
     // eslint-plugin-react
     './tests/eslint-plugin-react/rules/button-has-type.test.ts',
+    './tests/eslint-plugin-react/rules/forbid-component-props.test.ts',
     './tests/eslint-plugin-react/rules/jsx-child-element-spacing.test.ts',
     './tests/eslint-plugin-react/rules/self-closing-comp.test.ts',
     './tests/eslint-plugin-react/rules/void-dom-elements-no-children.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/forbid-component-props.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/forbid-component-props.test.ts
@@ -1,0 +1,877 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('forbid-component-props', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    {
+      code: `
+        var First = createReactClass({
+          render: function() {
+            return <div className="foo" />;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var First = createReactClass({
+          render: function() {
+            return <div style={{color: "red"}} />;
+          }
+        });
+      `,
+      options: [{ forbid: ['style'] }],
+    },
+    {
+      code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo bar="baz" />;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+      options: [{ forbid: ['style'] }],
+    },
+    {
+      code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+      options: [{ forbid: ['style', 'foo'] }],
+    },
+    {
+      code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <this.Foo bar="baz" />;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        class First extends createReactClass {
+          render() {
+            return <this.foo className="bar" />;
+          }
+        }
+      `,
+      options: [{ forbid: ['style'] }],
+    },
+    {
+      code: `
+        const First = (props) => (
+          <this.Foo {...props} />
+        );
+      `,
+    },
+    {
+      code: `
+        const item = (<ReactModal className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              allowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<MyLayout.Content className="customFoo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              allowedFor: ['MyLayout.Content'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<this.ReactModal className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              allowedFor: ['this.ReactModal'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<Foo className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `<fbt:param name="Total number of files" number={true} />`,
+    },
+    {
+      code: `
+        const item = (
+          <Foo className="bar">
+            <ReactModal style={{color: "red"}} />
+          </Foo>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['OtherModal', 'ReactModal'],
+            },
+            {
+              propName: 'style',
+              disallowedFor: ['Foo'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (
+          <Foo className="bar">
+            <ReactModal style={{color: "red"}} />
+          </Foo>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['OtherModal', 'ReactModal'],
+            },
+            {
+              propName: 'style',
+              allowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<this.ReactModal className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const MyComponent = () => (
+          <div aria-label="welcome" />
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propNamePattern: '**-**',
+              allowedFor: ['div'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <UIButton className="size-lg" />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              allowedForPatterns: ['*Icon', '*Svg', 'UI*'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <UIButton className="size-lg" />
+            <ButtonLegacy className="size-lg" />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              allowedFor: ['ButtonLegacy'],
+              allowedForPatterns: ['*Icon', '*Svg', 'UI*'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <UIButton className="size-lg" />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['Modal'],
+              disallowedForPatterns: ['*Legacy', 'Shared*'],
+            },
+          ],
+        },
+      ],
+    },
+
+    // ---- Additional edge cases ----
+    // DOM rightmost (`<Foo.bar>`) skipped — tag is "Foo.bar" but `bar` is lowercase.
+    { code: `<Foo.bar className="x" />;` },
+    // Empty forbid list disables the rule entirely.
+    { code: `<Foo className="x" style={{}} />;`, options: [{ forbid: [] }] },
+    // Spread-only Component — no JsxAttribute to check.
+    { code: `<Foo {...props} />;` },
+    // Boolean-shorthand attribute `<Foo bar />` not in default forbid.
+    { code: `<Foo bar />;` },
+    // JSX Fragment with multiple Components inside — each checked on its own.
+    {
+      code: `<><Foo bar="x" /><Bar baz="y" /></>;`,
+    },
+    // `forbid` with empty string entries — empties are skipped.
+    {
+      code: `<Foo other="x" />;`,
+      options: [{ forbid: ['', 'className'] }],
+    },
+    // DOM ancestors don't shield Component descendants from being checked
+    // (default forbid catches Component className, but `<a>` / `<span>`
+    // are DOM and skipped).
+    {
+      code: `
+        <a><Foo bar="ok"><span>text</span></Foo></a>
+      `,
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo style={{color: "red"}} />;
+          }
+        });
+      `,
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+      options: [{ forbid: ['className', 'style'] }],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo style={{color: "red"}} />;
+          }
+        });
+      `,
+      options: [{ forbid: ['className', 'style'] }],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo style={{color: "red"}} />;
+          }
+        });
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'style',
+              disallowedFor: ['Foo'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<Foo className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              allowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<this.ReactModal className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              allowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<this.ReactModal className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['this.ReactModal'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<ReactModal className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<MyLayout.Content className="customFoo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['MyLayout.Content'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<Foo className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              message: 'Please use ourCoolClassName instead of ClassName',
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: 'Please use ourCoolClassName instead of ClassName',
+        },
+      ],
+    },
+    {
+      code: `
+        const item = () => (
+          <Foo className="foo">
+            <Bar option="high" />
+          </Foo>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              message: 'Please use ourCoolClassName instead of ClassName',
+            },
+            {
+              propName: 'option',
+              message: 'Avoid using option',
+            },
+          ],
+        },
+      ],
+      errors: [
+        { message: 'Please use ourCoolClassName instead of ClassName' },
+        { message: 'Avoid using option' },
+      ],
+    },
+    {
+      code: `
+        const item = () => (
+          <Foo className="foo">
+            <Bar option="high" />
+          </Foo>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            { propName: 'className' },
+            {
+              propName: 'option',
+              message: 'Avoid using option',
+            },
+          ],
+        },
+      ],
+      errors: [
+        { messageId: 'propIsForbidden' },
+        { message: 'Avoid using option' },
+      ],
+    },
+    {
+      code: `
+        const MyComponent = () => (
+          <Foo kebab-case-prop={123} />
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propNamePattern: '**-**',
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const MyComponent = () => (
+          <Foo kebab-case-prop={123} />
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propNamePattern: '**-**',
+              message: 'Avoid using kebab-case',
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: 'Avoid using kebab-case',
+        },
+      ],
+    },
+    {
+      code: `
+        const MyComponent = () => (
+          <div>
+            <div aria-label="Hello World" />
+            <Foo kebab-case-prop={123} />
+          </div>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propNamePattern: '**-**',
+              allowedFor: ['div'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const MyComponent = () => (
+          <div>
+            <div aria-label="Hello World" />
+            <h1 data-id="my-heading" />
+            <Foo kebab-case-prop={123} />
+          </div>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propNamePattern: '**-**',
+              disallowedFor: ['Foo'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const rootElement = () => (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              message: 'className available only for icons',
+              allowedForPatterns: ['*Icon'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: 'className available only for icons',
+        },
+      ],
+    },
+    {
+      code: `
+        const rootElement = () => (
+          <Root>
+            <UICard style={{backgroundColor: black}}/>
+            <SomeIcon className="size-lg" />
+            <SomeSvg className="size-lg" style={{fill: currentColor}} />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              message: 'className available only for icons',
+              allowedForPatterns: ['*Icon'],
+            },
+            {
+              propName: 'style',
+              message: 'style available only for SVGs',
+              allowedForPatterns: ['*Svg'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        { message: 'style available only for SVGs' },
+        { message: 'className available only for icons' },
+      ],
+    },
+    {
+      code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <ButtonLegacy className="size-lg" />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['SomeSvg'],
+              disallowedForPatterns: ['UI*', '*Icon'],
+              message:
+                'Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns',
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns',
+        },
+        {
+          message:
+            'Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns',
+        },
+        {
+          message:
+            'Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns',
+        },
+        {
+          message:
+            'Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns',
+        },
+      ],
+    },
+
+    // ---- Additional lock-in cases ----
+    // `<Foo.Bar.Baz>` deep-nested member expression: tag becomes the literal
+    // `"undefined.Baz"` (mirrors upstream quirk).
+    {
+      code: `<Foo.Bar.Baz className="x" />;`,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['undefined.Baz'],
+            },
+          ],
+        },
+      ],
+      errors: [{ messageId: 'propIsForbidden' }],
+    },
+    // JSX namespaced name with default forbid: namespaced tags bypass the
+    // DOM lowercase-skip path and are treated as Components, so className
+    // is reported.
+    {
+      code: `<fbt:param className="x" />;`,
+      errors: [{ messageId: 'propIsForbidden' }],
+    },
+    // Multi-level Component nesting — every JsxAttribute on a Component is
+    // checked, regardless of depth. DOM `<div>` between Components is skipped.
+    {
+      code: `
+        <Outer className="o1">
+          <div className="d1">
+            <Inner className="i1">
+              <Leaf className="l1" />
+            </Inner>
+          </div>
+        </Outer>
+      `,
+      errors: [
+        { messageId: 'propIsForbidden' },
+        { messageId: 'propIsForbidden' },
+        { messageId: 'propIsForbidden' },
+      ],
+    },
+    // Spread + multiple named attributes: each forbidden named attr fires
+    // independently; the spread is ignored.
+    {
+      code: `<Foo {...rest} className="x" style={{}} />;`,
+      errors: [
+        { messageId: 'propIsForbidden' },
+        { messageId: 'propIsForbidden' },
+      ],
+    },
+    // Direct propName lookup beats a propNamePattern that would also match.
+    {
+      code: `<Foo className="x" />;`,
+      options: [
+        {
+          forbid: [
+            {
+              propNamePattern: '*Name',
+              message: 'Pattern wins (should NOT see this)',
+            },
+            { propName: 'className' },
+          ],
+        },
+      ],
+      errors: [{ messageId: 'propIsForbidden' }],
+    },
+    // Two pattern entries match the same prop — first-in-insertion-order wins.
+    {
+      code: `<Foo data-id="x" />;`,
+      options: [
+        {
+          forbid: [
+            { propNamePattern: 'data-*', message: 'First pattern' },
+            {
+              propNamePattern: '*-id',
+              message: 'Second pattern (should NOT see this)',
+            },
+          ],
+        },
+      ],
+      errors: [{ message: 'First pattern' }],
+    },
+    // 2-segment member expression `<Foo.Bar>`: tag is canonical "Foo.Bar".
+    {
+      code: `<Foo.Bar style={{}} />;`,
+      options: [
+        {
+          forbid: [{ propName: 'style', disallowedFor: ['Foo.Bar'] }],
+        },
+      ],
+      errors: [{ messageId: 'propIsForbidden' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -330,3 +330,4 @@ neighbour
 metacharacters
 CHARCLASS
 CLASSSET
+unrepresentable


### PR DESCRIPTION
## Summary

Port the `react/forbid-component-props` rule from `eslint-plugin-react` to rslint.

This rule prevents passing of certain props (defaults to `className` and `style`) to React Components (e.g. `<Foo />`), without affecting DOM nodes (e.g. `<div />`). The list of forbidden props can be customized with the `forbid` option, supporting per-prop allowlists / disallowlists, glob patterns, and custom messages.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/forbid-component-props.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).