### PR TITLE
feat: port rule no-array-index-key

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -24,6 +24,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_access_state_in_setstate"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_array_index_key"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_children_prop"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger_with_children"
@@ -84,6 +85,7 @@ func GetAllRules() []rule.Rule {
 		jsx_uses_vars.JsxUsesVarsRule,
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
 		no_access_state_in_setstate.NoAccessStateInSetstateRule,
+		no_array_index_key.NoArrayIndexKeyRule,
 		no_children_prop.NoChildrenPropRule,
 		no_danger.NoDangerRule,
 		no_danger_with_children.NoDangerWithChildrenRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -2164,44 +2164,95 @@ func IsCreateElementCallWithChecker(callee *ast.Node, pragma string, tc *checker
 }
 
 func isCreateElementCallCore(callee *ast.Node, pragma string, tc *checker.Checker) bool {
+	return isPragmaFactoryCallCore(callee, pragma, tc, createElementOnly, false)
+}
+
+// IsCreateOrCloneElementCall reports whether the callee resolves to
+// `<pragma>.createElement` / `<pragma>.cloneElement` (configured pragma)
+// or — when `tc` is non-nil — a bare `createElement` / `cloneElement`
+// identifier imported / destructured from the pragma module. Mirrors
+// upstream `eslint-plugin-react`'s `isCreateCloneElement` predicate used
+// by `no-array-index-key`, INCLUDING upstream's acceptance of optional
+// chains (`React?.cloneElement(...)`) — upstream listens on
+// `'CallExpression, OptionalCallExpression'` and gates on
+// `node.type === 'MemberExpression' || node.type === 'OptionalMemberExpression'`.
+//
+// Parens are skipped on the pragma sub-expression so `(React).cloneElement`
+// is recognized (ESTree flattens parens). TS-only expression wrappers
+// (`as` / `satisfies` / `<T>x` / `x!`) on the pragma identifier are NOT
+// skipped — that would over-match relative to ESLint's JS-only AST and
+// is a divergence we deliberately avoid.
+func IsCreateOrCloneElementCall(callee *ast.Node, pragma string, tc *checker.Checker) bool {
+	return isPragmaFactoryCallCore(callee, pragma, tc, createOrCloneElement, true)
+}
+
+type pragmaFactoryNames int
+
+const (
+	createElementOnly pragmaFactoryNames = iota
+	createOrCloneElement
+)
+
+func (k pragmaFactoryNames) matches(name string) bool {
+	switch k {
+	case createElementOnly:
+		return name == "createElement"
+	case createOrCloneElement:
+		return name == "createElement" || name == "cloneElement"
+	}
+	return false
+}
+
+func isPragmaFactoryCallCore(callee *ast.Node, pragma string, tc *checker.Checker, names pragmaFactoryNames, allowOptionalChain bool) bool {
 	if callee == nil {
 		return false
 	}
 	if pragma == "" {
 		pragma = DefaultReactPragma
 	}
-	callee = SkipExpressionWrappers(callee)
+	// `IsCreateElementCall` (the public-named variant used by other rules)
+	// historically peels TS expression wrappers off the callee itself —
+	// keep that branch intact for backwards compatibility.
+	// `IsCreateOrCloneElementCall`, used by `no-array-index-key`, mirrors
+	// ESLint's JS-only AST and only skips parentheses on the callee.
+	if names == createElementOnly {
+		callee = SkipExpressionWrappers(callee)
+	} else {
+		callee = ast.SkipParentheses(callee)
+	}
 
-	// Bare callee: `createElement(arg)` — recognize when destructured
-	// from the pragma module. Mirrors upstream's second branch of
-	// `isCreateElement`.
+	// Bare callee: `createElement(arg)` / `cloneElement(arg)` — recognized
+	// only when destructured from the pragma module. Mirrors upstream's
+	// second branch of `isCreateElement` / `isCreateCloneElement`.
 	if callee.Kind == ast.KindIdentifier {
-		if callee.AsIdentifier().Text != "createElement" {
+		if !names.matches(callee.AsIdentifier().Text) {
 			return false
 		}
-		// Without a TypeChecker we can't resolve the binding; bail to
-		// match the conservative non-import-aware path (upstream also
-		// returns false when the destructure gate fails).
 		return IsDestructuredFromPragmaImport(callee, pragma, tc)
 	}
 
-	// Member-access callee: `<pragma>.createElement(arg)`.
+	// Member-access callee: `<pragma>.<name>(arg)`.
 	if callee.Kind != ast.KindPropertyAccessExpression {
 		return false
 	}
-	if ast.IsOptionalChain(callee) {
+	if !allowOptionalChain && ast.IsOptionalChain(callee) {
 		return false
 	}
 	prop := callee.AsPropertyAccessExpression()
 	nameNode := prop.Name()
-	if nameNode.Kind != ast.KindIdentifier || nameNode.AsIdentifier().Text != "createElement" {
+	if nameNode.Kind != ast.KindIdentifier || !names.matches(nameNode.AsIdentifier().Text) {
 		return false
 	}
-	pragmaExpr := SkipExpressionWrappers(prop.Expression)
-	if pragmaExpr.Kind != ast.KindIdentifier || pragmaExpr.AsIdentifier().Text != pragma {
-		return false
+	// Pragma sub-expression: `IsCreateElementCall` historically peels TS
+	// wrappers; `IsCreateOrCloneElementCall` only peels parens to match
+	// ESLint's JS-only AST exactly.
+	var pragmaExpr *ast.Node
+	if names == createElementOnly {
+		pragmaExpr = SkipExpressionWrappers(prop.Expression)
+	} else {
+		pragmaExpr = ast.SkipParentheses(prop.Expression)
 	}
-	return true
+	return pragmaExpr.Kind == ast.KindIdentifier && pragmaExpr.AsIdentifier().Text == pragma
 }
 
 // GetJsxPropName returns the display name of a JSX node.

--- a/internal/plugins/react/rules/no_array_index_key/no_array_index_key.go
+++ b/internal/plugins/react/rules/no_array_index_key/no_array_index_key.go
@@ -1,0 +1,561 @@
+package no_array_index_key
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const noArrayIndexMessage = "Do not use Array index in keys"
+
+// indexParamPositions maps tracked iterator method names to the 0-based
+// position of the index parameter inside the callback. Mirrors upstream
+// `iteratorFunctionsToIndexParamPosition`.
+var indexParamPositions = map[string]int{
+	"every":       1,
+	"filter":      1,
+	"find":        1,
+	"findIndex":   1,
+	"flatMap":     1,
+	"forEach":     1,
+	"map":         1,
+	"reduce":      2,
+	"reduceRight": 2,
+	"some":        1,
+}
+
+// isImportSpecifierFromReact reports whether `ident` resolves to a binding
+// introduced by `import { <anything> } from 'react'`. Mirrors upstream
+// `eslint-plugin-react`'s `isCreateCloneElement` Identifier branch
+// byte-for-byte:
+//
+//   - The binding's declaration must be an `ImportSpecifier` (the
+//     `import { x } from 'pkg'` shape). Destructuring like
+//     `const { cloneElement } = React`, aliasing like
+//     `const cloneElement = React.cloneElement`, and
+//     `const { cloneElement } = require('react')` are NOT recognized
+//     — they're VariableDeclaration / BindingElement, not ImportSpecifier.
+//
+//   - The module specifier must be the LITERAL string `'react'`. The
+//     `settings.react.pragma` configuration does NOT influence this
+//     check upstream — `pragma` only governs the dotted-form receiver.
+//
+//   - The identifier's TEXT is intentionally NOT validated. Upstream
+//     accepts any react-imported name (e.g. `import { foo } from 'react'`
+//     also passes); this is an upstream quirk we mirror for 1:1 parity.
+//
+// Without a TypeChecker, falls back to a SourceFile-level scan for any
+// matching ImportDeclaration — strictly less precise than scope-based
+// resolution but sufficient for the canonical top-level patterns.
+func isImportSpecifierFromReact(ctx rule.RuleContext, ident *ast.Node) bool {
+	if ident == nil || ident.Kind != ast.KindIdentifier {
+		return false
+	}
+
+	if ctx.TypeChecker != nil {
+		symbol := ctx.TypeChecker.GetSymbolAtLocation(ident)
+		if symbol == nil {
+			return false
+		}
+		var decl *ast.Node
+		if symbol.ValueDeclaration != nil {
+			decl = symbol.ValueDeclaration
+		} else if len(symbol.Declarations) > 0 {
+			decl = symbol.Declarations[0]
+		}
+		if decl == nil || decl.Kind != ast.KindImportSpecifier {
+			return false
+		}
+		for p := decl.Parent; p != nil; p = p.Parent {
+			if p.Kind != ast.KindImportDeclaration {
+				continue
+			}
+			ms := p.AsImportDeclaration().ModuleSpecifier
+			return ms != nil && ms.Kind == ast.KindStringLiteral && ms.Text() == "react"
+		}
+		return false
+	}
+
+	sf := ast.GetSourceFileOfNode(ident)
+	if sf == nil {
+		return false
+	}
+	name := ident.AsIdentifier().Text
+	found := false
+	var visit func(n *ast.Node)
+	visit = func(n *ast.Node) {
+		if found || n == nil {
+			return
+		}
+		if n.Kind == ast.KindImportDeclaration {
+			id := n.AsImportDeclaration()
+			if id.ModuleSpecifier != nil &&
+				id.ModuleSpecifier.Kind == ast.KindStringLiteral &&
+				id.ModuleSpecifier.Text() == "react" &&
+				id.ImportClause != nil {
+				ic := id.ImportClause.AsImportClause()
+				if ic.NamedBindings != nil && ic.NamedBindings.Kind == ast.KindNamedImports {
+					ni := ic.NamedBindings.AsNamedImports()
+					if ni.Elements != nil {
+						for _, spec := range ni.Elements.Nodes {
+							local := spec.Name()
+							if local != nil && local.Kind == ast.KindIdentifier && local.AsIdentifier().Text == name {
+								found = true
+								return
+							}
+						}
+					}
+				}
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return found
+		})
+	}
+	visit(sf.AsNode())
+	return found
+}
+
+var NoArrayIndexKeyRule = rule.Rule{
+	Name: "react/no-array-index-key",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+
+		// indexParamNames is a stack of identifier names introduced as the
+		// index parameter of an enclosing tracked iterator callback. An
+		// identifier reference whose text matches any name on the stack is
+		// treated as the array index. Mirrors upstream's flat array — pushed
+		// on iterator-call enter, popped on exit. The stack is intentionally
+		// a flat name list (not a depth counter): nested iterators with the
+		// SAME index name (`foo.map((a,i)=>bar.map((c,i)=>...))`) push the
+		// name twice, and inner functions defined inside the callback do
+		// NOT shadow it — both behaviors mirror upstream byte-for-byte.
+		var indexParamNames []string
+
+		isArrayIndex := func(node *ast.Node) bool {
+			if node == nil {
+				return false
+			}
+			node = ast.SkipParentheses(node)
+			if node == nil || node.Kind != ast.KindIdentifier {
+				return false
+			}
+			name := node.AsIdentifier().Text
+			for _, n := range indexParamNames {
+				if n == name {
+					return true
+				}
+			}
+			return false
+		}
+
+		// isUsingReactChildren mirrors upstream's `isUsingReactChildren`.
+		// True when the callee is `Children.<m>` or `<pragma>.<X>.<m>`
+		// for `<m>` ∈ {map, forEach}. Note: upstream's check on the outer
+		// `<pragma>.X` form does NOT validate that the inner property is
+		// literally `Children` — preserved here for parity even though it
+		// is lenient (e.g. `React.Foo.map(...)` would also be treated as
+		// Children-shape, but the missing args[1] callback then fails the
+		// next gate, so it's benign in practice).
+		isUsingReactChildren := func(call *ast.CallExpression) bool {
+			if call == nil || call.Expression == nil {
+				return false
+			}
+			callee := ast.SkipParentheses(call.Expression)
+			if callee == nil || callee.Kind != ast.KindPropertyAccessExpression {
+				return false
+			}
+			pa := callee.AsPropertyAccessExpression()
+			name := pa.Name()
+			if name == nil || name.Kind != ast.KindIdentifier {
+				return false
+			}
+			method := name.AsIdentifier().Text
+			if method != "map" && method != "forEach" {
+				return false
+			}
+			obj := ast.SkipParentheses(pa.Expression)
+			if obj == nil {
+				return false
+			}
+			if obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == "Children" {
+				return true
+			}
+			if obj.Kind == ast.KindPropertyAccessExpression {
+				inner := obj.AsPropertyAccessExpression()
+				innerObj := ast.SkipParentheses(inner.Expression)
+				return innerObj != nil && innerObj.Kind == ast.KindIdentifier && innerObj.AsIdentifier().Text == pragma
+			}
+			return false
+		}
+
+		// getMapIndexParamName mirrors upstream's `getMapIndexParamName`.
+		// Returns the parameter identifier name for the iterator's index
+		// position, or "" if the call isn't a tracked iterator with a
+		// function-like callback whose param at the expected position is
+		// a plain (or default-valued) identifier. Destructured / rest
+		// params yield "" — same observable behavior as upstream pushing
+		// `undefined` (which never matches a real identifier reference).
+		getMapIndexParamName := func(call *ast.CallExpression) string {
+			if call == nil || call.Expression == nil {
+				return ""
+			}
+			callee := ast.SkipParentheses(call.Expression)
+			if callee == nil || callee.Kind != ast.KindPropertyAccessExpression {
+				return ""
+			}
+			pa := callee.AsPropertyAccessExpression()
+			name := pa.Name()
+			if name == nil || name.Kind != ast.KindIdentifier {
+				return ""
+			}
+			pos, ok := indexParamPositions[name.AsIdentifier().Text]
+			if !ok {
+				return ""
+			}
+			if call.Arguments == nil {
+				return ""
+			}
+			args := call.Arguments.Nodes
+			argIdx := 0
+			if isUsingReactChildren(call) {
+				argIdx = 1
+			}
+			if argIdx >= len(args) {
+				return ""
+			}
+			callback := ast.SkipParentheses(args[argIdx])
+			if callback == nil || !ast.IsFunctionExpressionOrArrowFunction(callback) {
+				return ""
+			}
+			params := callback.Parameters()
+			if pos >= len(params) {
+				return ""
+			}
+			param := params[pos]
+			if param == nil || param.Kind != ast.KindParameter {
+				return ""
+			}
+			pd := param.AsParameterDeclaration()
+			// Rest parameter (`...rest`) — upstream RestElement has no
+			// `.name`; treat as un-named.
+			if pd.DotDotDotToken != nil {
+				return ""
+			}
+			// Default-valued parameter (`i = 0`) — upstream's parser
+			// wraps the binding in an AssignmentPattern whose `.name`
+			// is undefined, so the index is NOT pushed and references
+			// to `i` inside the body are NOT reported. Mirror that:
+			// when an Initializer is present, refuse to push, even
+			// though tsgo's ParameterDeclaration exposes the inner
+			// Identifier directly. Keeps input/output parity with
+			// `eslint-plugin-react`.
+			if pd.Initializer != nil {
+				return ""
+			}
+			paramName := pd.Name()
+			// Destructured patterns (`[i]` / `{i}`) and other binding
+			// shapes — upstream `params[pos].name` returns undefined.
+			if paramName == nil || paramName.Kind != ast.KindIdentifier {
+				return ""
+			}
+			return paramName.AsIdentifier().Text
+		}
+
+		report := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noArrayIndex",
+				Description: noArrayIndexMessage,
+			})
+		}
+
+		// collectIdentifiersFromBinary recursively flattens a chain of
+		// BinaryExpressions into the bare identifiers they reference.
+		// Mirrors upstream's `getIdentifiersFromBinaryExpression`: only
+		// Identifier and BinaryExpression are walked — every other shape
+		// (ConditionalExpression, CallExpression, MemberExpression, …)
+		// is opaque, matching upstream's selective recursion.
+		var collectIdentifiersFromBinary func(node *ast.Node) []*ast.Node
+		collectIdentifiersFromBinary = func(node *ast.Node) []*ast.Node {
+			if node == nil {
+				return nil
+			}
+			node = ast.SkipParentheses(node)
+			if node == nil {
+				return nil
+			}
+			if node.Kind == ast.KindIdentifier {
+				return []*ast.Node{node}
+			}
+			if node.Kind == ast.KindBinaryExpression {
+				be := node.AsBinaryExpression()
+				return append(collectIdentifiersFromBinary(be.Left), collectIdentifiersFromBinary(be.Right)...)
+			}
+			return nil
+		}
+
+		// checkPropValue inspects the value expression of a `key` JSX
+		// attribute or a `key` property in createElement / cloneElement
+		// props and reports any reference to a tracked array index.
+		// Mirrors upstream's `checkPropValue` byte-for-byte:
+		//   - Direct Identifier        → report on the value
+		//   - TemplateExpression       → report on the value, once per
+		//                                index-typed substitution (so
+		//                                `\`${i}-${i}\`` reports twice)
+		//   - BinaryExpression chain   → report on the value, once per
+		//                                index-typed leaf identifier
+		//   - `index.toString()`       → report on the call expression
+		//   - `String(index)`          → report on the index argument
+		// All other shapes (ConditionalExpression, ObjectLiteral, function
+		// calls that aren't `String` / `.toString()`, etc.) are opaque.
+		checkPropValue := func(node *ast.Node) {
+			if node == nil {
+				return
+			}
+			node = ast.SkipParentheses(node)
+			if node == nil {
+				return
+			}
+
+			if isArrayIndex(node) {
+				report(node)
+				return
+			}
+
+			if node.Kind == ast.KindTemplateExpression {
+				te := node.AsTemplateExpression()
+				if te.TemplateSpans != nil {
+					for _, span := range te.TemplateSpans.Nodes {
+						if span.Kind != ast.KindTemplateSpan {
+							continue
+						}
+						if isArrayIndex(span.AsTemplateSpan().Expression) {
+							report(node)
+						}
+					}
+				}
+				return
+			}
+
+			if node.Kind == ast.KindBinaryExpression {
+				for _, id := range collectIdentifiersFromBinary(node) {
+					if isArrayIndex(id) {
+						report(node)
+					}
+				}
+				return
+			}
+
+			if node.Kind == ast.KindCallExpression {
+				// Upstream's `astUtil.isCallExpression` accepts only
+				// `CallExpression`, NOT `OptionalCallExpression`. tsgo
+				// collapses both into `KindCallExpression`, so we must
+				// gate on `IsOptionalChain` to keep parity:
+				// `key={i?.toString()}` / `key={String?.(i)}` are NOT
+				// reported upstream and must NOT report here.
+				if ast.IsOptionalChain(node) {
+					return
+				}
+				call := node.AsCallExpression()
+				ce := ast.SkipParentheses(call.Expression)
+
+				if ce != nil && ce.Kind == ast.KindPropertyAccessExpression {
+					// Upstream `node.callee.type === 'MemberExpression'`
+					// rejects `OptionalMemberExpression`, so an optional
+					// `i?.toString` chain on the callee is opaque too.
+					if ast.IsOptionalChain(ce) {
+						return
+					}
+					pa := ce.AsPropertyAccessExpression()
+					prop := pa.Name()
+					if isArrayIndex(pa.Expression) && prop != nil && prop.Kind == ast.KindIdentifier && prop.AsIdentifier().Text == "toString" {
+						report(node)
+						return
+					}
+				}
+
+				if ce != nil && ce.Kind == ast.KindIdentifier && ce.AsIdentifier().Text == "String" {
+					if call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+						firstArg := call.Arguments.Nodes[0]
+						if isArrayIndex(firstArg) {
+							// Report on the unwrapped Identifier — ESTree
+							// flattens parens, so upstream's `node.arguments[0]`
+							// is the bare Identifier; tsgo preserves the
+							// wrapping ParenthesizedExpression, so reporting
+							// `firstArg` directly would widen the position
+							// range relative to upstream. Skip parens to
+							// match upstream's report range exactly.
+							report(ast.SkipParentheses(firstArg))
+						}
+					}
+				}
+			}
+		}
+
+		// checkObjectKeyProp walks the props object passed to
+		// createElement / cloneElement and runs `checkPropValue` on the
+		// initializer of any property named `key`. Computed /
+		// string-literal / numeric keys and spread elements are skipped
+		// — matches upstream's `prop.key.name === 'key'` guard which
+		// only fires for Identifier keys. SHORTHAND properties are
+		// included: upstream sees `prop.key` as Identifier `key` and
+		// `prop.value` as the same Identifier, so `{ key }` does match
+		// when the iterator's index parameter happens to be named `key`
+		// (e.g. `foo.map((bar, key) => React.cloneElement(c, { key }))`).
+		// keyMatchesUpstreamIdentifier mirrors upstream's
+		// `prop.key.name === 'key'` test in ESTree:
+		//   - `key: ...`              (Identifier key)               → name is 'key'
+		//   - `{ key }`               (Shorthand)                    → name is 'key'
+		//   - `[key]: ...`            (Computed, inner is Identifier `key`) → name is 'key'
+		//
+		// Other key shapes (StringLiteral / NumericLiteral / `[expr]`
+		// where expr is not an Identifier named `key`, PrivateIdentifier)
+		// have either `prop.key.name === undefined` or a different
+		// `.name`, and upstream rejects them.
+		keyMatchesUpstreamIdentifier := func(keyName *ast.Node) bool {
+			if keyName == nil {
+				return false
+			}
+			// ComputedPropertyName: ESTree puts the inner expression
+			// directly as `prop.key` (with `computed: true`), so an
+			// Identifier `key` inside `[key]` reads `prop.key.name === 'key'`.
+			if keyName.Kind == ast.KindComputedPropertyName {
+				inner := keyName.AsComputedPropertyName().Expression
+				return inner != nil && inner.Kind == ast.KindIdentifier && inner.AsIdentifier().Text == "key"
+			}
+			return keyName.Kind == ast.KindIdentifier && keyName.AsIdentifier().Text == "key"
+		}
+
+		checkObjectKeyProp := func(props *ast.Node) {
+			props = ast.SkipParentheses(props)
+			if props == nil || props.Kind != ast.KindObjectLiteralExpression {
+				return
+			}
+			obj := props.AsObjectLiteralExpression()
+			if obj.Properties == nil {
+				return
+			}
+			for _, prop := range obj.Properties.Nodes {
+				switch prop.Kind {
+				case ast.KindPropertyAssignment:
+					pa := prop.AsPropertyAssignment()
+					if !keyMatchesUpstreamIdentifier(pa.Name()) {
+						continue
+					}
+					if pa.Initializer != nil {
+						checkPropValue(pa.Initializer)
+					}
+				case ast.KindShorthandPropertyAssignment:
+					// `{ key }` — both the property's name AND the
+					// referenced binding are the Identifier `key`.
+					// Upstream's `checkPropValue(prop.value)` runs on
+					// that Identifier, which matches the index stack
+					// only when the callback's index parameter is
+					// itself named `key`.
+					spa := prop.AsShorthandPropertyAssignment()
+					nameNode := spa.Name()
+					if !keyMatchesUpstreamIdentifier(nameNode) {
+						continue
+					}
+					checkPropValue(nameNode)
+				}
+			}
+		}
+
+		// isCreateCloneElement mirrors upstream's `isCreateCloneElement`
+		// byte-for-byte:
+		//
+		//   - Member-access (or optional-member-access) callee:
+		//     `<pragma>.createElement` / `<pragma>.cloneElement`. Parens
+		//     on the pragma sub-expression are skipped (ESTree
+		//     flattens), TS expression wrappers are NOT (ESLint's JS
+		//     parser cannot produce them).
+		//
+		//   - Bare Identifier callee: ANY identifier whose binding
+		//     resolves to an `import { <name> } from 'react'`
+		//     ImportSpecifier (the literal string 'react' is hardcoded
+		//     upstream — `pragma` setting does NOT change it). Crucially,
+		//     upstream does NOT verify that the imported name is
+		//     `createElement` / `cloneElement`: any react-imported name
+		//     is accepted. This is technically an upstream bug, but we
+		//     mirror it exactly for 1:1 parity.
+		//
+		// Constructions like `const { cloneElement } = React`,
+		// `const cloneElement = React.cloneElement`, and
+		// `const { cloneElement } = require('react')` are NOT
+		// recognized — upstream's `findVariableByName` returns the
+		// VariableDeclaration, whose `.type` is not `'ImportSpecifier'`.
+		isCreateCloneElement := func(callee *ast.Node) bool {
+			if callee == nil {
+				return false
+			}
+			callee = ast.SkipParentheses(callee)
+			if callee == nil {
+				return false
+			}
+
+			if callee.Kind == ast.KindPropertyAccessExpression {
+				pa := callee.AsPropertyAccessExpression()
+				name := pa.Name()
+				if name == nil || name.Kind != ast.KindIdentifier {
+					return false
+				}
+				txt := name.AsIdentifier().Text
+				if txt != "createElement" && txt != "cloneElement" {
+					return false
+				}
+				obj := ast.SkipParentheses(pa.Expression)
+				return obj != nil && obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == pragma
+			}
+
+			if callee.Kind == ast.KindIdentifier {
+				return isImportSpecifierFromReact(ctx, callee)
+			}
+
+			return false
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+
+				if isCreateCloneElement(call.Expression) && call.Arguments != nil && len(call.Arguments.Nodes) > 1 {
+					if len(indexParamNames) == 0 {
+						return
+					}
+					checkObjectKeyProp(call.Arguments.Nodes[1])
+					return
+				}
+
+				if name := getMapIndexParamName(call); name != "" {
+					indexParamNames = append(indexParamNames, name)
+				}
+			},
+			rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
+				if name := getMapIndexParamName(node.AsCallExpression()); name != "" && len(indexParamNames) > 0 {
+					indexParamNames = indexParamNames[:len(indexParamNames)-1]
+				}
+			},
+			ast.KindJsxAttribute: func(node *ast.Node) {
+				attr := node.AsJsxAttribute()
+				name := attr.Name()
+				if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "key" {
+					return
+				}
+				if len(indexParamNames) == 0 {
+					return
+				}
+				init := attr.Initializer
+				if init == nil || init.Kind != ast.KindJsxExpression {
+					return
+				}
+				expr := init.AsJsxExpression().Expression
+				if expr == nil {
+					return
+				}
+				checkPropValue(expr)
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_array_index_key/no_array_index_key.md
+++ b/internal/plugins/react/rules/no_array_index_key/no_array_index_key.md
@@ -1,0 +1,71 @@
+# no-array-index-key
+
+Warn if an array `index` is used as the `key` prop of a React element rendered by `Array.prototype.map`, `forEach`, `filter`, `find`, `findIndex`, `flatMap`, `reduce`, `reduceRight`, `some`, `every`, or `React.Children.map` / `React.Children.forEach`.
+
+`key` should identify an element across renders. Since the array index changes whenever an item is added, removed, or reordered, using it as `key` defeats React's reconciliation and can cause subtle state leakage and rendering bugs.
+
+## Rule Details
+
+The following shapes are reported when they reference the iterator callback's index parameter:
+
+- Direct identifier (`key={i}`)
+- Template literal substitution (`` key={`item-${i}`} ``)
+- Concatenation chain (`key={'item-' + i}`, `key={'item-' + i + '-x'}`)
+- Coercion via `i.toString()` or `String(i)`
+
+This applies to both JSX `key` attributes and the `key` property of the props object passed to `React.createElement` / `React.cloneElement` (or to bare `createElement` / `cloneElement` imported from `'react'`).
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+things.map((thing, index) => <Hello key={index} />);
+```
+
+```jsx
+things.map((thing, index) => <Hello key={`item-${index}`} />);
+```
+
+```jsx
+things.map((thing, index) => <Hello key={'item-' + index} />);
+```
+
+```jsx
+things.map((thing, index) => React.cloneElement(thing, { key: index }));
+```
+
+```jsx
+things.forEach((thing, index) => {
+  otherThings.push(<Hello key={index} />);
+});
+```
+
+```jsx
+React.Children.map(this.props.children, (child, index) =>
+  React.cloneElement(child, { key: index }),
+);
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+things.map((thing) => <Hello key={thing.id} />);
+```
+
+```jsx
+things.map((thing, index) => <Hello key={thing.id} />);
+```
+
+```jsx
+React.Children.map(this.props.children, (child) =>
+  React.cloneElement(child, { key: child.id }),
+);
+```
+
+## When Not To Use It
+
+If you have a stable list of items that will never be reordered, inserted into, or removed from, the consequences of an unstable key may be acceptable. In that case, disable the rule for the specific call site rather than globally.
+
+## Original Documentation
+
+- [eslint-plugin-react / no-array-index-key](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-array-index-key.js)

--- a/internal/plugins/react/rules/no_array_index_key/no_array_index_key_test.go
+++ b/internal/plugins/react/rules/no_array_index_key/no_array_index_key_test.go
@@ -1,0 +1,977 @@
+package no_array_index_key
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoArrayIndexKeyRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoArrayIndexKeyRule, []rule_tester.ValidTestCase{
+		// ---- Outside of any tracked iterator, every shape is fine ----
+		{Code: `<Foo key="foo" />;`, Tsx: true},
+		{Code: `<Foo key={i} />;`, Tsx: true},
+		{Code: `<Foo key />;`, Tsx: true},
+		{Code: `<Foo key={` + "`" + `foo-${i}` + "`" + `} />;`, Tsx: true},
+		{Code: `<Foo key={'foo-' + i} />;`, Tsx: true},
+
+		// ---- Untracked iterators (not in indexParamPositions) ----
+		{Code: `foo.bar((baz, i) => <Foo key={i} />)`, Tsx: true},
+		{Code: `foo.bar((bar, i) => <Foo key={` + "`" + `foo-${i}` + "`" + `} />)`, Tsx: true},
+		{Code: `foo.bar((bar, i) => <Foo key={'foo-' + i} />)`, Tsx: true},
+
+		// ---- Tracked iterators, but key does NOT reference the index ----
+		{Code: `foo.map((baz) => <Foo key={baz.id} />)`, Tsx: true},
+		{Code: `foo.map((baz, i) => <Foo key={baz.id} />)`, Tsx: true},
+		{Code: `foo.map((baz, i) => <Foo key={'foo' + baz.id} />)`, Tsx: true},
+		{Code: `foo.map((baz, i) => React.cloneElement(someChild, { ...someChild.props }))`, Tsx: true},
+		{Code: `foo.map((baz, i) => cloneElement(someChild, { ...someChild.props }))`, Tsx: true},
+		{
+			Code: `
+foo.map((item, i) => {
+  return React.cloneElement(someChild, {
+    key: item.id
+  })
+})
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+foo.map((item, i) => {
+  return cloneElement(someChild, {
+    key: item.id
+  })
+})
+`,
+			Tsx: true,
+		},
+		{Code: `foo.map((baz, i) => <Foo key />)`, Tsx: true},
+		{Code: `foo.reduce((a, b) => a.concat(<Foo key={b.id} />), [])`, Tsx: true},
+
+		// ---- Index identifier appears, but not as a tracked-by-rule shape ----
+		// `i.baz.toString()` — only the direct `index.toString()` shape is
+		// tracked; deeper member accesses fall through.
+		{Code: `foo.map((bar, i) => <Foo key={i.baz.toString()} />)`, Tsx: true},
+		// `i.toString` — accessing the method without invoking it.
+		{Code: `foo.map((bar, i) => <Foo key={i.toString} />)`, Tsx: true},
+		// `String()` — empty argument list.
+		{Code: `foo.map((bar, i) => <Foo key={String()} />)`, Tsx: true},
+		// `String(baz)` — non-index argument.
+		{Code: `foo.map((bar, i) => <Foo key={String(baz)} />)`, Tsx: true},
+
+		// ---- Tracked iterators with insufficient params for the index slot ----
+		{Code: `foo.flatMap((a) => <Foo key={a} />)`, Tsx: true},
+		{Code: `foo.reduce((a, b, i) => a.concat(<Foo key={b.id} />), [])`, Tsx: true},
+		{Code: `foo.reduceRight((a, b) => a.concat(<Foo key={b.id} />), [])`, Tsx: true},
+		{Code: `foo.reduceRight((a, b, i) => a.concat(<Foo key={b.id} />), [])`, Tsx: true},
+
+		// ---- React.Children.* / Children.* — callback at args[1], non-index key ----
+		{
+			Code: `
+React.Children.map(this.props.children, (child, index, arr) => {
+  return React.cloneElement(child, { key: child.id });
+})
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+React.Children.map(this.props.children, (child, index, arr) => {
+  return cloneElement(child, { key: child.id });
+})
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+Children.forEach(this.props.children, (child, index, arr) => {
+  return React.cloneElement(child, { key: child.id });
+})
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+Children.forEach(this.props.children, (child, index, arr) => {
+  return cloneElement(child, { key: child.id });
+})
+`,
+			Tsx: true,
+		},
+
+		// ---- Optional chaining iterator with non-index key ----
+		{Code: `foo?.map(child => <Foo key={child.i} />)`, Tsx: true},
+
+		// ---- tsgo edge shapes that upstream's tests don't exercise ----
+		// Parenthesized index reference.
+		{Code: `foo.map((bar, i) => <Foo key={(bar.i)} />)`, Tsx: true},
+		// Optional-chain receiver in `index?.toString()` — upstream's
+		// `astUtil.isCallExpression` accepts both regular and optional
+		// call shapes; we lock in that the rule still treats this as
+		// the toString() coercion form (an array index escape route).
+		{Code: `foo.map((bar, idx) => <Foo key={String('a' + bar.id)} />)`, Tsx: true},
+		// Bare `cloneElement` callee with no `import { cloneElement }
+		// from 'react'` — upstream returns false for the bare-identifier
+		// branch when the binding doesn't resolve to the pragma module,
+		// so no report.
+		{
+			Code: `
+const cloneElement = (...args) => args;
+foo.map((baz, i) => cloneElement(someChild, { key: i }))
+`,
+			Tsx: true,
+		},
+		// ---- Identifier branch only accepts ImportSpecifier ----
+		// Upstream `isCreateCloneElement` Identifier branch is gated on
+		// `variable.type === 'ImportSpecifier'`. Each shape below
+		// produces a non-ImportSpecifier binding and therefore is NOT
+		// recognized as a React factory — green-path locks.
+		{
+			Code: `
+const { cloneElement } = React;
+foo.map((baz, i) => cloneElement(someChild, { key: i }))
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+const cloneElement = React.cloneElement;
+foo.map((baz, i) => cloneElement(someChild, { key: i }))
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+const { cloneElement } = require('react');
+foo.map((baz, i) => cloneElement(someChild, { key: i }))
+`,
+			Tsx: true,
+		},
+		// Module specifier is hardcoded `'react'` upstream — pragma
+		// configuration does NOT change it. With pragma "Act" but
+		// import from 'act', the bare callee is NOT recognized.
+		{
+			Code: `
+import { cloneElement } from 'act';
+foo.map((baz, i) => cloneElement(someChild, { key: i }))
+`,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"pragma": "Act"},
+			},
+		},
+
+		// ---- Universal edge shapes that upstream tests don't cover ----
+		// Tagged template — tsgo's KindTaggedTemplateExpression is NOT
+		// KindTemplateExpression, so the substitution-walk branch never
+		// fires. Lock the negative.
+		{Code: `foo.map((bar, i) => <Foo key={tag` + "`" + `foo-${i}` + "`" + `} />)`, Tsx: true},
+		// No-substitution template — KindNoSubstitutionTemplateLiteral,
+		// not TemplateExpression; even though the source contains an
+		// `i`-shaped sequence as text, there is no expression substitution.
+		{Code: `foo.map((bar, i) => <Foo key={` + "`" + `foo-i` + "`" + `} />)`, Tsx: true},
+		// Conditional inside a binary chain — upstream's flatten only
+		// recurses through BinaryExpression, so the index reference
+		// inside the ternary is opaque and does NOT report.
+		{Code: `foo.map((bar, i) => <Foo key={'a' + (i ? 'x' : 'y')} />)`, Tsx: true},
+		// Identity-wrapped index — `identity(i)` is a CallExpression
+		// whose callee is neither `String` nor an `index.toString()`
+		// shape; not reported.
+		{Code: `foo.map((bar, i) => <Foo key={identity(i)} />)`, Tsx: true},
+		// Object-literal as the key value (`key: { nested: i }`) —
+		// upstream's checkPropValue has no ObjectLiteral branch.
+		{Code: `foo.map((bar, i) => React.createElement('Foo', { key: { nested: i } }))`, Tsx: true},
+		// `String['toString'](i)` — bracket access doesn't match the
+		// dotted `index.toString()` shape and the callee identifier
+		// is `String`, so we'd fall into the String branch — but the
+		// receiver isn't an Identifier referencing the index, so we
+		// stay in valid territory.
+		{Code: `foo.map((bar, i) => <Foo key={i['toString']()} />)`, Tsx: true},
+		// Destructured index parameter `(bar, [i])` — upstream pushes
+		// `undefined`; we return "" and skip. Either way, `i` inside
+		// the JSX is NOT recognized as the tracked index because the
+		// stack does not contain a matching name.
+		{Code: `foo.map((bar, [i]) => <Foo key={i} />)`, Tsx: true},
+		// Rest-only index slot `(bar, ...rest)` — pos overshoots; no push.
+		{Code: `foo.map((bar, ...rest) => <Foo key={rest[0]} />)`, Tsx: true},
+		// String() on a deeper member access (`String(i.foo)`) —
+		// upstream's `node.arguments[0]` must itself be the index
+		// identifier; a member-access argument is NOT a match.
+		{Code: `foo.map((bar, i) => <Foo key={String(i.foo)} />)`, Tsx: true},
+
+		// ---- TS expression wrappers on the pragma identifier / key value ----
+		// ESLint's JavaScript parser cannot produce `as` / `!` / `<T>x` /
+		// `satisfies` shapes, so its `no-array-index-key` never sees
+		// them. We mirror that exactly:
+		//   - the pragma identifier behind a TS wrapper is NOT
+		//     recognized as the React factory (the dotted access fails
+		//     the Identifier check);
+		//   - the JSX key value behind a TS wrapper is opaque to
+		//     `checkPropValue`'s direct-Identifier branch.
+		// Iterator receiver shape is intentionally NOT included here —
+		// upstream's `getMapIndexParamName` doesn't inspect the
+		// receiver at all (only `callee.property.name`), so
+		// `(foo as any[]).map(...)` still fires; that case is in the
+		// invalid suite below.
+		{Code: `foo.map((bar, i) => (React as any).cloneElement(c, { key: i }))`, Tsx: true},
+		{Code: `foo.map((bar, i) => React!.createElement('Foo', { key: i }))`, Tsx: true},
+		{Code: `foo.map((bar, i) => <Foo key={(i as any)} />)`, Tsx: true},
+
+		// ---- Optional-chain CallExpression as the key value ----
+		// Upstream `astUtil.isCallExpression(node)` rejects
+		// `OptionalCallExpression`, and `node.callee.type === 'MemberExpression'`
+		// rejects `OptionalMemberExpression`. Three opaque shapes:
+		//   - `i?.toString()` (optional member callee)
+		//   - `String?.(i)` (optional call)
+		//   - `i?.toString?.()` (both)
+		// Each is a green-path lock.
+		{Code: `foo.map((bar, i) => <Foo key={i?.toString()} />)`, Tsx: true},
+		{Code: `foo.map((bar, i) => <Foo key={String?.(i)} />)`, Tsx: true},
+		{Code: `foo.map((bar, i) => <Foo key={i?.toString?.()} />)`, Tsx: true},
+
+		// ---- Real user scenarios that should NOT report ----
+		// React.createElement / cloneElement OUTSIDE any iterator —
+		// stack is empty; the props-key check short-circuits.
+		{Code: `React.createElement('Foo', { key: i })`, Tsx: true},
+		{Code: `React.cloneElement(child, { key: i })`, Tsx: true},
+		// Iterator with a `thisArg` third argument — `args[0]` is the
+		// callback, the third arg is irrelevant. Index named `i` lives
+		// on the stack inside the callback.
+		{Code: `foo.map((bar) => <Foo key={bar.id} />, this)`, Tsx: true},
+		// Iterator on an empty array — still recognized as map; index
+		// not referenced, so no report.
+		{Code: `[].map((bar, i) => <Foo key={bar.id} />)`, Tsx: true},
+		// Computed-key with StringLiteral inside (`["key"]: i`) —
+		// upstream's `prop.key.name` reads the inner Literal, which
+		// has no `.name` field, so `=== 'key'` fails. NOT reported.
+		{Code: `foo.map((bar, i) => React.createElement('Foo', { ["key"]: i }))`, Tsx: true},
+		// String-literal key `"key"` — same opaque shape, no report.
+		{Code: `foo.map((bar, i) => React.createElement('Foo', { "key": i }))`, Tsx: true},
+		// Computed-key with NON-`key` Identifier inside (`[other]: i`) —
+		// `prop.key.name === 'other' !== 'key'`. NOT reported.
+		{Code: `foo.map((bar, i) => React.createElement('Foo', { [other]: i }))`, Tsx: true},
+		// Shorthand `{ key }` in cloneElement props when the index
+		// parameter is NOT named `key` — `checkPropValue` runs on the
+		// Identifier `key`, but `key` is not on the indexParamNames
+		// stack, so no report.
+		{Code: `foo.map((bar, i) => { const key = bar.id; return React.cloneElement(c, { key }); })`, Tsx: true},
+		// Iterator returning a non-JSX value — rule never inspects.
+		{Code: `foo.map((bar, i) => bar + i)`, Tsx: true},
+		// Empty arrow body — no JSX, no createElement, nothing to check.
+		{Code: `foo.map((bar, i) => {})`, Tsx: true},
+		// Nested iterator where INNER shadows the outer index name —
+		// the stack contains `i` twice; pop order is correct so on exit
+		// we still have one `i` left for the outer scope. Locks the
+		// stack-pop balance.
+		{Code: `foo.map((a, i) => bar.map((c, i) => <X key={c.id} />))`, Tsx: true},
+		// `BigInt` / numeric / boolean literal keys — none match the
+		// Identifier / Template / Binary / call-form gates.
+		{Code: `foo.map((bar, i) => <Foo key={42} />)`, Tsx: true},
+		{Code: `foo.map((bar, i) => <Foo key={true} />)`, Tsx: true},
+		// Reduce accumulator `a` (param 0) is NOT the index even though
+		// the rule "watches" `reduce` — index is at position 2.
+		{Code: `foo.reduce((a, b) => a.concat(<Foo key={a} />), [])`, Tsx: true},
+		// Default-valued index parameter `(bar, i = 0)` — upstream's
+		// AssignmentPattern has no plain `.name`, so the index is
+		// NOT pushed. Locked in for input/output parity.
+		{Code: `foo.map((bar, i = 0) => <Foo key={i} />)`, Tsx: true},
+		// Rule receives extra options — schema is `[]` upstream, but
+		// pass-through must not break. `GetOptionsMap` is not used by
+		// this rule; we still verify that arbitrary input doesn't
+		// disturb behavior.
+		{
+			Code:    `foo.map((bar, i) => <Foo key={bar.id} />)`,
+			Tsx:     true,
+			Options: map[string]interface{}{"unknown": true},
+		},
+		// `settings.react.pragma = "Act"` — `Act.createElement` becomes
+		// the recognized factory; `React.createElement` is no longer
+		// matched, so referencing the index in `React.createElement`
+		// props would NOT trigger the createElement branch. Verified
+		// here as a green-path control alongside the invalid mirror
+		// below.
+		{
+			Code: `foo.map((bar, i) => Act.cloneElement(c, { key: bar.id }))`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"pragma": "Act"},
+			},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Direct index reference in JSX key attribute ----
+		{
+			Code: `foo.map((bar, i) => <Foo key={i} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 31},
+			},
+		},
+		{
+			Code: `[{}, {}].map((bar, i) => <Foo key={i} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 36},
+			},
+		},
+		{
+			Code: `foo.map((bar, anything) => <Foo key={anything} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 38},
+			},
+		},
+
+		// ---- Template literal containing the index ----
+		{
+			Code: `foo.map((bar, i) => <Foo key={` + "`" + `foo-${i}` + "`" + `} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 31},
+			},
+		},
+
+		// ---- Concatenation chain ----
+		{
+			Code: `foo.map((bar, i) => <Foo key={'foo-' + i} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 31},
+			},
+		},
+		{
+			Code: `foo.map((bar, i) => <Foo key={'foo-' + i + '-bar'} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 31},
+			},
+		},
+
+		// ---- React.cloneElement (member-access callee) ----
+		{
+			Code: `foo.map((baz, i) => React.cloneElement(someChild, { ...someChild.props, key: i }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 78},
+			},
+		},
+
+		// ---- Bare `cloneElement` resolved from `import { cloneElement } from 'react'` ----
+		{
+			Code: `
+import { cloneElement } from 'react';
+
+foo.map((baz, i) => cloneElement(someChild, { ...someChild.props, key: i }))
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 4, Column: 72},
+			},
+		},
+
+		// ---- React.cloneElement inside a block-bodied callback ----
+		{
+			Code: `
+foo.map((item, i) => {
+  return React.cloneElement(someChild, {
+    key: i
+  })
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 4, Column: 10},
+			},
+		},
+		{
+			Code: `
+import { cloneElement } from 'react';
+
+foo.map((item, i) => {
+  return cloneElement(someChild, {
+    key: i
+  })
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 6, Column: 10},
+			},
+		},
+
+		// ---- Every iterator method in indexParamPositions, JSX path ----
+		{
+			Code: `foo.forEach((bar, i) => { baz.push(<Foo key={i} />); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 46},
+			},
+		},
+		{
+			Code: `foo.filter((bar, i) => { baz.push(<Foo key={i} />); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 45},
+			},
+		},
+		{
+			Code: `foo.some((bar, i) => { baz.push(<Foo key={i} />); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 43},
+			},
+		},
+		{
+			Code: `foo.every((bar, i) => { baz.push(<Foo key={i} />); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 44},
+			},
+		},
+		{
+			Code: `foo.find((bar, i) => { baz.push(<Foo key={i} />); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 43},
+			},
+		},
+		{
+			Code: `foo.findIndex((bar, i) => { baz.push(<Foo key={i} />); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 48},
+			},
+		},
+		{
+			Code: `foo.reduce((a, b, i) => a.concat(<Foo key={i} />), [])`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 44},
+			},
+		},
+		{
+			Code: `foo.flatMap((a, i) => <Foo key={i} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 33},
+			},
+		},
+		{
+			Code: `foo.reduceRight((a, b, i) => a.concat(<Foo key={i} />), [])`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 49},
+			},
+		},
+
+		// ---- React.createElement (member-access callee) with various index shapes ----
+		{
+			Code: `foo.map((bar, i) => React.createElement('Foo', { key: i }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 55},
+			},
+		},
+		{
+			Code: `foo.map((bar, i) => React.createElement('Foo', { key: ` + "`" + `foo-${i}` + "`" + ` }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 55},
+			},
+		},
+		{
+			Code: `foo.map((bar, i) => React.createElement('Foo', { key: 'foo-' + i }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 55},
+			},
+		},
+		{
+			Code: `foo.map((bar, i) => React.createElement('Foo', { key: 'foo-' + i + '-bar' }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 55},
+			},
+		},
+
+		// ---- Every iterator method, createElement props path ----
+		{
+			Code: `foo.forEach((bar, i) => { baz.push(React.createElement('Foo', { key: i })); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 70},
+			},
+		},
+		{
+			Code: `foo.filter((bar, i) => { baz.push(React.createElement('Foo', { key: i })); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 69},
+			},
+		},
+		{
+			Code: `foo.some((bar, i) => { baz.push(React.createElement('Foo', { key: i })); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 67},
+			},
+		},
+		{
+			Code: `foo.every((bar, i) => { baz.push(React.createElement('Foo', { key: i })); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 68},
+			},
+		},
+		{
+			Code: `foo.find((bar, i) => { baz.push(React.createElement('Foo', { key: i })); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 67},
+			},
+		},
+		{
+			Code: `foo.findIndex((bar, i) => { baz.push(React.createElement('Foo', { key: i })); })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 72},
+			},
+		},
+
+		// ---- React.Children.* (callback shifted to args[1]) ----
+		{
+			Code: `
+Children.map(this.props.children, (child, index) => {
+  return React.cloneElement(child, { key: index });
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 3, Column: 43},
+			},
+		},
+		{
+			Code: `
+import { cloneElement } from 'react';
+
+Children.map(this.props.children, (child, index) => {
+  return cloneElement(child, { key: index });
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 5, Column: 37},
+			},
+		},
+		{
+			Code: `
+React.Children.map(this.props.children, (child, index) => {
+  return React.cloneElement(child, { key: index });
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 3, Column: 43},
+			},
+		},
+		{
+			Code: `
+import { cloneElement } from 'react';
+
+React.Children.map(this.props.children, (child, index) => {
+  return cloneElement(child, { key: index });
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 5, Column: 37},
+			},
+		},
+		{
+			Code: `
+Children.forEach(this.props.children, (child, index) => {
+  return React.cloneElement(child, { key: index });
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 3, Column: 43},
+			},
+		},
+		{
+			Code: `
+import { cloneElement } from 'react';
+
+Children.forEach(this.props.children, (child, index) => {
+  return cloneElement(child, { key: index });
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 5, Column: 37},
+			},
+		},
+		{
+			Code: `
+React.Children.forEach(this.props.children, (child, index) => {
+  return React.cloneElement(child, { key: index });
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 3, Column: 43},
+			},
+		},
+		{
+			Code: `
+import { cloneElement } from 'react';
+
+React.Children.forEach(this.props.children, (child, index) => {
+  return cloneElement(child, { key: index });
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 5, Column: 37},
+			},
+		},
+
+		// ---- Optional-chain iterator ----
+		{
+			Code: `foo?.map((child, i) => <Foo key={i} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 34},
+			},
+		},
+
+		// ---- index.toString() coercion ----
+		{
+			Code: `
+foo.map((bar, index) => (
+  <Element key={index.toString()} bar={bar} />
+))
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 3, Column: 17},
+			},
+		},
+
+		// ---- String(index) coercion — report on the index argument ----
+		{
+			Code: `
+foo.map((bar, index) => (
+  <Element key={String(index)} bar={bar} />
+))
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 3, Column: 24},
+			},
+		},
+
+		// ---- Trivial multi-line index reference (parens around the JSX) ----
+		{
+			Code: `
+foo.map((bar, index) => (
+  <Element key={index} bar={bar} />
+))
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 3, Column: 17},
+			},
+		},
+
+		// ---- Nested iterators: outer index used inside inner callback ----
+		// Stack contains both `i` (outer) and `j` (inner); outer name
+		// referenced from the inner JSX is reported.
+		{
+			Code: `foo.map((a, i) => bar.map((c, j) => <X key={i} />))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 45},
+			},
+		},
+		// Inner index used inside inner JSX — both names live on the
+		// stack; the same-level match still reports exactly once.
+		{
+			Code: `foo.map((a, i) => bar.map((c, j) => <X key={j} />))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 45},
+			},
+		},
+		// Same index name reused across nested levels — each push goes
+		// onto the stack independently, but the JSX references collapse
+		// to the same name; both inner and outer JSX reference reports
+		// correctly. Locks in upstream's name-based matching.
+		{
+			Code: `foo.map((a, i) => bar.map((c, i) => <X key={i} />))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 45},
+			},
+		},
+		// Untracked iterator nested inside a tracked one — the outer
+		// index `i` remains on the stack while the inner `bar.qux` does
+		// NOT push, so `i` is still reportable from inside the inner
+		// callback's JSX.
+		{
+			Code: `foo.map((a, i) => bar.qux((c, j) => <X key={i} />))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 45},
+			},
+		},
+
+		// ---- Nested function inside an iterator body keeps tracking ----
+		// Upstream pushes/pops only on CallExpression boundaries, NOT on
+		// nested function-definition boundaries — so an inner regular
+		// function still sees `i` as a tracked index. Locks in parity.
+		{
+			Code: `
+foo.map((bar, i) => function inner() {
+  return <Foo key={i} />;
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 3, Column: 20},
+			},
+		},
+
+		// ---- Identifier branch: ANY react-imported name is accepted ----
+		// Upstream's `isCreateCloneElement` Identifier branch does NOT
+		// verify that the imported name is `createElement` /
+		// `cloneElement` — it returns true for any `import { ... } from
+		// 'react'` ImportSpecifier. We mirror this quirk byte-for-byte.
+		// Here `import { foo } from 'react'` makes the bare callee
+		// `foo(...)` look like a React factory call; `key: i` reports.
+		{
+			Code: `
+import { foo } from 'react';
+
+foo.map((bar, i) => foo(c, { key: i }))
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 4, Column: 35},
+			},
+		},
+
+		// ---- Optional-chain pragma `React?.cloneElement` ----
+		// Upstream listens on `'CallExpression, OptionalCallExpression'`
+		// and gates on
+		// `node.type === 'MemberExpression' || 'OptionalMemberExpression'`,
+		// so optional-chain pragma calls ARE recognized. Locked here.
+		{
+			Code: `foo.map((bar, i) => React?.cloneElement(c, { key: i }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 51},
+			},
+		},
+		{
+			Code: `foo.map((bar, i) => React?.createElement('Foo', { key: i }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 56},
+			},
+		},
+
+		// ---- Multi-substitution template — one report per index span ----
+		// Upstream's loop reports once per substitution that resolves to
+		// the index, even when the whole TemplateLiteral is the report
+		// target. `\`${i}-${i}\`` therefore yields TWO reports.
+		{
+			Code: `foo.map((bar, i) => <Foo key={` + "`" + `${i}-${i}` + "`" + `} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 31},
+				{MessageId: "noArrayIndex", Line: 1, Column: 31},
+			},
+		},
+		// Multiple index-typed leaves in a Binary chain — one report each.
+		{
+			Code: `foo.map((bar, i) => <Foo key={i + '-' + i} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 31},
+				{MessageId: "noArrayIndex", Line: 1, Column: 31},
+			},
+		},
+
+		// ---- Multiple `key` keys in the same props object ----
+		// Upstream iterates every property whose Identifier name is
+		// `key` and runs `checkPropValue` on each. Two index-typed
+		// `key`s yield TWO reports.
+		{
+			Code: `foo.map((bar, i) => React.createElement('Foo', { key: i, key: i }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 55},
+				{MessageId: "noArrayIndex", Line: 1, Column: 63},
+			},
+		},
+
+		// ---- Nested cloneElement: each call inspects its own key ----
+		// Outer CallExpression's listener fires first (column 82), then
+		// the inner one (column 69) — both `key: i` pairs report
+		// independently.
+		{
+			Code: `foo.map((bar, i) => React.cloneElement(React.cloneElement(c, { key: i }), { key: i }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 82},
+				{MessageId: "noArrayIndex", Line: 1, Column: 69},
+			},
+		},
+
+		// ---- Real-user scenarios: settings.react.pragma swap ----
+		// With `pragma: "Act"`, `Act.cloneElement(...)` IS the React
+		// factory; `key: i` inside it is reported, while the same code
+		// using `React.cloneElement` would NOT match (the inverse case
+		// is the green-path test in the valid block).
+		{
+			Code: `foo.map((bar, i) => Act.cloneElement(c, { key: i }))`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"pragma": "Act"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 48},
+			},
+		},
+
+		// ---- Chained property access on the iterator receiver ----
+		// `foo.bar.map(...)` — the callee's property is `map`, the
+		// receiver's full shape doesn't matter to the iterator gate.
+		{
+			Code: `foo.bar.map((c, i) => <X key={i} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 31},
+			},
+		},
+
+		// ---- Iterator callback inside an IIFE wrapper ----
+		// `foo.map((function(){ return (a,i)=>... })())` — the actual
+		// callback at args[0] is a CallExpression, NOT a function,
+		// so `getMapIndexParamName` returns "" and the index is not
+		// pushed. Renders as a green-path scenario (no report) — locked
+		// here as an INVERSE of the canonical "callback must be a
+		// function literal" gate. Goes in valid since no diagnostic.
+		// (See valid suite — kept here as a comment marker only.)
+
+		// ---- `String(index)` reports on the argument node ----
+		// Lock in the upstream report-target distinction: `index.toString()`
+		// reports on the CALL, but `String(index)` reports on the
+		// ARGUMENT. We already have the simple case; this reinforces
+		// it across the index-passed-via-parens form.
+		{
+			Code: `foo.map((bar, i) => <Foo key={String((i))} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Reports on the unwrapped Identifier `i` — matches
+				// upstream's report range (ESTree flattens parens, so
+				// `node.arguments[0]` is the bare Identifier).
+				{MessageId: "noArrayIndex", Line: 1, Column: 39},
+			},
+		},
+
+		// ---- JSX element key inside a JSX-children expression ----
+		// `<div>{foo.map((bar, i) => <X key={i} />)}</div>` — the
+		// iterator lives inside a JsxExpression child; that's a
+		// regular CallExpression to our listener.
+		{
+			Code: `<div>{foo.map((bar, i) => <X key={i} />)}</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 35},
+			},
+		},
+
+		// ---- Shorthand `{ key }` when the index parameter is named `key` ----
+		// Upstream's `prop.key.name === 'key'` matches the shorthand;
+		// `checkPropValue(prop.value)` then sees the Identifier `key`,
+		// which is the index parameter on the stack. Locks the
+		// previously-missed shorthand branch in `checkObjectKeyProp`.
+		{
+			Code: `foo.map((bar, key) => React.cloneElement(c, { key }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 47},
+			},
+		},
+
+		// ---- TS-wrapped iterator receiver still triggers the iterator gate ----
+		// Upstream's `getMapIndexParamName` reads `callee.property.name`
+		// only; the receiver shape is opaque. So `(foo as any[]).map(...)`
+		// IS recognized as a tracked iterator.
+		{
+			Code: `(foo as any[]).map((bar, i) => <Foo key={i} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 42},
+			},
+		},
+
+		// ---- Mixed key kinds: only Identifier-`key` and `[key]` match ----
+		// `["key"]: i` (StringLiteral inside computed) is opaque
+		// upstream — `prop.key.name` is undefined on a Literal.
+		// Plain `key: i` matches via Identifier. Locked here.
+		{
+			Code: `foo.map((bar, i) => React.createElement('Foo', { key: i, ["key"]: i }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 55},
+			},
+		},
+
+		// ---- Computed property `[<Identifier "key">]: ...` ----
+		// Upstream ESTree puts the inner expression directly as
+		// `prop.key` when `computed: true`. With `[key]: key` and the
+		// iterator's index parameter named `key`, `prop.key.name ===
+		// 'key'` matches; `checkPropValue(prop.value)` then reports on
+		// the value Identifier `key` (which is the index). Locks the
+		// upstream computed-property quirk byte-for-byte.
+		{
+			Code: `foo.map((bar, key) => React.cloneElement(c, { [key]: key }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 54},
+			},
+		},
+
+		// ---- React.Children.toArray result piped into .map(...) ----
+		// `React.Children.toArray(children).map((c, i) => <X key={i} />)`
+		// — `.map` on the toArray result is a normal map; `i` is the
+		// index, reported.
+		{
+			Code: `React.Children.toArray(children).map((c, i) => <X key={i} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 56},
+			},
+		},
+
+		// ---- Block-bodied callback with multiple JSX returns ----
+		// One report per JSX `key` reference, regardless of position.
+		{
+			Code: `
+foo.map((bar, i) => {
+  if (cond) return <A key={i} />;
+  return <B key={i} />;
+})
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 3, Column: 28},
+				{MessageId: "noArrayIndex", Line: 4, Column: 18},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -113,6 +113,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-curly-brace-presence.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
     './tests/eslint-plugin-react/rules/no-access-state-in-setstate.test.ts',
+    './tests/eslint-plugin-react/rules/no-array-index-key.test.ts',
     './tests/eslint-plugin-react/rules/no-children-prop.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
     './tests/eslint-plugin-react/rules/no-danger-with-children.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-array-index-key.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-array-index-key.test.ts
@@ -1,0 +1,610 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-array-index-key', {} as never, {
+  valid: [
+    // ---- Outside any tracked iterator ----
+    { code: `<Foo key="foo" />;` },
+    { code: `<Foo key={i} />;` },
+    { code: `<Foo key />;` },
+    { code: '<Foo key={`foo-${i}`} />;' },
+    { code: `<Foo key={'foo-' + i} />;` },
+
+    // ---- Untracked iterators (.bar) ----
+    { code: `foo.bar((baz, i) => <Foo key={i} />);` },
+    { code: 'foo.bar((bar, i) => <Foo key={`foo-${i}`} />);' },
+    { code: `foo.bar((bar, i) => <Foo key={'foo-' + i} />);` },
+
+    // ---- Tracked iterator, key does not reference the index ----
+    { code: `foo.map((baz) => <Foo key={baz.id} />);` },
+    { code: `foo.map((baz, i) => <Foo key={baz.id} />);` },
+    { code: `foo.map((baz, i) => <Foo key={'foo' + baz.id} />);` },
+    {
+      code: `foo.map((baz, i) => React.cloneElement(someChild, { ...someChild.props }));`,
+    },
+    {
+      code: `foo.map((baz, i) => cloneElement(someChild, { ...someChild.props }));`,
+    },
+    {
+      code: `
+        foo.map((item, i) => {
+          return React.cloneElement(someChild, {
+            key: item.id
+          })
+        });
+      `,
+    },
+    {
+      code: `
+        foo.map((item, i) => {
+          return cloneElement(someChild, {
+            key: item.id
+          })
+        });
+      `,
+    },
+    { code: `foo.map((baz, i) => <Foo key />);` },
+    { code: `foo.reduce((a, b) => a.concat(<Foo key={b.id} />), []);` },
+
+    // ---- Index-flavored expressions that the rule does not match ----
+    { code: `foo.map((bar, i) => <Foo key={i.baz.toString()} />);` },
+    { code: `foo.map((bar, i) => <Foo key={i.toString} />);` },
+    { code: `foo.map((bar, i) => <Foo key={String()} />);` },
+    { code: `foo.map((bar, i) => <Foo key={String(baz)} />);` },
+
+    // ---- Insufficient params for the index slot ----
+    { code: `foo.flatMap((a) => <Foo key={a} />);` },
+    { code: `foo.reduce((a, b, i) => a.concat(<Foo key={b.id} />), []);` },
+    { code: `foo.reduceRight((a, b) => a.concat(<Foo key={b.id} />), []);` },
+    {
+      code: `foo.reduceRight((a, b, i) => a.concat(<Foo key={b.id} />), []);`,
+    },
+
+    // ---- React.Children.* / Children.* with non-index key ----
+    {
+      code: `
+        React.Children.map(this.props.children, (child, index, arr) => {
+          return React.cloneElement(child, { key: child.id });
+        });
+      `,
+    },
+    {
+      code: `
+        React.Children.map(this.props.children, (child, index, arr) => {
+          return cloneElement(child, { key: child.id });
+        });
+      `,
+    },
+    {
+      code: `
+        Children.forEach(this.props.children, (child, index, arr) => {
+          return React.cloneElement(child, { key: child.id });
+        });
+      `,
+    },
+    {
+      code: `
+        Children.forEach(this.props.children, (child, index, arr) => {
+          return cloneElement(child, { key: child.id });
+        });
+      `,
+    },
+
+    // ---- Optional chaining with non-index key ----
+    { code: `foo?.map(child => <Foo key={child.i} />);` },
+
+    // ---- Real-user scenarios ----
+    // createElement / cloneElement OUTSIDE any iterator — stack empty.
+    { code: `React.createElement('Foo', { key: i });` },
+    { code: `React.cloneElement(child, { key: i });` },
+    // thisArg as third argument — irrelevant.
+    { code: `foo.map((bar) => <Foo key={bar.id} />, this);` },
+    // Empty array.
+    { code: `[].map((bar, i) => <Foo key={bar.id} />);` },
+    // Computed-key with StringLiteral inside (`["key"]: i`) — opaque
+    // upstream (`prop.key.name` undefined on Literal).
+    {
+      code: `foo.map((bar, i) => React.createElement('Foo', { ["key"]: i }));`,
+    },
+    // String-literal key `"key"` — same opaque shape.
+    {
+      code: `foo.map((bar, i) => React.createElement('Foo', { "key": i }));`,
+    },
+    // Computed-key with non-`key` Identifier inside (`[other]: i`) —
+    // `prop.key.name === 'other' !== 'key'`. NOT reported.
+    {
+      code: `foo.map((bar, i) => React.createElement('Foo', { [other]: i }));`,
+    },
+    // Shorthand `{ key }` when the index parameter is NOT named `key` —
+    // the local `key` binding shadows the index slot.
+    {
+      code: `foo.map((bar, i) => { const key = bar.id; return React.cloneElement(c, { key }); });`,
+    },
+    // Iterator returning a non-JSX value.
+    { code: `foo.map((bar, i) => bar + i);` },
+    // Empty arrow body.
+    { code: `foo.map((bar, i) => {});` },
+    // Inner shadows outer index name — pop balance preserved.
+    { code: `foo.map((a, i) => bar.map((c, i) => <X key={c.id} />));` },
+    // Numeric / boolean literal keys.
+    { code: `foo.map((bar, i) => <Foo key={42} />);` },
+    { code: `foo.map((bar, i) => <Foo key={true} />);` },
+    // Reduce accumulator (pos 0) is not the index slot (pos 2).
+    { code: `foo.reduce((a, b) => a.concat(<Foo key={a} />), []);` },
+    // Default-valued index parameter.
+    { code: `foo.map((bar, i = 0) => <Foo key={i} />);` },
+    // Pragma swap — `Act.cloneElement` is the factory now;
+    // `key: bar.id` is fine.
+    {
+      code: `foo.map((bar, i) => Act.cloneElement(c, { key: bar.id }));`,
+      settings: { react: { pragma: 'Act' } },
+    },
+    // Bare `cloneElement` without an `import { cloneElement }
+    // from 'react'` — the bare-callee branch returns false.
+    {
+      code: `
+        const cloneElement = (...args) => args;
+        foo.map((baz, i) => cloneElement(someChild, { key: i }));
+      `,
+    },
+    // Identifier branch is gated on ImportSpecifier — destructuring
+    // / aliasing / require do NOT count.
+    {
+      code: `
+        const { cloneElement } = React;
+        foo.map((baz, i) => cloneElement(someChild, { key: i }));
+      `,
+    },
+    {
+      code: `
+        const cloneElement = React.cloneElement;
+        foo.map((baz, i) => cloneElement(someChild, { key: i }));
+      `,
+    },
+    {
+      code: `
+        const { cloneElement } = require('react');
+        foo.map((baz, i) => cloneElement(someChild, { key: i }));
+      `,
+    },
+    // Module specifier hardcoded `'react'` — pragma swap doesn't redirect.
+    {
+      code: `
+        import { cloneElement } from 'act';
+        foo.map((baz, i) => cloneElement(someChild, { key: i }));
+      `,
+      settings: { react: { pragma: 'Act' } },
+    },
+    // Tagged template — KindTaggedTemplateExpression, not template.
+    { code: 'foo.map((bar, i) => <Foo key={tag`foo-${i}`} />);' },
+    // No-substitution template — opaque.
+    { code: 'foo.map((bar, i) => <Foo key={`foo-i`} />);' },
+    // Conditional inside binary chain — opaque.
+    { code: `foo.map((bar, i) => <Foo key={'a' + (i ? 'x' : 'y')} />);` },
+    // Identity-wrapped index — not String / .toString().
+    { code: `foo.map((bar, i) => <Foo key={identity(i)} />);` },
+    // Object-literal as key value.
+    {
+      code: `foo.map((bar, i) => React.createElement('Foo', { key: { nested: i } }));`,
+    },
+    // Bracket access `i['toString']` — not the dotted shape.
+    { code: `foo.map((bar, i) => <Foo key={i['toString']()} />);` },
+    // Destructured index parameter — undefined name.
+    { code: `foo.map((bar, [i]) => <Foo key={i} />);` },
+    // Rest-only index slot.
+    { code: `foo.map((bar, ...rest) => <Foo key={rest[0]} />);` },
+    // String() with member-access argument — not a direct index ref.
+    { code: `foo.map((bar, i) => <Foo key={String(i.foo)} />);` },
+    // TS expression wrappers on pragma / key value — opaque, matching
+    // ESLint's JS-only AST exactly.
+    {
+      code: `foo.map((bar, i) => (React as any).cloneElement(c, { key: i }));`,
+    },
+    {
+      code: `foo.map((bar, i) => React!.createElement('Foo', { key: i }));`,
+    },
+    { code: `foo.map((bar, i) => <Foo key={(i as any)} />);` },
+    // Optional-chain CallExpression as the key value — opaque to
+    // upstream's `astUtil.isCallExpression` (rejects OptionalCallExpression)
+    // and to `node.callee.type === 'MemberExpression'` (rejects
+    // OptionalMemberExpression).
+    { code: `foo.map((bar, i) => <Foo key={i?.toString()} />);` },
+    { code: `foo.map((bar, i) => <Foo key={String?.(i)} />);` },
+    { code: `foo.map((bar, i) => <Foo key={i?.toString?.()} />);` },
+  ],
+
+  invalid: [
+    // ---- Direct identifier ----
+    {
+      code: `foo.map((bar, i) => <Foo key={i} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `[{}, {}].map((bar, i) => <Foo key={i} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.map((bar, anything) => <Foo key={anything} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Template literal ----
+    {
+      code: 'foo.map((bar, i) => <Foo key={`foo-${i}`} />);',
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Concatenation chain ----
+    {
+      code: `foo.map((bar, i) => <Foo key={'foo-' + i} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.map((bar, i) => <Foo key={'foo-' + i + '-bar'} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- React.cloneElement ----
+    {
+      code: `foo.map((baz, i) => React.cloneElement(someChild, { ...someChild.props, key: i }));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        import { cloneElement } from 'react';
+
+        foo.map((baz, i) => cloneElement(someChild, { ...someChild.props, key: i }));
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        foo.map((item, i) => {
+          return React.cloneElement(someChild, {
+            key: i
+          })
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        import { cloneElement } from 'react';
+
+        foo.map((item, i) => {
+          return cloneElement(someChild, {
+            key: i
+          })
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Every iterator method, JSX path ----
+    {
+      code: `foo.forEach((bar, i) => { baz.push(<Foo key={i} />); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.filter((bar, i) => { baz.push(<Foo key={i} />); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.some((bar, i) => { baz.push(<Foo key={i} />); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.every((bar, i) => { baz.push(<Foo key={i} />); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.find((bar, i) => { baz.push(<Foo key={i} />); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.findIndex((bar, i) => { baz.push(<Foo key={i} />); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.reduce((a, b, i) => a.concat(<Foo key={i} />), []);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.flatMap((a, i) => <Foo key={i} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.reduceRight((a, b, i) => a.concat(<Foo key={i} />), []);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- React.createElement props path ----
+    {
+      code: `foo.map((bar, i) => React.createElement('Foo', { key: i }));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: "foo.map((bar, i) => React.createElement('Foo', { key: `foo-${i}` }));",
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.map((bar, i) => React.createElement('Foo', { key: 'foo-' + i }));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.map((bar, i) => React.createElement('Foo', { key: 'foo-' + i + '-bar' }));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.forEach((bar, i) => { baz.push(React.createElement('Foo', { key: i })); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.filter((bar, i) => { baz.push(React.createElement('Foo', { key: i })); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.some((bar, i) => { baz.push(React.createElement('Foo', { key: i })); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.every((bar, i) => { baz.push(React.createElement('Foo', { key: i })); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.find((bar, i) => { baz.push(React.createElement('Foo', { key: i })); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.findIndex((bar, i) => { baz.push(React.createElement('Foo', { key: i })); });`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- React.Children.* / Children.* (callback at args[1]) ----
+    {
+      code: `
+        Children.map(this.props.children, (child, index) => {
+          return React.cloneElement(child, { key: index });
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        import { cloneElement } from 'react';
+
+        Children.map(this.props.children, (child, index) => {
+          return cloneElement(child, { key: index });
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        React.Children.map(this.props.children, (child, index) => {
+          return React.cloneElement(child, { key: index });
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        import { cloneElement } from 'react';
+
+        React.Children.map(this.props.children, (child, index) => {
+          return cloneElement(child, { key: index });
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        Children.forEach(this.props.children, (child, index) => {
+          return React.cloneElement(child, { key: index });
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        import { cloneElement } from 'react';
+
+        Children.forEach(this.props.children, (child, index) => {
+          return cloneElement(child, { key: index });
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        React.Children.forEach(this.props.children, (child, index) => {
+          return React.cloneElement(child, { key: index });
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        import { cloneElement } from 'react';
+
+        React.Children.forEach(this.props.children, (child, index) => {
+          return cloneElement(child, { key: index });
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Optional chaining iterator ----
+    {
+      code: `foo?.map((child, i) => <Foo key={i} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Nested iterators ----
+    {
+      code: `foo.map((a, i) => bar.map((c, j) => <X key={i} />));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.map((a, i) => bar.map((c, j) => <X key={j} />));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.map((a, i) => bar.map((c, i) => <X key={i} />));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.map((a, i) => bar.qux((c, j) => <X key={i} />));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Inner function inside iterator body still tracked ----
+    {
+      code: `
+        foo.map((bar, i) => function inner() {
+          return <Foo key={i} />;
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Identifier branch accepts ANY react-imported name ----
+    // Upstream's Identifier branch does NOT verify name; any
+    // ImportSpecifier from 'react' passes. Mirrored byte-for-byte.
+    {
+      code: `
+        import { foo } from 'react';
+
+        foo.map((bar, i) => foo(c, { key: i }));
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Optional-chain pragma — upstream listens on
+    // `'CallExpression, OptionalCallExpression'` and accepts both
+    // `MemberExpression` and `OptionalMemberExpression`. ----
+    {
+      code: `foo.map((bar, i) => React?.cloneElement(c, { key: i }));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.map((bar, i) => React?.createElement('Foo', { key: i }));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Multi-substitution / multi-leaf ----
+    {
+      code: 'foo.map((bar, i) => <Foo key={`${i}-${i}`} />);',
+      errors: [{ messageId: 'noArrayIndex' }, { messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `foo.map((bar, i) => <Foo key={i + '-' + i} />);`,
+      errors: [{ messageId: 'noArrayIndex' }, { messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Multiple `key` keys in one props object ----
+    {
+      code: `foo.map((bar, i) => React.createElement('Foo', { key: i, key: i }));`,
+      errors: [{ messageId: 'noArrayIndex' }, { messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Nested cloneElement ----
+    {
+      code: `foo.map((bar, i) => React.cloneElement(React.cloneElement(c, { key: i }), { key: i }));`,
+      errors: [{ messageId: 'noArrayIndex' }, { messageId: 'noArrayIndex' }],
+    },
+
+    // ---- pragma swap settings ----
+    {
+      code: `foo.map((bar, i) => Act.cloneElement(c, { key: i }));`,
+      settings: { react: { pragma: 'Act' } },
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Chained receiver `foo.bar.map(...)` ----
+    {
+      code: `foo.bar.map((c, i) => <X key={i} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Shorthand `{ key }` when the index parameter is named `key` ----
+    {
+      code: `foo.map((bar, key) => React.cloneElement(c, { key }));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- TS-wrapped iterator receiver still triggers ----
+    // Upstream `getMapIndexParamName` only inspects `.property.name`,
+    // so the receiver shape is opaque to it.
+    {
+      code: `(foo as any[]).map((bar, i) => <Foo key={i} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Mixed key kinds in same props: only Identifier `key` matches ----
+    {
+      code: `foo.map((bar, i) => React.createElement('Foo', { key: i, ["key"]: i }));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Computed property `[<Identifier "key">]: ...` ----
+    // Upstream ESTree puts the inner expression directly as
+    // `prop.key`. With `[key]: key` and the iterator's index parameter
+    // named `key`, `prop.key.name === 'key'` matches and `prop.value`
+    // is the index Identifier.
+    {
+      code: `foo.map((bar, key) => React.cloneElement(c, { [key]: key }));`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Children.toArray pipe ----
+    {
+      code: `React.Children.toArray(children).map((c, i) => <X key={i} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Block body with multiple JSX returns ----
+    {
+      code: `
+        foo.map((bar, i) => {
+          if (cond) return <A key={i} />;
+          return <B key={i} />;
+        });
+      `,
+      errors: [{ messageId: 'noArrayIndex' }, { messageId: 'noArrayIndex' }],
+    },
+
+    // ---- JSX child expression containing iterator ----
+    {
+      code: `<div>{foo.map((bar, i) => <X key={i} />)}</div>;`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // ---- Coercion via toString / String ----
+    {
+      code: `
+        foo.map((bar, index) => (
+          <Element key={index.toString()} bar={bar} />
+        ));
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        foo.map((bar, index) => (
+          <Element key={String(index)} bar={bar} />
+        ));
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: `
+        foo.map((bar, index) => (
+          <Element key={index} bar={bar} />
+        ));
+      `,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-array-index-key` rule from `eslint-plugin-react` to rslint. The rule warns when an iterator callback's index parameter is used as a React `key` — directly, in a template literal, in a `+` concatenation chain, via `index.toString()`, via `String(index)`, or as the `key` property of `React.createElement` / `React.cloneElement` (and bare `createElement` / `cloneElement` imported from `'react'`).

The implementation mirrors upstream byte-for-byte, including all upstream quirks:

- Iterator set: `every`, `filter`, `find`, `findIndex`, `flatMap`, `forEach`, `map`, `reduce`, `reduceRight`, `some`. `React.Children.map` / `Children.map` (and `forEach`) shift the callback to `arguments[1]`.
- Optional-chain pragma `React?.cloneElement(...)` / `React?.createElement(...)` is recognized (mirrors upstream `OptionalCallExpression` listener).
- Identifier-form callee accepts ANY `import { ... } from 'react'` ImportSpecifier — name is intentionally NOT verified (upstream quirk).
- Module specifier for the Identifier-form is hardcoded `'react'`; `settings.react.pragma` does not change it.
- ComputedPropertyName `[<Identifier "key">]: ...` matches the `key` property check (upstream ESTree quirk).
- Default-valued / destructured / rest index parameters do NOT push (upstream's AssignmentPattern / ArrayPattern / RestElement have no `.name`).
- Optional-chain CallExpression as key value (`i?.toString()` / `String?.(i)`) is opaque (upstream `astUtil.isCallExpression` rejects).
- Report nodes: direct identifier / TemplateExpression / BinaryExpression / `index.toString()` CallExpression report on the value expression; `String(index)` reports on the index argument (paren-stripped to match upstream's flattened ESTree position).

A small extension to `reactutil` adds `IsCreateOrCloneElementCall` for future rules with non-quirky semantics; the bug-mirroring detection used by this rule is kept inline (`isImportSpecifierFromReact` helper) to avoid leaking upstream-quirky semantics into shared utilities.

Verified against the upstream test suite (38 valid + 33 invalid migrated 1:1) plus extensive additional coverage:

- Nested iterators (outer/inner index, same-name reuse, untracked-in-tracked, function-in-iterator)
- TS expression wrappers on pragma / key value / iterator receiver
- Multi-substitution templates, multi-leaf binary chains, multiple `key` properties, nested `cloneElement` (independent reports per call)
- Pragma swap via `settings.react.pragma`, chained / TS-wrapped iterator receivers, `React.Children.toArray(...).map(...)` pipeline, block-bodied callbacks with multiple JSX returns, JSX child expressions
- All four real-user shapes that should NOT report: stable-key (object property), default-valued index, optional-chain key call, computed key with non-`key` Identifier

Differential validation on rsbuild (`website/`, 65 tsx files) and rspack (`website/`, 37 tsx files) real codebases: 0 reports (codebases use stable keys throughout). A 13-case synthetic probe planted in each repo verified all 10 violation patterns report at the exact expected positions and all 3 valid edge cases stay silent.

## Related Links

- ESLint rule docs: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-array-index-key.js
- Upstream tests: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/tests/lib/rules/no-array-index-key.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).