### PR TITLE
feat: port rule react/no-multi-comp

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -34,6 +34,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_direct_mutation_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_multi_comp"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_redundant_should_component_update"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_render_return_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
@@ -96,6 +97,7 @@ func GetAllRules() []rule.Rule {
 		no_direct_mutation_state.NoDirectMutationStateRule,
 		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,
+		no_multi_comp.NoMultiCompRule,
 		no_unstable_nested_components.NoUnstableNestedComponentsRule,
 		no_unused_class_component_methods.NoUnusedClassComponentMethodsRule,
 		no_unused_state.NoUnusedStateRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -2975,7 +2975,12 @@ func WrapperWrapsKnownSiblingComponent(call *ast.Node, fn *ast.Node) bool {
 	if call == nil || call.Kind != ast.KindCallExpression {
 		return false
 	}
-	expr := call.AsCallExpression().Expression
+	// Paren / TS-wrapper transparent callee: `(R.memo)(arrow)` /
+	// `(R.memo as any)(arrow)` should still trip the gate because
+	// upstream's ESTree-flattened `node.callee.type === 'MemberExpression'`
+	// check sees the inner MemberExpression directly. tsgo preserves the
+	// wrapper, so we strip it before kind-checking.
+	expr := SkipExpressionWrappers(call.AsCallExpression().Expression)
 	if expr == nil || expr.Kind != ast.KindPropertyAccessExpression {
 		return false
 	}

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -662,6 +662,12 @@ func DefaultComponentWrappers(pragma string) []ComponentWrapperEntry {
 //   - object: {"property": "memo", "object": "React"} →
 //     {Object: "React", Property: "memo"}; "object" defaults to empty
 //     (bare call) when omitted
+//   - object with `"object": "<pragma>"` placeholder — upstream's
+//     `getWrapperFunctions` (Components.js) substitutes the placeholder
+//     with the configured pragma at read time, so users can write
+//     `{property: 'memo', object: '<pragma>'}` and have it match
+//     whichever pragma the file is configured with. We mirror that
+//     substitution exactly.
 //
 // Unknown / malformed entries are silently ignored, matching upstream.
 func GetComponentWrapperFunctions(settings map[string]interface{}, pragma string) []ComponentWrapperEntry {
@@ -672,6 +678,10 @@ func GetComponentWrapperFunctions(settings map[string]interface{}, pragma string
 	raw, ok := settings["componentWrapperFunctions"]
 	if !ok {
 		return out
+	}
+	resolvedPragma := pragma
+	if resolvedPragma == "" {
+		resolvedPragma = DefaultReactPragma
 	}
 	add := func(v interface{}) {
 		switch e := v.(type) {
@@ -685,6 +695,9 @@ func GetComponentWrapperFunctions(settings map[string]interface{}, pragma string
 				return
 			}
 			obj, _ := e["object"].(string)
+			if obj == "<pragma>" {
+				obj = resolvedPragma
+			}
 			out = append(out, ComponentWrapperEntry{Object: obj, Property: prop, IsUserConfigured: true})
 		}
 	}
@@ -765,25 +778,51 @@ func matchesAnyComponentWrapperCore(call, fn *ast.Node, wrappers []ComponentWrap
 		}
 		switch callee.Kind {
 		case ast.KindIdentifier:
-			if w.Object != "" {
-				continue
-			}
 			if callee.AsIdentifier().Text != w.Property {
 				continue
 			}
-			if w.IsUserConfigured {
-				// User-configured bare entry: accept any callee shape
-				// (call-level optional included). User entries don't
-				// need the pragma-import gate since they're explicit
-				// opt-in.
+			if w.Object == "" {
+				if w.IsUserConfigured {
+					// User-configured bare entry: accept any callee shape
+					// (call-level optional included). User entries don't
+					// need the pragma-import gate since they're explicit
+					// opt-in.
+					return true
+				}
+				// Hardcoded bare default (memo / forwardRef without
+				// object): upstream gates with
+				// `isDestructuredFromPragmaImport`. We always run that
+				// gate — when a TypeChecker is available it resolves
+				// the binding precisely, and when not it falls back to
+				// a syntax-only SourceFile scan that handles the
+				// canonical top-level pragma-import shapes.
+				if !IsDestructuredFromPragmaImport(callee, pragma, tc) {
+					continue
+				}
 				return true
 			}
-			// Hardcoded bare default (memo / forwardRef without object):
-			// upstream gates with `isDestructuredFromPragmaImport`. We
-			// always run that gate — when a TypeChecker is available
-			// it resolves the binding precisely, and when not it falls
-			// back to a syntax-only SourceFile scan that handles the
-			// canonical top-level pragma-import shapes.
+			// Entry HAS an Object — upstream's bare-callee arm:
+			//
+			//   wrapperFunction.property === node.callee.name && (
+			//     !wrapperFunction.object
+			//     || (wrapperFunction.object === pragma &&
+			//         this.isDestructuredFromPragmaImport(node, node.callee.name))
+			//   )
+			//
+			// translates to: when the entry's Object equals the active
+			// pragma AND the bare identifier callee is destructured /
+			// imported / required from the pragma module, the entry
+			// still matches even though `node.callee` is not a
+			// MemberExpression. This covers e.g.
+			// `componentWrapperFunctions: [{property: 'observer', object: '<pragma>'}]`
+			// + `import { observer } from 'react'` + `observer(arrow)`.
+			effectivePragma := pragma
+			if effectivePragma == "" {
+				effectivePragma = DefaultReactPragma
+			}
+			if w.Object != effectivePragma {
+				continue
+			}
 			if !IsDestructuredFromPragmaImport(callee, pragma, tc) {
 				continue
 			}
@@ -1616,10 +1655,21 @@ func isStatelessReactComponentCore(fn *ast.Node, pragma string, tc *checker.Chec
 		}
 	}
 
-	// Branch 16 — Property parent + returns only null ⇒ undefined. Already
-	// handled by Branch 10 when !id & !computed (strict isReturningJSX
-	// rejects null-only). The final `return node` for anonymous allowed-
-	// position fallbacks remains.
+	// Branch 16 — Property parent + returns only null ⇒ undefined.
+	// Upstream's tail check:
+	//
+	//   if (parent.type === 'Property' && utils.isReturningOnlyNull(node)) {
+	//     return undefined;
+	//   }
+	//
+	// This is reachable for shapes Branch 10 doesn't filter — anonymous
+	// arrow with a COMPUTED key (`{ [k]: () => null }`) and named FE
+	// values (`{ Foo: function Bar() { return null; } }` once Branch 14's
+	// id-capitalization check has passed). Both cases must fall through
+	// to here and get rejected when the body returns only `null`.
+	if parent.Kind == ast.KindPropertyAssignment && functionReturnsOnlyNull(fn) {
+		return false
+	}
 	return true
 }
 
@@ -2755,6 +2805,253 @@ func IsPropWrapperCall(call *ast.Node, wrappers []PropWrapperEntry) bool {
 				return true
 			}
 		}
+	}
+	return false
+}
+
+// IsFunctionLikeForComponent reports whether `node` is a function-shaped node
+// the React component-detection pipeline classifies as a "potential
+// component" candidate. Covers FunctionDeclaration / FunctionExpression /
+// ArrowFunction and the object-literal shorthand MethodDeclaration /
+// GetAccessor / SetAccessor (upstream's ESTree shape exposes these as a
+// `Property { method: true, value: FunctionExpression }`). Class methods
+// share the same Kind values but are not function-shaped *components*; rule
+// callers gate by parent / context where that matters.
+func IsFunctionLikeForComponent(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression,
+		ast.KindArrowFunction,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		return true
+	}
+	return false
+}
+
+// JSXRootTagName returns the tag-name of a JsxElement / JsxSelfClosingElement
+// (peeling paren / TS wrappers) when it's a plain Identifier, or "" otherwise.
+// Member-expression tag-names (`<Foo.Bar />`) and namespaced names
+// (`<svg:circle/>`) intentionally return "" — upstream's
+// `getComponentNameFromJSXElement` only matches plain identifiers via the
+// detected-components list keyed by the binding's local name.
+func JSXRootTagName(expr *ast.Node) string {
+	expr = SkipExpressionWrappers(expr)
+	if expr == nil {
+		return ""
+	}
+	var tag *ast.Node
+	switch expr.Kind {
+	case ast.KindJsxElement:
+		opening := expr.AsJsxElement().OpeningElement
+		if opening != nil {
+			tag = opening.AsJsxOpeningElement().TagName
+		}
+	case ast.KindJsxSelfClosingElement:
+		tag = expr.AsJsxSelfClosingElement().TagName
+	default:
+		return ""
+	}
+	if tag == nil || tag.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return tag.AsIdentifier().Text
+}
+
+// ReturnedJSXRootTagName extracts the root JSX tag name from a function's
+// body — covers both the concise-body case (`() => <Foo/>`) and the
+// block-body case where the FIRST top-level ReturnStatement is inspected.
+// Returns empty string when the body doesn't return a JSX element directly.
+func ReturnedJSXRootTagName(fn *ast.Node) string {
+	if fn == nil {
+		return ""
+	}
+	var body *ast.Node
+	switch fn.Kind {
+	case ast.KindArrowFunction:
+		body = fn.AsArrowFunction().Body
+	case ast.KindFunctionExpression:
+		body = fn.AsFunctionExpression().Body
+	case ast.KindFunctionDeclaration:
+		body = fn.AsFunctionDeclaration().Body
+	default:
+		return ""
+	}
+	if body == nil {
+		return ""
+	}
+	if body.Kind == ast.KindBlock {
+		var ret *ast.Node
+		body.ForEachChild(func(child *ast.Node) bool {
+			if child.Kind == ast.KindReturnStatement {
+				ret = child
+				return true
+			}
+			return false
+		})
+		if ret == nil {
+			return ""
+		}
+		return JSXRootTagName(ret.AsReturnStatement().Expression)
+	}
+	return JSXRootTagName(body)
+}
+
+// SourceHasComponentNamedBefore scans `root`'s subtree for a sibling/outer
+// component declaration whose name equals `name` and whose start position
+// precedes `before`. Mirrors upstream's `getDetectedComponents` filter —
+// only `class` declarations and arrow-assigned-to-VariableDeclarator
+// declarations qualify; function declarations do NOT (upstream's filter
+// in `Components.js getDetectedComponents` only retains those two kinds).
+// The position gate replicates upstream's order-dependence: a sibling
+// declared AFTER the use site has not yet been added to the components
+// list when `isPragmaComponentWrapper` runs, so it must not match here
+// either.
+func SourceHasComponentNamedBefore(root *ast.Node, name string, before int) bool {
+	if root == nil || name == "" {
+		return false
+	}
+	var found bool
+	var visit func(n *ast.Node)
+	visit = func(n *ast.Node) {
+		if found || n == nil {
+			return
+		}
+		if n.Pos() >= before {
+			return
+		}
+		switch n.Kind {
+		case ast.KindClassDeclaration:
+			id := n.Name()
+			if id != nil && id.Kind == ast.KindIdentifier && id.AsIdentifier().Text == name {
+				found = true
+				return
+			}
+		case ast.KindVariableDeclaration:
+			vd := n.AsVariableDeclaration()
+			if vd.Initializer == nil {
+				break
+			}
+			init := SkipExpressionWrappers(vd.Initializer)
+			if init == nil || init.Kind != ast.KindArrowFunction {
+				break
+			}
+			id := vd.Name()
+			if id != nil && id.Kind == ast.KindIdentifier && id.AsIdentifier().Text == name {
+				found = true
+				return
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return found
+		})
+	}
+	visit(root)
+	return found
+}
+
+// WrapperWrapsKnownSiblingComponent reports whether `call` is a
+// MemberExpression-callee wrapper (e.g. `React.memo(arrow)`) whose
+// FunctionLike argument's body returns JSX whose root tag-name matches a
+// sibling/outer arrow-assigned-to-VariableDeclarator or ClassDeclaration in
+// the same source file declared before `call`. Mirrors upstream's
+// `nodeWrapsComponent` gate inside `isPragmaComponentWrapper`, which is
+// intentionally name-based (not symbol-based) and only applied to the
+// MemberExpression form of the wrapper. The bare-callee form
+// (`memo(...)` after `import { memo } from 'react'`) is NOT gated this way
+// upstream and must NOT be gated here either.
+func WrapperWrapsKnownSiblingComponent(call *ast.Node, fn *ast.Node) bool {
+	if call == nil || call.Kind != ast.KindCallExpression {
+		return false
+	}
+	expr := call.AsCallExpression().Expression
+	if expr == nil || expr.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	tag := ReturnedJSXRootTagName(fn)
+	if tag == "" {
+		return false
+	}
+	src := ast.GetSourceFileOfNode(call)
+	if src == nil {
+		return false
+	}
+	return SourceHasComponentNamedBefore(src.AsNode(), tag, call.Pos())
+}
+
+// IsDetectedComponent reports whether `node` looks like a React component the
+// upstream `Components.detect` pipeline would classify with confidence ≥ 2 —
+// i.e. would surface in `components.list()`. Mirrors `components.get(node)`
+// for the four AST kinds upstream's detection visits:
+//
+//   - FunctionDeclaration / FunctionExpression / ArrowFunction (and the
+//     object-shorthand Method / Get / Set forms): defers to
+//     IsStatelessReactComponentWithWrappers, with a fallback for
+//     user-configured wrappers that the hardcoded memo/forwardRef branch
+//     wouldn't catch on its own.
+//   - ClassDeclaration / ClassExpression: an extends clause that resolves to
+//     `<pragma>.Component` / `Component`.
+//   - ObjectLiteralExpression: the argument shape of `<createClass>(...)`
+//     (ES5 component).
+//   - CallExpression: matches a configured wrapper, has a FunctionLike first
+//     argument, and is not a MemberExpression wrapper around a body whose
+//     root JSX tag refers to a sibling/outer detected component
+//     (`nodeWrapsComponent` gate — see WrapperWrapsKnownSiblingComponent).
+//
+// Note that this function returns true for the inner FunctionLike of a
+// pragma-wrapper call AND for the wrapper CallExpression itself — the same
+// dual classification upstream produces (the inner arrow's
+// `getStatelessComponent` redirects to the outer call, while the outer
+// CallExpression listener also runs). Callers that need single-component
+// identity must dedupe by node pointer or by remapping inner FunctionLike
+// to its enclosing wrapper call (see no-multi-comp's collection pass for
+// the canonical pattern).
+func IsDetectedComponent(node *ast.Node, pragma, createClass string, wrappers []ComponentWrapperEntry, tc *checker.Checker) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression,
+		ast.KindArrowFunction,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		if IsStatelessReactComponentWithWrappers(node, pragma, tc, wrappers) {
+			return true
+		}
+		parent := SkipExpressionWrappersUp(node)
+		if parent != nil && parent.Kind == ast.KindCallExpression &&
+			MatchesAnyComponentWrapperWithChecker(parent, node, wrappers, pragma, tc) &&
+			FunctionReturnsJSXOrNullWithChecker(node, pragma, tc) {
+			return true
+		}
+		return false
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		return ExtendsReactComponent(node, pragma)
+	case ast.KindObjectLiteralExpression:
+		return IsCreateReactClassObjectArg(node, pragma, createClass)
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+			return false
+		}
+		inner := SkipExpressionWrappers(call.Arguments.Nodes[0])
+		if inner == nil || !IsFunctionLikeForComponent(inner) {
+			return false
+		}
+		if !MatchesAnyComponentWrapperWithChecker(node, inner, wrappers, pragma, tc) {
+			return false
+		}
+		if WrapperWrapsKnownSiblingComponent(node, inner) {
+			return false
+		}
+		return true
 	}
 	return false
 }

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -1667,7 +1667,13 @@ func isStatelessReactComponentCore(fn *ast.Node, pragma string, tc *checker.Chec
 	// values (`{ Foo: function Bar() { return null; } }` once Branch 14's
 	// id-capitalization check has passed). Both cases must fall through
 	// to here and get rejected when the body returns only `null`.
-	if parent.Kind == ast.KindPropertyAssignment && functionReturnsOnlyNull(fn) {
+	//
+	// Use SkipExpressionWrappersUp to make the check paren / TS-wrapper
+	// transparent, mirroring ESTree's flattened parent (where
+	// `{ [k]: (() => null) }` resolves the arrow's parent directly to
+	// the Property node).
+	if effective := SkipExpressionWrappersUp(fn); effective != nil &&
+		effective.Kind == ast.KindPropertyAssignment && functionReturnsOnlyNull(fn) {
 		return false
 	}
 	return true

--- a/internal/plugins/react/rules/no_multi_comp/no_multi_comp.go
+++ b/internal/plugins/react/rules/no_multi_comp/no_multi_comp.go
@@ -46,11 +46,19 @@ type componentEntry struct {
 }
 
 // isAsyncGenerator reports whether `node` is a function expression /
-// declaration that is BOTH `async` AND a generator (`function*`). Mirrors
-// upstream's `node.async && node.generator` gate inside the
-// `Components.detect` FE / FD listeners — the only path that adds a node
-// with `confidence 0` and excludes it from `components.list()`. Arrow
-// functions cannot be generators, so this never fires on KindArrowFunction.
+// declaration / object-literal shorthand method that is BOTH `async` AND a
+// generator (`function*` or `async *Foo() {}`). Mirrors upstream's
+// `node.async && node.generator` gate inside the `Components.detect` FE / FD
+// listeners — the only path that adds a node with `confidence 0` and excludes
+// it from `components.list()`. Arrow functions cannot be generators, so this
+// never fires on KindArrowFunction.
+//
+// MethodDeclaration is included because ESTree's
+// `Property { method: true, value: FunctionExpression }` shape funnels object-
+// literal shorthand methods through the same FE listener upstream — so a
+// `{ async *Foo() {...} }` declaration is banned upstream as an async-generator
+// FE. tsgo collapses this into a MethodDeclaration whose AsteriskToken / async
+// modifier carry the same signal; we honor it here.
 func isAsyncGenerator(node *ast.Node) bool {
 	if node == nil {
 		return false
@@ -73,6 +81,8 @@ func isAsyncGenerator(node *ast.Node) bool {
 		return node.AsFunctionDeclaration().AsteriskToken != nil
 	case ast.KindFunctionExpression:
 		return node.AsFunctionExpression().AsteriskToken != nil
+	case ast.KindMethodDeclaration:
+		return node.AsMethodDeclaration().AsteriskToken != nil
 	}
 	return false
 }
@@ -167,6 +177,19 @@ func collectComponents(sf *ast.SourceFile, pragma, createClass string, wrappers 
 			// `IsStatelessReactComponentWithWrappers`'s first switch arm
 			// already classifies. Class-body occurrences are excluded
 			// inside that helper because their parent is a ClassLike.
+			//
+			// Banned-confidence gate: upstream's FE listener treats an
+			// `async *Foo() {...}` shorthand method as an async
+			// generator (`node.async && node.generator`) and registers
+			// it with confidence 0 — never surfacing in
+			// `components.list()`. We mirror that here so the
+			// MethodDeclaration form does not slip past
+			// IsStatelessReactComponentWithWrappers (which lacks this
+			// gate). Getters / setters cannot be generators by syntax,
+			// so `isAsyncGenerator` always returns false on them.
+			if isAsyncGenerator(n) {
+				break
+			}
 			if reactutil.IsStatelessReactComponentWithWrappers(n, pragma, tc, wrappers) {
 				add(n)
 			}

--- a/internal/plugins/react/rules/no_multi_comp/no_multi_comp.go
+++ b/internal/plugins/react/rules/no_multi_comp/no_multi_comp.go
@@ -1,0 +1,337 @@
+package no_multi_comp
+
+import (
+	"sort"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Options carries the parsed rule options. Mirrors upstream's schema:
+//
+//	[{
+//	  type: 'object',
+//	  properties: {
+//	    ignoreStateless: { default: false, type: 'boolean' },
+//	  },
+//	  additionalProperties: false,
+//	}]
+type Options struct {
+	IgnoreStateless bool
+}
+
+func parseOptions(options any) Options {
+	opts := Options{}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["ignoreStateless"].(bool); ok {
+			opts.IgnoreStateless = v
+		}
+	}
+	return opts
+}
+
+// componentEntry pairs a detected component's reporting node with its sort
+// key. `pos` is the trimmed position of the node (its source-file location
+// excluding any leading trivia / modifiers); we sort by `pos` so the report
+// order tracks the order in which upstream's listeners would have added the
+// nodes to `components.list()`. The `kind` is cached for the
+// `isIgnored`-equivalent classification done after sorting.
+type componentEntry struct {
+	node *ast.Node
+	pos  int
+}
+
+// isAsyncGenerator reports whether `node` is a function expression /
+// declaration that is BOTH `async` AND a generator (`function*`). Mirrors
+// upstream's `node.async && node.generator` gate inside the
+// `Components.detect` FE / FD listeners — the only path that adds a node
+// with `confidence 0` and excludes it from `components.list()`. Arrow
+// functions cannot be generators, so this never fires on KindArrowFunction.
+func isAsyncGenerator(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	mods := node.Modifiers()
+	hasAsync := false
+	if mods != nil {
+		for _, m := range mods.Nodes {
+			if m.Kind == ast.KindAsyncKeyword {
+				hasAsync = true
+				break
+			}
+		}
+	}
+	if !hasAsync {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return node.AsFunctionDeclaration().AsteriskToken != nil
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().AsteriskToken != nil
+	}
+	return false
+}
+
+// outermostWrapperCall walks up through nested pragma-wrapper calls (paren /
+// TS-wrapper transparent) and returns the outer-most CallExpression that
+// matches `wrappers`. Mirrors upstream's `getPragmaComponentWrapper` which
+// loops while `isPragmaComponentWrapper(currentNode.parent)` keeps yielding
+// truthy and tracks the last truthy ancestor. Returns nil when the immediate
+// effective parent is not a matching wrapper.
+//
+// Why upstream walks up: for `React.memo(React.forwardRef(arrow))`, the inner
+// arrow's getStatelessComponent returns `pragmaComponentWrapper` — the
+// OUTER-MOST wrapper, not the inner forwardRef call. The component is then
+// registered against the memo call's range, which on multi-line source
+// changes the report's line number compared to picking the inner wrapper.
+func outermostWrapperCall(fn *ast.Node, pragma string, wrappers []reactutil.ComponentWrapperEntry, tc *checker.Checker) *ast.Node {
+	cur := reactutil.SkipExpressionWrappersUp(fn)
+	if cur == nil || cur.Kind != ast.KindCallExpression ||
+		!reactutil.MatchesAnyComponentWrapperWithChecker(cur, fn, wrappers, pragma, tc) {
+		return nil
+	}
+	for {
+		// Try ascending one more level: the parent of the current
+		// wrapper call (paren/TS-wrapper transparent) must itself be a
+		// CallExpression matching the wrappers list, with `cur` as its
+		// FIRST argument.
+		next := reactutil.SkipExpressionWrappersUp(cur)
+		if next == nil || next.Kind != ast.KindCallExpression {
+			return cur
+		}
+		if !reactutil.MatchesAnyComponentWrapperWithChecker(next, cur, wrappers, pragma, tc) {
+			return cur
+		}
+		cur = next
+	}
+}
+
+// collectComponents walks the source file once and returns every node the
+// upstream `Components.detect` pipeline would register at confidence ≥ 2,
+// deduplicated by node pointer and sorted by source position. Mirrors
+// upstream's per-listener add semantics:
+//
+//   - ClassDeclaration / ClassExpression / ObjectLiteralExpression / a
+//     pragma-wrapper CallExpression: register the node itself.
+//   - FunctionDeclaration / FunctionExpression / ArrowFunction inside a
+//     pragma-wrapper call: upstream's `getStatelessComponent` redirects to
+//     the outer wrapper call, so we register the wrapper instead of the
+//     inner function. This avoids double-counting when both the
+//     FunctionLike listener and the CallExpression listener would
+//     otherwise add (and identify) the same outer node — matching
+//     upstream's `getId(node)` deduping inside `components.add`.
+//   - Bare FunctionLike that classifies as a stateless component on its
+//     own (capitalized name, returns JSX, in an allowed position): register
+//     the FunctionLike itself.
+func collectComponents(sf *ast.SourceFile, pragma, createClass string, wrappers []reactutil.ComponentWrapperEntry, tc *checker.Checker) []componentEntry {
+	seen := map[*ast.Node]bool{}
+	var entries []componentEntry
+
+	add := func(node *ast.Node) {
+		if node == nil || seen[node] {
+			return
+		}
+		seen[node] = true
+		trimmed := utils.TrimNodeTextRange(sf, node)
+		entries = append(entries, componentEntry{node: node, pos: trimmed.Pos()})
+	}
+
+	var visit ast.Visitor
+	visit = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		switch n.Kind {
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			if reactutil.ExtendsReactComponent(n, pragma) {
+				add(n)
+			}
+		case ast.KindObjectLiteralExpression:
+			if reactutil.IsCreateReactClassObjectArg(n, pragma, createClass) {
+				add(n)
+			}
+		case ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor:
+			// Object-literal shorthand methods / accessors. Upstream's
+			// FunctionExpression listener fires on these via ESTree's
+			// `Property { method: true, value: FunctionExpression }`
+			// shape. tsgo collapses both forms into a MethodDeclaration
+			// (or GetAccessor / SetAccessor) child of an
+			// ObjectLiteralExpression — which is what
+			// `IsStatelessReactComponentWithWrappers`'s first switch arm
+			// already classifies. Class-body occurrences are excluded
+			// inside that helper because their parent is a ClassLike.
+			if reactutil.IsStatelessReactComponentWithWrappers(n, pragma, tc, wrappers) {
+				add(n)
+			}
+		case ast.KindFunctionDeclaration,
+			ast.KindFunctionExpression,
+			ast.KindArrowFunction:
+			// Banned-confidence gate (upstream `Components.detect` FE/FD
+			// listeners): `node.async && node.generator` immediately
+			// adds the node with confidence 0, which never surfaces in
+			// `components.list()`. Arrow functions can't be generators
+			// (syntax) so this gate only fires on FE/FD.
+			if n.Kind != ast.KindArrowFunction && isAsyncGenerator(n) {
+				break
+			}
+			directParent := reactutil.SkipExpressionWrappersUp(n)
+			directInWrapper := directParent != nil && directParent.Kind == ast.KindCallExpression &&
+				reactutil.MatchesAnyComponentWrapperWithChecker(directParent, n, wrappers, pragma, tc)
+			// Wrap-known-sibling gate: when the FunctionLike's enclosing
+			// pragma-wrapper call's body returns JSX whose root tag names
+			// a sibling/outer detected component, upstream's
+			// `isPragmaComponentWrapper` short-circuits to false. The
+			// inner FunctionLike then fails Branch 12's allowed-position
+			// gate (its parent is the CallExpression) and also returns
+			// undefined from `getStatelessComponent`. Net effect: the
+			// inner FunctionLike is NOT classified as a component on its
+			// own, and the outer call is NOT classified as a wrapper.
+			//
+			// rslint's `IsStatelessReactComponentWithWrappers` does not
+			// thread the nodeWrapsComponent gate into Branch 11, so we
+			// guard here before consulting it. (The CallExpression arm
+			// below applies the same gate via `IsDetectedComponent`.)
+			if directInWrapper && reactutil.WrapperWrapsKnownSiblingComponent(directParent, n) {
+				break
+			}
+			if reactutil.IsStatelessReactComponentWithWrappers(n, pragma, tc, wrappers) {
+				// Pragma-wrapper redirect: upstream's
+				// `getStatelessComponent` returns
+				// `getPragmaComponentWrapper(node)` — the OUTER-MOST
+				// wrapper in a chain like `memo(forwardRef(arrow))`. We
+				// must mirror that ascent to keep the report node's
+				// line number aligned with upstream when wrappers span
+				// multiple lines.
+				if outer := outermostWrapperCall(n, pragma, wrappers, tc); outer != nil {
+					add(outer)
+				} else {
+					add(n)
+				}
+			} else if directInWrapper && reactutil.FunctionReturnsJSXOrNullWithChecker(n, pragma, tc) {
+				// User-configured wrapper fallback — same shape as
+				// reactutil.IsDetectedComponent's FunctionLike arm. The
+				// `IsStatelessReactComponentWithWrappers` decision tree
+				// only honors wrappers in its Branch 11; user wrappers
+				// applied to a FunctionLike that doesn't satisfy a
+				// branch's structural gates need this explicit check.
+				if outer := outermostWrapperCall(n, pragma, wrappers, tc); outer != nil {
+					add(outer)
+				}
+			}
+		case ast.KindCallExpression:
+			call := n.AsCallExpression()
+			if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+				break
+			}
+			inner := reactutil.SkipExpressionWrappers(call.Arguments.Nodes[0])
+			if inner == nil || !reactutil.IsFunctionLikeForComponent(inner) {
+				break
+			}
+			if !reactutil.MatchesAnyComponentWrapperWithChecker(n, inner, wrappers, pragma, tc) {
+				break
+			}
+			if reactutil.WrapperWrapsKnownSiblingComponent(n, inner) {
+				break
+			}
+			add(n)
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	sf.Node.ForEachChild(visit)
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].pos < entries[j].pos
+	})
+	return entries
+}
+
+// isStatelessKindForIgnore returns true for the upstream `isIgnored` filter:
+// a component is ignored under `ignoreStateless: true` when its registered
+// node is a `Function*`-typed AST node OR a pragma-wrapper CallExpression.
+//
+// Upstream check (`Components.js` `no-multi-comp.isIgnored`):
+//
+//	ignoreStateless && (
+//	  /Function/.test(component.node.type)
+//	  || utils.isPragmaComponentWrapper(component.node)
+//	)
+//
+// `/Function/.test` matches `FunctionDeclaration`, `FunctionExpression`,
+// and `ArrowFunctionExpression` (which all contain "Function" in their
+// ESTree type name). It does NOT match `MethodDefinition` or class shapes.
+//
+// AST-shape note: tsgo collapses ESTree's
+// `Property { method: true, value: FunctionExpression }` and
+// `Property { value: ArrowFunctionExpression }` shapes into a single
+// `MethodDeclaration` (or GetAccessor / SetAccessor) child of an
+// ObjectLiteralExpression. Upstream registers `Property.value` (a
+// FunctionExpression) as the component node, so `/Function/.test`
+// matches there. To preserve the SAME observable `ignoreStateless`
+// behavior in rslint, the object-literal method/accessor kinds we
+// register in `collectComponents` count as stateless here.
+//
+// For CallExpression nodes we trust the caller: every CallExpression we
+// added via `collectComponents` already passed the
+// `MatchesAnyComponentWrapperWithChecker` gate (and the
+// `WrapperWrapsKnownSiblingComponent` carve-out), so re-classifying it
+// here as a wrapper would be redundant.
+func isStatelessKindForIgnore(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression,
+		ast.KindArrowFunction,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor,
+		ast.KindCallExpression:
+		return true
+	}
+	return false
+}
+
+var NoMultiCompRule = rule.Rule{
+	Name: "react/no-multi-comp",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+		wrappers := reactutil.GetComponentWrapperFunctions(ctx.Settings, pragma)
+
+		entries := collectComponents(ctx.SourceFile, pragma, createClass, wrappers, ctx.TypeChecker)
+
+		kept := entries
+		if opts.IgnoreStateless {
+			filtered := kept[:0]
+			for _, e := range entries {
+				if isStatelessKindForIgnore(e.node) {
+					continue
+				}
+				filtered = append(filtered, e)
+			}
+			kept = filtered
+		}
+
+		if len(kept) <= 1 {
+			return rule.RuleListeners{}
+		}
+
+		for _, e := range kept[1:] {
+			ctx.ReportNode(e.node, rule.RuleMessage{
+				Id:          "onlyOneComponent",
+				Description: "Declare only one React component per file",
+			})
+		}
+		return rule.RuleListeners{}
+	},
+}

--- a/internal/plugins/react/rules/no_multi_comp/no_multi_comp.md
+++ b/internal/plugins/react/rules/no_multi_comp/no_multi_comp.md
@@ -1,0 +1,91 @@
+# no-multi-comp
+
+Disallow multiple component definition per file.
+
+Declaring only one component per file improves readability and reusability of components.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  render: function () {
+    return <div>Hello {this.props.name}</div>;
+  },
+});
+
+var HelloJohn = createReactClass({
+  render: function () {
+    return <Hello name="John" />;
+  },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+var Hello = require('./components/Hello');
+
+var HelloJohn = createReactClass({
+  render: function () {
+    return <Hello name="John" />;
+  },
+});
+```
+
+## Rule Options
+
+```json
+{ "react/no-multi-comp": ["error", { "ignoreStateless": false }] }
+```
+
+### `ignoreStateless`
+
+When `true` the rule will ignore stateless components and will allow you to have multiple stateless components, or one stateful component and some stateless components in the same file.
+
+Examples of **correct** code for this rule with `{ "ignoreStateless": true }`:
+
+```json
+{ "react/no-multi-comp": ["error", { "ignoreStateless": true }] }
+```
+
+```jsx
+function Hello(props) {
+  return <div>Hello {props.name}</div>;
+}
+function HelloAgain(props) {
+  return <div>Hello again {props.name}</div>;
+}
+```
+
+```json
+{ "react/no-multi-comp": ["error", { "ignoreStateless": true }] }
+```
+
+```jsx
+function Hello(props) {
+  return <div>Hello {props.name}</div>;
+}
+class HelloJohn extends React.Component {
+  render() {
+    return <Hello name="John" />;
+  }
+}
+module.exports = HelloJohn;
+```
+
+## When Not To Use It
+
+If you prefer to declare multiple components per file you can disable this rule.
+
+## Differences from ESLint
+
+- Classes recognized only via JSDoc tags (`@extends React.Component` /
+  `@augments React.PureComponent`) without an `extends` clause are not treated
+  as React components. Add an explicit `extends` clause to align both linters.
+
+## Original Documentation
+
+- [eslint-plugin-react / no-multi-comp](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-multi-comp.js)

--- a/internal/plugins/react/rules/no_multi_comp/no_multi_comp_test.go
+++ b/internal/plugins/react/rules/no_multi_comp/no_multi_comp_test.go
@@ -564,6 +564,28 @@ func TestNoMultiCompRule(t *testing.T) {
         class A extends React.Component { render() { return <div /> } }
       `, Tsx: true},
 
+		// ---- Lock-in: Branch 16 paren-transparent ----
+		// `{ [k]: (() => null) }` — paren-wrapped only-null arrow under
+		// computed key. ESTree flattens parens so upstream sees parent
+		// = Property and rejects via Branch 16; rslint must mirror that
+		// via SkipExpressionWrappersUp. Without the gate the paren-
+		// wrapped arrow would surface as a phantom component.
+		{Code: `
+        const obj = { [Symbol.iterator]: (() => null) };
+        class A extends React.Component { render() { return <div /> } }
+      `, Tsx: true},
+
+		// ---- Lock-in: async-generator object-literal shorthand method ----
+		// `{ async *Foo() { return <div/> } }` — upstream's FE listener
+		// (which fires on ESTree's `Property.value`) treats this as an
+		// async generator and registers with confidence 0; rslint
+		// MethodDeclaration arm must apply the same `isAsyncGenerator`
+		// gate so the method does NOT surface as a component.
+		{Code: `
+        const obj = { async *Foo() { return <div /> } };
+        function App() { return <div /> }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
 		// ---- Documented divergence: JSDoc @extends without extends clause ----
 		// Skip: true. ESLint's `isExplicitComponent` parses JSDoc tags
 		// (`@extends React.Component` / `@augments React.PureComponent`)

--- a/internal/plugins/react/rules/no_multi_comp/no_multi_comp_test.go
+++ b/internal/plugins/react/rules/no_multi_comp/no_multi_comp_test.go
@@ -1,0 +1,1404 @@
+package no_multi_comp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// crCode mirrors upstream's `code.split('\n').join('\r')` test fixture
+// transformation: every `\n` becomes a single `\r`. Used to verify the
+// rule's line numbers track the host parser's CR-only line-terminator
+// handling on the canonical "two createReactClass per file" / "three class
+// declarations per file" inputs.
+func crCode(s string) string {
+	return strings.ReplaceAll(s, "\n", "\r")
+}
+
+const (
+	onlyOne     = "onlyOneComponent"
+	onlyOneText = "Declare only one React component per file"
+)
+
+func TestNoMultiCompRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoMultiCompRule, []rule_tester.ValidTestCase{
+		// ---- Single component declarations ----
+		{Code: `
+        var Hello = require('./components/Hello');
+        var HelloJohn = createReactClass({
+          render: function() {
+            return <Hello name="John" />;
+          }
+        });
+      `, Tsx: true},
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true},
+		{Code: `
+        var Heading = createReactClass({
+          render: function() {
+            return (
+              <div>
+                {this.props.buttons.map(function(button, index) {
+                  return <Button {...button} key={index}/>;
+                })}
+              </div>
+            );
+          }
+        });
+      `, Tsx: true},
+
+		// ---- ignoreStateless: true ----
+		{Code: `
+        function Hello(props) {
+          return <div>Hello {props.name}</div>;
+        }
+        function HelloAgain(props) {
+          return <div>Hello again {props.name}</div>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+		{Code: `
+        function Hello(props) {
+          return <div>Hello {props.name}</div>;
+        }
+        class HelloJohn extends React.Component {
+          render() {
+            return <Hello name="John" />;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
+		// ---- Helper functions are not components ----
+		{Code: `
+        import React, { createElement } from "react"
+        const helperFoo = () => {
+          return true;
+        };
+        function helperBar() {
+          return false;
+        };
+        function RealComponent() {
+          return createElement("img");
+        };
+      `, Tsx: true},
+
+		// ---- React.memo / React.forwardRef wrapping ----
+		{Code: `
+        const Hello = React.memo(function(props) {
+          return <div>Hello {props.name}</div>;
+        });
+        class HelloJohn extends React.Component {
+          render() {
+            return <Hello name="John" />;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
+		// ---- forwardRef wrapping a sibling component (nodeWrapsComponent gate) ----
+		{Code: `
+        class StoreListItem extends React.PureComponent {
+          // A bunch of stuff here
+        }
+        export default React.forwardRef((props, ref) => <StoreListItem {...props} forwardRef={ref} />);
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": false}},
+		{Code: `
+        class StoreListItem extends React.PureComponent {
+          // A bunch of stuff here
+        }
+        export default React.forwardRef((props, ref) => {
+          return <StoreListItem {...props} forwardRef={ref} />
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": false}},
+		{Code: `
+        const HelloComponent = (props) => {
+          return <div></div>;
+        }
+        export default React.forwardRef((props, ref) => <HelloComponent {...props} forwardRef={ref} />);
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": false}},
+		{Code: `
+        class StoreListItem extends React.PureComponent {
+          // A bunch of stuff here
+        }
+        export default React.forwardRef(
+          function myFunction(props, ref) {
+            return <StoreListItem {...props} forwardedRef={ref} />;
+          }
+        );
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+		{Code: `
+        const HelloComponent = (props) => {
+          return <div></div>;
+        }
+        class StoreListItem extends React.PureComponent {
+          // A bunch of stuff here
+        }
+        export default React.forwardRef(
+          function myFunction(props, ref) {
+            return <StoreListItem {...props} forwardedRef={ref} />;
+          }
+        );
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+		{Code: `
+        const HelloComponent = (props) => {
+          return <div></div>;
+        }
+        export default React.memo((props, ref) => <HelloComponent {...props} />);
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
+		// ---- Class field arrow that consumes an unrelated `memo`-named helper ----
+		{Code: `
+        import React from 'react';
+        function memo() {
+          var outOfScope = "hello"
+          return null;
+        }
+        class ComponentY extends React.Component {
+          memoCities = memo((cities) => cities.map((v) => ({ label: v })));
+          render() {
+            return (
+              <div>
+                <div>Counter</div>
+              </div>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- forwardRef + .displayName / .propTypes / .defaultProps assignments ----
+		{Code: `
+        const MenuList = forwardRef(({onClose, ...props}, ref) => {
+          const {t} = useTranslation();
+          const handleLogout = useLogoutHandler();
+
+          const onLogout = useCallback(() => {
+            onClose();
+            handleLogout();
+          }, [onClose, handleLogout]);
+
+          return (
+            <MuiMenuList ref={ref} {...props}>
+              <MuiMenuItem key="logout" onClick={onLogout}>
+                {t('global-logout')}
+              </MuiMenuItem>
+            </MuiMenuList>
+          );
+        });
+
+        MenuList.displayName = 'MenuList';
+
+        MenuList.propTypes = {
+          onClose: PropTypes.func,
+        };
+
+        MenuList.defaultProps = {
+          onClose: () => null,
+        };
+
+        export default MenuList;
+      `, Tsx: true},
+		{Code: `
+        const MenuList = forwardRef(({ onClose, ...props }, ref) => {
+          const onLogout = useCallback(() => {
+            onClose()
+          }, [onClose])
+
+          return (
+            <BlnMenuList ref={ref} {...props}>
+              <BlnMenuItem key="logout" onClick={onLogout}>
+                Logout
+              </BlnMenuItem>
+            </BlnMenuList>
+          )
+        })
+
+        MenuList.displayName = 'MenuList'
+
+        MenuList.propTypes = {
+          onClose: PropTypes.func
+        }
+
+        MenuList.defaultProps = {
+          onClose: () => null
+        }
+
+        export default MenuList
+      `, Tsx: true},
+
+		// ---- Lock-in: branches not exercised by upstream's own valid suite ----
+
+		// Locks in upstream `getStatelessComponent` Branch 12 reject (`!isInAllowedPositionForComponent`):
+		// arrow nested as a CallExpression argument that is NOT a pragma wrapper —
+		// the inner arrow is rejected (parent is CallExpression, not in allowed
+		// positions list), so the only component is the outer ClassDeclaration.
+		{Code: `
+        class App extends React.Component {
+          render() {
+            return <div onClick={() => <div>nope</div>} />;
+          }
+        }
+      `, Tsx: true},
+
+		// Locks in upstream `getStatelessComponent` Branch 2 reject (lowercase VariableDeclarator):
+		// lowercase-named arrow is not a component; the only component is the class.
+		{Code: `
+        const helper = (props) => <div>{props.x}</div>;
+        class App extends React.Component {
+          render() { return <div />; }
+        }
+      `, Tsx: true},
+
+		// Locks in upstream Components.detect FunctionExpression banned-confidence path:
+		// async generators are explicitly registered with confidence 0, so they don't
+		// count as components even when paired with another stateless function.
+		{Code: `
+        async function* gen() {
+          yield 1;
+        }
+        function App(props) { return <div /> }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
+		// Locks in upstream's `nodeWrapsComponent` MemberExpression-only gate:
+		// the bare-callee form (`memo(arrow)` with `import { memo } from 'react'`)
+		// does NOT skip even when the inner arrow's root JSX names a sibling.
+		// There's no second component upstream OR rslint here — only one
+		// component is added, since the bare wrapper IS classified.
+		{Code: `
+        import { forwardRef } from 'react';
+        const Inner = (props) => <div />;
+      `, Tsx: true},
+
+		// ---- Dimension 4: Universal edge shapes ----
+
+		// Paren-wrapped class declaration RHS — tsgo preserves
+		// ParenthesizedExpression, ESTree flattens. Class is the only
+		// component; no diagnostic.
+		{Code: `
+        const A = (class extends React.Component { render() { return <div /> } });
+      `, Tsx: true},
+
+		// TS non-null assertion / `as` / `satisfies` wrappers around the
+		// arrow inside a forwardRef call: SkipExpressionWrappers must
+		// transparently peel them so the wrapper's first-argument match
+		// still recognizes the inner FunctionLike as a sibling-wrapping
+		// arrow.
+		{Code: `
+        class StoreListItem extends React.PureComponent {}
+        export default React.forwardRef(((props, ref) => <StoreListItem {...props} forwardRef={ref} />) as any);
+      `, Tsx: true},
+		{Code: `
+        class StoreListItem extends React.PureComponent {}
+        export default React.forwardRef(((props, ref) => <StoreListItem {...props} forwardRef={ref} />)!);
+      `, Tsx: true},
+
+		// PrivateIdentifier-keyed class field arrow that returns JSX must
+		// NOT be classified as a component (private fields are not
+		// detected by upstream's Components.detect).
+		{Code: `
+        class App extends React.Component {
+          #helper = (props) => <div>{props.x}</div>;
+          render() { return <div /> }
+        }
+      `, Tsx: true},
+
+		// Computed key with member-expression that does NOT return JSX:
+		// Branch 9 of upstream's `getStatelessComponent` rejects when
+		// neither JSX nor only-null is returned.
+		{Code: `
+        class App extends React.Component {
+          render() { return <div /> }
+        }
+        const obj = { [ns.X]: (props) => props.y };
+      `, Tsx: true},
+
+		// Async / generator / async-generator FE shapes are NOT
+		// components (upstream registers them with confidence 0).
+		{Code: `
+        async function fetchData() { return null; }
+        function* gen() { yield 1; }
+        async function* asyncGen() { yield 1; }
+        function App(props) { return <div /> }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
+		// Lock-in: async generator with capitalized name + JSX return —
+		// upstream's `node.async && node.generator` banned-confidence
+		// gate excludes this from components.list(). Without the gate
+		// rslint would surface a phantom component, paired here with
+		// a real sibling we'd otherwise diagnose.
+		{Code: `
+        async function* Gen() { return <div /> }
+        function App(props) { return <div /> }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
+		// Same-kind nesting: function-in-function where only the inner
+		// returns JSX. Upstream's `getStatelessComponent` Branch 7 / 8
+		// fires on the inner FE only when its enclosing scope is an
+		// AssignmentExpression / PropertyAssignment with capitalized LHS
+		// — neither holds here, so neither inner nor outer is a
+		// component. No diagnostic.
+		{Code: `
+        function helper() {
+          function inner() { return <div />; }
+          return inner;
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: TypeScript-typed function components ----
+
+		// `React.FC<Props>` typed function component declaration —
+		// VariableDeclarator with TypeReference annotation. Tsgo
+		// preserves the annotation; the arrow's parent path stays
+		// VariableDeclarator → resolves through Branch 2.
+		{Code: `
+        type Props = { name: string };
+        const Hello: React.FC<Props> = (props) => <div>{props.name}</div>;
+      `, Tsx: true},
+
+		// Generic forwardRef typed callsite — a single component.
+		{Code: `
+        interface Props { label: string }
+        const Btn = React.forwardRef<HTMLButtonElement, Props>((props, ref) => (
+          <button ref={ref}>{props.label}</button>
+        ));
+      `, Tsx: true},
+
+		// `as const` / `satisfies` after a sibling-wrap forwardRef does
+		// NOT add a phantom component — TS expression wrappers are
+		// peeled by SkipExpressionWrappers / SkipExpressionWrappersUp.
+		{Code: `
+        class StoreListItem extends React.PureComponent {}
+        export default React.forwardRef((props, ref) => <StoreListItem {...props} forwardRef={ref} />) satisfies React.ForwardRefExoticComponent<any>;
+      `, Tsx: true},
+
+		// ---- Real-world: HOC patterns ----
+
+		// Custom HOC that's NOT a registered wrapper — the outer call
+		// is just a regular call, the inner arrow is in a non-allowed
+		// position (CallExpression argument), so neither classifies.
+		// Pair with one class component → no diagnostic.
+		{Code: `
+        const enhanced = withFoo((props) => <div>{props.x}</div>);
+        class App extends React.Component { render() { return <div /> } }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
+		// Configured wrapper via componentWrapperFunctions — a string
+		// entry. Wrapped arrow becomes the only component.
+		{Code: `
+        const App = myObserver((props) => <div>{props.x}</div>);
+      `, Tsx: true, Settings: map[string]interface{}{
+			"componentWrapperFunctions": []interface{}{"myObserver"},
+		}},
+
+		// Configured wrapper as object form `{property, object}`.
+		{Code: `
+        const App = MyLib.observer((props) => <div>{props.x}</div>);
+      `, Tsx: true, Settings: map[string]interface{}{
+			"componentWrapperFunctions": []interface{}{
+				map[string]interface{}{"property": "observer", "object": "MyLib"},
+			},
+		}},
+
+		// ---- Real-world: optional chain and ESM dynamic imports ----
+
+		// `React?.memo(arrow)` member-level optional — upstream's
+		// `MatchesAnyComponentWrapper` recognizes member-level optional
+		// (PropertyAccessExpression flag) but not call-level. Single
+		// component → no diagnostic.
+		{Code: `
+        const Hello = React?.memo((props) => <div>{props.x}</div>);
+      `, Tsx: true},
+
+		// ---- Real-world: re-exported `React` namespace alias ----
+		// Aliasing the namespace itself doesn't change pragma matching —
+		// only the `pragma` setting controls it. Without setting,
+		// `Reactlike.memo(...)` is NOT a wrapper.
+		{Code: `
+        import * as Reactlike from 'react';
+        const App = Reactlike.memo((props) => <div>{props.x}</div>);
+        class Sibling extends React.Component { render() { return <div /> } }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
+		// ---- Real-world: lazy / Suspense / context ----
+		// `React.lazy` is NOT in default wrappers — argument is a
+		// dynamic-import callback, no FunctionLike there in practice.
+		// One class component → no diagnostic.
+		{Code: `
+        const LazyOne = React.lazy(() => import('./One'));
+        class App extends React.Component { render() { return <div /> } }
+      `, Tsx: true},
+
+		// ---- Real-world: hooks-only file (no components) ----
+		{Code: `
+        import { useState } from 'react';
+        export function useToggle(init) {
+          const [on, setOn] = useState(init);
+          return [on, () => setOn(v => !v)];
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: only render-prop callbacks, no top-level component ----
+		// All function-likes are arguments of non-wrapper calls →
+		// neither in allowed position. Zero detected components.
+		{Code: `
+        someLib.register('foo', (props) => <div>{props.x}</div>);
+        someLib.register('bar', (props) => <span>{props.y}</span>);
+      `, Tsx: true},
+
+		// ---- Lock-in: ignoreStateless filters object-literal `Method() {}` shorthands ----
+		// tsgo registers a MethodDeclaration child of an
+		// ObjectLiteralExpression (upstream's ESTree exposes the same
+		// shape as `Property { method: true, value: FunctionExpression }`,
+		// where `value.type === 'FunctionExpression'` matches
+		// `/Function/.test`). With `ignoreStateless: true`, the entire
+		// object-literal-of-methods file should produce zero diagnostics.
+		{Code: `
+        export default {
+          A() { return <div /> },
+          B() { return <div /> },
+          C() { return <div /> },
+        };
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
+		// ---- Lock-in: ignoreStateless ALSO filters object getters / setters returning JSX ----
+		{Code: `
+        export default {
+          get A() { return <div /> },
+        };
+        class B extends React.Component { render() { return <div /> } }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreStateless": true}},
+
+		// ---- Lock-in: `componentWrapperFunctions` `"object": "<pragma>"` placeholder ----
+		// Upstream's `getWrapperFunctions` substitutes the literal
+		// "<pragma>" string with the configured pragma. So with a custom
+		// pragma `Foo` and a wrapper entry `{property: 'observer',
+		// object: '<pragma>'}`, `Foo.observer((props) => <div/>)` must
+		// classify as a single component (no diagnostic).
+		{Code: `
+        const App = Foo.observer((props) => <div>{props.x}</div>);
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"pragma": "Foo"},
+				"componentWrapperFunctions": []interface{}{
+					map[string]interface{}{"property": "observer", "object": "<pragma>"},
+				},
+			},
+		},
+
+		// ---- Real-world: declaration-merging (function + namespace) ----
+		// Function declaration `App` merges with namespace `App`.
+		// Only the function declaration is a component candidate (the
+		// namespace doesn't contribute to Components.detect). Class
+		// inside the namespace doesn't extend React.Component → not a
+		// component. Single component → no diagnostic.
+		{Code: `
+        function App(props) { return <div>{props.x}</div>; }
+        namespace App {
+          export class Helper {}
+        }
+      `, Tsx: true},
+
+		// ---- Lock-in: bare `Component` / bare `PureComponent` extends ----
+		// `ExtendsReactComponent` matches both `<pragma>.Component` and
+		// the bare `Component` / `PureComponent` identifiers (regex
+		// /^(Pure)?Component$/). Single bare-Component class is one
+		// component — no diagnostic.
+		{Code: `
+        class A extends Component { render() { return <div /> } }
+      `, Tsx: true},
+		{Code: `
+        class A extends PureComponent { render() { return <div /> } }
+      `, Tsx: true},
+
+		// ---- Lock-in: PropertyAccess wrapper.object NOT matching pragma ----
+		// `Foo.memo(arrow)` with pragma=React must NOT classify as a
+		// wrapper. Inner arrow is in CallExpression argument position
+		// (Branch 12 reject). Pair with a sibling class — only the
+		// class is a component, no diagnostic.
+		{Code: `
+        const A = Foo.memo((props) => <div>{props.x}</div>);
+        class B extends React.Component { render() { return <div /> } }
+      `, Tsx: true},
+
+		// ---- Lock-in: ES5 component via `<pragma>.<createClass>` ----
+		// `React.createClass({...})` (MemberExpression callee) ES5
+		// component shape — `IsCreateReactClassObjectArg` recognizes
+		// both bare `createReactClass` and pragma-qualified
+		// `<pragma>.<createClass>`. Default `react.createClass` is
+		// `createReactClass`; for `React.createClass(...)` the
+		// `react.createClass: 'createClass'` setting is required to
+		// match upstream's `pragmaUtil.getCreateClassFromContext`.
+		// Single component → no diagnostic.
+		{Code: `
+        var A = React.createClass({
+          render: function() { return <div />; }
+        });
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"createClass": "createClass"},
+			},
+		},
+
+		// ---- Lock-in: export default anonymous FunctionDeclaration ----
+		// `export default function() {...}` — anonymous FD allowed only
+		// in this position; Branch FunctionDeclaration's name == nil
+		// arm requires the `default` modifier. Single component → no
+		// diagnostic.
+		{Code: `
+        export default function() { return <div /> }
+      `, Tsx: true},
+
+		// ---- Lock-in: Branch 16 reject — Property parent + only-null return ----
+		// Upstream `getStatelessComponent` Branch 16 rejects a
+		// PropertyAssignment-positioned FunctionLike whose body only
+		// returns `null`. Previously rslint's `IsStatelessReactComponentWithWrappers`
+		// fell through to `return true` for the (anon arrow + computed
+		// key + only-null) shape — surfacing a phantom component. Pair
+		// with a sibling class to verify the arrow is NOT counted.
+		{Code: `
+        const obj = { [Symbol.iterator]: () => null };
+        class A extends React.Component { render() { return <div /> } }
+      `, Tsx: true},
+
+		// ---- Documented divergence: JSDoc @extends without extends clause ----
+		// Skip: true. ESLint's `isExplicitComponent` parses JSDoc tags
+		// (`@extends React.Component` / `@augments React.PureComponent`)
+		// via `doctrine` and treats the class as an ES6 component on tag
+		// presence alone. rslint requires a real `extends` clause. With
+		// upstream this would be 2 components → 1 diagnostic; rslint
+		// sees 1 component → 0 diagnostics. Documented under the rule's
+		// "Differences from ESLint" section. Test kept skipped to lock
+		// in the divergence (will surface if the gap is closed later).
+		{Code: `
+        /** @extends React.Component */
+        class Hello {
+          render() { return <div /> }
+        }
+        class HelloJohn extends React.Component {
+          render() { return <div /> }
+        }
+      `, Tsx: true, Skip: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Two createReactClass / classes / functions / mixed ----
+		{
+			Code: crCode(`
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+        var HelloJohn = createReactClass({
+          render: function() {
+            return <Hello name="John" />;
+          }
+        });
+      `),
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 7},
+			},
+		},
+		{
+			Code: crCode(`
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+        class HelloJohn extends React.Component {
+          render() {
+            return <Hello name="John" />;
+          }
+        }
+        class HelloJohnny extends React.Component {
+          render() {
+            return <Hello name="Johnny" />;
+          }
+        }
+      `),
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 7},
+				{MessageId: onlyOne, Line: 12},
+			},
+		},
+		{
+			Code: `
+        function Hello(props) {
+          return <div>Hello {props.name}</div>;
+        }
+        function HelloAgain(props) {
+          return <div>Hello again {props.name}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 5},
+			},
+		},
+		{
+			Code: `
+        function Hello(props) {
+          return <div>Hello {props.name}</div>;
+        }
+        class HelloJohn extends React.Component {
+          render() {
+            return <Hello name="John" />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 5},
+			},
+		},
+
+		// ---- Object-literal property methods that are stateless components ----
+		{
+			Code: `
+        export default {
+          RenderHello(props) {
+            let {name} = props;
+            return <div>{name}</div>;
+          },
+          RenderHello2(props) {
+            let {name} = props;
+            return <div>{name}</div>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 7},
+			},
+		},
+
+		// ---- Fragment + nested-function component ----
+		{
+			Code: `
+        exports.Foo = function Foo() {
+          return <></>
+        }
+
+        exports.createSomeComponent = function createSomeComponent(opts) {
+          return function Foo() {
+            return <>{opts.a}</>
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 7},
+			},
+		},
+
+		// ---- forwardRef wrapping `<div>...</div>` (root tag is `div`, NOT a known sibling) ----
+		{
+			Code: `
+        class StoreListItem extends React.PureComponent {
+          // A bunch of stuff here
+        }
+        export default React.forwardRef((props, ref) => <div><StoreListItem {...props} forwardRef={ref} /></div>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 5},
+			},
+		},
+		{
+			Code: `
+        const HelloComponent = (props) => {
+          return <div></div>;
+        }
+        const HelloComponent2 = React.forwardRef((props, ref) => <div></div>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 5},
+			},
+		},
+
+		// ---- SequenceExpression that resolves to an arrow ----
+		{
+			Code: `
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = React.forwardRef((props, ref) => <><HelloComponent></HelloComponent></>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 5},
+			},
+		},
+
+		// ---- Various ways the wrapper callee can be aliased ----
+		{
+			Code: `
+        const forwardRef = React.forwardRef;
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = forwardRef((props, ref) => <HelloComponent></HelloComponent>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+		{
+			Code: `
+        const memo = React.memo;
+        const HelloComponent = (props) => {
+          return <div></div>;
+        };
+        const HelloComponent2 = memo((props) => <HelloComponent></HelloComponent>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+		{
+			Code: `
+        const {forwardRef} = React;
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = forwardRef((props, ref) => <HelloComponent></HelloComponent>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+		{
+			Code: `
+        const {memo} = React;
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = memo((props) => <HelloComponent></HelloComponent>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+		{
+			Code: `
+        import React, { memo } from 'react';
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = memo((props) => <HelloComponent></HelloComponent>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+		{
+			Code: `
+        import {forwardRef} from 'react';
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = forwardRef((props, ref) => <HelloComponent></HelloComponent>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+		{
+			Code: `
+        const { memo } = require('react');
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = memo((props) => <HelloComponent></HelloComponent>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+		{
+			Code: `
+        const {forwardRef} = require('react');
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = forwardRef((props, ref) => <HelloComponent></HelloComponent>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+		{
+			Code: `
+        const forwardRef = require('react').forwardRef;
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = forwardRef((props, ref) => <HelloComponent></HelloComponent>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+		{
+			Code: `
+        const memo = require('react').memo;
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = memo((props) => <HelloComponent></HelloComponent>);
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreStateless": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+
+		// ---- Custom pragma via `settings.react.pragma` ----
+		{
+			Code: `
+        import Foo, { memo, forwardRef } from 'foo';
+        const Text = forwardRef(({ text }, ref) => {
+          return <div ref={ref}>{text}</div>;
+        })
+        const Label = memo(() => <Text />);
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{
+					"pragma": "Foo",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne},
+			},
+		},
+
+		// ---- Lock-in: explicit `[{}]` (empty options object) lands on default `ignoreStateless = false` ----
+		// Verifies the `GetOptionsMap` JSON-path round-trip preserves defaults
+		// when the user supplies an empty options object — same behavior as
+		// supplying no options at all (the canonical first-paragraph invalid
+		// case is two function components, which `ignoreStateless: false`
+		// must report).
+		{
+			Code: `
+        function Hello(props) { return <div /> }
+        function HelloAgain(props) { return <div /> }
+      `,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- Lock-in: array-wrapped options shape (rule_tester / multi-element CLI) ----
+		{
+			Code: `
+        function Hello(props) { return <div /> }
+        class HelloJohn extends React.Component {
+          render() { return <div /> }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"ignoreStateless": false}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- Dimension 4: nested class-in-function where both qualify ----
+		{
+			Code: `
+        function Outer(props) {
+          class Inner extends React.Component { render() { return <div /> } }
+          return <Inner />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- Dimension 4: paren / TS wrapper around class expression VariableDeclarator init ----
+		// Both qualify as components. Outer is a class component; second
+		// VariableDeclarator inits to a paren-wrapped ClassExpression.
+		{
+			Code: `
+        class A extends React.Component { render() { return <div /> } }
+        const B = (class extends React.Component { render() { return <div /> } });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- Dimension 4: computed-key arrow that returns JSX is still a component ----
+		// Branch 9 of upstream's `getStatelessComponent` only rejects when
+		// the return is neither JSX nor only-null. JSX-returning arrow under
+		// a `[ns.X]: ...` computed key passes through to Branch 12+ and is
+		// classified — paired with a sibling class component, the second
+		// (declaration-order) entry must be reported.
+		{
+			Code: `
+        class App extends React.Component {
+          render() { return <div /> }
+        }
+        const obj = { [ns.X]: (props) => <div>{props.y}</div> };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 5},
+			},
+		},
+
+		// ---- Dimension 4: object literal with shorthand `Method() {}` style ----
+		// Upstream invariant: each method whose key is capitalized AND
+		// returns JSX is independently registered as a component.
+		// When THREE such methods exist, errors should fire on entries 2
+		// and 3.
+		{
+			Code: `
+        export default {
+          A() { return <div /> },
+          B() { return <div /> },
+          C() { return <div /> },
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 4},
+				{MessageId: onlyOne, Line: 5},
+			},
+		},
+
+		// ---- Real-world: TS class-with-generics + sibling typed FC ----
+		{
+			Code: `
+        type Props = { name: string };
+        class Hello extends React.Component<Props> { render() { return <div>{this.props.name}</div>; } }
+        const Bye: React.FC<Props> = (props) => <div>Bye {props.name}</div>;
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- Real-world: arrow returning ternary with JSX (Branch ` strict=true` paths) ----
+		{
+			Code: `
+        const A = (props) => props.cond ? <div /> : <span />;
+        const B = (props) => <div>{props.x}</div>;
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- Real-world: deep nesting — inner pragma-wrapper inside a class field ----
+		// Lock-in: upstream's `Components.detect` CallExpression listener
+		// adds `React.memo(arrow)` regardless of its enclosing position
+		// (allowed-position gate only applies to FunctionLike Branch 12;
+		// CallExpression listener has no such gate). So three components
+		// exist: Outer class, the React.memo wrapper inside the field
+		// initializer, and the Sibling function. Errors on entries 2 & 3.
+		{
+			Code: `
+        class Outer extends React.Component {
+          inner = React.memo((props) => <div>{props.x}</div>);
+          render() { return <div /> }
+        }
+        function Sibling(props) { return <div>{props.y}</div>; }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+				{MessageId: onlyOne, Line: 6},
+			},
+		},
+
+		// ---- Real-world: SequenceExpression chain `(0, 0, arrow)` ----
+		// Upstream's `getStatelessComponent` Branch 12 recognizes
+		// SequenceExpression position when the arrow is the LAST entry
+		// and the sequence is itself in an allowed position
+		// (VariableDeclarator). Two such siblings → second reports.
+		{
+			Code: `
+        const A = (0, 0, (props) => <div>{props.x}</div>);
+        const B = (0, (props) => <span>{props.y}</span>);
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- Real-world: configured wrapper user-defined entry ----
+		{
+			Code: `
+        const A = myObserver((props) => <div>{props.x}</div>);
+        const B = myObserver((props) => <div>{props.y}</div>);
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"componentWrapperFunctions": []interface{}{"myObserver"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- Real-world: configured wrapper user-defined entry, ignoreStateless filters wrapper-call CallExpression node too ----
+		{
+			Code: `
+        const A = myObserver((props) => <div>{props.x}</div>);
+        class B extends React.Component { render() { return <div /> } }
+        class C extends React.Component { render() { return <div /> } }
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{"ignoreStateless": true},
+			Settings: map[string]interface{}{
+				"componentWrapperFunctions": []interface{}{"myObserver"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- Real-world: declaration order matters — first wins, no resort ----
+		// Class is declared after function; function is the FIRST in
+		// declaration order, the class is reported. Confirms position-
+		// based ordering rather than kind-based.
+		{
+			Code: `
+        function Hello(props) { return <div>{props.name}</div>; }
+        class HelloAgain extends React.Component { render() { return <div /> } }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- Real-world: TS namespace + const that both yield components ----
+		// Two top-level components inside a namespace block. Both
+		// classify. Namespace traversal works because we use
+		// ForEachChild recursively.
+		{
+			Code: `
+        namespace UI {
+          export const A = (props) => <div>{props.x}</div>;
+          export const B = (props) => <span>{props.y}</span>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- Real-world: `module.exports = function() {...}` is allowed ----
+		// `module.exports` is special-cased in upstream's
+		// `getStatelessComponent` (`isModuleExportsAssignment`).
+		// PAIRED with a sibling component, the sibling is the SECOND
+		// component (the exports-assigned anonymous fn is FIRST).
+		{
+			Code: `
+        module.exports = function (props) { return <div>{props.x}</div>; };
+        class Sibling extends React.Component { render() { return <div /> } }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- Lock-in: `componentWrapperFunctions` `<pragma>` placeholder + bare imported callee ----
+		// Upstream `isPragmaComponentWrapper` bare-callee arm:
+		//   wrapperFunction.object === pragma && isDestructuredFromPragmaImport(callee)
+		// must match. Here a user entry `{property: 'observer', object: '<pragma>'}`
+		// is configured, pragma is default `React`, and `observer` is
+		// imported from 'react'. Bare `observer(arrow)` must classify as
+		// the wrapper component, paired with a sibling class → second
+		// component reports.
+		{
+			Code: `
+        import { observer } from 'react';
+        const A = observer((props) => <div>{props.x}</div>);
+        class B extends React.Component { render() { return <div /> } }
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"componentWrapperFunctions": []interface{}{
+					map[string]interface{}{"property": "observer", "object": "<pragma>"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- Lock-in: `<pragma>` placeholder with TWO matching wrapper calls ----
+		{
+			Code: `
+        const A = Foo.observer((props) => <div>{props.x}</div>);
+        const B = Foo.observer((props) => <div>{props.y}</div>);
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"pragma": "Foo"},
+				"componentWrapperFunctions": []interface{}{
+					map[string]interface{}{"property": "observer", "object": "<pragma>"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- Lock-in: nested wrapper `memo(forwardRef(arrow))` ----
+		// Upstream `Components.detect` registers BOTH wrappers as
+		// independent components (memo via the arrow's
+		// `getPragmaComponentWrapper` outer-most ascent, forwardRef via
+		// its own CallExpression listener). With a sibling class, total
+		// components = 3 → 2 diagnostics, on the memo and forwardRef
+		// lines.
+		{
+			Code: `
+        class A extends React.Component { render() { return <div /> } }
+        const Outer = React.memo(
+          React.forwardRef((props, ref) => <div ref={ref} />)
+        );
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- Real-world: deeply nested — three siblings in a single file ----
+		{
+			Code: `
+        function A() { return <div /> }
+        function B() { return <div /> }
+        function C() { return <div /> }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- Contract: exact message text + line/column/endLine/endColumn ----
+		// Locks in upstream's diagnostic surface byte-for-byte: the
+		// message string must equal `onlyOneText`, and the report range
+		// must cover the second component's full extent on the same
+		// line.
+		{
+			Code: `
+        function Hello(props) { return <div /> }
+        function HelloAgain(props) { return <div /> }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: onlyOne,
+					Message:   onlyOneText,
+					Line:      3,
+					Column:    9,
+					EndLine:   3,
+					EndColumn: 54,
+				},
+			},
+		},
+
+		// ---- Contract: multi-line component report — Line + Column + EndLine + EndColumn ----
+		// Locks in the position fields when the second component spans
+		// more than one source line. Class declaration starts at line
+		// 5 and ends at line 7.
+		{
+			Code: `
+        class First extends React.Component {
+          render() { return <div /> }
+        }
+        class Second extends React.Component {
+          render() { return <div /> }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: onlyOne,
+					Line:      5,
+					Column:    9,
+					EndLine:   7,
+					EndColumn: 10,
+				},
+			},
+		},
+
+		// ---- Branch 4 lock-in: AssignmentExpression non-MemberExpression LHS ----
+		// `Capitalized = function() { return <div/> }` — Identifier LHS,
+		// fn returns JSX, capitalized → component. Two such
+		// assignments in same file → second reports.
+		{
+			Code: `
+        var A, B;
+        A = function() { return <div /> }
+        B = function() { return <div /> }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- Branch 4 lock-in: named-FE id takes priority over LHS ----
+		// `lower = function CapitalizedFE() { return <div/> }` — even
+		// though LHS is lowercase, the FE's named id is capitalized so
+		// the FE classifies as a component (Branch 4 in
+		// IsStatelessReactComponentWithWrappers explicitly checks
+		// `fn.Kind == FunctionExpression && fn.Name() != nil` BEFORE
+		// looking at LHS). Pair with sibling class.
+		{
+			Code: `
+        var helper;
+        helper = function NamedComp() { return <div /> }
+        class App extends React.Component { render() { return <div /> } }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- Branch 5 lock-in: nested arrow whose outer arrow is in AssignmentExpression ----
+		// `X = () => () => <div/>` — outer arrow in AE with capitalized
+		// LHS, inner arrow returns JSX → inner classifies as
+		// component. Two of these → second reports.
+		{
+			Code: `
+        var A, B;
+        A = () => () => <div />;
+        B = () => () => <div />;
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- Branch 6 lock-in: nested arrow whose outer arrow is a PropertyAssignment value ----
+		// `{ Foo: () => () => <div/> }` — same as Branch 5 but
+		// PropertyAssignment instead of AE.
+		{
+			Code: `
+        const obj = {
+          Foo: () => () => <div />,
+          Bar: () => () => <div />,
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- Branch 7/8 lock-in: nested FE in ReturnStatement, outer FE in PropertyAssignment ----
+		{
+			Code: `
+        const obj = {
+          Foo: function() { return function() { return <div />; }; },
+          Bar: function() { return function() { return <div />; }; },
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 4},
+			},
+		},
+
+		// ---- React.createClass (MemberExpression callee) two siblings ----
+		// Lock-in for `<pragma>.<createClass>` ES5 detection — requires
+		// `settings.react.createClass` because the default factory name
+		// is `createReactClass`, not `createClass`.
+		{
+			Code: `
+        var A = React.createClass({ render: function() { return <div />; } });
+        var B = React.createClass({ render: function() { return <div />; } });
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"createClass": "createClass"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- bare Component / bare PureComponent extends ----
+		// Both bare identifiers match `/^(Pure)?Component$/`. Two
+		// classes extending bare Component / PureComponent → second
+		// reports.
+		{
+			Code: `
+        class A extends Component { render() { return <div /> } }
+        class B extends PureComponent { render() { return <div /> } }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+
+		// ---- export default anon FD + sibling ----
+		// Lock-in: anonymous FunctionDeclaration only legal as
+		// `export default function()`; the `default` modifier flag is
+		// what lets the FunctionDeclaration arm of
+		// IsStatelessReactComponentWithWrappers accept a name == nil
+		// fn. Pair with sibling class.
+		{
+			Code: `
+        class A extends React.Component { render() { return <div /> } }
+        export default function() { return <div /> }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: onlyOne, Line: 3},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_multi_comp/no_multi_comp_test.go
+++ b/internal/plugins/react/rules/no_multi_comp/no_multi_comp_test.go
@@ -575,6 +575,18 @@ func TestNoMultiCompRule(t *testing.T) {
         class A extends React.Component { render() { return <div /> } }
       `, Tsx: true},
 
+		// ---- Lock-in: paren-wrapped MemberExpression wrapper callee + nodeWrapsComponent gate ----
+		// `(React.forwardRef)(arrow)` — paren wraps the MemberExpression
+		// callee. ESTree flattens parens so upstream sees
+		// `callee.type === 'MemberExpression'` and applies the
+		// nodeWrapsComponent gate. tsgo preserves the paren, so
+		// `WrapperWrapsKnownSiblingComponent` must skip it before the
+		// kind check or the gate misfires (over-reports).
+		{Code: `
+        class StoreListItem extends React.PureComponent {}
+        export default (React.forwardRef)((props, ref) => <StoreListItem {...props} forwardRef={ref} />);
+      `, Tsx: true},
+
 		// ---- Lock-in: async-generator object-literal shorthand method ----
 		// `{ async *Foo() { return <div/> } }` — upstream's FE listener
 		// (which fires on ESTree's `Property.value`) treats this as an

--- a/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components.go
+++ b/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components.go
@@ -68,27 +68,6 @@ func unwrap(node *ast.Node) *ast.Node {
 	return reactutil.SkipExpressionWrappers(node)
 }
 
-// isFunctionLike reports whether `node` is a function-shaped node we
-// classify as a "potential component" — covers FunctionDeclaration,
-// FunctionExpression, ArrowFunction, and the object-literal shorthand
-// MethodDeclaration / GetAccessor / SetAccessor (upstream catches these
-// via ESTree's `Property { method: true, value: FunctionExpression }`).
-func isFunctionLike(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindFunctionDeclaration,
-		ast.KindFunctionExpression,
-		ast.KindArrowFunction,
-		ast.KindMethodDeclaration,
-		ast.KindGetAccessor,
-		ast.KindSetAccessor:
-		return true
-	}
-	return false
-}
-
 // componentEnv bundles the per-rule-invocation context every helper needs.
 // Threading a single struct keeps signatures readable and avoids drift when
 // new fields (TypeChecker, settings derivatives) are added later.
@@ -99,255 +78,11 @@ type componentEnv struct {
 	tc          *checker.Checker
 }
 
-// isDetectedComponent reports whether `node` looks like a React component.
-// Mirrors upstream's `components.get(node)` — a node is considered a
-// component when it would be classified by the plugin's Components.detect
-// pipeline. For functions we defer to `IsStatelessReactComponent` (which
-// itself recognizes the default `memo`/`forwardRef` wrapper); when an inner
-// FunctionLike sits inside a configured-but-non-default wrapper from
-// `settings.componentWrapperFunctions`, that fallback is handled here. For
-// classes we check the extends clause. For object literals we recognize the
-// `<createClass>(...)` argument shape (ES5 components). CallExpressions are
-// recognized as components when they match a configured wrapper — that's
-// what lets `validateCall` walk up from a custom `myMemo(fn)` call and find
-// itself as the closest component ancestor.
+// isDetectedComponent is a thin env-aware adapter over
+// reactutil.IsDetectedComponent — see that function's doc for the canonical
+// component-classification semantics.
 func isDetectedComponent(node *ast.Node, env componentEnv) bool {
-	if node == nil {
-		return false
-	}
-	pragma, createClass, wrappers := env.pragma, env.createClass, env.wrappers
-	switch node.Kind {
-	case ast.KindFunctionDeclaration,
-		ast.KindFunctionExpression,
-		ast.KindArrowFunction,
-		ast.KindMethodDeclaration,
-		ast.KindGetAccessor,
-		ast.KindSetAccessor:
-		// Use the wrappers-aware variant so user-configured
-		// `componentWrapperFunctions` entries participate in Branch 11
-		// (the pragma-component-wrapper arm). Without this, a
-		// `myMemo(() => null)` inner arrow would NOT classify as a
-		// stateless component, and `isStatelessComponentReturningNull`
-		// later would not be able to skip it the way upstream does.
-		if reactutil.IsStatelessReactComponentWithWrappers(node, pragma, env.tc, wrappers) {
-			return true
-		}
-		// User-configured wrapper fallback: an arrow / FE wrapped by a
-		// non-default wrapper (`myMemo(fn)` etc.) doesn't get picked up by
-		// IsStatelessReactComponent's hardcoded memo/forwardRef branch, so
-		// we walk paren / TS-wrapper hops up to the enclosing call and
-		// check the configured list. The function still has to return JSX
-		// or null on at least one path, matching upstream's
-		// `isReturningJSXOrNull` gate inside Components.detect's wrapper
-		// arm.
-		parent := reactutil.SkipExpressionWrappersUp(node)
-		if parent != nil && parent.Kind == ast.KindCallExpression &&
-			reactutil.MatchesAnyComponentWrapperWithChecker(parent, node, wrappers, env.pragma, env.tc) &&
-			reactutil.FunctionReturnsJSXOrNullWithChecker(node, pragma, env.tc) {
-			return true
-		}
-		return false
-	case ast.KindClassDeclaration, ast.KindClassExpression:
-		return reactutil.ExtendsReactComponent(node, pragma)
-	case ast.KindObjectLiteralExpression:
-		return reactutil.IsCreateReactClassObjectArg(node, pragma, createClass)
-	case ast.KindCallExpression:
-		// A wrapper call counts as a component when it matches the
-		// configured wrapper list AND its first argument is a
-		// FunctionLike. Upstream's CallExpression visitor in
-		// `Components.detect` registers via
-		// `components.add(call, 2)` whenever
-		// `isPragmaComponentWrapper(node) && isFunctionLikeExpression(arguments[0])`
-		// — note that it does NOT additionally check whether the inner
-		// FunctionLike returns JSX. Tracking that intentional looseness
-		// here keeps the report counts byte-aligned for cases like
-		// `React.memo(() => undefined)` which upstream still flags
-		// despite the inner arrow not returning JSX.
-		call := node.AsCallExpression()
-		if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
-			return false
-		}
-		inner := reactutil.SkipExpressionWrappers(call.Arguments.Nodes[0])
-		if inner == nil || !isFunctionLike(inner) {
-			return false
-		}
-		if !reactutil.MatchesAnyComponentWrapperWithChecker(node, inner, wrappers, env.pragma, env.tc) {
-			return false
-		}
-		// `nodeWrapsComponent` parity: when the wrapper is a
-		// MemberExpression (e.g. `React.memo(...)`) and its
-		// FunctionLike argument's body returns JSX whose root tag
-		// resolves to a sibling/outer detected component
-		// (arrow-assigned-to-VariableDeclarator or ClassDeclaration),
-		// upstream's `isPragmaComponentWrapper` short-circuits to
-		// false and the call is NOT registered as a component. The
-		// bare-callee form (e.g. `memo(...)` after `import { memo }
-		// from 'react'`) does NOT get this gate — see upstream
-		// `Components.js` `isPragmaComponentWrapper`, MemberExpression
-		// branch only.
-		if wrapsKnownSiblingComponent(node, inner) {
-			return false
-		}
-		return true
-	}
-	return false
-}
-
-// wrapsKnownSiblingComponent reports whether `call` is a MemberExpression
-// wrapper (e.g. `React.memo(arrow)`) whose FunctionLike argument's body
-// returns JSX (concise body or first ReturnStatement of a block) whose root
-// tag-name matches a sibling/outer arrow-assigned-to-VariableDeclarator or
-// ClassDeclaration in the same source file. Mirrors upstream's
-// `nodeWrapsComponent` gate, which is intentionally name-based (not symbol-
-// based) and only applied to the MemberExpression form of the wrapper.
-func wrapsKnownSiblingComponent(call *ast.Node, fn *ast.Node) bool {
-	if call == nil || call.Kind != ast.KindCallExpression {
-		return false
-	}
-	expr := call.AsCallExpression().Expression
-	if expr == nil || expr.Kind != ast.KindPropertyAccessExpression {
-		return false
-	}
-	tag := returnedJSXRootTagName(fn)
-	if tag == "" {
-		return false
-	}
-	src := ast.GetSourceFileOfNode(call)
-	if src == nil {
-		return false
-	}
-	// Position gate matches upstream's order-dependence:
-	// `getDetectedComponents()` only returns components that have been
-	// visited so far in AST walk order, which for non-overlapping
-	// declarations is equivalent to source-position order. A sibling
-	// declared AFTER the wrapper call is invisible to upstream and must
-	// be invisible here too — otherwise we'd skip a wrapper that
-	// upstream reports.
-	return sourceHasComponentNamedBefore(src.AsNode(), tag, call.Pos())
-}
-
-// returnedJSXRootTagName extracts the root JSX tag name from a function's
-// body — covers both the concise-body case (`() => <Foo/>`) and the
-// block-body case where the FIRST top-level ReturnStatement is inspected.
-// Returns empty string when the body doesn't return a JSX element directly.
-func returnedJSXRootTagName(fn *ast.Node) string {
-	if fn == nil {
-		return ""
-	}
-	var body *ast.Node
-	switch fn.Kind {
-	case ast.KindArrowFunction:
-		body = fn.AsArrowFunction().Body
-	case ast.KindFunctionExpression:
-		body = fn.AsFunctionExpression().Body
-	case ast.KindFunctionDeclaration:
-		body = fn.AsFunctionDeclaration().Body
-	default:
-		return ""
-	}
-	if body == nil {
-		return ""
-	}
-	if body.Kind == ast.KindBlock {
-		var ret *ast.Node
-		body.ForEachChild(func(child *ast.Node) bool {
-			if child.Kind == ast.KindReturnStatement {
-				ret = child
-				return true
-			}
-			return false
-		})
-		if ret == nil {
-			return ""
-		}
-		return jsxRootTagName(ret.AsReturnStatement().Expression)
-	}
-	return jsxRootTagName(body)
-}
-
-// jsxRootTagName returns the tag-name of a JsxElement / JsxSelfClosingElement
-// (peeling paren / TS wrappers) when it's a plain identifier, or "" otherwise.
-// Member-expression tag-names (`<Foo.Bar />`) and namespaced names
-// (`<svg:circle/>`) intentionally return "" — upstream's
-// `getComponentNameFromJSXElement` only matches plain identifiers via the
-// detected-components list keyed by the binding's local name.
-func jsxRootTagName(expr *ast.Node) string {
-	expr = reactutil.SkipExpressionWrappers(expr)
-	if expr == nil {
-		return ""
-	}
-	var tag *ast.Node
-	switch expr.Kind {
-	case ast.KindJsxElement:
-		opening := expr.AsJsxElement().OpeningElement
-		if opening != nil {
-			tag = opening.AsJsxOpeningElement().TagName
-		}
-	case ast.KindJsxSelfClosingElement:
-		tag = expr.AsJsxSelfClosingElement().TagName
-	default:
-		return ""
-	}
-	if tag == nil || tag.Kind != ast.KindIdentifier {
-		return ""
-	}
-	return tag.AsIdentifier().Text
-}
-
-// sourceHasComponentNamedBefore scans the source file for a sibling/outer
-// component declaration whose name equals `name` and whose start position
-// precedes `before`. Mirrors upstream's `getDetectedComponents` filter —
-// only `class` declarations and arrow-assigned-to-VariableDeclarator
-// declarations qualify; function declarations do NOT (upstream's filter
-// in `Components.js getDetectedComponents` only retains those two kinds).
-// The position gate replicates upstream's order-dependence: a sibling
-// declared AFTER the use site has not yet been added to the components
-// list when `isPragmaComponentWrapper` runs, so it must not match here
-// either.
-func sourceHasComponentNamedBefore(root *ast.Node, name string, before int) bool {
-	if root == nil || name == "" {
-		return false
-	}
-	var found bool
-	var visit func(n *ast.Node)
-	visit = func(n *ast.Node) {
-		if found || n == nil {
-			return
-		}
-		if n.Pos() >= before {
-			// Subtree starts at or after the use site — upstream's AST
-			// walk wouldn't have reached it yet. Skip the entire subtree.
-			return
-		}
-		switch n.Kind {
-		case ast.KindClassDeclaration:
-			id := n.Name()
-			if id != nil && id.Kind == ast.KindIdentifier && id.AsIdentifier().Text == name {
-				found = true
-				return
-			}
-		case ast.KindVariableDeclaration:
-			vd := n.AsVariableDeclaration()
-			if vd.Initializer == nil {
-				break
-			}
-			init := reactutil.SkipExpressionWrappers(vd.Initializer)
-			if init == nil || init.Kind != ast.KindArrowFunction {
-				break
-			}
-			id := vd.Name()
-			if id != nil && id.Kind == ast.KindIdentifier && id.AsIdentifier().Text == name {
-				found = true
-				return
-			}
-		}
-		n.ForEachChild(func(child *ast.Node) bool {
-			visit(child)
-			return found
-		})
-	}
-	visit(root)
-	return found
+	return reactutil.IsDetectedComponent(node, env.pragma, env.createClass, env.wrappers, env.tc)
 }
 
 // isInsideWrapperCall reports whether `node` is the FunctionLike argument of
@@ -646,7 +381,7 @@ func isStatelessComponentReturningNull(node *ast.Node, env componentEnv) bool {
 // as a "function component inside class component" purely on the basis
 // of returning JSX.
 func isFunctionComponentInsideClassComponent(node *ast.Node, env componentEnv) bool {
-	if !isFunctionLike(node) {
+	if !reactutil.IsFunctionLikeForComponent(node) {
 		return false
 	}
 	parent := getClosestParentComponent(node, env)
@@ -657,7 +392,7 @@ func isFunctionComponentInsideClassComponent(node *ast.Node, env componentEnv) b
 		return false
 	}
 	enclosingFn := ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
-		return isFunctionLike(n)
+		return reactutil.IsFunctionLikeForComponent(n)
 	})
 	if enclosingFn == nil {
 		return false
@@ -817,7 +552,7 @@ var NoUnstableNestedComponentsRule = rule.Rule{
 			// `components.add(call, 2)` registration). Suppress the inner
 			// FunctionLike report so the diagnostic position aligns with
 			// upstream byte-for-byte.
-			if isFunctionLike(node) && isInsideWrapperCall(node, env) {
+			if reactutil.IsFunctionLikeForComponent(node) && isInsideWrapperCall(node, env) {
 				return
 			}
 

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -126,6 +126,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-redundant-should-component-update.test.ts',
     './tests/eslint-plugin-react/rules/no-render-return-value.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
+    './tests/eslint-plugin-react/rules/no-multi-comp.test.ts',
     './tests/eslint-plugin-react/rules/no-this-in-sfc.test.ts',
     './tests/eslint-plugin-react/rules/no-unstable-nested-components.test.ts',
     './tests/eslint-plugin-react/rules/no-typos.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-multi-comp.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-multi-comp.test.ts
@@ -1,0 +1,683 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// Mirrors upstream's `code.split('\n').join('\r')` line-terminator transform.
+const cr = (s: string) => s.replace(/\n/g, '\r');
+
+ruleTester.run('no-multi-comp', {} as never, {
+  valid: [
+    // ---- Single component declarations ----
+    {
+      code: `
+        var Hello = require('./components/Hello');
+        var HelloJohn = createReactClass({
+          render: function() {
+            return <Hello name="John" />;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        var Heading = createReactClass({
+          render: function() {
+            return (
+              <div>
+                {this.props.buttons.map(function(button, index) {
+                  return <Button {...button} key={index}/>;
+                })}
+              </div>
+            );
+          }
+        });
+      `,
+    },
+
+    // ---- ignoreStateless: true ----
+    {
+      code: `
+        function Hello(props) {
+          return <div>Hello {props.name}</div>;
+        }
+        function HelloAgain(props) {
+          return <div>Hello again {props.name}</div>;
+        }
+      `,
+      options: [{ ignoreStateless: true }],
+    },
+    {
+      code: `
+        function Hello(props) {
+          return <div>Hello {props.name}</div>;
+        }
+        class HelloJohn extends React.Component {
+          render() {
+            return <Hello name="John" />;
+          }
+        }
+      `,
+      options: [{ ignoreStateless: true }],
+    },
+
+    // ---- Helper functions are not components ----
+    {
+      code: `
+        import React, { createElement } from "react"
+        const helperFoo = () => {
+          return true;
+        };
+        function helperBar() {
+          return false;
+        };
+        function RealComponent() {
+          return createElement("img");
+        };
+      `,
+    },
+
+    // ---- React.memo / React.forwardRef wrapping ----
+    {
+      code: `
+        const Hello = React.memo(function(props) {
+          return <div>Hello {props.name}</div>;
+        });
+        class HelloJohn extends React.Component {
+          render() {
+            return <Hello name="John" />;
+          }
+        }
+      `,
+      options: [{ ignoreStateless: true }],
+    },
+
+    // ---- forwardRef wrapping a sibling component (nodeWrapsComponent gate) ----
+    {
+      code: `
+        class StoreListItem extends React.PureComponent {
+          // A bunch of stuff here
+        }
+        export default React.forwardRef((props, ref) => <StoreListItem {...props} forwardRef={ref} />);
+      `,
+      options: [{ ignoreStateless: false }],
+    },
+    {
+      code: `
+        class StoreListItem extends React.PureComponent {
+          // A bunch of stuff here
+        }
+        export default React.forwardRef((props, ref) => {
+          return <StoreListItem {...props} forwardRef={ref} />
+        });
+      `,
+      options: [{ ignoreStateless: false }],
+    },
+    {
+      code: `
+        const HelloComponent = (props) => {
+          return <div></div>;
+        }
+        export default React.forwardRef((props, ref) => <HelloComponent {...props} forwardRef={ref} />);
+      `,
+      options: [{ ignoreStateless: false }],
+    },
+    {
+      code: `
+        class StoreListItem extends React.PureComponent {
+          // A bunch of stuff here
+        }
+        export default React.forwardRef(
+          function myFunction(props, ref) {
+            return <StoreListItem {...props} forwardedRef={ref} />;
+          }
+        );
+      `,
+      options: [{ ignoreStateless: true }],
+    },
+    {
+      code: `
+        const HelloComponent = (props) => {
+          return <div></div>;
+        }
+        class StoreListItem extends React.PureComponent {
+          // A bunch of stuff here
+        }
+        export default React.forwardRef(
+          function myFunction(props, ref) {
+            return <StoreListItem {...props} forwardedRef={ref} />;
+          }
+        );
+      `,
+      options: [{ ignoreStateless: true }],
+    },
+    {
+      code: `
+        const HelloComponent = (props) => {
+          return <div></div>;
+        }
+        export default React.memo((props, ref) => <HelloComponent {...props} />);
+      `,
+      options: [{ ignoreStateless: true }],
+    },
+
+    // ---- Class field arrow that consumes an unrelated `memo`-named helper ----
+    {
+      code: `
+        import React from 'react';
+        function memo() {
+          var outOfScope = "hello"
+          return null;
+        }
+        class ComponentY extends React.Component {
+          memoCities = memo((cities) => cities.map((v) => ({ label: v })));
+          render() {
+            return (
+              <div>
+                <div>Counter</div>
+              </div>
+            );
+          }
+        }
+      `,
+    },
+
+    // ---- forwardRef + .displayName / .propTypes / .defaultProps assignments ----
+    {
+      code: `
+        const MenuList = forwardRef(({onClose, ...props}, ref) => {
+          const {t} = useTranslation();
+          const handleLogout = useLogoutHandler();
+
+          const onLogout = useCallback(() => {
+            onClose();
+            handleLogout();
+          }, [onClose, handleLogout]);
+
+          return (
+            <MuiMenuList ref={ref} {...props}>
+              <MuiMenuItem key="logout" onClick={onLogout}>
+                {t('global-logout')}
+              </MuiMenuItem>
+            </MuiMenuList>
+          );
+        });
+
+        MenuList.displayName = 'MenuList';
+
+        MenuList.propTypes = {
+          onClose: PropTypes.func,
+        };
+
+        MenuList.defaultProps = {
+          onClose: () => null,
+        };
+
+        export default MenuList;
+      `,
+    },
+    {
+      code: `
+        const MenuList = forwardRef(({ onClose, ...props }, ref) => {
+          const onLogout = useCallback(() => {
+            onClose()
+          }, [onClose])
+
+          return (
+            <BlnMenuList ref={ref} {...props}>
+              <BlnMenuItem key="logout" onClick={onLogout}>
+                Logout
+              </BlnMenuItem>
+            </BlnMenuList>
+          )
+        })
+
+        MenuList.displayName = 'MenuList'
+
+        MenuList.propTypes = {
+          onClose: PropTypes.func
+        }
+
+        MenuList.defaultProps = {
+          onClose: () => null
+        }
+
+        export default MenuList
+      `,
+    },
+
+    // ---- Real-world extras (parity with Go suite) ----
+    {
+      code: `
+        type Props = { name: string };
+        const Hello: React.FC<Props> = (props) => <div>{props.name}</div>;
+      `,
+    },
+    {
+      code: `
+        interface Props { label: string }
+        const Btn = React.forwardRef<HTMLButtonElement, Props>((props, ref) => (
+          <button ref={ref}>{props.label}</button>
+        ));
+      `,
+    },
+    {
+      code: `
+        const enhanced = withFoo((props) => <div>{props.x}</div>);
+        class App extends React.Component { render() { return <div /> } }
+      `,
+      options: [{ ignoreStateless: true }],
+    },
+    {
+      code: `
+        const App = myObserver((props) => <div>{props.x}</div>);
+      `,
+      settings: { componentWrapperFunctions: ['myObserver'] },
+    },
+    {
+      code: `
+        const App = MyLib.observer((props) => <div>{props.x}</div>);
+      `,
+      settings: {
+        componentWrapperFunctions: [{ property: 'observer', object: 'MyLib' }],
+      },
+    },
+    {
+      code: `
+        const Hello = React?.memo((props) => <div>{props.x}</div>);
+      `,
+    },
+    {
+      code: `
+        import { useState } from 'react';
+        export function useToggle(init) {
+          const [on, setOn] = useState(init);
+          return [on, () => setOn(v => !v)];
+        }
+      `,
+    },
+    {
+      code: `
+        someLib.register('foo', (props) => <div>{props.x}</div>);
+        someLib.register('bar', (props) => <span>{props.y}</span>);
+      `,
+    },
+
+    // ---- `componentWrapperFunctions` "<pragma>" placeholder ----
+    {
+      code: `
+        const App = Foo.observer((props) => <div>{props.x}</div>);
+      `,
+      settings: {
+        react: { pragma: 'Foo' },
+        componentWrapperFunctions: [
+          { property: 'observer', object: '<pragma>' },
+        ],
+      },
+    },
+
+    // ---- ignoreStateless filters object-literal shorthand methods ----
+    {
+      code: `
+        export default {
+          A() { return <div /> },
+          B() { return <div /> },
+          C() { return <div /> },
+        };
+      `,
+      options: [{ ignoreStateless: true }],
+    },
+  ],
+  invalid: [
+    {
+      code: cr(`
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+        var HelloJohn = createReactClass({
+          render: function() {
+            return <Hello name="John" />;
+          }
+        });
+      `),
+      errors: [{ messageId: 'onlyOneComponent', line: 7 }],
+    },
+    {
+      code: cr(`
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+        class HelloJohn extends React.Component {
+          render() {
+            return <Hello name="John" />;
+          }
+        }
+        class HelloJohnny extends React.Component {
+          render() {
+            return <Hello name="Johnny" />;
+          }
+        }
+      `),
+      errors: [
+        { messageId: 'onlyOneComponent', line: 7 },
+        { messageId: 'onlyOneComponent', line: 12 },
+      ],
+    },
+    {
+      code: `
+        function Hello(props) {
+          return <div>Hello {props.name}</div>;
+        }
+        function HelloAgain(props) {
+          return <div>Hello again {props.name}</div>;
+        }
+      `,
+      errors: [{ messageId: 'onlyOneComponent', line: 5 }],
+    },
+    {
+      code: `
+        function Hello(props) {
+          return <div>Hello {props.name}</div>;
+        }
+        class HelloJohn extends React.Component {
+          render() {
+            return <Hello name="John" />;
+          }
+        }
+      `,
+      errors: [{ messageId: 'onlyOneComponent', line: 5 }],
+    },
+    {
+      code: `
+        export default {
+          RenderHello(props) {
+            let {name} = props;
+            return <div>{name}</div>;
+          },
+          RenderHello2(props) {
+            let {name} = props;
+            return <div>{name}</div>;
+          }
+        };
+      `,
+      errors: [{ messageId: 'onlyOneComponent', line: 7 }],
+    },
+    {
+      code: `
+        exports.Foo = function Foo() {
+          return <></>
+        }
+
+        exports.createSomeComponent = function createSomeComponent(opts) {
+          return function Foo() {
+            return <>{opts.a}</>
+          }
+        }
+      `,
+      errors: [{ messageId: 'onlyOneComponent', line: 7 }],
+    },
+    {
+      code: `
+        class StoreListItem extends React.PureComponent {
+          // A bunch of stuff here
+        }
+        export default React.forwardRef((props, ref) => <div><StoreListItem {...props} forwardRef={ref} /></div>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 5 }],
+    },
+    {
+      code: `
+        const HelloComponent = (props) => {
+          return <div></div>;
+        }
+        const HelloComponent2 = React.forwardRef((props, ref) => <div></div>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 5 }],
+    },
+    {
+      code: `
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = React.forwardRef((props, ref) => <><HelloComponent></HelloComponent></>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 5 }],
+    },
+    {
+      code: `
+        const forwardRef = React.forwardRef;
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = forwardRef((props, ref) => <HelloComponent></HelloComponent>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 6 }],
+    },
+    {
+      code: `
+        const memo = React.memo;
+        const HelloComponent = (props) => {
+          return <div></div>;
+        };
+        const HelloComponent2 = memo((props) => <HelloComponent></HelloComponent>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 6 }],
+    },
+    {
+      code: `
+        const {forwardRef} = React;
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = forwardRef((props, ref) => <HelloComponent></HelloComponent>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 6 }],
+    },
+    {
+      code: `
+        const {memo} = React;
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = memo((props) => <HelloComponent></HelloComponent>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 6 }],
+    },
+    {
+      code: `
+        import React, { memo } from 'react';
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = memo((props) => <HelloComponent></HelloComponent>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 6 }],
+    },
+    {
+      code: `
+        import {forwardRef} from 'react';
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = forwardRef((props, ref) => <HelloComponent></HelloComponent>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 6 }],
+    },
+    {
+      code: `
+        const { memo } = require('react');
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = memo((props) => <HelloComponent></HelloComponent>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 6 }],
+    },
+    {
+      code: `
+        const {forwardRef} = require('react');
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = forwardRef((props, ref) => <HelloComponent></HelloComponent>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 6 }],
+    },
+    {
+      code: `
+        const forwardRef = require('react').forwardRef;
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = forwardRef((props, ref) => <HelloComponent></HelloComponent>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 6 }],
+    },
+    {
+      code: `
+        const memo = require('react').memo;
+        const HelloComponent = (0, (props) => {
+          return <div></div>;
+        });
+        const HelloComponent2 = memo((props) => <HelloComponent></HelloComponent>);
+      `,
+      options: [{ ignoreStateless: false }],
+      errors: [{ messageId: 'onlyOneComponent', line: 6 }],
+    },
+    {
+      code: `
+        import Foo, { memo, forwardRef } from 'foo';
+        const Text = forwardRef(({ text }, ref) => {
+          return <div ref={ref}>{text}</div>;
+        })
+        const Label = memo(() => <Text />);
+      `,
+      settings: { react: { pragma: 'Foo' } },
+      errors: [{ messageId: 'onlyOneComponent' }],
+    },
+
+    // ---- Real-world extras (parity with Go suite) ----
+    {
+      code: `
+        type Props = { name: string };
+        class Hello extends React.Component<Props> { render() { return <div>{this.props.name}</div>; } }
+        const Bye: React.FC<Props> = (props) => <div>Bye {props.name}</div>;
+      `,
+      errors: [{ messageId: 'onlyOneComponent', line: 4 }],
+    },
+    {
+      code: `
+        const A = (props) => props.cond ? <div /> : <span />;
+        const B = (props) => <div>{props.x}</div>;
+      `,
+      errors: [{ messageId: 'onlyOneComponent', line: 3 }],
+    },
+    {
+      code: `
+        class Outer extends React.Component {
+          inner = React.memo((props) => <div>{props.x}</div>);
+          render() { return <div /> }
+        }
+        function Sibling(props) { return <div>{props.y}</div>; }
+      `,
+      errors: [
+        { messageId: 'onlyOneComponent', line: 3 },
+        { messageId: 'onlyOneComponent', line: 6 },
+      ],
+    },
+    {
+      code: `
+        const A = (0, 0, (props) => <div>{props.x}</div>);
+        const B = (0, (props) => <span>{props.y}</span>);
+      `,
+      errors: [{ messageId: 'onlyOneComponent', line: 3 }],
+    },
+    {
+      code: `
+        const A = myObserver((props) => <div>{props.x}</div>);
+        const B = myObserver((props) => <div>{props.y}</div>);
+      `,
+      settings: { componentWrapperFunctions: ['myObserver'] },
+      errors: [{ messageId: 'onlyOneComponent', line: 3 }],
+    },
+    {
+      code: `
+        function Hello(props) { return <div>{props.name}</div>; }
+        class HelloAgain extends React.Component { render() { return <div /> } }
+      `,
+      errors: [{ messageId: 'onlyOneComponent', line: 3 }],
+    },
+    {
+      code: `
+        function A() { return <div /> }
+        function B() { return <div /> }
+        function C() { return <div /> }
+      `,
+      errors: [
+        { messageId: 'onlyOneComponent', line: 3 },
+        { messageId: 'onlyOneComponent', line: 4 },
+      ],
+    },
+
+    // ---- Contract: exact message text + position fields ----
+    {
+      code: `
+        function Hello(props) { return <div /> }
+        function HelloAgain(props) { return <div /> }
+      `,
+      errors: [
+        {
+          messageId: 'onlyOneComponent',
+          message: 'Declare only one React component per file',
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 54,
+        },
+      ],
+    },
+    {
+      code: `
+        class First extends React.Component {
+          render() { return <div /> }
+        }
+        class Second extends React.Component {
+          render() { return <div /> }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'onlyOneComponent',
+          line: 5,
+          column: 9,
+          endLine: 7,
+          endColumn: 10,
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -333,3 +333,5 @@ CHARCLASS
 CLASSSET
 unrepresentable
 fluentui
+callsite
+Reactlike


### PR DESCRIPTION
## Summary

Port the `react/no-multi-comp` rule from eslint-plugin-react to rslint.

The rule disallows multiple component definitions per file. With `ignoreStateless: true` it ignores stateless / pragma-wrapper components, mirroring upstream's `/Function/.test(component.node.type) || isPragmaComponentWrapper(component.node)` filter.

To enable the port, several reusable React component-detection helpers were lifted out of `no-unstable-nested-components` into `reactutil/`: `IsFunctionLikeForComponent`, `JSXRootTagName`, `ReturnedJSXRootTagName`, `SourceHasComponentNamedBefore`, `WrapperWrapsKnownSiblingComponent`, and `IsDetectedComponent`. Three contract bugs in shared helpers were fixed along the way:

- `GetComponentWrapperFunctions` now substitutes the `"<pragma>"` placeholder in `componentWrapperFunctions` settings entries.
- `MatchesAnyComponentWrapper` bare-Identifier callee now matches entries with `Object === pragma` plus `isDestructuredFromPragmaImport`, mirroring upstream's `isPragmaComponentWrapper` bare-callee arm.
- `IsStatelessReactComponentWithWrappers` Branch 16 now rejects PropertyAssignment-positioned FunctionLike whose body returns only `null` (anonymous arrow + computed key path that previously surfaced phantom components).

## Related Links

- [eslint-plugin-react / no-multi-comp](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md)
- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-multi-comp.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).