### PR TITLE
feat: port rule react/jsx-closing-bracket-location

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -8,6 +8,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_elements"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_prop_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_boolean_value"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_closing_bracket_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_closing_tag_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_equals_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_filename_extension"
@@ -77,6 +78,7 @@ func GetAllRules() []rule.Rule {
 		forbid_elements.ForbidElementsRule,
 		forbid_prop_types.ForbidPropTypesRule,
 		jsx_boolean_value.JsxBooleanValueRule,
+		jsx_closing_bracket_location.JsxClosingBracketLocationRule,
 		jsx_closing_tag_location.JsxClosingTagLocationRule,
 		jsx_equals_spacing.JsxEqualsSpacingRule,
 		jsx_filename_extension.JsxFilenameExtensionRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -51,6 +51,47 @@ func IsHookName(name string) bool {
 	return hookNameRegex.MatchString(name)
 }
 
+// HorizontalWhitespacePrefix returns the longest prefix of s consisting of
+// ECMA WhiteSpace characters (excluding LineTerminators). It matches the
+// behavior of `/^\s*/` applied to a single line — used by JSX layout rules
+// that compute "indent of line N" without crossing into the next line.
+//
+// LineTerminators (\n, \r,  ,  ) are NOT consumed, so passing a
+// multi-line string only ever returns the indent of the first line.
+func HorizontalWhitespacePrefix(s string) string {
+	for i, r := range s {
+		if !isHorizontalWhitespace(r) {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+func isHorizontalWhitespace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\v', '\f', 0xFEFF:
+		return true
+	}
+	return unicode.Is(unicode.Zs, r)
+}
+
+// UTF16Length returns the number of UTF-16 code units required to encode s.
+// ASCII / BMP runes count as 1; runes outside the BMP (>= U+10000) count as
+// 2 (surrogate pair). Use this when computing column positions that must
+// agree with ESLint's `loc.column` semantics — Go's `len(s)` is byte length
+// (UTF-8), which can over-count for multi-byte characters.
+func UTF16Length(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < 0x10000 {
+			n++
+		} else {
+			n += 2
+		}
+	}
+	return n
+}
+
 // GlobToRegex converts a minimatch-style glob into a fully anchored
 // regular expression. Supports the subset of minimatch syntax the
 // eslint-plugin-react ecosystem relies on:

--- a/internal/plugins/react/rules/jsx_closing_bracket_location/jsx_closing_bracket_location.go
+++ b/internal/plugins/react/rules/jsx_closing_bracket_location/jsx_closing_bracket_location.go
@@ -1,0 +1,405 @@
+package jsx_closing_bracket_location
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const defaultLocation = "tag-aligned"
+
+var locationMessages = map[string]string{
+	"after-props":   "placed after the last prop",
+	"after-tag":     "placed after the opening tag",
+	"props-aligned": "aligned with the last prop",
+	"tag-aligned":   "aligned with the opening tag",
+	"line-aligned":  "aligned with the line containing the opening tag",
+}
+
+type bracketOptions struct {
+	nonEmpty       string
+	selfClosing    string
+	nonEmptyOff    bool
+	selfClosingOff bool
+}
+
+func parseOptions(options any) bracketOptions {
+	opts := bracketOptions{nonEmpty: defaultLocation, selfClosing: defaultLocation}
+	if options == nil {
+		return opts
+	}
+
+	raw := options
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) == 0 {
+			return opts
+		}
+		raw = arr[0]
+	}
+
+	switch v := raw.(type) {
+	case string:
+		opts.nonEmpty = v
+		opts.selfClosing = v
+	case map[string]interface{}:
+		applyMap(&opts, v)
+	}
+	return opts
+}
+
+func applyMap(opts *bracketOptions, m map[string]interface{}) {
+	if v, exists := m["location"]; exists {
+		if s, ok := v.(string); ok {
+			opts.nonEmpty = s
+			opts.selfClosing = s
+		}
+	}
+	if v, exists := m["nonEmpty"]; exists {
+		if s, ok := v.(string); ok {
+			opts.nonEmpty = s
+			opts.nonEmptyOff = false
+		} else if b, ok := v.(bool); ok && !b {
+			opts.nonEmptyOff = true
+		}
+	}
+	if v, exists := m["selfClosing"]; exists {
+		if s, ok := v.(string); ok {
+			opts.selfClosing = s
+			opts.selfClosingOff = false
+		} else if b, ok := v.(bool); ok && !b {
+			opts.selfClosingOff = true
+		}
+	}
+}
+
+type tokenInfo struct {
+	openingPos    int
+	openingLine   int
+	openingColumn int
+
+	closingPos    int
+	closingLine   int
+	closingColumn int
+
+	tagLine int
+
+	hasLastProp       bool
+	lastPropEnd       int
+	lastPropFirstLine int
+	lastPropLastLine  int
+	lastPropColumn    int
+
+	openingStartCol int
+
+	openTab  bool
+	closeTab bool
+
+	selfClosing bool
+}
+
+func leadingWhitespace(text string, lineStart int) string {
+	if lineStart >= len(text) {
+		return ""
+	}
+	return reactutil.HorizontalWhitespacePrefix(text[lineStart:])
+}
+
+// JsxClosingBracketLocationRule enforces the closing bracket location for JSX
+// multiline elements.
+var JsxClosingBracketLocationRule = rule.Rule{
+	Name: "react/jsx-closing-bracket-location",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		check := func(node *ast.Node) {
+			var tagName *ast.Node
+			var attrs []*ast.Node
+			var selfClosing bool
+
+			switch node.Kind {
+			case ast.KindJsxOpeningElement:
+				opening := node.AsJsxOpeningElement()
+				tagName = opening.TagName
+				if opening.Attributes != nil {
+					jsxAttrs := opening.Attributes.AsJsxAttributes()
+					if jsxAttrs.Properties != nil {
+						attrs = jsxAttrs.Properties.Nodes
+					}
+				}
+				selfClosing = false
+			case ast.KindJsxSelfClosingElement:
+				self := node.AsJsxSelfClosingElement()
+				tagName = self.TagName
+				if self.Attributes != nil {
+					jsxAttrs := self.Attributes.AsJsxAttributes()
+					if jsxAttrs.Properties != nil {
+						attrs = jsxAttrs.Properties.Nodes
+					}
+				}
+				selfClosing = true
+			default:
+				return
+			}
+
+			text := ctx.SourceFile.Text()
+			lineStarts := ctx.SourceFile.ECMALineMap()
+
+			elemTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			openingPos := elemTrimmed.Pos()
+			elemEnd := elemTrimmed.End()
+
+			gtPos := elemEnd - 1
+			for gtPos > openingPos && gtPos < len(text) && text[gtPos] != '>' {
+				gtPos--
+			}
+			if gtPos < 0 || gtPos >= len(text) || text[gtPos] != '>' {
+				return
+			}
+
+			closingPos := gtPos
+			if selfClosing {
+				slash := gtPos - 1
+				for slash > openingPos && (text[slash] == ' ' || text[slash] == '\t' || text[slash] == '\n' || text[slash] == '\r') {
+					slash--
+				}
+				if slash <= openingPos || text[slash] != '/' {
+					return
+				}
+				closingPos = slash
+			}
+
+			openingLine := scanner.ComputeLineOfPosition(lineStarts, openingPos)
+			openingLineStart := int(lineStarts[openingLine])
+			openingColumn := reactutil.UTF16Length(text[openingLineStart:openingPos])
+
+			closingLine := scanner.ComputeLineOfPosition(lineStarts, closingPos)
+			closingLineStart := int(lineStarts[closingLine])
+			closingColumn := reactutil.UTF16Length(text[closingLineStart:closingPos])
+
+			tagTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, tagName)
+			tagLine := scanner.ComputeLineOfPosition(lineStarts, tagTrimmed.Pos())
+
+			openingStartIndent := leadingWhitespace(text, openingLineStart)
+
+			info := tokenInfo{
+				openingPos:      openingPos,
+				openingLine:     openingLine,
+				openingColumn:   openingColumn,
+				closingPos:      closingPos,
+				closingLine:     closingLine,
+				closingColumn:   closingColumn,
+				tagLine:         tagLine,
+				openingStartCol: reactutil.UTF16Length(openingStartIndent),
+				openTab:         openingLineStart < len(text) && text[openingLineStart] == '\t',
+				closeTab:        closingLineStart < len(text) && text[closingLineStart] == '\t',
+				selfClosing:     selfClosing,
+			}
+
+			if len(attrs) > 0 {
+				lastProp := attrs[len(attrs)-1]
+				lpTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, lastProp)
+				lpStart := lpTrimmed.Pos()
+				lpEnd := lpTrimmed.End()
+				lpFirstLine := scanner.ComputeLineOfPosition(lineStarts, lpStart)
+				lpLastLine := scanner.ComputeLineOfPosition(lineStarts, lpEnd-1)
+				lpLineStart := int(lineStarts[lpFirstLine])
+				lpColumn := reactutil.UTF16Length(text[lpLineStart:lpStart])
+				info.hasLastProp = true
+				info.lastPropEnd = lpEnd
+				info.lastPropFirstLine = lpFirstLine
+				info.lastPropLastLine = lpLastLine
+				info.lastPropColumn = lpColumn
+			}
+
+			expectedLocation, disabled := getExpectedLocation(info, opts)
+			if disabled {
+				return
+			}
+
+			usingSameIndentation := true
+			if expectedLocation == "tag-aligned" {
+				usingSameIndentation = info.openTab == info.closeTab
+			}
+
+			if hasCorrectLocation(info, expectedLocation) && usingSameIndentation {
+				return
+			}
+
+			locationDesc, ok := locationMessages[expectedLocation]
+			if !ok {
+				return
+			}
+
+			details := ""
+			expectedNextLine := info.hasLastProp && info.lastPropLastLine == info.closingLine
+			correctColumn, hasCorrectColumn := getCorrectColumn(info, expectedLocation)
+			if hasCorrectColumn {
+				if expectedNextLine {
+					details = fmt.Sprintf(" (expected column %d on the next line)", correctColumn+1)
+				} else {
+					details = fmt.Sprintf(" (expected column %d)", correctColumn+1)
+				}
+			}
+
+			fix := buildFix(text, info, expectedLocation, expectedNextLine, correctColumn, lineStarts, elemEnd, tagTrimmed.End(), selfClosing)
+
+			msg := rule.RuleMessage{
+				Id:          "bracketLocation",
+				Description: fmt.Sprintf("The closing bracket must be %s%s", locationDesc, details),
+			}
+
+			closingEnd := closingPos + 1
+			if closingEnd > len(text) {
+				closingEnd = len(text)
+			}
+			reportRange := core.NewTextRange(closingPos, closingEnd)
+
+			if fix != nil {
+				ctx.ReportRangeWithFixes(reportRange, msg, *fix)
+			} else {
+				ctx.ReportRange(reportRange, msg)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}
+
+func getExpectedLocation(info tokenInfo, opts bracketOptions) (string, bool) {
+	if !info.hasLastProp {
+		return "after-tag", false
+	}
+	if info.openingLine == info.lastPropLastLine {
+		return "after-props", false
+	}
+	if info.selfClosing {
+		if opts.selfClosingOff {
+			return "", true
+		}
+		return opts.selfClosing, false
+	}
+	if opts.nonEmptyOff {
+		return "", true
+	}
+	return opts.nonEmpty, false
+}
+
+func hasCorrectLocation(info tokenInfo, expectedLocation string) bool {
+	switch expectedLocation {
+	case "after-tag":
+		return info.tagLine == info.closingLine
+	case "after-props":
+		return info.lastPropLastLine == info.closingLine
+	case "props-aligned", "tag-aligned", "line-aligned":
+		col, ok := getCorrectColumn(info, expectedLocation)
+		if !ok {
+			return true
+		}
+		return col == info.closingColumn
+	default:
+		return true
+	}
+}
+
+func getCorrectColumn(info tokenInfo, expectedLocation string) (int, bool) {
+	switch expectedLocation {
+	case "props-aligned":
+		if !info.hasLastProp {
+			return 0, false
+		}
+		return info.lastPropColumn, true
+	case "tag-aligned":
+		return info.openingColumn, true
+	case "line-aligned":
+		return info.openingStartCol, true
+	default:
+		return 0, false
+	}
+}
+
+func getIndentation(text string, lineStarts []core.TextPos, info tokenInfo, expectedLocation string, correctColumn int) string {
+	var indent string
+	switch expectedLocation {
+	case "props-aligned":
+		if info.hasLastProp {
+			indent = leadingWhitespace(text, int(lineStarts[info.lastPropFirstLine]))
+		}
+	case "tag-aligned", "line-aligned":
+		indent = leadingWhitespace(text, int(lineStarts[info.openingLine]))
+	}
+	indentUTF16 := reactutil.UTF16Length(indent)
+	if indentUTF16+1 < correctColumn+1 {
+		// Non-whitespace characters precede the bracket on the reference line —
+		// pad with spaces so the column matches.
+		if correctColumn > indentUTF16 {
+			indent = indent + strings.Repeat(" ", correctColumn-indentUTF16)
+		}
+	}
+	return indent
+}
+
+func buildFix(text string, info tokenInfo, expectedLocation string, expectedNextLine bool, correctColumn int, lineStarts []core.TextPos, elemEnd int, tagNameEnd int, selfClosing bool) *rule.RuleFix {
+	closingTag := ">"
+	if selfClosing {
+		closingTag = "/>"
+	}
+
+	var start, end int
+	var newText string
+
+	switch expectedLocation {
+	case "after-tag":
+		if info.hasLastProp {
+			start = info.lastPropEnd
+			end = elemEnd
+			if expectedNextLine {
+				newText = "\n" + closingTag
+			} else {
+				newText = closingTag
+			}
+		} else {
+			start = tagNameEnd
+			end = elemEnd
+			if expectedNextLine {
+				newText = "\n" + closingTag
+			} else {
+				newText = " " + closingTag
+			}
+		}
+	case "after-props":
+		if !info.hasLastProp {
+			return nil
+		}
+		start = info.lastPropEnd
+		end = elemEnd
+		if expectedNextLine {
+			newText = "\n" + closingTag
+		} else {
+			newText = closingTag
+		}
+	case "props-aligned", "tag-aligned", "line-aligned":
+		if !info.hasLastProp {
+			return nil
+		}
+		start = info.lastPropEnd
+		end = elemEnd
+		indent := getIndentation(text, lineStarts, info, expectedLocation, correctColumn)
+		newText = "\n" + indent + closingTag
+	default:
+		return nil
+	}
+
+	return &rule.RuleFix{
+		Text:  newText,
+		Range: core.NewTextRange(start, end),
+	}
+}

--- a/internal/plugins/react/rules/jsx_closing_bracket_location/jsx_closing_bracket_location.md
+++ b/internal/plugins/react/rules/jsx_closing_bracket_location/jsx_closing_bracket_location.md
@@ -1,0 +1,175 @@
+# jsx-closing-bracket-location
+
+## Rule Details
+
+Enforces the closing bracket location for JSX multiline elements. By default the closing bracket must be aligned with the opening tag.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<Hello
+  lastName="Smith"
+  firstName="John" />;
+
+<Hello
+  lastName="Smith"
+  firstName="John"
+  />;
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<Hello firstName="John" lastName="Smith" />;
+
+<Hello
+  firstName="John"
+  lastName="Smith"
+/>;
+```
+
+## Rule Options
+
+There are two ways to configure this rule.
+
+The first form is a string shortcut corresponding to the `location` values specified below. If omitted, it defaults to `"tag-aligned"`.
+
+```json
+{ "react/jsx-closing-bracket-location": ["error", "tag-aligned"] }
+```
+
+The second form allows you to distinguish between non-empty and self-closing tags. Both properties are optional, and both default to `"tag-aligned"`. You can also disable the rule for one particular type of tag by setting the value to `false`.
+
+```json
+{
+  "react/jsx-closing-bracket-location": [
+    "error",
+    { "nonEmpty": "tag-aligned", "selfClosing": "tag-aligned" }
+  ]
+}
+```
+
+### `location`
+
+Enforced location for the closing bracket.
+
+- `tag-aligned`: must be aligned with the opening tag.
+- `line-aligned`: must be aligned with the line containing the opening tag.
+- `after-props`: must be placed right after the last prop.
+- `props-aligned`: must be aligned with the last prop.
+
+Defaults to `tag-aligned`.
+
+For backward compatibility, you may pass an object `{ "location": <location> }` that is equivalent to the first string shortcut form.
+
+Examples of **incorrect** code for this rule with `"tag-aligned"` (default) or `"line-aligned"`:
+
+```jsx
+<Hello
+  firstName="John"
+  lastName="Smith"
+  />;
+
+<Say
+  firstName="John"
+  lastName="Smith">
+  Hello
+</Say>;
+```
+
+Examples of **incorrect** code for this rule with `"after-props"`:
+
+```json
+{ "react/jsx-closing-bracket-location": ["error", "after-props"] }
+```
+
+```jsx
+<Hello
+  firstName="John"
+  lastName="Smith" />;
+```
+
+Examples of **incorrect** code for this rule with `"props-aligned"`:
+
+```json
+{ "react/jsx-closing-bracket-location": ["error", "props-aligned"] }
+```
+
+```jsx
+<Hello
+  firstName="John"
+  lastName="Smith"
+  />;
+```
+
+Examples of **correct** code for this rule with `"tag-aligned"` (default) or `"line-aligned"`:
+
+```jsx
+<Hello
+  firstName="John"
+  lastName="Smith"
+/>;
+
+<Say
+  firstName="John"
+  lastName="Smith"
+>
+  Hello
+</Say>;
+```
+
+Examples of **correct** code for this rule with `{ "selfClosing": "after-props" }`:
+
+```json
+{
+  "react/jsx-closing-bracket-location": [
+    "error",
+    { "selfClosing": "after-props" }
+  ]
+}
+```
+
+```jsx
+<Hello
+  firstName="John"
+  lastName="Smith" />;
+
+<Say
+  firstName="John"
+  lastName="Smith"
+>
+  Hello
+</Say>;
+```
+
+Examples of **correct** code for this rule with `{ "selfClosing": "props-aligned", "nonEmpty": "after-props" }`:
+
+```json
+{
+  "react/jsx-closing-bracket-location": [
+    "error",
+    { "selfClosing": "props-aligned", "nonEmpty": "after-props" }
+  ]
+}
+```
+
+```jsx
+<Hello
+  firstName="John"
+  lastName="Smith"
+  />;
+
+<Say
+  firstName="John"
+  lastName="Smith">
+  Hello
+</Say>;
+```
+
+## When Not To Use It
+
+If you are not using JSX, you can disable this rule.
+
+## Original Documentation
+
+- [react/jsx-closing-bracket-location](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)

--- a/internal/plugins/react/rules/jsx_closing_bracket_location/jsx_closing_bracket_location_test.go
+++ b/internal/plugins/react/rules/jsx_closing_bracket_location/jsx_closing_bracket_location_test.go
@@ -1,0 +1,2423 @@
+package jsx_closing_bracket_location
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxClosingBracketLocationRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxClosingBracketLocationRule, []rule_tester.ValidTestCase{
+		{
+			Code: `
+        <App />
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        <App foo />
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        <App
+          foo
+        />
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        <App foo />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "after-props"},
+		},
+		{
+			Code: `
+        <App foo />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		{
+			Code: `
+        <App foo />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		{
+			Code: `
+        <App
+          foo />
+      `,
+			Tsx:     true,
+			Options: "after-props",
+		},
+		{
+			Code: `
+        <App
+          foo
+          />
+      `,
+			Tsx:     true,
+			Options: "props-aligned",
+		},
+		{
+			Code: `
+        <App
+          foo />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "after-props"},
+		},
+		{
+			Code: `
+        <App
+          foo
+        />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		{
+			Code: `
+        <App
+          foo
+        />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		{
+			Code: `
+        <App
+          foo
+          />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "props-aligned"},
+		},
+		{
+			Code: `
+        <App foo></App>
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        <App
+          foo
+        ></App>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		{
+			Code: `
+        <App
+          foo
+        ></App>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		{
+			Code: `
+        <App
+          foo
+          ></App>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "props-aligned"},
+		},
+		{
+			Code: `
+        <App
+          foo={function() {
+            console.log('bar');
+          }} />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "after-props"},
+		},
+		{
+			Code: `
+        <App
+          foo={function() {
+            console.log('bar');
+          }}
+          />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "props-aligned"},
+		},
+		{
+			Code: `
+        <App
+          foo={function() {
+            console.log('bar');
+          }}
+        />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		{
+			Code: `
+        <App
+          foo={function() {
+            console.log('bar');
+          }}
+        />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		{
+			Code: `
+        <App foo={function() {
+          console.log('bar');
+        }}/>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "after-props"},
+		},
+		{
+			Code: `
+         <App foo={function() {
+                console.log('bar');
+              }}
+              />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "props-aligned"},
+		},
+		{
+			Code: `
+        <App foo={function() {
+          console.log('bar');
+        }}
+        />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		{
+			Code: `
+        <App foo={function() {
+          console.log('bar');
+        }}
+        />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		{
+			Code: `
+        <Provider store>
+          <App
+            foo />
+        </Provider>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"selfClosing": "after-props"},
+		},
+		{
+			Code: `
+        <Provider
+          store
+        >
+          <App
+            foo />
+        </Provider>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"selfClosing": "after-props"},
+		},
+		{
+			Code: `
+        <Provider
+          store>
+          <App
+            foo
+          />
+        </Provider>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"nonEmpty": "after-props"},
+		},
+		{
+			Code: `
+        <Provider store>
+          <App
+            foo
+            />
+        </Provider>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"selfClosing": "props-aligned"},
+		},
+		{
+			Code: `
+        <Provider
+          store
+          >
+          <App
+            foo
+          />
+        </Provider>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"nonEmpty": "props-aligned"},
+		},
+		{
+			Code: `
+        var x = function() {
+          return <App
+            foo
+                 >
+              bar
+                 </App>
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		{
+			Code: `
+        var x = function() {
+          return <App
+            foo
+                 />
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		{
+			Code: `
+        var x = <App
+          foo
+                />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		{
+			Code: `
+        var x = function() {
+          return <App
+            foo={function() {
+              console.log('bar');
+            }}
+          />
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		{
+			Code: `
+        var x = <App
+          foo={function() {
+            console.log('bar');
+          }}
+        />
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		{
+			Code: `
+        <Provider
+          store
+        >
+          <App
+            foo={function() {
+              console.log('bar');
+            }}
+          />
+        </Provider>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		{
+			Code: `
+        <Provider
+          store
+        >
+          {baz && <App
+            foo={function() {
+              console.log('bar');
+            }}
+          />}
+        </Provider>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		{
+			Code: `
+        <App>
+          <Foo
+            bar
+          >
+          </Foo>
+          <Foo
+            bar />
+        </App>
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"nonEmpty":    false,
+				"selfClosing": "after-props",
+			},
+		},
+		{
+			Code: `
+        <App>
+          <Foo
+            bar>
+          </Foo>
+          <Foo
+            bar
+          />
+        </App>
+      `,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"nonEmpty":    "after-props",
+				"selfClosing": false,
+			},
+		},
+		{
+			Code: `
+        <div className={[
+          "some",
+          "stuff",
+          2 ]}
+        >
+          Some text
+        </div>
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		// ---- TS / non-Identifier tag forms (rslint-extra) ----
+		// JsxMemberExpression tag (`<Foo.Bar />`) — after-tag, no props.
+		{
+			Code: `<Foo.Bar />`,
+			Tsx:  true,
+		},
+		// JsxMemberExpression tag, single-line with prop — after-props.
+		{
+			Code: `<Foo.Bar foo />`,
+			Tsx:  true,
+		},
+		// JsxMemberExpression tag, multi-line — default tag-aligned.
+		{
+			Code: `<Foo.Bar
+  foo
+/>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		// JsxMemberExpression tag, non-self-closing multi-line.
+		{
+			Code: `<Foo.Bar
+  foo
+></Foo.Bar>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		// JsxNamespacedName tag (`<svg:circle />`) — after-tag.
+		{
+			Code: `<svg:circle />`,
+			Tsx:  true,
+		},
+		// JsxNamespacedName tag, multi-line tag-aligned.
+		{
+			Code: `<svg:circle
+  cx={1}
+/>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		// TS type arguments (`<App<T> foo />`) — single line, after-props.
+		{
+			Code: `<App<T> foo />`,
+			Tsx:  true,
+		},
+		// TS type arguments, multi-line tag-aligned.
+		{
+			Code: `<App<T>
+  foo
+/>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		// Expression containing '>' as a JSX attribute value — closing-bracket
+		// detection must not be confused by the expression-internal '>'.
+		{
+			Code: `<App foo={x > y} />`,
+			Tsx:  true,
+		},
+		// Nested JSX as attribute value — both elements are valid.
+		{
+			Code: `<App content={<Foo />} />`,
+			Tsx:  true,
+		},
+		// Nested JSX as attribute value, multi-line outer.
+		{
+			Code: `<App
+  content={<Foo />}
+/>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		// ---- JsxSpreadAttribute coverage (rslint-extra) ----
+		// Spread is the only attribute, single line — after-props.
+		{
+			Code: `<App {...props} />`,
+			Tsx:  true,
+		},
+		// Spread mixed with regular attribute, single line.
+		{
+			Code: `<App foo {...rest} />`,
+			Tsx:  true,
+		},
+		// Spread is the only attribute, multi-line tag-aligned default.
+		{
+			Code: `<App
+  {...spread}
+/>`,
+			Tsx: true,
+		},
+		// Multi-line with spread as last attribute — tag-aligned default.
+		{
+			Code: `<App
+  foo
+  {...rest}
+/>`,
+			Tsx: true,
+		},
+		// Spread in the middle, regular attribute at the tail.
+		{
+			Code: `<App
+  foo
+  {...mid}
+  bar
+/>`,
+			Tsx: true,
+		},
+		// Spread is last attribute, props-aligned (closing aligned with spread).
+		{
+			Code: `<App
+  foo
+  {...rest}
+  />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "props-aligned"},
+		},
+		// ---- Common attribute shapes ----
+		// Empty string attribute.
+		{
+			Code: `<App foo="" />`,
+			Tsx:  true,
+		},
+		// Boolean (shorthand) attribute.
+		{
+			Code: `<App disabled />`,
+			Tsx:  true,
+		},
+		// TS `as` expression as attribute value — '>' inside the expression must
+		// not be mistaken for the closing bracket.
+		{
+			Code: `<App foo={x as T} />`,
+			Tsx:  true,
+		},
+		// TS non-null assertion as attribute value.
+		{
+			Code: `<App foo={x!} />`,
+			Tsx:  true,
+		},
+		// Optional chain as attribute value.
+		{
+			Code: `<App foo={x?.y} />`,
+			Tsx:  true,
+		},
+		// `satisfies` expression as attribute value (TS 4.9+).
+		{
+			Code: `<App foo={x satisfies T} />`,
+			Tsx:  true,
+		},
+		// ---- Fragment / nesting / arrow-fn returning JSX ----
+		// Rule must not crash on JsxFragment / JsxOpeningFragment;
+		// the inner element should still be checked correctly.
+		{
+			Code: `<>
+  <App foo />
+</>`,
+			Tsx: true,
+		},
+		// Fragment with multiple sibling elements.
+		{
+			Code: `<>
+  <A />
+  <B />
+</>`,
+			Tsx: true,
+		},
+		// Multi-level nested elements — every OpeningElement processed
+		// independently, no boundary leak.
+		{
+			Code: `<App>
+  <B>
+    <C />
+  </B>
+</App>`,
+			Tsx: true,
+		},
+		// Arrow function that returns multi-line JSX (line-aligned).
+		{
+			Code: `var f = () => <App
+  foo
+/>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		// JSX inside an array literal.
+		{
+			Code: `var arr = [<A />, <B />];`,
+			Tsx:  true,
+		},
+		// ---- options JSON path robustness ----
+		// Array-wrapped string (matches rule_tester / multi-element CLI shape).
+		{
+			Code:    `<App foo />`,
+			Tsx:     true,
+			Options: []interface{}{"after-props"},
+		},
+		// Array-wrapped map (matches rule_tester / multi-element CLI shape).
+		{
+			Code:    `<App foo />`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"location": "after-props"}},
+		},
+		// Empty array of options should fall back to defaults.
+		{
+			Code:    `<App />`,
+			Tsx:     true,
+			Options: []interface{}{},
+		},
+		// nonEmpty:false alone — closing tag of `<App\n>...</App>` is unchecked.
+		{
+			Code: `<App
+  foo
+  ></App>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"nonEmpty": false},
+		},
+		// selfClosing:false alone — closing tag of `<App\n  foo\n  />` is unchecked.
+		{
+			Code: `<App
+  foo
+  />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"selfClosing": false},
+		},
+		// nonEmpty:false AND selfClosing:false — rule fully disabled for any
+		// shape (sanity: rule should not crash, no diagnostics emitted).
+		{
+			Code: `<>
+  <App
+  foo
+  />
+  <App
+  foo
+  ></App>
+</>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"nonEmpty": false, "selfClosing": false},
+		},
+		// Unknown enum string — ESLint schema rejects, but rslint should
+		// degrade gracefully (default behavior; do not panic).
+		{
+			Code:    `<App />`,
+			Tsx:     true,
+			Options: "unknown-location-value",
+		},
+		// Numeric / boolean options — invalid per schema, must not crash.
+		{
+			Code:    `<App />`,
+			Tsx:     true,
+			Options: 42,
+		},
+		{
+			Code:    `<App />`,
+			Tsx:     true,
+			Options: true,
+		},
+		// Map with unknown key — ignored, defaults take effect.
+		{
+			Code:    `<App foo />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"unknownKey": "tag-aligned"},
+		},
+		// nonEmpty / selfClosing as non-string non-false (true) — ignored.
+		{
+			Code:    `<App foo />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"nonEmpty": true, "selfClosing": true},
+		},
+		// ---- CRLF line terminators (Windows) ----
+		// CRLF-terminated source, default tag-aligned — valid.
+		{
+			Code: "<App\r\n  foo\r\n/>",
+			Tsx:  true,
+		},
+		// CRLF, options object, nested with provider.
+		{
+			Code:    "<Provider\r\n  store\r\n>\r\n  <App\r\n    foo\r\n  />\r\n</Provider>",
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "tag-aligned"},
+		},
+		// ---- JSX expression-internal comments ----
+		// `/* */` comment inside an attribute value expression — closing
+		// detection must not be confused.
+		{
+			Code: `<App foo={/* leading */ 1} />`,
+			Tsx:  true,
+		},
+		// `//` line comment inside an attribute value expression spanning
+		// multiple lines.
+		{
+			Code: `<App
+  foo={
+    // line comment
+    1
+  }
+/>`,
+			Tsx: true,
+		},
+		// ---- More TS generic forms ----
+		// Generic with multiple type arguments.
+		{
+			Code: `<App<T, U> foo />`,
+			Tsx:  true,
+		},
+		// Generic with multiple type arguments, multi-line.
+		{
+			Code: `<App<T, U>
+  foo
+/>`,
+			Tsx: true,
+		},
+		// ---- Non-self-closing symmetry (no props) ----
+		// `<App></App>` and `<App\n></App>` — after-tag rule applies the same
+		// way to non-self-closing elements with zero attributes.
+		{
+			Code: `<App></App>`,
+			Tsx:  true,
+		},
+		// ---- Large realistic React component lock-in ----
+		// Verifies the rule handles a deeply nested, multi-prop, mixed
+		// self-closing / non-self-closing tree without false positives.
+		{
+			Code: `<Provider
+  value={{
+    user,
+    onLogin: () => {},
+  }}
+>
+  <App
+    title="Home"
+    subtitle={` + "`Welcome ${user.name}`" + `}
+    onClose={handleClose}
+  />
+  <Footer
+    links={[
+      { href: '/a', label: 'A' },
+      { href: '/b', label: 'B' },
+    ]}
+  />
+</Provider>`,
+			Tsx: true,
+		},
+		// ---- Spread expression internal trivia ----
+		// Comment leading the spread argument.
+		{
+			Code: `<App {/* leading */ ...rest} />`,
+			Tsx:  true,
+		},
+		// Comment trailing the spread argument.
+		{
+			Code: `<App {...rest /* trailing */} />`,
+			Tsx:  true,
+		},
+		// Spread argument is itself a multi-line object expression.
+		{
+			Code: `<App
+  {...{
+    ...defaults,
+    extra: 1,
+  }}
+/>`,
+			Tsx: true,
+		},
+		// ---- Attribute values: fragment / ternary / template ----
+		// JSX fragment as attribute value.
+		{
+			Code: `<App content={<>foo</>} />`,
+			Tsx:  true,
+		},
+		// Multi-line ternary as attribute value (closing of outer JSX must
+		// not be confused by the ternary's contents).
+		{
+			Code: `<App
+  className={
+    x
+      ? 'a'
+      : 'b'
+  }
+/>`,
+			Tsx: true,
+		},
+		// Template literal with embedded expression as attribute value.
+		{
+			Code: `<App foo={` + "`hello ${name} world`" + `} />`,
+			Tsx:  true,
+		},
+		// JSX as logical-AND right operand (line-aligned: closing at line indent).
+		{
+			Code: `var x = cond && <App
+  foo
+/>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		// JSX as ternary branch (line-aligned).
+		{
+			Code: `var x = cond ? <App
+  foo
+/> : null`,
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+		},
+		// JSX as logical-AND right operand, tag-aligned (closing at `<` column).
+		{
+			Code: `var x = cond && <App
+                  foo
+                />`,
+			Tsx: true,
+		},
+		// ---- Multi-byte / unicode attribute name lock-in ----
+		// Lock-in: rule does not crash on JSX attribute / tag names that
+		// contain non-ASCII identifier characters. Closing detection works.
+		{
+			Code: `<App 中文Prop="x" />`,
+			Tsx:  true,
+		},
+		// ---- Spread BEFORE regular attribute (reverse order) ----
+		// Symmetry check: I already cover `foo {...rest}`; reverse order
+		// `{...rest} foo` should behave identically (lastProp = foo).
+		{
+			Code: `<App {...rest} foo />`,
+			Tsx:  true,
+		},
+		// Multi-line variant: spread first, regular tail, default tag-aligned.
+		{
+			Code: `<App
+  {...rest}
+  foo
+/>`,
+			Tsx: true,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- after-tag (no props) ----
+		{
+			Code: `
+        <App
+        />
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the opening tag",
+				},
+			},
+		},
+		// ---- after-props (default, lastProp on opening line) ----
+		{
+			Code: `
+        <App foo
+        />
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App foo/>
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		{
+			Code: `
+        <App foo
+        ></App>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App foo></App>
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		// ---- props-aligned vs current after-props -> needs newline ----
+		{
+			Code: `
+        <App
+          foo />
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo
+          />
+      `},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the last prop (expected column 11 on the next line)",
+					Line:      3,
+					Column:    15,
+				},
+			},
+		},
+		{
+			Code: `
+        <App
+          foo />
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo
+        />
+      `},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)",
+					Line:      3,
+					Column:    15,
+				},
+			},
+		},
+		{
+			Code: `
+        <App
+          foo />
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo
+        />
+      `},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 9 on the next line)",
+					Line:      3,
+					Column:    15,
+				},
+			},
+		},
+		// ---- after-props: collapse closing onto last prop line ----
+		{
+			Code: `
+        <App
+          foo
+        />
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo/>
+      `},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		{
+			Code: `
+        <App
+          foo
+        />
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo
+          />
+      `},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the last prop (expected column 11)",
+					Line:      4,
+					Column:    9,
+				},
+			},
+		},
+		{
+			Code: `
+        <App
+          foo
+          />
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo/>
+      `},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		{
+			Code: `
+        <App
+          foo
+          />
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo
+        />
+      `},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 9)",
+					Line:      4,
+					Column:    11,
+				},
+			},
+		},
+		{
+			Code: `
+        <App
+          foo
+          />
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo
+        />
+      `},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 9)",
+					Line:      4,
+					Column:    11,
+				},
+			},
+		},
+		// ---- non-self-closing equivalents ----
+		{
+			Code: `
+        <App
+          foo
+        ></App>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo></App>
+      `},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		{
+			Code: `
+        <App
+          foo
+        ></App>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo
+          ></App>
+      `},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the last prop (expected column 11)",
+					Line:      4,
+					Column:    9,
+				},
+			},
+		},
+		{
+			Code: `
+        <App
+          foo
+          ></App>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo></App>
+      `},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		{
+			Code: `
+        <App
+          foo
+          ></App>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo
+        ></App>
+      `},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 9)",
+					Line:      4,
+					Column:    11,
+				},
+			},
+		},
+		{
+			Code: `
+        <App
+          foo
+          ></App>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <App
+          foo
+        ></App>
+      `},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 9)",
+					Line:      4,
+					Column:    11,
+				},
+			},
+		},
+		// ---- nested elements with selfClosing/nonEmpty ----
+		{
+			Code: `
+        <Provider
+          store>
+          <App
+            foo
+            />
+        </Provider>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <Provider
+          store
+        >
+          <App
+            foo
+            />
+        </Provider>
+      `},
+			Options: map[string]interface{}{"selfClosing": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)",
+					Line:      3,
+					Column:    16,
+				},
+			},
+		},
+		// ---- props-aligned with very-far closing bracket ----
+		{
+			Code: `
+        const Button = function(props) {
+          return (
+            <Button
+              size={size}
+              onClick={onClick}
+                                            >
+              Button Text
+            </Button>
+          );
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Button = function(props) {
+          return (
+            <Button
+              size={size}
+              onClick={onClick}
+              >
+              Button Text
+            </Button>
+          );
+        };
+      `},
+			Options: "props-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the last prop (expected column 15)",
+					Line:      7,
+					Column:    45,
+				},
+			},
+		},
+		{
+			Code: `
+        const Button = function(props) {
+          return (
+            <Button
+              size={size}
+              onClick={onClick}
+                                            >
+              Button Text
+            </Button>
+          );
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Button = function(props) {
+          return (
+            <Button
+              size={size}
+              onClick={onClick}
+            >
+              Button Text
+            </Button>
+          );
+        };
+      `},
+			Options: "tag-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 13)",
+					Line:      7,
+					Column:    45,
+				},
+			},
+		},
+		{
+			Code: `
+        const Button = function(props) {
+          return (
+            <Button
+              size={size}
+              onClick={onClick}
+                                            >
+              Button Text
+            </Button>
+          );
+        };
+      `,
+			Tsx: true,
+			Output: []string{`
+        const Button = function(props) {
+          return (
+            <Button
+              size={size}
+              onClick={onClick}
+            >
+              Button Text
+            </Button>
+          );
+        };
+      `},
+			Options: "line-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 13)",
+					Line:      7,
+					Column:    45,
+				},
+			},
+		},
+		// ---- nonEmpty=props-aligned: nested App fix ----
+		{
+			Code: `
+        <Provider
+          store
+          >
+          <App
+            foo
+            />
+        </Provider>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <Provider
+          store
+          >
+          <App
+            foo
+          />
+        </Provider>
+      `},
+			Options: map[string]interface{}{"nonEmpty": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 11)",
+					Line:      7,
+					Column:    13,
+				},
+			},
+		},
+		{
+			Code: `
+        <Provider
+          store>
+          <App
+            foo />
+        </Provider>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <Provider
+          store
+        >
+          <App
+            foo />
+        </Provider>
+      `},
+			Options: map[string]interface{}{"selfClosing": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)",
+					Line:      3,
+					Column:    16,
+				},
+			},
+		},
+		{
+			Code: `
+        <Provider
+          store>
+          <App
+            foo
+            />
+        </Provider>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <Provider
+          store>
+          <App
+            foo
+          />
+        </Provider>
+      `},
+			Options: map[string]interface{}{"nonEmpty": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 11)",
+					Line:      6,
+					Column:    13,
+				},
+			},
+		},
+		// ---- line-aligned vs tag-aligned distinction ----
+		{
+			Code: `
+        var x = function() {
+          return <App
+            foo
+                />
+        }
+      `,
+			Tsx: true,
+			Output: []string{`
+        var x = function() {
+          return <App
+            foo
+          />
+        }
+      `},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 11)",
+					Line:      5,
+					Column:    17,
+				},
+			},
+		},
+		{
+			Code: `
+        var x = <App
+          foo
+                />
+      `,
+			Tsx: true,
+			Output: []string{`
+        var x = <App
+          foo
+        />
+      `},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 9)",
+					Line:      4,
+					Column:    17,
+				},
+			},
+		},
+		{
+			Code: `
+        var x = (
+          <div
+            className="MyComponent"
+            {...props} />
+        )
+      `,
+			Tsx: true,
+			Output: []string{`
+        var x = (
+          <div
+            className="MyComponent"
+            {...props}
+          />
+        )
+      `},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 11 on the next line)",
+					Line:      5,
+					Column:    24,
+				},
+			},
+		},
+		{
+			Code: `
+        var x = (
+          <Something
+            content={<Foo />} />
+        )
+      `,
+			Tsx: true,
+			Output: []string{`
+        var x = (
+          <Something
+            content={<Foo />}
+          />
+        )
+      `},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 11 on the next line)",
+					Line:      4,
+					Column:    31,
+				},
+			},
+		},
+		{
+			Code: `
+        var x = (
+          <Something
+            />
+        )
+      `,
+			Tsx: true,
+			Output: []string{`
+        var x = (
+          <Something />
+        )
+      `},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the opening tag",
+				},
+			},
+		},
+		// ---- multi-line array attribute -> tag-aligned forces newline ----
+		{
+			Code: `
+        <div className={[
+          "some",
+          "stuff",
+          2 ]}>
+          Some text
+        </div>
+      `,
+			Tsx: true,
+			Output: []string{`
+        <div className={[
+          "some",
+          "stuff",
+          2 ]}
+        >
+          Some text
+        </div>
+      `},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)",
+					Line:      5,
+					Column:    15,
+				},
+			},
+		},
+		// ---- tab-indented variants (props-aligned / tag-aligned / line-aligned) ----
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo />\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the last prop (expected column 6 on the next line)",
+					Line:      3,
+					Column:    10,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo />\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)",
+					Line:      3,
+					Column:    10,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo />\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 5 on the next line)",
+					Line:      3,
+					Column:    10,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo/>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the last prop (expected column 6)",
+					Line:      4,
+					Column:    5,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo/>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 5)",
+					Line:      4,
+					Column:    6,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 5)",
+					Line:      4,
+					Column:    6,
+				},
+			},
+		},
+		// ---- non-self-closing tab variants ----
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo></App>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the last prop (expected column 6)",
+					Line:      4,
+					Column:    5,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo></App>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 5)",
+					Line:      4,
+					Column:    6,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 5)",
+					Line:      4,
+					Column:    6,
+				},
+			},
+		},
+		// ---- nested with selfClosing/nonEmpty (tab) ----
+		{
+			Code: "\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"selfClosing": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)",
+					Line:      3,
+					Column:    11,
+				},
+			},
+		},
+		// ---- props-aligned/tag-aligned/line-aligned with very-far closing bracket (tab) ----
+		{
+			Code: "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+			},
+			Options: "props-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the last prop (expected column 8)",
+					Line:      7,
+					Column:    23,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+			},
+			Options: "tag-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 7)",
+					Line:      7,
+					Column:    23,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+			},
+			Options: "line-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 7)",
+					Line:      7,
+					Column:    23,
+				},
+			},
+		},
+		// ---- nonEmpty=props-aligned: nested App fix (tab) ----
+		{
+			Code: "\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"nonEmpty": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 6)",
+					Line:      7,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo />\n\t\t\t\t</Provider>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo />\n\t\t\t\t</Provider>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"selfClosing": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)",
+					Line:      3,
+					Column:    11,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"nonEmpty": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 6)",
+					Line:      6,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\tvar x = function() {\n\t\t\t\t\treturn <App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t\t\t/>\n\t\t\t\t}\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\tvar x = function() {\n\t\t\t\t\treturn <App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t\t}\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 6)",
+					Line:      5,
+					Column:    9,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\tvar x = <App\n\t\t\t\t\tfoo\n\t\t\t\t\t\t\t\t/>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\tvar x = <App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 5)",
+					Line:      4,
+					Column:    9,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\tvar x = (\n\t\t\t\t\t<div\n\t\t\t\t\t\tclassName=\"MyComponent\"\n\t\t\t\t\t\t{...props} />\n\t\t\t\t)\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\tvar x = (\n\t\t\t\t\t<div\n\t\t\t\t\t\tclassName=\"MyComponent\"\n\t\t\t\t\t\t{...props}\n\t\t\t\t\t/>\n\t\t\t\t)\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 6 on the next line)",
+					Line:      5,
+					Column:    18,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something\n\t\t\t\t\t\tcontent={<Foo />} />\n\t\t\t\t)\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something\n\t\t\t\t\t\tcontent={<Foo />}\n\t\t\t\t\t/>\n\t\t\t\t)\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 6 on the next line)",
+					Line:      4,
+					Column:    25,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something\n\t\t\t\t\t\t/>\n\t\t\t\t)\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something />\n\t\t\t\t)\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the opening tag",
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t<div className={[\n\t\t\t\t\t\"some\",\n\t\t\t\t\t\"stuff\",\n\t\t\t\t\t2 ]}>\n\t\t\t\t\tSome text\n\t\t\t\t</div>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t<div className={[\n\t\t\t\t\t\"some\",\n\t\t\t\t\t\"stuff\",\n\t\t\t\t\t2 ]}\n\t\t\t\t>\n\t\t\t\t\tSome text\n\t\t\t\t</div>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)",
+					Line:      5,
+					Column:    10,
+				},
+			},
+		},
+		{
+			Code: "\n\t\t\t\t\t\t\t<div\n\t\t\t\t\t\t\t\tclassName={styles}\n\t\t\t\t\t >\n\t\t\t\t\t\t\t\t{props}\n\t\t\t\t\t\t\t</div>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t\t\t\t<div\n\t\t\t\t\t\t\t\tclassName={styles}\n\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\t\t{props}\n\t\t\t\t\t\t\t</div>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 8)",
+					Line:      4,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code: `
+          <div
+            className={styles}
+            >
+            {props}
+          </div>
+      `,
+			Tsx: true,
+			Output: []string{`
+          <div
+            className={styles}
+          >
+            {props}
+          </div>
+      `},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 11)",
+					Line:      4,
+					Column:    13,
+				},
+			},
+		},
+		{
+			Code: `
+          <App
+            foo
+            />
+      `,
+			Tsx: true,
+			Output: []string{`
+          <App
+            foo
+          />
+      `},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 11)",
+					Line:      4,
+					Column:    13,
+				},
+			},
+		},
+		// Mixed-tab edge case: opening line uses 6 tabs, prop line 7 tabs, closing line 5 tabs
+		{
+			Code: "\n\t\t\t\t\t\t<App\n\t\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+			Tsx:  true,
+			Output: []string{
+				"\n\t\t\t\t\t\t<App\n\t\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t",
+			},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 7)",
+					Line:      4,
+					Column:    6,
+				},
+			},
+		},
+		// ---- TS / non-Identifier tag forms (rslint-extra) ----
+		// JsxMemberExpression tag with multi-line prop — column accounting must
+		// use the '<' position, not anywhere inside the dotted name.
+		{
+			Code: `<Foo.Bar
+  foo />`,
+			Tsx: true,
+			Output: []string{`<Foo.Bar
+  foo
+/>`},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 1 on the next line)",
+					Line:      2,
+					Column:    7,
+				},
+			},
+		},
+		// JsxNamespacedName tag with multi-line prop.
+		{
+			Code: `<svg:circle
+  cx={1} />`,
+			Tsx: true,
+			Output: []string{`<svg:circle
+  cx={1}
+/>`},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 1 on the next line)",
+					Line:      2,
+					Column:    10,
+				},
+			},
+		},
+		// Expression containing '>' on a later line — closing detection must
+		// pick the JSX-element '>' / '/' even when '>' chars appear in
+		// attribute expressions earlier in the source.
+		{
+			Code: `<App foo={x > y}
+/>`,
+			Tsx: true,
+			Output: []string{`<App foo={x > y}/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		// Nested JSX as attribute value, multi-line outer with misaligned
+		// closing — locks in that the inner `<Foo />` doesn't disturb the
+		// outer closing's column accounting.
+		{
+			Code: `<App
+  content={<Foo />}
+  />`,
+			Tsx: true,
+			Output: []string{`<App
+  content={<Foo />}
+/>`},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+		// ---- Spread attribute as last prop ----
+		// Single spread attribute as lastProp, after-tag → after-props collapse.
+		{
+			Code: `<App {...props}
+/>`,
+			Tsx:    true,
+			Output: []string{`<App {...props}/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		// Multi-line, spread is last prop, default tag-aligned, misaligned `/>`.
+		{
+			Code: `<App
+  foo
+  {...rest}
+  />`,
+			Tsx: true,
+			Output: []string{`<App
+  foo
+  {...rest}
+/>`},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+					Line:      4,
+					Column:    3,
+				},
+			},
+		},
+		// Spread is last prop, on the same line as `/>`, after-props expects collapse.
+		{
+			Code: `<App foo {...rest}
+/>`,
+			Tsx:    true,
+			Output: []string{`<App foo {...rest}/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the last prop",
+				},
+			},
+		},
+		// Spread is last prop, props-aligned with `/>` on next line at wrong column.
+		{
+			Code: `<App
+  foo
+  {...rest} />`,
+			Tsx: true,
+			Output: []string{`<App
+  foo
+  {...rest}
+  />`},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the last prop (expected column 3 on the next line)",
+					Line:      3,
+					Column:    13,
+				},
+			},
+		},
+		// ---- Multi-level nested elements ----
+		// Inner element misalign — verify outer/inner are independently checked.
+		{
+			Code: `<App>
+  <B
+    bar
+    />
+</App>`,
+			Tsx: true,
+			Output: []string{`<App>
+  <B
+    bar
+  />
+</App>`},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 3)",
+					Line:      4,
+					Column:    5,
+				},
+			},
+		},
+		// ---- Arrow function returning multi-line JSX ----
+		// `() => <App\n  foo\n />` line-aligned — `/>` should align with the
+		// line containing `() =>`, not the `<App` column.
+		{
+			Code: `var f = () => <App
+  foo
+ />`,
+			Tsx: true,
+			Output: []string{`var f = () => <App
+  foo
+/>`},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 1)",
+					Line:      3,
+					Column:    2,
+				},
+			},
+		},
+		// ---- Conditional rendering inside parent JSX ----
+		// `{cond && <App\n  foo />}` line-aligned — `/>` should align with the
+		// expression's outer line indent.
+		{
+			Code: `<Wrapper>
+  {cond && <App
+    foo />}
+</Wrapper>`,
+			Tsx: true,
+			Output: []string{`<Wrapper>
+  {cond && <App
+    foo
+  />}
+</Wrapper>`},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 3 on the next line)",
+					Line:      3,
+					Column:    9,
+				},
+			},
+		},
+		// ---- Options-error fallback still triggers default behavior ----
+		// Even with non-string non-map options, default tag-aligned applies.
+		{
+			Code: `<App
+  foo
+  />`,
+			Tsx:     true,
+			Options: 42,
+			Output: []string{`<App
+  foo
+/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+		// Map with unknown key — defaults still apply.
+		{
+			Code: `<App
+  foo
+  />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"unknownKey": "props-aligned"},
+			Output: []string{`<App
+  foo
+/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+		// ---- CRLF line terminators (Windows) — invalid ----
+		// CRLF source with misaligned `/>` should report and fix correctly.
+		{
+			Code: "<App\r\n  foo\r\n  />",
+			Tsx:  true,
+			Output: []string{
+				"<App\r\n  foo\n/>",
+			},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+		// ---- Non-self-closing symmetry: `<App\n></App>` after-tag invalid ----
+		// Mirror of upstream invalid case 1 (`<App\n/>`) for non-self-closing form.
+		{
+			Code: `<App
+></App>`,
+			Tsx:    true,
+			Output: []string{`<App ></App>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the opening tag",
+				},
+			},
+		},
+		// ---- Multi-byte character column lock-in ----
+		// Opening line contains multi-byte identifier characters (中文 = 6 bytes
+		// UTF-8 / 2 UTF-16 code units). The "expected column N" in the message
+		// MUST match the UTF-16 column shown in the user's IDE — not the byte
+		// offset within the line.
+		//
+		// `var 中文 = <App` → `<` is at:
+		//   - UTF-16 column 10 (1-based): "var 中文 = " = 4+2+3 = 9 units, '<' at 10
+		//   - byte column 14 (1-based): "var " 4 + "中文" 6 + " = " 3 = 13 bytes, '<' at 14
+		// We assert the message contains "expected column 10" (UTF-16, matches IDE).
+		{
+			Code: `var x = (() => {
+  return <中文Comp
+    foo />
+})`,
+			Tsx: true,
+			Output: []string{`var x = (() => {
+  return <中文Comp
+    foo
+  />
+})`},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					// Line 2 (`  return <中文Comp`) is the opening line.
+					// `line-aligned` indent = 2 spaces (line 2 leading whitespace).
+					// "expected column 3" (1-based UTF-16) — same as IDE shows.
+					Message: "The closing bracket must be aligned with the line containing the opening tag (expected column 3 on the next line)",
+					Line:    3,
+					Column:  9,
+				},
+			},
+		},
+		// Tag-aligned with multi-byte chars before opening — expected column
+		// must reflect UTF-16 position of '<', NOT byte offset.
+		{
+			Code: `var 中文Var = <App
+  foo />`,
+			Tsx: true,
+			Output: []string{`var 中文Var = <App
+  foo
+            />`},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					// `var 中文Var = <App` — '<' at UTF-16 col 13 (0-based 12).
+					// "expected column 13" (UTF-16); byte-based would be col 15.
+					Message: "The closing bracket must be aligned with the opening tag (expected column 13 on the next line)",
+					Line:    2,
+					Column:  7,
+				},
+			},
+		},
+		// ---- After-tag with whitespace-only line between opening tag and `/>` ----
+		// Verifies `tag.line === closing.line` check fires correctly even when
+		// the gap is filled by a whitespace-only line (no attributes, just
+		// trivia). Fix collapses to single-line `<App />`.
+		{
+			Code: `<App
+
+/>`,
+			Tsx:    true,
+			Output: []string{`<App />`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					Message:   "The closing bracket must be placed after the opening tag",
+				},
+			},
+		},
+		// ---- Three-level nested element: props-aligned column lock-in ----
+		// Outermost is `<App>` (no attrs), middle is `<B foo>...</B>`, innermost
+		// is `<C\n      bar\n      />` (props-aligned, expected at bar's column).
+		// Misalign the innermost `/>` and verify column is computed from the
+		// innermost lastProp (`bar`), not from outer elements.
+		{
+			Code: `<App>
+  <B foo>
+    <C
+      bar
+        />
+  </B>
+</App>`,
+			Tsx: true,
+			Output: []string{`<App>
+  <B foo>
+    <C
+      bar
+      />
+  </B>
+</App>`},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bracketLocation",
+					// `bar` at UTF-16 col 7 (1-based) → "expected column 7".
+					Message: "The closing bracket must be aligned with the last prop (expected column 7)",
+					Line:    5,
+					Column:  9,
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/jsx_no_leaked_render/jsx_no_leaked_render.go
+++ b/internal/plugins/react/rules/jsx_no_leaked_render/jsx_no_leaked_render.go
@@ -496,7 +496,7 @@ func buildFix(
 		lines := strings.Split(rightInnerText, "\n")
 		if len(lines) > 1 {
 			lastLine := lines[len(lines)-1]
-			indent := leadingWhitespaceLen(lastLine)
+			indent := len(reactutil.HorizontalWhitespacePrefix(lastLine))
 			indentStart := strings.Repeat(" ", indent)
 			closeIndent := indent - 2
 			if closeIndent < 0 {
@@ -562,11 +562,3 @@ func isLiteralLike(n *ast.Node) bool {
 	return false
 }
 
-func leadingWhitespaceLen(s string) int {
-	for i, r := range s {
-		if r != ' ' && r != '\t' {
-			return i
-		}
-	}
-	return len(s)
-}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -112,6 +112,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-no-undef.test.ts',
     './tests/eslint-plugin-react/rules/jsx-pascal-case.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-closing-bracket-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-curly-brace-presence.test.ts',
     './tests/eslint-plugin-react/rules/jsx-curly-spacing.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-closing-bracket-location.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-closing-bracket-location.test.ts
@@ -1,0 +1,62 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-closing-bracket-location', {} as never, {
+  valid: [
+    { code: `<App />` },
+    { code: `<App foo />` },
+    { code: `<App\n  foo\n/>` },
+    {
+      code: `<App\n  foo />`,
+      options: ['after-props'],
+    },
+    {
+      code: `<App\n  foo\n  />`,
+      options: ['props-aligned'],
+    },
+    {
+      code: `<App foo></App>`,
+    },
+    {
+      code: `<App>\n  <Foo\n    bar\n  >\n  </Foo>\n  <Foo\n    bar />\n</App>`,
+      options: [{ nonEmpty: false, selfClosing: 'after-props' }],
+    },
+  ],
+  invalid: [
+    {
+      code: `<App\n/>`,
+      options: ['tag-aligned'],
+      errors: [
+        { message: 'The closing bracket must be placed after the opening tag' },
+      ],
+    },
+    {
+      code: `<App foo\n/>`,
+      options: ['tag-aligned'],
+      errors: [
+        { message: 'The closing bracket must be placed after the last prop' },
+      ],
+    },
+    {
+      code: `<App\n  foo />`,
+      options: ['tag-aligned'],
+      errors: [
+        {
+          message:
+            'The closing bracket must be aligned with the opening tag (expected column 1 on the next line)',
+        },
+      ],
+    },
+    {
+      code: `<App\n  foo />`,
+      options: ['props-aligned'],
+      errors: [
+        {
+          message:
+            'The closing bracket must be aligned with the last prop (expected column 3 on the next line)',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/jsx-closing-bracket-location` rule from `eslint-plugin-react` to rslint.

The rule enforces the closing bracket location for JSX multiline elements. It supports four `location` values (`tag-aligned`, `line-aligned`, `after-props`, `props-aligned`), the back-compat `{ location }` form, and the per-tag `{ nonEmpty, selfClosing }` form (each accepts a location string or `false` to disable).

Highlights:

- 1:1 algorithm parity with upstream (`getExpectedLocation` / `hasCorrectLocation` / `getCorrectColumn` / `getIndentation`, including `tag-aligned`'s `isTab` consistency check and the indent-padding formula).
- Autofix matches upstream for all three branches (after-tag, after-props, aligned).
- Column counting uses UTF-16 code units to match the column users see in their IDE / `loc.column` (verified by Chinese-identifier lock-in tests).
- Extracted shared `reactutil.HorizontalWhitespacePrefix` (and `UTF16Length`) so `jsx-no-leaked-render` can drop its local copy of the same helper.
- 176 Go tests (full upstream migration + extra edge cases: spread attributes, TS generic / member / namespaced tag, fragment / nested JSX as attribute value, CRLF source, expression-internal `>`, multibyte identifier, malformed options) plus a JS rule-tester suite.
- Differential validation on rsbuild and rspack websites: `after-props` flagged 7 + 19 real misalignments across ~10 files; every reported `column` precisely points to the `/` (self-closing) or `>` (non-self-closing) character.

## Related Links

- ESLint plugin rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-closing-bracket-location.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).