### PR TITLE
feat: port rule react/forbid-foreign-prop-types

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -6,6 +6,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_component_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_dom_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_elements"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_foreign_prop_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_prop_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_boolean_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_closing_tag_location"
@@ -75,6 +76,7 @@ func GetAllRules() []rule.Rule {
 		forbid_component_props.ForbidComponentPropsRule,
 		forbid_dom_props.ForbidDomPropsRule,
 		forbid_elements.ForbidElementsRule,
+		forbid_foreign_prop_types.ForbidForeignPropTypesRule,
 		forbid_prop_types.ForbidPropTypesRule,
 		jsx_boolean_value.JsxBooleanValueRule,
 		jsx_closing_tag_location.JsxClosingTagLocationRule,

--- a/internal/plugins/react/rules/forbid_foreign_prop_types/forbid_foreign_prop_types.go
+++ b/internal/plugins/react/rules/forbid_foreign_prop_types/forbid_foreign_prop_types.go
@@ -1,0 +1,285 @@
+package forbid_foreign_prop_types
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const msgForbiddenPropType = "Using propTypes from another component is not safe because they may be removed in production builds"
+
+type ruleOptions struct {
+	allowInPropTypes bool
+}
+
+// parseOptions reads `allowInPropTypes` (boolean) from the rule options.
+// Mirrors upstream's defaults — missing option / non-bool falls back to false.
+func parseOptions(input any) ruleOptions {
+	opts := ruleOptions{}
+	m := utils.GetOptionsMap(input)
+	if m == nil {
+		return opts
+	}
+	if v, ok := m["allowInPropTypes"].(bool); ok {
+		opts.allowInPropTypes = v
+	}
+	return opts
+}
+
+// effectiveParent walks up through ParenthesizedExpression wrappers to find
+// the topmost paren-wrapped node and its non-paren ancestor. Mirrors
+// ESTree's transparent-paren parent: in upstream `node.parent` already
+// skips parentheses; in tsgo we must skip them explicitly to match.
+func effectiveParent(node *ast.Node) (*ast.Node, *ast.Node) {
+	current := node
+	parent := current.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		current = parent
+		parent = current.Parent
+	}
+	return current, parent
+}
+
+// isAssignmentLHS mirrors upstream's `ast.isAssignmentLHS`:
+//
+//	node.parent.type === 'AssignmentExpression' && node.parent.left === node
+//
+// Strict direct-LHS only — does NOT walk up through nested destructuring
+// targets (e.g. `({a: Foo.propTypes} = X)`). Compound assignments
+// (`+=`, `||=`, `??=`, …) all share the same ESTree
+// `AssignmentExpression` type, so any assignment-style operator counts.
+//
+// We use this — not the broader `ast.IsAssignmentTarget` — because
+// upstream only excludes the direct LHS form (`Foo.propTypes = X`).
+// `ast.IsAssignmentTarget` walks up through nested patterns and would
+// over-exclude.
+func isAssignmentLHS(node *ast.Node) bool {
+	current, parent := effectiveParent(node)
+	if parent == nil || !ast.IsAssignmentExpression(parent, false) {
+		return false
+	}
+	return parent.AsBinaryExpression().Left == current
+}
+
+// isAllowedAssignment reports whether `node` sits inside a `propTypes`
+// declaration that the option `allowInPropTypes: true` excuses. Mirrors
+// upstream's two-pronged check:
+//  1. nearest enclosing AssignmentExpression has LHS `<expr>.propTypes`
+//  2. nearest enclosing ClassProperty / PropertyDefinition is keyed by
+//     the Identifier `propTypes`
+//
+// Both prongs require the dotted-identifier form — string-literal /
+// computed key shapes don't satisfy upstream's `key.name === 'propTypes'`
+// or `left.property.name === 'propTypes'` checks.
+func isAllowedAssignment(node *ast.Node, allow bool) bool {
+	if !allow {
+		return false
+	}
+
+	// Closest enclosing assignment with LHS `<expr>.propTypes`.
+	if assign := ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
+		return ast.IsAssignmentExpression(n, false)
+	}); assign != nil {
+		// Strip parens on the LHS — ESTree flattens parens, tsgo
+		// preserves them. Matches upstream's `assignment.left.property`
+		// access on a flat MemberExpression.
+		left := ast.SkipParentheses(assign.AsBinaryExpression().Left)
+		if left != nil && left.Kind == ast.KindPropertyAccessExpression {
+			name := left.AsPropertyAccessExpression().Name()
+			if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "propTypes" {
+				return true
+			}
+		}
+	}
+
+	// Closest enclosing class field whose key is the Identifier `propTypes`.
+	// Upstream's `classProperty.key.name === 'propTypes'` only matches
+	// Identifier keys (StringLiteral / ComputedPropertyName have no `.name`).
+	if cp := ast.FindAncestorKind(node.Parent, ast.KindPropertyDeclaration); cp != nil {
+		keyNode := cp.AsPropertyDeclaration().Name()
+		if keyNode != nil && keyNode.Kind == ast.KindIdentifier && keyNode.AsIdentifier().Text == "propTypes" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isJsxTagName reports whether `node` is the TagName of a JSX element
+// (or any link in a dotted JSX tag chain like `<Foo.Bar.Baz />`). tsgo
+// represents dotted JSX tags as `PropertyAccessExpression`, but ESTree
+// uses a distinct `JSXMemberExpression` node type — ESLint's
+// `MemberExpression` listener does NOT fire on JSXMemberExpression.
+// We exclude this case to align byte-for-byte.
+func isJsxTagName(node *ast.Node) bool {
+	// Walk up the PA chain (each inner PA is the `.Expression` of its
+	// outer PA). If the outermost reaches a Jsx* element TagName, skip.
+	outer := node
+	for {
+		p := outer.Parent
+		if p == nil || p.Kind != ast.KindPropertyAccessExpression {
+			break
+		}
+		if p.AsPropertyAccessExpression().Expression != outer {
+			break
+		}
+		outer = p
+	}
+	parent := outer.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindJsxOpeningElement, ast.KindJsxSelfClosingElement, ast.KindJsxClosingElement:
+		return true
+	}
+	return false
+}
+
+// findPropTypesKey returns the first element whose effective key is the
+// Identifier `propTypes`, or nil. Shared between the
+// ObjectBindingPattern listener (declaration form) and the
+// ObjectLiteralExpression listener (destructuring-assignment form).
+// Mirrors upstream's
+// `'name' in property.key && property.key.name === 'propTypes'`:
+// rest / spread elements, computed keys, string-literal keys, and
+// methods / accessors are silently skipped.
+func findPropTypesKey(elements []*ast.Node) *ast.Node {
+	for _, prop := range elements {
+		var key *ast.Node
+		switch prop.Kind {
+		case ast.KindBindingElement:
+			be := prop.AsBindingElement()
+			if be == nil || be.DotDotDotToken != nil {
+				continue
+			}
+			if be.PropertyName != nil {
+				key = be.PropertyName
+			} else {
+				key = be.Name()
+			}
+		case ast.KindPropertyAssignment:
+			key = prop.AsPropertyAssignment().Name()
+		case ast.KindShorthandPropertyAssignment:
+			key = prop.AsShorthandPropertyAssignment().Name()
+		default:
+			// SpreadAssignment, methods, accessors, etc. — upstream's
+			// `property.type === 'Property'` filter excludes these.
+			continue
+		}
+		if key == nil || key.Kind != ast.KindIdentifier {
+			continue
+		}
+		if key.AsIdentifier().Text != "propTypes" {
+			continue
+		}
+		return prop
+	}
+	return nil
+}
+
+var ForbidForeignPropTypesRule = rule.Rule{
+	Name: "react/forbid-foreign-prop-types",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		msg := rule.RuleMessage{
+			Id:          "forbiddenPropType",
+			Description: msgForbiddenPropType,
+		}
+
+		return rule.RuleListeners{
+			// Dotted access `<expr>.propTypes`. ESTree's `MemberExpression`
+			// non-computed branch with `property.type === 'Identifier'`.
+			// PrivateIdentifier (`#propTypes`) is intentionally ignored —
+			// upstream's `property.type === 'Identifier'` check excludes
+			// PrivateIdentifier (its ESTree type is `PrivateIdentifier`).
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				name := node.AsPropertyAccessExpression().Name()
+				if name == nil || name.Kind != ast.KindIdentifier {
+					return
+				}
+				if name.AsIdentifier().Text != "propTypes" {
+					return
+				}
+				if isAssignmentLHS(node) {
+					return
+				}
+				if isJsxTagName(node) {
+					return
+				}
+				if isAllowedAssignment(node, opts.allowInPropTypes) {
+					return
+				}
+				ctx.ReportNode(name, msg)
+			},
+
+			// Bracketed access `<expr>['propTypes']`. ESTree's
+			// `MemberExpression` computed branch with property a Literal
+			// whose value is `'propTypes'`. Upstream also accepts JSXText
+			// here, but JSXText cannot syntactically appear inside a
+			// MemberExpression's brackets, so it's a dead branch upstream
+			// and we omit it.
+			//
+			// Template literals (no-substitution form) are NOT matched —
+			// upstream's `property.type === 'Literal'` excludes
+			// TemplateLiteral. Locked in by the `Foo[\`propTypes\`]` valid
+			// test case.
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				arg := node.AsElementAccessExpression().ArgumentExpression
+				if arg == nil || arg.Kind != ast.KindStringLiteral {
+					return
+				}
+				if arg.AsStringLiteral().Text != "propTypes" {
+					return
+				}
+				if isAssignmentLHS(node) {
+					return
+				}
+				if isAllowedAssignment(node, opts.allowInPropTypes) {
+					return
+				}
+				ctx.ReportNode(arg, msg)
+			},
+
+			// Object destructuring in declaration form: `var { propTypes }
+			// = X`, `const { propTypes: alias } = X`, function parameters
+			// `function f({ propTypes }) {}`, etc. tsgo represents these
+			// as `ObjectBindingPattern` containing `BindingElement`s.
+			ast.KindObjectBindingPattern: func(node *ast.Node) {
+				bp := node.AsBindingPattern()
+				if bp == nil || bp.Elements == nil {
+					return
+				}
+				if match := findPropTypesKey(bp.Elements.Nodes); match != nil {
+					ctx.ReportNode(match, msg)
+				}
+			},
+
+			// Object destructuring in expression form: `({ propTypes } =
+			// X)`, `[{ propTypes }] = X`, nested patterns inside a larger
+			// destructuring target. tsgo represents the LHS of such
+			// assignments as `ObjectLiteralExpression` (only the
+			// assignment context reclassifies it as a pattern), so we
+			// gate on `ast.IsAssignmentTarget`, which walks up through
+			// parens / arrays / nested object literals to confirm the
+			// node is in an assignment-target position.
+			//
+			// Upstream covers this via its single `ObjectPattern`
+			// listener — ESLint emits ObjectPattern for both var-decl
+			// and assignment forms; tsgo splits them into two distinct
+			// kinds, so the rule needs two listeners.
+			ast.KindObjectLiteralExpression: func(node *ast.Node) {
+				if !ast.IsAssignmentTarget(node) {
+					return
+				}
+				obj := node.AsObjectLiteralExpression()
+				if obj == nil || obj.Properties == nil {
+					return
+				}
+				if match := findPropTypesKey(obj.Properties.Nodes); match != nil {
+					ctx.ReportNode(match, msg)
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/forbid_foreign_prop_types/forbid_foreign_prop_types.md
+++ b/internal/plugins/react/rules/forbid_foreign_prop_types/forbid_foreign_prop_types.md
@@ -1,0 +1,72 @@
+# forbid-foreign-prop-types
+
+## Rule Details
+
+This rule forbids using another component's prop types unless they are
+explicitly imported / exported. It allows tools such as
+[`babel-plugin-transform-react-remove-prop-types`](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types)
+to safely strip `propTypes` from production builds.
+
+To ensure imports are explicitly exported, pair this rule with the
+[`named` rule in `eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/named.md).
+
+Examples of **incorrect** code for this rule:
+
+```js
+import SomeComponent from './SomeComponent';
+SomeComponent.propTypes;
+
+var { propTypes } = SomeComponent;
+
+SomeComponent['propTypes'];
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import SomeComponent, { propTypes as someComponentPropTypes } from './SomeComponent';
+```
+
+## Rule Options
+
+```json
+{ "react/forbid-foreign-prop-types": ["error", { "allowInPropTypes": true }] }
+```
+
+### `allowInPropTypes`
+
+If `true`, the rule does not report foreign `propTypes` usage when it
+appears inside a `propTypes` declaration. The declaration may be either
+an assignment to `<Component>.propTypes` or a `static propTypes` class
+field.
+
+Examples of **correct** code with `{ "allowInPropTypes": true }`:
+
+```json
+{ "react/forbid-foreign-prop-types": ["error", { "allowInPropTypes": true }] }
+```
+
+```jsx
+const Hello = (props) => <div>{props.name}</div>;
+Hello.propTypes = {
+  name: Message.propTypes.message,
+};
+
+class MyComponent extends React.Component {
+  static propTypes = {
+    baz: Qux.propTypes.baz,
+  };
+}
+```
+
+## When Not To Use It
+
+This rule helps make removing `propTypes` from production code safe.
+Skip it if you don't strip `propTypes` in production. Higher-order
+components that hoist a wrapped component's `propTypes` may also need
+this rule disabled.
+
+## Original Documentation
+
+- [eslint-plugin-react / forbid-foreign-prop-types](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/forbid-foreign-prop-types.js)

--- a/internal/plugins/react/rules/forbid_foreign_prop_types/forbid_foreign_prop_types_test.go
+++ b/internal/plugins/react/rules/forbid_foreign_prop_types/forbid_foreign_prop_types_test.go
@@ -1,0 +1,1271 @@
+package forbid_foreign_prop_types
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestForbidForeignPropTypesRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ForbidForeignPropTypesRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{
+			Code: `import { propTypes } from "SomeComponent";`,
+			Tsx:  true,
+		},
+		{
+			Code: `import { propTypes as someComponentPropTypes } from "SomeComponent";`,
+			Tsx:  true,
+		},
+		{
+			Code: `const foo = propTypes`,
+			Tsx:  true,
+		},
+		{
+			Code: `foo(propTypes)`,
+			Tsx:  true,
+		},
+		{
+			Code: `foo + propTypes`,
+			Tsx:  true,
+		},
+		{
+			Code: `const foo = [propTypes]`,
+			Tsx:  true,
+		},
+		// Shorthand `{ propTypes }` in an ObjectLiteralExpression — NOT a
+		// destructuring pattern, so the ObjectBindingPattern listener does
+		// not fire. Locked in here.
+		{
+			Code: `const foo = { propTypes }`,
+			Tsx:  true,
+		},
+		// LHS of dotted assignment — `isAssignmentLHS` excludes.
+		{
+			Code: `Foo.propTypes = propTypes`,
+			Tsx:  true,
+		},
+		// LHS of bracket assignment — `isAssignmentLHS` excludes too.
+		{
+			Code: `Foo["propTypes"] = propTypes`,
+			Tsx:  true,
+		},
+		// Computed access whose argument is a non-literal Identifier — does
+		// NOT match upstream's `Literal` branch. Locked in.
+		{
+			Code: `const propTypes = "bar"; Foo[propTypes];`,
+			Tsx:  true,
+		},
+		// allowInPropTypes: true + assignment-context propTypes use.
+		{
+			Code: `
+        const Message = (props) => (<div>{props.message}</div>);
+        Message.propTypes = {
+          message: PropTypes.string
+        };
+        const Hello = (props) => (<Message>Hello {props.name}</Message>);
+        Hello.propTypes = {
+          name: Message.propTypes.message
+        };
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+		},
+		// allowInPropTypes: true + class-field-context propTypes use.
+		{
+			Code: `
+        class MyComponent extends React.Component {
+          static propTypes = {
+            baz: Qux.propTypes.baz
+          };
+        }
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+		},
+
+		// ---- Universal edge shapes (Dimension 4) ----
+		// Template-literal computed access — upstream does NOT match
+		// TemplateLiteral, only Literal. Lock-in: locks upstream's
+		// `property.type === 'Literal'` arm — without this case a future
+		// refactor that broadens to NoSubstitutionTemplateLiteral would
+		// silently drift. (Goes here, not invalid, because upstream
+		// passes too.)
+		{
+			Code: "Foo[`propTypes`]",
+			Tsx:  true,
+		},
+		// PrivateIdentifier `#propTypes` — upstream's
+		// `property.type === 'Identifier'` excludes PrivateIdentifier.
+		// Lock-in for the type-check we make on `KindIdentifier`.
+		{
+			Code: `class C { #propTypes = 1; m() { return this.#propTypes } }`,
+			Tsx:  true,
+		},
+		// Computed access whose argument is a numeric literal — not 'propTypes'.
+		{
+			Code: `Foo[0]`,
+			Tsx:  true,
+		},
+		// Property name "propTypes" used as a *string-literal key* in an
+		// ObjectBindingPattern. Upstream's `'name' in property.key` check
+		// excludes string-literal keys. Lock-in for the Identifier-only
+		// destructuring gate.
+		{
+			Code: `var { "propTypes": x } = SomeComponent;`,
+			Tsx:  true,
+		},
+		// Rest element `{ ...propTypes }` — upstream's
+		// `property.type === 'Property'` filter excludes RestElement, so
+		// the rest binding `propTypes` is not reported. Locked in via the
+		// `DotDotDotToken != nil` skip in the listener.
+		{
+			Code: `var { ...propTypes } = SomeComponent;`,
+			Tsx:  true,
+		},
+		// LHS of compound assignment — upstream `isAssignmentLHS` matches
+		// any AssignmentExpression, regardless of operator. `+=` etc.
+		// should NOT report on the LHS. Lock-in for `IsAssignmentOperator`
+		// covering compound forms.
+		{
+			Code: `Foo.propTypes += {}`,
+			Tsx:  true,
+		},
+		// Parenthesized LHS `(Foo.propTypes) = X` — ESTree flattens the
+		// parens so upstream sees the property as the assignment LHS and
+		// does NOT report. tsgo preserves the ParenthesizedExpression;
+		// `effectiveParent` inside `isAssignmentLHS` walks through it so
+		// we behave the same.
+		{
+			Code: `(Foo.propTypes) = {};`,
+			Tsx:  true,
+		},
+		// Foreign propTypes used inside an arrow function body in a
+		// propTypes assignment — closest enclosing AssignmentExpression
+		// has LHS `Bar.propTypes`, so allowInPropTypes:true excuses it.
+		// Locks in the parent walk through nested function bodies.
+		{
+			Code: `
+        Bar.propTypes = {
+          x: () => Foo.propTypes
+        };
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+		},
+		// Same as above, but for the class-field branch — the parent walk
+		// must traverse a method/getter body without losing track of the
+		// enclosing `static propTypes` field.
+		{
+			Code: `
+        class C {
+          static propTypes = {
+            x: () => Foo.propTypes
+          };
+        }
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+		},
+		// Object destructuring with key `'propTypes'` written with a
+		// computed-string literal `[...]` — upstream's `'name' in
+		// property.key` check excludes ComputedPropertyName too.
+		{
+			Code: `var { ["propTypes"]: x } = SomeComponent;`,
+			Tsx:  true,
+		},
+		// Object destructuring assignment where the KEY is a non-propTypes
+		// identifier and the VALUE local is named `propTypes`. Upstream
+		// gates on KEY.name === 'propTypes', so this is fine.
+		{
+			Code: `var { foo: propTypes } = SomeComponent;`,
+			Tsx:  true,
+		},
+
+		// ---- TS type-level positions (NOT MemberExpression) ----
+		// `typeof Foo.propTypes` in a type alias — tsgo represents the
+		// type-level dotted name as `KindQualifiedName`, NOT
+		// `KindPropertyAccessExpression`, so the listener correctly does
+		// not fire. Mirrors @typescript-eslint/parser emitting
+		// `TSQualifiedName` (also not MemberExpression).
+		{
+			Code: `type X = typeof Foo.propTypes;`,
+			Tsx:  true,
+		},
+		{
+			Code: `type X = { p: typeof Foo.propTypes };`,
+			Tsx:  true,
+		},
+		// ---- allowInPropTypes: true + deeply nested foreign access ----
+		// HOC pattern: spread of foreign propTypes inside own propTypes
+		// assignment.
+		{
+			Code: `
+        function withFoo(C) {
+          C.propTypes = { ...Inner.propTypes };
+          return C;
+        }
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+		},
+		// Two-level nested function bodies — parent walk must traverse
+		// both function expressions to find the enclosing assignment.
+		{
+			Code: `
+        Foo.propTypes = {
+          x: function() {
+            return { y: function() { return Bar.propTypes; } };
+          }
+        };
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+		},
+		// Conditional / logical expressions inside propTypes assignment.
+		{
+			Code: `
+        Foo.propTypes = (cond ? Bar.propTypes : Baz.propTypes) || {};
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+		},
+		// Same idea for class field — spread + conditional inside the
+		// `static propTypes` initializer.
+		{
+			Code: `
+        class C {
+          static propTypes = { ...Other.propTypes, x: cond ? Inner.propTypes.y : null };
+        }
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+		},
+
+		// ---- Regular ObjectLiteralExpression must NOT fire ----
+		// A plain object containing a key called `propTypes` is not
+		// destructuring; the OLE listener gates on `IsAssignmentTarget`.
+		{
+			Code: `const x = { propTypes: 1, foo: 2 };`,
+			Tsx:  true,
+		},
+		// Nested OLE that is NEITHER an assignment target — same rule.
+		{
+			Code: `const x = { y: { propTypes: 1 } };`,
+			Tsx:  true,
+		},
+
+		// ---- Bracket access with non-string literal arguments (NOT match) ----
+		// Numeric separator literal — `KindNumericLiteral`, not `KindStringLiteral`.
+		{
+			Code: `Foo[1_000];`,
+			Tsx:  true,
+		},
+		// BigInt literal — `KindBigIntLiteral`, not `KindStringLiteral`.
+		{
+			Code: `Foo[1n];`,
+			Tsx:  true,
+		},
+
+		// ---- Destructuring with computed template-literal key (NOT match) ----
+		// Upstream `'name' in property.key` excludes ComputedPropertyName
+		// regardless of what's inside; lock both common forms.
+		{
+			Code: "var { [`propTypes`]: x } = SomeComponent;",
+			Tsx:  true,
+		},
+
+		// ---- Function rest param destructuring (NOT match) ----
+		// `function f({...propTypes})` — propTypes is the REST target,
+		// not a regular key. `findPropTypesKey` skips `DotDotDotToken != nil`.
+		{
+			Code: `function f({ ...propTypes }) {}`,
+			Tsx:  true,
+		},
+
+		// ---- Case-sensitivity ----
+		// Exact-match only — `PropTypes` (uppercase P) is a different name.
+		{
+			Code: `Foo.PropTypes;`,
+			Tsx:  true,
+		},
+		{
+			Code: `Foo.proptypes;`,
+			Tsx:  true,
+		},
+		{
+			Code: `Foo["PropTypes"];`,
+			Tsx:  true,
+		},
+		{
+			Code: `var { PropTypes } = SomeComponent;`,
+			Tsx:  true,
+		},
+
+		// ---- defaultProps / contextTypes / similar (NOT match) ----
+		// The rule is specific to `propTypes`. Other React static fields
+		// must not be reported.
+		{
+			Code: `Foo.defaultProps;`,
+			Tsx:  true,
+		},
+		{
+			Code: `Foo.contextTypes;`,
+			Tsx:  true,
+		},
+
+		// ---- JSX dotted tag (NOT match) ----
+		// `<Foo.propTypes />` and `<Foo.propTypes></Foo.propTypes>` —
+		// tsgo represents dotted JSX tags as `PropertyAccessExpression`,
+		// but ESTree's `JSXMemberExpression` is a DIFFERENT node type.
+		// ESLint's `MemberExpression` listener does NOT fire on JSX
+		// dotted tags; the `isJsxTagName` skip aligns us byte-for-byte.
+		{
+			Code: `var X = <Foo.propTypes />;`,
+			Tsx:  true,
+		},
+		{
+			Code: `var X = <Foo.propTypes></Foo.propTypes>;`,
+			Tsx:  true,
+		},
+		// Chained dotted JSX tag — `<Foo.propTypes.Bar />`. The walk-up
+		// in `isJsxTagName` follows the PA chain to its outermost link.
+		{
+			Code: `var X = <Foo.propTypes.Bar />;`,
+			Tsx:  true,
+		},
+		// JSX dotted tag must not affect the rule when propTypes appears
+		// inside an attribute value of the same element — that PA is
+		// inside a JsxExpression, not the TagName position.
+		// (Inverse already covered in invalid: `<Foo p={Bar.propTypes} />`)
+
+		// ---- typeof in TS type-query (already covered) + value-context typeof ----
+		// `typeof Foo.propTypes` as a TYPE QUERY (in a type alias) does
+		// NOT fire — see earlier valid block. The inverse — `typeof X.p`
+		// in VALUE context — IS a regular MemberExpression and fires;
+		// see the invalid block below for the lock-in.
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code: `
+        var Foo = createReactClass({
+          propTypes: Bar.propTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      3,
+					Column:    26,
+					EndLine:   3,
+					EndColumn: 35,
+				},
+			},
+		},
+		{
+			Code: `
+        var Foo = createReactClass({
+          propTypes: Bar["propTypes"],
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      3,
+					Column:    26,
+					EndLine:   3,
+					EndColumn: 37,
+				},
+			},
+		},
+		{
+			Code: `
+        var { propTypes } = SomeComponent
+        var Foo = createReactClass({
+          propTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      2,
+					Column:    15,
+					EndLine:   2,
+					EndColumn: 24,
+				},
+			},
+		},
+		{
+			Code: `
+        var { propTypes: things, ...foo } = SomeComponent
+        var Foo = createReactClass({
+          propTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      2,
+					Column:    15,
+					EndLine:   2,
+					EndColumn: 32,
+				},
+			},
+		},
+		// Upstream marks this `no-ts` (skipped under TS parsers) due to a
+		// TS-mode bug in the parent walk. Our tsgo-based port correctly
+		// finds the enclosing `static fooBar = {...}` PropertyDeclaration,
+		// confirms it is NOT a `propTypes` field, and reports under
+		// default options. Lock-in: tsgo handles the case upstream skips.
+		{
+			Code: `
+        class MyComponent extends React.Component {
+          static fooBar = {
+            baz: Qux.propTypes.baz
+          };
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      4,
+					Column:    22,
+					EndLine:   4,
+					EndColumn: 31,
+				},
+			},
+		},
+		{
+			Code: `
+        var { propTypes: typesOfProps } = SomeComponent
+        var Foo = createReactClass({
+          propTypes: typesOfProps,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      2,
+					Column:    15,
+					EndLine:   2,
+					EndColumn: 38,
+				},
+			},
+		},
+		{
+			Code: `
+        const Message = (props) => (<div>{props.message}</div>);
+        Message.propTypes = {
+          message: PropTypes.string
+        };
+        const Hello = (props) => (<Message>Hello {props.name}</Message>);
+        Hello.propTypes = {
+          name: Message.propTypes.message
+        };
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": false},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      8,
+					Column:    25,
+					EndLine:   8,
+					EndColumn: 34,
+				},
+			},
+		},
+		// Same caveat as case 5 — upstream `no-ts`, tsgo handles correctly.
+		{
+			Code: `
+        class MyComponent extends React.Component {
+          static propTypes = {
+            baz: Qux.propTypes.baz
+          };
+        }
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": false},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      4,
+					Column:    22,
+					EndLine:   4,
+					EndColumn: 31,
+				},
+			},
+		},
+
+		// ---- Lock-in tests (universal edge shapes + upstream branch coverage) ----
+
+		// Optional-chain receiver `Foo?.propTypes` — tsgo represents
+		// optional chains as a flag on PropertyAccessExpression, not a
+		// separate `ChainExpression` wrapper. Locked-in here so a future
+		// shape change (e.g. a new wrapper kind) doesn't silently miss
+		// the report.
+		{
+			Code: `Foo?.propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      1,
+					Column:    6,
+					EndLine:   1,
+					EndColumn: 15,
+				},
+			},
+		},
+		// Parenthesized receiver `(Foo).propTypes` — tsgo preserves
+		// ParenthesizedExpression while ESTree flattens it. The receiver
+		// being parenthesized must not affect the property check.
+		{
+			Code: `(Foo).propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      1,
+					Column:    7,
+					EndLine:   1,
+					EndColumn: 16,
+				},
+			},
+		},
+		// Non-null-assertion receiver `Foo!.propTypes` — TS-only AST
+		// shape. Confirms the rule fires on the property regardless of
+		// receiver wrappers.
+		{
+			Code: `declare const Foo: any; Foo!.propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      1,
+					Column:    30,
+					EndLine:   1,
+					EndColumn: 39,
+				},
+			},
+		},
+		// Chained access `Foo.propTypes.isRequired` — the inner
+		// `Foo.propTypes` fires; the outer `.isRequired` does not. One
+		// report total.
+		{
+			Code: `Foo.propTypes.isRequired;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      1,
+					Column:    5,
+					EndLine:   1,
+					EndColumn: 14,
+				},
+			},
+		},
+		// allowInPropTypes: true does NOT shield foreign propTypes inside
+		// an *unrelated* class field (`static fooBar = ...`). Mirrors
+		// upstream `findParentClassProperty` returning the field but its
+		// key NOT being `propTypes`.
+		{
+			Code: `
+        class MyComponent extends React.Component {
+          static fooBar = {
+            baz: Qux.propTypes.baz
+          };
+        }
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      4,
+					Column:    22,
+					EndLine:   4,
+					EndColumn: 31,
+				},
+			},
+		},
+		// allowInPropTypes: true + assignment to NON-propTypes left-hand
+		// side — should still report. Locks `assignment.left.property.name
+		// === 'propTypes'` arm.
+		{
+			Code:    `Foo.notPropTypes = { x: Bar.propTypes.x };`,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      1,
+					Column:    29,
+					EndLine:   1,
+					EndColumn: 38,
+				},
+			},
+		},
+		// Bracket-keyed assignment LHS `Foo['propTypes'] = ...` does NOT
+		// satisfy upstream's `assignment.left.property.name === 'propTypes'`
+		// (the property is a Literal, has no `.name`). With
+		// allowInPropTypes: true the rule must still report Bar.propTypes
+		// inside the RHS, because the assignment is not recognized as a
+		// propTypes-shaped assignment.
+		{
+			Code:    `Foo['propTypes'] = { x: Bar.propTypes.x };`,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      1,
+					Column:    29,
+					EndLine:   1,
+					EndColumn: 38,
+				},
+			},
+		},
+
+		// ---- Destructuring-assignment form (`(...) = X`) ----
+		// Upstream's `ObjectPattern` listener fires on both var-declaration
+		// and assignment forms — ESLint emits the same node kind. tsgo
+		// splits them: declarations use `ObjectBindingPattern`, the
+		// assignment form keeps the LHS as `ObjectLiteralExpression`. The
+		// dedicated OLE listener (gated on `ast.IsAssignmentTarget`) covers
+		// these.
+		{
+			Code: `({ propTypes } = SomeComponent);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      1,
+					Column:    4,
+					EndLine:   1,
+					EndColumn: 13,
+				},
+			},
+		},
+		{
+			Code: `({ propTypes: alias } = SomeComponent);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      1,
+					Column:    4,
+					EndLine:   1,
+					EndColumn: 20,
+				},
+			},
+		},
+		// Nested destructuring assignment — the inner OLE is in an
+		// assignment-target position via the outer object literal. tsgo's
+		// `ast.IsAssignmentTarget` walks up through nested object literals
+		// to confirm.
+		{
+			Code: `({ a: { propTypes } } = SomeComponent);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      1,
+					Column:    9,
+					EndLine:   1,
+					EndColumn: 18,
+				},
+			},
+		},
+		// Array-destructuring containing object-destructuring.
+		// `[{propTypes}] = X` requires parens to be parseable in
+		// expression position; the inner OLE still sits in an assignment
+		// target via the array literal.
+		{
+			Code: `([{ propTypes }] = [SomeComponent]);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      1,
+					Column:    5,
+					EndLine:   1,
+					EndColumn: 14,
+				},
+			},
+		},
+
+		// ---- Other nesting / scoping (Dimension 2) ----
+		// Static class block — `findParentClassProperty` returns nil
+		// (KindClassStaticBlockDeclaration is not KindPropertyDeclaration),
+		// so even `allowInPropTypes: true` does not shield the access.
+		{
+			Code: `
+        class C {
+          static block = (() => {
+            return Bar.propTypes;
+          })();
+        }
+      `,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenPropType",
+					Line:      4,
+					Column:    24,
+					EndLine:   4,
+					EndColumn: 33,
+				},
+			},
+		},
+		// Multiple `propTypes` accesses in the same expression — each
+		// PropertyAccessExpression / ElementAccessExpression fires the
+		// listener independently.
+		{
+			Code: `var a = Foo.propTypes; var b = Bar["propTypes"];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 13, EndLine: 1, EndColumn: 22},
+				{MessageId: "forbiddenPropType", Line: 1, Column: 36, EndLine: 1, EndColumn: 47},
+			},
+		},
+
+		// ---- JSX context ----
+		// PA inside JSX expression child.
+		{
+			Code: `var X = <div>{Bar.propTypes}</div>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 19, EndLine: 1, EndColumn: 28},
+			},
+		},
+		// PA inside JSX attribute value.
+		{
+			Code: `var X = <Foo p={Bar.propTypes} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 21, EndLine: 1, EndColumn: 30},
+			},
+		},
+		// PA inside JSX spread attribute `{...Bar.propTypes}`.
+		{
+			Code: `var X = <Foo {...Bar.propTypes} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 22, EndLine: 1, EndColumn: 31},
+			},
+		},
+
+		// ---- TypeScript receiver / suffix wrappers ----
+		// `as`-cast receiver — tsgo: PA(AsExpression(Foo, any), propTypes).
+		{
+			Code: `(Foo as any).propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 14, EndLine: 1, EndColumn: 23},
+			},
+		},
+		// `satisfies`-receiver — same shape, different wrapper kind.
+		{
+			Code: `(Foo satisfies any).propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 21, EndLine: 1, EndColumn: 30},
+			},
+		},
+		// Non-null suffix on the access result `Foo.propTypes!` — the
+		// inner PA still fires.
+		{
+			Code: `Foo.propTypes!;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 5, EndLine: 1, EndColumn: 14},
+			},
+		},
+		// Non-null suffix between accesses — `Foo.propTypes!.x` reports
+		// only on the inner `propTypes` (outer access is `.x`).
+		{
+			Code: `Foo.propTypes!.x;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 5, EndLine: 1, EndColumn: 14},
+			},
+		},
+		// Optional chain bracket access `Foo?.['propTypes']`.
+		{
+			Code: `Foo?.['propTypes'];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 7, EndLine: 1, EndColumn: 18},
+			},
+		},
+
+		// ---- Spread / array / object literal positions ----
+		// Spread of foreign propTypes inside an object literal (NOT an
+		// assignment target).
+		{
+			Code: `const x = {...Foo.propTypes};`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 19, EndLine: 1, EndColumn: 28},
+			},
+		},
+		// PA used inside an array literal element.
+		{
+			Code: `const x = [Foo.propTypes];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 16, EndLine: 1, EndColumn: 25},
+			},
+		},
+		// Spread of foreign propTypes inside an array literal.
+		{
+			Code: `const x = [...Foo.propTypes];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 19, EndLine: 1, EndColumn: 28},
+			},
+		},
+
+		// ---- Function parameter / default contexts ----
+		// Default-value initializer in a parameter.
+		{
+			Code: `function f(x = Foo.propTypes) {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 20, EndLine: 1, EndColumn: 29},
+			},
+		},
+		// Object-destructuring parameter pulling out `propTypes`.
+		{
+			Code: `function f({ propTypes }) {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 14, EndLine: 1, EndColumn: 23},
+			},
+		},
+		// Nested destructuring parameter — inner ObjectBindingPattern fires.
+		{
+			Code: `function f({ a: { propTypes } }) {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 19, EndLine: 1, EndColumn: 28},
+			},
+		},
+		// Destructuring parameter with default — `{propTypes = X}` is
+		// still keyed by `propTypes` Identifier.
+		{
+			Code: `function f({ propTypes = {} }) {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 14, EndLine: 1, EndColumn: 28},
+			},
+		},
+		// Array destructuring containing object destructuring (declaration).
+		{
+			Code: `var [{ propTypes }] = arr;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 8, EndLine: 1, EndColumn: 17},
+			},
+		},
+
+		// ---- Class / decorator positions ----
+		// `extends` clause uses value-level PA (not type-level).
+		{
+			Code: `class C extends Foo.propTypes {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 21, EndLine: 1, EndColumn: 30},
+			},
+		},
+		// Computed method name `[Foo.propTypes]() {}`.
+		{
+			Code: `class C { [Foo.propTypes]() {} }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 16, EndLine: 1, EndColumn: 25},
+			},
+		},
+		// Class decorator `@Foo.propTypes`.
+		{
+			Code: `@Foo.propTypes class X {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 6, EndLine: 1, EndColumn: 15},
+			},
+		},
+		// Interface heritage clause — tsgo represents
+		// `interface I extends Foo.propTypes {}` with a value-level
+		// PropertyAccessExpression in the heritage clause's
+		// ExpressionWithTypeArguments (mirroring TypeScript's grammar:
+		// `extends` takes a LeftHandSideExpression). Upstream's
+		// MemberExpression listener fires equivalently.
+		{
+			Code: `interface I extends Foo.propTypes {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 25, EndLine: 1, EndColumn: 34},
+			},
+		},
+		// Class method NAMED `propTypes` — `findParentClassProperty`
+		// returns nil (MethodDeclaration is not PropertyDeclaration), so
+		// `allowInPropTypes:true` does NOT shield foreign access inside
+		// the body. Locks the field-vs-method asymmetry.
+		{
+			Code:    `class C { static propTypes() { return Bar.propTypes; } }`,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 43, EndLine: 1, EndColumn: 52},
+			},
+		},
+		// Class getter NAMED `propTypes` — same story (GetAccessor is
+		// not PropertyDeclaration).
+		{
+			Code:    `class C { static get propTypes() { return Bar.propTypes; } }`,
+			Options: map[string]interface{}{"allowInPropTypes": true},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 47, EndLine: 1, EndColumn: 56},
+			},
+		},
+
+		// ---- Tagged template / call / new ----
+		// Tagged template: tag is `Foo.propTypes`.
+		{
+			Code: "Foo.propTypes`x`;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 5, EndLine: 1, EndColumn: 14},
+			},
+		},
+		// Call on propTypes — `Foo.propTypes()`.
+		{
+			Code: `Foo.propTypes();`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 5, EndLine: 1, EndColumn: 14},
+			},
+		},
+		// `new` on propTypes — `new Foo.propTypes()`.
+		{
+			Code: `new Foo.propTypes();`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 9, EndLine: 1, EndColumn: 18},
+			},
+		},
+		// Generic call — `Foo.propTypes<T>()`.
+		{
+			Code: `Foo.propTypes<any>();`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 5, EndLine: 1, EndColumn: 14},
+			},
+		},
+		// Template-literal substitution `${Foo.propTypes}`.
+		{
+			Code: "`${Foo.propTypes}`;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 8, EndLine: 1, EndColumn: 17},
+			},
+		},
+
+		// ---- Loops / control flow ----
+		{
+			Code: `for (const k in Foo.propTypes) {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 21, EndLine: 1, EndColumn: 30},
+			},
+		},
+		{
+			Code: `for (const v of Foo.propTypes) {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 21, EndLine: 1, EndColumn: 30},
+			},
+		},
+		{
+			Code: `while (Foo.propTypes) {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 12, EndLine: 1, EndColumn: 21},
+			},
+		},
+		// Async / generator: await + yield expression operands.
+		{
+			Code: `async function f() { return await Foo.propTypes; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 39, EndLine: 1, EndColumn: 48},
+			},
+		},
+		{
+			Code: `function* g() { yield Foo.propTypes; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 27, EndLine: 1, EndColumn: 36},
+			},
+		},
+
+		// ---- Destructuring assignment edge cases ----
+		// Multiple keys with `propTypes` after another property — listener
+		// reports the FIRST matching key (upstream uses `.find`).
+		{
+			Code: `({ foo: a, propTypes } = SomeComponent);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 12, EndLine: 1, EndColumn: 21},
+			},
+		},
+		// Spread (`...rest`) is skipped; `propTypes` shorthand still
+		// reports.
+		{
+			Code: `({ propTypes, ...rest } = SomeComponent);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 4, EndLine: 1, EndColumn: 13},
+			},
+		},
+		// Default initializer in destructuring assignment shorthand —
+		// `({propTypes = {}} = X)`. The ShorthandPropertyAssignment node
+		// spans `propTypes = {}`.
+		{
+			Code: `({ propTypes = {} } = SomeComponent);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 4, EndLine: 1, EndColumn: 18},
+			},
+		},
+
+		// ---- Receiver-type variations (rule is purely syntactic) ----
+		// `this.propTypes` — `this` keyword as receiver. Rule fires; the
+		// rule does not filter by what the receiver "is".
+		{
+			Code: `class C { m() { return this.propTypes; } }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 29, EndLine: 1, EndColumn: 38},
+			},
+		},
+		// `super.propTypes` — `super` keyword as receiver.
+		{
+			Code: `class C extends D { m() { return super.propTypes; } }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 40, EndLine: 1, EndColumn: 49},
+			},
+		},
+		// CallExpression receiver — `f().propTypes`. Outer PA fires.
+		{
+			Code: `f().propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 5, EndLine: 1, EndColumn: 14},
+			},
+		},
+		// ConditionalExpression receiver — `(cond ? A : B).propTypes`.
+		{
+			Code: `(cond ? A : B).propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 16, EndLine: 1, EndColumn: 25},
+			},
+		},
+		// Sequence-expression receiver `(a, B).propTypes` — tsgo represents
+		// the comma operator as a `BinaryExpression(KindCommaToken)`.
+		{
+			Code: `(a, B).propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 8, EndLine: 1, EndColumn: 17},
+			},
+		},
+		// ElementAccess receiver — `arr[0].propTypes`.
+		{
+			Code: `arr[0].propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 8, EndLine: 1, EndColumn: 17},
+			},
+		},
+		// Dynamic import — `import('x').propTypes`. The receiver is a
+		// CallExpression with `import` as the keyword tag.
+		{
+			Code: `import('x').propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 13, EndLine: 1, EndColumn: 22},
+			},
+		},
+
+		// ---- Chained / repeated propTypes ----
+		// `Foo.propTypes.propTypes` — outer PA's name is also `propTypes`,
+		// so BOTH fire (inner reports on inner `propTypes`, outer reports
+		// on outer `propTypes`). Mirrors upstream's per-MemberExpression
+		// fire. tsgo's listener visits parent-first, so the outer report
+		// is emitted before the inner one.
+		{
+			Code: `Foo.propTypes.propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 15, EndLine: 1, EndColumn: 24},
+				{MessageId: "forbiddenPropType", Line: 1, Column: 5, EndLine: 1, EndColumn: 14},
+			},
+		},
+
+		// ---- ES2021 logical assignment operators on LHS (NOT match) ----
+		// These emit BinaryExpression with `||=` / `&&=` / `??=` operator
+		// tokens — `ast.IsAssignmentOperator` returns true for all three,
+		// so `isAssignmentLHS` correctly excludes the LHS.
+		// The RIGHT side is `Bar.propTypes` and DOES fire.
+		{
+			Code: `Foo.propTypes ||= Bar.propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 23, EndLine: 1, EndColumn: 32},
+			},
+		},
+		{
+			Code: `Foo.propTypes &&= Bar.propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 23, EndLine: 1, EndColumn: 32},
+			},
+		},
+		{
+			Code: `Foo.propTypes ??= Bar.propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 23, EndLine: 1, EndColumn: 32},
+			},
+		},
+
+		// ---- Operator / unary positions ----
+		// `delete Foo.propTypes` — DeleteExpression with PA operand.
+		{
+			Code: `delete Foo.propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 12, EndLine: 1, EndColumn: 21},
+			},
+		},
+		// `typeof Foo.propTypes` in VALUE context — UnaryExpression /
+		// TypeOfExpression with PA operand. Distinct from the type-level
+		// `typeof Foo.propTypes` inside `type X = ...` (QualifiedName,
+		// covered in valid).
+		{
+			Code: `var x = typeof Foo.propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 20, EndLine: 1, EndColumn: 29},
+			},
+		},
+		// `void Foo.propTypes` — VoidExpression.
+		{
+			Code: `void Foo.propTypes;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 10, EndLine: 1, EndColumn: 19},
+			},
+		},
+
+		// ---- Class expression / nested classes ----
+		// Class expression with extends: `const X = class extends Foo.propTypes {}`.
+		{
+			Code: `const X = class extends Foo.propTypes {};`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 29, EndLine: 1, EndColumn: 38},
+			},
+		},
+
+		// ---- Catch parameter destructuring ----
+		// `try {} catch ({ propTypes }) {}` — catch with destructuring
+		// parameter. ObjectBindingPattern listener fires.
+		{
+			Code: `try {} catch ({ propTypes }) {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 17, EndLine: 1, EndColumn: 26},
+			},
+		},
+
+		// ---- JSX fragment ----
+		// `<>{Foo.propTypes}</>` — fragment expression child.
+		{
+			Code: `var X = <>{Foo.propTypes}</>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 16, EndLine: 1, EndColumn: 25},
+			},
+		},
+
+		// ---- Spread argument in call ----
+		// `f(...Foo.propTypes)` — spread argument.
+		{
+			Code: `f(...Foo.propTypes);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 10, EndLine: 1, EndColumn: 19},
+			},
+		},
+
+		// ---- Decorator on class member ----
+		// Member-level decorator on a class field — PA inside decorator
+		// fires.
+		{
+			Code: `class C { @Foo.propTypes prop = 1; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 16, EndLine: 1, EndColumn: 25},
+			},
+		},
+		// `for (const {propTypes} of arr) {}` — for-of with destructuring
+		// in the loop variable position. The ObjectBindingPattern listener
+		// fires.
+		{
+			Code: `for (const { propTypes } of arr) {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 14, EndLine: 1, EndColumn: 23},
+			},
+		},
+		// JSX with foreign propTypes in attribute value AND a JSX dotted
+		// tag — confirms only the attribute-value PA is reported, the
+		// JSX tag PA is correctly skipped via `isJsxTagName`.
+		{
+			Code: `var X = <NS.Foo p={Bar.propTypes} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenPropType", Line: 1, Column: 24, EndLine: 1, EndColumn: 33},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -89,6 +89,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/forbid-component-props.test.ts',
     './tests/eslint-plugin-react/rules/forbid-dom-props.test.ts',
     './tests/eslint-plugin-react/rules/forbid-elements.test.ts',
+    './tests/eslint-plugin-react/rules/forbid-foreign-prop-types.test.ts',
     './tests/eslint-plugin-react/rules/forbid-prop-types.test.ts',
     './tests/eslint-plugin-react/rules/jsx-child-element-spacing.test.ts',
     './tests/eslint-plugin-react/rules/self-closing-comp.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/forbid-foreign-prop-types.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/forbid-foreign-prop-types.test.ts
@@ -1,0 +1,612 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('forbid-foreign-prop-types', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    {
+      code: `import { propTypes } from "SomeComponent";`,
+    },
+    {
+      code: `import { propTypes as someComponentPropTypes } from "SomeComponent";`,
+    },
+    {
+      code: `const foo = propTypes`,
+    },
+    {
+      code: `foo(propTypes)`,
+    },
+    {
+      code: `foo + propTypes`,
+    },
+    {
+      code: `const foo = [propTypes]`,
+    },
+    {
+      code: `const foo = { propTypes }`,
+    },
+    {
+      code: `Foo.propTypes = propTypes`,
+    },
+    {
+      code: `Foo["propTypes"] = propTypes`,
+    },
+    {
+      code: `const propTypes = "bar"; Foo[propTypes];`,
+    },
+    {
+      code: `
+        const Message = (props) => (<div>{props.message}</div>);
+        Message.propTypes = {
+          message: PropTypes.string
+        };
+        const Hello = (props) => (<Message>Hello {props.name}</Message>);
+        Hello.propTypes = {
+          name: Message.propTypes.message
+        };
+      `,
+      options: [{ allowInPropTypes: true }],
+    },
+    {
+      code: `
+        class MyComponent extends React.Component {
+          static propTypes = {
+            baz: Qux.propTypes.baz
+          };
+        }
+      `,
+      options: [{ allowInPropTypes: true }],
+    },
+    // ---- Universal edge shapes locked-in ----
+    {
+      code: 'Foo[`propTypes`]',
+    },
+    {
+      code: `class C { #propTypes = 1; m() { return this.#propTypes } }`,
+    },
+    {
+      code: `Foo[0]`,
+    },
+    {
+      code: `var { "propTypes": x } = SomeComponent;`,
+    },
+    {
+      code: `var { ...propTypes } = SomeComponent;`,
+    },
+    {
+      code: `Foo.propTypes += {}`,
+    },
+    {
+      code: `(Foo.propTypes) = {};`,
+    },
+    {
+      code: `
+        Bar.propTypes = {
+          x: () => Foo.propTypes
+        };
+      `,
+      options: [{ allowInPropTypes: true }],
+    },
+    {
+      code: `
+        class C {
+          static propTypes = {
+            x: () => Foo.propTypes
+          };
+        }
+      `,
+      options: [{ allowInPropTypes: true }],
+    },
+    {
+      code: `var { ["propTypes"]: x } = SomeComponent;`,
+    },
+    {
+      code: `var { foo: propTypes } = SomeComponent;`,
+    },
+    // ---- TS type-level positions (do NOT fire) ----
+    {
+      code: `type X = typeof Foo.propTypes;`,
+    },
+    {
+      code: `type X = { p: typeof Foo.propTypes };`,
+    },
+    // ---- allowInPropTypes: true + deeply nested foreign access ----
+    {
+      code: `
+        function withFoo(C) {
+          C.propTypes = { ...Inner.propTypes };
+          return C;
+        }
+      `,
+      options: [{ allowInPropTypes: true }],
+    },
+    {
+      code: `
+        Foo.propTypes = {
+          x: function() {
+            return { y: function() { return Bar.propTypes; } };
+          }
+        };
+      `,
+      options: [{ allowInPropTypes: true }],
+    },
+    {
+      code: `Foo.propTypes = (cond ? Bar.propTypes : Baz.propTypes) || {};`,
+      options: [{ allowInPropTypes: true }],
+    },
+    {
+      code: `
+        class C {
+          static propTypes = { ...Other.propTypes, x: cond ? Inner.propTypes.y : null };
+        }
+      `,
+      options: [{ allowInPropTypes: true }],
+    },
+    // ---- Regular OLE must NOT fire ----
+    {
+      code: `const x = { propTypes: 1, foo: 2 };`,
+    },
+    {
+      code: `const x = { y: { propTypes: 1 } };`,
+    },
+    // ---- Bracket access with non-string literal arguments (NOT match) ----
+    {
+      code: `Foo[1_000];`,
+    },
+    {
+      code: `Foo[1n];`,
+    },
+    // ---- Computed template-literal destructuring key (NOT match) ----
+    {
+      code: 'var { [`propTypes`]: x } = SomeComponent;',
+    },
+    // ---- Function rest param destructuring (NOT match) ----
+    {
+      code: `function f({ ...propTypes }) {}`,
+    },
+    // ---- Case sensitivity ----
+    {
+      code: `Foo.PropTypes;`,
+    },
+    {
+      code: `Foo.proptypes;`,
+    },
+    {
+      code: `Foo["PropTypes"];`,
+    },
+    {
+      code: `var { PropTypes } = SomeComponent;`,
+    },
+    // ---- Other React static fields (NOT match) ----
+    {
+      code: `Foo.defaultProps;`,
+    },
+    {
+      code: `Foo.contextTypes;`,
+    },
+    // ---- JSX dotted tag (NOT match) ----
+    // tsgo represents `<Foo.Bar />` with PropertyAccessExpression while
+    // ESTree uses a distinct JSXMemberExpression. The `isJsxTagName`
+    // skip aligns the byte-for-byte output.
+    {
+      code: `var X = <Foo.propTypes />;`,
+    },
+    {
+      code: `var X = <Foo.propTypes></Foo.propTypes>;`,
+    },
+    {
+      code: `var X = <Foo.propTypes.Bar />;`,
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: `
+        var Foo = createReactClass({
+          propTypes: Bar.propTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `
+        var Foo = createReactClass({
+          propTypes: Bar["propTypes"],
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `
+        var { propTypes } = SomeComponent
+        var Foo = createReactClass({
+          propTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `
+        var { propTypes: things, ...foo } = SomeComponent
+        var Foo = createReactClass({
+          propTypes,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `
+        class MyComponent extends React.Component {
+          static fooBar = {
+            baz: Qux.propTypes.baz
+          };
+        }
+      `,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `
+        var { propTypes: typesOfProps } = SomeComponent
+        var Foo = createReactClass({
+          propTypes: typesOfProps,
+          render: function() {
+            return <Foo className="bar" />;
+          }
+        });
+      `,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `
+        const Message = (props) => (<div>{props.message}</div>);
+        Message.propTypes = {
+          message: PropTypes.string
+        };
+        const Hello = (props) => (<Message>Hello {props.name}</Message>);
+        Hello.propTypes = {
+          name: Message.propTypes.message
+        };
+      `,
+      options: [{ allowInPropTypes: false }],
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `
+        class MyComponent extends React.Component {
+          static propTypes = {
+            baz: Qux.propTypes.baz
+          };
+        }
+      `,
+      options: [{ allowInPropTypes: false }],
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Lock-in tests ----
+    {
+      code: `Foo?.propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `(Foo).propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `declare const Foo: any; Foo!.propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `Foo.propTypes.isRequired;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `
+        class MyComponent extends React.Component {
+          static fooBar = {
+            baz: Qux.propTypes.baz
+          };
+        }
+      `,
+      options: [{ allowInPropTypes: true }],
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `Foo.notPropTypes = { x: Bar.propTypes.x };`,
+      options: [{ allowInPropTypes: true }],
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `Foo['propTypes'] = { x: Bar.propTypes.x };`,
+      options: [{ allowInPropTypes: true }],
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `({ propTypes } = SomeComponent);`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `({ propTypes: alias } = SomeComponent);`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `({ a: { propTypes } } = SomeComponent);`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `([{ propTypes }] = [SomeComponent]);`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `
+        class C {
+          static block = (() => {
+            return Bar.propTypes;
+          })();
+        }
+      `,
+      options: [{ allowInPropTypes: true }],
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `var a = Foo.propTypes; var b = Bar["propTypes"];`,
+      errors: [
+        { messageId: 'forbiddenPropType' },
+        { messageId: 'forbiddenPropType' },
+      ],
+    },
+    // ---- JSX context ----
+    {
+      code: `var X = <div>{Bar.propTypes}</div>;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `var X = <Foo p={Bar.propTypes} />;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `var X = <Foo {...Bar.propTypes} />;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- TypeScript receiver / suffix wrappers ----
+    {
+      code: `(Foo as any).propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `(Foo satisfies any).propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `Foo.propTypes!;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `Foo.propTypes!.x;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `Foo?.['propTypes'];`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Spread / array / object literal positions ----
+    {
+      code: `const x = {...Foo.propTypes};`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `const x = [Foo.propTypes];`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `const x = [...Foo.propTypes];`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Function parameter / default contexts ----
+    {
+      code: `function f(x = Foo.propTypes) {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `function f({ propTypes }) {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `function f({ a: { propTypes } }) {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `function f({ propTypes = {} }) {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `var [{ propTypes }] = arr;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Class / decorator positions ----
+    {
+      code: `class C extends Foo.propTypes {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `class C { [Foo.propTypes]() {} }`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `@Foo.propTypes class X {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `interface I extends Foo.propTypes {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `class C { static propTypes() { return Bar.propTypes; } }`,
+      options: [{ allowInPropTypes: true }],
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `class C { static get propTypes() { return Bar.propTypes; } }`,
+      options: [{ allowInPropTypes: true }],
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Tagged template / call / new ----
+    {
+      code: 'Foo.propTypes`x`;',
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `Foo.propTypes();`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `new Foo.propTypes();`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `Foo.propTypes<any>();`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: '`${Foo.propTypes}`;',
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Loops / control flow ----
+    {
+      code: `for (const k in Foo.propTypes) {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `for (const v of Foo.propTypes) {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `while (Foo.propTypes) {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `async function f() { return await Foo.propTypes; }`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `function* g() { yield Foo.propTypes; }`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Destructuring assignment edge cases ----
+    {
+      code: `({ foo: a, propTypes } = SomeComponent);`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `({ propTypes, ...rest } = SomeComponent);`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `({ propTypes = {} } = SomeComponent);`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Receiver-type variations ----
+    {
+      code: `class C { m() { return this.propTypes; } }`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `class C extends D { m() { return super.propTypes; } }`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `f().propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `(cond ? A : B).propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `(a, B).propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `arr[0].propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `import('x').propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Chained .propTypes.propTypes (both fire) ----
+    {
+      code: `Foo.propTypes.propTypes;`,
+      errors: [
+        { messageId: 'forbiddenPropType' },
+        { messageId: 'forbiddenPropType' },
+      ],
+    },
+    // ---- Logical assignment LHS exclusions; RHS still fires ----
+    {
+      code: `Foo.propTypes ||= Bar.propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `Foo.propTypes &&= Bar.propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `Foo.propTypes ??= Bar.propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Operator / unary positions ----
+    {
+      code: `delete Foo.propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `var x = typeof Foo.propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `void Foo.propTypes;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    // ---- Class expression / catch / fragment / spread call / member decorator ----
+    {
+      code: `const X = class extends Foo.propTypes {};`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `try {} catch ({ propTypes }) {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `var X = <>{Foo.propTypes}</>;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `f(...Foo.propTypes);`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `class C { @Foo.propTypes prop = 1; }`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `for (const { propTypes } of arr) {}`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+    {
+      code: `var X = <NS.Foo p={Bar.propTypes} />;`,
+      errors: [{ messageId: 'forbiddenPropType' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -140,6 +140,7 @@ preact
 Prag
 Prettier
 propertyassignment
+proptypes
 Ptrs
 quasis
 quxx


### PR DESCRIPTION
## Summary

Port the `react/forbid-foreign-prop-types` rule from `eslint-plugin-react` to rslint.

The rule forbids using another component's `propTypes` unless they are explicitly imported / exported, so production-build tools that strip `propTypes` (e.g. `babel-plugin-transform-react-remove-prop-types`) can do so safely.

Supports the `allowInPropTypes` option (default `false`); when enabled, foreign `propTypes` are allowed inside a `propTypes` declaration (`<Component>.propTypes = {...}` or `static propTypes = {...}`).

Implementation notes:
- Maps ESLint's single `MemberExpression` + `ObjectPattern` listeners onto four tsgo listeners (`PropertyAccessExpression`, `ElementAccessExpression`, `ObjectBindingPattern`, `ObjectLiteralExpression` gated by `ast.IsAssignmentTarget`) to cover both declaration-form and assignment-form destructuring.
- Skips JSX dotted tag-name positions so behavior aligns with ESTree's distinct `JSXMemberExpression` node (`isJsxTagName` walks the PA chain).
- Strict direct-LHS exclusion mirrors upstream's `isAssignmentLHS` semantics; paren transparency is handled via `ast.SkipParentheses` and an upward paren walk.
- Two upstream `no-ts` cases (skipped by upstream under TS parsers due to a known FIXME) are correctly handled here.

Test coverage: 44 valid + 77 invalid Go cases; full upstream test suite migrated 1:1, plus extensive lock-in tests for AST-shape divergences (paren / `!` / `as` / `satisfies` / optional chain / template literal / numeric / BigInt / private identifier / JSX dotted tag / typeof type-context / destructuring assignment / nested patterns / class extends / decorators / loops / await / yield / etc.). End-to-end verified through the built `rslint` binary against constructed cases.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/forbid-foreign-prop-types.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).