### PR TITLE
feat: expose structured SymbolNameKind in tsgo wire format

### DIFF
--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -10,13 +10,35 @@ import (
 	"github.com/microsoft/typescript-go/shim/compiler"
 )
 
-// sanitizeSymbolName replaces the internal symbol name prefix (\xFE) with "__"
-// so that consumers receive valid UTF-8 symbol names.
-func sanitizeSymbolName(name string) []byte {
-	if strings.HasPrefix(name, ast.InternalSymbolNamePrefix) {
-		return []byte("__" + name[len(ast.InternalSymbolNamePrefix):])
+// SymbolNameKind classifies a symbol's name origin so consumers can tell
+// user-spelled identifiers apart from typescript-go's internal sentinel names
+// without having to inspect string prefixes.
+type SymbolNameKind uint8
+
+const (
+	// SymbolNameKindUser is a regular user-spelled identifier or literal.
+	SymbolNameKindUser SymbolNameKind = 0
+	// SymbolNameKindInternal is one of TypeScript's InternalSymbolName values
+	// (e.g. "index", "call", "new", "type"). Reported with the "\xFE"
+	// sentinel stripped.
+	SymbolNameKindInternal SymbolNameKind = 1
+	// SymbolNameKindPrivate is a private class member. Reported in the form
+	// "#<class-id>@#<name>" with the "\xFE" sentinel stripped.
+	SymbolNameKindPrivate SymbolNameKind = 2
+)
+
+// classifySymbolName strips typescript-go's "\xFE" sentinel and tags how the
+// resulting name should be interpreted. The returned bytes are always valid
+// UTF-8 and never re-encode the sentinel.
+func classifySymbolName(name string) (SymbolNameKind, []byte) {
+	rest, ok := strings.CutPrefix(name, ast.InternalSymbolNamePrefix)
+	if !ok {
+		return SymbolNameKindUser, []byte(name)
 	}
-	return []byte(name)
+	if strings.HasPrefix(rest, "#") {
+		return SymbolNameKindPrivate, []byte(rest)
+	}
+	return SymbolNameKindInternal, []byte(rest)
 }
 
 //go:linkname getAliasedSymbol github.com/microsoft/typescript-go/internal/checker.(*Checker).GetAliasedSymbol
@@ -32,10 +54,11 @@ type NodeReference struct {
 	End          int          `json:"end"`
 }
 type SymbolInfo struct {
-	Id         ast.SymbolId `json:"id"`
-	Name       CString      `json:"name"`
-	Flags      int          `json:"flags"`
-	CheckFlags int          `json:"check_flags"`
+	Id         ast.SymbolId   `json:"id"`
+	Name       CString        `json:"name"`
+	NameKind   SymbolNameKind `json:"name_kind"`
+	Flags      int            `json:"flags"`
+	CheckFlags int            `json:"check_flags"`
 	// Declaration node reference (if available)
 	Decl *NodeReference `json:"decl,omitempty"`
 }
@@ -218,9 +241,11 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 						}
 					}
 
+					nameKind, name := classifySymbolName(symbol.Name)
 					semantic.Symtab[sym_id] = SymbolInfo{
 						Id:         sym_id,
-						Name:       sanitizeSymbolName(symbol.Name),
+						Name:       name,
+						NameKind:   nameKind,
 						Flags:      int(symbol.Flags),
 						CheckFlags: int(symbol.CheckFlags),
 						Decl:       declRef,
@@ -263,9 +288,11 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 							}
 						}
 
+						nameKind, name := classifySymbolName(valueSymbol.Name)
 						semantic.Symtab[value_sym_id] = SymbolInfo{
 							Id:         value_sym_id,
-							Name:       sanitizeSymbolName(valueSymbol.Name),
+							Name:       name,
+							NameKind:   nameKind,
 							Flags:      int(valueSymbol.Flags),
 							CheckFlags: int(valueSymbol.CheckFlags),
 							Decl:       declRef,

--- a/cmd/tsgo/semantic_test.go
+++ b/cmd/tsgo/semantic_test.go
@@ -230,13 +230,23 @@ func TestSemanticSnapshot_NonBMPCharPositions(t *testing.T) {
 
 func TestSemanticSnapshot_InternalSymbolNameSanitized(t *testing.T) {
 	// Arrow functions produce an internal symbol with name "\xFEfunction".
-	// Verify that the \xFE prefix is sanitized to "__" in the output.
+	// Verify the wire-format strips the sentinel and tags the name kind.
 	fixture := buildSemanticFixture(t, "const f = () => 1;")
 
+	var sawInternal bool
 	for _, sym := range fixture.semantic.Symtab {
 		name := string(sym.Name)
 		if strings.Contains(name, "\xFE") {
-			t.Fatalf("symbol name contains unsanitized \\xFE: %q", name)
+			t.Fatalf("symbol name contains unstripped \\xFE: %q", name)
 		}
+		if sym.NameKind == SymbolNameKindInternal {
+			sawInternal = true
+			if name == "function" && sym.NameKind != SymbolNameKindInternal {
+				t.Fatalf("expected NameKind=Internal for %q, got %d", name, sym.NameKind)
+			}
+		}
+	}
+	if !sawInternal {
+		t.Fatalf("expected at least one Internal-kind symbol from arrow function fixture")
 	}
 }

--- a/crates/tsgo-client/src/proto.rs
+++ b/crates/tsgo-client/src/proto.rs
@@ -60,10 +60,28 @@ pub struct NodeReference {
     pub end: u32,
 }
 
+/// Origin of a symbol's `name` field. Lets consumers distinguish user-spelled
+/// identifiers from typescript-go's internal sentinel-prefixed names without
+/// having to inspect the string contents.
+///
+/// Wire format: serialized as a `u8` tag.
+pub mod symbol_name_kind {
+    /// User-spelled identifier or literal.
+    pub const USER: u8 = 0;
+    /// One of TypeScript's `InternalSymbolName` values (e.g. `"index"`,
+    /// `"call"`, `"new"`, `"type"`); the `\xFE` sentinel has been stripped.
+    pub const INTERNAL: u8 = 1;
+    /// Private class member, reported as `"#<class-id>@#<name>"` with the
+    /// `\xFE` sentinel stripped.
+    pub const PRIVATE: u8 = 2;
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct SymbolData {
     #[serde(with = "serde_bytes")]
     pub name: Vec<u8>,
+    #[serde(default)]
+    pub name_kind: u8,
     pub flags: u32,
     pub check_flags: u32,
     #[serde(default)]


### PR DESCRIPTION
## Summary

typescript-go uses a `\xFE` sentinel prefix on `Symbol.Name` to mark its
internal symbol names (`__index`, `__call`, `__type`, ...). The previous
wire format escaped the sentinel to ASCII `__` so consumers could parse
the prefix back, which had two problems:

- The "is this an internal symbol" semantic was encoded into the string
  contents — consumers had to do prefix scanning to recover it.
- A user-spelled identifier like `__foo` is indistinguishable from an
  internal name at the prefix level.

This PR replaces the prefix escape with a structured `name_kind` enum
field (`User` / `Internal` / `Private`). The sentinel is stripped from
`name`, and the new field is the single source of truth for symbol-name
origin.

- `cmd/tsgo`: drop `sanitizeSymbolName`; introduce `SymbolNameKind` and
  `classifySymbolName`; `SymbolInfo` gains a `name_kind` field; both
  call sites switched.
- `crates/tsgo-client`: `SymbolData` exposes `name_kind: u8` plus a
  `symbol_name_kind` constant module so consumers can match on it
  without depending on string prefixes.

Wire format change: `name` for internal/private symbols no longer carries
the `__` prefix; consumers should switch from name-prefix detection to
`name_kind`.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).