### PR TITLE
feat: port rule react/boolean-prop-naming

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -1,6 +1,7 @@
 package react_plugin
 
 import (
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/boolean_prop_naming"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/button_has_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_component_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_boolean_value"
@@ -28,9 +29,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_direct_mutation_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
-	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unstable_nested_components"
-	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unused_class_component_methods"
-	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unused_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_redundant_should_component_update"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_render_return_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
@@ -38,6 +36,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_typos"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unknown_property"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unstable_nested_components"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unused_class_component_methods"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unused_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_will_update_set_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/prefer_es6_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/prefer_stateless_function"
@@ -57,6 +58,7 @@ import (
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
+		boolean_prop_naming.BooleanPropNamingRule,
 		button_has_type.ButtonHasTypeRule,
 		forbid_component_props.ForbidComponentPropsRule,
 		jsx_boolean_value.JsxBooleanValueRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -2091,7 +2091,7 @@ func findInitializerInStatements(scope *ast.Node, name string) *ast.Node {
 // name (`lib/util/isFirstLetterCapitalized.js`). The semantics are:
 //
 //  1. Strip leading underscores: `_Foo` → "Foo" (so `_Foo` is treated the
-//     same as `Foo`, matching upstream's `word.replace(/^_+/, '')`).
+//     same as `Foo`, matching upstream's `word.replace(/^_+/, ”)`).
 //  2. A character is "capitalized" iff `unicode.ToUpper(r) == r` —
 //     equivalent to upstream's `firstLetter.toUpperCase() === firstLetter`.
 //
@@ -2514,4 +2514,199 @@ func IsJsxLike(node *ast.Node) bool {
 		return false
 	}
 	return IsJsxElementLike(node) || ast.IsJsxFragment(node)
+}
+
+// EnclosingClass returns the nearest ClassDeclaration / ClassExpression
+// ancestor of `node`, or nil when `node` is at the top level. Used by rules
+// that need to test whether a class member belongs to a React component.
+func EnclosingClass(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	for p := node.Parent; p != nil; p = p.Parent {
+		switch p.Kind {
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			return p
+		}
+	}
+	return nil
+}
+
+// BindingIdentifierName returns the identifier text of a named declaration's
+// binding, or "" when the declaration is anonymous, the binding is a pattern
+// rather than a bare Identifier, or `n` is nil.
+func BindingIdentifierName(n *ast.Node) string {
+	if n == nil {
+		return ""
+	}
+	name := n.Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return name.AsIdentifier().Text
+}
+
+// FunctionParameters returns the parameter list of a function-like node
+// (FunctionDeclaration / FunctionExpression / ArrowFunction). Returns nil
+// for nil input or any other node kind. Methods / accessors / constructors
+// are intentionally not covered — callers that need them should add the
+// kind explicitly to keep this helper a thin shim over the common shapes.
+func FunctionParameters(fn *ast.Node) []*ast.Node {
+	if fn == nil {
+		return nil
+	}
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		fd := fn.AsFunctionDeclaration()
+		if fd.Parameters == nil {
+			return nil
+		}
+		return fd.Parameters.Nodes
+	case ast.KindFunctionExpression:
+		fe := fn.AsFunctionExpression()
+		if fe.Parameters == nil {
+			return nil
+		}
+		return fe.Parameters.Nodes
+	case ast.KindArrowFunction:
+		af := fn.AsArrowFunction()
+		if af.Parameters == nil {
+			return nil
+		}
+		return af.Parameters.Nodes
+	}
+	return nil
+}
+
+// FirstParamType returns the type annotation of the first parameter of `fn`
+// (a FunctionDeclaration / FunctionExpression / ArrowFunction), or nil when
+// the function has no parameters or the first parameter is untyped.
+func FirstParamType(fn *ast.Node) *ast.Node {
+	params := FunctionParameters(fn)
+	if len(params) == 0 {
+		return nil
+	}
+	pd := params[0].AsParameterDeclaration()
+	if pd == nil {
+		return nil
+	}
+	return pd.Type
+}
+
+// PropWrapperEntry encodes one entry of `settings.propWrapperFunctions`. The
+// raw entries can be either a bare string (`"forbidExtraProps"`) or an
+// `{object, property}` pair (`{ object: "Object", property: "assign" }` →
+// matches `Object.assign(...)`). Both shapes are normalized to this struct.
+type PropWrapperEntry struct {
+	// Object is the receiver portion of a member-call wrapper (e.g.
+	// `"Object"` for `Object.assign`). Empty for bare-identifier wrappers.
+	Object string
+	// Property is the function name (e.g. `"assign"` for `Object.assign`,
+	// or `"forbidExtraProps"` for a bare-identifier wrapper).
+	Property string
+}
+
+// GetPropWrapperFunctions reads `settings.propWrapperFunctions` from the
+// rslint config and returns the parsed entries. Unknown shapes (a non-array
+// value, an entry that's neither a string nor a `{object, property}` map,
+// an entry with empty `property`) are silently dropped — this matches
+// eslint-plugin-react's `propWrapperUtil` permissive parsing.
+func GetPropWrapperFunctions(settings map[string]interface{}) []PropWrapperEntry {
+	v, ok := settings["propWrapperFunctions"]
+	if !ok {
+		return nil
+	}
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	var out []PropWrapperEntry
+	for _, entry := range arr {
+		switch t := entry.(type) {
+		case string:
+			if t != "" {
+				if dot := strings.IndexByte(t, '.'); dot > 0 && dot < len(t)-1 {
+					// Allow `"Object.assign"` style strings (legacy upstream
+					// shape) by splitting on the first dot.
+					out = append(out, PropWrapperEntry{Object: t[:dot], Property: t[dot+1:]})
+				} else {
+					out = append(out, PropWrapperEntry{Property: t})
+				}
+			}
+		case map[string]interface{}:
+			obj, _ := t["object"].(string)
+			prop, _ := t["property"].(string)
+			if prop == "" {
+				continue
+			}
+			out = append(out, PropWrapperEntry{Object: obj, Property: prop})
+		}
+	}
+	return out
+}
+
+// IsPropWrapperCall reports whether `call` is a CallExpression whose callee
+// matches one of the user-configured `propWrapperFunctions` entries.
+//
+// Supports:
+//   - bare identifier callees: `forbidExtraProps(...)`, `merge(...)` —
+//     match an entry with empty `Object`.
+//   - dotted-property callees: `Object.assign(...)`, `_.assign(...)` —
+//     match an entry whose `Object` and `Property` both equal the receiver
+//     and method names respectively.
+//
+// `call` may be wrapped in parens / TS expression wrappers; the callee is
+// unwrapped via `SkipExpressionWrappers`. Anything more complex (computed
+// access, optional-chain wrappers around the callee head) is treated as
+// not matching.
+func IsPropWrapperCall(call *ast.Node, wrappers []PropWrapperEntry) bool {
+	if len(wrappers) == 0 || call == nil || call.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := SkipExpressionWrappers(call.AsCallExpression().Expression)
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		name := callee.AsIdentifier().Text
+		for _, w := range wrappers {
+			if w.Object == "" && w.Property == name {
+				return true
+			}
+		}
+	case ast.KindPropertyAccessExpression:
+		pa := callee.AsPropertyAccessExpression()
+		obj := SkipExpressionWrappers(pa.Expression)
+		nameNode := pa.Name()
+		if obj.Kind != ast.KindIdentifier || nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			return false
+		}
+		objText := obj.AsIdentifier().Text
+		propText := nameNode.AsIdentifier().Text
+		for _, w := range wrappers {
+			if w.Object == objText && w.Property == propText {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// EntityNameRightmost returns the rightmost Identifier of a TypeReference's
+// EntityName. For a bare `Foo`, returns `Foo`. For `A.B.C`, returns `C`.
+// Returns nil if no identifier can be extracted.
+func EntityNameRightmost(name *ast.Node) *ast.Node {
+	for name != nil {
+		switch name.Kind {
+		case ast.KindIdentifier:
+			return name
+		case ast.KindQualifiedName:
+			qn := name.AsQualifiedName()
+			if qn == nil || qn.Right == nil {
+				return nil
+			}
+			name = qn.Right
+		default:
+			return nil
+		}
+	}
+	return nil
 }

--- a/internal/plugins/react/rules/boolean_prop_naming/boolean_prop_naming.go
+++ b/internal/plugins/react/rules/boolean_prop_naming/boolean_prop_naming.go
@@ -1,0 +1,790 @@
+package boolean_prop_naming
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var BooleanPropNamingRule = rule.Rule{
+	Name: "react/boolean-prop-naming",
+	Run:  runRule,
+}
+
+type ruleOptions struct {
+	rule           *regexp.Regexp
+	rulePattern    string
+	propTypeNames  map[string]bool
+	customMessage  string
+	validateNested bool
+}
+
+// parseOptions extracts the rule's options from rslint's weakly-typed input.
+//
+// Mirrors upstream's behavior at the boundary:
+//   - missing / non-object options → all defaults; rule is a no-op (rule is
+//     gated by an explicit `rule` regex below).
+//   - missing `propTypeNames` → defaults to `["bool"]`.
+//   - empty `propTypeNames` array (`[]`) → user explicitly cleared the
+//     allow-list, so no PropTypes-style identifier counts as a boolean
+//     marker. TS `: boolean` annotations remain checked because they go
+//     through the `tsCheck` path independent of `propTypeNames`. Upstream
+//     would have its loader reject this via `minItems: 1`; rslint can't
+//     refuse the config so we honor user intent over loader behavior.
+//   - `rule` is read as a string. An empty string ("") is preserved and
+//     produces a no-op (matching upstream's `config.rule ? ... : null`).
+func parseOptions(input any) ruleOptions {
+	opts := ruleOptions{
+		propTypeNames: map[string]bool{"bool": true},
+	}
+	optsMap := utils.GetOptionsMap(input)
+	if optsMap == nil {
+		return opts
+	}
+	if pat, ok := optsMap["rule"].(string); ok {
+		opts.rulePattern = pat
+	}
+	if names, ok := optsMap["propTypeNames"].([]interface{}); ok {
+		set := map[string]bool{}
+		for _, n := range names {
+			if s, ok := n.(string); ok && s != "" {
+				set[s] = true
+			}
+		}
+		// Even when set is empty, swap it in — caller cleared the list.
+		opts.propTypeNames = set
+	}
+	if msg, ok := optsMap["message"].(string); ok {
+		opts.customMessage = msg
+	}
+	if v, ok := optsMap["validateNested"].(bool); ok {
+		opts.validateNested = v
+	}
+	return opts
+}
+
+// templatePlaceholder matches an ESLint-style `{{key}}` placeholder.
+// Mirrors ESLint's `interpolate(message, data)` regex (`/{{([^{}]+?)}}/g`):
+// any non-brace content between `{{` and `}}` is captured as the key, with
+// surrounding whitespace stripped before lookup. Unknown keys (not present
+// in `data`) are left as the literal `{{key}}`, matching upstream.
+var templatePlaceholder = regexp.MustCompile(`\{\{([^{}]+?)\}\}`)
+
+func renderTemplate(tmpl string, data map[string]string) string {
+	return templatePlaceholder.ReplaceAllStringFunc(tmpl, func(match string) string {
+		m := templatePlaceholder.FindStringSubmatch(match)
+		key := strings.TrimSpace(m[1])
+		if v, ok := data[key]; ok {
+			return v
+		}
+		return match
+	})
+}
+
+// resolveDepth caps `validateTypeNode`'s recursion so a pathological
+// `type A = B; type B = A` (reachable upstream too, where the equivalent
+// `objectTypeAnnotations.get(...)` returns nothing on cycles) can't recurse
+// forever. The budget is consumed by every recursive hop —
+// intersection / union branches, parenthesized wrappers, type-alias
+// indirection, interface heritage extends — so a value of 8 covers
+// realistic depth (e.g. `type Outer = Mid & (Inner1 | Inner2)` with two
+// alias hops on each side) while still bounding pathological chains.
+// Deeper chains degrade gracefully to "no validation" (same as upstream's
+// single-level lookup for unresolvable references).
+const resolveDepth = 8
+
+func runRule(ctx rule.RuleContext, input any) rule.RuleListeners {
+	opts := parseOptions(input)
+	// Upstream: `const rule = config.rule ? new RegExp(config.rule) : null;`
+	// followed by `if (!rule) return;` in every listener.
+	if opts.rulePattern == "" {
+		return rule.RuleListeners{}
+	}
+	re, err := regexp.Compile(opts.rulePattern)
+	if err != nil {
+		// Upstream throws (`new RegExp(...)`) on a malformed pattern,
+		// blowing up the whole lint run. We choose to silently degrade so
+		// one bad project config doesn't make rslint unusable. This is a
+		// documented divergence; tests lock the no-op behavior.
+		return rule.RuleListeners{}
+	}
+	opts.rule = re
+
+	pragma := reactutil.GetReactPragma(ctx.Settings)
+	createClass := reactutil.GetReactCreateClass(ctx.Settings)
+	propWrappers := reactutil.GetPropWrapperFunctions(ctx.Settings)
+	componentWrappers := reactutil.GetComponentWrapperFunctions(ctx.Settings, pragma)
+
+	// reportedSet protects against a single PropertySignature / property
+	// being reported twice when both `static propTypes = {...}` and `props:
+	// {...}` declarations exist on the same class, or both
+	// `getComponentTypeAnnotation` paths (param[0] type + variable type
+	// argument) resolve to the same node. Upstream's component-centric
+	// accumulator is what implicitly dedupes; we dedupe by node pointer.
+	reportedSet := map[*ast.Node]bool{}
+	report := func(propNode *ast.Node, propName string) {
+		if reportedSet[propNode] {
+			return
+		}
+		reportedSet[propNode] = true
+		data := map[string]string{
+			"propName":  propName,
+			"component": propName,
+			"pattern":   opts.rulePattern,
+		}
+		var description string
+		if opts.customMessage != "" {
+			description = renderTemplate(opts.customMessage, data)
+		} else {
+			description = renderTemplate("Prop name `{{propName}}` doesn't match rule `{{pattern}}`", data)
+		}
+		ctx.ReportNode(propNode, rule.RuleMessage{
+			Id:          "patternMismatch",
+			Description: description,
+			Data:        data,
+		})
+	}
+
+	// First pass over the source file:
+	//
+	//  1. Build typeAliasMap: type-alias / interface name → its expanded
+	//     set of TypeLiteral / InterfaceDeclaration nodes (intersection /
+	//     union / parenthesized wrappers are flattened). Mirrors upstream's
+	//     `findAllTypeAnnotations`. Interface declaration merging is
+	//     supported because each declaration appends to the slice under
+	//     the same name.
+	//
+	//  2. Populate componentsByName so `Foo.propTypes = ...` and
+	//     `Foo['propTypes'] = ...` listeners can gate off non-component
+	//     identifiers (mirrors upstream's `Components.detect` +
+	//     `getRelatedComponent`).
+	//
+	//  3. Validate each function-component's TS type annotation directly —
+	//     either the first parameter's type annotation, or the first type
+	//     argument of the variable's type (for `React.FC<Props>` and
+	//     friends). This is the rslint replacement for upstream's
+	//     `Program:exit` traversal.
+	//
+	// rule.Run runs once per file before any listener fires, so the
+	// alias map and component name set are fully populated by the time the
+	// listeners need them.
+	typeAliasMap := map[string][]*ast.Node{}
+	componentsByName := map[string]bool{}
+	type fnComponentEntry struct {
+		paramType *ast.Node
+		fcTypeArg *ast.Node
+	}
+	var fnComponents []fnComponentEntry
+
+	var preWalk ast.Visitor
+	preWalk = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		switch n.Kind {
+		case ast.KindTypeAliasDeclaration:
+			decl := n.AsTypeAliasDeclaration()
+			if decl != nil && decl.Name() != nil && decl.Name().Kind == ast.KindIdentifier {
+				flattenTypeIntoMap(typeAliasMap, decl.Name().AsIdentifier().Text, decl.Type)
+			}
+		case ast.KindInterfaceDeclaration:
+			// Interface declaration merging: each `interface Foo {...}`
+			// appends under the same name.
+			decl := n.AsInterfaceDeclaration()
+			if decl != nil && decl.Name() != nil && decl.Name().Kind == ast.KindIdentifier {
+				name := decl.Name().AsIdentifier().Text
+				typeAliasMap[name] = append(typeAliasMap[name], n)
+			}
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			if reactutil.ExtendsReactComponent(n, pragma) {
+				if name := reactutil.BindingIdentifierName(n); name != "" {
+					componentsByName[name] = true
+				}
+			}
+		case ast.KindFunctionDeclaration:
+			if reactutil.IsStatelessReactComponent(n, pragma) {
+				if name := reactutil.BindingIdentifierName(n); name != "" {
+					componentsByName[name] = true
+				}
+				if pt := reactutil.FirstParamType(n); pt != nil {
+					fnComponents = append(fnComponents, fnComponentEntry{paramType: pt})
+				}
+			}
+		case ast.KindVariableDeclaration:
+			vd := n.AsVariableDeclaration()
+			if vd == nil || vd.Initializer == nil {
+				break
+			}
+			nameNode := vd.Name()
+			if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+				break
+			}
+			init := reactutil.SkipExpressionWrappers(vd.Initializer)
+
+			var fcArg *ast.Node
+			if vd.Type != nil {
+				fcArg = firstTypeArgumentOfType(vd.Type)
+			}
+
+			// `const X = class extends React.Component {}` registers `X` as
+			// a component without further checks.
+			if init.Kind == ast.KindClassExpression && reactutil.ExtendsReactComponent(init, pragma) {
+				componentsByName[nameNode.AsIdentifier().Text] = true
+				break
+			}
+			// `const X = memo(...)` / `forwardRef(...)` / nested
+			// combinations like `memo(forwardRef(fn))`. Mirrors
+			// upstream's `Components.detect` HOC recognition; honors
+			// `settings.componentWrapperFunctions` via the shared
+			// reactutil helper. We unwrap the chain and validate the
+			// innermost function's first param type annotation.
+			if init.Kind == ast.KindCallExpression {
+				inner := unwrapComponentWrapperChain(init, componentWrappers)
+				if inner != nil {
+					componentsByName[nameNode.AsIdentifier().Text] = true
+					if pt := reactutil.FirstParamType(inner); pt != nil {
+						fnComponents = append(fnComponents, fnComponentEntry{paramType: pt})
+					}
+					if vd.Type != nil {
+						if fcArg2 := firstTypeArgumentOfType(vd.Type); fcArg2 != nil {
+							fnComponents = append(fnComponents, fnComponentEntry{fcTypeArg: fcArg2})
+						}
+					}
+					break
+				}
+			}
+			if init.Kind != ast.KindArrowFunction && init.Kind != ast.KindFunctionExpression {
+				break
+			}
+			isComp := false
+			if reactutil.IsStatelessReactComponent(init, pragma) {
+				isComp = true
+			} else if fcArg != nil {
+				// Trust an explicit `React.FC<Props>` / `<Props>`
+				// generic annotation even when the body wouldn't on its
+				// own classify (e.g. `() => null`). Matches upstream:
+				// `getComponentTypeAnnotation` for the
+				// VariableDeclarator+typeAnnotation arm doesn't gate on
+				// JSX-return-ness.
+				isComp = true
+			}
+			if !isComp {
+				break
+			}
+			componentsByName[nameNode.AsIdentifier().Text] = true
+
+			pt := reactutil.FirstParamType(init)
+			if pt != nil || fcArg != nil {
+				fnComponents = append(fnComponents, fnComponentEntry{paramType: pt, fcTypeArg: fcArg})
+			}
+		}
+		n.ForEachChild(preWalk)
+		return false
+	}
+	ctx.SourceFile.Node.ForEachChild(preWalk)
+
+	for _, c := range fnComponents {
+		if c.paramType != nil {
+			validateTypeNode(c.paramType, typeAliasMap, opts, report, resolveDepth)
+		}
+		if c.fcTypeArg != nil {
+			validateTypeNode(c.fcTypeArg, typeAliasMap, opts, report, resolveDepth)
+		}
+	}
+
+	return rule.RuleListeners{
+		// Class fields: `static propTypes = {...}` and TS / Flow-style
+		// `props: <Type>`. Both are PropertyDeclaration in tsgo.
+		ast.KindPropertyDeclaration: func(node *ast.Node) {
+			pd := node.AsPropertyDeclaration()
+			if pd == nil {
+				return
+			}
+			cls := reactutil.EnclosingClass(node)
+			if cls == nil || !reactutil.ExtendsReactComponent(cls, pragma) {
+				return
+			}
+			keyNode := pd.Name()
+			if keyNode == nil {
+				return
+			}
+			keyName, ok := utils.GetStaticPropertyName(keyNode)
+			if !ok {
+				return
+			}
+			isPropsField := keyName == "props" && pd.Type != nil
+			if keyName != "propTypes" && !isPropsField {
+				return
+			}
+			if pd.Initializer != nil {
+				init := reactutil.SkipExpressionWrappers(pd.Initializer)
+				if init.Kind == ast.KindCallExpression && reactutil.IsPropWrapperCall(init, propWrappers) {
+					checkPropWrapperArguments(init, opts, report)
+				} else if init.Kind == ast.KindObjectLiteralExpression {
+					validateObjectLiteralProps(init, opts, report)
+				}
+			}
+			if pd.Type != nil {
+				validateTypeNode(pd.Type, typeAliasMap, opts, report, resolveDepth)
+			}
+		},
+
+		// Assignment outside the class body:
+		//   `Foo.propTypes = ...`,
+		//   `Foo['propTypes'] = ...`,
+		//   `ns.Foo.propTypes = ...`.
+		// All three reach this listener as a BinaryExpression with `=`.
+		ast.KindBinaryExpression: func(node *ast.Node) {
+			bin := node.AsBinaryExpression()
+			if bin == nil || bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindEqualsToken {
+				return
+			}
+			left := reactutil.SkipExpressionWrappers(bin.Left)
+
+			// LHS shapes accepted:
+			//   - `<expr>.propTypes`        (PropertyAccessExpression)
+			//   - `<expr>["propTypes"]`     (ElementAccessExpression with
+			//     a static string-literal argument)
+			var componentExpr *ast.Node
+			var propertyName string
+			switch left.Kind {
+			case ast.KindPropertyAccessExpression:
+				pa := left.AsPropertyAccessExpression()
+				nameNode := pa.Name()
+				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+					return
+				}
+				componentExpr = pa.Expression
+				propertyName = nameNode.AsIdentifier().Text
+			case ast.KindElementAccessExpression:
+				ea := left.AsElementAccessExpression()
+				if ea == nil || ea.ArgumentExpression == nil {
+					return
+				}
+				name, ok := utils.GetStaticPropertyName(ea.ArgumentExpression)
+				if !ok {
+					return
+				}
+				componentExpr = ea.Expression
+				propertyName = name
+			default:
+				return
+			}
+			if propertyName != "propTypes" {
+				return
+			}
+			if !isKnownComponentExpr(componentExpr, componentsByName) {
+				return
+			}
+			right := reactutil.SkipExpressionWrappers(bin.Right)
+			if right.Kind == ast.KindCallExpression && reactutil.IsPropWrapperCall(right, propWrappers) {
+				checkPropWrapperArguments(right, opts, report)
+				return
+			}
+			if right.Kind == ast.KindObjectLiteralExpression {
+				validateObjectLiteralProps(right, opts, report)
+			}
+		},
+
+		// `createReactClass({propTypes: {...}})` /
+		// `<pragma>.createClass({...})`. Other listeners cover the class /
+		// assignment forms.
+		ast.KindObjectLiteralExpression: func(node *ast.Node) {
+			if !reactutil.IsCreateReactClassObjectArg(node, pragma, createClass) {
+				return
+			}
+			for _, prop := range node.AsObjectLiteralExpression().Properties.Nodes {
+				if prop.Kind != ast.KindPropertyAssignment {
+					continue
+				}
+				pa := prop.AsPropertyAssignment()
+				key := pa.Name()
+				if key == nil {
+					continue
+				}
+				keyName, ok := utils.GetStaticPropertyName(key)
+				if !ok || keyName != "propTypes" {
+					continue
+				}
+				value := reactutil.SkipExpressionWrappers(pa.Initializer)
+				if value.Kind == ast.KindObjectLiteralExpression {
+					validateObjectLiteralProps(value, opts, report)
+				} else if value.Kind == ast.KindCallExpression && reactutil.IsPropWrapperCall(value, propWrappers) {
+					// Upstream's `validatePropNaming` is invoked with
+					// `property.value.properties` so a wrapped propTypes
+					// inside a createReactClass arg is silently skipped.
+					// We choose to honor propWrapperFunctions here too —
+					// it's a strict superset of upstream's behavior, and
+					// the equivalent class-form path below already does
+					// the same. Document if a real conflict arises.
+					checkPropWrapperArguments(value, opts, report)
+				}
+			}
+		},
+	}
+}
+
+// isKnownComponentExpr reports whether `expr` (the receiver of a
+// `.propTypes`-style assignment LHS) names something we previously
+// classified as a React component.
+//
+// Accepted shapes:
+//   - bare Identifier: `Foo`
+//   - PropertyAccessExpression chain ending in an Identifier whose name is
+//     in `componentsByName`: `ns.Foo`, `outer.inner.Foo`. Upstream uses
+//     `utils.getRelatedComponent(node)` which walks the file's component
+//     map; we approximate by checking the rightmost identifier of any
+//     bare member chain. This is intentionally conservative — call
+//     receivers (`getFoo().propTypes`) and computed access aren't
+//     accepted, matching upstream's preference for static recognition.
+func isKnownComponentExpr(expr *ast.Node, componentsByName map[string]bool) bool {
+	expr = reactutil.SkipExpressionWrappers(expr)
+	if expr == nil {
+		return false
+	}
+	switch expr.Kind {
+	case ast.KindIdentifier:
+		return componentsByName[expr.AsIdentifier().Text]
+	case ast.KindPropertyAccessExpression:
+		pa := expr.AsPropertyAccessExpression()
+		nameNode := pa.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			return false
+		}
+		return componentsByName[nameNode.AsIdentifier().Text]
+	}
+	return false
+}
+
+// flattenTypeIntoMap registers each leaf TypeLiteral / InterfaceDeclaration
+// reachable from `typeNode` under `name`. Intersection / union /
+// parenthesized wrappers are descended into. Named TypeReferences are
+// stored as forwarding entries so a chain like `type A = B; type B =
+// {x:boolean}` resolves at validation time (rslint extends upstream here:
+// upstream's `findAllTypeAnnotations` ignores TypeReferences entirely, so
+// `type A = B` would silently lose its boolean members on the alias map).
+//
+// `validateTypeNode` is responsible for following the forwarding entries
+// with a depth budget, so cycles can't recurse forever.
+func flattenTypeIntoMap(m map[string][]*ast.Node, name string, typeNode *ast.Node) {
+	if typeNode == nil {
+		return
+	}
+	switch typeNode.Kind {
+	case ast.KindTypeLiteral, ast.KindInterfaceDeclaration, ast.KindTypeReference:
+		m[name] = append(m[name], typeNode)
+	case ast.KindParenthesizedType:
+		flattenTypeIntoMap(m, name, typeNode.AsParenthesizedTypeNode().Type)
+	case ast.KindIntersectionType:
+		for _, t := range typeNode.AsIntersectionTypeNode().Types.Nodes {
+			flattenTypeIntoMap(m, name, t)
+		}
+	case ast.KindUnionType:
+		for _, t := range typeNode.AsUnionTypeNode().Types.Nodes {
+			flattenTypeIntoMap(m, name, t)
+		}
+	}
+}
+
+// validateTypeNode resolves `typeNode` to a list of TypeLiteral / Interface
+// member sets and validates each. TypeReferences are looked up in
+// typeAliasMap (one hop per call; the depth budget allows us to follow
+// `type A = B; type B = {x:boolean}` without recursing forever on cycles).
+// Intersection / union / parenthesized wrappers are descended into. Inline
+// TypeLiterals are validated directly. Anything else (primitive keyword,
+// function type, generic with a non-resolvable name) is ignored.
+func validateTypeNode(typeNode *ast.Node, typeAliasMap map[string][]*ast.Node, opts ruleOptions, report func(*ast.Node, string), depth int) {
+	if typeNode == nil || depth <= 0 {
+		return
+	}
+	switch typeNode.Kind {
+	case ast.KindTypeLiteral:
+		validateMembers(typeNode.AsTypeLiteralNode().Members.Nodes, opts, report)
+	case ast.KindInterfaceDeclaration:
+		decl := typeNode.AsInterfaceDeclaration()
+		validateMembers(decl.Members.Nodes, opts, report)
+		// Walk `extends` clauses so `interface A extends B { ... }`
+		// validates B's members too. ESLint's plugin doesn't follow
+		// heritage (it treats the interface as opaque outside the
+		// component's own annotation chain), but real-world TS code
+		// composes extensively via interface extension; following one
+		// hop covers the common case without paying for arbitrary
+		// recursion depth (the depth budget caps it anyway).
+		if decl.HeritageClauses != nil {
+			for _, hc := range decl.HeritageClauses.Nodes {
+				if hc.Kind != ast.KindHeritageClause {
+					continue
+				}
+				clause := hc.AsHeritageClause()
+				if clause == nil || clause.Types == nil {
+					continue
+				}
+				for _, t := range clause.Types.Nodes {
+					// Each entry is ExpressionWithTypeArguments;
+					// resolve via its expression as a type-name lookup.
+					if t.Kind != ast.KindExpressionWithTypeArguments {
+						continue
+					}
+					expr := t.AsExpressionWithTypeArguments()
+					if expr == nil {
+						continue
+					}
+					name := reactutil.EntityNameRightmost(expr.Expression)
+					if name == nil {
+						continue
+					}
+					for _, target := range typeAliasMap[name.AsIdentifier().Text] {
+						validateTypeNode(target, typeAliasMap, opts, report, depth-1)
+					}
+				}
+			}
+		}
+	case ast.KindTypeReference:
+		ref := typeNode.AsTypeReferenceNode()
+		nameIdent := reactutil.EntityNameRightmost(ref.TypeName)
+		if nameIdent == nil {
+			return
+		}
+		for _, t := range typeAliasMap[nameIdent.AsIdentifier().Text] {
+			validateTypeNode(t, typeAliasMap, opts, report, depth-1)
+		}
+	case ast.KindParenthesizedType:
+		validateTypeNode(typeNode.AsParenthesizedTypeNode().Type, typeAliasMap, opts, report, depth-1)
+	case ast.KindIntersectionType:
+		for _, t := range typeNode.AsIntersectionTypeNode().Types.Nodes {
+			validateTypeNode(t, typeAliasMap, opts, report, depth-1)
+		}
+	case ast.KindUnionType:
+		for _, t := range typeNode.AsUnionTypeNode().Types.Nodes {
+			validateTypeNode(t, typeAliasMap, opts, report, depth-1)
+		}
+	}
+}
+
+// validateMembers walks TypeElement members of a TypeLiteral / Interface and
+// reports each PropertySignature whose type is `boolean` and whose name does
+// not match the configured pattern. Other member kinds (index signatures,
+// method signatures, call signatures) are ignored.
+//
+// `boolean` recognition includes parenthesized wrappers (`(boolean)`) so
+// `prop: (boolean)` reports identically to `prop: boolean`. Type references
+// to user types are not resolved here — `prop: MyBool` is treated as opaque,
+// mirroring upstream's `tsCheck` which only matches `TSBooleanKeyword`.
+func validateMembers(members []*ast.Node, opts ruleOptions, report func(*ast.Node, string)) {
+	for _, m := range members {
+		if m.Kind != ast.KindPropertySignature {
+			continue
+		}
+		ps := m.AsPropertySignatureDeclaration()
+		if !typeIsBooleanKeyword(ps.Type) {
+			continue
+		}
+		nameNode := ps.Name()
+		if nameNode == nil {
+			continue
+		}
+		name, ok := utils.GetStaticPropertyName(nameNode)
+		if !ok || name == "" {
+			continue
+		}
+		if !opts.rule.MatchString(name) {
+			report(m, name)
+		}
+	}
+}
+
+// typeIsBooleanKeyword reports whether `t` resolves to `boolean`, peeling
+// any number of `ParenthesizedType` wrappers — `boolean` and `((boolean))`
+// are equivalent.
+func typeIsBooleanKeyword(t *ast.Node) bool {
+	for t != nil {
+		switch t.Kind {
+		case ast.KindBooleanKeyword:
+			return true
+		case ast.KindParenthesizedType:
+			t = t.AsParenthesizedTypeNode().Type
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// validateObjectLiteralProps walks an object literal of PropTypes-style
+// declarations and reports each entry whose value resolves to one of the
+// configured propTypeNames AND whose key does not match the regex.
+//
+// Recurses into `PropTypes.shape({...})` arguments when `validateNested` is
+// enabled, mirroring upstream's `runCheck`. The recursion accepts
+// CallExpression unconditionally — upstream gates on `Property` (non-spread,
+// non-shorthand) only, which we cover by the early continue above.
+func validateObjectLiteralProps(obj *ast.Node, opts ruleOptions, report func(*ast.Node, string)) {
+	for _, prop := range obj.AsObjectLiteralExpression().Properties.Nodes {
+		if prop.Kind != ast.KindPropertyAssignment {
+			// SpreadAssignment, ShorthandPropertyAssignment, methods,
+			// accessors — none have a `key: PropTypes.X` shape we can
+			// examine, so all are skipped (matches upstream's
+			// `getPropKey` which returns null for these).
+			continue
+		}
+		pa := prop.AsPropertyAssignment()
+		if pa.Initializer == nil {
+			continue
+		}
+		valueUnwrapped := reactutil.SkipExpressionWrappers(pa.Initializer)
+
+		if opts.validateNested && valueUnwrapped.Kind == ast.KindCallExpression {
+			call := valueUnwrapped.AsCallExpression()
+			if call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+				inner := reactutil.SkipExpressionWrappers(call.Arguments.Nodes[0])
+				if inner.Kind == ast.KindObjectLiteralExpression {
+					validateObjectLiteralProps(inner, opts, report)
+					continue
+				}
+			}
+		}
+
+		propKey := getPropTypeKey(valueUnwrapped)
+		if propKey == "" || !opts.propTypeNames[propKey] {
+			continue
+		}
+		nameNode := pa.Name()
+		if nameNode == nil {
+			continue
+		}
+		name, ok := utils.GetStaticPropertyName(nameNode)
+		if !ok || name == "" {
+			continue
+		}
+		if !opts.rule.MatchString(name) {
+			report(prop, name)
+		}
+	}
+}
+
+// getPropTypeKey extracts the rightmost type-name identifier of a prop
+// value expression — `PropTypes.bool`, `React.PropTypes.bool`, `bool`, and
+// `PropTypes.bool.isRequired` all yield `"bool"`. Returns "" for shapes
+// upstream's `getPropKey` rejects (e.g. the `.isRequired` of a
+// `shape({...}).isRequired`, where the inner is a CallExpression).
+//
+// Receivers in the chain are unwrapped via `SkipExpressionWrappers`, so
+// `(PropTypes.bool as any)` and `PropTypes.bool!` resolve identically to
+// `PropTypes.bool`.
+func getPropTypeKey(value *ast.Node) string {
+	value = reactutil.SkipExpressionWrappers(value)
+	switch value.Kind {
+	case ast.KindIdentifier:
+		return value.AsIdentifier().Text
+	case ast.KindPropertyAccessExpression:
+		pa := value.AsPropertyAccessExpression()
+		nameNode := pa.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			return ""
+		}
+		propName := nameNode.AsIdentifier().Text
+		if propName == "isRequired" {
+			obj := reactutil.SkipExpressionWrappers(pa.Expression)
+			if obj.Kind != ast.KindPropertyAccessExpression {
+				return ""
+			}
+			objPa := obj.AsPropertyAccessExpression()
+			objName := objPa.Name()
+			if objName == nil || objName.Kind != ast.KindIdentifier {
+				return ""
+			}
+			return objName.AsIdentifier().Text
+		}
+		return propName
+	}
+	return ""
+}
+
+// firstTypeArgumentOfType returns the FIRST type argument of a TypeReference
+// (e.g. `React.FC<Props>` → `Props`). Returns nil if the type is not a
+// TypeReference, or has no type arguments.
+//
+// Mirrors upstream's `annotationTypeArguments.params.find(...)` — but unlike
+// upstream we don't filter by node kind, since `validateTypeNode`
+// gracefully ignores primitive-keyword and other non-object kinds at the
+// leaf.
+func firstTypeArgumentOfType(typeNode *ast.Node) *ast.Node {
+	if typeNode == nil || typeNode.Kind != ast.KindTypeReference {
+		return nil
+	}
+	ref := typeNode.AsTypeReferenceNode()
+	if ref.TypeArguments == nil || len(ref.TypeArguments.Nodes) == 0 {
+		return nil
+	}
+	return ref.TypeArguments.Nodes[0]
+}
+
+// unwrapComponentWrapperChain peels off any number of nested known
+// component-wrapper calls (`memo(...)`, `forwardRef(...)`,
+// `React.memo(...)`, `React.forwardRef(...)`, plus any user-configured
+// `settings.componentWrapperFunctions` entries) and returns the innermost
+// arrow / function expression — or nil if no wrapper at the head matches,
+// or if the innermost argument is not a function expression.
+//
+// Examples (assume default wrappers):
+//
+//	memo(fn)                       → fn
+//	memo(forwardRef(fn))           → fn
+//	React.memo(forwardRef(fn))     → fn
+//	connect(s,d)(memo(fn))         → nil (outer call's callee isn't a
+//	                                  recognized wrapper, even though the
+//	                                  inner is — upstream's
+//	                                  `isPragmaComponentWrapper` makes the
+//	                                  same conservative call)
+//	memo(someIdentifier)           → nil (innermost arg is not a function
+//	                                  literal; we can't validate its props)
+//
+// The chain depth is implicitly bounded by the source file's nesting
+// depth, but we cap at 16 hops as a defensive guard.
+func unwrapComponentWrapperChain(call *ast.Node, wrappers []reactutil.ComponentWrapperEntry) *ast.Node {
+	for range 16 {
+		if call == nil || call.Kind != ast.KindCallExpression {
+			return nil
+		}
+		args := call.AsCallExpression().Arguments
+		if args == nil || len(args.Nodes) == 0 {
+			return nil
+		}
+		first := reactutil.SkipExpressionWrappers(args.Nodes[0])
+		// `MatchesAnyComponentWrapper` requires the inner `fn` for its
+		// first-arg sanity check; we already have it as `first`.
+		if !reactutil.MatchesAnyComponentWrapper(call, first, wrappers) {
+			return nil
+		}
+		switch first.Kind {
+		case ast.KindArrowFunction, ast.KindFunctionExpression:
+			return first
+		case ast.KindCallExpression:
+			call = first
+			continue
+		}
+		return nil
+	}
+	return nil
+}
+
+// checkPropWrapperArguments validates each ObjectLiteralExpression argument
+// of `call`. Non-object arguments (e.g. the `{}` target and
+// `Card.propTypes` reference of `Object.assign({}, Card.propTypes, {...})`)
+// are ignored. TS-wrapped object arguments (`(arg as Foo)`) are accepted.
+func checkPropWrapperArguments(call *ast.Node, opts ruleOptions, report func(*ast.Node, string)) {
+	args := call.AsCallExpression().Arguments
+	if args == nil {
+		return
+	}
+	for _, arg := range args.Nodes {
+		obj := reactutil.SkipExpressionWrappers(arg)
+		if obj.Kind == ast.KindObjectLiteralExpression {
+			validateObjectLiteralProps(obj, opts, report)
+		}
+	}
+}

--- a/internal/plugins/react/rules/boolean_prop_naming/boolean_prop_naming.md
+++ b/internal/plugins/react/rules/boolean_prop_naming/boolean_prop_naming.md
@@ -1,0 +1,126 @@
+# boolean-prop-naming
+
+Enforces consistent naming for boolean React props.
+
+## Rule Details
+
+This rule checks declared React component prop types and reports any
+boolean-typed prop whose name does not match a configurable regex (default
+`^(is|has)[A-Z]([A-Za-z0-9]?)+`). It looks at:
+
+- `static propTypes = {...}` declared on a class that extends
+  `React.Component` / `React.PureComponent` / `Component` / `PureComponent`
+- `Foo.propTypes = {...}` assignments where `Foo` is a known React component
+- `createReactClass({propTypes: {...}})` and `React.createClass(...)` literal
+  arguments
+- TypeScript type annotations on the first parameter of a functional
+  component (`(props: Props) => ...` or `({a, b}: {a: boolean}) => ...`)
+- TypeScript type arguments on the variable's annotation
+  (`const Hello: React.FC<Props> = (props) => ...`), including
+  intersection / union compositions
+
+The rule is a **no-op** when no `rule` regex is configured. Add a `rule`
+option to turn it on.
+
+Examples of **incorrect** code for this rule:
+
+```json
+{ "react/boolean-prop-naming": ["error", { "rule": "^is[A-Z]([A-Za-z0-9]?)+" }] }
+```
+
+```javascript
+class Hello extends React.Component {
+  static propTypes = { something: PropTypes.bool };
+  render() { return <div />; }
+}
+```
+
+```json
+{ "react/boolean-prop-naming": ["error", { "rule": "^is[A-Z]([A-Za-z0-9]?)+" }] }
+```
+
+```javascript
+type Props = { enabled: boolean };
+const Hello = (props: Props) => <div />;
+```
+
+Examples of **correct** code for this rule:
+
+```json
+{ "react/boolean-prop-naming": ["error", { "rule": "^is[A-Z]([A-Za-z0-9]?)+" }] }
+```
+
+```javascript
+class Hello extends React.Component {
+  static propTypes = { isSomething: PropTypes.bool };
+  render() { return <div />; }
+}
+```
+
+```json
+{ "react/boolean-prop-naming": ["error", { "rule": "^is[A-Z]([A-Za-z0-9]?)+" }] }
+```
+
+```javascript
+type Props = { isEnabled: boolean };
+const Hello: React.FC<Props> = (props) => <div />;
+```
+
+## Options
+
+```json
+{
+  "react/boolean-prop-naming": ["error", {
+    "rule": "^(is|has)[A-Z]([A-Za-z0-9]?)+",
+    "propTypeNames": ["bool"],
+    "message": "Boolean prop names must begin with `is` or `has`",
+    "validateNested": false
+  }]
+}
+```
+
+- `rule` (string) — regex source the prop name must match. **Required to
+  enable the rule** (omitted / empty → no-op). Default in upstream docs is
+  `^(is|has)[A-Z]([A-Za-z0-9]?)+` but the rule is not turned on unless you
+  pass it explicitly.
+- `propTypeNames` (string[]) — names treated as boolean PropTypes. Default
+  `["bool"]`. Add custom validators (`["bool", "mutuallyExclusiveTrueProps"]`)
+  to recognize them as boolean.
+- `message` (string) — custom error message; supports `{{ propName }}` and
+  `{{ pattern }}` placeholders.
+- `validateNested` (boolean, default `false`) — when `true`, recurse into the
+  first argument of any call inside a prop value (e.g. `nested:
+  PropTypes.shape({ failingItIs: PropTypes.bool })`).
+
+## Settings
+
+`settings.propWrapperFunctions` — array of identifiers (or
+`{ object, property }` pairs) that wrap propTypes objects, so the rule can
+inspect inside them. Examples:
+
+```json
+{
+  "settings": {
+    "propWrapperFunctions": [
+      "forbidExtraProps",
+      "merge",
+      { "object": "Object", "property": "assign" },
+      { "object": "_", "property": "assign" }
+    ]
+  }
+}
+```
+
+## Differences from ESLint
+
+- Flow type annotations (`type Props = { x: boolean }` with
+  `BooleanTypeAnnotation`, `ObjectTypeProperty`, etc.) are not validated —
+  rslint parses these as TypeScript, so only the equivalent TypeScript shapes
+  (`TypeLiteralNode`, `TSPropertySignature`, `BooleanKeyword`) are checked.
+  TypeScript-flavored equivalents of every Flow case in the upstream test
+  suite report identically.
+
+## Original Documentation
+
+- [eslint-plugin-react / boolean-prop-naming](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/boolean-prop-naming.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/boolean-prop-naming.js)

--- a/internal/plugins/react/rules/boolean_prop_naming/boolean_prop_naming_test.go
+++ b/internal/plugins/react/rules/boolean_prop_naming/boolean_prop_naming_test.go
@@ -1,0 +1,1897 @@
+package boolean_prop_naming
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// patternIs is the most-common rule pattern across upstream tests.
+const patternIs = "^is[A-Z]([A-Za-z0-9]?)+"
+
+// patternIsHas is the documented default pattern; upstream uses it whenever
+// both prefixes are accepted.
+const patternIsHas = "^(is|has)[A-Z]([A-Za-z0-9]?)+"
+
+// optsIs / optsIsHas are array-wrapped Options shapes — they exercise the
+// JSON-array path that CLI / multi-element configs take. The bare-map shape
+// is exercised separately under "Options-shape coverage".
+var (
+	optsIs    = []interface{}{map[string]interface{}{"rule": patternIs}}
+	optsIsHas = []interface{}{map[string]interface{}{"rule": patternIsHas}}
+)
+
+func TestBooleanPropNamingRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &BooleanPropNamingRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// Upstream valid cases (all migrated; Flow-only cases use the
+		// equivalent TypeScript shape since rslint parses TS, not Flow).
+		// ============================================================
+
+		// ---- Default behavior: missing `rule` regex → rule is a no-op ----
+		// Upstream sets `rule = config.rule ? new RegExp(config.rule) : null`
+		// and bails on every listener; both `is*` and `has*` names pass not
+		// because they match the documented default but because nothing is
+		// checked.
+		{Code: `
+          var Hello = createReactClass({
+            propTypes: {isSomething: PropTypes.bool, hasValue: PropTypes.bool},
+            render: function() { return <div />; }
+          });
+        `, Tsx: true},
+
+		// ---- createReactClass + PropTypes.bool / React.PropTypes.bool ----
+		{Code: `
+          var Hello = createReactClass({
+            propTypes: {isSomething: PropTypes.bool},
+            render: function() { return <div />; }
+          });
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          var Hello = createReactClass({
+            propTypes: {isSomething: React.PropTypes.bool},
+            render: function() { return <div />; }
+          });
+        `, Tsx: true, Options: optsIs},
+		{
+			Code: `
+              var Hello = React.createClass({
+                propTypes: {isSomething: PropTypes.bool},
+                render: function() { return <div />; }
+              });
+            `,
+			Tsx:      true,
+			Options:  optsIs,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass"}},
+		},
+		{
+			// Non-boolean PropTypes.any is ignored entirely.
+			Code: `
+              var Hello = React.createClass({
+                propTypes: {something: PropTypes.any},
+                render: function() { return <div />; }
+              });
+            `,
+			Tsx:      true,
+			Options:  optsIs,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass"}},
+		},
+
+		// ---- ES6 class extends React.Component / Component ----
+		{Code: `
+          class Hello extends React.Component {
+            render () { return <div />; }
+          }
+          Hello.propTypes = {isSomething: PropTypes.bool}
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          class Hello extends React.Component {
+            render () { return <div />; }
+          }
+          Hello.propTypes = wrap({ a: PropTypes.bool })
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          class Hello extends React.Component {
+            render () { return <div />; }
+          }
+          Hello.propTypes = {something: PropTypes.any}
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          class Hello extends Component {
+            render () { return <div />; }
+          }
+          Hello.propTypes = {isSomething: PropTypes.bool}
+        `, Tsx: true, Options: optsIs},
+
+		// ---- ES6 components with static class properties ----
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {isSomething: PropTypes.bool};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          const spreadProps = { aSpreadProp: PropTypes.string };
+          class Hello extends React.Component {
+            static propTypes = {isSomething: PropTypes.bool, ...spreadProps};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          const spreadProps = { aSpreadProp: PropTypes.string };
+          class Hello extends Component {
+            render () { return <div />; }
+          }
+          Hello.propTypes = {isSomething: PropTypes.bool, ...spreadProps}
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {isSomething: React.PropTypes.bool};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {something: PropTypes.any};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- TS-equivalent of the upstream Flow `props: {x: boolean}` ----
+		// Upstream marks this `features: ['flow']`. In tsgo the same syntax
+		// parses as a TS class field with a TypeLiteral annotation, and the
+		// rule path validates it.
+		{Code: `
+          class Hello extends React.Component {
+            props: {isSomething: boolean};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          class Hello extends React.Component {
+            props: {something: any};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Stateless components with PropTypes ----
+		{Code: `
+          var Hello = ({isSomething}) => { return <div /> }
+          Hello.propTypes = {isSomething: PropTypes.bool};
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          type Props = { isSomething: boolean };
+          function Hello(props: Props): React.Element { return <div /> }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Custom propTypeNames ----
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {
+              isSomething: PropTypes.mutuallyExclusiveTrueProps,
+              something: PropTypes.bool
+            };
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{
+			"propTypeNames": []interface{}{"mutuallyExclusiveTrueProps"},
+			"rule":          patternIs,
+		}}},
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {
+              isSomething: mutuallyExclusiveTrueProps,
+              isSomethingElse: bool
+            };
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{
+			"propTypeNames": []interface{}{"bool", "mutuallyExclusiveTrueProps"},
+			"rule":          patternIs,
+		}}},
+
+		// ---- Misc shapes that must not crash ----
+		{Code: `
+          var x = {a: 1}
+          var y = {...x}
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          class Hello extends PureComponent {
+            props: PropsType;
+            render () { return <div /> }
+          }
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          function Card(props) {
+            return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+          }
+          Card.propTypes = merge({}, Card.propTypes, {
+              showScore: PropTypes.bool
+          });`,
+			Tsx: true, Options: optsIsHas,
+		},
+
+		// ---- isRequired chains ----
+		{Code: `
+          var Hello = createReactClass({
+            propTypes: {isSomething: PropTypes.bool.isRequired, hasValue: PropTypes.bool.isRequired},
+            render: function() { return <div />; }
+          });
+        `, Tsx: true},
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {
+              isSomething: PropTypes.bool.isRequired,
+              hasValue: PropTypes.bool.isRequired
+            };
+            render() { return ( <div /> ); }
+          }
+        `, Tsx: true},
+		{Code: `
+          class Hello extends React.Component {
+            render() { return ( <div /> ); }
+          }
+          Hello.propTypes = {
+            isSomething: PropTypes.bool.isRequired,
+            hasValue: PropTypes.bool.isRequired
+          }
+        `, Tsx: true},
+		{Code: `
+          var Hello = createReactClass({
+            propTypes: {something: PropTypes.shape({}).isRequired},
+            render: function() { return <div />; }
+          });
+        `, Tsx: true, Options: optsIs},
+
+		// ---- validateNested ----
+		{Code: `
+          class Hello extends React.Component {
+            render() { return ( <div /> ); }
+          }
+          Hello.propTypes = {
+            isSomething: PropTypes.bool.isRequired,
+            nested: PropTypes.shape({
+              isWorking: PropTypes.bool
+            })
+          };
+        `, Tsx: true},
+		{Code: `
+          class Hello extends React.Component {
+            render() { return ( <div /> ); }
+          }
+          Hello.propTypes = {
+            isSomething: PropTypes.bool.isRequired,
+            nested: PropTypes.shape({
+              nested: PropTypes.shape({
+                isWorking: PropTypes.bool
+              })
+            })
+          };
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{
+			"rule":           patternIs,
+			"validateNested": true,
+		}}},
+
+		// ---- TypeScript type annotations on functional components ----
+		{Code: `
+          type TestFNType = {
+            isEnabled: boolean
+          }
+          const HelloNew = (props: TestFNType) => { return <div /> };
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          type Props = {
+            isEnabled: boolean
+          } & OtherProps
+          const HelloNew = (props: Props) => { return <div /> };
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          type Props = {
+            isEnabled: boolean
+          } & {
+            hasLOL: boolean
+          } & OtherProps
+          const HelloNew = (props: Props) => { return <div /> };
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{"rule": "(is|has)[A-Z]([A-Za-z0-9]?)+"}}},
+		{Code: `
+          type Props = {
+            isEnabled: boolean
+          }
+          const HelloNew: React.FC<Props> = (props) => { return <div /> };
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          type Props = {
+            isEnabled: boolean
+          } & {
+            hasLOL: boolean
+          }
+          const HelloNew: React.FC<Props> = (props) => { return <div /> };
+        `, Tsx: true, Options: optsIsHas},
+		{Code: `
+          type Props = {
+            isEnabled: boolean
+          } | {
+            hasLOL: boolean
+          }
+          const HelloNew = (props: Props) => { return <div /> };
+        `, Tsx: true, Options: optsIsHas},
+		{Code: `
+          type Props = {
+            isEnabled: boolean
+          } & ({
+            hasLOL: boolean
+          } | {
+            isLOL: boolean
+          })
+          const HelloNew = (props: Props) => { return <div /> };
+        `, Tsx: true, Options: optsIsHas},
+		{Code: `
+          export const DataRow = (props: { label: string; value: string; } & React.HTMLAttributes<HTMLDivElement>) => {
+              const { label, value, ...otherProps } = props;
+              return (
+                  <div {...otherProps}>
+                      <span>{label}</span>
+                      <span>{value}</span>
+                  </div>
+              );
+          };
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{"rule": "(^(is|has|should|without)[A-Z]([A-Za-z0-9]?)+|disabled|required|checked|defaultChecked)"}}},
+		{Code: `
+          // Non-component code — must not crash.
+          const resultCode = result.code
+            .replace('/** @jsxRuntime automatic */', '')
+            .replace('/** @jsxImportSource @fluentui/react-jsx-runtime */', '');
+        `, Tsx: true},
+
+		// ============================================================
+		// Additional valid cases (Phase 1 Dimensions 1–4 + real-world).
+		// ============================================================
+
+		// ---- Dimension 1 / 4: Empty containers ----
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+		{Code: `const Hello = (props: {}) => <div />;`, Tsx: true, Options: optsIs},
+		{Code: `
+          interface Empty {}
+          const Hello = (props: Empty) => <div />;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Dimension 4: Non-component class / non-component identifier ----
+		// Class without `extends Component` — propTypes field is irrelevant.
+		{Code: `
+          class NotAComponent {
+            propTypes = {something: PropTypes.bool};
+          }
+        `, Tsx: true, Options: optsIs},
+		// Non-component identifier `.propTypes` assignment must not report.
+		{Code: `
+          var notAComponent = 1;
+          notAComponent.propTypes = {something: PropTypes.bool};
+        `, Tsx: true, Options: optsIs},
+		// Non-component receiver via member chain.
+		{Code: `
+          var ns = {};
+          ns.notAComponent.propTypes = {something: PropTypes.bool};
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Dimension 4: Key-form variants on PropTypes object ----
+		// String literal key — same equivalence class as identifier, valid name.
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = { "isSomething": PropTypes.bool };
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Dimension 3: TS expression wrappers on prop value ----
+		// `(PropTypes.bool as any)` / `PropTypes.bool!` / `(X satisfies Y)`
+		// must unwrap to the same chain — matching name → no report.
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {isSomething: (PropTypes.bool as any)};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {isSomething: PropTypes.bool!};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {isSomething: (PropTypes.bool satisfies any)};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+		// Parens around the whole object literal initializer.
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = ({isSomething: PropTypes.bool});
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Dimension 4: ElementAccess assignment LHS ----
+		// `Hello['propTypes'] = {...}` — must report identical to the dotted form.
+		{Code: `
+          class Hello extends React.Component {
+            render () { return <div />; }
+          }
+          Hello['propTypes'] = {isSomething: PropTypes.bool};
+        `, Tsx: true, Options: optsIs},
+		// ElementAccess with a non-string-literal arg → not recognized.
+		{Code: `
+          var key = 'propTypes';
+          class Hello extends React.Component {
+            render () { return <div />; }
+          }
+          Hello[key] = {something: PropTypes.bool};
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Dimension 4: Multi-segment receiver `outer.inner.Hello.propTypes` ----
+		// Rightmost ID is the component name — accepted (conservative match).
+		{Code: `
+          class Hello extends React.Component {
+            render () { return <div />; }
+          }
+          ns.Hello.propTypes = {isSomething: PropTypes.bool};
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Dimension 1: TypeReference to QualifiedName (`A.B`) ----
+		// Rightmost segment is the lookup key. With the alias `Inner` defined,
+		// `A.Inner` resolves and validates.
+		{Code: `
+          type Inner = { isFoo: boolean };
+          const Hello = (props: ns.Inner) => <div />;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Dimension 1: Interface declaration merging ----
+		{Code: `
+          interface Props { isFoo: boolean }
+          interface Props { isBar: boolean }
+          const Hello = (props: Props) => <div />;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Dimension 1: Type alias indirection ----
+		{Code: `
+          type A = B;
+          type B = { isEnabled: boolean };
+          const Hello = (props: A) => <div />;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Dimension 1: Three-level type composition ----
+		{Code: `
+          type A = { isFoo: boolean };
+          type B = { hasBar: boolean };
+          type C = { isBaz: boolean };
+          const Hello = (props: A & (B | C)) => <div />;
+        `, Tsx: true, Options: optsIsHas},
+
+		// ---- Both static propTypes and props: TypeLiteral (dual-path) ----
+		// Both names match → no report from either path.
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = { isFoo: PropTypes.bool };
+            props: { isBar: boolean };
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- HOC wrapping — name is still a known component ----
+		// Bare `memo` requires destructure-import from React (matches
+		// upstream's `isDestructuredFromPragmaImport` gate).
+		{Code: `
+          import { memo } from 'react';
+          const Hello = memo((props) => <div/>);
+          Hello.propTypes = {isSomething: PropTypes.bool};
+        `, Tsx: true, Options: optsIs},
+		// ---- HOC wrapping via React.memo (no import gate) ----
+		{Code: `
+          const Hello = React.memo((props: { isFoo: boolean }) => <div/>);
+        `, Tsx: true, Options: optsIs},
+		// ---- Nested HOC wrappers ----
+		{Code: `
+          const Hello = React.memo(React.forwardRef((props: { isFoo: boolean }, ref) => <div ref={ref}/>));
+        `, Tsx: true, Options: optsIs},
+
+		// ---- propWrapperFunctions: `wrap` not configured → silently skip ----
+		{Code: `
+          function Card(props) { return <div /> }
+          Card.propTypes = wrap({ showScore: PropTypes.bool });
+        `, Tsx: true, Options: optsIsHas},
+
+		// ---- Locks in: invalid regex degrades to no-op ----
+		// Rather than throw (upstream behavior), the Go implementation
+		// silently disables the rule. This is a documented divergence; the
+		// test ensures the chosen behavior cannot regress.
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {something: PropTypes.bool};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{"rule": "[unclosed"}}},
+
+		// ---- Locks in: empty `propTypeNames` array → falls back to default ['bool'] ----
+		// Upstream's schema requires `minItems: 1`; an empty array is
+		// malformed config. We coerce to the default rather than throw.
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {isSomething: PropTypes.bool};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{
+			"rule":          patternIs,
+			"propTypeNames": []interface{}{},
+		}}},
+
+		// ---- Locks in: empty `rule` string → no-op ----
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {something: PropTypes.bool};
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{"rule": ""}}},
+
+		// ---- Bare-map Options shape (single-option CLI shape) ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = {isSomething: PropTypes.bool};
+                render () { return <div />; }
+              }
+            `,
+			Tsx:     true,
+			Options: map[string]interface{}{"rule": patternIs},
+		},
+
+		// ---- nil Options ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = {something: PropTypes.bool};
+                render () { return <div />; }
+              }
+            `,
+			Tsx: true,
+		},
+
+		// ---- Options array with a non-map first element (malformed) → defaults ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = {something: PropTypes.bool};
+                render () { return <div />; }
+              }
+            `,
+			Tsx:     true,
+			Options: []interface{}{"not-a-map"},
+		},
+
+		// ---- Interface heritage: `interface A extends B` ----
+		// Both A's and B's bool members must match.
+		{Code: `
+          interface Base { isVisible: boolean }
+          interface Props extends Base { isReady: boolean }
+          const Hello = (props: Props) => <div />;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- 3-segment QualifiedName: `a.b.C` ----
+		{Code: `
+          type C = { isFoo: boolean };
+          const Hello = (props: ns.sub.C) => <div />;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Namespace-scoped component (recursive descent) ----
+		// pre-walk should descend into ModuleDeclaration bodies so the
+		// inner const HelloIn is registered as a component.
+		{Code: `
+          namespace UI {
+            export const HelloIn = (props: { isFoo: boolean }) => <div/>;
+          }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- React.PropsWithChildren<Props> ----
+		// firstTypeArgumentOfType returns Props; validateTypeNode resolves.
+		{Code: `
+          type Props = { isFoo: boolean };
+          const Hello: React.PropsWithChildren<Props> = (props) => <div/>;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Optional / readonly modifiers on PropertySignature ----
+		// `?` modifier and `readonly` modifier both pass through;
+		// validateMembers should still recognize the bool annotation.
+		{Code: `
+          type Props = { isFoo?: boolean; readonly isBar: boolean };
+          const Hello = (props: Props) => <div/>;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Generic component ----
+		{Code: `
+          function Hello<T>(props: { isReady: boolean; data: T }) { return <div/>; }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- React.FC with composed generic ----
+		{Code: `
+          type Props = { isFoo: boolean };
+          const Hello: React.FC<Props & { isExtra?: boolean }> = (props) => <div/>;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- prop-types via various import shapes (no behavioral diff) ----
+		{Code: `
+          import PropTypes from 'prop-types';
+          class Hello extends React.Component {
+            static propTypes = { isFoo: PropTypes.bool };
+            render() { return <div/>; }
+          }
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          import * as PropTypes from 'prop-types';
+          class Hello extends React.Component {
+            static propTypes = { isFoo: PropTypes.bool };
+            render() { return <div/>; }
+          }
+        `, Tsx: true, Options: optsIs},
+		{Code: `
+          import { bool, func, string } from 'prop-types';
+          class Hello extends React.Component {
+            static propTypes = { isFoo: bool, name: string };
+            render() { return <div/>; }
+          }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Mapped types — opaque (upstream too) ----
+		// A mapped type produces no PropertySignature members in the AST,
+		// so nothing is checked; the rule must not crash.
+		{Code: `
+          type Props = { [K in 'a' | 'b']: boolean };
+          const Hello = (props: Props) => <div/>;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Utility-type generics — opaque (upstream too) ----
+		// Pick / Omit / Partial / Required don't expand without a
+		// TypeChecker; rslint treats them as opaque, mirroring upstream's
+		// "objectTypeAnnotations.get(name) returns undefined" behavior.
+		{Code: `
+          type Base = { something: boolean };
+          const Hello = (props: Pick<Base, 'something'>) => <div/>;
+        `, Tsx: true, Options: optsIs},
+
+		// ---- as const suffix on object literal ----
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = ({isFoo: PropTypes.bool} as const);
+            render() { return <div/>; }
+          }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- Numeric / unicode regex pattern ----
+		// rule pattern that accepts 中文 prefix; matching name passes.
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = { 是否启用: PropTypes.bool };
+            render() { return <div/>; }
+          }
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{"rule": "^[\\p{L}]+$"}}},
+
+		// ---- Empty propTypeNames → user-cleared list, no PropTypes match ----
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = { something: PropTypes.bool };
+            render () { return <div />; }
+          }
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{
+			"rule":          patternIs,
+			"propTypeNames": []interface{}{},
+		}}},
+
+		// ---- Empty propTypeNames doesn't disable TS `: boolean` path ----
+		// (Documented difference from upstream; lock-in.)
+		// Although this is `valid` because the name matches the pattern,
+		// the test verifies that the TS path runs even without
+		// propTypeNames entries.
+		{Code: `
+          const Hello = (props: { isFoo: boolean }) => <div/>;
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{
+			"rule":          patternIs,
+			"propTypeNames": []interface{}{},
+		}}},
+
+		// ---- 5-level validateNested (depth) ----
+		{Code: `
+          class Hello extends React.Component {
+            render() { return <div/>; }
+          }
+          Hello.propTypes = {
+            isA: PropTypes.shape({
+              isB: PropTypes.shape({
+                isC: PropTypes.shape({
+                  isD: PropTypes.shape({
+                    isE: PropTypes.bool
+                  })
+                })
+              })
+            })
+          };
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{
+			"rule":           patternIs,
+			"validateNested": true,
+		}}},
+
+		// ---- Long propTypes object (50 keys) — performance / no crash ----
+		// Generated inline so the test reads as one string; all keys
+		// match the pattern.
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = {
+              isProp00: PropTypes.bool, isProp01: PropTypes.bool, isProp02: PropTypes.bool, isProp03: PropTypes.bool,
+              isProp04: PropTypes.bool, isProp05: PropTypes.bool, isProp06: PropTypes.bool, isProp07: PropTypes.bool,
+              isProp08: PropTypes.bool, isProp09: PropTypes.bool, isProp10: PropTypes.bool, isProp11: PropTypes.bool,
+              isProp12: PropTypes.bool, isProp13: PropTypes.bool, isProp14: PropTypes.bool, isProp15: PropTypes.bool,
+              isProp16: PropTypes.bool, isProp17: PropTypes.bool, isProp18: PropTypes.bool, isProp19: PropTypes.bool,
+              isProp20: PropTypes.bool, isProp21: PropTypes.bool, isProp22: PropTypes.bool, isProp23: PropTypes.bool,
+              isProp24: PropTypes.bool, isProp25: PropTypes.bool, isProp26: PropTypes.bool, isProp27: PropTypes.bool,
+              isProp28: PropTypes.bool, isProp29: PropTypes.bool, isProp30: PropTypes.bool, isProp31: PropTypes.bool,
+              isProp32: PropTypes.bool, isProp33: PropTypes.bool, isProp34: PropTypes.bool, isProp35: PropTypes.bool,
+              isProp36: PropTypes.bool, isProp37: PropTypes.bool, isProp38: PropTypes.bool, isProp39: PropTypes.bool,
+              isProp40: PropTypes.bool, isProp41: PropTypes.bool, isProp42: PropTypes.bool, isProp43: PropTypes.bool,
+              isProp44: PropTypes.bool, isProp45: PropTypes.bool, isProp46: PropTypes.bool, isProp47: PropTypes.bool,
+              isProp48: PropTypes.bool, isProp49: PropTypes.bool
+            };
+            render() { return <div/>; }
+          }
+        `, Tsx: true, Options: optsIs},
+
+		// ---- regex with lookahead (Go RE2 unsupported) → silent no-op ----
+		// `^(?=is)` is a JS-only lookahead; Go's regexp.Compile rejects
+		// it; the rule degrades silently.
+		{Code: `
+          class Hello extends React.Component {
+            static propTypes = { something: PropTypes.bool };
+            render() { return <div/>; }
+          }
+        `, Tsx: true, Options: []interface{}{map[string]interface{}{"rule": "^(?=is)"}}},
+
+		// ---- Empty file / imports-only file ----
+		{Code: ``, Tsx: true, Options: optsIs},
+		{Code: `import * as React from 'react';`, Tsx: true, Options: optsIs},
+
+		// ---- .ts file (no JSX) with lower-cased non-component fn ----
+		// Lowercase function name fails upstream's capitalized-id check
+		// in `getStatelessComponent`; the function is not a component, so
+		// nothing is validated.
+		{Code: `
+          type Props = { something: boolean };
+          function helper(props: Props) { return null; }
+        `, Options: optsIs},
+
+		// ---- Real-world smoke: large mixed file ----
+		// A single file containing several components in different shapes
+		// shouldn't false-positive on any unrelated identifier and
+		// shouldn't crash on missing pieces.
+		{Code: `
+          import * as React from 'react';
+          import PropTypes from 'prop-types';
+
+          // Class component (matches).
+          class Card extends React.Component {
+            static propTypes = { isOpen: PropTypes.bool };
+            render() { return <div />; }
+          }
+
+          // Stateless component (matches).
+          const Avatar = ({ isOnline }: { isOnline: boolean }) => <div />;
+
+          // Plain helper class — no propTypes consideration.
+          class Repo {
+            propTypes = { something: PropTypes.bool };
+            run() {}
+          }
+
+          // Pure data shape — no React linkage.
+          const config = { propTypes: { something: 1 } };
+
+          // Function that isn't a component (no JSX, lower-cased name).
+          function helper(props: { isReady: boolean }) { return null; }
+
+          export { Card, Avatar };
+        `, Tsx: true, Options: optsIs},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// Upstream invalid cases (all migrated, 1:1 with optional Flow→TS).
+		// ============================================================
+
+		// ---- createReactClass ----
+		{
+			Code: `
+              var Hello = createReactClass({
+                propTypes: {something: PropTypes.bool},
+                render: function() { return <div />; }
+              });
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "patternMismatch",
+				Message:   "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+				Line:      3,
+				Column:    29,
+				EndLine:   3,
+				EndColumn: 54,
+			}},
+		},
+		{
+			Code: `
+              var Hello = createReactClass({
+                propTypes: {something: React.PropTypes.bool},
+                render: function() { return <div />; }
+              });
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              var Hello = React.createClass({
+                propTypes: {something: PropTypes.bool},
+                render: function() { return <div />; }
+              });
+            `,
+			Tsx:      true,
+			Options:  optsIs,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass"}},
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- ES6 class extends React.Component / Component ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                render () { return <div />; }
+              }
+              Hello.propTypes = {something: PropTypes.bool}
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "patternMismatch",
+				Message:   "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+				Line:      5,
+				Column:    34,
+				EndLine:   5,
+				EndColumn: 59,
+			}},
+		},
+		{
+			Code: `
+              class Hello extends Component {
+                render () { return <div />; }
+              }
+              Hello.propTypes = {something: PropTypes.bool}
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = {something: PropTypes.bool};
+                render () { return <div />; }
+              }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			// Spread in static propTypes.
+			Code: `
+              const spreadProps = { aSpreadProp: PropTypes.string };
+              class Hello extends Component {
+                render () { return <div />; }
+              }
+              Hello.propTypes = {something: PropTypes.bool, ...spreadProps}
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              const spreadProps = { aSpreadProp: PropTypes.string };
+              class Hello extends React.Component {
+                static propTypes = {something: PropTypes.bool, ...spreadProps};
+                render () { return <div />; }
+              }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			// Class with TS-style `props: {something: boolean}` field
+			// (upstream's Flow-equivalent test).
+			Code: `
+              class Hello extends React.Component {
+                props: {something: boolean};
+                render () { return <div />; }
+              }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "patternMismatch",
+				Message:   "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+				Line:      3,
+				Column:    25,
+				EndLine:   3,
+				EndColumn: 43,
+			}},
+		},
+
+		// ---- Stateless components ----
+		{
+			Code: `
+              var Hello = ({something}) => { return <div /> }
+              Hello.propTypes = {something: PropTypes.bool};
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		// Function component with TS type alias on first param (TS form
+		// of upstream's Flow `function Hello(props: Props): React.Element`).
+		{
+			Code: `
+              type Props = {
+                something: boolean;
+              };
+              function Hello(props: Props): React.Element { return <div /> }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Custom propTypeNames ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = {something: PropTypes.mutuallyExclusiveTrueProps};
+                render () { return <div />; }
+              }
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"propTypeNames": []interface{}{"bool", "mutuallyExclusiveTrueProps"},
+				"rule":          patternIs,
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = {
+                  something: PropTypes.mutuallyExclusiveTrueProps,
+                  somethingElse: PropTypes.bool
+                };
+                render () { return <div />; }
+              }
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"propTypeNames": []interface{}{"bool", "mutuallyExclusiveTrueProps"},
+				"rule":          patternIs,
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+		{
+			// Bare-identifier values (`mutuallyExclusiveTrueProps`, `bool`).
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = {
+                  something: mutuallyExclusiveTrueProps,
+                  somethingElse: bool
+                };
+                render () { return <div />; }
+              }
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"propTypeNames": []interface{}{"bool", "mutuallyExclusiveTrueProps"},
+				"rule":          patternIs,
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+
+		// ---- propWrapperFunctions matrix ----
+		{
+			Code: `
+              function Card(props) {
+                return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+              }
+              Card.propTypes = merge({}, Card.propTypes, {
+                  showScore: PropTypes.bool
+              });`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"propWrapperFunctions": []interface{}{"merge"}},
+			Options:  optsIsHas,
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			// `Object.assign` configured as `{object, property}` pair.
+			Code: `
+              function Card(props) {
+                return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+              }
+              Card.propTypes = Object.assign({}, Card.propTypes, {
+                  showScore: PropTypes.bool
+              });`,
+			Tsx: true,
+			Settings: map[string]interface{}{"propWrapperFunctions": []interface{}{
+				map[string]interface{}{"object": "Object", "property": "assign"},
+			}},
+			Options: optsIsHas,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			// `_.assign` via `{object, property}`.
+			Code: `
+              function Card(props) {
+                return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+              }
+              Card.propTypes = _.assign({}, Card.propTypes, {
+                  showScore: PropTypes.bool
+              });`,
+			Tsx: true,
+			Settings: map[string]interface{}{"propWrapperFunctions": []interface{}{
+				map[string]interface{}{"object": "_", "property": "assign"},
+			}},
+			Options: optsIsHas,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			// Legacy `"Object.assign"` string shape — split on first dot.
+			Code: `
+              function Card(props) { return <div /> }
+              Card.propTypes = Object.assign({}, Card.propTypes, {
+                  showScore: PropTypes.bool
+              });`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"propWrapperFunctions": []interface{}{"Object.assign"}},
+			Options:  optsIsHas,
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              function Card(props) {
+                return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+              }
+              Card.propTypes = forbidExtraProps({
+                  showScore: PropTypes.bool
+              });`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"propWrapperFunctions": []interface{}{"forbidExtraProps"}},
+			Options:  optsIsHas,
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              class Card extends React.Component {
+                render() { return <div>{this.props.showScore ? 'yeh' : 'no'}</div>; }
+              }
+              Card.propTypes = forbidExtraProps({
+                  showScore: PropTypes.bool
+              });`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"propWrapperFunctions": []interface{}{"forbidExtraProps"}},
+			Options:  optsIsHas,
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              class Card extends React.Component {
+                static propTypes = forbidExtraProps({
+                  showScore: PropTypes.bool
+                });
+                render() { return <div /> }
+              }`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"propWrapperFunctions": []interface{}{"forbidExtraProps"}},
+			Options:  optsIsHas,
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Custom message ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                render () { return <div />; }
+              }
+              Hello.propTypes = {something: PropTypes.bool}
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"rule":    patternIs,
+				"message": "Boolean prop names must begin with either 'is' or 'has'",
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "patternMismatch",
+				Message:   "Boolean prop names must begin with either 'is' or 'has'",
+			}},
+		},
+		{
+			Code: `
+              class Hello extends React.Component {
+                render () { return <div />; }
+              }
+              Hello.propTypes = {something: PropTypes.bool}
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"rule":    patternIs,
+				"message": "It is better if your prop ({{ propName }}) matches this pattern: ({{ pattern }})",
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "patternMismatch",
+				Message:   "It is better if your prop (something) matches this pattern: (^is[A-Z]([A-Za-z0-9]?)+)",
+			}},
+		},
+
+		// ---- isRequired chains report on the inner type ----
+		{
+			Code: `
+              var Hello = createReactClass({
+                propTypes: {something: PropTypes.bool.isRequired},
+                render: function() { return <div />; }
+              });
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = { something: PropTypes.bool.isRequired };
+                render() { return <div />; }
+              }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              class Hello extends React.Component {
+                render() { return <div />; }
+              }
+              Hello.propTypes = { something: PropTypes.bool.isRequired }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Inline TypeScript parameter type literal ----
+		{
+			Code: `
+              function SomeComponent({ something }: { something: boolean }) {
+                  return ( <span>{something}</span> );
+              }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "patternMismatch",
+				Message:   "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+				Line:      2,
+				Column:    55,
+				EndLine:   2,
+				EndColumn: 73,
+			}},
+		},
+
+		// ---- validateNested ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                render() { return <div />; }
+              }
+              Hello.propTypes = {
+                isSomething: PropTypes.bool.isRequired,
+                nested: PropTypes.shape({ failingItIs: PropTypes.bool })
+              };
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"rule":           patternIs,
+				"validateNested": true,
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			// Two-level nesting.
+			Code: `
+              class Hello extends React.Component {
+                render() { return <div />; }
+              }
+              Hello.propTypes = {
+                isSomething: PropTypes.bool.isRequired,
+                nested: PropTypes.shape({
+                  nested: PropTypes.shape({ failingItIs: PropTypes.bool })
+                })
+              };
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"rule":           patternIs,
+				"validateNested": true,
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Bare identifier (imported `bool`) ----
+		{
+			Code: `
+              import { bool } from 'prop-types';
+              var Hello = createReactClass({
+                propTypes: {something: bool},
+                render: function() { return <div />; }
+              });
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"rule":           patternIs,
+				"validateNested": true,
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- TypeScript type annotations on functional components ----
+		{
+			Code: `
+              type TestConstType = {
+                enabled: boolean
+              }
+              const HelloNew = (props: TestConstType) => { return <div /> };
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              type Props = {
+                enabled: boolean
+              } & OtherProps
+              const HelloNew = (props: Props) => { return <div /> };
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              type Props = {
+                enabled: boolean
+              } & {
+                hasLOL: boolean
+              } & OtherProps
+              const HelloNew = (props: Props) => { return <div /> };
+            `,
+			Tsx:     true,
+			Options: optsIsHas,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              type Props = {
+                enabled: boolean
+              }
+              const HelloNew: React.FC<Props> = (props) => { return <div /> };
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "patternMismatch",
+				Message:   "Prop name `enabled` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+				Line:      3,
+				Column:    17,
+				EndLine:   3,
+				EndColumn: 33,
+			}},
+		},
+		{
+			Code: `
+              type Props = {
+                enabled: boolean
+              } & {
+                hasLOL: boolean
+              }
+              const HelloNew: React.FC<Props> = (props) => { return <div /> };
+            `,
+			Tsx:     true,
+			Options: optsIsHas,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              type Props = {
+                enabled: boolean
+              } | {
+                hasLOL: boolean
+              }
+              const HelloNew = (props: Props) => { return <div /> };
+            `,
+			Tsx:     true,
+			Options: optsIsHas,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              type Props = {
+                enabled: boolean
+              } & ({
+                hasLOL: boolean
+              } | {
+                lol: boolean
+              })
+              const HelloNew = (props: Props) => { return <div /> };
+            `,
+			Tsx:     true,
+			Options: optsIsHas,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+		{
+			Code: `
+              interface TestFNType {
+                enabled: boolean
+              }
+              const HelloNew = (props: TestFNType) => { return <div /> };
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code:    `const Hello = (props: {enabled:boolean}) => <div />;`,
+			Tsx:     true,
+			Options: optsIsHas,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              type Props = {
+                enabled: boolean
+              };
+              type BaseProps = {
+                semi: boolean
+              };
+              const Hello = (props: Props & BaseProps) => <div />;
+            `,
+			Tsx:     true,
+			Options: optsIsHas,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+		{
+			Code: `
+              type Props = {
+                enabled: boolean
+              };
+              const Hello = (props: Props & {
+                semi: boolean
+              }) => <div />;
+            `,
+			Tsx:     true,
+			Options: optsIsHas,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+
+		// ============================================================
+		// Additional invalid cases: real-world / lock-in tests.
+		// ============================================================
+
+		// ---- ElementAccess on assignment LHS ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                render () { return <div />; }
+              }
+              Hello['propTypes'] = {something: PropTypes.bool};
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Multi-segment receiver `ns.Hello.propTypes = {...}` ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                render () { return <div />; }
+              }
+              ns.Hello.propTypes = {something: PropTypes.bool};
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- TS expression wrappers on prop value (mismatch reports) ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                render () { return <div />; }
+              }
+              Hello.propTypes = {something: (PropTypes.bool as any)}
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		{
+			Code: `
+              class Hello extends React.Component {
+                render () { return <div />; }
+              }
+              Hello.propTypes = {something: PropTypes.bool!}
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- TypeReference using QualifiedName (`A.B`) ----
+		{
+			Code: `
+              type Inner = { enabled: boolean };
+              const Hello = (props: ns.Inner) => <div />;
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Interface declaration merging both report ----
+		{
+			Code: `
+              interface Props { enabled: boolean }
+              interface Props { switched: boolean }
+              const Hello = (props: Props) => <div />;
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+
+		// ---- Type alias indirection (one hop) ----
+		{
+			Code: `
+              type A = B;
+              type B = { enabled: boolean };
+              const Hello = (props: A) => <div />;
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Three-level type composition ----
+		{
+			Code: `
+              type A = { enabled: boolean };
+              type B = { hasBar: boolean };
+              type C = { lol: boolean };
+              const Hello = (props: A & (B | C)) => <div />;
+            `,
+			Tsx:     true,
+			Options: optsIsHas,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+
+		// ---- Both static propTypes + props: TypeLiteral mismatch ----
+		// Both paths must report; reportedSet keeps each diagnostic distinct
+		// (different source node) but doesn't deduplicate across paths.
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = { something: PropTypes.bool };
+                props: { fooBar: boolean };
+                render () { return <div />; }
+              }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+
+		// ---- HOC wrapping doesn't strip the component name ----
+		// Bare `memo` matches the wrapper list only when the binding is
+		// destructure-imported from the React pragma; without the
+		// import, upstream's `Components.detect` likewise wouldn't
+		// classify (matches its `isDestructuredFromPragmaImport` gate).
+		{
+			Code: `
+              import { memo } from 'react';
+              const Hello = memo((props) => <div/>);
+              Hello.propTypes = {something: PropTypes.bool};
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		// ---- HOC wrapping via React.memo / nested HOC ----
+		{
+			Code: `
+              import * as React from 'react';
+              const Hello = React.memo(React.forwardRef((props: { enabled: boolean }, ref) => <div ref={ref}/>));
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+		// ---- HOC wrapping via user-configured `componentWrapperFunctions` ----
+		{
+			Code: `
+              const Hello = myMemo((props: { enabled: boolean }) => <div/>);
+            `,
+			Tsx:      true,
+			Options:  optsIs,
+			Settings: map[string]interface{}{"componentWrapperFunctions": []interface{}{"myMemo"}},
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Multi-line TypeLiteral + position assertions ----
+		{
+			Code: `
+              const Hello = (props: {
+                enabled: boolean,
+                isReady: boolean,
+              }) => <div />;
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "patternMismatch",
+				Line:      3,
+				Column:    17,
+				EndLine:   3,
+				EndColumn: 34,
+			}},
+		},
+
+		// ---- `propTypeNames` only allowing a custom name → bool no longer counts ----
+		// Bare identifier `bool` is no longer in propTypeNames, so it isn't
+		// even considered; only `mutuallyExclusiveTrueProps` triggers.
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = {
+                  something: bool,
+                  somethingElse: mutuallyExclusiveTrueProps
+                };
+                render () { return <div />; }
+              }
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"rule":          patternIs,
+				"propTypeNames": []interface{}{"mutuallyExclusiveTrueProps"},
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Interface heritage: `interface Props extends Base` ----
+		// Both members reported.
+		{
+			Code: `
+              interface Base { hidden: boolean }
+              interface Props extends Base { ready: boolean }
+              const Hello = (props: Props) => <div />;
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+
+		// ---- 3-segment QualifiedName: `a.b.C` ----
+		{
+			Code: `
+              type C = { enabled: boolean };
+              const Hello = (props: ns.sub.C) => <div />;
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Namespace-scoped component ----
+		{
+			Code: `
+              namespace UI {
+                export const HelloIn = (props: { enabled: boolean }) => <div/>;
+              }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- React.PropsWithChildren<Props> mismatch ----
+		{
+			Code: `
+              type Props = { enabled: boolean };
+              const Hello: React.PropsWithChildren<Props> = (props) => <div/>;
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Optional / readonly modifiers don't gate validation ----
+		{
+			Code: `
+              type Props = { enabled?: boolean; readonly visible: boolean };
+              const Hello = (props: Props) => <div/>;
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+
+		// ---- Generic component mismatch ----
+		{
+			Code: `
+              function Hello<T>(props: { enabled: boolean; data: T }) { return <div/>; }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- React.FC composed generic mismatch ----
+		{
+			Code: `
+              type Props = { enabled: boolean };
+              const Hello: React.FC<Props & { extra: boolean }> = (props) => <div/>;
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+
+		// ---- as const suffix on object literal ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = ({something: PropTypes.bool} as const);
+                render() { return <div/>; }
+              }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Default-export named class component ----
+		{
+			Code: `
+              export default class Hello extends React.Component {
+                static propTypes = { something: PropTypes.bool };
+                render() { return <div/>; }
+              }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Anonymous default-export function component ----
+		{
+			Code: `
+              export default function (props: { enabled: boolean }) { return <div/>; }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Named export const arrow component ----
+		{
+			Code: `
+              export const Hello = (props: { enabled: boolean }) => <div/>;
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- HOC + import + .propTypes assignment ----
+		{
+			Code: `
+              import { memo } from 'react';
+              const Hello = memo((props: { enabled: boolean }) => <div/>);
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Multi-component file (5 components, mixed shapes) ----
+		// Three are invalid (something / enabled / disabled), two are
+		// valid (isFoo / hasBar). All five must be detected and only the
+		// three mismatches reported, in source order.
+		{
+			Code: `
+              import * as React from 'react';
+              import PropTypes from 'prop-types';
+
+              class Card extends React.Component {
+                static propTypes = { something: PropTypes.bool };
+                render() { return <div/>; }
+              }
+
+              const Avatar = (props: { isFoo: boolean }) => <div/>;
+
+              type RowProps = { hasBar: boolean; enabled: boolean };
+              const Row: React.FC<RowProps> = (props) => <div/>;
+
+              function Header(props: { disabled: boolean }) { return <div/>; }
+
+              const Footer = React.memo((props: { isOK: boolean }) => <div/>);
+            `,
+			Tsx:     true,
+			Options: optsIsHas,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+				{MessageId: "patternMismatch"},
+			},
+		},
+
+		// ---- 5-level validateNested mismatch at deepest level ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                render() { return <div/>; }
+              }
+              Hello.propTypes = {
+                isA: PropTypes.shape({
+                  isB: PropTypes.shape({
+                    isC: PropTypes.shape({
+                      isD: PropTypes.shape({
+                        leaf: PropTypes.bool
+                      })
+                    })
+                  })
+                })
+              };
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"rule":           patternIs,
+				"validateNested": true,
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- TS expression wrapper around the whole assignment RHS ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                render () { return <div />; }
+              }
+              Hello.propTypes = ({something: PropTypes.bool} as any);
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- ElementAccess with TS-wrapped RHS ----
+		{
+			Code: `
+              class Hello extends React.Component {
+                render () { return <div />; }
+              }
+              Hello['propTypes'] = ({something: PropTypes.bool}!);
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Settings: custom pragma changes class detection ----
+		// `extends Preact.Component` only counts when pragma=Preact.
+		{
+			Code: `
+              class Hello extends Preact.Component {
+                static propTypes = { something: PropTypes.bool };
+                render() { return <div/>; }
+              }
+            `,
+			Tsx:      true,
+			Options:  optsIs,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+
+		// ---- Custom message with unknown placeholder kept literal ----
+		// Mirrors ESLint's `interpolate`: keys not in `data` stay as
+		// `{{key}}` in the rendered output rather than being deleted or
+		// throwing.
+		{
+			Code: `
+              class Hello extends React.Component {
+                render () { return <div />; }
+              }
+              Hello.propTypes = {something: PropTypes.bool}
+            `,
+			Tsx: true,
+			Options: []interface{}{map[string]interface{}{
+				"rule":    patternIs,
+				"message": "{{ propName }} fails {{ pattern }} (unknown: {{ unknown }})",
+			}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "patternMismatch",
+				Message:   "something fails ^is[A-Z]([A-Za-z0-9]?)+ (unknown: {{ unknown }})",
+			}},
+		},
+
+		// ---- Double TS expression wrappers on prop value ----
+		// `((PropTypes.bool as any) satisfies any)` — peeled correctly
+		// by reactutil.SkipExpressionWrappers, name still reported.
+		{
+			Code: `
+              class Hello extends React.Component {
+                static propTypes = {something: ((PropTypes.bool as any) satisfies any)};
+                render () { return <div />; }
+              }
+            `,
+			Tsx:     true,
+			Options: optsIs,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "patternMismatch"}},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_typos/no_typos.go
+++ b/internal/plugins/react/rules/no_typos/no_typos.go
@@ -92,7 +92,7 @@ func runRule(ctx rule.RuleContext, options any) rule.RuleListeners {
 			handleImportDecl(ctx, n, &propTypesPackageName, &reactPackageName)
 		case ast.KindClassDeclaration, ast.KindClassExpression:
 			if reactutil.ExtendsReactComponent(n, pragma) || hasJSDocExtendsReactComponent(n) {
-				if name := declName(n); name != "" {
+				if name := reactutil.BindingIdentifierName(n); name != "" {
 					componentsByName[name] = true
 				}
 			}
@@ -396,7 +396,7 @@ func runRule(ctx rule.RuleContext, options any) rule.RuleListeners {
 			if !ast.IsStatic(node) {
 				return
 			}
-			classNode := enclosingClass(node)
+			classNode := reactutil.EnclosingClass(node)
 			if classNode == nil || !reactutil.ExtendsReactComponent(classNode, pragma) {
 				return
 			}
@@ -620,30 +620,6 @@ func propertyValueNode(prop *ast.Node) *ast.Node {
 		// so shorthand is effectively a no-op there. For static-class-property
 		// typo detection the value is unused, so returning nil is fine.
 		return nil
-	}
-	return nil
-}
-
-// declName returns the identifier text of a named declaration (class or
-// function), or "" when the declaration is anonymous or the name is not a
-// bare Identifier.
-func declName(n *ast.Node) string {
-	name := n.Name()
-	if name == nil || name.Kind != ast.KindIdentifier {
-		return ""
-	}
-	return name.AsIdentifier().Text
-}
-
-// enclosingClass returns the nearest ClassDeclaration / ClassExpression
-// ancestor of `node`, or nil. Used to find the class of a PropertyDeclaration
-// so we can test the extends clause.
-func enclosingClass(node *ast.Node) *ast.Node {
-	for p := node.Parent; p != nil; p = p.Parent {
-		switch p.Kind {
-		case ast.KindClassDeclaration, ast.KindClassExpression:
-			return p
-		}
 	}
 	return nil
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -84,6 +84,7 @@ export default defineConfig({
     './tests/eslint-plugin-import/rules/no-webpack-loader-syntax.test.ts',
 
     // eslint-plugin-react
+    './tests/eslint-plugin-react/rules/boolean-prop-naming.test.ts',
     './tests/eslint-plugin-react/rules/button-has-type.test.ts',
     './tests/eslint-plugin-react/rules/forbid-component-props.test.ts',
     './tests/eslint-plugin-react/rules/jsx-child-element-spacing.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/boolean-prop-naming.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/boolean-prop-naming.test.ts
@@ -1,0 +1,514 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const patternIs = '^is[A-Z]([A-Za-z0-9]?)+';
+const patternIsHas = '^(is|has)[A-Z]([A-Za-z0-9]?)+';
+
+ruleTester.run('boolean-prop-naming', {} as never, {
+  valid: [
+    // Default (no options) → rule is a no-op.
+    {
+      code: `
+        var Hello = createReactClass({
+          propTypes: {isSomething: PropTypes.bool, hasValue: PropTypes.bool},
+          render: function() { return <div />; }
+        });
+      `,
+    },
+    // Matching name with `is` pattern.
+    {
+      code: `
+        class Hello extends React.Component {
+          static propTypes = {isSomething: PropTypes.bool};
+          render () { return <div />; }
+        }
+      `,
+      options: [{ rule: patternIs }],
+    },
+    // React.FC<Props> with matching name.
+    {
+      code: `
+        type Props = { isEnabled: boolean };
+        const HelloNew: React.FC<Props> = (props) => { return <div /> };
+      `,
+      options: [{ rule: patternIs }],
+    },
+    // Wrapper not in propWrapperFunctions setting → silently skipped.
+    {
+      code: `
+        function Card(props) {
+          return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+        }
+        Card.propTypes = wrap({ showScore: PropTypes.bool });
+      `,
+      options: [{ rule: patternIsHas }],
+    },
+    // Empty propTypes / empty type literal — must not crash.
+    {
+      code: `
+        class Hello extends React.Component {
+          static propTypes = {};
+          render () { return <div />; }
+        }
+      `,
+      options: [{ rule: patternIs }],
+    },
+    {
+      code: `const Hello = (props: {}) => <div />;`,
+      options: [{ rule: patternIs }],
+    },
+    // Non-component class with `propTypes` field — no report.
+    {
+      code: `
+        class NotAComponent {
+          propTypes = {something: PropTypes.bool};
+        }
+      `,
+      options: [{ rule: patternIs }],
+    },
+    // TS expression wrappers on prop value (matching name still passes).
+    {
+      code: `
+        class Hello extends React.Component {
+          static propTypes = {isSomething: (PropTypes.bool as any)};
+          render () { return <div />; }
+        }
+      `,
+      options: [{ rule: patternIs }],
+    },
+    // Type alias indirection: A → B → object literal.
+    {
+      code: `
+        type A = B;
+        type B = { isEnabled: boolean };
+        const Hello = (props: A) => <div />;
+      `,
+      options: [{ rule: patternIs }],
+    },
+    // Interface declaration merging — both members must match.
+    {
+      code: `
+        interface Props { isFoo: boolean }
+        interface Props { isBar: boolean }
+        const Hello = (props: Props) => <div />;
+      `,
+      options: [{ rule: patternIs }],
+    },
+    // Three-level type composition (intersection × union × parens).
+    {
+      code: `
+        type A = { isFoo: boolean };
+        type B = { hasBar: boolean };
+        type C = { isBaz: boolean };
+        const Hello = (props: A & (B | C)) => <div />;
+      `,
+      options: [{ rule: patternIsHas }],
+    },
+    // Empty rule pattern → no-op.
+    {
+      code: `
+        class Hello extends React.Component {
+          static propTypes = {something: PropTypes.bool};
+          render () { return <div />; }
+        }
+      `,
+      options: [{ rule: '' }],
+    },
+    // Invalid regex degrades to no-op.
+    {
+      code: `
+        class Hello extends React.Component {
+          static propTypes = {something: PropTypes.bool};
+          render () { return <div />; }
+        }
+      `,
+      options: [{ rule: '[unclosed' }],
+    },
+    // Empty propTypeNames array → user-cleared list, no PropTypes match.
+    {
+      code: `
+        class Hello extends React.Component {
+          static propTypes = { something: PropTypes.bool };
+          render () { return <div />; }
+        }
+      `,
+      options: [{ rule: patternIs, propTypeNames: [] }],
+    },
+    // Interface heritage — matching members pass.
+    {
+      code: `
+        interface Base { isVisible: boolean }
+        interface Props extends Base { isReady: boolean }
+        const Hello = (props: Props) => <div />;
+      `,
+      options: [{ rule: patternIs }],
+    },
+  ],
+  invalid: [
+    // createReactClass with non-matching prop.
+    {
+      code: `
+        var Hello = createReactClass({
+          propTypes: {something: PropTypes.bool},
+          render: function() { return <div />; }
+        });
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // Static class field.
+    {
+      code: `
+        class Hello extends React.Component {
+          static propTypes = {something: PropTypes.bool};
+          render () { return <div />; }
+        }
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // .propTypes assignment outside body.
+    {
+      code: `
+        class Hello extends React.Component {
+          render () { return <div />; }
+        }
+        Hello.propTypes = {something: PropTypes.bool}
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // ElementAccess assignment LHS.
+    {
+      code: `
+        class Hello extends React.Component {
+          render () { return <div />; }
+        }
+        Hello['propTypes'] = {something: PropTypes.bool};
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // Multi-segment receiver.
+    {
+      code: `
+        class Hello extends React.Component {
+          render () { return <div />; }
+        }
+        ns.Hello.propTypes = {something: PropTypes.bool};
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // TS expression wrappers report on mismatch.
+    {
+      code: `
+        class Hello extends React.Component {
+          render () { return <div />; }
+        }
+        Hello.propTypes = {something: (PropTypes.bool as any)};
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // Inline TS parameter type literal.
+    {
+      code: `const Hello = (props: {enabled:boolean}) => <div />;`,
+      options: [{ rule: patternIsHas }],
+      errors: [
+        {
+          message:
+            "Prop name `enabled` doesn't match rule `^(is|has)[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // React.FC<Props> with type alias.
+    {
+      code: `
+        type Props = { enabled: boolean }
+        const HelloNew: React.FC<Props> = (props) => { return <div /> };
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `enabled` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // Intersection of type alias + inline literal.
+    {
+      code: `
+        type Props = { enabled: boolean };
+        const Hello = (props: Props & { semi: boolean }) => <div />;
+      `,
+      options: [{ rule: patternIsHas }],
+      errors: [
+        {
+          message:
+            "Prop name `enabled` doesn't match rule `^(is|has)[A-Z]([A-Za-z0-9]?)+`",
+        },
+        {
+          message:
+            "Prop name `semi` doesn't match rule `^(is|has)[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // Interface via type reference on first param.
+    {
+      code: `
+        interface TestFNType { enabled: boolean }
+        const HelloNew = (props: TestFNType) => { return <div /> };
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `enabled` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // QualifiedName type reference (`A.B`).
+    {
+      code: `
+        type Inner = { enabled: boolean };
+        const Hello = (props: ns.Inner) => <div />;
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `enabled` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // Type alias indirection.
+    {
+      code: `
+        type A = B;
+        type B = { enabled: boolean };
+        const Hello = (props: A) => <div />;
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `enabled` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // Interface declaration merging.
+    {
+      code: `
+        interface Props { enabled: boolean }
+        interface Props { switched: boolean }
+        const Hello = (props: Props) => <div />;
+      `,
+      options: [{ rule: patternIs }],
+      errors: 2,
+    },
+    // HOC wrapping with import.
+    {
+      code: `
+        import { memo } from 'react';
+        const Hello = memo((props) => <div/>);
+        Hello.propTypes = {something: PropTypes.bool};
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `something` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // Custom message with placeholders.
+    {
+      code: `
+        class Hello extends React.Component {
+          render () { return <div />; }
+        }
+        Hello.propTypes = {something: PropTypes.bool}
+      `,
+      options: [
+        {
+          rule: patternIs,
+          message:
+            'It is better if your prop ({{ propName }}) matches this pattern: ({{ pattern }})',
+        },
+      ],
+      errors: [
+        {
+          message:
+            'It is better if your prop (something) matches this pattern: (^is[A-Z]([A-Za-z0-9]?)+)',
+        },
+      ],
+    },
+    // Custom propTypeNames including bare identifiers.
+    {
+      code: `
+        class Hello extends React.Component {
+          static propTypes = {
+            something: mutuallyExclusiveTrueProps,
+            somethingElse: bool
+          };
+          render () { return <div />; }
+        }
+      `,
+      options: [
+        {
+          propTypeNames: ['bool', 'mutuallyExclusiveTrueProps'],
+          rule: patternIs,
+        },
+      ],
+      errors: 2,
+    },
+    // propWrapperFunctions: bare-string entry.
+    {
+      code: `
+        function Card(props) {
+          return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+        }
+        Card.propTypes = forbidExtraProps({
+          showScore: PropTypes.bool
+        });
+      `,
+      settings: { propWrapperFunctions: ['forbidExtraProps'] },
+      options: [{ rule: patternIsHas }],
+      errors: [
+        {
+          message:
+            "Prop name `showScore` doesn't match rule `^(is|has)[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // propWrapperFunctions: {object, property} pair.
+    {
+      code: `
+        function Card(props) { return <div /> }
+        Card.propTypes = Object.assign({}, Card.propTypes, {
+          showScore: PropTypes.bool
+        });
+      `,
+      settings: {
+        propWrapperFunctions: [{ object: 'Object', property: 'assign' }],
+      },
+      options: [{ rule: patternIsHas }],
+      errors: [
+        {
+          message:
+            "Prop name `showScore` doesn't match rule `^(is|has)[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // validateNested + PropTypes.shape recursion.
+    {
+      code: `
+        class Hello extends React.Component {
+          render() { return <div />; }
+        }
+        Hello.propTypes = {
+          isSomething: PropTypes.bool.isRequired,
+          nested: PropTypes.shape({ failingItIs: PropTypes.bool })
+        };
+      `,
+      options: [{ rule: patternIs, validateNested: true }],
+      errors: [
+        {
+          message:
+            "Prop name `failingItIs` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // Both static propTypes + props: TypeLiteral.
+    {
+      code: `
+        class Hello extends React.Component {
+          static propTypes = { something: PropTypes.bool };
+          props: { fooBar: boolean };
+          render () { return <div />; }
+        }
+      `,
+      options: [{ rule: patternIs }],
+      errors: 2,
+    },
+    // Interface heritage `extends`.
+    {
+      code: `
+        interface Base { hidden: boolean }
+        interface Props extends Base { ready: boolean }
+        const Hello = (props: Props) => <div />;
+      `,
+      options: [{ rule: patternIs }],
+      errors: 2,
+    },
+    // Optional / readonly modifiers.
+    {
+      code: `
+        type Props = { enabled?: boolean; readonly visible: boolean };
+        const Hello = (props: Props) => <div/>;
+      `,
+      options: [{ rule: patternIs }],
+      errors: 2,
+    },
+    // 3-segment QualifiedName.
+    {
+      code: `
+        type C = { enabled: boolean };
+        const Hello = (props: ns.sub.C) => <div />;
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `enabled` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+    // React.PropsWithChildren<Props>.
+    {
+      code: `
+        type Props = { enabled: boolean };
+        const Hello: React.PropsWithChildren<Props> = (props) => <div/>;
+      `,
+      options: [{ rule: patternIs }],
+      errors: [
+        {
+          message:
+            "Prop name `enabled` doesn't match rule `^is[A-Z]([A-Za-z0-9]?)+`",
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -331,3 +331,4 @@ metacharacters
 CHARCLASS
 CLASSSET
 unrepresentable
+fluentui


### PR DESCRIPTION
## Summary

Port the `react/boolean-prop-naming` rule from `eslint-plugin-react` to rslint.

The rule enforces consistent naming for boolean React props by validating
prop names against a configurable regex pattern. It checks:

- `static propTypes = {...}` on classes extending `React.Component` /
  `Component` / `PureComponent` / `React.PureComponent`
- `Foo.propTypes = {...}` and `Foo['propTypes'] = {...}` assignments where
  `Foo` is a known React component (including HOC-wrapped: `memo`,
  `forwardRef`, user-configured `componentWrapperFunctions`)
- `createReactClass({propTypes: {...}})` / `<pragma>.createClass({...})`
- TypeScript type annotations on functional components — first-parameter
  type, plus the first type argument of variable annotations like
  `React.FC<Props>` / `React.PropsWithChildren<Props>`
- Composed types: intersection / union / parenthesized / interface
  declaration merging / interface heritage `extends` / type alias
  indirection / `QualifiedName` (e.g. `ns.Inner`)
- TS expression wrappers on prop values (`as`, `!`, `satisfies`, parens)

Supports the full upstream options surface (`rule`, `propTypeNames`,
`message` with `{{propName}}` / `{{pattern}}` placeholders,
`validateNested`) and settings (`propWrapperFunctions` in both string
and `{object, property}` shapes, `componentWrapperFunctions`,
`react.pragma`, `react.createClass`).

The rule is a no-op when no `rule` regex is configured (matching upstream
`config.rule ? ... : null`).

Verified end-to-end on real codebases:

- `rsbuild/website` (mixed React + TS): 0 reports — true negative, no
  `: boolean` typed props or `PropTypes.bool` in component code.
- `rspack/website` (mixed React + TS): 1 report on
  `website/components/ApiMeta.tsx:19:3 — inline?: boolean` (interface
  `ApiMetaProps` referenced via `(props: ApiMetaProps)`); other 5
  non-boolean fields correctly skipped.

### Differences from ESLint

- Flow type annotations (`type Props = { x: boolean }` with
  `BooleanTypeAnnotation` / `ObjectTypeProperty`) aren't validated since
  rslint parses with tsgo, not Flow. All upstream Flow test cases have
  TypeScript-shaped equivalents in the test suite that report identically.
- Invalid `rule` regex degrades to a silent no-op rather than throwing
  (upstream throws). Same observable outcome (no diagnostics emitted)
  while keeping the broader lint run alive on bad config.
- `propTypeNames: []` (empty array) is honored as "user cleared the
  list" — TS `: boolean` checks still run, but no PropTypes-style
  identifier matches. Upstream's loader rejects this via
  `minItems: 1`; rslint has no schema-rejection layer.

## Related Links

- ESLint plugin: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/boolean-prop-naming.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/boolean-prop-naming.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).