### PR TITLE
feat: port rule react/jsx-max-depth

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -14,6 +14,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_first_prop_new_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_handler_names"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_key"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_depth"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_props_per_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_bind"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_duplicate_props"
@@ -82,6 +83,7 @@ func GetAllRules() []rule.Rule {
 		jsx_first_prop_new_line.JsxFirstPropNewLineRule,
 		jsx_handler_names.JsxHandlerNamesRule,
 		jsx_key.JsxKeyRule,
+		jsx_max_depth.JsxMaxDepthRule,
 		jsx_max_props_per_line.JsxMaxPropsPerLineRule,
 		jsx_no_bind.JsxNoBindRule,
 		jsx_no_duplicate_props.JsxNoDuplicatePropsRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -24,6 +24,24 @@ const DefaultReactPragma = "React"
 // rule that needs to recognize hook calls re-derives the same predicate.
 var hookNameRegex = regexp.MustCompile(`^use[A-Z0-9].*$`)
 
+// ApplyData expands `{{key}}` placeholders in a message template using the
+// given data map, mirroring ESLint's `RuleMessage.data` interpolation. Keys
+// not present in `data` are left untouched, matching ESLint's behavior of
+// passing through unknown placeholders verbatim. Use this whenever a rule
+// emits a templated `RuleMessage.Description` so the in-rule code reads like
+// the upstream `messages` table instead of hand-rolled `strings.ReplaceAll`
+// loops.
+func ApplyData(template string, data map[string]string) string {
+	if len(data) == 0 {
+		return template
+	}
+	out := template
+	for k, v := range data {
+		out = strings.ReplaceAll(out, "{{"+k+"}}", v)
+	}
+	return out
+}
+
 // IsHookName reports whether `name` matches the React hook naming convention.
 // Returns false for empty input.
 func IsHookName(name string) bool {
@@ -2320,7 +2338,7 @@ func isJSXExpression(expr *ast.Node, acceptNull bool, pragma string, tc *checker
 		// (`createElement`) / nested Identifiers. We mirror that here:
 		// resolve the initializer one step, accept iff the resolved node
 		// is itself a JSX element/fragment. Anything else returns false.
-		init := resolveIdentifierInitializer(expr, tc)
+		init := ResolveIdentifierInitializer(expr, tc)
 		if init == nil {
 			return false
 		}
@@ -2350,7 +2368,7 @@ func isJSXExpression(expr *ast.Node, acceptNull bool, pragma string, tc *checker
 	return false
 }
 
-// resolveIdentifierInitializer returns the value-side AST node that an
+// ResolveIdentifierInitializer returns the value-side AST node that an
 // Identifier reference is bound to, or nil when the binding cannot be
 // determined.
 //
@@ -2365,7 +2383,7 @@ func isJSXExpression(expr *ast.Node, acceptNull bool, pragma string, tc *checker
 //     SourceFile / ModuleBlock / CaseBlock statements for a
 //     `VariableStatement` declaring `name` — catches the common
 //     same-block initializer case without scope analysis.
-func resolveIdentifierInitializer(ident *ast.Node, tc *checker.Checker) *ast.Node {
+func ResolveIdentifierInitializer(ident *ast.Node, tc *checker.Checker) *ast.Node {
 	if ident == nil || ident.Kind != ast.KindIdentifier {
 		return nil
 	}

--- a/internal/plugins/react/rules/jsx_handler_names/jsx_handler_names.go
+++ b/internal/plugins/react/rules/jsx_handler_names/jsx_handler_names.go
@@ -343,7 +343,7 @@ var JsxHandlerNamesRule = rule.Rule{
 					}
 					ctx.ReportNode(node, rule.RuleMessage{
 						Id:          "badHandlerName",
-						Description: applyData(msgBadHandlerName, data),
+						Description: reactutil.ApplyData(msgBadHandlerName, data),
 						Data:        data,
 					})
 				case propFnIsNamedCorrectly && opts.propEventHandlerRegex != nil && !propIsEventHandler:
@@ -353,7 +353,7 @@ var JsxHandlerNamesRule = rule.Rule{
 					}
 					ctx.ReportNode(node, rule.RuleMessage{
 						Id:          "badPropKey",
-						Description: applyData(msgBadPropKey, data),
+						Description: reactutil.ApplyData(msgBadPropKey, data),
 						Data:        data,
 					})
 				}
@@ -362,10 +362,3 @@ var JsxHandlerNamesRule = rule.Rule{
 	},
 }
 
-func applyData(template string, data map[string]string) string {
-	out := template
-	for k, v := range data {
-		out = strings.ReplaceAll(out, "{{"+k+"}}", v)
-	}
-	return out
-}

--- a/internal/plugins/react/rules/jsx_max_depth/jsx_max_depth.go
+++ b/internal/plugins/react/rules/jsx_max_depth/jsx_max_depth.go
@@ -1,0 +1,1056 @@
+package jsx_max_depth
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Bound on the identifier-resolution chain length. Upstream uses ESLint's
+// `containDuplicates` check on the scope reference list; we approximate it
+// with a (symbol|name)-keyed visited set plus this fixed cap so any
+// pathological aliasing — even one our visited set fails to fingerprint —
+// terminates.
+const maxResolveDepth = 32
+
+const msgWrongDepth = "Expected the depth of nested jsx elements to be <= {{needed}}, but found {{found}}."
+
+const defaultMaxDepth = 2
+
+type options struct {
+	max int
+}
+
+func parseOptions(raw any) options {
+	opts := options{max: defaultMaxDepth}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	if v, ok := m["max"]; ok {
+		// JS-config / CLI numbers come through as float64 (json.Unmarshal default);
+		// Go-test maps may pass int / int64 directly. Reject negatives — upstream's
+		// JSON schema declares `minimum: 0` and the option only makes sense for
+		// non-negative depths.
+		switch val := v.(type) {
+		case float64:
+			if val >= 0 {
+				opts.max = int(val)
+			}
+		case int:
+			if val >= 0 {
+				opts.max = val
+			}
+		case int64:
+			if val >= 0 {
+				opts.max = int(val)
+			}
+		}
+	}
+	return opts
+}
+
+// isJsxExpressionNode is a nil-safe wrapper over `ast.IsJsxExpression`. tsgo's
+// shim predicate dereferences `node.Kind` directly, so callers that may pass
+// nil need this guard.
+func isJsxExpressionNode(node *ast.Node) bool {
+	return node != nil && ast.IsJsxExpression(node)
+}
+
+func jsxExpressionInner(node *ast.Node) *ast.Node {
+	if !isJsxExpressionNode(node) {
+		return nil
+	}
+	return node.AsJsxExpression().Expression
+}
+
+// hasJSX mirrors upstream's
+// `jsxUtil.isJSX(node) || (isExpression(node) && jsxUtil.isJSX(node.expression))`:
+// a JSX element/fragment, OR a `{...}` whose direct expression is JSX.
+// Used to decide whether a child of a JSX container counts as "JSX-bearing".
+func hasJSX(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if reactutil.IsJsxLike(node) {
+		return true
+	}
+	if isJsxExpressionNode(node) {
+		return reactutil.IsJsxLike(jsxExpressionInner(node))
+	}
+	return false
+}
+
+// isLeaf mirrors upstream's
+// `!children || children.length === 0 || !children.some(hasJSX)`. Note that
+// `reactutil.GetJsxChildren` returns nil for any non-element/fragment kind
+// (JsxSelfClosingElement, JsxExpression, …), so those uniformly count as
+// leaves — which is exactly what upstream's `node.children` undefined check
+// does on a JSXExpressionContainer or JSXText sibling.
+func isLeaf(node *ast.Node) bool {
+	children := reactutil.GetJsxChildren(node)
+	if len(children) == 0 {
+		return true
+	}
+	for _, c := range children {
+		if hasJSX(c) {
+			return false
+		}
+	}
+	return true
+}
+
+// getDepth counts JSX element/fragment ancestors of `node`, walking through
+// JsxExpression containers (which don't add depth themselves but do bridge
+// a JSX value across an interpolation boundary). Mirrors upstream's
+// `while (jsxUtil.isJSX(node.parent) || isExpression(node.parent))`.
+func getDepth(node *ast.Node) int {
+	count := 0
+	cur := node
+	for cur != nil && cur.Parent != nil {
+		parent := cur.Parent
+		if !reactutil.IsJsxLike(parent) && !isJsxExpressionNode(parent) {
+			break
+		}
+		cur = parent
+		if reactutil.IsJsxLike(cur) {
+			count++
+		}
+	}
+	return count
+}
+
+func report(ctx rule.RuleContext, node *ast.Node, found, needed int) {
+	data := map[string]string{
+		"found":  strconv.Itoa(found),
+		"needed": strconv.Itoa(needed),
+	}
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          "wrongDepth",
+		Description: reactutil.ApplyData(msgWrongDepth, data),
+		Data:        data,
+	})
+}
+
+// findJsxElementOrFragment mirrors upstream's `findJSXElementOrFragment`:
+// resolves an Identifier reference to its underlying JSX value by following
+// the binding chain, taking the **most recent write** (declaration init OR
+// reassignment) in source order at every step.
+//
+// Cycle detection uses a (symbol-pointer | name)-keyed visited set plus a
+// hard depth cap so a `let x = y; let y = x;` pair can't loop. Parens are
+// unwrapped because tsgo preserves them as explicit nodes; TS type-expression
+// wrappers (`as`, `satisfies`, non-null `!`) are intentionally NOT peeled to
+// keep upstream's literal Identifier-only matching.
+func findJsxElementOrFragment(ident *ast.Node, tc *checker.Checker, visited map[string]bool, depth int) *ast.Node {
+	if ident == nil || ident.Kind != ast.KindIdentifier {
+		return nil
+	}
+	if depth >= maxResolveDepth {
+		return nil
+	}
+	name := ident.AsIdentifier().Text
+	var key string
+	if tc != nil {
+		if sym := tc.GetSymbolAtLocation(ident); sym != nil {
+			key = fmt.Sprintf("s:%p", sym)
+		}
+	}
+	if key == "" {
+		key = "n:" + name
+	}
+	if visited[key] {
+		return nil
+	}
+	visited[key] = true
+
+	write := resolveLatestWrite(ident, tc)
+	if write == nil {
+		return nil
+	}
+	write = ast.SkipParentheses(write)
+	if write == nil {
+		return nil
+	}
+	if reactutil.IsJsxLike(write) {
+		return write
+	}
+	if write.Kind == ast.KindIdentifier {
+		return findJsxElementOrFragment(write, tc, visited, depth+1)
+	}
+	return nil
+}
+
+// resolveLatestWrite returns the source-order latest write expression for the
+// binding referenced by `ident`. Mirrors ESLint scope-manager's
+// reverse-iteration over `variable.references`: declaration init counts as
+// a write, every direct `name = expr` reassignment counts as a write, and
+// the LAST one in source order wins regardless of where the use site sits.
+//
+// Inner functions / methods are descended into when they DON'T shadow `name`
+// (parameter or local declaration with the same identifier) — that captures
+// closure writes the way ESLint's scope manager does. Functions that DO
+// shadow `name` are skipped because their writes refer to a different binding.
+//
+// Handles three declaration shapes:
+//
+//   - VariableDeclaration (`let x = …` / `const x = …` / `var x = …`).
+//     Scope is the enclosing Block / SourceFile / ForStatement / etc.
+//
+//   - Parameter (`function f(x = <jsx>)`). Scope is the function body;
+//     the parameter's `Initializer` (default value) seeds the write list
+//     so `<jsx>` can be picked up even though it lives outside the body.
+//
+//   - BindingElement (destructured parameter or destructured variable
+//     declarator: `function f({ x = <jsx> })`, `const { x = <jsx> } = …`).
+//     Scope follows the enclosing Parameter or VariableDeclaration; the
+//     element's `Initializer` (default value) seeds the write list.
+//
+// Returns nil when:
+//   - The binding can't be resolved (free identifier, function declaration,
+//     class declaration, import, type-only binding).
+//   - The declaration is bound to a non-Identifier name (e.g. a top-level
+//     ObjectBindingPattern from `const {x} = …` is followed via its inner
+//     BindingElement, not its outer VariableDeclaration).
+func resolveLatestWrite(ident *ast.Node, tc *checker.Checker) *ast.Node {
+	name := ident.AsIdentifier().Text
+	decl := resolveDeclarationOf(ident, name, tc)
+	if decl == nil {
+		return nil
+	}
+
+	var (
+		scope          *ast.Node
+		seedWrite      *ast.Node
+		seedWritePos   = -1
+		fallbackResult *ast.Node
+	)
+	switch decl.Kind {
+	case ast.KindVariableDeclaration:
+		scope = enclosingScopeContainer(decl)
+		fallbackResult = decl.AsVariableDeclaration().Initializer
+	case ast.KindParameter:
+		scope = parameterScope(decl)
+		if init := decl.AsParameterDeclaration().Initializer; init != nil {
+			seedWrite = init
+			seedWritePos = decl.Pos()
+			fallbackResult = init
+		}
+	case ast.KindBindingElement:
+		// Two seed strategies, decided by the BindingElement's enclosing
+		// declaration kind:
+		//
+		//   - Inside a Parameter (`function f({ x = <jsx> })`): ESLint's
+		//     scope manager surfaces the BindingElement's default as the
+		//     binding's writeExpr. Seed with the default.
+		//
+		//   - Inside a VariableDeclaration (`const { x = <jsx> } = obj`):
+		//     ESLint's scope manager surfaces the VariableDeclaration's
+		//     `init` (the destructure RHS), NOT the BindingElement default.
+		//     Seed with the RHS, which then resolves through the normal
+		//     Identifier-recurse path or bails on a non-Identifier value.
+		//     Verified empirically against upstream.
+		container := enclosingDeclOrParameter(decl)
+		if container == nil {
+			scope = bindingElementScope(decl)
+			break
+		}
+		switch container.Kind {
+		case ast.KindParameter:
+			scope = parameterScope(container)
+			if init := decl.AsBindingElement().Initializer; init != nil {
+				seedWrite = init
+				seedWritePos = decl.Pos()
+				fallbackResult = init
+			}
+		case ast.KindVariableDeclaration:
+			scope = enclosingScopeContainer(container)
+			if init := container.AsVariableDeclaration().Initializer; init != nil {
+				seedWrite = init
+				seedWritePos = container.Pos()
+				fallbackResult = init
+			}
+		}
+	default:
+		return nil
+	}
+	if scope == nil {
+		return fallbackResult
+	}
+
+	latest := seedWrite
+	latestPos := seedWritePos
+
+	var visit func(n *ast.Node)
+	visit = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		// At a function-like boundary other than the scope itself, descend
+		// only when the inner function doesn't shadow `name` (parameter or
+		// local declaration). Shadowing means writes inside refer to a
+		// different binding and must not bleed into our resolution.
+		if n != scope && isFunctionLikeContainer(n) {
+			if functionLikeShadowsName(n, name) {
+				return
+			}
+		}
+		// Block-level shadowing: `let` / `const` introduce fresh bindings
+		// scoped to the enclosing Block (or CaseBlock). When an inner block
+		// redeclares `name` with `let` / `const`, every write inside refers
+		// to the inner binding and must not bleed into our resolution.
+		// `var` declarations are function-scoped and don't shadow at block
+		// level, so they're intentionally excluded from this check.
+		if n != scope && (n.Kind == ast.KindBlock || n.Kind == ast.KindCaseBlock) {
+			if blockShadowsName(n, name) {
+				return
+			}
+		}
+		// For-loop init shadowing: `for (let|const x = …; …; …)`,
+		// `for (let|const x of …)`, `for (let|const x in …)` introduce a
+		// fresh `name` binding scoped to the entire ForStatement. Writes
+		// inside the for refer to the inner binding. `var` is excluded
+		// (function-hoisted, not block-scoped).
+		if n != scope && (n.Kind == ast.KindForStatement ||
+			n.Kind == ast.KindForInStatement ||
+			n.Kind == ast.KindForOfStatement) {
+			if forInitShadowsName(n, name) {
+				return
+			}
+		}
+		// Catch-clause parameter shadowing: `try { } catch (name) { … }`
+		// binds the caught error to a fresh `name` scoped to the catch.
+		// Writes inside the catch refer to the parameter, not an outer
+		// same-name binding.
+		if n != scope && n.Kind == ast.KindCatchClause {
+			if catchClauseShadowsName(n, name) {
+				return
+			}
+		}
+		switch n.Kind {
+		case ast.KindVariableDeclaration:
+			vd := n.AsVariableDeclaration()
+			if vd.Name() != nil && vd.Name().Kind == ast.KindIdentifier &&
+				vd.Name().AsIdentifier().Text == name && vd.Initializer != nil {
+				if pos := n.Pos(); pos > latestPos {
+					latestPos = pos
+					latest = vd.Initializer
+				}
+			}
+		case ast.KindBinaryExpression:
+			bin := n.AsBinaryExpression()
+			if bin.OperatorToken != nil &&
+				bin.OperatorToken.Kind == ast.KindEqualsToken &&
+				bin.Left != nil &&
+				bin.Left.Kind == ast.KindIdentifier &&
+				bin.Left.AsIdentifier().Text == name {
+				if pos := n.Pos(); pos > latestPos {
+					latestPos = pos
+					latest = bin.Right
+				}
+			}
+		}
+		n.ForEachChild(func(c *ast.Node) bool {
+			visit(c)
+			return false
+		})
+	}
+	visit(scope)
+	return latest
+}
+
+// resolveDeclarationOf returns the declaration node that defines the
+// binding referenced by `ident`. Tries the TypeChecker first (the only
+// path that resolves cross-module imports correctly) and falls back to a
+// local scan over enclosing scopes. Recognizes three declaration kinds:
+//
+//   - VariableDeclaration (`var/let/const name = …`)
+//   - Parameter (`function f(name = …)`)
+//   - BindingElement (destructured: `function f({ name = … })` or
+//     `const { name } = …`)
+//
+// Returns nil when the binding can't be resolved or the declaration kind
+// isn't one of those three (e.g. function declaration, class declaration,
+// import specifier).
+func resolveDeclarationOf(ident *ast.Node, name string, tc *checker.Checker) *ast.Node {
+	if tc != nil {
+		if sym := tc.GetSymbolAtLocation(ident); sym != nil {
+			d := sym.ValueDeclaration
+			if d == nil && len(sym.Declarations) > 0 {
+				d = sym.Declarations[0]
+			}
+			if d != nil {
+				switch d.Kind {
+				case ast.KindVariableDeclaration:
+					// tsgo's TypeChecker returns the outer VariableDeclaration
+					// even for destructured bindings (`const { x } = obj` →
+					// ValueDeclaration is the whole `const`). Drill into the
+					// binding pattern when the declaration's name doesn't
+					// match `name` directly.
+					if found := matchVarDeclBinding(d, name); found != nil {
+						return found
+					}
+				case ast.KindParameter:
+					if pn := d.AsParameterDeclaration().Name(); pn != nil &&
+						pn.Kind == ast.KindIdentifier &&
+						pn.AsIdentifier().Text == name {
+						return d
+					}
+					// Destructured parameter: drill in.
+					if pn := d.AsParameterDeclaration().Name(); pn != nil {
+						if be := findBindingElementByName(pn, name); be != nil {
+							return be
+						}
+					}
+				case ast.KindBindingElement:
+					return d
+				}
+			}
+		}
+	}
+	for cur := ident.Parent; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindBlock, ast.KindSourceFile, ast.KindCaseBlock, ast.KindModuleBlock:
+			if d := findVarDeclByName(cur, name); d != nil {
+				return d
+			}
+		case ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement:
+			// `for (let x = ...; ...; ...)`, `for (let x of …)`, and
+			// `for (let x in …)` all bind `x` to the loop's scope, not
+			// the enclosing Block. The init list lives on the loop's
+			// Initializer slot — check it directly.
+			if d := findVarDeclInForInit(cur, name); d != nil {
+				return d
+			}
+		}
+		// Function-like containers introduce parameter bindings scoped to
+		// the function body. The closest such container that binds `name`
+		// wins (innermost shadow rule).
+		if isFunctionLikeContainer(cur) {
+			if d := findParamByName(cur, name); d != nil {
+				return d
+			}
+		}
+	}
+	return nil
+}
+
+// findParamByName searches the parameter list of `funcLike` for a binding
+// named `name`. Returns the Parameter when bound directly as an Identifier,
+// or the BindingElement when bound via an Object / Array destructure
+// pattern. Returns nil when no parameter binds `name`.
+func findParamByName(funcLike *ast.Node, name string) *ast.Node {
+	for _, p := range functionParameters(funcLike) {
+		if p == nil || p.Kind != ast.KindParameter {
+			continue
+		}
+		pn := p.AsParameterDeclaration().Name()
+		if pn == nil {
+			continue
+		}
+		if pn.Kind == ast.KindIdentifier {
+			if pn.AsIdentifier().Text == name {
+				return p
+			}
+			continue
+		}
+		if be := findBindingElementByName(pn, name); be != nil {
+			return be
+		}
+	}
+	return nil
+}
+
+// findBindingElementByName recursively searches an Object / Array binding
+// pattern for a BindingElement bound to a bare Identifier matching `name`.
+// Nested patterns are followed (e.g. `{ a: { name } }`). Rest elements
+// (`{ ...name }`) are also matched when their target is an Identifier.
+func findBindingElementByName(pattern *ast.Node, name string) *ast.Node {
+	if pattern == nil {
+		return nil
+	}
+	switch pattern.Kind {
+	case ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
+	default:
+		return nil
+	}
+	bp := pattern.AsBindingPattern()
+	if bp == nil || bp.Elements == nil {
+		return nil
+	}
+	for _, el := range bp.Elements.Nodes {
+		if el == nil || el.Kind != ast.KindBindingElement {
+			continue
+		}
+		be := el.AsBindingElement()
+		if be == nil {
+			continue
+		}
+		beName := be.Name()
+		if beName == nil {
+			continue
+		}
+		if beName.Kind == ast.KindIdentifier {
+			if beName.AsIdentifier().Text == name {
+				return el
+			}
+			continue
+		}
+		if nested := findBindingElementByName(beName, name); nested != nil {
+			return nested
+		}
+	}
+	return nil
+}
+
+// parameterScope returns the function body Block that scopes the parameter's
+// binding. Returns nil when the Parameter isn't actually inside a
+// function-like container (shouldn't happen in well-formed AST).
+func parameterScope(parameter *ast.Node) *ast.Node {
+	for cur := parameter.Parent; cur != nil; cur = cur.Parent {
+		if isFunctionLikeContainer(cur) {
+			return functionBody(cur)
+		}
+	}
+	return nil
+}
+
+// bindingElementScope returns the scope of a BindingElement based on whether
+// it sits inside a Parameter or a VariableDeclaration. Walks up until either
+// is found.
+func bindingElementScope(be *ast.Node) *ast.Node {
+	if c := enclosingDeclOrParameter(be); c != nil {
+		switch c.Kind {
+		case ast.KindParameter:
+			return parameterScope(c)
+		case ast.KindVariableDeclaration:
+			return enclosingScopeContainer(c)
+		}
+	}
+	return nil
+}
+
+// enclosingDeclOrParameter walks up from a BindingElement to find the nearest
+// Parameter or VariableDeclaration that anchors its scope and seed value.
+// Used by both `bindingElementScope` and the seed-strategy switch in
+// `resolveLatestWrite`.
+func enclosingDeclOrParameter(be *ast.Node) *ast.Node {
+	for cur := be.Parent; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindParameter, ast.KindVariableDeclaration:
+			return cur
+		}
+	}
+	return nil
+}
+
+// findVarDeclInForInit returns the binding for `name` declared in a for-loop
+// initializer (`for (let|const name = …; …; …)`, `for (let|const name of …)`,
+// `for (let|const { name } of …)`). Returns the VariableDeclaration for bare
+// Identifier bindings or the inner BindingElement for destructure patterns.
+func findVarDeclInForInit(forNode *ast.Node, name string) *ast.Node {
+	var initList *ast.Node
+	switch forNode.Kind {
+	case ast.KindForStatement:
+		initList = forNode.AsForStatement().Initializer
+	case ast.KindForInStatement:
+		initList = forNode.AsForInOrOfStatement().Initializer
+	case ast.KindForOfStatement:
+		initList = forNode.AsForInOrOfStatement().Initializer
+	}
+	if initList == nil || initList.Kind != ast.KindVariableDeclarationList {
+		return nil
+	}
+	decls := initList.AsVariableDeclarationList()
+	if decls == nil || decls.Declarations == nil {
+		return nil
+	}
+	for _, d := range decls.Declarations.Nodes {
+		if found := matchVarDeclBinding(d, name); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// findVarDeclByName scans `scope`'s direct VariableStatement children for a
+// VariableDeclaration with an Identifier-named binding equal to `name`.
+// For CaseBlock the scan descends into each clause's Statements (per
+// ES2015 `let` / `const` are scoped to the entire CaseBlock, so a binding
+// in `case 'a':` is visible to all sibling cases).
+//
+// For other scope kinds, does NOT descend — callers do their own walk if
+// recursive lookup is needed.
+func findVarDeclByName(scope *ast.Node, name string) *ast.Node {
+	var found *ast.Node
+	if scope != nil && scope.Kind == ast.KindCaseBlock {
+		scope.ForEachChild(func(clause *ast.Node) bool {
+			if found != nil || clause == nil {
+				return found != nil
+			}
+			clause.ForEachChild(func(stmt *ast.Node) bool {
+				if found != nil {
+					return true
+				}
+				if d := findVarDeclByNameInStmt(stmt, name); d != nil {
+					found = d
+					return true
+				}
+				return false
+			})
+			return found != nil
+		})
+		return found
+	}
+	scope.ForEachChild(func(stmt *ast.Node) bool {
+		if found != nil {
+			return true
+		}
+		if stmt == nil {
+			return false
+		}
+		if d := findVarDeclByNameInStmt(stmt, name); d != nil {
+			found = d
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+// findVarDeclByNameInStmt extracts the per-statement check used by
+// findVarDeclByName (and its CaseBlock descend). Returns:
+//   - the VariableDeclaration when `stmt` declares `name` via a bare
+//     Identifier binding (`let name = …`)
+//   - the BindingElement when `stmt` declares `name` via a destructure
+//     pattern (`let { name = … } = …`, `let [name] = …`, including nested)
+//   - nil otherwise.
+func findVarDeclByNameInStmt(stmt *ast.Node, name string) *ast.Node {
+	if stmt == nil || stmt.Kind != ast.KindVariableStatement {
+		return nil
+	}
+	list := stmt.AsVariableStatement().DeclarationList
+	if list == nil {
+		return nil
+	}
+	decls := list.AsVariableDeclarationList()
+	if decls == nil || decls.Declarations == nil {
+		return nil
+	}
+	for _, d := range decls.Declarations.Nodes {
+		if d == nil || d.Kind != ast.KindVariableDeclaration {
+			continue
+		}
+		if found := matchVarDeclBinding(d, name); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// matchVarDeclBinding returns:
+//   - `vd` itself when the declaration's name is the bare Identifier `name`.
+//   - the inner BindingElement when the declaration uses a destructure
+//     pattern that binds `name` (recursive search via findBindingElementByName).
+//   - nil otherwise.
+func matchVarDeclBinding(vd *ast.Node, name string) *ast.Node {
+	if vd == nil || vd.Kind != ast.KindVariableDeclaration {
+		return nil
+	}
+	n := vd.AsVariableDeclaration().Name()
+	if n == nil {
+		return nil
+	}
+	if n.Kind == ast.KindIdentifier {
+		if n.AsIdentifier().Text == name {
+			return vd
+		}
+		return nil
+	}
+	return findBindingElementByName(n, name)
+}
+
+// enclosingScopeContainer returns the AST node that owns `node`'s binding's
+// lexical scope. Walks up the parent chain looking for the nearest
+// scope-introducing kind:
+//
+//   - For a VariableDeclaration declared in a for-loop initializer
+//     (`for (let x = …; …; …)`, `for (let x of …)`, `for (let x in …)`),
+//     the loop statement itself is the scope — `let` / `const` introduced
+//     in for-init are scoped to the entire ForStatement (init + condition
+//     + incrementor + body), not the enclosing Block. Returning the outer
+//     Block would let us see same-name writes that don't refer to this
+//     binding and miss reassignments in the loop body.
+//   - Otherwise, the nearest enclosing Block / SourceFile / ModuleBlock /
+//     CaseBlock.
+func enclosingScopeContainer(node *ast.Node) *ast.Node {
+	if node != nil && node.Parent != nil &&
+		node.Parent.Kind == ast.KindVariableDeclarationList {
+		if gp := node.Parent.Parent; gp != nil {
+			switch gp.Kind {
+			case ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement:
+				return gp
+			}
+		}
+	}
+	for cur := node.Parent; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindBlock, ast.KindSourceFile, ast.KindModuleBlock, ast.KindCaseBlock:
+			return cur
+		}
+	}
+	return nil
+}
+
+// isFunctionLikeContainer reports whether `n` introduces its own variable
+// scope. Class static blocks are included because their bodies declare
+// fresh `let`/`const` bindings independent of the enclosing class.
+func isFunctionLikeContainer(n *ast.Node) bool {
+	switch n.Kind {
+	case ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression,
+		ast.KindArrowFunction,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor,
+		ast.KindConstructor,
+		ast.KindClassStaticBlockDeclaration:
+		return true
+	}
+	return false
+}
+
+// forInitShadowsName reports whether the `for` / `for-in` / `for-of`
+// statement's initializer declares a `let` / `const` binding for `name`.
+// Such bindings are scoped to the whole ForStatement, so any write to
+// `name` inside the loop refers to the inner binding — not an outer
+// same-name. `var` initializers are skipped because they hoist to the
+// enclosing function scope.
+func forInitShadowsName(forNode *ast.Node, name string) bool {
+	var initList *ast.Node
+	switch forNode.Kind {
+	case ast.KindForStatement:
+		initList = forNode.AsForStatement().Initializer
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		initList = forNode.AsForInOrOfStatement().Initializer
+	}
+	if initList == nil || initList.Kind != ast.KindVariableDeclarationList {
+		return false
+	}
+	decls := initList.AsVariableDeclarationList()
+	if decls == nil || decls.Declarations == nil {
+		return false
+	}
+	if decls.Flags&ast.NodeFlagsBlockScoped == 0 {
+		return false
+	}
+	for _, d := range decls.Declarations.Nodes {
+		if d == nil || d.Kind != ast.KindVariableDeclaration {
+			continue
+		}
+		vd := d.AsVariableDeclaration()
+		if vd.Name() != nil && bindingNameContains(vd.Name(), name) {
+			return true
+		}
+	}
+	return false
+}
+
+// catchClauseShadowsName reports whether the `catch (…)` clause binds
+// `name` (either as a bare Identifier `catch (name)` or as a destructure
+// pattern `catch ({ name })`). Bare `catch {}` (no binding) returns false.
+func catchClauseShadowsName(catchClause *ast.Node, name string) bool {
+	if catchClause == nil || catchClause.Kind != ast.KindCatchClause {
+		return false
+	}
+	cc := catchClause.AsCatchClause()
+	if cc == nil || cc.VariableDeclaration == nil {
+		return false
+	}
+	vd := cc.VariableDeclaration
+	if vd.Kind != ast.KindVariableDeclaration {
+		return false
+	}
+	bn := vd.AsVariableDeclaration().Name()
+	if bn == nil {
+		return false
+	}
+	return bindingNameContains(bn, name)
+}
+
+// blockShadowsName reports whether `block` (a Block / CaseBlock) introduces
+// a `let` / `const` binding named `name`. `var` declarations are skipped
+// because they hoist to the enclosing function scope and don't shadow at
+// block level.
+func blockShadowsName(block *ast.Node, name string) bool {
+	var found bool
+	visitVariableStatements := func(stmt *ast.Node) bool {
+		if stmt == nil || stmt.Kind != ast.KindVariableStatement {
+			return false
+		}
+		list := stmt.AsVariableStatement().DeclarationList
+		if list == nil {
+			return false
+		}
+		// Only block-scoped (`let` / `const`) declarations shadow.
+		if list.Flags&ast.NodeFlagsBlockScoped == 0 {
+			return false
+		}
+		decls := list.AsVariableDeclarationList()
+		if decls == nil || decls.Declarations == nil {
+			return false
+		}
+		for _, d := range decls.Declarations.Nodes {
+			if d == nil || d.Kind != ast.KindVariableDeclaration {
+				continue
+			}
+			vd := d.AsVariableDeclaration()
+			if vd.Name() != nil && bindingNameContains(vd.Name(), name) {
+				found = true
+				return true
+			}
+		}
+		return false
+	}
+	switch block.Kind {
+	case ast.KindBlock:
+		block.ForEachChild(func(stmt *ast.Node) bool {
+			if found {
+				return true
+			}
+			return visitVariableStatements(stmt)
+		})
+	case ast.KindCaseBlock:
+		// CaseBlock contains CaseClause / DefaultClause; each holds a
+		// Statements list. Treat all clauses as one shared scope, matching
+		// JS semantics for `case` falls-through.
+		block.ForEachChild(func(clause *ast.Node) bool {
+			if found || clause == nil {
+				return found
+			}
+			clause.ForEachChild(func(stmt *ast.Node) bool {
+				if found {
+					return true
+				}
+				return visitVariableStatements(stmt)
+			})
+			return found
+		})
+	}
+	return found
+}
+
+// functionLikeShadowsName reports whether `funcLike` introduces a binding
+// named `name` that would shadow an outer binding. Checks parameters and
+// top-level `var/let/const` declarations in the function body — covers the
+// cases where descending into the body would attribute writes to the wrong
+// binding.
+func functionLikeShadowsName(funcLike *ast.Node, name string) bool {
+	for _, p := range functionParameters(funcLike) {
+		if parameterBindsName(p, name) {
+			return true
+		}
+	}
+	body := functionBody(funcLike)
+	if body != nil && findVarDeclByName(body, name) != nil {
+		return true
+	}
+	return false
+}
+
+func functionParameters(funcLike *ast.Node) []*ast.Node {
+	switch funcLike.Kind {
+	case ast.KindFunctionDeclaration:
+		if fd := funcLike.AsFunctionDeclaration(); fd.Parameters != nil {
+			return fd.Parameters.Nodes
+		}
+	case ast.KindFunctionExpression:
+		if fe := funcLike.AsFunctionExpression(); fe.Parameters != nil {
+			return fe.Parameters.Nodes
+		}
+	case ast.KindArrowFunction:
+		if af := funcLike.AsArrowFunction(); af.Parameters != nil {
+			return af.Parameters.Nodes
+		}
+	case ast.KindMethodDeclaration:
+		if md := funcLike.AsMethodDeclaration(); md.Parameters != nil {
+			return md.Parameters.Nodes
+		}
+	case ast.KindGetAccessor:
+		if ga := funcLike.AsGetAccessorDeclaration(); ga.Parameters != nil {
+			return ga.Parameters.Nodes
+		}
+	case ast.KindSetAccessor:
+		if sa := funcLike.AsSetAccessorDeclaration(); sa.Parameters != nil {
+			return sa.Parameters.Nodes
+		}
+	case ast.KindConstructor:
+		if cd := funcLike.AsConstructorDeclaration(); cd.Parameters != nil {
+			return cd.Parameters.Nodes
+		}
+	}
+	return nil
+}
+
+// parameterBindsName recognises the common shapes — bare Identifier and
+// `{ name }` / `[ name ]` destructuring pattern — and returns true when any
+// of them binds `name`. Rest parameters (`...rest`) and assignment patterns
+// (`name = default`) are also covered because they wrap an Identifier or
+// pattern that we descend through.
+func parameterBindsName(p *ast.Node, name string) bool {
+	if p == nil || p.Kind != ast.KindParameter {
+		return false
+	}
+	pn := p.AsParameterDeclaration().Name()
+	return bindingNameContains(pn, name)
+}
+
+func bindingNameContains(n *ast.Node, name string) bool {
+	if n == nil {
+		return false
+	}
+	switch n.Kind {
+	case ast.KindIdentifier:
+		return n.AsIdentifier().Text == name
+	case ast.KindObjectBindingPattern:
+		obp := n.AsBindingPattern()
+		if obp == nil || obp.Elements == nil {
+			return false
+		}
+		for _, el := range obp.Elements.Nodes {
+			if el == nil {
+				continue
+			}
+			be := el.AsBindingElement()
+			if be == nil {
+				continue
+			}
+			if bindingNameContains(be.Name(), name) {
+				return true
+			}
+		}
+	case ast.KindArrayBindingPattern:
+		abp := n.AsBindingPattern()
+		if abp == nil || abp.Elements == nil {
+			return false
+		}
+		for _, el := range abp.Elements.Nodes {
+			if el == nil || el.Kind != ast.KindBindingElement {
+				continue
+			}
+			be := el.AsBindingElement()
+			if be == nil {
+				continue
+			}
+			if bindingNameContains(be.Name(), name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func functionBody(funcLike *ast.Node) *ast.Node {
+	switch funcLike.Kind {
+	case ast.KindFunctionDeclaration:
+		return funcLike.AsFunctionDeclaration().Body
+	case ast.KindFunctionExpression:
+		return funcLike.AsFunctionExpression().Body
+	case ast.KindArrowFunction:
+		body := funcLike.AsArrowFunction().Body
+		if body != nil && body.Kind == ast.KindBlock {
+			return body
+		}
+	case ast.KindMethodDeclaration:
+		return funcLike.AsMethodDeclaration().Body
+	case ast.KindGetAccessor:
+		return funcLike.AsGetAccessorDeclaration().Body
+	case ast.KindSetAccessor:
+		return funcLike.AsSetAccessorDeclaration().Body
+	case ast.KindConstructor:
+		return funcLike.AsConstructorDeclaration().Body
+	case ast.KindClassStaticBlockDeclaration:
+		return funcLike.AsClassStaticBlockDeclaration().Body
+	}
+	return nil
+}
+
+// checkDescendant mirrors upstream verbatim: walk JSX-bearing children, report
+// each one whose effective depth (baseDepth + 1, then recursively) exceeds
+// the configured max, and recurse only into JsxElement / JsxFragment children
+// that are non-leaves. JsxExpressionContainer children are treated as leaves
+// (their `.children` is undefined in ESTree), so we do NOT unwrap them and
+// keep walking — doing so would silently fire on shapes upstream never
+// reports.
+func checkDescendant(ctx rule.RuleContext, baseDepth, maxDepth int, children []*ast.Node) {
+	baseDepth++
+	for _, child := range children {
+		if !hasJSX(child) {
+			continue
+		}
+		if baseDepth > maxDepth {
+			report(ctx, child, baseDepth, maxDepth)
+			continue
+		}
+		// `isLeaf` returns true for any non-element/fragment kind (including
+		// JsxExpressionContainer with JSX inner), so the recursion stops at
+		// the same boundaries upstream's `node.children` does.
+		if !isLeaf(child) {
+			checkDescendant(ctx, baseDepth, maxDepth, reactutil.GetJsxChildren(child))
+		}
+	}
+}
+
+var JsxMaxDepthRule = rule.Rule{
+	Name: "react/jsx-max-depth",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		handleJSX := func(node *ast.Node) {
+			// Only the OUTERMOST leaf in a leaf chain reports here; non-leaf
+			// containers are handled implicitly by their descendants firing
+			// the same listener. This mirrors upstream's `if (!isLeaf(node)) return`
+			// and avoids double-counting any container's depth.
+			if !isLeaf(node) {
+				return
+			}
+			d := getDepth(node)
+			if d > opts.max {
+				report(ctx, node, d, opts.max)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxElement:            handleJSX,
+			ast.KindJsxSelfClosingElement: handleJSX,
+			ast.KindJsxFragment:           handleJSX,
+			ast.KindJsxExpression: func(node *ast.Node) {
+				// Upstream gates on `node.expression.type === 'Identifier'`.
+				// tsgo preserves Parens as explicit nodes — peel them so
+				// `{(x)}` resolves identically to `{x}` (espree flattens parens
+				// at the AST level so upstream sees them the same way). TS-only
+				// wrappers (`x as T`, `x!`, `x satisfies T`) are intentionally
+				// NOT peeled to keep upstream's literal Identifier-only match.
+				expr := jsxExpressionInner(node)
+				if expr == nil {
+					return
+				}
+				expr = ast.SkipParentheses(expr)
+				if expr == nil || expr.Kind != ast.KindIdentifier {
+					return
+				}
+				element := findJsxElementOrFragment(expr, ctx.TypeChecker, map[string]bool{}, 0)
+				if element == nil {
+					return
+				}
+				baseDepth := getDepth(node)
+				checkDescendant(ctx, baseDepth, opts.max, reactutil.GetJsxChildren(element))
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/jsx_max_depth/jsx_max_depth.md
+++ b/internal/plugins/react/rules/jsx_max_depth/jsx_max_depth.md
@@ -1,0 +1,120 @@
+# jsx-max-depth
+
+Enforce JSX maximum depth.
+
+## Rule Details
+
+This rule validates a specific depth for JSX elements.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<App>
+  <Foo>
+    <Bar>
+      <Baz />
+    </Bar>
+  </Foo>
+</App>
+```
+
+## Rule Options
+
+It takes one option object with a positive `max` integer (default: `2`).
+
+```json
+{ "react/jsx-max-depth": ["error", { "max": 2 }] }
+```
+
+Examples of **incorrect** code for this rule with `{ "max": 1 }`:
+
+```json
+{ "react/jsx-max-depth": ["error", { "max": 1 }] }
+```
+
+```jsx
+<App>
+  <Foo>
+    <Bar />
+  </Foo>
+</App>
+```
+
+```json
+{ "react/jsx-max-depth": ["error", { "max": 1 }] }
+```
+
+```jsx
+const foobar = (
+  <Foo>
+    <Bar />
+  </Foo>
+);
+<App>{foobar}</App>;
+```
+
+Examples of **incorrect** code for this rule with `{ "max": 2 }`:
+
+```json
+{ "react/jsx-max-depth": ["error", { "max": 2 }] }
+```
+
+```jsx
+<App>
+  <Foo>
+    <Bar>
+      <Baz />
+    </Bar>
+  </Foo>
+</App>
+```
+
+Examples of **correct** code for this rule with `{ "max": 1 }`:
+
+```json
+{ "react/jsx-max-depth": ["error", { "max": 1 }] }
+```
+
+```jsx
+<App>
+  <Hello />
+</App>
+```
+
+Examples of **correct** code for this rule with `{ "max": 2 }`:
+
+```json
+{ "react/jsx-max-depth": ["error", { "max": 2 }] }
+```
+
+```jsx
+<App>
+  <Foo>
+    <Bar />
+  </Foo>
+</App>
+```
+
+Examples of **correct** code for this rule with `{ "max": 3 }`:
+
+```json
+{ "react/jsx-max-depth": ["error", { "max": 3 }] }
+```
+
+```jsx
+<App>
+  <Foo>
+    <Bar>
+      <Baz />
+    </Bar>
+  </Foo>
+</App>
+```
+
+## When Not To Use It
+
+If you are not using JSX then you can disable this rule.
+
+## Original Documentation
+
+- [eslint-plugin-react/docs/rules/jsx-max-depth.md](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-max-depth.md)

--- a/internal/plugins/react/rules/jsx_max_depth/jsx_max_depth_test.go
+++ b/internal/plugins/react/rules/jsx_max_depth/jsx_max_depth_test.go
@@ -1,0 +1,1653 @@
+package jsx_max_depth
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxMaxDepthRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxMaxDepthRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: depth 0 (default max=2) ----
+		{Code: `<App />`, Tsx: true},
+
+		// ---- Upstream: explicit max=1, depth 1 ----
+		{Code: `
+        <App>
+          <foo />
+        </App>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Upstream: default max=2, depth 2 ----
+		{Code: `
+        <App>
+          <foo>
+            <bar />
+          </foo>
+        </App>
+      `, Tsx: true},
+		{Code: `
+        <App>
+          <foo>
+            <bar />
+          </foo>
+        </App>
+      `, Tsx: true, Options: map[string]interface{}{"max": 2}},
+
+		// ---- Upstream: identifier resolution to JSX ----
+		{Code: `
+        const x = <div><em>x</em></div>;
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 2}},
+		{Code: `const foo = (x) => <div><em>{x}</em></div>;`, Tsx: true, Options: map[string]interface{}{"max": 2}},
+
+		// ---- Upstream: fragments ----
+		{Code: `<></>`, Tsx: true},
+		{Code: `
+        <>
+          <foo />
+        </>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		{Code: `
+        const x = <><em>x</em></>;
+        <>{x}</>
+      `, Tsx: true, Options: map[string]interface{}{"max": 2}},
+
+		// ---- Upstream: identifier-resolved table fragment, depth fits max=2 ----
+		{Code: `
+        const x = (
+          <tr>
+            <td>1</td>
+            <td>2</td>
+          </tr>
+        );
+        <tbody>
+          {x}
+        </tbody>
+      `, Tsx: true, Options: map[string]interface{}{"max": 2}},
+
+		// ---- Upstream: function-with-loop returns leaf JSX, max=1 ----
+		{Code: `
+        const Example = props => {
+          for (let i = 0; i < length; i++) {
+            return <Text key={i} />;
+          }
+        };
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Upstream: React.Fragment with an interpolation; default max=2 ----
+		// Inside the React.Fragment the `{ <div /> }` JsxExpression wraps a
+		// JsxSelfClosingElement — but the fragment's only JSX-bearing child IS
+		// that wrapper, and the wrapped element is itself a leaf. The outer
+		// `<div>{A}</div>` resolves A to the React.Fragment, then descends into
+		// its children (the wrapped `<div />`) at baseDepth=1+1=2 which fits.
+		{Code: `
+        export function MyComponent() {
+          const A = <React.Fragment>{<div />}</React.Fragment>;
+          return <div>{A}</div>;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: circular references must not stall the resolver ----
+		{Code: `
+        function Component() {
+          let first = "";
+          const second = first;
+          first = second;
+          return <div id={first} />;
+        };
+      `, Tsx: true},
+		{Code: `
+        function Component() {
+          let first = "";
+          let second = "";
+          let third = "";
+          let fourth = "";
+          const fifth = first;
+          first = second;
+          second = third;
+          third = fourth;
+          fourth = fifth;
+          return <div id={first} />;
+        };
+      `, Tsx: true},
+
+		// ---- Lock-in: parens around the resolved identifier ----
+		// tsgo preserves ParenthesizedExpression as an explicit node; espree
+		// flattens it. We SkipParentheses so `{(x)}` resolves identically to
+		// `{x}` — anything else would silently miss real-world wrapper code.
+		{Code: `
+        const x = <div><span /></div>;
+        <div>{(x)}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 2}},
+
+		// ---- Lock-in: TS-only wrappers are NOT peeled ----
+		// Upstream's `node.expression.type === 'Identifier'` rejects any TS
+		// wrapper outright; we mirror that to keep the diagnostic surface
+		// equal on the same input. `<div>{(x as any)}</div>` therefore does
+		// NOT trigger the resolve path even though the underlying value is JSX.
+		{Code: `
+        const x = <div><span /></div>;
+        <div>{x as any}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		{Code: `
+        const x = <div><span /></div>;
+        <div>{x!}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		{Code: `
+        const x = <div><span /></div>;
+        <div>{x satisfies any}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Lock-in: JSX inside an attribute is at depth 0, not depth 1 ----
+		// The JsxExpression that hosts the attribute value is NOT a JSX
+		// container, so the parent walk for an attribute-positioned `<span/>`
+		// must terminate at the JsxAttribute (count=0). Without this the
+		// attribute would inherit the parent element's depth.
+		{Code: `<div title={<span />} />`, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Lock-in: text-only children remain leaves ----
+		// JsxText nodes never satisfy hasJSX, so an element whose only children
+		// are text is still a leaf — this is what lets `<App />` and
+		// `<div>hello</div>` share the same isLeaf result.
+		{Code: `<div>hello</div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// ---- Lock-in: identifier resolution to a non-JSX value ----
+		// `findJsxElementOrFragment` must return nil when the resolved
+		// initializer is a non-JSX, non-Identifier value (string / number /
+		// object / call). Without that bail the descendant walk would crash
+		// on a missing children list.
+		{Code: `
+        const x = "hello";
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		{Code: `
+        const x = 42;
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// ---- Lock-in: option key with non-numeric value falls back to default ----
+		// Upstream's schema rejects `max: "two"` at config-load; rslint's
+		// option parsing tolerates it by defaulting to max=2 instead of
+		// crashing. Verify the default still applies (depth 2 fits max 2).
+		{Code: `
+        <App>
+          <foo>
+            <bar />
+          </foo>
+        </App>
+      `, Tsx: true, Options: map[string]interface{}{"max": "two"}},
+
+		// ---- Lock-in: reassignment to non-JSX after JSX init also bails ----
+		// Upstream picks the LAST write in source order; if it's neither JSX
+		// nor an Identifier the resolver returns null and no descendant walk
+		// fires. The earlier JSX init is intentionally NOT consulted as a
+		// fallback (mirrors `findJSXElementOrFragment.find` returning on the
+		// first writeExpr seen reverse-iterating).
+		{Code: `
+        let x = <div><span /></div>;
+        x = "";
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Lock-in: parameter binding has no resolvable write ----
+		// `findJSXElementOrFragment` resolves through VariableDeclarations
+		// only. A parameter (with or without default) yields no write
+		// expression — matches upstream which doesn't surface parameter
+		// defaults as `references[].writeExpr` for our purpose either.
+		{Code: `
+        function Foo(x) {
+          return <div>{x}</div>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// ---- Lock-in: destructured binding doesn't resolve ----
+		// Object / array binding patterns aren't tracked; the resolver
+		// returns nil so the descendant walk doesn't fire even if the
+		// destructured value happens to be JSX.
+		{Code: `
+        const { x } = obj;
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// ---- Lock-in: property assignment to a same-name property is NOT a write ----
+		// `obj.x = <JSX>` writes to a property, not the binding `x`. The
+		// reassignment scan must reject anything whose LHS isn't a bare
+		// Identifier matching the binding name. With max=1 the JSX in
+		// `obj.x = ...` doesn't itself violate; if the LHS were
+		// mis-classified, the JsxExpression listener would resolve `x`
+		// through it and flag a 2-deep <span/> descend.
+		{Code: `
+        let x = "hello";
+        obj.x = <div><span /></div>;
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Lock-in: compound assignment is NOT a write ----
+		// Only `=` reassigns the binding; `+=` / `&&=` / etc. are skipped
+		// because they don't produce a fresh JSX value the same way ESLint's
+		// scope manager wouldn't surface them as `writeExpr` either.
+		{Code: `
+        let x = "hello";
+        x += "world";
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// ---- Lock-in: shadowed inner block binding is independent ----
+		// Inner `let x = <div><span/></div>` shadows outer `let x = ""`;
+		// the outer reference resolves to outer's init only and does not
+		// pick up the inner block's write. JSX inside the inner block sits
+		// at depth 1 which fits max=1, so any extra report would only come
+		// from a mis-resolved descend.
+		{Code: `
+        let x = "";
+        if (cond) {
+          let x = <div><span /></div>;
+          void x;
+        }
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Lock-in: function parameter shadows outer binding ----
+		// Inner function with parameter `x` writes to the parameter, not
+		// the outer `let x`. Same depth-1 setup so any leak would surface
+		// via a JsxExpression-listener descend on outer `{x}`.
+		{Code: `
+        let x = "";
+        function inner(x) {
+          x = <div><span /></div>;
+          return x;
+        }
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Lock-in: function-body `let x` shadows the outer binding ----
+		// `function inner() { let x = <div><span/></div>; }` declares its
+		// own `x`; the closure-write descent must skip it.
+		{Code: `
+        let x = "";
+        function inner() {
+          let x = <div><span /></div>;
+          return x;
+        }
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Lock-in: `var` declarations are function-scoped, not block-scoped ----
+		// `if (cond) { var x = <JSX>; }` does NOT shadow at block level;
+		// the inner var hoists to the enclosing function. Verify we don't
+		// crash on the form (we still pick the latest write, which is the
+		// `var` init that lives in the same hoisted scope).
+		{Code: `
+        function Foo() {
+          if (cond) {
+            var x = "";
+          }
+          return <div>{x}</div>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// ---- Lock-in: ConditionalExpression breaks the parent walk ----
+		// `<span/>` inside `{cond ? <span/> : null}` has a ConditionalExpression
+		// parent, which is neither JSX nor JsxExpression. getDepth therefore
+		// stops at count=0 — matching upstream's `while (isJSX || isExpression)`
+		// loop semantics. The `<div>` that surrounds the interpolation does
+		// NOT add to the inner JSX's depth.
+		{Code: `<div>{cond ? <span /> : null}</div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// ---- Lock-in: class component returning JSX from render ----
+		// The parent chain from inner JSX walks through MethodDeclaration /
+		// ClassDeclaration / ReturnStatement — none JSX-like — so depth is
+		// counted correctly within the returned tree only.
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return (
+              <div>
+                <span />
+              </div>
+            );
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Lock-in: arrow with block body returning JSX ----
+		{Code: `
+        const Foo = () => {
+          return (
+            <div>
+              <span />
+            </div>
+          );
+        };
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ---- Lock-in: JsxExpression child wrapping non-leaf JSX is opaque ----
+		// `checkDescendant` must NOT recurse through a JsxExpressionContainer
+		// to inspect its inner JSX's children. Upstream's `isLeaf` returns
+		// true for any node without a `.children` field (including JSX
+		// expression containers), so for max=2 the JsxExpression child sits
+		// at baseDepth=2 and reports nothing — even though the wrapped
+		// `<div><span/></div>` would itself violate at depth 3.
+		{Code: `
+        const A = <Fragment>{<div><span /></div>}</Fragment>;
+        <div>{A}</div>;
+      `, Tsx: true, Options: map[string]interface{}{"max": 3}},
+
+		// ====== Option-shape coverage ======
+		// Each shape exercises a different `parseOptions` branch.
+		// nil options (no second-position arg from JS) → defaults.
+		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: nil},
+		// Empty array (`[]`) → defaults.
+		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: []interface{}{}},
+		// Empty object (`[{}]`) → defaults.
+		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{}},
+		// Numeric string `"2"` falls through to default rather than parsing
+		// (mirrors upstream's `has(option, 'max') ? option.max : 2` — when
+		// `max` IS present but isn't a number, ESLint also fails the schema
+		// at config-load and disables the rule). We default to be lenient.
+		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{"max": "2"}},
+		// `max: false` (boolean) → defaults.
+		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{"max": false}},
+		// `max: null` → defaults.
+		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{"max": nil}},
+		// Negative `max: -1` → defaults (upstream schema enforces minimum 0;
+		// we silently fall back to default rather than crashing).
+		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{"max": -1}},
+		// Unknown extra option keys are ignored.
+		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{"max": 2, "unknown": true}},
+		// max=100 — anything fits.
+		{Code: `
+        <a><b><c><d><e><f><g><h><i /></h></g></f></e></d></c></b></a>
+      `, Tsx: true, Options: map[string]interface{}{"max": 100}},
+
+		// ====== JsxExpression inner shapes that are NOT Identifier ======
+		// `{this.x}` — PropertyAccessExpression. Listener bails immediately.
+		{Code: `<div>{this.x}</div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// `{x?.y}` — optional chain. Bail.
+		{Code: `<div>{x?.y}</div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// `{x()}` — call expression. Bail.
+		{Code: `<div>{makeJSX()}</div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// `{...arr}` — spread (parsed as JsxExpression with no inner Identifier).
+		{Code: `<div>{...arr}</div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// `{}` — empty JsxExpression has nil inner; listener returns early.
+		{Code: `<div>{}</div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// `{/* comment */}` — JsxExpression whose inner is nil after the
+		// comment scrub; listener returns early.
+		{Code: `<div>{/* nothing */}</div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// `{x + y}` — binary expression. Bail.
+		{Code: `<div>{x + y}</div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// `{cond && <span/>}` — logical-and rendering pattern. Inner is
+		// BinaryExpression, listener bails. The inner <span/> is reachable
+		// via the leaf listener at depth 0 (LogicalExpression breaks parent
+		// walk), which fits max=0.
+		{Code: `<div>{cond && <span />}</div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// ====== Real React patterns ======
+		// Render-prop fallback: JSX in attribute is depth 0 regardless of
+		// the surrounding component depth.
+		{Code: `
+        <Suspense fallback={<Loading />}>
+          <App />
+        </Suspense>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// Render-prop function: arrow body is a fresh scope; its JSX depth
+		// starts at 0 even when invoked from a deeply nested element.
+		{Code: `
+        <Provider>
+          <Consumer>
+            {(value) => <span>{value}</span>}
+          </Consumer>
+        </Provider>
+      `, Tsx: true, Options: map[string]interface{}{"max": 2}},
+		// Iteration via .map: `<li>` rendered per item — leaf depth 0
+		// inside the arrow body.
+		{Code: `<ul>{items.map((item) => <li>{item}</li>)}</ul>`, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// useMemo/useCallback returning JSX: `useMemo(() => <div/>, deps)` —
+		// the call result isn't followed.
+		{Code: `
+        const Foo = () => {
+          const memo = useMemo(() => <div><span /></div>, []);
+          return <div>{memo}</div>;
+        };
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// JSX inside a default parameter — parameter binding is not tracked.
+		{Code: `
+        function Foo({ children = <span /> }) {
+          return <div>{children}</div>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// ====== Identifier resolution edge cases ======
+		// `let x = x;` — self-init. Cycle detection bails.
+		{Code: `
+        let x = x;
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// Mutual aliasing.
+		{Code: `
+        let x = y;
+        let y = x;
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// Long aliasing chain (well within the 32-step cap), terminating
+		// at a non-JSX init.
+		{Code: `
+        let a = "";
+        let b = a;
+        let c = b;
+        let d = c;
+        let e = d;
+        <div>{e}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// Resolution to a function call result — non-JSX, non-Identifier.
+		{Code: `
+        const x = makeJSX();
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// ====== JSX shape edges ======
+		// Empty fragment.
+		{Code: `<></>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// Empty element.
+		{Code: `<div></div>`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// JSX with comments interleaved between children.
+		{Code: `
+        <div>
+          {/* comment */}
+          <span />
+        </div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// JSX with spread attribute — attributes don't influence depth.
+		{Code: `
+        <div {...props}>
+          <span {...spanProps} />
+        </div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// Multi-level member-access tag `<a.b.c.d/>` — single JSX node.
+		{Code: `<a.b.c.d />`, Tsx: true, Options: map[string]interface{}{"max": 0}},
+		// JSX as the right-hand side of an arrow with concise body.
+		{Code: `const F = () => <div><span /></div>;`, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ====== Reassignment inside diverse control flow ======
+		// Reassign in `try` block.
+		{Code: `
+        function Foo() {
+          let x = "";
+          try { x = <div />; } catch (e) {}
+          return <div>{x}</div>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// Reassign in `catch` block.
+		{Code: `
+        function Foo() {
+          let x = "";
+          try {} catch (e) { x = <div />; }
+          return <div>{x}</div>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// Reassign in `finally` block.
+		{Code: `
+        function Foo() {
+          let x = "";
+          try {} finally { x = <div />; }
+          return <div>{x}</div>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// Reassign in `while` body.
+		{Code: `
+        function Foo() {
+          let x = "";
+          while (cond) { x = <div />; }
+          return <div>{x}</div>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// Reassign in `switch` case.
+		{Code: `
+        function Foo() {
+          let x = "";
+          switch (kind) {
+            case "a": x = <div />; break;
+          }
+          return <div>{x}</div>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ====== For-loop init scope isolation ======
+		// Outer `let x = <a/>` and an inner `for (let x of items)` — uses
+		// of `x` inside the loop body resolve to the for-init binding, NOT
+		// the outer let. The outer let's writes must not leak in.
+		{Code: `
+        let x = <a />;
+        function Foo() {
+          for (let x of items) {
+            return <div>{x}</div>;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// `for (let x = ...; ...; ...)` — same isolation.
+		{Code: `
+        let x = <a />;
+        function Foo() {
+          for (let x = 0; x < n; x++) {
+            return <span key={x} />;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// `for (let x in obj)` — same isolation.
+		{Code: `
+        let x = <a />;
+        function Foo() {
+          for (let x in obj) {
+            return <span key={x} />;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// `for (const x of items)` followed by use OUTSIDE the loop — the
+		// outer `x` resolves to the outer declaration. With shadow check
+		// honoured, the inner for-init `x` doesn't leak out.
+		{Code: `
+        let x = "";
+        for (const x of items) { void x; }
+        <div>{x}</div>
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+
+		// Reassignment inside an inner for-of `let x` body MUST NOT leak
+		// to outer same-name binding. Differential-validated against upstream.
+		{Code: `
+        let x = "";
+        for (let x of items) { x = <div><span /></div>; }
+        <wrap>{x}</wrap>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// Same scenario for `for (let x = …; …; …)`.
+		{Code: `
+        let x = "";
+        for (let x = 0; x < n; x++) { x = <div><span /></div>; }
+        <wrap>{x}</wrap>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// CatchClause parameter shadows outer `let x`; reassignment to
+		// the catch param MUST NOT leak. Differential-validated.
+		{Code: `
+        let x = "";
+        try { foo(); } catch (x) { x = <div><span /></div>; }
+        <wrap>{x}</wrap>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// Destructured catch param: `catch ({ name })` also shadows.
+		{Code: `
+        let err = "";
+        try { foo(); } catch ({ err }) { err = <div><span /></div>; }
+        <wrap>{err}</wrap>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// for-in variant.
+		{Code: `
+        let k = "";
+        for (let k in obj) { k = <div><span /></div>; }
+        <wrap>{k}</wrap>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ====== Parameter / destructured-param default tracking ======
+		// Bare parameter with default JSX that fits max=1.
+		{Code: `
+        function Foo(x = <a />) {
+          return <wrap>{x}</wrap>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// Destructured parameter with default JSX that fits max=1 (depth 1
+		// inside <div>{children}</div> + 0-depth default <span/> = 1).
+		{Code: `
+        function Foo({ children = <span /> }) {
+          return <div>{children}</div>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		// Reassign parameter in body to non-JSX — latest write bails.
+		{Code: `
+        function Foo(x = <div><span /></div>) {
+          x = "";
+          return <wrap>{x}</wrap>;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ====== Switch case-let scope ======
+		// `let x` declared in case 'a' is visible in case 'b' (per ES2015
+		// CaseBlock scoping). Resolution must descend into clauses.
+		// max=1 with x → <a/> (shallow): no descent violation.
+		{Code: `
+        function Foo(kind) {
+          switch (kind) {
+            case 'a': let x = <a />; break;
+            case 'b': return <wrap>{x}</wrap>;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ====== Destructured const default is NOT tracked as writeExpr ======
+		// Differential validation against upstream confirms: for
+		// `const { x = <jsx> } = obj`, ESLint's scope manager surfaces
+		// the destructure RHS (`obj`), NOT the default, as `writeExpr`.
+		// So even a default that would violate max=1 produces ZERO reports.
+		// The same holds for `let { x = <jsx> } = obj`. Parameter destructure
+		// (`function f({ x = <jsx> })`) DOES track the default — see the
+		// invalid suite for that contrast.
+		{Code: `
+        const { x = <a /> } = obj;
+        <wrap>{x}</wrap>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		{Code: `
+        const { x = <div><span /></div> } = obj;
+        <wrap>{x}</wrap>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		{Code: `
+        let { x = <div><span /></div> } = obj;
+        <wrap>{x}</wrap>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+		{Code: `
+        const [x = <div><span /></div>] = arr;
+        <wrap>{x}</wrap>
+      `, Tsx: true, Options: map[string]interface{}{"max": 1}},
+
+		// ====== for-of with destructured pattern ======
+		// `for (const { x } of items)` — body uses x. No default, no
+		// reassignment in body, so no resolution either way. Just verify
+		// the destructure doesn't crash the resolver.
+		{Code: `
+        function Foo() {
+          for (const { x } of items) {
+            return <wrap>{x}</wrap>;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"max": 0}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: max=0 with depth 1 ----
+		{
+			Code: `
+        <App>
+          <foo />
+        </App>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 0},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Message: "Expected the depth of nested jsx elements to be <= 0, but found 1.", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: max=0 with depth 1, JsxExpression child whose inner is non-JSX ----
+		// `<foo>{bar}</foo>` is a leaf because `{bar}` is an Identifier, not JSX.
+		{
+			Code: `
+        <App>
+          <foo>{bar}</foo>
+        </App>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 0},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: max=1 with depth 2 ----
+		{
+			Code: `
+        <App>
+          <foo>
+            <bar />
+          </foo>
+        </App>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: identifier-resolved JSX puts <span/> at depth 2 ----
+		{
+			Code: `
+        const x = <div><span /></div>;
+        <div>{x}</div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- Upstream: chain through a re-binding `let y = x` ----
+		{
+			Code: `
+        const x = <div><span /></div>;
+        let y = x;
+        <div>{y}</div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- Upstream: two interpolations report independently ----
+		{
+			Code: `
+        const x = <div><span /></div>;
+        let y = x;
+        <div>{x}-{y}</div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 24},
+				{MessageId: "wrongDepth", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- Upstream: inline `{<div>...</div>}` — JsxExpression with JSX
+		// inner does NOT trigger the identifier path; <span/> reports via
+		// the leaf listener at depth 3.
+		{
+			Code: `
+        <div>
+        {<div><div><span /></div></div>}
+        </div>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 3, Column: 20},
+			},
+		},
+
+		// ---- Upstream: fragment, max=0, depth 1 ----
+		{
+			Code: `
+        <>
+          <foo />
+        </>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 0},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: nested fragments, max=1, depth 2 ----
+		{
+			Code: `
+        <>
+          <>
+            <bar />
+          </>
+        </>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: fragment-wrapped duplicate interpolations ----
+		{
+			Code: `
+        const x = <><span /></>;
+        let y = x;
+        <>{x}-{y}</>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 21},
+				{MessageId: "wrongDepth", Line: 2, Column: 21},
+			},
+		},
+
+		// ---- Upstream: identifier-resolved table — both <td>s exceed max=1 ----
+		{
+			Code: `
+        const x = (
+          <tr>
+            <td>1</td>
+            <td>2</td>
+          </tr>
+        );
+        <tbody>
+          {x}
+        </tbody>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 13},
+				{MessageId: "wrongDepth", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Upstream: deeply nested modal scaffold, max=4 ----
+		// Only the inner <Button> reports — its leaf-checked depth is 5, while
+		// every other container at depth 4 either has a leaf body that fits
+		// (Icon, content div) or is a non-leaf container that defers to its
+		// descendants.
+		{
+			Code: `
+        <div className="custom_modal">
+          <Modal className={classes.modal} open={isOpen} closeAfterTransition>
+            <Fade in={isOpen}>
+              <DialogContent>
+                <Icon icon="cancel" onClick={onClose} popoverText="Close Modal" />
+                <div className="modal_content">{children}</div>
+                <div className={clsx('modal_buttons', classes.buttons)}>
+                  <Button className="modal_buttons--cancel" onClick={onCancel}>
+                    {cancelMsg ? cancelMsg : 'Cancel'}
+                  </Button>
+                </div>
+              </DialogContent>
+            </Fade>
+          </Modal>
+        </div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 4},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 9, Column: 19},
+			},
+		},
+
+		// ---- Lock-in: parens around resolved identifier still report ----
+		{
+			Code: `
+        const x = <div><span /></div>;
+        <div>{(x)}</div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- Lock-in: array option shape (matches multi-element CLI config) ----
+		// utils.GetOptionsMap unwraps a single-element array; verify that the
+		// `max` key still parses through the array path.
+		{
+			Code: `
+        <App>
+          <foo />
+        </App>
+      `,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"max": 0}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Lock-in: Fragment-wrapped JSX inside an interpolation ----
+		// `<><span /></>` inside `{<><span /></>}` is reachable via the leaf
+		// listener path: the outer `<div>` is non-leaf (has a JsxExpression
+		// child whose inner is JSX), the JsxExpression listener no-ops
+		// (inner is JSX, not Identifier), and `<span />` reports as a leaf
+		// at depth = outer-div + Fragment + (JsxExpression skipped) = 2.
+		{
+			Code: `
+        <div>{<><span /></>}</div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 17},
+			},
+		},
+
+		// ---- Reassignment: latest write wins (matches upstream) ----
+		// `let x = ""` followed by `x = <div><span/></div>` puts the JSX
+		// reassignment LATER in source order. ESLint's scope manager picks
+		// it as the reference's write expression; we mirror that by scanning
+		// every `name = expr` in the binding's enclosing scope.
+		{
+			Code: `
+        let x = "";
+        x = <div><span /></div>;
+        <div>{x}</div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 3, Column: 18},
+			},
+		},
+
+		// ---- Reassignment: declaration without initializer ----
+		// `let x;` produces no write expression, then `x = <JSX>` is the
+		// only write. The scan picks it up.
+		{
+			Code: `
+        let x;
+        x = <div><span /></div>;
+        <div>{x}</div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 3, Column: 18},
+			},
+		},
+
+		// ---- Reassignment: multiple writes, latest wins ----
+		// Three writes — declaration init `<a/>`, reassignment `<b><c/></b>`,
+		// reassignment `<d><e><f/></e></d>`. The deepest violation comes
+		// from the LAST write in source order; the earlier writes are
+		// silenced. (Upstream takes the same "first reverse-iter" branch.)
+		//
+		// Two reports fire in traversal order:
+		//   - `<f/>` leaf via the leaf listener while traversing the third
+		//     reassignment (depth=2 > 1).
+		//   - `<e>` via the JsxExpression listener on the later `{x}` site,
+		//     which resolves to the latest write `<d><e><f/></e></d>` and
+		//     reports `<e>` at baseDepth=2 > 1.
+		{
+			Code: `
+        let x = <a />;
+        x = <b><c /></b>;
+        x = <d><e><f /></e></d>;
+        <div>{x}</div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 19},
+				{MessageId: "wrongDepth", Line: 4, Column: 16},
+			},
+		},
+
+		// ---- Reassignment: inside an `if` branch ----
+		// The reassignment lives in an inner Block, but the binding's scope
+		// is the enclosing function body — the scan must descend through
+		// nested Blocks.
+		{
+			Code: `
+        function Foo() {
+          let x = "";
+          if (cond) {
+            x = <div><span /></div>;
+          }
+          return <div>{x}</div>;
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 5, Column: 22},
+			},
+		},
+
+		// ---- Reassignment: closure write from a non-shadowing inner function ----
+		// Inner function does NOT redeclare `x`, so its write to `x` is a
+		// closure write to the outer binding. ESLint's scope manager tracks
+		// this via the variable's reference list; we descend into inner
+		// function bodies that don't shadow `name`.
+		{
+			Code: `
+        function outer() {
+          let x = "";
+          function inner() {
+            x = <div><span /></div>;
+          }
+          return <div>{x}</div>;
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 5, Column: 22},
+			},
+		},
+
+		// ---- Reassignment chain: y → x with x reassigned to JSX ----
+		// `let y = x` (init = Identifier x). Recurse on x. x's latest write
+		// is the JSX reassignment, not the empty-string init.
+		{
+			Code: `
+        let x = "";
+        x = <div><span /></div>;
+        let y = x;
+        <div>{y}</div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 3, Column: 18},
+			},
+		},
+
+		// ---- Reassignment: multi-decl statement `let a, b = <JSX>, c` ----
+		// Multiple declarations in one VariableStatement — the scan must
+		// pick the right one by Identifier name.
+		{
+			Code: `
+        let a = 1, b = <div><span /></div>, c = 3;
+        <div>{b}</div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 29},
+			},
+		},
+
+		// ---- Class component returning deep JSX violates max=1 ----
+		// Locks in the leaf listener's behavior across the full
+		// MethodDeclaration → ClassDeclaration → SourceFile parent chain.
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return (
+              <div>
+                <div>
+                  <span />
+                </div>
+              </div>
+            );
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 7, Column: 19},
+			},
+		},
+
+		// ---- Class field arrow returning deep JSX ----
+		// `class C { render = () => (<div><div><span/></div></div>); }` —
+		// arrow stored as a class field, not a method. Same depth count
+		// applies; only the parent chain shape is different.
+		{
+			Code: `
+        class Foo extends React.Component {
+          render = () => (
+            <div>
+              <div>
+                <span />
+              </div>
+            </div>
+          );
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 6, Column: 17},
+			},
+		},
+
+		// ---- TS generic component tag ----
+		// `<Foo<string>>` parses as a JsxOpeningElement with type-argument;
+		// the rule must treat it as a normal JSX element so its child
+		// depth still counts.
+		{
+			Code: `
+        <Foo<string>>
+          <Bar>
+            <Baz />
+          </Bar>
+        </Foo>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Member-access tag name ----
+		// `<Module.Foo>` is a single JsxElement with a PropertyAccess tag —
+		// IsJsxLike must still match it for the parent walk and leaf check.
+		{
+			Code: `
+        <Module.Foo>
+          <Bar>
+            <Baz />
+          </Bar>
+        </Module.Foo>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Namespaced tag name ----
+		// `<svg:line/>` uses JsxNamespacedName as the tag — same handling.
+		{
+			Code: `
+        <svg>
+          <svg:g>
+            <svg:line />
+          </svg:g>
+        </svg>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Deep fragment chain — every level counts ----
+		// `<><><><><x/></></></></>` puts <x/> at depth 4. Default max=2.
+		{
+			Code: `
+        <>
+          <>
+            <>
+              <>
+                <x />
+              </>
+            </>
+          </>
+        </>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 6, Column: 17},
+			},
+		},
+
+		// ---- Mixed element / fragment nesting ----
+		// Verify counting works the same regardless of which JsxKind sits
+		// at each level.
+		{
+			Code: `
+        <App>
+          <>
+            <Foo>
+              <Bar />
+            </Foo>
+          </>
+        </App>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"max": 2},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 5, Column: 15},
+			},
+		},
+
+		// ====== Boundary depth + message-data alignment ======
+		// max=0 with depth-1 leaf — exact message text alignment. The
+		// `{{found}}` / `{{needed}}` interpolation must produce ESLint's
+		// exact wording.
+		{
+			Code: `<App><foo /></App>`,
+			Tsx:  true, Options: map[string]interface{}{"max": 0},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Message: "Expected the depth of nested jsx elements to be <= 0, but found 1.", Line: 1, Column: 6},
+			},
+		},
+		// max=0 with depth-2 leaf — only the LEAF reports (depth 2),
+		// non-leaf containers don't fire. Message data: found=2 needed=0.
+		{
+			Code: `<App><foo><bar /></foo></App>`,
+			Tsx:  true, Options: map[string]interface{}{"max": 0},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Message: "Expected the depth of nested jsx elements to be <= 0, but found 2.", Line: 1, Column: 11},
+			},
+		},
+		// Off-by-one: max=2 with depth-3 leaf reports; depth-2 sibling
+		// doesn't. Verifies the strict `>` comparison.
+		{
+			Code: `<a><b><c><d /></c></b></a>`,
+			Tsx:  true, Options: map[string]interface{}{"max": 2},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Message: "Expected the depth of nested jsx elements to be <= 2, but found 3.", Line: 1, Column: 10},
+			},
+		},
+		// Large max value with deeper actual: max=5, depth=6.
+		{
+			Code: `<a><b><c><d><e><f><g /></f></e></d></c></b></a>`,
+			Tsx:  true, Options: map[string]interface{}{"max": 5},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Message: "Expected the depth of nested jsx elements to be <= 5, but found 6.", Line: 1, Column: 19},
+			},
+		},
+
+		// ====== Leaf vs non-leaf in same container ======
+		// Two siblings — one leaf at over-depth, one non-leaf that itself
+		// contains a deeper leaf. Both should report at their own leaves.
+		{
+			Code: `
+        <a>
+          <b />
+          <c><d /></c>
+        </a>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 14},
+			},
+		},
+
+		// ====== Reassignment in control flow that DOES exceed ======
+		// While-loop body with deep JSX reassignment.
+		{
+			Code: `
+        function Foo() {
+          let x = "";
+          while (cond) { x = <div><span /></div>; }
+          return <div>{x}</div>;
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 35},
+			},
+		},
+		// Try-catch reassignment.
+		{
+			Code: `
+        function Foo() {
+          let x = "";
+          try { x = <div><span /></div>; } catch (e) {}
+          return <div>{x}</div>;
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 26},
+			},
+		},
+		// Switch case reassignment.
+		{
+			Code: `
+        function Foo() {
+          let x = "";
+          switch (kind) {
+            case "deep": x = <div><span /></div>; break;
+          }
+          return <div>{x}</div>;
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 5, Column: 35},
+			},
+		},
+
+		// ====== Closure descent through TWO function levels ======
+		// Reassign happens inside a nested function whose own body doesn't
+		// shadow `x`. Walking must descend through both layers.
+		{
+			Code: `
+        function outer() {
+          let x = "";
+          function mid() {
+            function inner() {
+              x = <div><span /></div>;
+            }
+          }
+          return <div>{x}</div>;
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 6, Column: 24},
+			},
+		},
+
+		// ====== Multiple use sites of the same binding ======
+		// Three `{x}` interpolations — each reports independently.
+		{
+			Code: `
+        const x = <div><span /></div>;
+        <div>{x}{x}{x}</div>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 24},
+				{MessageId: "wrongDepth", Line: 2, Column: 24},
+				{MessageId: "wrongDepth", Line: 2, Column: 24},
+			},
+		},
+
+		// ====== Resolution chain length ======
+		// y → x where x is reassigned to JSX in source: chain still works.
+		{
+			Code: `
+        let x = "";
+        let y = x;
+        x = <div><span /></div>;
+        <div>{y}</div>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 18},
+			},
+		},
+
+		// ====== Destructured parameter default IS tracked as a write ======
+		// `function Foo({ children = <div><span/></div> })` — the BindingElement
+		// default seeds the write list, so `<div>{children}</div>` resolves
+		// children → <div><span/></div> and the descendant walk reports at
+		// depth 2. The leaf listener also reports the SAME `<span/>` from the
+		// default at depth 1 — two reports total at the same position.
+		{
+			Code: `
+        function Foo({ children = <div><span /></div> }) {
+          return <div>{children}</div>;
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 0},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 40},
+				{MessageId: "wrongDepth", Line: 2, Column: 40},
+			},
+		},
+
+		// ====== Multibyte source positions ======
+		// Multibyte chars in JsxText shift byte offsets but UTF-16 column
+		// counts (which rslint emits) align with what ESLint reports for
+		// the same source.
+		{
+			Code: `
+        <App>
+          <foo>日本語</foo>
+          <bar><baz /></bar>
+        </App>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 16},
+			},
+		},
+
+		// ====== Nested resolution: y → x, both reassigned ======
+		// y's latest write is `<a><b/></a>` (Identifier x is overwritten).
+		// Without latest-write tracking, we'd resolve y to x → ... and miss.
+		{
+			Code: `
+        let x = "";
+        let y = "";
+        x = <div><span /></div>;
+        y = <a><b /></a>;
+        <div>{y}</div>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 5, Column: 16},
+			},
+		},
+
+		// ====== Same-line multi-element ======
+		// All on one line — verifies column counting without leading
+		// indentation.
+		{
+			Code: `<a><b><c /></b></a>`,
+			Tsx:  true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 1, Column: 7},
+			},
+		},
+
+		// ====== TS generic with multiple type args ======
+		{
+			Code: `
+        <Foo<string, number>>
+          <Bar>
+            <Baz />
+          </Bar>
+        </Foo>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 13},
+			},
+		},
+
+		// ====== Stress: aliasing chain to a deep JSX value ======
+		// e → d → c → b → a, where a's reassignment goes deeper.
+		{
+			Code: `
+        let a = "";
+        const b = a;
+        const c = b;
+        const d = c;
+        const e = d;
+        a = <div><span /></div>;
+        <div>{e}</div>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 7, Column: 18},
+			},
+		},
+
+		// ====== For-init binding reassigned to JSX in loop body ======
+		// `for (let x of items)` followed by `x = <JSX>` in body — the
+		// reassignment IS within the for-init binding's scope (the entire
+		// ForStatement), so resolution picks it up. Without ForStatement
+		// scope detection, we'd attribute the write to the wrong binding.
+		{
+			Code: `
+        function Foo() {
+          for (let x of items) {
+            x = <div><span /></div>;
+            return <div>{x}</div>;
+          }
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 22},
+			},
+		},
+
+		// `for (let x = init; ...; ...)` reassigned in body to deeper JSX.
+		{
+			Code: `
+        function Foo() {
+          for (let x = <a />; cond; ) {
+            x = <div><span /></div>;
+            return <div>{x}</div>;
+          }
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 22},
+			},
+		},
+
+		// ====== Parameter default JSX exceeds via descend ======
+		// `function Foo(x = <div><span/></div>)` — parameter default has
+		// depth 1 (so leaf listener at <span/> is OK with max=1), but the
+		// `<wrap>{x}</wrap>` resolves x → <div><span/></div> and the
+		// descend reports <span/> at baseDepth 2.
+		{
+			Code: `
+        function Foo(x = <div><span /></div>) {
+          return <wrap>{x}</wrap>;
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 31},
+			},
+		},
+
+		// ====== Switch case-let scope (cross-clause resolution) ======
+		// `let x = <div><span/></div>` declared in case 'a' is visible in
+		// case 'b'. Descent into clauses MUST find it.
+		{
+			Code: `
+        function Foo(kind) {
+          switch (kind) {
+            case 'a': let x = <div><span /></div>; break;
+            case 'b': return <wrap>{x}</wrap>;
+          }
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 36},
+			},
+		},
+
+		// ====== Destructured const reassigned in scope ======
+		// `const { x } = obj; x = <jsx>` — even though `const` re-assignment
+		// is a runtime TypeError, it parses and ESLint's scope picks it up.
+		// We mirror that.
+		{
+			Code: `
+        const { x } = obj;
+        x = <div><span /></div>;
+        <wrap>{x}</wrap>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 3, Column: 18},
+			},
+		},
+
+		// ====== Parameter reassigned in body (latest wins) ======
+		// `x` parameter reassigned in body to deeper JSX.
+		{
+			Code: `
+        function Foo(x = <a />) {
+          x = <div><span /></div>;
+          return <wrap>{x}</wrap>;
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 3, Column: 20},
+			},
+		},
+
+		// ====== Resolution chain crosses a shadowed binding ======
+		// Outer `x` is `<a/>` (shallow), inner shadow is `<b><c/></b>`.
+		// `y = x` inside inner refers to inner x. Walk through `let y`
+		// initializer must resolve x in the inner scope and pick the inner
+		// JSX, not the outer one. With max=1, <c/> at depth 2 must fire.
+		{
+			Code: `
+        const x = <a />;
+        function inner() {
+          const x = <b><c /></b>;
+          const y = x;
+          return <div>{y}</div>;
+        }
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 24},
+			},
+		},
+
+		// ====== Fragment at top level wrapping deeper JSX ======
+		// Top-level Fragment counts toward depth from its child JSX.
+		{
+			Code: `
+        <>
+          <App>
+            <Child />
+          </App>
+        </>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 4, Column: 13},
+			},
+		},
+
+		// ====== Mixed Fragment + Element five levels deep ======
+		// Each level (regardless of Fragment vs Element) increments depth.
+		// max=3 with depth 4 → leaf reports.
+		{
+			Code: `
+        <Outer>
+          <>
+            <Mid>
+              <>
+                <Leaf />
+              </>
+            </Mid>
+          </>
+        </Outer>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 3},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 6, Column: 17},
+			},
+		},
+
+		// ====== Reassignment latest-wins picks NON-violating value ======
+		// First reassignment `<a><b/></a>` violates max=1, but a later
+		// reassignment to a flatter `<x/>` is the latest. Resolution must
+		// pick the latest, so the JsxExpression listener finds no
+		// violation through `{r}` — but the leaf listener still fires on
+		// `<b/>` at line 3 (its source-level depth=1 only, fits max=1, OK)
+		// and only the second reassignment's `<x/>` is at depth 0. The
+		// JsxExpression listener thus produces ZERO reports — moved to
+		// Valid. Lock in via the inverse: a deeper JSX in latest write.
+		// (See valid suite for the matching "latest win, fits" case.)
+
+		// ====== JSX in array literal — each element is depth 0 ======
+		// Ensure JSX siblings inside an ArrayLiteralExpression don't add
+		// depth to each other. `<b/>` inside `[<a/>, <b/>, <c/>]` is leaf
+		// depth 0 — and the rule only sees them via the leaf listener.
+		// max=0 fits because depth is 0 for all of them. Locked here as
+		// invalid by adding nesting inside one element.
+		{
+			Code: `
+        const arr = [<a />, <b><c /></b>, <d />];
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 0},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 32},
+			},
+		},
+
+		// ====== Long alias chain hits the depth cap ======
+		// 32+ aliasing levels should bail without infinite recursion.
+		// Even though semantically the chain terminates at JSX, our cap
+		// trips first — no diagnostic, no crash. Locks the cap behavior;
+		// upstream's `containDuplicates` set serves the same purpose, just
+		// detected differently.
+		{
+			Code: `
+        const a0 = <div><span /></div>;
+        const a1 = a0;
+        const a2 = a1; const a3 = a2; const a4 = a3; const a5 = a4;
+        const a6 = a5; const a7 = a6; const a8 = a7; const a9 = a8;
+        const a10 = a9; const a11 = a10; const a12 = a11; const a13 = a12;
+        const a14 = a13; const a15 = a14; const a16 = a15; const a17 = a16;
+        const a18 = a17; const a19 = a18; const a20 = a19; const a21 = a20;
+        const a22 = a21; const a23 = a22; const a24 = a23; const a25 = a24;
+        const a26 = a25; const a27 = a26; const a28 = a27; const a29 = a28;
+        const a30 = a29; const a31 = a30; const a32 = a31;
+        // a32 → a31 → ... → a0 → JSX. Chain length 33 > cap.
+        // Resolution bails; only the leaf listener fires on the original
+        // <span/> at depth 1 — which violates max=0.
+        <div>{a32}</div>
+      `,
+			Tsx: true, Options: map[string]interface{}{"max": 0},
+			// Single report from the leaf listener at the original <span/>.
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongDepth", Line: 2, Column: 25},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -100,6 +100,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-first-prop-new-line.test.ts',
     './tests/eslint-plugin-react/rules/jsx-handler-names.test.ts',
     './tests/eslint-plugin-react/rules/jsx-key.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-max-depth.test.ts',
     './tests/eslint-plugin-react/rules/jsx-max-props-per-line.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-bind.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-comment-textnodes.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-max-depth.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-max-depth.test.ts
@@ -1,0 +1,1165 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-max-depth', {} as never, {
+  valid: [
+    // ---- Default max=2 ----
+    { code: `<App />` },
+    {
+      code: `
+        <App>
+          <foo>
+            <bar />
+          </foo>
+        </App>
+      `,
+    },
+
+    // ---- Explicit max=1, depth 1 ----
+    {
+      code: `
+        <App>
+          <foo />
+        </App>
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        <App>
+          <foo>
+            <bar />
+          </foo>
+        </App>
+      `,
+      options: [{ max: 2 }],
+    },
+
+    // ---- Identifier resolution to JSX ----
+    {
+      code: `
+        const x = <div><em>x</em></div>;
+        <div>{x}</div>;
+      `,
+      options: [{ max: 2 }],
+    },
+    {
+      code: `const foo = (x) => <div><em>{x}</em></div>;`,
+      options: [{ max: 2 }],
+    },
+
+    // ---- Fragments ----
+    { code: `<></>;` },
+    {
+      code: `
+        <>
+          <foo />
+        </>
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        const x = <><em>x</em></>;
+        <>{x}</>;
+      `,
+      options: [{ max: 2 }],
+    },
+
+    // ---- Identifier-resolved table fragment, depth fits max=2 ----
+    {
+      code: `
+        const x = (
+          <tr>
+            <td>1</td>
+            <td>2</td>
+          </tr>
+        );
+        <tbody>
+          {x}
+        </tbody>
+      `,
+      options: [{ max: 2 }],
+    },
+
+    // ---- Function-with-loop returns leaf JSX, max=1 ----
+    {
+      code: `
+        const Example = props => {
+          for (let i = 0; i < length; i++) {
+            return <Text key={i} />;
+          }
+        };
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- React.Fragment with an interpolation ----
+    {
+      code: `
+        export function MyComponent() {
+          const A = <React.Fragment>{<div />}</React.Fragment>;
+          return <div>{A}</div>;
+        }
+      `,
+    },
+
+    // ---- Circular references (single level) ----
+    {
+      code: `
+        function Component() {
+          let first = "";
+          const second = first;
+          first = second;
+          return <div id={first} />;
+        }
+      `,
+    },
+
+    // ---- Circular references (multi level) ----
+    {
+      code: `
+        function Component() {
+          let first = "";
+          let second = "";
+          let third = "";
+          let fourth = "";
+          const fifth = first;
+          first = second;
+          second = third;
+          third = fourth;
+          fourth = fifth;
+          return <div id={first} />;
+        }
+      `,
+    },
+
+    // ---- tsgo preserves parens; SkipParentheses keeps `{(x)}` aligned ----
+    {
+      code: `
+        const x = <div><span /></div>;
+        <div>{(x)}</div>;
+      `,
+      options: [{ max: 2 }],
+    },
+
+    // ---- TS-only wrappers do NOT trigger the resolve path ----
+    {
+      code: `
+        const x = <div><span /></div>;
+        <div>{x as any}</div>;
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        const x = <div><span /></div>;
+        <div>{x!}</div>;
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- JSX inside an attribute is at depth 0 ----
+    { code: `<div title={<span />} />`, options: [{ max: 1 }] },
+
+    // ---- Text-only children remain leaves ----
+    { code: `<div>hello</div>`, options: [{ max: 0 }] },
+
+    // ---- Identifier resolution to non-JSX ----
+    {
+      code: `
+        const x = "hello";
+        <div>{x}</div>;
+      `,
+      options: [{ max: 0 }],
+    },
+    {
+      code: `
+        const x = 42;
+        <div>{x}</div>;
+      `,
+      options: [{ max: 0 }],
+    },
+
+    // ---- Reassignment to non-JSX after JSX init bails ----
+    {
+      code: `
+        let x = <div><span /></div>;
+        x = "";
+        <div>{x}</div>;
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- Parameter binding has no resolvable write ----
+    {
+      code: `
+        function Foo(x) {
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 0 }],
+    },
+
+    // ---- Destructured binding doesn't resolve ----
+    {
+      code: `
+        const { x } = obj;
+        <div>{x}</div>;
+      `,
+      options: [{ max: 0 }],
+    },
+
+    // ---- Property assignment is not a write to the binding ----
+    {
+      code: `
+        let x = "hello";
+        obj.x = <div><span /></div>;
+        <div>{x}</div>;
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- Compound assignment is not a write ----
+    {
+      code: `
+        let x = "hello";
+        x += "world";
+        <div>{x}</div>;
+      `,
+      options: [{ max: 0 }],
+    },
+
+    // ---- Block-level shadowing via inner let ----
+    {
+      code: `
+        let x = "";
+        if (cond) {
+          let x = <div><span /></div>;
+          void x;
+        }
+        <div>{x}</div>;
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- Function parameter shadowing ----
+    {
+      code: `
+        let x = "";
+        function inner(x) {
+          x = <div><span /></div>;
+          return x;
+        }
+        <div>{x}</div>;
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- Function-body let shadowing ----
+    {
+      code: `
+        let x = "";
+        function inner() {
+          let x = <div><span /></div>;
+          return x;
+        }
+        <div>{x}</div>;
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- ConditionalExpression breaks the parent walk ----
+    {
+      code: `<div>{cond ? <span /> : null}</div>`,
+      options: [{ max: 0 }],
+    },
+
+    // ---- Class component returning fitting JSX ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return (
+              <div>
+                <span />
+              </div>
+            );
+          }
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- Arrow with block body ----
+    {
+      code: `
+        const Foo = () => {
+          return (
+            <div>
+              <span />
+            </div>
+          );
+        };
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- JsxExpression wrapping JSX inside a Fragment is opaque (max=3 fits) ----
+    {
+      code: `
+        const A = <Fragment>{<div><span /></div>}</Fragment>;
+        <div>{A}</div>;
+      `,
+      options: [{ max: 3 }],
+    },
+
+    // ---- Option-shape coverage ----
+    { code: `<App><foo><bar/></foo></App>`, options: [] },
+    { code: `<App><foo><bar/></foo></App>`, options: [{}] },
+    {
+      code: `<App><foo><bar/></foo></App>`,
+      options: [{ max: 'two' }],
+    },
+    {
+      code: `<App><foo><bar/></foo></App>`,
+      options: [{ max: false }],
+    },
+    {
+      code: `<App><foo><bar/></foo></App>`,
+      options: [{ max: null }],
+    },
+    {
+      code: `<App><foo><bar/></foo></App>`,
+      options: [{ max: -1 }],
+    },
+    {
+      code: `<App><foo><bar/></foo></App>`,
+      options: [{ max: 2, unknown: true }],
+    },
+    {
+      code: `
+        <a><b><c><d><e><f><g><h><i /></h></g></f></e></d></c></b></a>
+      `,
+      options: [{ max: 100 }],
+    },
+
+    // ---- JsxExpression non-Identifier inner shapes ----
+    { code: `<div>{this.x}</div>`, options: [{ max: 0 }] },
+    { code: `<div>{x?.y}</div>`, options: [{ max: 0 }] },
+    { code: `<div>{makeJSX()}</div>`, options: [{ max: 0 }] },
+    { code: `<div>{...arr}</div>`, options: [{ max: 0 }] },
+    { code: `<div>{}</div>`, options: [{ max: 0 }] },
+    { code: `<div>{/* nothing */}</div>`, options: [{ max: 0 }] },
+    { code: `<div>{x + y}</div>`, options: [{ max: 0 }] },
+    { code: `<div>{cond && <span />}</div>`, options: [{ max: 0 }] },
+
+    // ---- Real React patterns ----
+    {
+      code: `
+        <Suspense fallback={<Loading />}>
+          <App />
+        </Suspense>
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        <Provider>
+          <Consumer>
+            {(value) => <span>{value}</span>}
+          </Consumer>
+        </Provider>
+      `,
+      options: [{ max: 2 }],
+    },
+    {
+      code: `<ul>{items.map((item) => <li>{item}</li>)}</ul>`,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        const Foo = () => {
+          const memo = useMemo(() => <div><span /></div>, []);
+          return <div>{memo}</div>;
+        };
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        function Foo({ children = <span /> }) {
+          return <div>{children}</div>;
+        }
+      `,
+      options: [{ max: 0 }],
+    },
+
+    // ---- Identifier resolution edge cases ----
+    {
+      code: `
+        let x = x;
+        <div>{x}</div>;
+      `,
+      options: [{ max: 0 }],
+    },
+    {
+      code: `
+        let x = y;
+        let y = x;
+        <div>{x}</div>;
+      `,
+      options: [{ max: 0 }],
+    },
+    {
+      code: `
+        let a = "";
+        let b = a;
+        let c = b;
+        let d = c;
+        let e = d;
+        <div>{e}</div>;
+      `,
+      options: [{ max: 0 }],
+    },
+    {
+      code: `
+        const x = makeJSX();
+        <div>{x}</div>;
+      `,
+      options: [{ max: 0 }],
+    },
+
+    // ---- JSX shape edges ----
+    { code: `<></>;`, options: [{ max: 0 }] },
+    { code: `<div></div>;`, options: [{ max: 0 }] },
+    {
+      code: `
+        <div>
+          {/* comment */}
+          <span />
+        </div>
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        <div {...props}>
+          <span {...spanProps} />
+        </div>
+      `,
+      options: [{ max: 1 }],
+    },
+    { code: `<a.b.c.d />;`, options: [{ max: 0 }] },
+    {
+      code: `const F = () => <div><span /></div>;`,
+      options: [{ max: 1 }],
+    },
+
+    // ---- TS satisfies wrapper not peeled ----
+    {
+      code: `
+        const x = <div><span /></div>;
+        <div>{x satisfies any}</div>;
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- Reassignment in control flow that fits ----
+    {
+      code: `
+        function Foo() {
+          let x = "";
+          try { x = <div />; } catch (e) {}
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        function Foo() {
+          let x = "";
+          while (cond) { x = <div />; }
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        function Foo() {
+          let x = "";
+          switch (kind) { case "a": x = <div />; break; }
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        function Foo() {
+          if (cond) { var x = ""; }
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 0 }],
+    },
+
+    // ---- For-loop init scope isolation ----
+    {
+      code: `
+        let x = <a />;
+        function Foo() {
+          for (let x of items) {
+            return <div>{x}</div>;
+          }
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        let x = <a />;
+        function Foo() {
+          for (let x = 0; x < n; x++) {
+            return <span key={x} />;
+          }
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        let x = <a />;
+        function Foo() {
+          for (let x in obj) {
+            return <span key={x} />;
+          }
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        let x = "";
+        for (const x of items) { void x; }
+        <div>{x}</div>;
+      `,
+      options: [{ max: 0 }],
+    },
+
+    // ---- Inner for-of `let x` reassignment must not leak to outer `let x` ----
+    {
+      code: `
+        let x = "";
+        for (let x of items) { x = <div><span /></div>; }
+        const y = <wrap>{x}</wrap>;
+      `,
+      options: [{ max: 1 }],
+    },
+    // for (let x = …; …; …) variant
+    {
+      code: `
+        let x = "";
+        for (let x = 0; x < n; x++) { x = <div><span /></div>; }
+        const y = <wrap>{x}</wrap>;
+      `,
+      options: [{ max: 1 }],
+    },
+    // for-in variant
+    {
+      code: `
+        let k = "";
+        for (let k in obj) { k = <div><span /></div>; }
+        const y = <wrap>{k}</wrap>;
+      `,
+      options: [{ max: 1 }],
+    },
+    // ---- catch (x) parameter shadows outer let x ----
+    {
+      code: `
+        let x = "";
+        try { foo(); } catch (x) { x = <div><span /></div>; }
+        const y = <wrap>{x}</wrap>;
+      `,
+      options: [{ max: 1 }],
+    },
+    // Destructured catch param: catch ({ name })
+    {
+      code: `
+        let err = "";
+        try { foo(); } catch ({ err }) { err = <div><span /></div>; }
+        const y = <wrap>{err}</wrap>;
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- Parameter / destructured default ----
+    {
+      code: `
+        function Foo(x = <a />) {
+          return <wrap>{x}</wrap>;
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        function Foo({ children = <span /> }) {
+          return <div>{children}</div>;
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        function Foo(x = <div><span /></div>) {
+          x = "";
+          return <wrap>{x}</wrap>;
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- Switch case-let scope ----
+    {
+      code: `
+        function Foo(kind) {
+          switch (kind) {
+            case 'a': let x = <a />; break;
+            case 'b': return <wrap>{x}</wrap>;
+          }
+        }
+      `,
+      options: [{ max: 1 }],
+    },
+
+    // ---- Destructured VariableDeclaration default is NOT a write ----
+    // Differential validation against upstream confirms ESLint's scope
+    // manager surfaces the destructure RHS, not the BindingElement default.
+    {
+      code: `
+        const { x = <div><span /></div> } = obj;
+        const y = <wrap>{x}</wrap>;
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        let { x = <div><span /></div> } = obj;
+        const y = <wrap>{x}</wrap>;
+      `,
+      options: [{ max: 1 }],
+    },
+    {
+      code: `
+        const [x = <div><span /></div>] = arr;
+        const y = <wrap>{x}</wrap>;
+      `,
+      options: [{ max: 1 }],
+    },
+  ],
+
+  invalid: [
+    // ---- max=0 with depth 1 ----
+    {
+      code: `
+        <App>
+          <foo />
+        </App>
+      `,
+      options: [{ max: 0 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    // ---- max=0 with depth 1, JsxExpression child whose inner is non-JSX ----
+    {
+      code: `
+        <App>
+          <foo>{bar}</foo>
+        </App>
+      `,
+      options: [{ max: 0 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    // ---- max=1 with depth 2 ----
+    {
+      code: `
+        <App>
+          <foo>
+            <bar />
+          </foo>
+        </App>
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    // ---- Identifier resolution puts <span/> at depth 2 ----
+    {
+      code: `
+        const x = <div><span /></div>;
+        <div>{x}</div>;
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    // ---- Chain through `let y = x` ----
+    {
+      code: `
+        const x = <div><span /></div>;
+        let y = x;
+        <div>{y}</div>;
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    // ---- Two interpolations report independently ----
+    {
+      code: `
+        const x = <div><span /></div>;
+        let y = x;
+        <div>{x}-{y}</div>;
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }, { messageId: 'wrongDepth' }],
+    },
+    // ---- Inline `{<div>...</div>}`; <span/> at depth 3 ----
+    {
+      code: `
+        <div>
+        {<div><div><span /></div></div>}
+        </div>
+      `,
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    // ---- Fragment with depth 1, max=0 ----
+    {
+      code: `
+        <>
+          <foo />
+        </>
+      `,
+      options: [{ max: 0 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    // ---- Nested fragments, max=1, depth 2 ----
+    {
+      code: `
+        <>
+          <>
+            <bar />
+          </>
+        </>
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    // ---- Fragment-wrapped duplicate interpolations ----
+    {
+      code: `
+        const x = <><span /></>;
+        let y = x;
+        <>{x}-{y}</>;
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }, { messageId: 'wrongDepth' }],
+    },
+    // ---- Identifier-resolved table — both <td>s exceed max=1 ----
+    {
+      code: `
+        const x = (
+          <tr>
+            <td>1</td>
+            <td>2</td>
+          </tr>
+        );
+        <tbody>
+          {x}
+        </tbody>
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }, { messageId: 'wrongDepth' }],
+    },
+    // ---- Deeply nested modal scaffold, max=4 ----
+    {
+      code: `
+        <div className="custom_modal">
+          <Modal className={classes.modal} open={isOpen} closeAfterTransition>
+            <Fade in={isOpen}>
+              <DialogContent>
+                <Icon icon="cancel" onClick={onClose} popoverText="Close Modal" />
+                <div className="modal_content">{children}</div>
+                <div className={clsx('modal_buttons', classes.buttons)}>
+                  <Button className="modal_buttons--cancel" onClick={onCancel}>
+                    {cancelMsg ? cancelMsg : 'Cancel'}
+                  </Button>
+                </div>
+              </DialogContent>
+            </Fade>
+          </Modal>
+        </div>
+      `,
+      options: [{ max: 4 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    // ---- Parens around resolved identifier still report ----
+    {
+      code: `
+        const x = <div><span /></div>;
+        <div>{(x)}</div>;
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Reassignment: latest write wins ----
+    {
+      code: `
+        let x = "";
+        x = <div><span /></div>;
+        <div>{x}</div>;
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Reassignment: declaration without init ----
+    {
+      code: `
+        let x;
+        x = <div><span /></div>;
+        <div>{x}</div>;
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Reassignment inside an if branch ----
+    {
+      code: `
+        function Foo() {
+          let x = "";
+          if (cond) {
+            x = <div><span /></div>;
+          }
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Closure write from a non-shadowing inner function ----
+    {
+      code: `
+        function outer() {
+          let x = "";
+          function inner() {
+            x = <div><span /></div>;
+          }
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Reassignment chain y → x ----
+    {
+      code: `
+        let x = "";
+        x = <div><span /></div>;
+        let y = x;
+        <div>{y}</div>;
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Multi-decl statement ----
+    {
+      code: `
+        let a = 1, b = <div><span /></div>, c = 3;
+        <div>{b}</div>;
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- TS generic component tag ----
+    {
+      code: `
+        <Foo<string>>
+          <Bar>
+            <Baz />
+          </Bar>
+        </Foo>
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Member-access tag name ----
+    {
+      code: `
+        <Module.Foo>
+          <Bar>
+            <Baz />
+          </Bar>
+        </Module.Foo>
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Mixed element / fragment nesting ----
+    {
+      code: `
+        <App>
+          <>
+            <Foo>
+              <Bar />
+            </Foo>
+          </>
+        </App>
+      `,
+      options: [{ max: 2 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Boundary depth with exact message text ----
+    {
+      code: `<App><foo /></App>`,
+      options: [{ max: 0 }],
+      errors: [
+        {
+          messageId: 'wrongDepth',
+          message:
+            'Expected the depth of nested jsx elements to be <= 0, but found 1.',
+        },
+      ],
+    },
+    {
+      code: `<App><foo><bar /></foo></App>`,
+      options: [{ max: 0 }],
+      errors: [
+        {
+          messageId: 'wrongDepth',
+          message:
+            'Expected the depth of nested jsx elements to be <= 0, but found 2.',
+        },
+      ],
+    },
+    {
+      code: `<a><b><c><d /></c></b></a>`,
+      options: [{ max: 2 }],
+      errors: [
+        {
+          messageId: 'wrongDepth',
+          message:
+            'Expected the depth of nested jsx elements to be <= 2, but found 3.',
+        },
+      ],
+    },
+    {
+      code: `<a><b><c><d><e><f><g /></f></e></d></c></b></a>`,
+      options: [{ max: 5 }],
+      errors: [
+        {
+          messageId: 'wrongDepth',
+          message:
+            'Expected the depth of nested jsx elements to be <= 5, but found 6.',
+        },
+      ],
+    },
+
+    // ---- Reassignment in control flow that exceeds ----
+    {
+      code: `
+        function Foo() {
+          let x = "";
+          while (cond) { x = <div><span /></div>; }
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    {
+      code: `
+        function Foo() {
+          let x = "";
+          try { x = <div><span /></div>; } catch (e) {}
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    {
+      code: `
+        function Foo() {
+          let x = "";
+          switch (kind) {
+            case "deep": x = <div><span /></div>; break;
+          }
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Closure descent through TWO function levels ----
+    {
+      code: `
+        function outer() {
+          let x = "";
+          function mid() {
+            function inner() {
+              x = <div><span /></div>;
+            }
+          }
+          return <div>{x}</div>;
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Multiple use sites of the same binding ----
+    {
+      code: `
+        const x = <div><span /></div>;
+        <div>{x}{x}{x}</div>;
+      `,
+      options: [{ max: 1 }],
+      errors: [
+        { messageId: 'wrongDepth' },
+        { messageId: 'wrongDepth' },
+        { messageId: 'wrongDepth' },
+      ],
+    },
+
+    // ---- Default parameter JSX itself violates + descend reports ----
+    {
+      code: `
+        function Foo({ children = <div><span /></div> }) {
+          return <div>{children}</div>;
+        }
+      `,
+      options: [{ max: 0 }],
+      errors: [{ messageId: 'wrongDepth' }, { messageId: 'wrongDepth' }],
+    },
+
+    // ---- Same-line multi-element ----
+    {
+      code: `<a><b><c /></b></a>`,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- TS generic with multiple type args ----
+    {
+      code: `
+        <Foo<string, number>>
+          <Bar>
+            <Baz />
+          </Bar>
+        </Foo>
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Stress: aliasing chain to deep JSX value ----
+    {
+      code: `
+        let a = "";
+        const b = a;
+        const c = b;
+        const d = c;
+        const e = d;
+        a = <div><span /></div>;
+        <div>{e}</div>;
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- For-init binding reassigned to JSX in loop body ----
+    {
+      code: `
+        function Foo() {
+          for (let x of items) {
+            x = <div><span /></div>;
+            return <div>{x}</div>;
+          }
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+    {
+      code: `
+        function Foo() {
+          for (let x = <a />; cond; ) {
+            x = <div><span /></div>;
+            return <div>{x}</div>;
+          }
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Parameter default JSX exceeds via descend ----
+    {
+      code: `
+        function Foo(x = <div><span /></div>) {
+          return <wrap>{x}</wrap>;
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Destructured parameter default exceeds (also leaf in default) ----
+    {
+      code: `
+        function Foo({ children = <div><span /></div> }) {
+          return <div>{children}</div>;
+        }
+      `,
+      options: [{ max: 0 }],
+      errors: [{ messageId: 'wrongDepth' }, { messageId: 'wrongDepth' }],
+    },
+
+    // ---- Switch case-let cross-clause resolution ----
+    {
+      code: `
+        function Foo(kind) {
+          switch (kind) {
+            case 'a': let x = <div><span /></div>; break;
+            case 'b': return <wrap>{x}</wrap>;
+          }
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+
+    // ---- Parameter reassigned in body ----
+    {
+      code: `
+        function Foo(x = <a />) {
+          x = <div><span /></div>;
+          return <wrap>{x}</wrap>;
+        }
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'wrongDepth' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -349,3 +349,4 @@ handl
 ZWNBSP
 recognises
 recognisable
+clsx


### PR DESCRIPTION
## Summary

Port the `react/jsx-max-depth` rule from `eslint-plugin-react` to rslint.

The rule enforces a maximum depth of nested JSX elements. It accepts a single option `{ max: number }` (default `2`) and reports a `wrongDepth` violation at every leaf JSX whose depth exceeds the configured maximum, plus violations surfaced through identifier resolution: when a JSX-bearing variable is used inside `<wrap>{x}</wrap>`, the rule descends into the resolved JSX and reports children that would exceed the budget.

To match upstream's `findJSXElementOrFragment` semantics on rslint's tsgo AST, the resolver implements scope-aware **latest-write** tracking — declaration init + reassignments in the binding's enclosing scope, with descent into non-shadowing inner functions for closure writes. Block-level (`let`/`const`), function-parameter, and function-body shadowing are all detected. Parameter and BindingElement defaults are dispatched separately so that `function f({ x = <jsx> })` tracks the default (matching upstream) while `const { x = <jsx> } = obj` does NOT (also matching upstream — its writeExpr is the destructure RHS).

Verified empirically against upstream ESLint via differential validation: 19 isolated fixtures and 13 real-world reports across `web-infra-dev/rsbuild` and `web-infra-dev/rspack` websites — every diagnostic position, depth, and message matches.

## Related Links

- ESLint rule: <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-max-depth.md>
- Source code: <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-max-depth.js>

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).