### PR TITLE
fix: align --type-check with tsc --noEmit when tsconfig omits noEmit

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -486,7 +486,7 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
 4. **Program Creation**: Go builds one or more tsconfig-backed Programs, plus optional no-tsconfig or gap-file fallback Programs
 5. **Ownership Filtering**: multi-config mode computes nearest-config ownership so files are linted once
 6. **Rule Resolution**: `getRulesForFile` resolves enabled rules per file
-7. **Rule Execution**: `RunLinter()` schedules per-Program work and `RunLinterInProgram()` does the actual file traversal
+7. **Rule Execution**: `RunLinter()` schedules per-Program work; the unexported `runLintRulesInProgram()` does the actual per-file traversal. When `--type-check` is enabled, a second program-level pass runs after Phase 1 and aggregates `tsc --noEmit`-aligned diagnostics through the internal `collectNoEmitDiagnostics()` helper
 8. **Result Aggregation**: diagnostics are sent through one run-scoped diagnostics channel and collected at the CLI layer
 9. **Fix Passes**: when enabled, fixes are applied and Programs can be rebuilt for another pass
 10. **Output Formatting**: default, JSON line, and GitHub workflow formats are supported
@@ -565,7 +565,7 @@ those typescript-go itself creates for syntactic / semantic work.
 
 - **Native Go Implementation**: Eliminates JavaScript runtime overhead
 - **Direct TypeScript AST**: No AST conversion between parsers
-- **Shared Type Checker**: `RunLinterInProgram` acquires one checker for the lint phase and reuses it across files and rules in the same `Program`
+- **Shared Type Checker**: `runLintRulesInProgram` acquires one checker for the lint phase and reuses it across files and rules in the same `Program`. The subsequent type-check phase (when `--type-check` is enabled) lets `GetSemanticDiagnostics` reacquire its own checker so the lint-phase checker can be released first
 - **Checker Phase Separation**: the checker is released before TypeScript semantic diagnostics run, so `GetSemanticDiagnostics` can reacquire its own checker cleanly
 - **File Filtering**: Skip node_modules and bundled files automatically
 - **Gap-File Degradation**: fallback gap-file Programs skip type-aware rules and semantic diagnostics instead of paying unreliable semantic costs
@@ -757,7 +757,7 @@ If the rule-porting workflow changes, update the material under `agents/port-rul
 │  internal/lsp + ts-go project.Session                                        │
 │     │                                                                        │
 │     ▼                                                                        │
-│  RunLinterInProgram on session Program                                       │
+│  LintSingleFile on session Program (per-file LSP path)                       │
 │     │                                                                        │
 │     ▼                                                                        │
 │  LSP Diagnostics / Quick Fix / Fix All                                       │

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -383,10 +383,12 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 // opts.Scope, opts.PerProgramFilter and the program's own owned-file set.
 //
 // Phase 2 — type-check (skipped when opts.TypeCheck is false): each
-// non-skipped program is handed to runTypeCheckAcrossPrograms, which calls
-// compiler.GetDiagnosticsOfAnyProgram(file=nil). Type-check is NOT
-// constrained by Scope / PerProgramFilter / ExcludePaths — it covers the
-// full program just like tsc.
+// non-skipped program is handed to runTypeCheckAcrossPrograms, which
+// aggregates diagnostics through collectNoEmitDiagnostics — a helper that
+// mirrors compiler.GetDiagnosticsOfAnyProgram(file=nil) but enforces
+// `tsc --noEmit` semantics regardless of whether the user's tsconfig
+// sets noEmit. Type-check is NOT constrained by Scope / PerProgramFilter
+// / ExcludePaths — it covers the full program just like tsc.
 //
 // See RunLinterOptions for each field's zero-value semantics.
 func RunLinter(opts RunLinterOptions) (*LintResult, error) {

--- a/internal/linter/linter_typecheck_boundary_test.go
+++ b/internal/linter/linter_typecheck_boundary_test.go
@@ -112,16 +112,19 @@ func TestBoundary_DefaultLibsCleanAcrossPrograms(t *testing.T) {
 
 // === Boundary 2: program-level vs per-file equivalence === //
 //
-// rslint's runTypeCheckForProgram calls GetDiagnosticsOfAnyProgram with
-// file=nil, which goes through compilerCheckerPool.forEachCheckerGroupDo
-// internally. The legacy file-scoped path called GetSemanticDiagnostics
-// per file in a Goroutine pool that calls SkipTypeChecking BEFORE the
-// per-file collect function.
+// rslint's runTypeCheckForProgram aggregates diagnostics via
+// collectNoEmitDiagnostics, which calls GetSemanticDiagnostics(file=nil)
+// internally — going through compilerCheckerPool.forEachCheckerGroupDo.
+// The legacy file-scoped path called GetSemanticDiagnostics per file in
+// a Goroutine pool that calls SkipTypeChecking BEFORE the per-file
+// collect function.
 //
 // These two paths can in principle diverge if SkipTypeChecking is gated
 // differently. This test pins the invariant: the per-file *semantic*
 // diagnostic set (gathered by walking each source file individually) is
-// a SUBSET of what we extract from GetDiagnosticsOfAnyProgram. Failure
+// a SUBSET of what we extract from the program-level path (here probed
+// directly via GetDiagnosticsOfAnyProgram so the test stays grounded in
+// the upstream contract that collectNoEmitDiagnostics mirrors). Failure
 // means the program-level path silently drops a diagnostic that per-file
 // would have surfaced.
 func TestBoundary_ProgramLevelMatchesPerFileSemanticDiagnostics(t *testing.T) {

--- a/internal/linter/linter_typecheck_matrix_test.go
+++ b/internal/linter/linter_typecheck_matrix_test.go
@@ -7,9 +7,15 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/microsoft/typescript-go/shim/tsoptions"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // Cross-matrix tests for --type-check semantics.
@@ -584,4 +590,122 @@ func TestMatrix_NoImplicitAny_HonoredByProgram(t *testing.T) {
 	// `export function fn(x) {...}` — parameter `x` at col 20.
 	assertOneDiag(t, strict, "TS7006", "a.ts", 1, 20)
 	assertExactDiagCount(t, strict, 1)
+}
+
+// === noEmit-equivalent semantics for --type-check ===
+//
+// rslint --type-check must align with `tsc --noEmit`. Real tsc injects
+// noEmit at the command-line layer, so noEmit-gated option errors (TS5096
+// for allowImportingTsExtensions, TS5055 for outFile-vs-input collisions,
+// etc.) never enter the program's diagnostic cache. rslint receives the
+// user's tsconfig as-is, so those option errors do enter the cache —
+// anchored to tsconfig.json (or to no file). The previous implementation
+// then dropped them downstream and short-circuited semantic collection,
+// silently masking real type errors. These tests pin the fix.
+
+// reviewer's reproduction case: allowImportingTsExtensions:true without
+// noEmit:true. tsc --noEmit reports the in-source TS2322 because --noEmit
+// suppresses TS5096; rslint --type-check must do the same.
+func TestMatrix_NoEmitSemantics_AllowImportingTsExtensionsWithoutNoEmit(t *testing.T) {
+	const aSrc = "import { y } from './b.ts';\nconst x: number = 'oops';\nexport const z = y + x.length;\n"
+	const bSrc = "export const y = 1;\n"
+	build := func(opts string) []rule.RuleDiagnostic {
+		dir := t.TempDir()
+		writeFiles(t, dir, map[string]string{
+			"a.ts":          aSrc,
+			"b.ts":          bSrc,
+			"tsconfig.json": `{"compilerOptions":{"module":"esnext","moduleResolution":"bundler","allowImportingTsExtensions":true,` + opts + `},"include":["a.ts","b.ts"]}`,
+		})
+		return runProgramTypeCheck(t, createProgramFromTsconfigDir(t, dir))
+	}
+
+	// Without noEmit: typecheck must still report the file-anchored TS2322
+	// at a.ts:2:7. Before the fix, the TS5096 fileless option error would
+	// short-circuit semantic collection and this returned 0 diagnostics.
+	withoutNoEmit := build(``)
+	assertOneDiag(t, withoutNoEmit, "TS2322", "a.ts", 2, 7)
+	assertExactCodeCount(t, withoutNoEmit, "TS2322", 1)
+
+	// Control: explicit noEmit:true must produce the SAME diagnostics, so
+	// the noEmit-aligned path is symmetric with respect to the user's
+	// configuration. (Equality of code+location, not raw equality.)
+	withNoEmit := build(`"noEmit":true`)
+	assertOneDiag(t, withNoEmit, "TS2322", "a.ts", 2, 7)
+	assertExactCodeCount(t, withNoEmit, "TS2322", 1)
+	if len(withoutNoEmit) != len(withNoEmit) {
+		t.Errorf("expected identical diagnostic counts with and without noEmit, got %d vs %d. without=%s with=%s",
+			len(withoutNoEmit), len(withNoEmit), dumpDiags(withoutNoEmit), dumpDiags(withNoEmit))
+	}
+}
+
+// File-anchored syntactic errors must still short-circuit semantic
+// collection — that is tsc's behaviour and the noEmit-alignment fix must
+// preserve it. We assert the syntactic error is reported and the (would-be
+// downstream) TS2322 from the same file is NOT reported, matching tsc.
+func TestMatrix_NoEmitSemantics_SyntacticErrorStillShortCircuits(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		// Trailing `=` is a hard parse error; line 2 has a clear type error.
+		"a.ts":          "const x: number = ;\nconst y: number = 'oops';\n",
+		"tsconfig.json": `{"include":["a.ts"]}`,
+	})
+	// createProgramFromTsconfigDir surfaces syntactic errors via
+	// utils.CreateProgram and would fail the test, so build the program
+	// directly instead.
+	dirAbs, _ := filepath.Abs(dir)
+	host := utils.CreateCompilerHost(dirAbs, bundled.WrapFS(cachedvfs.From(osvfs.FS())))
+	configParse, _ := tsoptions.GetParsedCommandLineOfConfigFile(
+		filepath.Join(dirAbs, "tsconfig.json"), &core.CompilerOptions{}, nil, host, nil)
+	program := compiler.NewProgram(compiler.ProgramOptions{
+		Config:         configParse,
+		SingleThreaded: core.TSTrue,
+		Host:           host,
+	})
+	if program == nil {
+		t.Fatal("could not build program")
+	}
+
+	diags := runProgramTypeCheck(t, program)
+
+	// At least one syntactic error from a.ts (TS1109 "Expression expected"
+	// or similar) must be reported.
+	hasSyntactic := false
+	for _, d := range diags {
+		if strings.HasPrefix(d.RuleName, "TypeScript(TS1") && strings.HasSuffix(d.SourceFile.FileName(), "a.ts") {
+			hasSyntactic = true
+			break
+		}
+	}
+	if !hasSyntactic {
+		t.Errorf("expected at least one syntactic TS1xxx diag in a.ts, got %s", dumpDiags(diags))
+	}
+
+	// The would-be TS2322 from line 2 must NOT be reported — tsc skips
+	// semantic checking when syntactic errors are present.
+	for _, d := range diags {
+		if d.RuleName == "TypeScript(TS2322)" {
+			t.Errorf("expected no TS2322 (semantic short-circuit), got %s", dumpDiags(diags))
+			break
+		}
+	}
+}
+
+// SkippedOnNoEmit emit-only checks (e.g. __esModule reservation, TS18027)
+// must drop out under --type-check, matching tsc --noEmit. Re-using
+// __esModule as a top-level export name triggers TS18027; tsc --noEmit
+// suppresses it.
+func TestMatrix_NoEmitSemantics_SkippedOnNoEmitFiltered(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		// `__esModule` is reserved when emitting ESM/commonjs; tsc surfaces
+		// TS18027 only when emitting. With --noEmit, the diagnostic is
+		// suppressed.
+		"a.ts":          "export const __esModule = true;\nexport const __esModule2: number = 'wrong';\n",
+		"tsconfig.json": `{"compilerOptions":{"module":"commonjs"},"include":["a.ts"]}`,
+	})
+	diags := runProgramTypeCheck(t, createProgramFromTsconfigDir(t, dir))
+	// Real type error at line 2 must reach the user.
+	assertOneDiag(t, diags, "TS2322", "a.ts", 2, 14)
+	// SkippedOnNoEmit code (TS18027) must NOT.
+	assertExactCodeCount(t, diags, "TS18027", 0)
 }

--- a/internal/linter/linter_typecheck_program_test.go
+++ b/internal/linter/linter_typecheck_program_test.go
@@ -249,8 +249,9 @@ func TestTypeCheck_SkipTypeCheckProgramsHonored(t *testing.T) {
 }
 
 // (6) TS2578 ("unused @ts-expect-error") surfaces under the new path.
-// Verifies that GetDiagnosticsOfAnyProgram emits this when the directive
-// turns out unused.
+// Verifies that the noEmit-aligned aggregator (collectNoEmitDiagnostics)
+// emits this when the directive turns out unused, matching upstream
+// GetDiagnosticsOfAnyProgram behaviour.
 func TestTypeCheck_UnusedTsExpectErrorStillReportsTS2578(t *testing.T) {
 	dir := t.TempDir()
 	writeFiles(t, dir, map[string]string{

--- a/internal/linter/typecheck.go
+++ b/internal/linter/typecheck.go
@@ -30,10 +30,13 @@ type typeCheckRequest struct {
 // runTypeCheckAcrossPrograms runs program-scoped semantic diagnostics
 // against every program except those explicitly opted out.
 //
-// Uses compiler.GetDiagnosticsOfAnyProgram(file=nil) — tsc's own aggregate.
-// It covers config-parsing, syntactic, program, global, and semantic
-// diagnostics, with NoEmit filtering, @ts-ignore / @ts-expect-error
-// suppression, and TS2578 unused-directive errors handled internally.
+// Aggregates diagnostics via collectNoEmitDiagnostics, which mirrors
+// compiler.GetDiagnosticsOfAnyProgram(file=nil) but enforces tsc --noEmit
+// semantics regardless of whether the user's tsconfig sets noEmit.
+// It covers config-parsing, syntactic, program, global, semantic, and
+// (when GetEmitDeclarations() is set) declaration diagnostics.
+// @ts-ignore / @ts-expect-error suppression and TS2578 unused-directive
+// errors are handled inside typescript-go.
 //
 // Cross-program dedupe: shared declaration files (typical with project
 // references and pulled-in node_modules .d.ts) appear in multiple programs.
@@ -57,11 +60,7 @@ func runTypeCheckAcrossPrograms(req typeCheckRequest) {
 
 func runTypeCheckForProgram(prog *compiler.Program, seen *sync.Map, typeInfoFiles map[string]struct{}, onDiagnostic DiagnosticHandler) {
 	ctx := context.Background()
-	diags := compiler.GetDiagnosticsOfAnyProgram(
-		ctx, prog, nil, false,
-		prog.GetBindDiagnostics,
-		prog.GetSemanticDiagnostics,
-	)
+	diags := collectNoEmitDiagnostics(ctx, prog, typeInfoFiles)
 
 	for _, d := range diags {
 		file := d.File()
@@ -163,3 +162,116 @@ func flattenMessageChain(b *strings.Builder, chain *ast.Diagnostic, level int) {
 	}
 }
 
+// collectNoEmitDiagnostics aggregates program-scoped diagnostics in the
+// same shape as compiler.GetDiagnosticsOfAnyProgram(file=nil) but adjusted
+// to behave as if --noEmit had been on the command line.
+//
+// Why we don't just call GetDiagnosticsOfAnyProgram directly:
+//
+//   - tsc --noEmit injects NoEmit=true at the command-line layer, so when
+//     verifyCompilerOptions runs during program construction it never
+//     produces noEmit-gated option errors (e.g. TS5096 for
+//     allowImportingTsExtensions, TS5055 for output overwriting input).
+//   - rslint cannot inject anything at that layer: it just receives the
+//     user's tsconfig as-is, so those option errors land in the program's
+//     cached programDiagnostics. They are anchored to the tsconfig file
+//     (or have no file at all) — either way, rslint's downstream filters
+//     drop them, so the user never sees them.
+//   - GetDiagnosticsOfAnyProgram short-circuits binding / global / semantic
+//     diagnostic collection whenever config-parsing + syntactic + program
+//     diagnostics exceed the config-parsing baseline. Because rslint
+//     drops the option errors downstream, the user gets neither the
+//     option error nor any of the real semantic errors — silent failure.
+//
+// This function reproduces the GetDiagnosticsOfAnyProgram contract but:
+//
+//  1. Strips diagnostics that would not survive runTypeCheckForProgram's
+//     downstream filters (nil file, or file outside typeInfoFiles when the
+//     gap-file gate is in effect) before applying the short-circuit.
+//     This keeps invisible option errors from masking real semantic work.
+//     File-anchored syntactic / program errors that DO reach the user
+//     still short-circuit semantic collection — matching tsc's behaviour
+//     for real pre-semantic errors.
+//  2. Re-applies compiler.FilterNoEmitSemanticDiagnostics over the
+//     semantic diagnostics with NoEmit=true, so emit-only checks
+//     (SkippedOnNoEmit, e.g. __esModule reservation errors) drop out
+//     even when the user's tsconfig leaves NoEmit unset.
+//  3. Collects declaration diagnostics under the noEmit branch, matching
+//     tsc --noEmit's behaviour when GetEmitDeclarations() is set.
+//
+// typeInfoFiles is the set of files for which type errors should reach
+// the user; nil means no gap-file restriction.
+func collectNoEmitDiagnostics(ctx context.Context, prog *compiler.Program, typeInfoFiles map[string]struct{}) []*ast.Diagnostic {
+	noEmitOpts := prog.Options().Clone()
+	noEmitOpts.NoEmit = core.TSTrue
+	configFilePath := prog.Options().ConfigFilePath
+
+	keep := func(in []*ast.Diagnostic) []*ast.Diagnostic {
+		return filterShortCircuitDiagnostics(in, typeInfoFiles, configFilePath)
+	}
+
+	configDiags := keep(prog.GetConfigFileParsingDiagnostics())
+	baseline := len(configDiags)
+	all := append([]*ast.Diagnostic(nil), configDiags...)
+
+	all = append(all, keep(prog.GetSyntacticDiagnostics(ctx, nil))...)
+	all = append(all, keep(prog.GetProgramDiagnostics())...)
+
+	if len(all) != baseline {
+		return all
+	}
+
+	// Match GetDiagnosticsOfAnyProgram: bind early so its time is tracked
+	// separately; do not aggregate bind diagnostics.
+	prog.GetBindDiagnostics(ctx, nil)
+
+	if prog.Options().ListFilesOnly.IsTrue() {
+		return all
+	}
+
+	all = append(all, prog.GetGlobalDiagnostics(ctx)...)
+	if len(all) == baseline {
+		semantic := compiler.FilterNoEmitSemanticDiagnostics(prog.GetSemanticDiagnostics(ctx, nil), noEmitOpts)
+		all = append(all, semantic...)
+		// Globals can grow once the checker pulls in missing types — re-collect.
+		all = append(all, prog.GetGlobalDiagnostics(ctx)...)
+	}
+	if noEmitOpts.GetEmitDeclarations() && len(all) == baseline {
+		all = append(all, prog.GetDeclarationDiagnostics(ctx, nil)...)
+	}
+	return all
+}
+
+// filterShortCircuitDiagnostics returns the subset of diagnostics that should
+// participate in GetDiagnosticsOfAnyProgram's short-circuit check. We exclude:
+//
+//   - diagnostics with no source file (rslint always drops these downstream),
+//   - diagnostics anchored to the program's tsconfig file (the implicit form
+//     of "fileless" — they record an option-level problem with the tsconfig
+//     itself, not with the user's source code, and rslint --type-check is
+//     defined to mirror tsc --noEmit, which silently suppresses noEmit-gated
+//     option errors when --noEmit is on the command line),
+//   - diagnostics anchored to a file outside typeInfoFiles when the gap-file
+//     gate is active (those will be dropped downstream too).
+//
+// Diagnostics anchored to user source files (real syntactic / program errors)
+// flow through unchanged, so they still trip the short-circuit — matching tsc.
+func filterShortCircuitDiagnostics(in []*ast.Diagnostic, typeInfoFiles map[string]struct{}, configFilePath string) []*ast.Diagnostic {
+	out := make([]*ast.Diagnostic, 0, len(in))
+	for _, d := range in {
+		f := d.File()
+		if f == nil {
+			continue
+		}
+		if configFilePath != "" && f.FileName() == configFilePath {
+			continue
+		}
+		if typeInfoFiles != nil {
+			if _, ok := typeInfoFiles[f.FileName()]; !ok {
+				continue
+			}
+		}
+		out = append(out, d)
+	}
+	return out
+}

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -48,6 +48,7 @@ exclam
 execdir
 fatih
 fdescribe
+fileless
 fixall
 flaggable
 fltr


### PR DESCRIPTION
## Summary

Follow-up to #823. When the user's tsconfig has noEmit-gated options (e.g. `allowImportingTsExtensions: true`) without `noEmit: true`, `--type-check` was silently dropping real file-anchored type errors:

1. `verifyCompilerOptions` produces a `TS5096` option diagnostic at program creation, anchored to `tsconfig.json`.
2. `compiler.GetDiagnosticsOfAnyProgram` short-circuits binding/global/semantic diagnostic collection because the program-level diagnostic count exceeds the config-parsing baseline.
3. Downstream filters in `runTypeCheckForProgram` (and the `typeInfoFiles` gap-file gate) drop the `TS5096` from user output.

Net effect: the user sees neither the option warning nor the real `TS2322` from their source files. `tsc --noEmit` does not have this issue because `--noEmit` is injected on the command line, so the option error never enters the cache.

This change replaces the direct `GetDiagnosticsOfAnyProgram` call with `collectNoEmitDiagnostics`, which mirrors its contract but:

- excludes invisible diagnostics (nil file, anchored to the tsconfig file, or outside `typeInfoFiles`) from the short-circuit baseline so they cannot mask real semantic work — file-anchored syntactic / program errors still short-circuit, matching tsc;
- re-applies `compiler.FilterNoEmitSemanticDiagnostics` over the semantic results with `NoEmit=true`, so emit-only checks (`SkippedOnNoEmit`, e.g. `__esModule` reservation errors) drop out even when the underlying program is configured without `noEmit`;
- collects declaration diagnostics under the noEmit branch.

Also syncs `architecture.md` to the current entry-point names (`RunLinter` / `runLintRulesInProgram` / `LintSingleFile`) and removes a trailing blank line at EOF in `typecheck.go` (`git diff --check` was failing on the previous PR's merge commit).

## Related Links

- Follow-up to #823 (PR review feedback).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Test plan

- [x] `pnpm run check-spell` (added `fileless` to dictionary)
- [x] `pnpm run format:check`
- [x] `pnpm run lint:go`
- [x] `go test ./internal/linter/... ./internal/config/... ./internal/lsp/... ./internal/utils/... ./cmd/rslint/...`
- [x] New regression tests in `internal/linter/linter_typecheck_matrix_test.go`:
  - `TestMatrix_NoEmitSemantics_AllowImportingTsExtensionsWithoutNoEmit` — reviewer's exact reproduction; asserts `TS2322` surfaces with and without `noEmit:true`, and that diagnostic counts match.
  - `TestMatrix_NoEmitSemantics_SyntacticErrorStillShortCircuits` — guard rail: file-anchored syntactic errors must still short-circuit semantic collection (matching tsc), so the fix does not over-report.
  - `TestMatrix_NoEmitSemantics_SkippedOnNoEmitFiltered` — `SkippedOnNoEmit` (`TS18027`) is filtered out while real type errors still surface.
- [x] Manual end-to-end: built rslint locally, reproduced reviewer's case, confirmed `TS2322` now surfaces (matches `tsc --noEmit`).