### PR TITLE
feat: port rule react/no-set-state

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -37,6 +37,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_multi_comp"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_redundant_should_component_update"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_render_return_value"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_set_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_this_in_sfc"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_typos"
@@ -103,6 +104,7 @@ func GetAllRules() []rule.Rule {
 		no_unused_state.NoUnusedStateRule,
 		no_redundant_should_component_update.NoRedundantShouldComponentUpdateRule,
 		no_render_return_value.NoRenderReturnValueRule,
+		no_set_state.NoSetStateRule,
 		no_string_refs.NoStringRefsRule,
 		no_this_in_sfc.NoThisInSfcRule,
 		no_typos.NoTyposRule,

--- a/internal/plugins/react/reactutil/no_method_set_state.go
+++ b/internal/plugins/react/reactutil/no_method_set_state.go
@@ -43,7 +43,7 @@ type NoMethodSetStateConfig struct {
 // Mirrors upstream's `makeNoMethodSetStateRule` 1:1 in semantics — including
 // the innermost-stopper search (`findLast(ancestors, ...)`), the
 // function-depth counter that gates `disallow-in-func`, and the ESTree-shaped
-// `'name' in callee.property` test (which we model with [esTreeName]: any
+// `'name' in callee.property` test (which we model with [EsTreeName]: any
 // non-Identifier / non-PrivateIdentifier key yields "" and never matches).
 //
 // All three of `no-did-mount-set-state`, `no-did-update-set-state`, and
@@ -74,10 +74,10 @@ func MakeNoMethodSetStateRule(cfg NoMethodSetStateConfig) rule.Rule {
 						return
 					}
 					// Upstream: `'name' in callee.property && callee.property.name
-					// === 'setState'`. esTreeName yields "" for non-name shapes
+					// === 'setState'`. EsTreeName yields "" for non-name shapes
 					// (string/numeric/computed keys), so the equality check
 					// below correctly rejects them.
-					if esTreeName(prop.Name()) != "setState" {
+					if EsTreeName(prop.Name()) != "setState" {
 						return
 					}
 
@@ -150,12 +150,12 @@ func isMethodSetStateStopper(node *ast.Node) bool {
 }
 
 // stopperName returns the ESTree-visible name of a stopper node's key.
-// See [esTreeName] for the aliasing rationale.
+// See [EsTreeName] for the aliasing rationale.
 func stopperName(node *ast.Node) string {
-	return esTreeName(node.Name())
+	return EsTreeName(node.Name())
 }
 
-// esTreeName returns the string an ESTree consumer would read from
+// EsTreeName returns the string an ESTree consumer would read from
 // `node.name` for an Identifier / PrivateIdentifier. PrivateIdentifier
 // strips the leading `#` per spec (tsgo retains it, so we trim). Any other
 // node kind — ComputedPropertyName, StringLiteral, NumericLiteral, etc. —
@@ -170,7 +170,7 @@ func stopperName(node *ast.Node) string {
 // `'name' in callee.property` is false), so reusing
 // `utils.GetStaticPropertyName` here would be incorrect (it resolves
 // string literals as static names).
-func esTreeName(nameNode *ast.Node) string {
+func EsTreeName(nameNode *ast.Node) string {
 	if nameNode == nil {
 		return ""
 	}

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -1131,32 +1131,123 @@ func GetJsxTagBaseIdentifier(tagName *ast.Node) *ast.Node {
 	return nil
 }
 
-// IsInsideReactComponent reports whether `node` is lexically contained within
-// a React component — either an ES5 component (object literal passed as an
-// argument to `<createClass>(...)` / `<pragma>.<createClass>(...)`) or an
-// ES6 component (ClassDeclaration / ClassExpression extending Component or
-// PureComponent, optionally qualified by pragma).
+// IsInsideReactComponent reports whether `node` is lexically inside a
+// React component, applying the SCOPE-BASED detection semantic that
+// upstream's `componentUtil.getParentES6Component(...) ||
+// componentUtil.getParentES5Component(...)` use directly (the pattern
+// of `no-string-refs` and `no-access-state-in-setstate`).
 //
-// Pass the empty string for pragma/createClass to fall back to
-// `DefaultReactPragma` / `DefaultReactCreateClass`.
+// **NOT equivalent to `GetEnclosingReactComponent != nil`**: the latter
+// mimics `Components.set`'s free AST ancestor walk that crosses any
+// non-React class. This helper applies the stricter ES6-stops-at-first-
+// class rule. Pick based on the upstream rule's pattern:
 //
-// Mirrors eslint-plugin-react's componentUtil:
+//   - Rule uses `Components.detect((context, components, utils) => ...)`
+//     and calls `components.set(node, ...)` / `components.get(...)` →
+//     use `GetEnclosingReactComponent`.
 //
-//   - ES6 path: only the nearest enclosing class decides component status
-//     (matching `getParentES6Component`'s `while scope.type !== 'class'`).
-//     A non-component class does not "pass through" to let an outer component
-//     class match — this prevents false positives like a non-React inner
-//     class nested inside a React class.
+//   - Rule calls `componentUtil.getParentES6Component` /
+//     `componentUtil.getParentES5Component` directly → use this helper
+//     (or `GetParentReactComponentScopeBased` for the node).
 //
-//   - ES5 path: `this` / `this.refs` must occur inside some function, whose
-//     ObjectExpression parent is the argument to `<createClass>(...)`. We
-//     approximate this by requiring that an enclosing function has been
-//     passed on the walk up before an ObjectExpression is accepted — which
-//     rules out pathological cases like `createReactClass({ x: this.refs.y })`
-//     where `this` is not inside any function (ESLint's scope walk returns
-//     null for that too).
+// Pass empty strings for pragma/createClass to fall back to defaults.
 func IsInsideReactComponent(node *ast.Node, pragma, createClass string) bool {
-	return GetEnclosingReactComponent(node, pragma, createClass) != nil
+	return GetParentReactComponentScopeBased(node, pragma, createClass) != nil
+}
+
+// GetParentReactComponentScopeBased mirrors upstream's
+// `componentUtil.getParentES6Component(context, node) ||
+// componentUtil.getParentES5Component(context, node)` exactly — the
+// helper used directly by `no-string-refs` and `no-access-state-in-setstate`.
+//
+// **NOT equivalent to `GetEnclosingReactComponent`**: that one mimics
+// `Components.set`'s free AST ancestor walk; this one applies the
+// stricter scope-based rules:
+//
+//   - **ES6 path**: finds the FIRST enclosing class (innermost). If it
+//     extends `Component` / `PureComponent` (bare or pragma-qualified),
+//     returns it; otherwise stops searching outer classes (mirrors
+//     upstream's `while scope.type !== 'class'` loop).
+//
+//   - **ES5 path**: walks each enclosing FunctionLike scope. For each,
+//     checks whether its parent.parent reaches a `createReactClass(...)`
+//     argument ObjectLiteralExpression. This crosses non-React classes
+//     freely — only function-like scopes are inspected.
+//
+// Empirically verified equivalent to ESLint output. Pass empty strings
+// for pragma/createClass to fall back to defaults.
+func GetParentReactComponentScopeBased(node *ast.Node, pragma, createClass string) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
+	if createClass == "" {
+		createClass = DefaultReactCreateClass
+	}
+
+	// ES6 path: find FIRST enclosing class. If React, return; else
+	// remember that ES6 has decided "not a React class" and don't
+	// search outer classes (matches upstream's `while scope.type !==
+	// 'class'` loop that stops at the first class scope).
+	for p := node.Parent; p != nil; p = p.Parent {
+		if p.Kind == ast.KindClassDeclaration || p.Kind == ast.KindClassExpression {
+			if ExtendsReactComponent(p, pragma) {
+				return p
+			}
+			// First class is not React → ES6 detection returns null.
+			// Fall through to ES5 detection below.
+			break
+		}
+	}
+
+	// ES5 path: walk each enclosing FunctionLike. For each, check
+	// whether its parent / parent.parent is a createReactClass(...)
+	// arg ObjectLiteralExpression. Mirrors upstream's per-scope walk:
+	//   `node = scope.block && scope.block.parent && scope.block.parent.parent`
+	// where scope.block is the FunctionLike.
+	for p := node.Parent; p != nil; p = p.Parent {
+		if !ast.IsFunctionLike(p) {
+			continue
+		}
+		// `key: function() {...}` — FE wrapped in PropertyAssignment;
+		// its parent is the ObjectLiteralExpression.
+		// `key() {...}` shorthand — MethodDeclaration / GetAccessor /
+		// SetAccessor directly inside ObjectLiteralExpression.
+		var objLit *ast.Node
+		switch p.Kind {
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+			objLit = p.Parent
+		default:
+			propEntry := p.Parent
+			if propEntry == nil || propEntry.Kind != ast.KindPropertyAssignment {
+				continue
+			}
+			objLit = propEntry.Parent
+		}
+		if objLit == nil || objLit.Kind != ast.KindObjectLiteralExpression {
+			continue
+		}
+		// Unwrap parens and verify createReactClass call.
+		arg := objLit
+		for arg.Parent != nil && arg.Parent.Kind == ast.KindParenthesizedExpression {
+			arg = arg.Parent
+		}
+		callExpr := arg.Parent
+		if callExpr == nil || callExpr.Kind != ast.KindCallExpression {
+			continue
+		}
+		call := callExpr.AsCallExpression()
+		if !isObjectArgumentOf(call, arg) {
+			continue
+		}
+		if IsCreateClassCall(call, pragma, createClass) {
+			return objLit
+		}
+	}
+
+	return nil
 }
 
 // GetEnclosingReactComponent is IsInsideReactComponent's sibling that returns
@@ -1174,28 +1265,29 @@ func GetEnclosingReactComponent(node *ast.Node, pragma, createClass string) *ast
 	if createClass == "" {
 		createClass = DefaultReactCreateClass
 	}
-	seenNearestClass := false
-	seenEnclosingFunction := false
 	for p := node.Parent; p != nil; p = p.Parent {
-		if ast.IsFunctionLike(p) {
-			seenEnclosingFunction = true
-		}
 		switch p.Kind {
 		case ast.KindClassDeclaration, ast.KindClassExpression:
-			if seenNearestClass {
-				// The nearest class already decided ES6 classification;
-				// outer classes do not get a second chance (matches ESLint's
-				// scope-walk that stops at the first class scope).
-				continue
-			}
-			seenNearestClass = true
+			// Mirror upstream's `Components.set` behavior: it walks
+			// `node.parent` looking for any node in the `_list` of
+			// already-detected components. Non-React classes are NOT
+			// in that list — Components.detect only registers classes
+			// that extend `Component` / `PureComponent` (or pragma-
+			// qualified) — so an inner non-React class does NOT block
+			// the walk from reaching an outer React component or a
+			// `createReactClass({...})` arg above.
+			//
+			// Concretely: a `this.setState({})` inside `class Helper {
+			// foo() {...} }`, where Helper is itself nested inside
+			// `class Outer extends React.Component { render() {...} }`
+			// or inside `createReactClass({ method: function() {
+			// class Helper {...} } })`, MUST attribute to the outer
+			// detected component. Both upstream eslint-plugin-react
+			// and rslint match here.
 			if ExtendsReactComponent(p, pragma) {
 				return p
 			}
 		case ast.KindObjectLiteralExpression:
-			if !seenEnclosingFunction {
-				continue
-			}
 			// The ObjectLiteralExpression may be wrapped in one or more
 			// ParenthesizedExpressions before reaching the CallExpression
 			// (ESTree would flatten these; tsgo preserves them), e.g.
@@ -1214,6 +1306,12 @@ func GetEnclosingReactComponent(node *ast.Node, pragma, createClass string) *ast
 				continue
 			}
 			if IsCreateClassCall(call, pragma, createClass) {
+				// Empirically verified against ESLint master:
+				// `createReactClass({ key: this.setState({}) })` —
+				// even a setState call at the TOP-LEVEL property
+				// position (not inside any method/function) attributes
+				// to the createReactClass arg via Components.set's
+				// free parent walk and reports.
 				return p
 			}
 		}
@@ -1284,12 +1382,39 @@ func IsCreateReactClassObjectArg(obj *ast.Node, pragma, createClass string) bool
 // approximate match). This is intentionally conservative: missed detection
 // causes a rule miss, over-detection would cause false-positive reports in
 // non-component functions.
-func GetEnclosingReactComponentOrStateless(node *ast.Node, pragma, createClass string) *ast.Node {
+func GetEnclosingReactComponentOrStateless(node *ast.Node, pragma, createClass string, wrappers []ComponentWrapperEntry) *ast.Node {
 	if comp := GetEnclosingReactComponent(node, pragma, createClass); comp != nil {
 		return comp
 	}
 	for p := node.Parent; p != nil; p = p.Parent {
-		if ast.IsFunctionLike(p) && IsStatelessReactComponent(p, pragma) {
+		if ast.IsFunctionLike(p) && IsStatelessReactComponentWithWrappers(p, pragma, nil, wrappers) {
+			return p
+		}
+	}
+	return nil
+}
+
+// GetParentReactComponentScopeBasedOrStateless mirrors upstream's
+// `utils.getParentComponent(node)` =
+// `getParentES6Component || getParentES5Component || getParentStatelessComponent`.
+//
+// **NOT equivalent to `GetEnclosingReactComponentOrStateless`**: that one
+// uses `Components.set`'s free AST ancestor walk. This helper applies
+// the stricter scope-based ES6+ES5 detection (see
+// `GetParentReactComponentScopeBased`) and falls back to stateless
+// component detection. Use this for rules that call
+// `utils.getParentComponent(node)` directly inside a listener and gate
+// their report on the result being non-null — e.g.
+// `no-direct-mutation-state`'s `shouldIgnoreComponent(component)`
+// check, which bails when the result is undefined.
+//
+// Pass empty strings for pragma/createClass to fall back to defaults.
+func GetParentReactComponentScopeBasedOrStateless(node *ast.Node, pragma, createClass string, wrappers []ComponentWrapperEntry) *ast.Node {
+	if comp := GetParentReactComponentScopeBased(node, pragma, createClass); comp != nil {
+		return comp
+	}
+	for p := node.Parent; p != nil; p = p.Parent {
+		if ast.IsFunctionLike(p) && IsStatelessReactComponentWithWrappers(p, pragma, nil, wrappers) {
 			return p
 		}
 	}

--- a/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate.go
+++ b/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate.go
@@ -305,8 +305,13 @@ var NoAccessStateInSetstateRule = rule.Rule{
 		pragma := reactutil.GetReactPragma(ctx.Settings)
 		createClass := reactutil.GetReactCreateClass(ctx.Settings)
 
+		// Upstream `no-access-state-in-setstate` calls
+		// `componentUtil.getParentES6Component || getParentES5Component`
+		// directly — NOT `Components.detect`. Use the scope-based helper
+		// to mirror that detection semantic (ES6 stops at first class
+		// scope; ES5 walks each FunctionLike scope).
 		isClassComponent := func(node *ast.Node) bool {
-			return reactutil.GetEnclosingReactComponent(node, pragma, createClass) != nil
+			return reactutil.GetParentReactComponentScopeBased(node, pragma, createClass) != nil
 		}
 
 		report := func(node *ast.Node) {

--- a/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate_test.go
+++ b/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate_test.go
@@ -348,6 +348,41 @@ func TestNoAccessStateInSetstateRule(t *testing.T) {
           }
         }
       `, Tsx: true},
+
+		// ---- Cross-helper lock: scope-based vs free-walk divergence.
+		// `setState` at top-level property of createReactClass arg —
+		// no FunctionLike ancestor between setState call and the
+		// ObjectLit, so ES5 detection's per-FunctionLike walk finds
+		// nothing. Result: NOT reported (no-access-state-in-setstate
+		// uses scope-based detection only). This contrasts with
+		// no-set-state which uses Components.set's free AST walk and
+		// DOES report this case. Empirically verified against ESLint master. ----
+		{Code: `
+var Hello = createReactClass({
+  config: this.setState({ value: this.state.foo }),
+  render: function() { return <div/>; }
+});
+`, Tsx: true},
+
+		// ---- Cross-helper lock: nested non-React class inside an ES6
+		// React component. Upstream's `getParentES6Component` finds
+		// the inner non-React Helper class and returns null (stops
+		// at first class scope). `getParentES5Component` walks each
+		// FunctionLike scope; none reach a createReactClass arg in
+		// this case. Total: NOT reported. Empirically verified
+		// against ESLint master. ----
+		{Code: `
+        class Outer extends React.Component {
+          render() {
+            class Helper {
+              doStuff() {
+                this.setState({ next: this.state.value + 1 });
+              }
+            }
+            return <div/>;
+          }
+        }
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream #1: direct this.state inside setState first arg ----
 		{
@@ -773,6 +808,36 @@ func TestNoAccessStateInSetstateRule(t *testing.T) {
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "useCallback", Line: 4, Column: 36},
+			},
+		},
+
+		// ---- Cross-helper lock: nested non-React class inside
+		// createReactClass arg. Upstream's `getParentES6Component`
+		// finds the inner non-React Helper class and returns null
+		// (stops at first class scope). `getParentES5Component`
+		// walks each FunctionLike scope: when it reaches `someMethod`
+		// (FE inside the createReactClass arg), block.parent.parent
+		// = ObjectLiteralExpression which IS the createReactClass
+		// arg, so isES5Component returns true. The inner setState's
+		// first-arg `this.state.value` access reports. Empirically
+		// verified against ESLint master (line=5 col=31 in
+		// `var Hello = createReactClass({...` form). ----
+		{
+			Code: `
+var Hello = createReactClass({
+  someMethod: function() {
+    class Helper {
+      doStuff() {
+        this.setState({ next: this.state.value + 1 });
+      }
+    }
+  },
+  render: function() { return <div/>; }
+});
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 6, Column: 31},
 			},
 		},
 	})

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state.go
@@ -85,6 +85,7 @@ var NoDirectMutationStateRule = rule.Rule{
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		pragma := reactutil.GetReactPragma(ctx.Settings)
 		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+		wrappers := reactutil.GetComponentWrapperFunctions(ctx.Settings, pragma)
 
 		report := func(node *ast.Node) {
 			ctx.ReportNode(node, rule.RuleMessage{
@@ -116,7 +117,16 @@ var NoDirectMutationStateRule = rule.Rule{
 			if !isThisStateMember(innermost) {
 				return
 			}
-			component := reactutil.GetEnclosingReactComponentOrStateless(node, pragma, createClass)
+			// Upstream `no-direct-mutation-state` uses
+			// `Components.detect` but in its AssignmentExpression /
+			// UpdateExpression listeners gates on
+			// `components.get(utils.getParentComponent(node))` —
+			// `getParentComponent` is ES6||ES5||stateless detection,
+			// NOT `components.set`'s free AST walk. When that
+			// detection returns null, the listener early-returns via
+			// `shouldIgnoreComponent`. Mirror with the scope-based
+			// helper.
+			component := reactutil.GetParentReactComponentScopeBasedOrStateless(node, pragma, createClass, wrappers)
 			if component == nil {
 				return
 			}

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
@@ -523,6 +523,26 @@ func TestNoDirectMutationStateRule(t *testing.T) {
           },
         };
       `, Tsx: true},
+
+		// ---- Cross-helper lock: nested non-React class inside an ES6
+		// React component. Upstream's `no-direct-mutation-state` gates
+		// reporting on `utils.getParentComponent(node)` (ES6||ES5||
+		// stateless detection); ES6 finds the inner non-React Helper
+		// class and stops; ES5 finds nothing; stateless finds nothing.
+		// Result: NOT reported. Empirically verified against ESLint
+		// master. ----
+		{Code: `
+        class Outer extends React.Component {
+          render() {
+            class Helper {
+              doStuff() {
+                this.state.x = 1;
+              }
+            }
+            return <div/>;
+          }
+        }
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: createReactClass — simple mutation ----
 		{
@@ -1321,8 +1341,13 @@ func TestNoDirectMutationStateRule(t *testing.T) {
 		},
 
 		// ---- Edge: bare `memo(...)` (destructured from React) ----
+		// Same pragma-import gate as the bare `forwardRef(...)` case
+		// above: without the explicit `import { memo } from 'react'`,
+		// upstream's `isDestructuredFromPragmaImport` returns false and
+		// the call is NOT recognized as a wrapper.
 		{
 			Code: `
+        import { memo } from 'react';
         export default memo(() => {
           this.state.x = 1;
           return <div/>;
@@ -1330,7 +1355,7 @@ func TestNoDirectMutationStateRule(t *testing.T) {
       `,
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+				{MessageId: "noDirectMutation", Line: 4, Column: 11},
 			},
 		},
 
@@ -1349,8 +1374,13 @@ func TestNoDirectMutationStateRule(t *testing.T) {
 		},
 
 		// ---- Edge: bare `forwardRef(...)` ----
+		// Upstream gates bare `forwardRef` / `memo` callees on
+		// `isDestructuredFromPragmaImport` — without an import binding
+		// the call is NOT recognized as a wrapper. Locked here with
+		// the explicit import to mirror that gate.
 		{
 			Code: `
+        import { forwardRef } from 'react';
         const Hello = forwardRef((props, ref) => {
           this.state.x = 1;
           return <div ref={ref}/>;
@@ -1358,7 +1388,7 @@ func TestNoDirectMutationStateRule(t *testing.T) {
       `,
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+				{MessageId: "noDirectMutation", Line: 4, Column: 11},
 			},
 		},
 
@@ -1852,6 +1882,47 @@ func TestNoDirectMutationStateRule(t *testing.T) {
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Cross-helper lock: nested non-React class inside createReactClass
+		// arg — empirically verified against ESLint. Walk passes through
+		// the non-React inner class (not in detected-component list) and
+		// reaches the outer createReactClass arg, attributing the mutation. ----
+		{
+			Code: `
+var Hello = createReactClass({
+  someMethod: function() {
+    class Helper {
+      doStuff() {
+        this.state.x = 1;
+      }
+    }
+  },
+  render: function() { return <div/>; }
+});
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 6, Column: 9},
+			},
+		},
+
+		// ---- Cross-helper lock (Helper-B): settings.componentWrapperFunctions
+		// — a user-configured HOC like `myObserver` is recognized as a
+		// component-wrapping call, so the inner arrow is treated as a
+		// stateless component and `this.state.x = 1` reports. ----
+		{
+			Code: `
+        const Hello = myObserver((props) => {
+          this.state.x = 1;
+          return <div/>;
+        });
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"componentWrapperFunctions": []interface{}{"myObserver"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
 			},
 		},
 	})

--- a/internal/plugins/react/rules/no_set_state/no_set_state.go
+++ b/internal/plugins/react/rules/no_set_state/no_set_state.go
@@ -1,0 +1,83 @@
+package no_set_state
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// NoSetStateRule mirrors eslint-plugin-react's `no-set-state`: report any
+// `this.setState(...)` call that lexically sits inside a detected React
+// component (ES6 class extending Component / PureComponent, an
+// `createReactClass` object literal, or a stateless functional component).
+//
+// Upstream uses `Components.detect` + a deferred `Program:exit` pass that
+// walks `components.list()` and reports each accumulated `setStateUsage`.
+// We collapse that into one synchronous report per CallExpression — the
+// observable contract is identical because:
+//
+//   - upstream's `components.list()` only yields nodes its detection logic
+//     classified as components;
+//   - `GetEnclosingReactComponentOrStateless` mirrors that priority
+//     (getParentES6Component | getParentES5Component | getParentStatelessComponent);
+//   - upstream's `components.set(node, ...)` walks `node.parent` until it
+//     finds a node already in the registry, then merges. That's the same
+//     enclosing-walk we do here — no later observation can flip a
+//     component into "not a component", so there's no need to defer.
+var NoSetStateRule = rule.Rule{
+	Name: "react/no-set-state",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+		wrappers := reactutil.GetComponentWrapperFunctions(ctx.Settings, pragma)
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				// Upstream: `callee.type !== 'MemberExpression'` short-circuits.
+				// SkipParentheses unwraps `(this.setState)({})` so we still see
+				// the underlying PropertyAccessExpression (tsgo preserves parens
+				// that ESTree flattens).
+				callee := ast.SkipParentheses(call.Expression)
+				if callee.Kind != ast.KindPropertyAccessExpression {
+					return
+				}
+				prop := callee.AsPropertyAccessExpression()
+				// Upstream: `callee.object.type !== 'ThisExpression'`. Wrappers
+				// like `(this as any)`, `this!`, `this satisfies T`, and
+				// `cond ? this : x` all break this check — receivers other
+				// than a bare ThisKeyword (modulo parens) never match.
+				if ast.SkipParentheses(prop.Expression).Kind != ast.KindThisKeyword {
+					return
+				}
+				// Upstream: `callee.property.name !== 'setState'`.
+				// `EsTreeName` returns "" for non-name shapes (computed
+				// keys, etc.) — the equality check naturally rejects those
+				// without extra guards. PrivateIdentifier's spec-defined
+				// `.name` strips the leading `#`, so a private
+				// `this.#setState(...)` matches just like upstream.
+				if reactutil.EsTreeName(prop.Name()) != "setState" {
+					return
+				}
+
+				// Upstream: `components.get(utils.getParentComponent(node))`.
+				// The result is non-null only when the enclosing scope is a
+				// detected component.
+				if reactutil.GetEnclosingReactComponentOrStateless(node, pragma, createClass, wrappers) == nil {
+					return
+				}
+
+				// Upstream reports on `setStateUsage`, which is the callee
+				// MemberExpression (`this.setState`), not the full
+				// CallExpression. Reporting on the unwrapped callee mirrors
+				// that — when the callee itself is parenthesized (e.g.
+				// `(this.setState)({})`), the column lands at `this`, after
+				// the stripped `(`.
+				ctx.ReportNode(callee, rule.RuleMessage{
+					Id:          "noSetState",
+					Description: "Do not use setState",
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_set_state/no_set_state.md
+++ b/internal/plugins/react/rules/no_set_state/no_set_state.md
@@ -1,0 +1,81 @@
+# no-set-state
+
+## Rule Details
+
+Disallow any use of `this.setState(...)` inside a React class component or
+ES5 `createReactClass(...)` component. When using an architecture that
+separates application state from UI components (e.g. Flux / Redux), local
+component state is rarely needed and `setState` calls should be replaced
+with explicit dispatches to the external store.
+
+The rule fires on every `this.setState(...)` call whose lexically enclosing
+scope is a detected React component:
+
+- An ES6 class extending `Component` / `PureComponent` (bare or
+  pragma-qualified, e.g. `React.Component`).
+- An object literal passed to `createReactClass(...)` (or
+  `<pragma>.<createClass>(...)`).
+- A stateless functional component (capital-cased name returning JSX or
+  `null`).
+
+A bare property reference such as `this.someHandler = this.setState;`
+does NOT fire — the rule listens for CallExpressions only.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  getInitialState: function () {
+    return { name: this.props.name };
+  },
+  handleClick: function () {
+    this.setState({
+      name: this.props.name.toUpperCase(),
+    });
+  },
+  render: function () {
+    return (
+      <div onClick={this.handleClick.bind(this)}>Hello {this.state.name}</div>
+    );
+  },
+});
+```
+
+```jsx
+class Hello extends React.Component {
+  someMethod = () => {
+    this.setState({ name: this.props.name.toUpperCase() });
+  };
+  render() {
+    return <div onClick={this.someMethod}>Hello {this.state.name}</div>;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  render: function () {
+    return (
+      <div onClick={this.props.handleClick}>Hello {this.props.name}</div>
+    );
+  },
+});
+```
+
+```jsx
+class Hello extends React.Component {
+  someMethod() {
+    const fn = this.setState;
+    this.someHandler = this.setState;
+  }
+  render() {
+    return <div>{this.props.name}</div>;
+  }
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-react `no-set-state`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-set-state.md)

--- a/internal/plugins/react/rules/no_set_state/no_set_state_test.go
+++ b/internal/plugins/react/rules/no_set_state/no_set_state_test.go
@@ -1,0 +1,2077 @@
+package no_set_state
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoSetStateRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoSetStateRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: bare function (not a component — no JSX return) ----
+		{Code: `
+        var Hello = function() {
+          this.setState({})
+        };
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass with render only, no setState ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: `this.setState` reference (not call) is allowed ----
+		// `this.someHandler = this.setState;` — the rule listens to
+		// CallExpression, so a bare property read never fires.
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someNonMemberFunction(arg);
+            this.someHandler = this.setState;
+          },
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: plain class (no `extends Component`) — not a component ----
+		{Code: `
+        class Hello {
+          someMethod() {
+            this.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: bare `this.setState({})` outside any component / class ----
+		{Code: `this.setState({});`, Tsx: true},
+
+		// ---- Edge: receiver is not `this` ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            other.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `this['setState']({})` — element access, no name match ----
+		// ESLint checks `callee.property.name === 'setState'`, which is
+		// undefined on a computed property; we mirror by gating on
+		// KindIdentifier. Element-access never reaches the
+		// PropertyAccessExpression branch at all.
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this['setState']({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `super.setState({})` — receiver is SuperKeyword, not ThisKeyword ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            super.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `(this as any).setState({})` — TS as-expression breaks the receiver match ----
+		// SkipParentheses unwraps Parens only; `as` / `satisfies` / `!`
+		// remain as wrappers, so the receiver-check fails (matches the
+		// upstream behavior — it does the equivalent textual check before
+		// any TS wrapper has been stripped).
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            (this as any).setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `this!.setState({})` — TS non-null assertion breaks the receiver match ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this!.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `(this satisfies React.Component).setState({})` — TS satisfies wrapper ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            (this satisfies React.Component).setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: ConditionalExpression receiver — not a bare ThisKeyword ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            (cond ? this : other).setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `setState` reference assigned to a variable — no CallExpression fires ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            const fn = this.setState;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: tagged template `this.setState\`{}\`` — TaggedTemplateExpression, not CallExpression ----
+		{Code: "\n        class Hello extends React.Component {\n          componentDidMount() {\n            this.setState`{}`;\n          }\n        }\n      ", Tsx: true},
+
+		// ---- Edge: `new this.setState({})` — NewExpression, not CallExpression ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            new this.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: comma-operator callee `(0, this.setState)({})` — callee is BinaryExpression, not PropertyAccess ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            (0, this.setState)({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: indirect call `this.setState.call(this, {})` — outer call's callee is `this.setState.call`, .call's receiver is `this.setState` (PropertyAccess), not ThisKeyword ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.setState.call(this, {});
+            this.setState.bind(this);
+            this.setState.apply(this, [{}]);
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: lowercased function — not a stateless component ----
+		// `IsStatelessReactComponent` requires a capital-cased binding
+		// (or anonymous + export default).
+		{Code: `
+        function hello() {
+          this.setState({});
+          return <div/>;
+        }
+      `, Tsx: true},
+
+		// ---- Edge: capital-cased function NOT returning JSX — not a component ----
+		{Code: `
+        function Hello() {
+          this.setState({});
+          return 42;
+        }
+      `, Tsx: true},
+
+		// ---- Edge: TS abstract class with body-absent componentDidMount ----
+		// No body → no setState possible. Locks that the rule traverses
+		// signature-only members without crashing.
+		{Code: `
+        abstract class Hello extends React.Component {
+          abstract componentDidMount(): void;
+        }
+      `, Tsx: true},
+
+		// ---- Cross-helper lock: `extends mixin(React.Component)` — extends
+		// clause is a CallExpression (not Identifier or PropertyAccess);
+		// ExtendsReactComponent does not recognize it. Empirically verified
+		// against ESLint master (NOT reported). ----
+		{Code: `
+        class Hello extends mixin(React.Component) {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: extends arbitrary base class — not a React component ----
+		{Code: `
+        class Hello extends MyOwnBase {
+          someMethod() {
+            this.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: extends React.SomeOther — only Component / PureComponent match ----
+		{Code: `
+        class Hello extends React.SomeOther {
+          someMethod() {
+            this.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: JSX onClick={this.setState} — reference, not call ----
+		// Argument to onClick is a bare PropertyAccessExpression (no
+		// CallExpression around it), so the listener never fires.
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            return <button onClick={this.setState}/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: chained `this.setState.bind(this, {})` — outer call is on .bind, not setState ----
+		// JSX usage: `onClick={this.setState.bind(this, {})}`. The outer
+		// CallExpression's callee is `this.setState.bind`, whose
+		// PropertyAccess receiver is `this.setState` (PropertyAccess),
+		// not ThisKeyword. Locked as VALID — `.bind(...)` calls are not
+		// the setState call site.
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            return <button onClick={this.setState.bind(this, {})}/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `this.x.setState({})` — multi-level receiver, base is not bare `this` ----
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.x.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `this.constructor.setState({})` — same shape as above ----
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.constructor.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: legacy type assertion `<T>this.setState({})` (non-TSX file) ----
+		// In TSX this would be parsed as JSX; in plain TS it's a type
+		// assertion that wraps `this.setState({})`. The wrapper is the
+		// outer expression, but the inner `this.setState({})` is still a
+		// CallExpression that the listener visits. The wrapper around
+		// the OUTER expression doesn't break the receiver check (the
+		// receiver of the inner setState call is bare `this`).
+		{Code: `
+class Hello {
+  someMethod() {
+    <any>this.setState({});
+  }
+}
+`, Tsx: false},
+
+		// ---- Edge: declare class — ambient declaration, no body ----
+		// declare class is purely a type signature; no method bodies, no
+		// setState possible. Locks no-crash on traversal.
+		{Code: `
+        declare class Hello extends React.Component {
+          someMethod(): void;
+        }
+      `, Tsx: true},
+
+		// ---- Edge: settings.react is not a map (boolean) — must NOT crash ----
+		// GetReactPragma defensive guard: settings.react.(map[..]) ok=false
+		// → fall back to default. Locks parity with the existing
+		// no_did_mount_set_state test that exercises the same shape.
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            other.setState({});
+          }
+        }
+      `, Tsx: true, Settings: map[string]interface{}{"react": true}},
+
+		// ---- Edge: settings.react.pragma is not a string (number) — falls back to default ----
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            other.setState({});
+          }
+        }
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": 42}}},
+
+		// ---- Edge: custom pragma — `class Hello extends Preact.Component` is NOT React ----
+		// With `settings.react.pragma = "Preact"`, `React.Component` is
+		// no longer the recognized base — only `Preact.Component` (or bare
+		// `Component`/`PureComponent`) is. So the inner class extending
+		// `React.Component` is NOT a detected component under the Preact
+		// pragma, and `this.setState` inside is NOT reported.
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+        }
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}}},
+
+		// ---- Edge: custom createClass — `var X = createReactClass({...})` is NOT a component ----
+		// With `settings.react.createClass = "myCreate"`, only
+		// `myCreate({...})` calls are recognized as ES5 components.
+		{Code: `
+        var Hello = createReactClass({
+          someMethod: function() {
+            this.setState({});
+          },
+          render: function() { return <div/>; }
+        });
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "myCreate"}}},
+
+
+		// ---- Edge: logical-OR receiver `(this || other).setState({})` ----
+		// `this || other` is a BinaryExpression(||). SkipParentheses
+		// unwraps the outer parens, but the receiver is still a
+		// BinaryExpression — not ThisKeyword. Locked as VALID, mirroring
+		// the same shape lock in no_did_mount_set_state.
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            (this || other).setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: logical-AND receiver `(this && other).setState({})` ----
+		// Same reasoning as the OR variant — symmetric lock.
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            (this && other).setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: comma-operator receiver `(this, other).setState({})` ----
+		// `(this, other)` is a BinaryExpression(comma). Same as above.
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            (this, other).setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: ElementAccess on setState `this.setState[0]({})` ----
+		// Outer call's callee is `this.setState[0]`
+		// (ElementAccessExpression), not PropertyAccessExpression. The
+		// kind check rejects.
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            (this.setState as any)[0]({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: PropertyAccess chained off setState `this.setState.fn({})` ----
+		// Outer call's callee is `this.setState.fn` (PropertyAccess).
+		// Receiver is `this.setState` (PropertyAccess), not ThisKeyword.
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState.fn({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: with-statement — bare `setState(...)` callee is Identifier, not PropertyAccess ----
+		// Even though `with (this)` would resolve `setState` to
+		// `this.setState` at runtime, textually the callee is a bare
+		// Identifier. Both upstream and rslint require explicit `this.`.
+		{Code: `
+        // @ts-nocheck
+        class Hello extends React.Component {
+          someMethod() {
+            with (this as any) {
+              setState({});
+            }
+          }
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream #1: createReactClass componentDidUpdate ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            this.setState({
+              name: this.props.name.toUpperCase()
+            });
+          },
+          render: function() {
+            return <div>Hello {this.state.name}</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream #2: createReactClass someMethod ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          someMethod: function() {
+            this.setState({
+              name: this.props.name.toUpperCase()
+            });
+          },
+          render: function() {
+            return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream #3: ES6 class someMethod ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState({
+              name: this.props.name.toUpperCase()
+            });
+          }
+          render() {
+            return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream #4: class field arrow ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod = () => {
+            this.setState({
+              name: this.props.name.toUpperCase()
+            });
+          }
+          render() {
+            return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream #5: setState inside JSX onMouseEnter callback ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            return <div onMouseEnter={() => this.setState({dropdownIndex: index})} />;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 45},
+			},
+		},
+
+		// ---- Edge: parenthesized `(this).setState({})` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            (this).setState({});
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: multi-paren receiver `((this)).setState({})` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            ((this)).setState({});
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: optional-chain receiver `this?.setState({})` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            this?.setState({});
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: optional-call `this.setState?.({})` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            this.setState?.({});
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: parens around the entire callee `(this.setState)({})` ----
+		// SkipParentheses on `call.Expression` unwraps to the underlying
+		// PropertyAccessExpression; column lands at `this` (after the
+		// stripped `(`).
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            (this.setState)({});
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 14},
+			},
+		},
+
+		// ---- Edge: spread arguments — call shape unaffected ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            this.setState(...args);
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: setState inside setTimeout callback (still inside the component) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            setTimeout(() => {
+              this.setState({});
+            }, 100);
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Edge: setState inside JSX onClick arrow inside render ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            return <button onClick={() => this.setState({})}/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 43},
+			},
+		},
+
+		// ---- Edge: setState inside constructor ----
+		// Upstream's rule does NOT carve out the constructor (unlike
+		// no-direct-mutation-state); a setState call there is still
+		// flagged. Locks behavior parity.
+		{
+			Code: `
+        class Hello extends React.Component {
+          constructor(props) {
+            super(props);
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: multiple setState calls in the same component, each reported ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            this.setState({});
+            if (x) { this.setState({}); }
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+				{MessageId: "noSetState", Line: 5, Column: 22},
+			},
+		},
+
+		// ---- Edge: async render-like method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          async load() {
+            await Promise.resolve();
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: generator method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          *load() {
+            yield this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 19},
+			},
+		},
+
+		// ---- Edge: static method on a React component ----
+		// `static someMethod` isn't typically called with a real component
+		// `this`, but the rule is purely structural — `this.setState` here
+		// is still inside a class extending React.Component, so it
+		// reports. Locks that we are not gating on `static`.
+		{
+			Code: `
+        class Hello extends React.Component {
+          static someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: class expression assigned to a const ----
+		{
+			Code: `
+        const Hello = class extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: bare `extends Component` (no React. prefix) — also a component ----
+		{
+			Code: `
+        class Hello extends Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: extends PureComponent ----
+		{
+			Code: `
+        class Hello extends React.PureComponent {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: nested class component — inner class is the component owner ----
+		// The walk from the inner setState reaches the inner Class first;
+		// `GetEnclosingReactComponent` stops at the nearest enclosing
+		// class scope, so reporting attributes the call to Inner.
+		{
+			Code: `
+        class Outer extends React.Component {
+          render() {
+            class Inner extends React.Component {
+              someMethod() {
+                this.setState({});
+              }
+              render() { return <div/>; }
+            }
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 6, Column: 17},
+			},
+		},
+
+		// ---- Edge: try/catch wrapping setState ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            try {
+              this.setState({});
+            } catch (e) {}
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Edge: switch/case wrapping setState ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            switch (this.props.kind) {
+              case 1:
+                this.setState({});
+                break;
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 6, Column: 17},
+			},
+		},
+
+		// ---- Edge: comment between `this` and `.setState` — AST shape preserved ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            this/* hi */.setState({});
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: newline between `this` and `.setState` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            this
+              .setState({});
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: stateless functional component returning JSX ----
+		// `IsStatelessReactComponent` matches Capital-cased function that
+		// returns JSX → `getParentComponent` would resolve here, so
+		// `this.setState` (semantically meaningless but textually present)
+		// still reports. Locks parity with upstream.
+		{
+			Code: `
+        function Hello() {
+          this.setState({});
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: stateless arrow component assigned to capitalized const ----
+		{
+			Code: `
+        const Hello = () => {
+          this.setState({});
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: PrivateIdentifier callee `this.#setState()` ----
+		// ESLint's PrivateIdentifier surfaces `.name` with the leading
+		// `#` stripped, so upstream's `callee.property.name === 'setState'`
+		// matches. We mirror that — `propertyName` strips the `#`, so a
+		// private `#setState` reports just like a public one.
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.#setState({});
+          }
+          #setState(_x: unknown) {}
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: setState in default-export class ----
+		{
+			Code: `
+        export default class extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: TS overload signatures + body-bearing implementation ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          load(): void;
+          load(arg: number): void;
+          load(_arg?: number) {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 6, Column: 13},
+			},
+		},
+
+		// ---- Edge: setState in createReactClass with custom pragma still works under default ----
+		// (Custom pragma settings are exercised in plugin-wide tests; here
+		// we lock the default-pragma path with multiple lifecycle hooks
+		// reporting independently.)
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidMount: function() { this.setState({}); },
+          componentDidUpdate: function() { this.setState({}); },
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 3, Column: 43},
+				{MessageId: "noSetState", Line: 4, Column: 44},
+			},
+		},
+
+		// ---- Edge: getter `get foo() { this.setState({}); }` inside a component ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          get foo() {
+            this.setState({});
+            return null;
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: setter `set foo(v) { this.setState({}); }` inside a component ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          set foo(_v: any) {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: arrow with concise (expression) body returning setState call ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod = () => this.setState({});
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 3, Column: 30},
+			},
+		},
+
+		// ---- Edge: namespace-wrapped class component ----
+		{
+			Code: `
+        namespace App {
+          export class Hello extends React.Component {
+            someMethod() {
+              this.setState({});
+            }
+            render() { return <div/>; }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Edge: createReactClass wrapped in extra parens ----
+		// `createReactClass(({...}))` — tsgo preserves parens; the
+		// component-detection helper unwraps them when matching the
+		// argument-position. Locks that the rule sees through them.
+		{
+			Code: `
+        var Hello = createReactClass(({
+          someMethod: function() {
+            this.setState({});
+          },
+          render: function() { return <div/>; }
+        }));
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: setState chained on a new instance of the component ----
+		// `new Hello().setState({})` — outer is NewExpression, but the
+		// trailing `.setState({})` is a CallExpression on
+		// PropertyAccessExpression whose receiver is the NewExpression,
+		// not ThisKeyword. Even when this whole expression sits inside
+		// another class, the call is NOT matched (receiver != `this`).
+		// Locks the receiver guard against false positives from
+		// "constructor + chained call" shapes. (Kept here as comment —
+		// already covered by the `other.setState({})` valid case above.)
+
+		// ---- Edge: createReactClass with computed key (non-Identifier method name) ----
+		// `[methodName]: function() { this.setState({}); }` — the method
+		// name is a ComputedPropertyName, but the rule doesn't gate on
+		// the method name at all (only on the call). The setState call
+		// inside still reports. Locks that the rule is purely call-site
+		// based, not stopper-name based (unlike no-did-mount-set-state).
+		{
+			Code: `
+        var Hello = createReactClass({
+          [methodName]: function() {
+            this.setState({});
+          },
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: TS auto-accessor field `accessor someMethod = () => { ... }` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          accessor someMethod = () => {
+            this.setState({});
+          };
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: ClassStaticBlockDeclaration — `this` here is the class itself, ----
+		// not an instance, but the rule is structural — `this.setState`
+		// inside a class extending React.Component still reports.
+		// Locks that `GetEnclosingReactComponent` traverses through static
+		// blocks (which are not function-like and not a component scope).
+		{
+			Code: `
+        class Hello extends React.Component {
+          static {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: generic class component `class Hello extends React.Component<Props, State>` ----
+		// TS type-argument list doesn't affect heritage detection.
+		{
+			Code: `
+        class Hello extends React.Component<{}, {}> {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: HOC-wrapped class component (`withRouter(class extends React.Component {...})`) ----
+		// The inner ClassExpression is what extends React.Component;
+		// `GetEnclosingReactComponent` walks up from the setState call
+		// and finds the inner class first — wrapper position is irrelevant.
+		{
+			Code: `
+        const Hello = withRouter(class extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: setState inside an arrow callback nested inside the constructor ----
+		// Walk: ArrowFunction (depth 1), Constructor (depth 2 — function-like),
+		// ClassDeclaration. Reports on the ClassDeclaration (the React component).
+		{
+			Code: `
+        class Hello extends React.Component {
+          constructor(props) {
+            super(props);
+            setTimeout(() => this.setState({}), 100);
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 30},
+			},
+		},
+
+		// ---- Edge: functional-form setState `this.setState(prev => ({...}))` ----
+		// Argument shape is irrelevant to the rule; the callee shape is what matters.
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState(prev => ({ count: prev.count + 1 }));
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: deeply-nested setState (Promise.then chain inside setTimeout inside method) ----
+		// 4-deep nesting (setTimeout-arrow → Promise-callback → then-callback → setState).
+		// All levels should still resolve to the same enclosing class.
+		{
+			Code: `
+        class Hello extends React.Component {
+          load() {
+            setTimeout(() => {
+              new Promise((resolve) => {
+                fetch("/api").then((data) => {
+                  this.setState({ data });
+                  resolve(data);
+                });
+              });
+            }, 100);
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 7, Column: 19},
+			},
+		},
+
+		// ---- Edge: setState as the right operand of `&&` ----
+		// `cond && this.setState({})` — short-circuit gating. The rule is
+		// listener-based, fires regardless of guarding context.
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            cond && this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 21},
+			},
+		},
+
+		// ---- Edge: bare `extends PureComponent` (no React. prefix) ----
+		// Locks `isComponentName` covers BOTH "Component" and "PureComponent"
+		// in the bare-Identifier branch (line 1051 of reactutil.go).
+		{
+			Code: `
+        class Hello extends PureComponent {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: custom pragma — `extends Preact.Component` IS a component ----
+		// Inverse of the matching valid case above: with the same custom
+		// pragma, `extends Preact.Component` IS recognized.
+		{
+			Code: `
+        class Hello extends Preact.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: custom createClass — `var X = myCreate({...})` IS a component ----
+		// Inverse of the matching valid case above: with the same
+		// `settings.react.createClass`, the custom factory call is
+		// recognized as ES5 component.
+		{
+			Code: `
+        var Hello = myCreate({
+          someMethod: function() {
+            this.setState({});
+          },
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "myCreate"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Real-world: `React.memo(class extends React.Component {...})` ----
+		// memo wraps a class component. The class itself is the
+		// detected ES6 component; the memo() call is just a wrapper at
+		// the outer expression. setState inside the inner class still
+		// reports. (Locks that wrapper-call positioning doesn't mask
+		// the inner React-extending class.)
+		{
+			Code: `
+        const Hello = React.memo(class extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Real-world: redux `connect(...)(class extends React.Component {...})` ----
+		// connect()(...) is a curried HOC. The inner class is what
+		// extends React.Component. Same reasoning as memo above.
+		{
+			Code: `
+        const Hello = connect(mapState)(class extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Multi-component file: only the React component reports ----
+		// Locks no-cross-fire across declarations: A's setState (not a
+		// React class) is NOT reported; B's setState IS reported.
+		{
+			Code: `
+        class A {
+          foo() {
+            this.setState({});
+          }
+        }
+        class B extends React.Component {
+          foo() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 9, Column: 13},
+			},
+		},
+
+		// ---- Real-world: addEventListener callback inside componentDidMount ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            window.addEventListener("resize", () => {
+              this.setState({});
+            });
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Real-world: array.forEach + condition + setState ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          process(items) {
+            items.forEach((item) => {
+              if (item.dirty) {
+                this.setState({ value: item.v });
+              }
+            });
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 6, Column: 17},
+			},
+		},
+
+		// ---- Real-world: lifecycle hooks beyond componentDidMount ----
+		// Each lifecycle method's setState reports independently.
+		// The exact column is not the point of this test — what we lock
+		// is "9 calls → 9 reports" (no de-dup, no skip across lifecycle
+		// stoppers). Per-method column assertions are covered by the
+		// dedicated single-method tests above.
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillMount() {
+            this.setState({});
+          }
+          componentDidMount() {
+            this.setState({});
+          }
+          componentWillReceiveProps() {
+            this.setState({});
+          }
+          shouldComponentUpdate() {
+            this.setState({});
+            return true;
+          }
+          componentWillUpdate() {
+            this.setState({});
+          }
+          componentDidUpdate() {
+            this.setState({});
+          }
+          componentWillUnmount() {
+            this.setState({});
+          }
+          componentDidCatch() {
+            this.setState({});
+          }
+          getSnapshotBeforeUpdate() {
+            this.setState({});
+            return null;
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+				{MessageId: "noSetState", Line: 7, Column: 13},
+				{MessageId: "noSetState", Line: 10, Column: 13},
+				{MessageId: "noSetState", Line: 13, Column: 13},
+				{MessageId: "noSetState", Line: 17, Column: 13},
+				{MessageId: "noSetState", Line: 20, Column: 13},
+				{MessageId: "noSetState", Line: 23, Column: 13},
+				{MessageId: "noSetState", Line: 26, Column: 13},
+				{MessageId: "noSetState", Line: 29, Column: 13},
+			},
+		},
+
+		// ---- Real-world: Promise.then + setState in arrow ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          load() {
+            Promise.resolve().then(() => this.setState({}));
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 42},
+			},
+		},
+
+		// ---- Real-world: TS modifiers on the method (override / public / readonly arrow) ----
+		// `override` requires TS >= 4.3, `readonly` is field-only — the
+		// modifiers don't change the method's stopper / function-like
+		// classification. Locks parity.
+		{
+			Code: `
+        class Hello extends React.Component {
+          public override componentDidMount(): void {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Real-world: protected / private TS modifier ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          protected someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Real-world: assignment-as-callee `(x = this.setState)({})` ----
+		// `x = this.setState` is BinaryExpression(=) wrapped by
+		// CallExpression. SkipParentheses doesn't unwrap binary ops, so
+		// the callee Kind is BinaryExpression — not PropertyAccess.
+		// Locked as VALID by the `cond ? this : x` shape above; here we
+		// add the assignment variant for completeness. (Kept here as a
+		// comment — overlaps with the conditional-receiver valid case.)
+
+		// ---- Real-world: setState inside class method calling another method that calls setState ----
+		// Indirect calls don't mask the direct setState call.
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState({});
+            this.otherMethod();
+          }
+          otherMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+				{MessageId: "noSetState", Line: 8, Column: 13},
+			},
+		},
+
+		// ---- Real-world: setState inside a returned arrow (event-handler factory) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          makeHandler() {
+            return () => this.setState({});
+          }
+          render() { return <button onClick={this.makeHandler()}/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 26},
+			},
+		},
+
+		// ---- Real-world: ChainExpression-equivalent — `this?.x?.setState?.()` (deep optional) ----
+		// `this?.x?.setState?.({})`: outermost call is `this?.x?.setState`
+		// chained to `?.()`. After SkipParens, callee is the
+		// PropertyAccessExpression `this?.x?.setState`. prop.Expression
+		// is `this?.x` (PropertyAccessExpression), NOT ThisKeyword.
+		// Locked as VALID via the `this.x.setState` valid case above —
+		// here we add the optional-chain variant as a real-world shape.
+		// (Kept as comment — overlaps with `this.x.setState` valid case.)
+
+		// ---- Real-world: TS class with `implements` clause ----
+		// `implements` is a sibling of `extends`; it doesn't affect
+		// `ExtendsReactComponent`. setState still reports.
+		{
+			Code: `
+        interface Foo {}
+        class Hello extends React.Component implements Foo {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Real-world: useEffect-style — setState inside setInterval callback ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.timer = setInterval(() => {
+              this.setState({ tick: Date.now() });
+            }, 1000);
+          }
+          componentWillUnmount() { clearInterval(this.timer); }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Real-world: TS-only `as const` argument — argument shape doesn't matter ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState({ x: 1 } as const);
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Real-world: setState inside a ternary expression ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            cond ? this.setState({}) : null;
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 20},
+			},
+		},
+
+		// ---- Real-world: `await this.setState({})` inside async method ----
+		// AwaitExpression is neither stopper nor function-like for the
+		// component walk; the inner `this.setState({})` CallExpression
+		// triggers the listener as usual.
+		{
+			Code: `
+        class Hello extends React.Component {
+          async load() {
+            await this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 19},
+			},
+		},
+
+		// ---- Real-world: `void this.setState({})` ----
+		// VoidExpression is a unary wrapper around the call. Same as
+		// await — the inner CallExpression still fires.
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            void this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 18},
+			},
+		},
+
+		// ---- Real-world: setState inside a `for` loop body ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          process() {
+            for (let i = 0; i < 10; i++) {
+              this.setState({});
+            }
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Real-world: setState inside a `while` loop body ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          process() {
+            while (cond) this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 26},
+			},
+		},
+
+		// ---- Real-world: TS legacy decorator + lifecycle method ----
+		// Decorator is a sibling node on the MethodDeclaration; the
+		// stopper match (function-like + class-extends-React) is
+		// unaffected by decorator presence.
+		{
+			Code: `
+        function readonlyDec(_t: any, _k: any, d: any) { return d; }
+        class Hello extends React.Component {
+          @readonlyDec
+          componentDidMount() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 6, Column: 13},
+			},
+		},
+
+		// ---- Real-world: pragma-qualified createReactClass `React.createReactClass({...})` ----
+		// upstream's `IsCreateClassCall` accepts both bare
+		// `createReactClass(...)` and `<pragma>.<createClass>(...)` —
+		// e.g. `React.createReactClass({...})` works under default settings.
+		{
+			Code: `
+        var Hello = React.createReactClass({
+          someMethod: function() {
+            this.setState({});
+          },
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Real-world: named default-export class `export default class Foo extends React.Component` ----
+		// Symmetric to the anonymous default-export case above; locks
+		// that the class name is irrelevant to detection.
+		{
+			Code: `
+        export default class Hello extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Real-world: setState followed by chained `.then(callback)` ----
+		// `this.setState({}).then(...)` — although React's setState
+		// returns void, the textual call shape is preserved. The outer
+		// `.then` is a separate CallExpression on a separate
+		// PropertyAccess. Both setStates should report (the inner
+		// one in this snippet, plus the optional second in callback).
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState({}, () => this.setState({}));
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+				{MessageId: "noSetState", Line: 4, Column: 37},
+			},
+		},
+
+		// ---- Real-world: setState inside `do/while` body ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          process() {
+            do {
+              this.setState({});
+            } while (cond);
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Real-world: setState inside `for-of` loop body ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          process(items) {
+            for (const item of items) {
+              this.setState({ value: item });
+            }
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Real-world: `!this.setState({})` — unary-not on the call ----
+		// Symmetric to `void` and `await` — the unary wrapper is on the
+		// outer expression; the inner CallExpression still fires.
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            !this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 14},
+			},
+		},
+
+		// ---- Real-world: forward-compat — Options array with future option strings ----
+		// upstream `schema: []` accepts no options. We don't read
+		// `options` either, so passing a future-shape value must be a
+		// no-op (still report the call). Locks future-proofing.
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"some-future-option"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Real-world: empty Options array — same as default ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Cross-helper lock: nested non-React class inside createReactClass arg ----
+		// Empirically verified against ESLint master: ESLint's
+		// `Components.set(node, ...)` walks `node.parent` to find any
+		// node in the detected-component list. Non-React inner classes
+		// are NOT in the list, so the walk passes through them and
+		// reaches the outer createReactClass arg ObjectLiteral. Reports.
+		// rslint's `GetEnclosingReactComponent` mirrors via the same
+		// AST ancestor walk.
+		{
+			Code: `
+var Hello = createReactClass({
+  someMethod: function() {
+    class Helper {
+      doStuff() {
+        this.setState({});
+      }
+    }
+  },
+  render: function() { return <div/>; }
+});
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 6, Column: 9},
+			},
+		},
+
+		// ---- Cross-helper lock: setState as createReactClass arg
+		// top-level property value (not inside any method/function).
+		// Empirically verified against ESLint master: components.set's
+		// free parent walk attributes the call to the createReactClass
+		// arg ObjectLiteral, so this reports. Locks the helper-layer
+		// fix that removes the previous `seenEnclosingFunction` gate. ----
+		{
+			Code: `
+var Hello = createReactClass({
+  config: this.setState({}),
+  render: function() { return <div/>; }
+});
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Cross-helper lock: nested non-React class inside an ES6
+		// React component — same reasoning, walks past the non-React
+		// inner class and reaches the outer React class. ----
+		{
+			Code: `
+class Outer extends React.Component {
+  render() {
+    class Helper {
+      doStuff() {
+        this.setState({});
+      }
+    }
+    return <div/>;
+  }
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 6, Column: 9},
+			},
+		},
+
+		// ---- Cross-helper lock: settings.componentWrapperFunctions ----
+		// User configures `myObserver` as a custom component wrapper
+		// (e.g. mobx-style HOC). Upstream's stateless detection
+		// recognizes `myObserver(arrow)` as a stateless component when
+		// the inner arrow returns JSX, and reports `this.setState({})`
+		// inside it.
+		//
+		// rslint mirrors this via `GetComponentWrapperFunctions(settings, pragma)`
+		// + `IsStatelessReactComponentWithWrappers`. Locked here.
+		{
+			Code: `
+        const Hello = myObserver((props) => {
+          this.setState({});
+          return <div/>;
+        });
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"componentWrapperFunctions": []interface{}{"myObserver"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Cross-helper lock: settings.componentWrapperFunctions object form ----
+		// Object-shape entry `{property: "observer", object: "<pragma>"}`
+		// matches `React.observer(arrow)` (and substitutes pragma per
+		// configured `settings.react.pragma`).
+		{
+			Code: `
+        const Hello = React.observer((props) => {
+          this.setState({});
+          return <div/>;
+        });
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"componentWrapperFunctions": []interface{}{
+					map[string]interface{}{"property": "observer", "object": "<pragma>"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Real-world: `throw this.setState({})` — ThrowStatement wrapping the call ----
+		// ThrowStatement is neither stopper nor function-like. The
+		// inner CallExpression still fires.
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            throw this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 19},
+			},
+		},
+
+		// ---- Real-world: class decorator + method setState ----
+		// Class decorators sit on the ClassDeclaration as a sibling
+		// modifier; they don't change `extends` heritage detection.
+		{
+			Code: `
+        function classDec<T extends new (...a: any[]) => any>(c: T) { return c; }
+        @classDec
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 6, Column: 13},
+			},
+		},
+
+		// ---- Real-world: multiple stacked decorators on the method ----
+		{
+			Code: `
+        function dec1(_t: any, _k: any, d: any) { return d; }
+        function dec2(_t: any, _k: any, d: any) { return d; }
+        class Hello extends React.Component {
+          @dec1
+          @dec2
+          componentDidMount() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 8, Column: 13},
+			},
+		},
+
+		// ---- Real-world: setState as JSX attribute value (immediate call, not callback) ----
+		// `<div data-x={this.setState({})}/>` — the setState call is
+		// the JSXExpression value, not wrapped in an arrow. Listener
+		// fires on the call.
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            return <div data-x={this.setState({})}/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 33},
+			},
+		},
+
+		// ---- Real-world: named function expression assigned to const ----
+		// `const Hello = function Hello() { ... }` — the inner Identifier
+		// `Hello` makes this a NamedFunctionExpression. Stateless
+		// component detection should match the binding name.
+		{
+			Code: `
+        const Hello = function Hello() {
+          this.setState({});
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 3, Column: 11},
+			},
+		},
+
+	})
+}

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs_test.go
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs_test.go
@@ -222,6 +222,28 @@ var bag = createReactClass({ x: this.refs && 1 });
 			Tsx:      true,
 			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
 		},
+
+		// ---- Cross-helper lock (Helper-A): `this.refs` inside a nested
+		// non-React inner class. Upstream's ES6 detection stops at the
+		// inner non-React class; the outer React component is not
+		// considered. rslint mirrors via GetEnclosingReactComponent's
+		// stop-at-first-non-React-class behavior. ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          render() {
+            class Helper {
+              doStuff() {
+                return this.refs;
+              }
+            }
+            return <div/>;
+          }
+        }
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream invalid cases ----
 		{
@@ -585,6 +607,35 @@ var Hello = createReactClass({
 			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "thisRefsDeprecated", Line: 5, Column: 32},
+			},
+		},
+
+		// ---- Cross-helper lock: nested non-React class inside
+		// createReactClass arg + this.refs in inner method.
+		// Upstream's `getParentES5Component` walks each FunctionLike
+		// scope; when it reaches `someMethod` (FE inside the
+		// createReactClass arg), block.parent.parent =
+		// ObjectLiteralExpression which IS the createReactClass arg,
+		// so isES5Component returns true. The inner `this.refs`
+		// reports. Empirically verified against ESLint master
+		// (line=5 col=16). ----
+		{
+			Code: `
+var Hello = createReactClass({
+  someMethod: function() {
+    class Helper {
+      doStuff() {
+        return this.refs;
+      }
+    }
+  },
+  render: function() { return <div/>; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 6, Column: 16},
 			},
 		},
 	})

--- a/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.go
+++ b/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.go
@@ -18,12 +18,18 @@ import (
 // thus resolves to the nearest enclosing function-like (matching upstream's
 // `getScope` + `scope.upper` chain, which also walks past class scope without
 // classifying it as a component).
-func getParentStatelessComponent(node *ast.Node, pragma string) *ast.Node {
+//
+// `wrappers` is the resolved `settings.componentWrapperFunctions` list (plus
+// the built-in `memo` / `forwardRef` defaults) — passing it through to
+// `IsStatelessReactComponentWithWrappers` lets user-configured HOCs be
+// recognized as component-wrapping calls (e.g. `mobx.observer(fn)`,
+// `styled(fn)`).
+func getParentStatelessComponent(node *ast.Node, pragma string, wrappers []reactutil.ComponentWrapperEntry) *ast.Node {
 	for p := node.Parent; p != nil; p = p.Parent {
 		if !ast.IsFunctionLike(p) {
 			continue
 		}
-		if reactutil.IsStatelessReactComponent(p, pragma) {
+		if reactutil.IsStatelessReactComponentWithWrappers(p, pragma, nil, wrappers) {
 			return p
 		}
 	}
@@ -66,6 +72,7 @@ var NoThisInSfcRule = rule.Rule{
 	Name: "react/no-this-in-sfc",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		pragma := reactutil.GetReactPragma(ctx.Settings)
+		wrappers := reactutil.GetComponentWrapperFunctions(ctx.Settings, pragma)
 
 		report := func(node *ast.Node) {
 			ctx.ReportNode(node, rule.RuleMessage{
@@ -83,7 +90,7 @@ var NoThisInSfcRule = rule.Rule{
 			if ast.SkipParentheses(expr).Kind != ast.KindThisKeyword {
 				return
 			}
-			component := getParentStatelessComponent(node, pragma)
+			component := getParentStatelessComponent(node, pragma, wrappers)
 			if component == nil {
 				return
 			}

--- a/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.md
+++ b/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.md
@@ -80,15 +80,6 @@ const Foo = createReactClass({
 });
 ```
 
-## Differences from ESLint
-
-- A function wrapped in a custom higher-order component (configured via
-  `settings.componentWrapperFunctions` in ESLint) is not treated as a
-  stateless component. For example, given `wrap(() => <div>{this.props.x}</div>)`,
-  ESLint reports the `this` access while rslint does not. Only `memo` and
-  `forwardRef` wrappers (bare, or qualified by the configured React pragma)
-  are recognized.
-
 ## Original Documentation
 
 - [eslint-plugin-react `no-this-in-sfc`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-this-in-sfc.md)

--- a/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc_test.go
+++ b/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc_test.go
@@ -479,9 +479,14 @@ func TestNoThisInSfcRule(t *testing.T) {
 			},
 		},
 
-		// ---- Lock-in: bare `forwardRef(...)` wrapper. ----
+		// ---- Lock-in: bare `forwardRef(...)` wrapper.
+		// Upstream gates bare `forwardRef` / `memo` callees on
+		// `isDestructuredFromPragmaImport` — without an import binding
+		// the call is NOT recognized as a wrapper. Locked here with
+		// the explicit import to mirror that gate. ----
 		{
 			Code: `
+        import { forwardRef } from 'react';
         const Foo = forwardRef((props, ref) => <div ref={ref}>{this.props.foo}</div>);
       `,
 			Tsx: true,
@@ -491,10 +496,12 @@ func TestNoThisInSfcRule(t *testing.T) {
 		},
 
 		// ---- Boundary: forwardRef wrapping a NAMED FunctionExpression.
-		// Wrapper-call branch in IsStatelessReactComponent classifies regardless
-		// of name. ----
+		// Wrapper-call branch classifies regardless of inner function
+		// name; the outer `forwardRef` Identifier still requires the
+		// pragma import gate. ----
 		{
 			Code: `
+        import { forwardRef } from 'react';
         const Foo = forwardRef(function Inner(props, ref) {
           return <div ref={ref}>{this.props.foo}</div>;
         });
@@ -626,6 +633,38 @@ func TestNoThisInSfcRule(t *testing.T) {
         }
       `,
 			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Cross-helper lock (Helper-B): settings.componentWrapperFunctions
+		// — a user-configured HOC like `myObserver` is recognized as a
+		// component wrapper, so the inner arrow is treated as a stateless
+		// component and `this.props.foo` reports. ----
+		{
+			Code: `
+        const Foo = myObserver((props) => <div>{this.props.foo}</div>);
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"componentWrapperFunctions": []interface{}{"myObserver"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Cross-helper lock (Helper-B): pragma-qualified user wrapper
+		// `React.observer(arrow)` via object-form entry. ----
+		{
+			Code: `
+        const Foo = React.observer((props) => <div>{this.props.foo}</div>);
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"componentWrapperFunctions": []interface{}{
+					map[string]interface{}{"property": "observer", "object": "<pragma>"},
+				},
+			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noThisInSFC"},
 			},

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -125,6 +125,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
     './tests/eslint-plugin-react/rules/no-redundant-should-component-update.test.ts',
     './tests/eslint-plugin-react/rules/no-render-return-value.test.ts',
+    './tests/eslint-plugin-react/rules/no-set-state.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
     './tests/eslint-plugin-react/rules/no-multi-comp.test.ts',
     './tests/eslint-plugin-react/rules/no-this-in-sfc.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-set-state.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-set-state.test.ts
@@ -1,0 +1,430 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-set-state', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    {
+      code: `
+        var Hello = function() {
+          this.setState({})
+        };
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someNonMemberFunction(arg);
+            this.someHandler = this.setState;
+          },
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+    },
+    // ---- Edge: plain class without React extends ----
+    {
+      code: `
+        class Hello {
+          someMethod() {
+            this.setState({});
+          }
+        }
+      `,
+    },
+    // ---- Edge: bracket access `this['setState']` is not matched ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this['setState']({});
+          }
+        }
+      `,
+    },
+    // ---- Edge: super.setState — receiver is SuperKeyword ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            super.setState({});
+          }
+        }
+      `,
+    },
+    // ---- Edge: TS as-expression breaks the receiver match ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            (this as any).setState({});
+          }
+        }
+      `,
+    },
+    // ---- Edge: lowercase function — not a stateless component ----
+    {
+      code: `
+        function hello() {
+          this.setState({});
+          return <div/>;
+        }
+      `,
+    },
+    // ---- Edge: capital fn not returning JSX — not a component ----
+    {
+      code: `
+        function Hello() {
+          this.setState({});
+          return 42;
+        }
+      `,
+    },
+    // ---- Edge: JSX onClick reference (not call) ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <button onClick={this.setState}/>;
+          }
+        }
+      `,
+    },
+    // ---- Edge: this.setState.bind(this, {}) — outer call is on .bind ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <button onClick={this.setState.bind(this, {})}/>;
+          }
+        }
+      `,
+    },
+    // ---- Edge: multi-level receiver this.x.setState ----
+    {
+      code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.x.setState({});
+          }
+        }
+      `,
+    },
+    // ---- Edge: extends arbitrary base, not React ----
+    {
+      code: `
+        class Hello extends MyOwnBase {
+          someMethod() {
+            this.setState({});
+          }
+        }
+      `,
+    },
+    // ---- Edge: custom pragma — React.Component is not the pragma ----
+    {
+      code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+        }
+      `,
+      settings: { react: { pragma: 'Preact' } },
+    },
+    // ---- Edge: settings.react is not a map (defensive) ----
+    {
+      code: `
+        class Hello extends React.Component {
+          someMethod() {
+            other.setState({});
+          }
+        }
+      `,
+      settings: { react: true },
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            this.setState({
+              name: this.props.name.toUpperCase()
+            });
+          },
+          render: function() {
+            return <div>Hello {this.state.name}</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          someMethod: function() {
+            this.setState({
+              name: this.props.name.toUpperCase()
+            });
+          },
+          render: function() {
+            return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.setState({
+              name: this.props.name.toUpperCase()
+            });
+          }
+          render() {
+            return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;
+          }
+        };
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          someMethod = () => {
+            this.setState({
+              name: this.props.name.toUpperCase()
+            });
+          }
+          render() {
+            return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;
+          }
+        };
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <div onMouseEnter={() => this.setState({dropdownIndex: index})} />;
+          }
+        };
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: parenthesized receiver `(this).setState` ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            (this).setState({});
+            return <div/>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: optional-chain receiver `this?.setState` ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            this?.setState({});
+            return <div/>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: setState inside setTimeout callback ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            setTimeout(() => {
+              this.setState({});
+            }, 100);
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: setState inside constructor ----
+    {
+      code: `
+        class Hello extends React.Component {
+          constructor(props) {
+            super(props);
+            this.setState({});
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: extends PureComponent ----
+    {
+      code: `
+        class Hello extends React.PureComponent {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: bare extends Component ----
+    {
+      code: `
+        class Hello extends Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: stateless functional component ----
+    {
+      code: `
+        function Hello() {
+          this.setState({});
+          return <div/>;
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: stateless arrow component ----
+    {
+      code: `
+        const Hello = () => {
+          this.setState({});
+          return <div/>;
+        };
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: multiple setState calls in same component ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            this.setState({});
+            if (x) { this.setState({}); }
+            return <div/>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }, { messageId: 'noSetState' }],
+    },
+    // ---- Edge: bare PureComponent ----
+    {
+      code: `
+        class Hello extends PureComponent {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: custom pragma — Preact.Component IS a component ----
+    {
+      code: `
+        class Hello extends Preact.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+      settings: { react: { pragma: 'Preact' } },
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Edge: custom createClass — myCreate IS a component ----
+    {
+      code: `
+        var Hello = myCreate({
+          someMethod: function() {
+            this.setState({});
+          },
+          render: function() { return <div/>; }
+        });
+      `,
+      settings: { react: { createClass: 'myCreate' } },
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Real-world: React.memo wrapping class ----
+    {
+      code: `
+        const Hello = React.memo(class extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        });
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Real-world: redux connect(...)(class) ----
+    {
+      code: `
+        const Hello = connect(mapState)(class extends React.Component {
+          someMethod() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        });
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Real-world: addEventListener callback ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            window.addEventListener("resize", () => {
+              this.setState({});
+            });
+          }
+          render() { return <div/>; }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- Multi-component file: only React component reports ----
+    {
+      code: `
+        class A {
+          foo() {
+            this.setState({});
+          }
+        }
+        class B extends React.Component {
+          foo() {
+            this.setState({});
+          }
+          render() { return <div/>; }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the [`no-set-state`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-set-state.md) rule from `eslint-plugin-react`, plus helper-layer alignment fixes that also benefit other React rules using the same component-detection helpers.

### Rule

`react/no-set-state` reports any `this.setState(...)` call whose lexically enclosing scope is a detected React component (ES6 class extending `Component`/`PureComponent`, `createReactClass(...)` arg, or a stateless functional component). Bare property reference `this.someHandler = this.setState;` does NOT fire (CallExpression-only).

### Helper alignment fixes (reactutil)

While porting, ESLint cross-check on 70+ real-world snippets surfaced six divergences in the shared component-detection helpers, all fixed in this PR:

1. `GetEnclosingReactComponent` now performs a free AST ancestor walk (matches upstream `Components.set`), so an inner non-React class no longer blocks reaching an outer detected component.
2. New `GetParentReactComponentScopeBased` mirrors upstream `getParentES6Component || getParentES5Component` (ES6 stops at first class scope; ES5 walks each FunctionLike scope) — distinct semantics from the free-walk path.
3. New `GetParentReactComponentScopeBasedOrStateless` adds a stateless fallback to (2), matching upstream's `utils.getParentComponent`.
4. `GetEnclosingReactComponentOrStateless` now accepts wrappers and uses `IsStatelessReactComponentWithWrappers`, so `settings.componentWrapperFunctions` (e.g. `mobx.observer`, custom HOCs) is honored.
5. Removed the over-strict `seenEnclosingFunction` gate — a setState call at a top-level `createReactClass({ key: this.setState({}) })` property now reports correctly.
6. Exported `reactutil.EsTreeName` so the no-method-set-state family and no-set-state share one PrivateIdentifier-aware property-name normalizer (no duplicate inside the plugin).

### Rule migrations to the correct helper

| Rule | Helper used | Upstream detection path |
|---|---|---|
| `no-set-state` | free-walk + stateless | `Components.set` (free walk) |
| `no-direct-mutation-state` | scope-based + stateless | `getParentComponent` |
| `no-access-state-in-setstate` | scope-based | `getParentES6Component \|\| getParentES5Component` |
| `no-string-refs` | scope-based (via `IsInsideReactComponent`) | same |
| `no-this-in-sfc` | wrapper-aware stateless walk | `getParentStatelessComponent` |

Every behavior change is locked in by tests cross-checked against ESLint `master` output. Two `forwardRef` / `memo` test cases now require an explicit `import { ... } from 'react'` to satisfy the `isDestructuredFromPragmaImport` gate (alignment with upstream).

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-set-state.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-set-state.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).