### PR TITLE
feat: port rule react/jsx-no-literals

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -62,6 +62,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_curly_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_comment_textnodes"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_leaked_render"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_literals"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_script_url"
 )
 
@@ -126,6 +127,7 @@ func GetAllRules() []rule.Rule {
 		jsx_curly_spacing.JsxCurlySpacingRule,
 		jsx_no_comment_textnodes.JsxNoCommentTextnodesRule,
 		jsx_no_leaked_render.JsxNoLeakedRenderRule,
+		jsx_no_literals.JsxNoLiteralsRule,
 		jsx_no_script_url.JsxNoScriptUrlRule,
 	}
 }

--- a/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals.go
+++ b/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals.go
@@ -1,0 +1,730 @@
+// cspell:ignore mdash
+package jsx_no_literals
+
+import (
+	"html"
+	"math"
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// reOverridableElement mirrors upstream's `^[A-Z][\w.]*$` — overrides apply
+// only to user-component names (capitalized identifiers, optionally
+// dot-chained like `Foo.Bar`). The regex intentionally rejects DOM tag names
+// like `div` so a `div` override silently no-ops, matching upstream's
+// "HTML element tag names are not supported" docs note. Tests still rely on
+// the validation gate skipping `div`-cased overrides without crashing.
+var reOverridableElement = regexp.MustCompile(`^[A-Z][\w.]*$`)
+
+const (
+	configTypeElement  = "element"
+	configTypeOverride = "override"
+)
+
+const (
+	msgInvalidPropValue                  = "invalidPropValue"
+	msgInvalidPropValueInElement         = "invalidPropValueInElement"
+	msgNoStringsInAttributes             = "noStringsInAttributes"
+	msgNoStringsInAttributesInElement    = "noStringsInAttributesInElement"
+	msgNoStringsInJSX                    = "noStringsInJSX"
+	msgNoStringsInJSXInElement           = "noStringsInJSXInElement"
+	msgLiteralNotInJSXExpression         = "literalNotInJSXExpression"
+	msgLiteralNotInJSXExpressionInElement = "literalNotInJSXExpressionInElement"
+	msgRestrictedAttributeString         = "restrictedAttributeString"
+	msgRestrictedAttributeStringInElement = "restrictedAttributeStringInElement"
+)
+
+type elementConfig struct {
+	configType            string
+	name                  string
+	noStrings             bool
+	allowedStrings        map[string]struct{}
+	ignoreProps           bool
+	noAttributeStrings    bool
+	restrictedAttributes  map[string]struct{}
+	allowElement          bool
+	applyToNestedElements bool
+}
+
+type ruleConfig struct {
+	base             elementConfig
+	elementOverrides map[string]*elementConfig
+}
+
+func (c *ruleConfig) hasElementOverrides() bool {
+	return len(c.elementOverrides) > 0
+}
+
+func parseConfig(options any) ruleConfig {
+	cfg := ruleConfig{
+		base: elementConfig{
+			configType:           configTypeElement,
+			allowedStrings:       map[string]struct{}{},
+			restrictedAttributes: map[string]struct{}{},
+		},
+		elementOverrides: map[string]*elementConfig{},
+	}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return cfg
+	}
+	populateElementConfig(&cfg.base, optsMap)
+	rawOverrides, _ := optsMap["elementOverrides"].(map[string]interface{})
+	for elementName, raw := range rawOverrides {
+		if !reOverridableElement.MatchString(elementName) {
+			continue
+		}
+		childMap, _ := raw.(map[string]interface{})
+		if childMap == nil {
+			childMap = map[string]interface{}{}
+		}
+		child := &elementConfig{
+			configType:            configTypeOverride,
+			name:                  elementName,
+			allowedStrings:        map[string]struct{}{},
+			restrictedAttributes:  map[string]struct{}{},
+			applyToNestedElements: true,
+		}
+		populateElementConfig(child, childMap)
+		if v, ok := childMap["allowElement"].(bool); ok {
+			child.allowElement = v
+		}
+		// applyToNestedElements defaults to true; only an explicit falsy
+		// value flips it. Upstream's `typeof v === 'undefined' || !!v`
+		// collapses to: present and JS-falsy → false; otherwise → true.
+		if v, ok := childMap["applyToNestedElements"]; ok {
+			child.applyToNestedElements = truthyBool(v)
+		}
+		cfg.elementOverrides[elementName] = child
+	}
+	return cfg
+}
+
+func populateElementConfig(c *elementConfig, m map[string]interface{}) {
+	if v, ok := m["noStrings"].(bool); ok {
+		c.noStrings = v
+	}
+	if v, ok := m["ignoreProps"].(bool); ok {
+		c.ignoreProps = v
+	}
+	if v, ok := m["noAttributeStrings"].(bool); ok {
+		c.noAttributeStrings = v
+	}
+	populateStringSetFromMap(m, "allowedStrings", c.allowedStrings)
+	populateStringSetFromMap(m, "restrictedAttributes", c.restrictedAttributes)
+}
+
+// populateStringSetFromMap reads the array-of-strings option at `key` from
+// `source`, trims each entry, and inserts it into `target`. Mirrors upstream's
+// `new Set(map(iterFrom(config.<key>), trimIfString))` shape.
+func populateStringSetFromMap(source map[string]interface{}, key string, target map[string]struct{}) {
+	arr, ok := source[key].([]interface{})
+	if !ok {
+		return
+	}
+	for _, s := range arr {
+		if str, ok := s.(string); ok {
+			target[strings.TrimSpace(str)] = struct{}{}
+		}
+	}
+}
+
+// truthyBool emulates JS `!!v` for option values. JSON-decoded numbers
+// arrive as float64 (with `0` and `NaN` falsy); strings are truthy unless
+// empty; objects / arrays are always truthy. Used for `applyToNestedElements`
+// where upstream writes `typeof v === 'undefined' || !!v`.
+func truthyBool(v interface{}) bool {
+	switch x := v.(type) {
+	case bool:
+		return x
+	case string:
+		return x != ""
+	case nil:
+		return false
+	case float64:
+		return x != 0 && !math.IsNaN(x)
+	case float32:
+		return x != 0 && !math.IsNaN(float64(x))
+	case int:
+		return x != 0
+	case int32:
+		return x != 0
+	case int64:
+		return x != 0
+	default:
+		return true
+	}
+}
+
+// skipBinaryAndParens walks up while the parent is a `BinaryExpression` or a
+// `ParenthesizedExpression`. Upstream skips only `BinaryExpression` because
+// ESTree drops parens at parse time; tsgo keeps parens as explicit nodes, so
+// we additionally peel them to match the same observable behavior on inputs
+// like `<div>{('foo')}</div>` and `<div>{('foo' + 'bar')}</div>`.
+func skipBinaryAndParens(node *ast.Node) *ast.Node {
+	for node != nil && node.Parent != nil {
+		switch node.Parent.Kind {
+		case ast.KindBinaryExpression, ast.KindParenthesizedExpression:
+			node = node.Parent
+			continue
+		}
+		return node
+	}
+	return node
+}
+
+// parentIgnoringBinaryAndParens returns the first ancestor of `node` that is
+// NOT a `BinaryExpression` / `ParenthesizedExpression`. Mirrors upstream's
+// `getParentIgnoringBinaryExpressions`, but also peels parens (see
+// skipBinaryAndParens).
+func parentIgnoringBinaryAndParens(node *ast.Node) *ast.Node {
+	current := skipBinaryAndParens(node)
+	if current == nil {
+		return nil
+	}
+	return current.Parent
+}
+
+// jsxContentParentKind reports whether `kind` is a JSX content container
+// (JsxElement / JsxFragment). JsxSelfClosingElement is excluded because it
+// has no children, so a literal can never appear inside one.
+func jsxContentParentKind(kind ast.Kind) bool {
+	return kind == ast.KindJsxElement || kind == ast.KindJsxFragment
+}
+
+// hasJSXContentParentOrGrandParent mirrors upstream's
+// `hasJSXElementParentOrGrandParent` — true when the literal lives directly
+// in JSX content (not in a JSX attribute).
+func hasJSXContentParentOrGrandParent(node *ast.Node) bool {
+	parent := parentIgnoringBinaryAndParens(node)
+	if parent == nil {
+		return false
+	}
+	if jsxContentParentKind(parent.Kind) {
+		return true
+	}
+	grand := parent.Parent
+	// Peel an extra ParenthesizedExpression layer between parent and the JSX
+	// container — `<div>{('foo')}</div>` parses as
+	// StringLiteral > ParenthesizedExpression > JsxExpression > JsxElement
+	// in tsgo, so grandParent reads as JsxExpression and the JsxElement is
+	// one level higher. Walking up here keeps parity with the no-parens
+	// ESTree shape upstream's logic targets.
+	for grand != nil && grand.Kind == ast.KindParenthesizedExpression {
+		grand = grand.Parent
+	}
+	return grand != nil && jsxContentParentKind(grand.Kind)
+}
+
+// isStandardJSXNode is the inner branch of upstream's `isViableTextNode` that
+// classifies whether the parent shape qualifies as a JSX literal site.
+// `text` is the cooked literal value used to check whitespace-only short-circuit.
+func isStandardJSXNode(text string, parentKind ast.Kind, cfg *elementConfig) bool {
+	if strings.TrimSpace(text) == "" {
+		return false
+	}
+	switch parentKind {
+	case ast.KindJsxAttribute, ast.KindJsxElement, ast.KindJsxExpression, ast.KindJsxFragment:
+	default:
+		return false
+	}
+	if cfg.noAttributeStrings {
+		return parentKind == ast.KindJsxAttribute || parentKind == ast.KindJsxElement
+	}
+	return parentKind != ast.KindJsxAttribute
+}
+
+func isViableTextNode(rawText, cookedText string, parentKind ast.Kind, cfg *elementConfig) bool {
+	rawTrim := strings.TrimSpace(rawText)
+	cookedTrim := strings.TrimSpace(cookedText)
+	if _, ok := cfg.allowedStrings[rawTrim]; ok {
+		return false
+	}
+	if _, ok := cfg.allowedStrings[cookedTrim]; ok {
+		return false
+	}
+	standard := isStandardJSXNode(cookedText, parentKind, cfg)
+	if cfg.noStrings {
+		return standard
+	}
+	return standard && parentKind != ast.KindJsxExpression
+}
+
+// elementNameInfo carries the simple + dotted display name of a JSX element's
+// tag, with renamed-import resolution already applied to the leftmost segment.
+type elementNameInfo struct {
+	name         string
+	compoundName string
+}
+
+// jsxElementName mirrors upstream's `getJSXElementName`. Peels paired
+// JsxElement → its OpeningElement so the same code-path handles both
+// `<Foo>...</Foo>` and `<Foo />`, then delegates to
+// `reactutil.GetJsxElementTypeString` for the dotted source string and
+// applies renamed-import resolution to the root segment. For a member-chain
+// tag (`Foo.Bar.Baz`), returns the last segment as `name` and the dotted
+// form as `compoundName` (after rename). Namespaced (`<a:b>`) and `<this.X>`
+// shapes pass through and are filtered later by the upstream-validated
+// `reOverridableElement` regex.
+func jsxElementName(element *ast.Node, renamedImports map[string]string) (elementNameInfo, bool) {
+	target := element
+	if target != nil && target.Kind == ast.KindJsxElement {
+		target = target.AsJsxElement().OpeningElement
+	}
+	typeStr := reactutil.GetJsxElementTypeString(target)
+	if typeStr == "" {
+		return elementNameInfo{}, false
+	}
+	parts := strings.Split(typeStr, ".")
+	if mapped, ok := renamedImports[parts[0]]; ok {
+		parts[0] = mapped
+	}
+	info := elementNameInfo{name: parts[len(parts)-1]}
+	if len(parts) > 1 {
+		info.compoundName = strings.Join(parts, ".")
+	}
+	return info, true
+}
+
+// jsxElementAncestors returns all enclosing JsxElement ancestors, innermost
+// first. JsxFragment ancestors are skipped — fragments have no name and
+// cannot match an override.
+func jsxElementAncestors(node *ast.Node) []*ast.Node {
+	var out []*ast.Node
+	for cur := node; cur != nil; cur = cur.Parent {
+		if cur.Kind == ast.KindJsxElement || cur.Kind == ast.KindJsxSelfClosingElement {
+			out = append(out, cur)
+		}
+	}
+	return out
+}
+
+func resolveOverride(node *ast.Node, cfg *ruleConfig, renamedImports map[string]string) *elementConfig {
+	if !cfg.hasElementOverrides() {
+		return nil
+	}
+	ancestors := jsxElementAncestors(node)
+	if len(ancestors) == 0 {
+		return nil
+	}
+	for i, ancestor := range ancestors {
+		isClosest := i == 0
+		info, ok := jsxElementName(ancestor, renamedImports)
+		if !ok || info.name == "" {
+			continue
+		}
+		base := cfg.elementOverrides[info.name]
+		var candidate *elementConfig
+		if info.compoundName != "" {
+			if c, ok := cfg.elementOverrides[info.compoundName]; ok {
+				candidate = c
+			} else {
+				candidate = base
+			}
+		} else {
+			candidate = base
+		}
+		if candidate == nil {
+			continue
+		}
+		if isClosest || candidate.applyToNestedElements {
+			return candidate
+		}
+	}
+	return nil
+}
+
+func shouldAllowElement(cfg *elementConfig) bool {
+	return cfg.configType == configTypeOverride && cfg.allowElement
+}
+
+// defaultMessageId mirrors upstream's `defaultMessageId(ancestorIsJSXElement, resolvedConfig)`.
+// `ancestorIsJSXElement` follows upstream's parameter name: true when the
+// literal lives inside JSX content (vs. inside a JSX attribute).
+func defaultMessageId(ancestorIsJSXElement bool, cfg *elementConfig) string {
+	if cfg.noAttributeStrings && !ancestorIsJSXElement {
+		if cfg.configType == configTypeOverride {
+			return msgNoStringsInAttributesInElement
+		}
+		return msgNoStringsInAttributes
+	}
+	if cfg.noStrings {
+		if cfg.configType == configTypeOverride {
+			return msgNoStringsInJSXInElement
+		}
+		return msgNoStringsInJSX
+	}
+	if cfg.configType == configTypeOverride {
+		return msgLiteralNotInJSXExpressionInElement
+	}
+	return msgLiteralNotInJSXExpression
+}
+
+func formatMessage(messageId string, text, attribute, element string) string {
+	switch messageId {
+	case msgInvalidPropValue:
+		return "Invalid prop value: \"" + text + "\""
+	case msgInvalidPropValueInElement:
+		return "Invalid prop value: \"" + text + "\" in " + element
+	case msgNoStringsInAttributes:
+		return "Strings not allowed in attributes: \"" + text + "\""
+	case msgNoStringsInAttributesInElement:
+		return "Strings not allowed in attributes: \"" + text + "\" in " + element
+	case msgNoStringsInJSX:
+		return "Strings not allowed in JSX files: \"" + text + "\""
+	case msgNoStringsInJSXInElement:
+		return "Strings not allowed in JSX files: \"" + text + "\" in " + element
+	case msgLiteralNotInJSXExpression:
+		return "Missing JSX expression container around literal string: \"" + text + "\""
+	case msgLiteralNotInJSXExpressionInElement:
+		return "Missing JSX expression container around literal string: \"" + text + "\" in " + element
+	case msgRestrictedAttributeString:
+		return "Restricted attribute string: \"" + text + "\" in " + attribute
+	case msgRestrictedAttributeStringInElement:
+		return "Restricted attribute string: \"" + text + "\" in " + attribute + " of " + element
+	}
+	return ""
+}
+
+func reportLiteralNode(ctx rule.RuleContext, node *ast.Node, messageId string, cfg *elementConfig, text string) {
+	element := ""
+	if cfg.configType == configTypeOverride {
+		element = cfg.name
+	}
+	desc := formatMessage(messageId, text, "", element)
+	data := map[string]string{"text": text}
+	if element != "" {
+		data["element"] = element
+	}
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          messageId,
+		Description: desc,
+		Data:        data,
+	})
+}
+
+func reportRestrictedAttribute(ctx rule.RuleContext, attrNode *ast.Node, valueText, attribute string, cfg *elementConfig) {
+	messageId := msgRestrictedAttributeString
+	element := ""
+	if cfg.configType == configTypeOverride {
+		messageId = msgRestrictedAttributeStringInElement
+		element = cfg.name
+	}
+	desc := formatMessage(messageId, valueText, attribute, element)
+	data := map[string]string{"text": valueText, "attribute": attribute}
+	if element != "" {
+		data["element"] = element
+	}
+	ctx.ReportNode(attrNode, rule.RuleMessage{
+		Id:          messageId,
+		Description: desc,
+		Data:        data,
+	})
+}
+
+// isRequireCall mirrors upstream's `isRequireStatement` — peels nested
+// PropertyAccess to find a `require(...)` CallExpression. Used to gate the
+// `const { T: U } = require(...)` renamed-binding harvest. Skips
+// ParenthesizedExpression at every read site (tsgo retains them as nodes;
+// ESTree drops at parse time) so `(require('foo')).Foo` is detected just
+// like the unparenthesized form upstream sees.
+func isRequireCall(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipParentheses(node)
+	switch node.Kind {
+	case ast.KindCallExpression:
+		callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+		if callee != nil && callee.Kind == ast.KindIdentifier {
+			return callee.AsIdentifier().Text == "require"
+		}
+		return false
+	case ast.KindPropertyAccessExpression:
+		return isRequireCall(node.AsPropertyAccessExpression().Expression)
+	}
+	return false
+}
+
+func collectRenamedImports(sf *ast.SourceFile) map[string]string {
+	out := map[string]string{}
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Kind {
+		case ast.KindImportDeclaration:
+			id := n.AsImportDeclaration()
+			if id.ImportClause != nil {
+				ic := id.ImportClause.AsImportClause()
+				if ic.NamedBindings != nil && ic.NamedBindings.Kind == ast.KindNamedImports {
+					ni := ic.NamedBindings.AsNamedImports()
+					if ni.Elements != nil {
+						for _, spec := range ni.Elements.Nodes {
+							s := spec.AsImportSpecifier()
+							local := s.Name()
+							if local == nil || local.Kind != ast.KindIdentifier {
+								continue
+							}
+							imported := local.AsIdentifier().Text
+							if s.PropertyName != nil && s.PropertyName.Kind == ast.KindIdentifier {
+								imported = s.PropertyName.AsIdentifier().Text
+							}
+							out[local.AsIdentifier().Text] = imported
+						}
+					}
+				}
+			}
+		case ast.KindVariableStatement:
+			vs := n.AsVariableStatement()
+			if vs.DeclarationList == nil {
+				return
+			}
+			decls := vs.DeclarationList.AsVariableDeclarationList().Declarations
+			if decls == nil {
+				return
+			}
+			for _, d := range decls.Nodes {
+				vd := d.AsVariableDeclaration()
+				if vd.Initializer == nil || !isRequireCall(vd.Initializer) {
+					continue
+				}
+				name := vd.Name()
+				if name == nil || name.Kind != ast.KindObjectBindingPattern {
+					continue
+				}
+				bp := name.AsBindingPattern()
+				if bp.Elements == nil {
+					continue
+				}
+				for _, el := range bp.Elements.Nodes {
+					be := el.AsBindingElement()
+					// Upstream's filter is `property.type === 'Property'`,
+					// which excludes RestElement (`{ ...rest }`). tsgo
+					// represents rest patterns as a BindingElement with a
+					// non-nil DotDotDotToken; skip them.
+					if be.DotDotDotToken != nil {
+						continue
+					}
+					if be.Name() == nil || be.Name().Kind != ast.KindIdentifier {
+						continue
+					}
+					// Upstream maps `property.value.name` (local) → `property.key.name`
+					// (imported). `{ T: U }` → PropertyName="T", name="U" → U → T.
+					// Shorthand `{ T }` → PropertyName=nil, name="T" → T → T (no-op).
+					localName := be.Name().AsIdentifier().Text
+					importedName := localName
+					if be.PropertyName != nil && be.PropertyName.Kind == ast.KindIdentifier {
+						importedName = be.PropertyName.AsIdentifier().Text
+					}
+					out[localName] = importedName
+				}
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(sf.AsNode())
+	return out
+}
+
+// trimmedSource returns `node`'s raw source text with leading/trailing whitespace stripped.
+func trimmedSource(ctx rule.RuleContext, node *ast.Node) string {
+	return strings.TrimSpace(utils.TrimmedNodeText(ctx.SourceFile, node))
+}
+
+// stringLiteralValue extracts the cooked text of a StringLiteral node.
+func stringLiteralValue(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text
+	}
+	return ""
+}
+
+func handleJsxAttribute(ctx rule.RuleContext, node *ast.Node, cfg *ruleConfig, renamedImports map[string]string) {
+	attr := node.AsJsxAttribute()
+	if attr.Initializer == nil {
+		return
+	}
+	init := attr.Initializer
+	if init.Kind != ast.KindStringLiteral {
+		return
+	}
+	resolved := resolveOverride(node, cfg, renamedImports)
+	if resolved == nil {
+		resolved = &cfg.base
+	}
+
+	// Upstream gates the restrictedAttributes branch on
+	// `node.name.type === 'JSXIdentifier'`, which excludes JsxNamespacedName
+	// (`xlink:href`). The noStrings fall-through still applies to
+	// namespaced attrs — match that asymmetry.
+	nameNode := attr.Name()
+	isSimpleIdentifier := nameNode != nil && nameNode.Kind == ast.KindIdentifier
+	if len(resolved.restrictedAttributes) > 0 && isSimpleIdentifier {
+		attrName := nameNode.AsIdentifier().Text
+		if _, restricted := resolved.restrictedAttributes[attrName]; restricted {
+			cooked := stringLiteralValue(init)
+			if _, allowed := resolved.allowedStrings[strings.TrimSpace(cooked)]; !allowed {
+				reportRestrictedAttribute(ctx, node, trimmedSource(ctx, init), attrName, resolved)
+			}
+			return
+		}
+	}
+
+	if !resolved.noStrings || resolved.ignoreProps {
+		return
+	}
+	cooked := stringLiteralValue(init)
+	if _, allowed := resolved.allowedStrings[cooked]; allowed {
+		return
+	}
+	messageId := msgInvalidPropValue
+	if resolved.configType == configTypeOverride {
+		messageId = msgInvalidPropValueInElement
+	}
+	reportLiteralNode(ctx, node, messageId, resolved, trimmedSource(ctx, node))
+}
+
+// handleStringLiteral handles upstream's Literal listener for string-typed values.
+// In tsgo a StringLiteral nested under a JsxAttribute is also routed here, but
+// the upstream `Literal` handler intentionally bails on attribute-direct
+// literals (the JSXAttribute handler owns that report); replicated here via
+// the parent-kind check inside `isStandardJSXNode`.
+func handleStringLiteral(ctx rule.RuleContext, node *ast.Node, cfg *ruleConfig, renamedImports map[string]string) {
+	resolved := resolveOverride(node, cfg, renamedImports)
+	if resolved == nil {
+		resolved = &cfg.base
+	}
+	hasJSXContent := hasJSXContentParentOrGrandParent(node)
+	if hasJSXContent && shouldAllowElement(resolved) {
+		return
+	}
+	parent := parentIgnoringBinaryAndParens(node)
+	if parent == nil {
+		return
+	}
+	cooked := node.AsStringLiteral().Text
+	rawSource := trimmedSource(ctx, node)
+	if !isViableTextNode(rawSource, cooked, parent.Kind, resolved) {
+		return
+	}
+	// Upstream gates the report on `hasJSXParentOrGrandParent || !config.ignoreProps`
+	// where `config` is the BASE config — not the resolved override. Preserved
+	// here so an override can't bypass the base `ignoreProps` for non-content
+	// literals (e.g. attribute-context literals when the base says ignoreProps).
+	if !hasJSXContent && cfg.base.ignoreProps {
+		return
+	}
+	reportLiteralNode(ctx, node, defaultMessageId(hasJSXContent, resolved), resolved, rawSource)
+}
+
+func handleJsxText(ctx rule.RuleContext, node *ast.Node, cfg *ruleConfig, renamedImports map[string]string) {
+	resolved := resolveOverride(node, cfg, renamedImports)
+	if resolved == nil {
+		resolved = &cfg.base
+	}
+	if shouldAllowElement(resolved) {
+		return
+	}
+	jt := node.AsJsxText()
+	if jt.ContainsOnlyTriviaWhiteSpaces {
+		return
+	}
+	// tsgo's JsxText.Text is the raw source text — HTML entities like
+	// `&mdash;` stay encoded (decoding happens later, during JSX transform).
+	// ESLint's espree+acorn-jsx feeds the rule a decoded `node.value`, so to
+	// keep `allowedStrings` lookups byte-equivalent we decode here. The raw
+	// form is still checked separately via `rawSource` below.
+	cooked := html.UnescapeString(jt.Text)
+	rawSource := trimmedSource(ctx, node)
+	parent := node.Parent
+	if parent == nil {
+		return
+	}
+	if !isViableTextNode(rawSource, cooked, parent.Kind, resolved) {
+		return
+	}
+	hasJSXContent := hasJSXContentParentOrGrandParent(node)
+	reportLiteralNode(ctx, node, defaultMessageId(hasJSXContent, resolved), resolved, rawSource)
+}
+
+// handleTemplate handles upstream's TemplateLiteral listener for both
+// no-substitution and substitution shapes. tsgo splits these into
+// KindNoSubstitutionTemplateLiteral and KindTemplateExpression respectively;
+// upstream's ESTree groups both under TemplateLiteral.
+func handleTemplate(ctx rule.RuleContext, node *ast.Node, cfg *ruleConfig, renamedImports map[string]string) {
+	parent := parentIgnoringBinaryAndParens(node)
+	if parent == nil {
+		return
+	}
+	// Upstream guards `isParentJSXExpressionCont` — only fire when the
+	// container is a JsxExpression. NoSubstitutionTemplateLiteral can also
+	// appear directly as a JsxAttribute initializer in some grammars; tsgo
+	// rejects that form, so the JsxExpression-only gate is sufficient.
+	if parent.Kind != ast.KindJsxExpression {
+		return
+	}
+	grand := parent.Parent
+	for grand != nil && grand.Kind == ast.KindParenthesizedExpression {
+		grand = grand.Parent
+	}
+	isParentJSXElement := grand != nil && jsxContentParentKind(grand.Kind)
+
+	resolved := resolveOverride(node, cfg, renamedImports)
+	if resolved == nil {
+		resolved = &cfg.base
+	}
+	if !resolved.noStrings {
+		return
+	}
+	if !isParentJSXElement && resolved.ignoreProps {
+		return
+	}
+	reportLiteralNode(ctx, node, defaultMessageId(isParentJSXElement, resolved), resolved, trimmedSource(ctx, node))
+}
+
+var JsxNoLiteralsRule = rule.Rule{
+	Name: "react/jsx-no-literals",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		cfg := parseConfig(options)
+		var renamedImports map[string]string
+		if cfg.hasElementOverrides() {
+			renamedImports = collectRenamedImports(ctx.SourceFile)
+		} else {
+			renamedImports = map[string]string{}
+		}
+
+		return rule.RuleListeners{
+			ast.KindStringLiteral: func(node *ast.Node) {
+				handleStringLiteral(ctx, node, &cfg, renamedImports)
+			},
+			ast.KindJsxText: func(node *ast.Node) {
+				handleJsxText(ctx, node, &cfg, renamedImports)
+			},
+			ast.KindNoSubstitutionTemplateLiteral: func(node *ast.Node) {
+				handleTemplate(ctx, node, &cfg, renamedImports)
+			},
+			ast.KindTemplateExpression: func(node *ast.Node) {
+				handleTemplate(ctx, node, &cfg, renamedImports)
+			},
+			ast.KindJsxAttribute: func(node *ast.Node) {
+				handleJsxAttribute(ctx, node, &cfg, renamedImports)
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals.md
+++ b/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals.md
@@ -1,0 +1,132 @@
+# jsx-no-literals
+
+## Rule Details
+
+This rule prevents the use of unwrapped string literals as direct children of JSX elements. By default, JSX text such as `<div>foo</div>` must be wrapped in an expression container (`<div>{'foo'}</div>`). When the `noStrings` option is enabled, even wrapped string literals are forbidden — the rule then expects values to come from translation helpers, identifiers, or other non-literal sources.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div>foo</div>
+```
+
+```jsx
+<div>
+  bar
+</div>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div>{'foo'}</div>
+```
+
+```jsx
+<div>{translate('greeting')}</div>
+```
+
+### Options
+
+```json
+{
+  "react/jsx-no-literals": [
+    "error",
+    {
+      "noStrings": false,
+      "allowedStrings": [],
+      "ignoreProps": false,
+      "noAttributeStrings": false,
+      "restrictedAttributes": [],
+      "elementOverrides": {}
+    }
+  ]
+}
+```
+
+#### `noStrings`
+
+When `true`, also forbids wrapped string literals (`{'foo'}`, `` {`foo`} ``) inside JSX. Defaults to `false`.
+
+Examples of **incorrect** code for this rule with `{ "noStrings": true }`:
+
+```json
+{ "react/jsx-no-literals": ["error", { "noStrings": true }] }
+```
+
+```jsx
+<Foo>{'Test'}</Foo>
+```
+
+#### `allowedStrings`
+
+An array of literal strings that are exempt from the rule. Surrounding whitespace on each entry is trimmed before matching, and matching is performed against the raw and cooked text of the literal.
+
+Examples of **correct** code for this rule with `{ "noStrings": true, "allowedStrings": ["&nbsp;"] }`:
+
+```json
+{ "react/jsx-no-literals": ["error", { "noStrings": true, "allowedStrings": ["&nbsp;"] }] }
+```
+
+```jsx
+<div>&nbsp;</div>
+```
+
+#### `ignoreProps`
+
+When `true`, attribute values are exempt from `noStrings`. Defaults to `false`.
+
+#### `noAttributeStrings`
+
+When `true`, string literals used as attribute values are reported. Defaults to `false`.
+
+Examples of **incorrect** code for this rule with `{ "noAttributeStrings": true }`:
+
+```json
+{ "react/jsx-no-literals": ["error", { "noAttributeStrings": true }] }
+```
+
+```jsx
+<img alt="logo" />
+```
+
+#### `restrictedAttributes`
+
+An array of attribute names. Listed attributes report on any string literal value, regardless of `noStrings` or `noAttributeStrings`.
+
+Examples of **incorrect** code for this rule with `{ "restrictedAttributes": ["className"] }`:
+
+```json
+{ "react/jsx-no-literals": ["error", { "restrictedAttributes": ["className"] }] }
+```
+
+```jsx
+<div className="card" />
+```
+
+#### `elementOverrides`
+
+A map from component name to a per-element override config. The element name must match the regex `^[A-Z][\w.]*$` — HTML element tag names are not supported and silently ignored. The override accepts the same keys as the top-level config plus:
+
+- `allowElement` — when `true`, suppress all reports inside the element.
+- `applyToNestedElements` — when `false`, only the closest matching JSX ancestor uses the override; descendant elements fall back to the base config. Defaults to `true`.
+
+When the JSX tag is renamed at import time (`import { T as U } from 'foo'` or `const { T: U } = require('foo')`), the override looks up by the imported name, not the local alias.
+
+Examples of **correct** code for this rule with `{ "elementOverrides": { "Trans": { "allowElement": true } } }`:
+
+```json
+{ "react/jsx-no-literals": ["error", { "elementOverrides": { "Trans": { "allowElement": true } } }] }
+```
+
+```jsx
+<Trans>Welcome back</Trans>
+```
+
+## When Not To Use It
+
+If your project does not need to enforce wrapping JSX text in expressions or has no localization workflow, this rule is unnecessary.
+
+## Original Documentation
+
+- [react/jsx-no-literals](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md)

--- a/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals_test.go
+++ b/internal/plugins/react/rules/jsx_no_literals/jsx_no_literals_test.go
@@ -1,0 +1,1795 @@
+// cspell:ignore asdjfl blarg mdash
+package jsx_no_literals
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxNoLiterals(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoLiteralsRule, []rule_tester.ValidTestCase{
+		// ---- noStrings + allowedStrings allow specific attribute strings ----
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (
+      <div>
+        <button type="button"></button>
+      </div>
+    );
+  }
+}
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noStrings":      true,
+				"allowedStrings": []interface{}{"button", "submit"},
+			},
+		},
+
+		// ---- Default config: literals inside JSXExpressionContainer pass ----
+		{
+			Code: `
+class Comp2 extends Component {
+  render() {
+    return (
+      <div>
+        {'asdjfl'}
+      </div>
+    );
+  }
+}
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (
+      <>
+        {'asdjfl'}
+      </>
+    );
+  }
+}
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (<div>{'test'}</div>);
+  }
+}
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    const bar = (<div>{'hello'}</div>);
+    return bar;
+  }
+}
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+var Hello = createReactClass({
+  foo: (<div>{'hello'}</div>),
+  render() {
+    return this.foo;
+  },
+});
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (
+      <div>
+        {'asdjfl'}
+        {'test'}
+        {'foo'}
+      </div>
+    );
+  }
+}
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (
+      <div>
+      </div>
+    );
+  }
+}
+`,
+			Tsx: true,
+		},
+		{Code: `var foo = require('foo');`, Tsx: true},
+
+		// ---- Attribute string literals are not Literal-handler reports by default ----
+		{
+			Code: `
+<Foo bar='test'>
+  {'blarg'}
+</Foo>
+`,
+			Tsx: true,
+		},
+
+		// ---- ignoreProps: true suppresses attribute / non-content reports ----
+		{
+			Code: `
+<Foo bar="test">
+  {intl.formatText(message)}
+</Foo>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": true},
+		},
+		{
+			Code: `
+<Foo bar="test">
+  {translate('my.translate.key')}
+</Foo>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": true},
+		},
+
+		// ---- noStrings allows non-string JSX expressions ----
+		{Code: `<Foo bar={true} />`, Tsx: true, Options: map[string]interface{}{"noStrings": true}},
+		{Code: `<Foo bar={false} />`, Tsx: true, Options: map[string]interface{}{"noStrings": true}},
+		{Code: `<Foo bar={100} />`, Tsx: true, Options: map[string]interface{}{"noStrings": true}},
+		{Code: `<Foo bar={null} />`, Tsx: true, Options: map[string]interface{}{"noStrings": true}},
+		{Code: `<Foo bar={{}} />`, Tsx: true, Options: map[string]interface{}{"noStrings": true}},
+
+		// ---- ignoreProps allows method-bound and identifier props with class attr ----
+		{
+			Code: `
+class Comp1 extends Component {
+  asdf() {}
+  render() {
+    return <Foo bar={this.asdf} class='xx' />;
+  }
+}
+`,
+			Tsx: true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": true},
+		},
+
+		// ---- Template literals in non-JSX contexts are ignored ----
+		{
+			Code: "\nclass Comp1 extends Component {\n  render() {\n    let foo = `bar`;\n    return <div />;\n  }\n}\n",
+			Tsx:  true,
+			Options: map[string]interface{}{"noStrings": true},
+		},
+
+		// ---- allowedStrings exempts specific JSX text ----
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return <div>asdf</div>
+  }
+}
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowedStrings": []interface{}{"asdf"}},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return <div>asdf</div>
+  }
+}
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": false, "allowedStrings": []interface{}{"asdf"}},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return <div>&nbsp;</div>
+  }
+}
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"&nbsp;"}},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (
+      <div>
+        &nbsp;
+      </div>
+    );
+  }
+}
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"&nbsp;"}},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return <div>foo: {bar}*</div>
+  }
+}
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"foo: ", "*"}},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return <div>foo</div>
+  }
+}
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"   foo   "}},
+		},
+
+		// ---- Identifier expression children are unaffected ----
+		{
+			Code: `
+class Comp1 extends Component {
+  asdf() {}
+  render() {
+    const xx = 'xx';
+
+    return <Foo bar={this.asdf} class={xx} />;
+  }
+}
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+		},
+
+		// ---- Default: attribute strings are allowed ----
+		{Code: `<img alt='blank image'></img>`, Tsx: true},
+
+		// ---- Mixed allowedStrings (entity + glyph) ----
+		{
+			Code:    `<div>&mdash;</div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"&mdash;", "—"}},
+		},
+		{
+			Code:    `<div>—</div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"&mdash;", "—"}},
+		},
+
+		// ---- restrictedAttributes only fires on listed attributes ----
+		{
+			Code:    `<img src="image.jpg" alt="text" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"restrictedAttributes": []interface{}{"className", "id"}},
+		},
+		{
+			Code:    `<div className="allowed" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"restrictedAttributes": []interface{}{"className"}, "allowedStrings": []interface{}{"allowed"}},
+		},
+		{
+			Code: `<div className="test" title="hello" />`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"noStrings":            true,
+				"ignoreProps":          true,
+				"restrictedAttributes": []interface{}{"className"},
+				"allowedStrings":       []interface{}{"test"},
+			},
+		},
+		{
+			Code:    `<div className="test" id="foo" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"restrictedAttributes": []interface{}{}},
+		},
+
+		// ---- elementOverrides: allowElement ----
+		{
+			Code: `<T>foo</T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+		{
+			Code: `<T>foo <div>bar</div></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+		{
+			Code: `<T>foo <div>{'bar'}</div></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true, "applyToNestedElements": false},
+				},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>{'foo'}</div>
+  <T>{2}</T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true},
+				},
+			},
+		},
+		{
+			Code: `<T>{2}<div>{2}</div></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true},
+				},
+			},
+		},
+		{
+			Code: `<T>{2}<div>{'foo'}</div></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true, "applyToNestedElements": false},
+				},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>{'foo'}</div>
+  <T>foo</T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowedStrings": []interface{}{"foo"}},
+				},
+			},
+		},
+		{
+			Code: `<T>foo<div>foo</div></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowedStrings": []interface{}{"foo"}},
+				},
+			},
+		},
+		{
+			Code: `<T>foo<div>{'foo'}</div></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowedStrings": []interface{}{"foo"}, "applyToNestedElements": false},
+				},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo={2} />
+  <T foo="bar" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true, "ignoreProps": true},
+				},
+			},
+		},
+		{
+			Code: `<T foo="bar"><div foo="bar" /></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"noStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true, "ignoreProps": true},
+				},
+			},
+		},
+		{
+			Code: `<T foo="bar"><div foo={2} /></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"noStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true, "ignoreProps": true, "applyToNestedElements": false},
+				},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo="foo" />
+  <T foo={2} />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noAttributeStrings": true},
+				},
+			},
+		},
+		{
+			Code: `<T foo={2}><div foo={2} /></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noAttributeStrings": true},
+				},
+			},
+		},
+		{
+			Code: `<T foo={2}><div foo="foo" /></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noAttributeStrings": true, "applyToNestedElements": false},
+				},
+			},
+		},
+		{
+			Code: `<T>foo<U>foo</U></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowedStrings": []interface{}{"foo"}},
+					"U": map[string]interface{}{"allowedStrings": []interface{}{"foo"}},
+				},
+			},
+		},
+
+		// ---- Renamed-import resolution ----
+		{
+			Code: `
+import { T } from 'foo';
+<T>{'foo'}</T>
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+import { T as U } from 'foo';
+<U>foo</U>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+		{
+			Code: `
+const { T: U } = require('foo');
+<U>foo</U>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+		{
+			Code: `
+const { T: U } = require('foo').Foo;
+<U>foo</U>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+		{
+			Code: `
+const { T: U } = require('foo').Foo.Foo;
+<U>foo</U>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+		{
+			Code: `
+const foo = 2;
+<T>foo</T>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+
+		// ---- Compound (member-access) tag-name overrides ----
+		{
+			Code: `<T.U>foo</T.U>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T.U": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+		{
+			Code: `
+import { T as U } from 'foo';
+<U.U>foo</U.U>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T.U": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+		{
+			Code: `<React.Fragment>foo</React.Fragment>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"Fragment": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+		{
+			Code: `<React.Fragment>foo</React.Fragment>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"React.Fragment": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+
+		// ---- HTML element overrides are silently rejected (regex gates them out) ----
+		{
+			Code: `<div>{'foo'}</div>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"div": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+
+		// ---- Per-element restrictedAttributes ----
+		{
+			Code: `
+<div>
+  <Input type="text" />
+  <Button className="primary" />
+  <Image src="photo.jpg" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"Input":  map[string]interface{}{"restrictedAttributes": []interface{}{"placeholder"}},
+					"Button": map[string]interface{}{"restrictedAttributes": []interface{}{"type"}},
+				},
+			},
+		},
+		{
+			Code: `
+<div title="container">
+  <Button className="btn" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"restrictedAttributes": []interface{}{"className"},
+				"elementOverrides": map[string]interface{}{
+					"Button": map[string]interface{}{"restrictedAttributes": []interface{}{"disabled"}},
+				},
+			},
+		},
+		{
+			Code: `<Button className="btn" />`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"noAttributeStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"Button": map[string]interface{}{"restrictedAttributes": []interface{}{"type"}},
+				},
+			},
+		},
+
+		// ---- tsgo edge: paren-wrapped literal in JSX content (default OK) ----
+		// `<div>{('foo')}</div>` parses with explicit ParenthesizedExpression
+		// in tsgo (ESTree drops parens). Default config: literal lives under
+		// JsxExpression after paren-skip, so the "wrapped" form is accepted.
+		{Code: `<div>{('foo')}</div>`, Tsx: true},
+		{Code: `<div>{(('foo'))}</div>`, Tsx: true},
+
+		// ---- tsgo edge: TS `as` wrapper around a literal ----
+		// Parent walk does NOT peel TSAsExpression (matches upstream's
+		// `getParentIgnoringBinaryExpressions`, which only skips Binary).
+		// The literal's effective parent is AsExpression — not in the
+		// JSX-shape set — so no report fires even with noStrings:true.
+		{Code: `<div>{'foo' as string}</div>`, Tsx: true},
+		{
+			Code:    `<div>{'foo' as string}</div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true},
+		},
+
+		// ---- tsgo edge: JsxFragment outer / JsxElement override-target inner ----
+		// jsxElementAncestors collects only JsxElement / JsxSelfClosingElement;
+		// fragments are skipped because they have no name. Confirms an
+		// `allowElement` override on T still matches when T is wrapped in a
+		// fragment.
+		{
+			Code: `<><T>foo</T></>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+
+		// ---- tsgo edge: namespaced attribute name passes through unchanged ----
+		// Default config has no restrictedAttributes / noStrings, so the
+		// attribute string is allowed.
+		{Code: `<svg xlink:href="https://example.com" />`, Tsx: true},
+
+		// ---- Namespaced attribute is INVISIBLE to restrictedAttributes ----
+		// Upstream gates `restrictedAttributes` on `name.type === 'JSXIdentifier'`,
+		// so a JsxNamespacedName never triggers this branch even when the
+		// joined name (`xlink:href`) is in the list. Locks in the asymmetry.
+		{
+			Code:    `<svg xlink:href="anything" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"restrictedAttributes": []interface{}{"xlink:href"}},
+		},
+
+		// ---- tsgo edge: paren-wrapped require() in destructure init ----
+		// `isRequireCall` peels ParenthesizedExpression at every read site so
+		// the wrapped form behaves the same as upstream's ESTree-flat shape.
+		{
+			Code: `
+const { T: U } = (require('foo')).Foo;
+<U>foo</U>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+
+		// ---- tsgo edge: rest binding in destructure is ignored ----
+		// Upstream's `property.type === 'Property'` filter excludes
+		// `RestElement`. We mirror by skipping BindingElements with a
+		// DotDotDotToken so a `Rest → Rest` no-op entry never lands in the
+		// renamed-import map.
+		{
+			Code: `
+const { T, ...rest } = require('foo');
+<T>foo</T>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowElement": true},
+				},
+			},
+		},
+
+		// ---- HTML-entity decoding parity: source uses entity, allowedStrings
+		// lists only the decoded form. ESTree's `node.value` is decoded; we
+		// decode tsgo's raw JsxText so the cooked-set lookup matches. ----
+		{
+			Code:    `<div>&amp;</div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"&"}},
+		},
+		{
+			Code:    `<div>&mdash;</div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"—"}},
+		},
+		// And the inverse: source uses the glyph, allowedStrings lists only
+		// the entity form — matches via the raw-source path.
+		{
+			Code:    `<div>—</div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"—"}},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Default: bare JSX text reports literalNotInJSXExpression ----
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (<div>test</div>);
+  }
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "test"`, Line: 4, Column: 18},
+			},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (<>test</>);
+  }
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "test"`},
+			},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    const foo = (<div>test</div>);
+    return foo;
+  }
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "test"`},
+			},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    const varObjectTest = { testKey : (<div>test</div>) };
+    return varObjectTest.testKey;
+  }
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "test"`},
+			},
+		},
+		{
+			Code: `
+var Hello = createReactClass({
+  foo: (<div>hello</div>),
+  render() {
+    return this.foo;
+  },
+});
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "hello"`},
+			},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (
+      <div>
+        asdjfl
+      </div>
+    );
+  }
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "asdjfl"`},
+			},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (
+      <div>
+        asdjfl
+        test
+        foo
+      </div>
+    );
+  }
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: "Missing JSX expression container around literal string: \"asdjfl\n        test\n        foo\""},
+			},
+		},
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return (
+      <div>
+        {'asdjfl'}
+        test
+        {'foo'}
+      </div>
+    );
+  }
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "test"`},
+			},
+		},
+
+		// ---- noStrings: attribute literal + JSX child literal ----
+		{
+			Code: `
+<Foo bar="test">
+  {'Test'}
+</Foo>
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropValue", Message: `Invalid prop value: "bar="test""`},
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'Test'"`},
+			},
+		},
+		{
+			Code: `
+<Foo bar="test">
+  {'Test' + name}
+</Foo>
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropValue", Message: `Invalid prop value: "bar="test""`},
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'Test'"`},
+			},
+		},
+		{
+			Code: `
+<Foo bar="test">
+  Test
+</Foo>
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropValue", Message: `Invalid prop value: "bar="test""`},
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "Test"`},
+			},
+		},
+
+		// ---- TemplateLiteral handler ----
+		{
+			Code:    "\n<Foo>\n  {`Test`}\n</Foo>\n",
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: "Strings not allowed in JSX files: \"`Test`\""},
+			},
+		},
+		{
+			Code:    "<Foo bar={`Test`} />",
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: "Strings not allowed in JSX files: \"`Test`\""},
+			},
+		},
+		{
+			Code:    "<Foo bar={`${baz}`} />",
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: "Strings not allowed in JSX files: \"`${baz}`\""},
+			},
+		},
+		{
+			Code:    "<Foo bar={`Test ${baz}`} />",
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: "Strings not allowed in JSX files: \"`Test ${baz}`\""},
+			},
+		},
+		{
+			Code:    "<Foo bar={`foo` + 'bar'} />",
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: "Strings not allowed in JSX files: \"`foo`\""},
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'bar'"`},
+			},
+		},
+		{
+			Code:    "<Foo bar={`foo` + `bar`} />",
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: "Strings not allowed in JSX files: \"`foo`\""},
+				{MessageId: "noStringsInJSX", Message: "Strings not allowed in JSX files: \"`bar`\""},
+			},
+		},
+		{
+			Code:    "<Foo bar={'foo' + `bar`} />",
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'foo'"`},
+				{MessageId: "noStringsInJSX", Message: "Strings not allowed in JSX files: \"`bar`\""},
+			},
+		},
+
+		// ---- noStrings + allowedStrings exempts only listed strings ----
+		{
+			Code: `
+class Comp1 extends Component {
+  render() {
+    return <div bar={'foo'}>asdf</div>
+  }
+}
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"asd"}, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'foo'"`},
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "asdf"`},
+			},
+		},
+		{
+			Code:    `<Foo bar={'bar'} />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'bar'"`},
+			},
+		},
+
+		// ---- noAttributeStrings ----
+		{
+			Code:    `<img alt='blank image'></img>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noAttributeStrings": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributes", Message: `Strings not allowed in attributes: "'blank image'"`},
+			},
+		},
+		{
+			Code:    `export const WithChildren = ({}) => <div>baz bob</div>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noAttributeStrings": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "baz bob"`},
+			},
+		},
+		{
+			Code:    `export const WithAttributes = ({}) => <div title="foo bar" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noAttributeStrings": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributes", Message: `Strings not allowed in attributes: ""foo bar""`},
+			},
+		},
+		{
+			Code: `
+export const WithAttributesAndChildren = ({}) => (
+  <div title="foo bar">baz bob</div>
+);
+`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noAttributeStrings": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributes", Message: `Strings not allowed in attributes: ""foo bar""`},
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "baz bob"`},
+			},
+		},
+
+		// ---- restrictedAttributes ----
+		{
+			Code:    `<div className="test" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"restrictedAttributes": []interface{}{"className"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "restrictedAttributeString", Message: `Restricted attribute string: ""test"" in className`},
+			},
+		},
+		{
+			Code:    `<div className="test" id="foo" title="bar" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"restrictedAttributes": []interface{}{"className", "id"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "restrictedAttributeString", Message: `Restricted attribute string: ""test"" in className`},
+				{MessageId: "restrictedAttributeString", Message: `Restricted attribute string: ""foo"" in id`},
+			},
+		},
+		{
+			Code:    `<div src="image.jpg" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noAttributeStrings": true, "restrictedAttributes": []interface{}{"className"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributes", Message: `Strings not allowed in attributes: ""image.jpg""`},
+			},
+		},
+		{
+			Code:    `<div title="text">test</div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"restrictedAttributes": []interface{}{"title"}, "noStrings": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "restrictedAttributeString", Message: `Restricted attribute string: ""text"" in title`},
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "test"`},
+			},
+		},
+		{
+			Code:    `<div className="test" title="hello" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false, "restrictedAttributes": []interface{}{"className"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "restrictedAttributeString", Message: `Restricted attribute string: ""test"" in className`},
+				{MessageId: "invalidPropValue", Message: `Invalid prop value: "title="hello""`},
+			},
+		},
+		{
+			Code:    `<div className="test" title="hello" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": true, "restrictedAttributes": []interface{}{"className"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "restrictedAttributeString", Message: `Restricted attribute string: ""test"" in className`},
+			},
+		},
+
+		// ---- elementOverrides errors ----
+		{
+			Code: `
+<div>
+  <div>foo</div>
+  <T>bar</T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{"T": map[string]interface{}{}},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "foo"`},
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "bar" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>foo</div>
+  <T>bar</T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{"T": map[string]interface{}{"allowElement": true}},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "foo"`},
+			},
+		},
+		{
+			Code: `<T>foo <div>bar</div></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{"T": map[string]interface{}{"allowElement": true, "applyToNestedElements": false}},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "bar"`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>foo</div>
+  <T>{'bar'}</T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{"T": map[string]interface{}{"noStrings": true}},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "foo"`},
+				{MessageId: "noStringsInJSXInElement", Message: `Strings not allowed in JSX files: "'bar'" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>foo</div>
+  <T>{'bar'}<div>{'baz'}</div></T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{"T": map[string]interface{}{"noStrings": true}},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "foo"`},
+				{MessageId: "noStringsInJSXInElement", Message: `Strings not allowed in JSX files: "'bar'" in T`},
+				{MessageId: "noStringsInJSXInElement", Message: `Strings not allowed in JSX files: "'baz'" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>foo</div>
+  <T>{'bar'}<div>{'baz'}</div></T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{"T": map[string]interface{}{"noStrings": true, "applyToNestedElements": false}},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "foo"`},
+				{MessageId: "noStringsInJSXInElement", Message: `Strings not allowed in JSX files: "'bar'" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>{'foo'}</div>
+  <T>{'foo'}</T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"foo"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'foo'"`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>{'foo'}</div>
+  <T>{'foo'}<div>{'foo'}</div></T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"foo"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'foo'"`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>{'foo'}</div>
+  <T>{'foo'}<div>{'foo'}</div></T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true, "allowedStrings": []interface{}{"foo"}, "applyToNestedElements": false},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'foo'"`},
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'foo'"`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo1="bar" />
+  <T foo2="bar" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true, "ignoreProps": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropValue", Message: `Invalid prop value: "foo1="bar""`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo1="bar" />
+  <T foo2="bar"><div foo3="bar" /></T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true, "ignoreProps": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropValue", Message: `Invalid prop value: "foo1="bar""`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo1="bar" />
+  <T foo2="bar"><div foo3="bar" /></T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true, "ignoreProps": true, "applyToNestedElements": false},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropValue", Message: `Invalid prop value: "foo1="bar""`},
+				{MessageId: "invalidPropValue", Message: `Invalid prop value: "foo3="bar""`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo1="bar1" />
+  <T foo2="bar2" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noAttributeStrings": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributesInElement", Message: `Strings not allowed in attributes: ""bar2"" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo1="bar1" />
+  <T foo2="bar2"><div foo3="bar3" /></T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noAttributeStrings": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributesInElement", Message: `Strings not allowed in attributes: ""bar2"" in T`},
+				{MessageId: "noStringsInAttributesInElement", Message: `Strings not allowed in attributes: ""bar3"" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo1="bar1" />
+  <T foo2="bar2"><div foo3="bar3" /></T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noAttributeStrings": true, "applyToNestedElements": false},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributesInElement", Message: `Strings not allowed in attributes: ""bar2"" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>{'foo'}</div>
+  <T>{'bar'}</T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'foo'"`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>foo</div>
+  <T>foo</T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"allowedStrings": []interface{}{"foo"},
+				"elementOverrides": map[string]interface{}{"T": map[string]interface{}{}},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "foo" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div>foo</div>
+  <T>foo</T>
+  <T>bar</T>
+  <T>baz</T>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"allowedStrings": []interface{}{"foo"},
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowedStrings": []interface{}{"bar"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "foo" in T`},
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "baz" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo1="bar1" />
+  <T foo2="bar2" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noStrings":   true,
+				"ignoreProps": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropValueInElement", Message: `Invalid prop value: "foo2="bar2"" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo1="bar1" />
+  <T foo2="bar2" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noAttributeStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributes", Message: `Strings not allowed in attributes: ""bar1""`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <T>foo</T>
+  <U>bar</U>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{},
+					"U": map[string]interface{}{},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "foo" in T`},
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "bar" in U`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <T>foo</T>
+  <U>bar</U>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{},
+					"U": map[string]interface{}{"allowElement": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "foo" in T`},
+			},
+		},
+		{
+			Code: `<T>foo <U>bar</U></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{},
+					"U": map[string]interface{}{"allowElement": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "foo" in T`},
+			},
+		},
+		{
+			Code: `<T>{'foo'}<U>{'bar'}</U></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true},
+					"U": map[string]interface{}{},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSXInElement", Message: `Strings not allowed in JSX files: "'foo'" in T`},
+			},
+		},
+		{
+			Code: `<T>foo<U>foo</U></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"allowedStrings": []interface{}{"foo"}},
+					"U": map[string]interface{}{},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "foo" in U`},
+			},
+		},
+		{
+			Code: `<T>foo<U>foo</U></T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{},
+					"U": map[string]interface{}{"allowedStrings": []interface{}{"foo"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "foo" in T`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <Fragment>foo</Fragment>
+  <React.Fragment>foo</React.Fragment>
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"React.Fragment": map[string]interface{}{"allowElement": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "foo"`},
+			},
+		},
+		{
+			Code: `<div>foo</div>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"div": map[string]interface{}{"allowElement": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "foo"`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div type="text" />
+  <Button type="submit" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"Button": map[string]interface{}{"restrictedAttributes": []interface{}{"type"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "restrictedAttributeStringInElement", Message: `Restricted attribute string: ""submit"" in type of Button`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <Input placeholder="Enter text" type="password" />
+  <Button type="submit" disabled="true" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"Input":  map[string]interface{}{"restrictedAttributes": []interface{}{"placeholder"}},
+					"Button": map[string]interface{}{"restrictedAttributes": []interface{}{"disabled"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "restrictedAttributeStringInElement", Message: `Restricted attribute string: ""Enter text"" in placeholder of Input`},
+				{MessageId: "restrictedAttributeStringInElement", Message: `Restricted attribute string: ""true"" in disabled of Button`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div className="wrapper" id="main" />
+  <Button className="btn" id="submit-btn" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"restrictedAttributes": []interface{}{"className"},
+				"elementOverrides": map[string]interface{}{
+					"Button": map[string]interface{}{"restrictedAttributes": []interface{}{"id"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "restrictedAttributeString", Message: `Restricted attribute string: ""wrapper"" in className`},
+				{MessageId: "restrictedAttributeStringInElement", Message: `Restricted attribute string: ""submit-btn"" in id of Button`},
+			},
+		},
+		{
+			Code: `
+<div>
+  <div foo1="bar1" />
+  <T foo2="bar2" />
+</div>
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"noAttributeStrings": true,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"restrictedAttributes": []interface{}{"foo2"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributes", Message: `Strings not allowed in attributes: ""bar1""`},
+				{MessageId: "restrictedAttributeStringInElement", Message: `Restricted attribute string: ""bar2"" in foo2 of T`},
+			},
+		},
+
+		// ---- Position assertions per messageId variant ----
+		// One small-source case per emit-site so future refactors of the
+		// trimmed-range / report path can't silently shift columns.
+		{
+			Code: `<div>test</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpression", Message: `Missing JSX expression container around literal string: "test"`, Line: 1, Column: 6, EndLine: 1, EndColumn: 10},
+			},
+		},
+		{
+			Code:    `<Foo bar="test"></Foo>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropValue", Message: `Invalid prop value: "bar="test""`, Line: 1, Column: 6, EndLine: 1, EndColumn: 16},
+			},
+		},
+		{
+			Code:    `<div>{'foo'}</div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'foo'"`, Line: 1, Column: 7, EndLine: 1, EndColumn: 12},
+			},
+		},
+		{
+			Code:    `<img alt='blank image' />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noAttributeStrings": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributes", Message: `Strings not allowed in attributes: "'blank image'"`, Line: 1, Column: 10, EndLine: 1, EndColumn: 23},
+			},
+		},
+		{
+			Code:    `<div className="test" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"restrictedAttributes": []interface{}{"className"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "restrictedAttributeString", Message: `Restricted attribute string: ""test"" in className`, Line: 1, Column: 6, EndLine: 1, EndColumn: 22},
+			},
+		},
+		{
+			Code: `<T>foo</T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "foo" in T`, Line: 1, Column: 4, EndLine: 1, EndColumn: 7},
+			},
+		},
+		{
+			Code: `<T>{'foo'}</T>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSXInElement", Message: `Strings not allowed in JSX files: "'foo'" in T`, Line: 1, Column: 5, EndLine: 1, EndColumn: 10},
+			},
+		},
+		{
+			Code: `<T foo="bar" />`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noAttributeStrings": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInAttributesInElement", Message: `Strings not allowed in attributes: ""bar"" in T`, Line: 1, Column: 8, EndLine: 1, EndColumn: 13},
+			},
+		},
+		{
+			Code: `<T foo="bar" />`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"noStrings":   true,
+				"ignoreProps": false,
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"noStrings": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropValueInElement", Message: `Invalid prop value: "foo="bar"" in T`, Line: 1, Column: 4, EndLine: 1, EndColumn: 13},
+			},
+		},
+		{
+			Code: `<T foo="bar" />`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{"restrictedAttributes": []interface{}{"foo"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "restrictedAttributeStringInElement", Message: `Restricted attribute string: ""bar"" in foo of T`, Line: 1, Column: 4, EndLine: 1, EndColumn: 13},
+			},
+		},
+
+		// ---- tsgo edge cases ----
+		// Paren-wrapped literal in JSX content fires under noStrings. Locks
+		// in `skipBinaryAndParens` peeling the explicit ParenthesizedExpression
+		// node that tsgo retains (vs. ESTree's parse-time drop).
+		{
+			Code:    `<div>{('foo')}</div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'foo'"`},
+			},
+		},
+		// Paren around a binary keeps both literals reachable.
+		{
+			Code:    `<Foo bar={('foo' + 'bar')} />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'foo'"`},
+				{MessageId: "noStringsInJSX", Message: `Strings not allowed in JSX files: "'bar'"`},
+			},
+		},
+		// Namespaced attribute is invisible to restrictedAttributes (upstream
+		// gates that branch on JsxIdentifier only) but the noStrings
+		// fall-through DOES still cover it — emits invalidPropValue.
+		{
+			Code:    `<svg xlink:href="bad" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true, "ignoreProps": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropValue", Message: `Invalid prop value: "xlink:href="bad""`},
+			},
+		},
+		// Nested templates: only the OUTER (parent = JsxExpression) reports;
+		// the inner template's parent is TemplateSpan, outside the gate.
+		{
+			Code:    "<div>{`a ${`b`} c`}</div>",
+			Tsx:     true,
+			Options: map[string]interface{}{"noStrings": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStringsInJSX", Message: "Strings not allowed in JSX files: \"`a ${`b`} c`\""},
+			},
+		},
+		// JsxFragment outer with override-target inner: the fragment is
+		// invisible to jsxElementAncestors, so the T override still applies.
+		{
+			Code: `<><T>foo</T></>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"elementOverrides": map[string]interface{}{
+					"T": map[string]interface{}{},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalNotInJSXExpressionInElement", Message: `Missing JSX expression container around literal string: "foo" in T`},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -105,6 +105,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-no-comment-textnodes.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-duplicate-props.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-leaked-render.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-no-literals.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-script-url.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-target-blank.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-undef.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-literals.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-literals.test.ts
@@ -1,0 +1,398 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-no-literals', {} as never, {
+  valid: [
+    // ---- noStrings + allowedStrings allow specific attribute strings ----
+    {
+      code: `
+class Comp1 extends Component {
+  render() {
+    return (
+      <div>
+        <button type="button"></button>
+      </div>
+    );
+  }
+}
+`,
+      options: [{ noStrings: true, allowedStrings: ['button', 'submit'] }],
+    },
+
+    // ---- Default config: literals inside JSXExpressionContainer pass ----
+    {
+      code: `
+class Comp2 extends Component {
+  render() {
+    return (
+      <div>
+        {'asdjfl'}
+      </div>
+    );
+  }
+}
+`,
+    },
+    {
+      code: `
+class Comp1 extends Component {
+  render() {
+    return (
+      <>
+        {'asdjfl'}
+      </>
+    );
+  }
+}
+`,
+    },
+    { code: `<div>{'test'}</div>` },
+    { code: `var foo = require('foo');` },
+    { code: `<Foo bar='test'>{'blarg'}</Foo>` },
+    {
+      code: `<Foo bar="test">{intl.formatText(message)}</Foo>`,
+      options: [{ noStrings: true, ignoreProps: true }],
+    },
+    { code: `<Foo bar={true} />`, options: [{ noStrings: true }] },
+    { code: `<Foo bar={false} />`, options: [{ noStrings: true }] },
+    { code: `<Foo bar={100} />`, options: [{ noStrings: true }] },
+    { code: `<Foo bar={null} />`, options: [{ noStrings: true }] },
+    { code: `<Foo bar={{}} />`, options: [{ noStrings: true }] },
+
+    // ---- allowedStrings ----
+    {
+      code: `<div>asdf</div>`,
+      options: [{ allowedStrings: ['asdf'] }],
+    },
+    {
+      code: `<div>&nbsp;</div>`,
+      options: [{ noStrings: true, allowedStrings: ['&nbsp;'] }],
+    },
+    {
+      code: `<div>foo</div>`,
+      options: [{ noStrings: true, allowedStrings: ['   foo   '] }],
+    },
+
+    // ---- Default: attribute strings allowed ----
+    { code: `<img alt='blank image'></img>` },
+
+    // ---- restrictedAttributes ----
+    {
+      code: `<img src="image.jpg" alt="text" />`,
+      options: [{ restrictedAttributes: ['className', 'id'] }],
+    },
+    {
+      code: `<div className="allowed" />`,
+      options: [
+        { restrictedAttributes: ['className'], allowedStrings: ['allowed'] },
+      ],
+    },
+    {
+      code: `<div className="test" id="foo" />`,
+      options: [{ restrictedAttributes: [] }],
+    },
+
+    // ---- elementOverrides ----
+    {
+      code: `<T>foo</T>`,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `<T>foo <div>bar</div></T>`,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `<T>foo <div>{'bar'}</div></T>`,
+      options: [
+        {
+          elementOverrides: {
+            T: { allowElement: true, applyToNestedElements: false },
+          },
+        },
+      ],
+    },
+    {
+      code: `<T>{2}<div>{2}</div></T>`,
+      options: [{ elementOverrides: { T: { noStrings: true } } }],
+    },
+    {
+      code: `<T>foo<div>foo</div></T>`,
+      options: [{ elementOverrides: { T: { allowedStrings: ['foo'] } } }],
+    },
+    {
+      code: `<T foo="bar"><div foo="bar" /></T>`,
+      options: [
+        {
+          noStrings: true,
+          elementOverrides: { T: { noStrings: true, ignoreProps: true } },
+        },
+      ],
+    },
+    {
+      code: `<T foo={2}><div foo={2} /></T>`,
+      options: [{ elementOverrides: { T: { noAttributeStrings: true } } }],
+    },
+    {
+      code: `<T>foo<U>foo</U></T>`,
+      options: [
+        {
+          elementOverrides: {
+            T: { allowedStrings: ['foo'] },
+            U: { allowedStrings: ['foo'] },
+          },
+        },
+      ],
+    },
+    {
+      code: `
+import { T } from 'foo';
+<T>{'foo'}</T>
+`,
+    },
+    {
+      code: `
+import { T as U } from 'foo';
+<U>foo</U>
+`,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `
+const { T: U } = require('foo');
+<U>foo</U>
+`,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `<T.U>foo</T.U>`,
+      options: [{ elementOverrides: { 'T.U': { allowElement: true } } }],
+    },
+    {
+      code: `<React.Fragment>foo</React.Fragment>`,
+      options: [
+        { elementOverrides: { 'React.Fragment': { allowElement: true } } },
+      ],
+    },
+    {
+      code: `<div>{'foo'}</div>`,
+      options: [{ elementOverrides: { div: { allowElement: true } } }],
+    },
+    {
+      code: `
+<div>
+  <Input type="text" />
+  <Button className="primary" />
+  <Image src="photo.jpg" />
+</div>
+`,
+      options: [
+        {
+          elementOverrides: {
+            Input: { restrictedAttributes: ['placeholder'] },
+            Button: { restrictedAttributes: ['type'] },
+          },
+        },
+      ],
+    },
+  ],
+
+  invalid: [
+    // ---- Default: bare JSX text reports literalNotInJSXExpression ----
+    {
+      code: `<div>test</div>`,
+      errors: [{ messageId: 'literalNotInJSXExpression' }],
+    },
+    {
+      code: `<>test</>`,
+      errors: [{ messageId: 'literalNotInJSXExpression' }],
+    },
+    {
+      code: `
+<div>
+  asdjfl
+</div>
+`,
+      errors: [{ messageId: 'literalNotInJSXExpression' }],
+    },
+
+    // ---- noStrings: attribute literal + JSX child literal ----
+    {
+      code: `<Foo bar="test">{'Test'}</Foo>`,
+      options: [{ noStrings: true, ignoreProps: false }],
+      errors: [
+        { messageId: 'invalidPropValue' },
+        { messageId: 'noStringsInJSX' },
+      ],
+    },
+    {
+      code: `<Foo bar="test">Test</Foo>`,
+      options: [{ noStrings: true, ignoreProps: false }],
+      errors: [
+        { messageId: 'invalidPropValue' },
+        { messageId: 'noStringsInJSX' },
+      ],
+    },
+    // ---- TemplateLiteral handler ----
+    {
+      code: '<Foo>{`Test`}</Foo>',
+      options: [{ noStrings: true }],
+      errors: [{ messageId: 'noStringsInJSX' }],
+    },
+    {
+      code: '<Foo bar={`Test`} />',
+      options: [{ noStrings: true, ignoreProps: false }],
+      errors: [{ messageId: 'noStringsInJSX' }],
+    },
+    {
+      code: '<Foo bar={`Test ${baz}`} />',
+      options: [{ noStrings: true, ignoreProps: false }],
+      errors: [{ messageId: 'noStringsInJSX' }],
+    },
+
+    // ---- noAttributeStrings ----
+    {
+      code: `<img alt='blank image'></img>`,
+      options: [{ noAttributeStrings: true }],
+      errors: [{ messageId: 'noStringsInAttributes' }],
+    },
+    {
+      code: `export const WithAttributes = ({}) => <div title="foo bar" />;`,
+      options: [{ noAttributeStrings: true }],
+      errors: [{ messageId: 'noStringsInAttributes' }],
+    },
+    {
+      code: `
+export const WithAttributesAndChildren = ({}) => (
+  <div title="foo bar">baz bob</div>
+);
+`,
+      options: [{ noAttributeStrings: true }],
+      errors: [
+        { messageId: 'noStringsInAttributes' },
+        { messageId: 'literalNotInJSXExpression' },
+      ],
+    },
+
+    // ---- restrictedAttributes ----
+    {
+      code: `<div className="test" />`,
+      options: [{ restrictedAttributes: ['className'] }],
+      errors: [{ messageId: 'restrictedAttributeString' }],
+    },
+    {
+      code: `<div className="test" id="foo" title="bar" />`,
+      options: [{ restrictedAttributes: ['className', 'id'] }],
+      errors: [
+        { messageId: 'restrictedAttributeString' },
+        { messageId: 'restrictedAttributeString' },
+      ],
+    },
+    {
+      code: `<div title="text">test</div>`,
+      options: [{ restrictedAttributes: ['title'], noStrings: true }],
+      errors: [
+        { messageId: 'restrictedAttributeString' },
+        { messageId: 'noStringsInJSX' },
+      ],
+    },
+    {
+      code: `<div className="test" title="hello" />`,
+      options: [
+        {
+          noStrings: true,
+          ignoreProps: false,
+          restrictedAttributes: ['className'],
+        },
+      ],
+      errors: [
+        { messageId: 'restrictedAttributeString' },
+        { messageId: 'invalidPropValue' },
+      ],
+    },
+
+    // ---- elementOverrides ----
+    {
+      code: `
+<div>
+  <div>foo</div>
+  <T>bar</T>
+</div>
+`,
+      options: [{ elementOverrides: { T: {} } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpression' },
+        { messageId: 'literalNotInJSXExpressionInElement' },
+      ],
+    },
+    {
+      code: `
+<div>
+  <div>foo</div>
+  <T>bar</T>
+</div>
+`,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+      errors: [{ messageId: 'literalNotInJSXExpression' }],
+    },
+    {
+      code: `
+<div>
+  <div>foo</div>
+  <T>{'bar'}</T>
+</div>
+`,
+      options: [{ elementOverrides: { T: { noStrings: true } } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpression' },
+        { messageId: 'noStringsInJSXInElement' },
+      ],
+    },
+    {
+      code: `
+<div>
+  <div foo1="bar1" />
+  <T foo2="bar2" />
+</div>
+`,
+      options: [{ elementOverrides: { T: { noAttributeStrings: true } } }],
+      errors: [{ messageId: 'noStringsInAttributesInElement' }],
+    },
+    {
+      code: `
+<div>
+  <div type="text" />
+  <Button type="submit" />
+</div>
+`,
+      options: [
+        {
+          elementOverrides: {
+            Button: { restrictedAttributes: ['type'] },
+          },
+        },
+      ],
+      errors: [{ messageId: 'restrictedAttributeStringInElement' }],
+    },
+    {
+      code: `
+<div>
+  <div className="wrapper" id="main" />
+  <Button className="btn" id="submit-btn" />
+</div>
+`,
+      options: [
+        {
+          restrictedAttributes: ['className'],
+          elementOverrides: {
+            Button: { restrictedAttributes: ['id'] },
+          },
+        },
+      ],
+      errors: [
+        { messageId: 'restrictedAttributeString' },
+        { messageId: 'restrictedAttributeStringInElement' },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/jsx-no-literals` rule from `eslint-plugin-react` to rslint.

The rule reports unwrapped string literals in JSX content (`<div>foo</div>`). With the `noStrings` option it also reports wrapped literals (`<div>{'foo'}</div>`, `` <div>{`foo`}</div> ``), and additional options control attribute strings (`noAttributeStrings`), per-attribute restrictions (`restrictedAttributes`), exemption strings (`allowedStrings`), and per-component overrides (`elementOverrides`).

Highlights of the port:

- 1:1 alignment of all 10 messageIds (`literalNotInJSXExpression`, `noStringsInJSX`, `noStringsInAttributes`, `restrictedAttributeString`, `invalidPropValue` and their `*InElement` override variants), message text, and data placeholders against upstream master.
- Renamed-import resolution for `import { T as U } from 'foo'` and `const { T: U } = require('foo')` (including paren-wrapped require chains and nested `MemberExpression`).
- HTML entity decoding (`html.UnescapeString`) so `<div>&amp;</div>` matches `allowedStrings: ['&']` the same way it does in ESLint.
- tsgo-specific handling: peel `ParenthesizedExpression` in parent walks, recognize both `KindJsxElement` and `KindJsxSelfClosingElement` as JSX-element ancestors, gate `restrictedAttributes` on `JsxIdentifier` only (matches upstream's `node.name.type === 'JSXIdentifier'` check).
- Validated on `rsbuild` (314 diagnostics, 119 files) and `rspack` (117 diagnostics, 15 files) with `noStrings: true, ignoreProps: false`; sampled diagnostics across attribute / JsxText / template-literal / multi-line / SVG cases — every reported position and message text matched the expected upstream behavior.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-no-literals.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).