### PR TITLE
feat: port rule react/jsx-indent

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -14,6 +14,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_filename_extension"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_first_prop_new_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_handler_names"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_indent"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_key"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_depth"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_props_per_line"
@@ -84,6 +85,7 @@ func GetAllRules() []rule.Rule {
 		jsx_filename_extension.JsxFilenameExtensionRule,
 		jsx_first_prop_new_line.JsxFirstPropNewLineRule,
 		jsx_handler_names.JsxHandlerNamesRule,
+		jsx_indent.JsxIndentRule,
 		jsx_key.JsxKeyRule,
 		jsx_max_depth.JsxMaxDepthRule,
 		jsx_max_props_per_line.JsxMaxPropsPerLineRule,

--- a/internal/plugins/react/rules/jsx_indent/jsx_indent.go
+++ b/internal/plugins/react/rules/jsx_indent/jsx_indent.go
@@ -1,0 +1,843 @@
+package jsx_indent
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// JsxIndentRule enforces JSX indentation.
+//
+// Ported from eslint-plugin-react's `jsx-indent` rule. Each opening / closing
+// tag, JSXExpressionContainer, JSXText and JSX-returning ReturnStatement is
+// checked against a parent-derived "expected indent"; violations carry an
+// autofix that rewrites the leading whitespace of the offending line.
+//
+// tsgo↔ESTree shape adjustments (vs the upstream JS rule):
+//   - Self-closing `<Foo />` is `JsxSelfClosingElement` with no wrapping
+//     `JsxElement`, so the listener resolves the "operand position" via
+//     `jsxOperandPosition(node)` before walking up the tree.
+//   - Parens / `as` / `satisfies` / `!` are explicit nodes; we use
+//     `reactutil.SkipExpressionWrappersUp` to flatten them when matching
+//     LogicalExpression / ConditionalExpression ancestors.
+//   - Token positions for source-level scans (e.g. "is the previous char a
+//     colon") are computed from `SourceFile.Text()`; line numbers from
+//     `ECMALineMap()` + `scanner.ComputeLineOfPosition`.
+var JsxIndentRule = rule.Rule{
+	Name: "react/jsx-indent",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		indentType, indentSize, indentChar := parseIndentOption(options)
+		checkAttributes, indentLogicalExpressions := parseSecondOption(options)
+
+		text := ctx.SourceFile.Text()
+		lineMap := ctx.SourceFile.ECMALineMap()
+
+		lineOfPos := func(pos int) int {
+			return scanner.ComputeLineOfPosition(lineMap, pos)
+		}
+
+		// lineStartOfPos returns the byte offset of the first char of the
+		// line containing pos, using the line map.
+		lineStartOfPos := func(pos int) int {
+			line := lineOfPos(pos)
+			return int(lineMap[line])
+		}
+
+		// lineIndentAt returns the count of leading `indentChar` runs at
+		// the start of the line containing pos. Mirrors upstream's
+		// `^[ ]+` / `^[\t]+` slice on `getText(node, node.loc.start.column)`.
+		lineIndentAt := func(pos int) int {
+			start := lineStartOfPos(pos)
+			count := 0
+			for i := start; i < len(text); i++ {
+				if text[i] != indentChar {
+					break
+				}
+				count++
+			}
+			return count
+		}
+
+		nodeStartIndent := func(node *ast.Node) int {
+			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			return lineIndentAt(trimmed.Pos())
+		}
+		nodeEndIndent := func(node *ast.Node) int {
+			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			pos := trimmed.End()
+			if pos > 0 {
+				pos--
+			}
+			return lineIndentAt(pos)
+		}
+
+		// isNodeFirstInLine reports whether node is the first non-whitespace
+		// (and non-comma) source character on its line. Walks back from the
+		// trimmed start over spaces, tabs, commas and CR; a leading newline
+		// (or start-of-file) means yes, anything else means no. The comma
+		// skip mirrors upstream's `getFirstNodeInLine` behaviour for
+		// array-literal siblings.
+		isNodeFirstInLine := func(node *ast.Node) bool {
+			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			i := trimmed.Pos() - 1
+			for i >= 0 {
+				c := text[i]
+				if c == '\n' {
+					return true
+				}
+				if c == ' ' || c == '\t' || c == ',' || c == '\r' {
+					i--
+					continue
+				}
+				return false
+			}
+			return true
+		}
+
+		// makeMsg builds the wrongIndent diagnostic message.
+		makeMsg := func(needed, gotten int) rule.RuleMessage {
+			characters := "characters"
+			if needed == 1 {
+				characters = "character"
+			}
+			return rule.RuleMessage{
+				Id: "wrongIndent",
+				Description: fmt.Sprintf(
+					"Expected indentation of %d %s %s but found %d.",
+					needed, indentType, characters, gotten,
+				),
+				Data: map[string]string{
+					"needed":     strconv.Itoa(needed),
+					"type":       indentType,
+					"characters": characters,
+					"gotten":     strconv.Itoa(gotten),
+				},
+			}
+		}
+
+		// reportIndent emits a wrongIndent diagnostic with the upstream
+		// "default" fix (replace whitespace from start-of-line to node
+		// start with the expected indent). Used for JsxOpeningElement /
+		// JsxClosingElement / JsxExpression. JsxText, ReturnStatement and
+		// JsxAttribute take dedicated paths via reportLiteral /
+		// reportReturn / reportAttribute below.
+		reportIndent := func(node *ast.Node, needed, gotten int) {
+			indent := strings.Repeat(string(indentChar), needed)
+			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			startCol := trimmed.Pos()
+			lineStart := lineStartOfPos(startCol)
+			ctx.ReportNodeWithFixes(node, makeMsg(needed, gotten), rule.RuleFix{
+				Text:  indent,
+				Range: core.NewTextRange(lineStart, startCol),
+			})
+		}
+
+		// reportLiteral emits one diagnostic per mis-indented line of a
+		// JsxText. The report and fix BOTH use the JsxText's RAW range —
+		// tsgo treats the leading newline / whitespace as trivia, but
+		// upstream's `report(node, …)` anchors at `node.loc.start` which
+		// sits at the JsxText's raw start (right after the preceding `>`
+		// of the parent's opening tag).
+		reportLiteral := func(node *ast.Node, needed, gotten int, fixed string) {
+			rawRange := core.NewTextRange(node.Pos(), node.End())
+			ctx.ReportRangeWithFixes(rawRange, makeMsg(needed, gotten), rule.RuleFix{
+				Text:  fixed,
+				Range: rawRange,
+			})
+		}
+
+		// reportReturn emits a wrongIndent diagnostic for a ReturnStatement
+		// whose opening / closing column don't match. Fix replaces just
+		// the last line of the return; mirrors upstream's
+		// `replaceTextRange([lastNL, end])`.
+		reportReturn := func(node *ast.Node, needed, gotten int) {
+			indent := strings.Repeat(string(indentChar), needed)
+			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			start := trimmed.Pos()
+			end := trimmed.End()
+			raw := text[start:end]
+			if !strings.Contains(raw, "\n") {
+				ctx.ReportNode(node, makeMsg(needed, gotten))
+				return
+			}
+			lastNL := strings.LastIndex(raw, "\n")
+			lastLine := raw[lastNL:]
+			fixedLast := replaceFirstLeadingIndent(lastLine, indent)
+			ctx.ReportNodeWithFixes(node, makeMsg(needed, gotten), rule.RuleFix{
+				Text:  fixedLast,
+				Range: core.NewTextRange(start+lastNL, end),
+			})
+		}
+
+		// reportAttribute emits a wrongIndent diagnostic anchored at the
+		// `)` punctuator (or whatever first-in-line anchor we found
+		// inside the attribute value). Mirrors upstream's
+		// `report(firstInLine, …)` — the diagnostic line/col reports on
+		// the anchor token, NOT on the JsxAttribute.
+		reportAttribute := func(anchorPos int, needed, gotten int, fixRange core.TextRange, fixText string) {
+			anchorRange := core.NewTextRange(anchorPos, anchorPos+1)
+			ctx.ReportRangeWithFixes(anchorRange, makeMsg(needed, gotten), rule.RuleFix{
+				Text:  fixText,
+				Range: fixRange,
+			})
+		}
+
+		// jsxOperandPosition returns the AST node that occupies the
+		// "operand position" upstream's ESTree-walking checks reach via
+		// `node.parent`. For a wrapping JsxElement / JsxFragment the
+		// answer is that element; for a self-closing element the answer
+		// is the node itself.
+		jsxOperandPosition := func(node *ast.Node) *ast.Node {
+			switch node.Kind {
+			case ast.KindJsxOpeningElement, ast.KindJsxOpeningFragment:
+				return node.Parent
+			default:
+				return node
+			}
+		}
+
+		// containerAfterWrappers returns the first non-paren / non-TS-cast
+		// ancestor of `operand`. Equivalent to `reactutil.SkipExpressionWrappersUp`
+		// rooted at `operand` rather than at `operand.Parent`. We need the
+		// child position too (which wrapper is the immediate operand of
+		// the resulting container) so the caller can compare with `.Right`,
+		// `.WhenFalse`, etc.
+		containerAfterWrappers := func(operand *ast.Node) (cur *ast.Node, parent *ast.Node) {
+			cur = operand
+			parent = cur.Parent
+			for parent != nil {
+				switch parent.Kind {
+				case ast.KindParenthesizedExpression,
+					ast.KindAsExpression,
+					ast.KindSatisfiesExpression,
+					ast.KindNonNullExpression,
+					ast.KindTypeAssertionExpression:
+					cur = parent
+					parent = cur.Parent
+					continue
+				}
+				break
+			}
+			return cur, parent
+		}
+
+		// isRightInLogicalExp — node sits in the right operand of a
+		// logical (&&, ||, ??) expression, AND `indentLogicalExpressions`
+		// is OFF.
+		isRightInLogicalExp := func(node *ast.Node) bool {
+			if indentLogicalExpressions {
+				return false
+			}
+			operand := jsxOperandPosition(node)
+			if operand == nil {
+				return false
+			}
+			cur, parent := containerAfterWrappers(operand)
+			if parent == nil || parent.Kind != ast.KindBinaryExpression {
+				return false
+			}
+			be := parent.AsBinaryExpression()
+			op := be.OperatorToken.Kind
+			if op != ast.KindAmpersandAmpersandToken &&
+				op != ast.KindBarBarToken &&
+				op != ast.KindQuestionQuestionToken {
+				return false
+			}
+			return be.Right == cur
+		}
+
+		// isAlternateInConditionalExp — node sits in the alternate
+		// (whenFalse) branch of a `?:`, AND the previous non-whitespace
+		// char before node start is not `(` (upstream skips alternates
+		// wrapped in their own parens).
+		isAlternateInConditionalExp := func(node *ast.Node) bool {
+			operand := jsxOperandPosition(node)
+			if operand == nil {
+				return false
+			}
+			cur, parent := containerAfterWrappers(operand)
+			if parent == nil || parent.Kind != ast.KindConditionalExpression {
+				return false
+			}
+			ce := parent.AsConditionalExpression()
+			if ce.WhenFalse != cur {
+				return false
+			}
+			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			i := trimmed.Pos() - 1
+			for i >= 0 {
+				c := text[i]
+				if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
+					i--
+					continue
+				}
+				return c != '('
+			}
+			return true
+		}
+
+		checkNodesIndent := func(node *ast.Node, indent int) {
+			nodeIndent := nodeStartIndent(node)
+			isCorrectRightInLogicalExp := isRightInLogicalExp(node) && (nodeIndent-indent) == indentSize
+			isCorrectAlternateInCondExp := isAlternateInConditionalExp(node) && (nodeIndent-indent) == 0
+			if nodeIndent != indent &&
+				isNodeFirstInLine(node) &&
+				!isCorrectRightInLogicalExp &&
+				!isCorrectAlternateInCondExp {
+				reportIndent(node, indent, nodeIndent)
+			}
+		}
+
+		// checkLiteralNodeIndent — for each line of a JsxText that has
+		// content, compare its leading indent to the expected value;
+		// emit one diagnostic per mismatched line.
+		checkLiteralNodeIndent := func(node *ast.Node, expected int) {
+			rawStart := node.Pos()
+			rawEnd := node.End()
+			value := text[rawStart:rawEnd]
+			indents := scanLiteralIndents(value, indentChar)
+			if len(indents) == 0 {
+				return
+			}
+			allMatch := true
+			for _, ind := range indents {
+				if ind != expected {
+					allMatch = false
+					break
+				}
+			}
+			if allMatch {
+				return
+			}
+			indentStr := strings.Repeat(string(indentChar), expected)
+			fixedText := replaceLeadingIndentInText(value, indentStr)
+			for _, actualIndent := range indents {
+				reportLiteral(node, expected, actualIndent, fixedText)
+			}
+		}
+
+		// commaContainer walks up from the operand position through any
+		// expression wrappers and returns the nearest list-y container —
+		// the AST node that ESLint's `getNodeByRangeIndex(commaPos)` would
+		// resolve to for a comma between siblings.
+		commaContainer := func(node *ast.Node) *ast.Node {
+			operand := jsxOperandPosition(node)
+			if operand == nil {
+				return nil
+			}
+			_, parent := containerAfterWrappers(operand)
+			if parent == nil {
+				return nil
+			}
+			switch parent.Kind {
+			case ast.KindArrayLiteralExpression,
+				ast.KindCallExpression,
+				ast.KindNewExpression,
+				ast.KindObjectLiteralExpression:
+				return parent
+			}
+			return nil
+		}
+
+		// colonAnchor — when the previous source char before `<` is a `:`,
+		// upstream rewinds past punctuators (excluding `/`) until it hits
+		// a non-punctuator, then climbs the AST until the parent is a
+		// ConditionalExpression. The result is whichever
+		// ConditionalExpression child contains that token — almost always
+		// the consequent. We replicate the same outcome by locating the
+		// nearest ConditionalExpression ancestor (skipping paren wrappers)
+		// and returning its `WhenTrue` after stripping wrappers.
+		colonAnchor := func(node *ast.Node) *ast.Node {
+			operand := jsxOperandPosition(node)
+			if operand == nil {
+				return nil
+			}
+			cur := operand
+			parent := cur.Parent
+			for parent != nil {
+				if parent.Kind == ast.KindConditionalExpression {
+					ce := parent.AsConditionalExpression()
+					if ce.WhenFalse == cur {
+						return reactutil.SkipExpressionWrappers(ce.WhenTrue)
+					}
+					return nil
+				}
+				switch parent.Kind {
+				case ast.KindParenthesizedExpression,
+					ast.KindAsExpression,
+					ast.KindSatisfiesExpression,
+					ast.KindNonNullExpression,
+					ast.KindTypeAssertionExpression:
+					cur = parent
+					parent = cur.Parent
+					continue
+				}
+				return nil
+			}
+			return nil
+		}
+
+		// jsxParentOpening returns the opening tag of the surrounding
+		// JsxElement / JsxFragment when `node` (or the JsxElement that
+		// wraps it) is positioned as one of that container's children. In
+		// upstream this is the JSXText/parent re-mapping branch:
+		//
+		//   if (prevToken.type === 'JSXText' || ...) {
+		//     prevToken = sourceCode.getNodeByRangeIndex(prevToken.range[0]);
+		//     prevToken = prevToken.type === 'Literal' || prevToken.type === 'JSXText'
+		//       ? prevToken.parent : prevToken;
+		//   }
+		//
+		// Same idea — when a JSX child is preceded by JsxText (whitespace
+		// or content), the anchor is the surrounding element's opening
+		// tag, not the previous sibling's tail.
+		jsxParentOpening := func(node *ast.Node) *ast.Node {
+			operand := jsxOperandPosition(node)
+			if operand == nil {
+				return nil
+			}
+			parent := operand.Parent
+			if parent == nil {
+				return nil
+			}
+			switch parent.Kind {
+			case ast.KindJsxElement:
+				return parent.AsJsxElement().OpeningElement
+			case ast.KindJsxFragment:
+				return parent.AsJsxFragment().OpeningFragment
+			}
+			return nil
+		}
+
+		// previousAnchorIndent returns (parentIndent, sameLine) for the
+		// "previous token" before node's opening `<`. Order of dispatch
+		// mirrors upstream:
+		//
+		//  1. If we sit inside a JsxElement/JsxFragment as a child, the
+		//     anchor is the parent's opening tag (upstream JSXText
+		//     remap).
+		//  2. Otherwise scan back to the previous non-whitespace source
+		//     char: comma → list-container, `:` → conditional's
+		//     consequent, anything else → that char's line.
+		previousAnchorIndent := func(node *ast.Node) (int, bool, bool) {
+			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			startPos := trimmed.Pos()
+
+			if opening := jsxParentOpening(node); opening != nil {
+				openingTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, opening)
+				sameLine := lineOfPos(openingTrimmed.Pos()) == lineOfPos(startPos)
+				return lineIndentAt(openingTrimmed.Pos()), sameLine, true
+			}
+
+			i := startPos - 1
+			for i >= 0 && (text[i] == ' ' || text[i] == '\t' || text[i] == '\r' || text[i] == '\n') {
+				i--
+			}
+			if i < 0 {
+				return 0, false, false
+			}
+			if text[i] == ',' {
+				container := commaContainer(node)
+				if container != nil {
+					containerTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, container)
+					sameLine := lineOfPos(containerTrimmed.Pos()) == lineOfPos(startPos)
+					return lineIndentAt(containerTrimmed.Pos()), sameLine, true
+				}
+				i--
+				for i >= 0 && (text[i] == ' ' || text[i] == '\t' || text[i] == '\r' || text[i] == '\n') {
+					i--
+				}
+				if i < 0 {
+					return 0, false, true
+				}
+				return lineIndentAt(i), false, true
+			}
+			if text[i] == ':' {
+				anchor := colonAnchor(node)
+				if anchor != nil {
+					anchorTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, anchor)
+					sameLine := lineOfPos(anchorTrimmed.Pos()) == lineOfPos(startPos)
+					return lineIndentAt(anchorTrimmed.Pos()), sameLine, true
+				}
+				// Fall through: no enclosing conditional — use the `:`
+				// position.
+			}
+			sameLine := lineOfPos(i) == lineOfPos(startPos)
+			return lineIndentAt(i), sameLine, true
+		}
+
+		handleOpeningElement := func(node *ast.Node) {
+			parentIndent, sameLine, ok := previousAnchorIndent(node)
+			if !ok {
+				return
+			}
+			additional := indentSize
+			if sameLine ||
+				isRightInLogicalExp(node) ||
+				isAlternateInConditionalExp(node) {
+				additional = 0
+			}
+			checkNodesIndent(node, parentIndent+additional)
+		}
+
+		handleClosingElement := func(node *ast.Node) {
+			parent := node.Parent
+			if parent == nil {
+				return
+			}
+			var openingNode *ast.Node
+			switch parent.Kind {
+			case ast.KindJsxElement:
+				openingNode = parent.AsJsxElement().OpeningElement
+			case ast.KindJsxFragment:
+				openingNode = parent.AsJsxFragment().OpeningFragment
+			default:
+				return
+			}
+			peerIndent := nodeStartIndent(openingNode)
+			checkNodesIndent(node, peerIndent)
+		}
+
+		handleAttribute := func(node *ast.Node) {
+			if !checkAttributes {
+				return
+			}
+			attr := node.AsJsxAttribute()
+			if attr == nil || attr.Initializer == nil || attr.Initializer.Kind != ast.KindJsxExpression {
+				return
+			}
+			nameNode := attr.Name()
+			if nameNode == nil {
+				return
+			}
+			value := attr.Initializer
+			je := value.AsJsxExpression()
+			if je == nil || je.Expression == nil {
+				return
+			}
+			// Replicate upstream's `getFirstNodeInLine(lastToken)`: walk
+			// back from `}` (the JsxExpression's last char) over all
+			// trivia (whitespace, newlines) to land on the previous
+			// non-trivia source byte. That byte is the anchor; we report
+			// against the line containing it.
+			closeBracePos := value.End() - 1
+			i := closeBracePos - 1
+			for i >= 0 && (text[i] == ' ' || text[i] == '\t' || text[i] == '\r' || text[i] == '\n') {
+				i--
+			}
+			if i < 0 {
+				return
+			}
+			anchorPos := i
+			lineStart := lineStartOfPos(anchorPos)
+			actualIndent := 0
+			for j := lineStart; j < anchorPos; j++ {
+				if text[j] != indentChar {
+					break
+				}
+				actualIndent++
+			}
+			// The anchor must itself be first-in-line (after WS / commas)
+			// to be a meaningful indent target — mirrors checkNodesIndent's
+			// `isNodeFirstInLine` gate.
+			isFirst := true
+			for j := anchorPos - 1; j >= lineStart; j-- {
+				c := text[j]
+				if c != ' ' && c != '\t' && c != ',' && c != '\r' {
+					isFirst = false
+					break
+				}
+			}
+			if !isFirst {
+				return
+			}
+			nameLine := lineOfPos(nameNode.Pos())
+			anchorLine := lineOfPos(anchorPos)
+			expectedIndent := nodeStartIndent(nameNode)
+			if nameLine == anchorLine {
+				expectedIndent = 0
+			}
+			if actualIndent == expectedIndent {
+				return
+			}
+			indentStr := strings.Repeat(string(indentChar), expectedIndent)
+			fixRange := core.NewTextRange(lineStart, anchorPos)
+			reportAttribute(anchorPos, expectedIndent, actualIndent, fixRange, indentStr)
+		}
+
+		handleJsxExpression := func(node *ast.Node) {
+			parent := node.Parent
+			if parent == nil {
+				return
+			}
+			parentIndent := nodeStartIndent(parent)
+			checkNodesIndent(node, parentIndent+indentSize)
+		}
+
+		handleJsxText := func(node *ast.Node) {
+			parent := node.Parent
+			if parent == nil {
+				return
+			}
+			if parent.Kind != ast.KindJsxElement && parent.Kind != ast.KindJsxFragment {
+				return
+			}
+			parentIndent := nodeStartIndent(parent)
+			checkLiteralNodeIndent(node, parentIndent+indentSize)
+		}
+
+		handleReturn := func(node *ast.Node) {
+			ret := node.AsReturnStatement()
+			if ret == nil || ret.Expression == nil {
+				return
+			}
+			// Mirror upstream's `jsxUtil.isJSX(node.argument)` gate
+			// exactly: only JsxElement / JsxFragment / JsxSelfClosingElement
+			// qualifies; TS wrappers (`as`, `satisfies`, `!`,
+			// `<T>x`) deliberately do NOT, since ESTree exposes them
+			// as their own node types and `isJSX` returns false. We do
+			// strip plain parens because ESTree flattens those.
+			arg := ast.SkipParentheses(ret.Expression)
+			if !reactutil.IsJsxLike(arg) {
+				return
+			}
+			fn := node.Parent
+			for fn != nil &&
+				fn.Kind != ast.KindFunctionDeclaration &&
+				fn.Kind != ast.KindFunctionExpression {
+				fn = fn.Parent
+			}
+			if fn == nil {
+				return
+			}
+			openingIndent := nodeStartIndent(node)
+			closingIndent := nodeEndIndent(node)
+			if openingIndent != closingIndent {
+				reportReturn(node, openingIndent, closingIndent)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     handleOpeningElement,
+			ast.KindJsxSelfClosingElement: handleOpeningElement,
+			ast.KindJsxOpeningFragment:    handleOpeningElement,
+			ast.KindJsxClosingElement:     handleClosingElement,
+			ast.KindJsxClosingFragment:    handleClosingElement,
+			ast.KindJsxAttribute:          handleAttribute,
+			ast.KindJsxExpression:         handleJsxExpression,
+			ast.KindJsxText:               handleJsxText,
+			ast.KindReturnStatement:       handleReturn,
+		}
+	},
+}
+
+// parseIndentOption parses the first option:
+//   - "tab" → ("tab", 1, '\t')
+//   - integer N → ("space", N, ' ')
+//   - default → ("space", 4, ' ')
+func parseIndentOption(options any) (string, int, byte) {
+	indentType := "space"
+	indentSize := 4
+	indentChar := byte(' ')
+
+	var first any
+	if options == nil {
+		return indentType, indentSize, indentChar
+	}
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) > 0 {
+			first = arr[0]
+		}
+	} else {
+		first = options
+	}
+
+	switch v := first.(type) {
+	case string:
+		if v == "tab" {
+			indentType = "tab"
+			indentSize = 1
+			indentChar = '\t'
+		}
+	case float64:
+		indentType = "space"
+		indentSize = int(v)
+		indentChar = ' '
+	case int:
+		indentType = "space"
+		indentSize = v
+		indentChar = ' '
+	}
+	return indentType, indentSize, indentChar
+}
+
+// parseSecondOption parses the second-position object:
+//
+//	{ checkAttributes: bool, indentLogicalExpressions: bool }
+func parseSecondOption(options any) (bool, bool) {
+	checkAttributes := false
+	indentLogicalExpressions := false
+
+	arr, ok := options.([]interface{})
+	if !ok || len(arr) < 2 {
+		return checkAttributes, indentLogicalExpressions
+	}
+	m, ok := arr[1].(map[string]interface{})
+	if !ok {
+		return checkAttributes, indentLogicalExpressions
+	}
+	if v, ok := m["checkAttributes"].(bool); ok {
+		checkAttributes = v
+	}
+	if v, ok := m["indentLogicalExpressions"].(bool); ok {
+		indentLogicalExpressions = v
+	}
+	return checkAttributes, indentLogicalExpressions
+}
+
+// scanLiteralIndents extracts the leading-indent run of every "content line"
+// of a JsxText literal. A content line is a line that has at least one
+// non-whitespace character; the run is consecutive `indentChar` characters
+// at line start (mirroring upstream's `\n( *)[\t ]*\S` regex).
+//
+// Upstream applies its regex against the JSXText *decoded* `value`, which
+// turns `&nbsp;` / `&#160;` / `&#xA0;` and a literal NBSP byte sequence
+// into U+00A0 — and U+00A0 matches JS `\s`, so a line whose only content
+// is an NBSP-equivalent entity does NOT count as a content line. tsgo
+// keeps `JsxText.Text` raw, so we explicitly skip those entities here to
+// stay aligned.
+func scanLiteralIndents(value string, indentChar byte) []int {
+	var out []int
+	for i := range len(value) {
+		if value[i] != '\n' {
+			continue
+		}
+		j := i + 1
+		count := 0
+		for j < len(value) && value[j] == indentChar {
+			count++
+			j++
+		}
+		j = skipWhitespaceAndNBSPEntities(value, j)
+		if j >= len(value) {
+			continue
+		}
+		if value[j] == '\n' || value[j] == '\r' {
+			continue
+		}
+		out = append(out, count)
+	}
+	return out
+}
+
+// skipWhitespaceAndNBSPEntities advances past ASCII spaces, tabs, raw
+// UTF-8 NBSP bytes (\xc2\xa0), and the case-insensitive HTML entities that
+// decode to U+00A0: `&nbsp;`, `&#160;`, `&#xA0;`. Upstream's regex
+// `[\t ]*` runs against the decoded value where these are already real
+// whitespace chars; we replicate that by recognizing them in raw source.
+func skipWhitespaceAndNBSPEntities(s string, i int) int {
+	for i < len(s) {
+		c := s[i]
+		if c == ' ' || c == '\t' {
+			i++
+			continue
+		}
+		if i+1 < len(s) && c == '\xc2' && s[i+1] == '\xa0' {
+			i += 2
+			continue
+		}
+		if c == '&' {
+			if n := matchNBSPEntity(s, i); n > 0 {
+				i += n
+				continue
+			}
+		}
+		break
+	}
+	return i
+}
+
+// matchNBSPEntity returns the byte length of an NBSP-equivalent HTML
+// entity reference starting at s[i] ('&'), or 0 if no match. Recognises
+// `&nbsp;` (any case), `&#160;`, and `&#xA0;` / `&#xa0;` / `&#XA0;`.
+func matchNBSPEntity(s string, i int) int {
+	if i >= len(s) || s[i] != '&' {
+		return 0
+	}
+	rest := s[i:]
+	if len(rest) >= 6 {
+		hd := rest[:6]
+		if hd[0] == '&' && (hd[1] == 'n' || hd[1] == 'N') && (hd[2] == 'b' || hd[2] == 'B') &&
+			(hd[3] == 's' || hd[3] == 'S') && (hd[4] == 'p' || hd[4] == 'P') && hd[5] == ';' {
+			return 6
+		}
+		if hd == "&#160;" {
+			return 6
+		}
+	}
+	if len(rest) >= 6 {
+		hd := rest[:6]
+		if hd[0] == '&' && hd[1] == '#' && (hd[2] == 'x' || hd[2] == 'X') &&
+			(hd[3] == 'A' || hd[3] == 'a') && (hd[4] == '0') && hd[5] == ';' {
+			return 6
+		}
+	}
+	return 0
+}
+
+// replaceLeadingIndentInText rewrites every `\n<ws>*<non-ws>` run so the
+// post-newline whitespace is exactly `indent`. Mirrors upstream's
+// `\n[\t ]*(\S)` → `\n<indent>$1` substitution: a trailing `\n<ws>+` with
+// no following non-whitespace char (e.g. the JsxText that closes a
+// container, ending right before `</tag>`) is preserved verbatim — the
+// upstream regex doesn't match, so the indent stays as-is. Lines whose
+// only post-indent content is an NBSP-equivalent entity (`&nbsp;` etc.)
+// are also left alone, mirroring upstream where `&nbsp;` decodes to
+// U+00A0 (whitespace) and the regex doesn't match.
+func replaceLeadingIndentInText(s, indent string) string {
+	var b strings.Builder
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		b.WriteByte(c)
+		if c != '\n' {
+			i++
+			continue
+		}
+		i++
+		wsStart := i
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+			i++
+		}
+		afterWs := skipWhitespaceAndNBSPEntities(s, i)
+		if afterWs >= len(s) || s[afterWs] == '\n' || s[afterWs] == '\r' {
+			b.WriteString(s[wsStart:i])
+			continue
+		}
+		b.WriteString(indent)
+	}
+	return b.String()
+}
+
+// replaceFirstLeadingIndent replaces only the first `\n<ws>*<non-ws>` run.
+// Used for the ReturnStatement last-line fix.
+func replaceFirstLeadingIndent(s, indent string) string {
+	if len(s) == 0 || s[0] != '\n' {
+		return s
+	}
+	i := 1
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	if i >= len(s) || s[i] == '\n' || s[i] == '\r' {
+		return s
+	}
+	return "\n" + indent + s[i:]
+}

--- a/internal/plugins/react/rules/jsx_indent/jsx_indent.md
+++ b/internal/plugins/react/rules/jsx_indent/jsx_indent.md
@@ -1,0 +1,114 @@
+# jsx-indent
+
+## Rule Details
+
+This rule enforces a consistent indentation style for JSX. The default style is `4 spaces`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<App>
+  <Hello />
+</App>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<App>
+    <Hello />
+</App>
+```
+
+## Rule Options
+
+The first option is either the string `"tab"` for tab-based indentation, or a non-negative integer for space-based indentation.
+
+The second option is an object with two boolean keys (each defaulting to `false`):
+
+- `checkAttributes` — also enforce indentation inside JSX-expression attribute values.
+- `indentLogicalExpressions` — also indent JSX nested inside the right side of a logical (`&&`, `||`, `??`) expression.
+
+Examples of **incorrect** code for this rule with `["error", 2]`:
+
+```json
+{ "react/jsx-indent": ["error", 2] }
+```
+
+```jsx
+<App>
+    <Hello />
+</App>
+```
+
+Examples of **correct** code for this rule with `["error", 2]`:
+
+```json
+{ "react/jsx-indent": ["error", 2] }
+```
+
+```jsx
+<App>
+  <Hello />
+</App>
+```
+
+Examples of **correct** code for this rule with `["error", "tab"]`:
+
+```json
+{ "react/jsx-indent": ["error", "tab"] }
+```
+
+```jsx
+<App>
+	<Hello />
+</App>
+```
+
+Examples of **correct** code for this rule with `["error", 0]`:
+
+```json
+{ "react/jsx-indent": ["error", 0] }
+```
+
+```jsx
+<App>
+<Hello />
+</App>
+```
+
+Examples of **incorrect** code for this rule with `["error", 2, { "indentLogicalExpressions": true }]`:
+
+```json
+{ "react/jsx-indent": ["error", 2, { "indentLogicalExpressions": true }] }
+```
+
+```jsx
+<App>
+  {condition && (
+  <Hello />
+  )}
+</App>
+```
+
+Examples of **correct** code for this rule with `["error", 2, { "indentLogicalExpressions": true }]`:
+
+```json
+{ "react/jsx-indent": ["error", 2, { "indentLogicalExpressions": true }] }
+```
+
+```jsx
+<App>
+  {condition && (
+    <Hello />
+  )}
+</App>
+```
+
+## When Not To Use It
+
+If you are not using JSX, you can disable this rule. If you use a code formatter (e.g. Prettier) that already enforces JSX indentation, prefer relying on the formatter instead.
+
+## Original Documentation
+
+- [react/jsx-indent](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md)

--- a/internal/plugins/react/rules/jsx_indent/jsx_indent_test.go
+++ b/internal/plugins/react/rules/jsx_indent/jsx_indent_test.go
@@ -1,0 +1,2623 @@
+package jsx_indent
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestJsxIndentRule mirrors the upstream eslint-plugin-react test suite at
+// `tests/lib/rules/jsx-indent.js`. Each upstream case is migrated 1:1; cases
+// that exercise stage-1 / non-tsgo features are kept as `Skip: true` with a
+// short reason so the file still maps to the upstream layout.
+//
+// Layout note: most upstream `valid` cases anchor their JSX with the same
+// 8-space outer indent ESLint's tagged-template literals introduce, so we
+// keep that prefix verbatim. Switching them to flush-left would break the
+// indent arithmetic.
+func TestJsxIndentRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxIndentRule, []rule_tester.ValidTestCase{
+		// ---- Single-line elements / fragments — no inner content to check ----
+		{Code: "\n        <App></App>\n      ", Tsx: true},
+		{Code: "\n        <></>\n      ", Tsx: true},
+
+		// ---- Multi-line element with no children ----
+		{Code: "\n        <App>\n        </App>\n      ", Tsx: true},
+		{Code: "\n        <>\n        </>\n      ", Tsx: true},
+
+		// ---- 2-space option ----
+		{
+			Code:    "\n        <App>\n          <Foo />\n        </App>\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        <App>\n          <></>\n        </App>\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        <>\n          <Foo />\n        </>\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- 0-indent option ----
+		{
+			Code:    "\n        <App>\n        <Foo />\n        </App>\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(0)},
+		},
+
+		// ---- Negative offset (rare upstream test — child sits two cols
+		// to the LEFT of the open / close). ----
+		{
+			Code:    "\n          <App>\n        <Foo />\n          </App>\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(-2)},
+		},
+
+		// ---- Tab indentation ----
+		{
+			Code:    "\n\t\t\t\t<App>\n\t\t\t\t\t<Foo />\n\t\t\t\t</App>\n\t\t\t",
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+		},
+
+		// ---- Function with `return <jsx>` (no parens) — return / closing
+		// tag share a column. ----
+		{
+			Code:    "\n        function App() {\n          return <App>\n            <Foo />\n          </App>;\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        function App() {\n          return <App>\n            <></>\n          </App>;\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Function with `return (<jsx>)` — opening paren on return line. ----
+		{
+			Code:    "\n        function App() {\n          return (<App>\n            <Foo />\n          </App>);\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        function App() {\n          return (<App>\n            <></>\n          </App>);\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Function with `return (\n  <jsx>\n)` — JSX on its own indent
+		// inside the parens. ----
+		{
+			Code:    "\n        function App() {\n          return (\n            <App>\n              <Foo />\n            </App>\n          );\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        function App() {\n          return (\n            <App>\n              <></>\n            </App>\n          );\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Call argument with parenthesized JSX ----
+		{
+			Code:    "\n        it(\n          (\n            <div>\n              <span />\n            </div>\n          )\n        )\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        it(\n          (\n            <div>\n              <></>\n            </div>\n          )\n        )\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        it(\n          (<div>\n            <span />\n            <span />\n            <span />\n          </div>)\n        )\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        (\n          <div>\n            <span />\n          </div>\n        )\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Logical `&&` in expression-statement context — JSX may
+		// share parent indent (default indentLogicalExpressions: false). ----
+		{
+			Code:    "\n        {\n          head.title &&\n          <h1>\n            {head.title}\n          </h1>\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        {\n          head.title &&\n          <>\n            {head.title}\n          </>\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        {\n          head.title &&\n            <h1>\n              {head.title}\n            </h1>\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        {\n          head.title && (\n          <h1>\n            {head.title}\n          </h1>)\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        {\n          head.title && (\n            <h1>\n              {head.title}\n            </h1>\n          )\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Array literal of JSX (comma-anchored to array start). ----
+		{
+			Code:    "\n        [\n          <div />,\n          <div />\n        ]\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        [\n          <></>,\n          <></>\n        ]\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Default 4-space, deeply nested array inside JsxExpression ----
+		{Code: "\n        <div>\n            {\n                [\n                    <Foo />,\n                    <Bar />\n                ]\n            }\n        </div>\n      ", Tsx: true},
+		{Code: "\n        <div>\n            {foo &&\n                [\n                    <Foo />,\n                    <Bar />\n                ]\n            }\n        </div>\n      ", Tsx: true},
+		{Code: "\n        <div>\n            {foo &&\n                [\n                    <></>,\n                    <></>\n                ]\n            }\n        </div>\n      ", Tsx: true},
+
+		// ---- Default 4-space, JsxText with mixed inline JSX ----
+		{Code: "\n        <div>\n            bar <div>\n                bar\n                bar {foo}\n                bar </div>\n        </div>\n      ", Tsx: true},
+		{Code: "\n        <>\n            bar <>\n                bar\n                bar {foo}\n                bar </>\n        </>\n      ", Tsx: true},
+
+		// ---- Multiline ternary — colon at end of consequent ----
+		{Code: "\n        foo ?\n            <Foo /> :\n            <Bar />\n      ", Tsx: true},
+		{Code: "\n        foo ?\n            <></> :\n            <></>\n      ", Tsx: true},
+
+		// ---- Multiline ternary — colon at start of second expr ----
+		{Code: "\n        foo ?\n            <Foo />\n            : <Bar />\n      ", Tsx: true},
+		{Code: "\n        foo ?\n            <></>\n            : <></>\n      ", Tsx: true},
+
+		// ---- Multiline ternary — colon on its own line ----
+		{Code: "\n        foo ?\n            <Foo />\n        :\n            <Bar />\n      ", Tsx: true},
+		{Code: "\n        foo ?\n            <></>\n        :\n            <></>\n      ", Tsx: true},
+
+		// ---- Multiline JSX inside ternary, colon on its own line ----
+		{Code: "\n        {!foo ?\n            <Foo\n                onClick={this.onClick}\n            />\n        :\n            <Bar\n                onClick={this.onClick}\n            />\n        }\n      ", Tsx: true},
+
+		// ---- Test expr on first line, colon at end of consequent ----
+		{Code: "\n        foo ? <Foo /> :\n        <Bar />\n      ", Tsx: true},
+		{Code: "\n        foo ? <></> :\n        <></>\n      ", Tsx: true},
+
+		// ---- Test expr on first line, colon on second line ----
+		{Code: "\n        foo ? <Foo />\n        : <Bar />\n      ", Tsx: true},
+		{Code: "\n        foo ? <></>\n        : <></>\n      ", Tsx: true},
+
+		// ---- Test expr on first line, colon on its own line ----
+		{Code: "\n        foo ? <Foo />\n        :\n        <Bar />\n      ", Tsx: true},
+		{Code: "\n        foo ? <></>\n        :\n        <></>\n      ", Tsx: true},
+
+		// ---- Parenthesized first expression ----
+		{Code: "\n        foo ? (\n            <Foo />\n        ) :\n            <Bar />\n      ", Tsx: true},
+		{Code: "\n        foo ? (\n            <></>\n        ) :\n            <></>\n      ", Tsx: true},
+		{Code: "\n        foo ? (\n            <Foo />\n        )\n            : <Bar />\n      ", Tsx: true},
+		{Code: "\n        foo ? (\n            <></>\n        )\n            : <></>\n      ", Tsx: true},
+		{Code: "\n        foo ? (\n            <Foo />\n        )\n        :\n            <Bar />\n      ", Tsx: true},
+		{Code: "\n        foo ? (\n            <></>\n        )\n        :\n            <></>\n      ", Tsx: true},
+
+		// ---- Parenthesized second expression ----
+		{Code: "\n        foo ?\n            <Foo /> : (\n                <Bar />\n            )\n      ", Tsx: true},
+		{Code: "\n        foo ?\n            <></> : (\n                <></>\n            )\n      ", Tsx: true},
+		{Code: "\n        foo ?\n            <Foo />\n        : (\n            <Bar />\n        )\n      ", Tsx: true},
+		{Code: "\n        foo ?\n            <></>\n        : (\n            <></>\n        )\n      ", Tsx: true},
+		{Code: "\n        foo ?\n            <Foo />\n            : (\n                <Bar />\n            )\n      ", Tsx: true},
+		{Code: "\n        foo ?\n            <></>\n            : (\n                <></>\n            )\n      ", Tsx: true},
+
+		// ---- Both branches parenthesized ----
+		{Code: "\n        foo ? (\n            <Foo />\n        ) : (\n            <Bar />\n        )\n      ", Tsx: true},
+		{Code: "\n        foo ? (\n            <></>\n        ) : (\n            <></>\n        )\n      ", Tsx: true},
+		{Code: "\n        foo ? (\n            <Foo />\n        )\n        : (\n            <Bar />\n        )\n      ", Tsx: true},
+		{Code: "\n        foo ? (\n            <></>\n        )\n        : (\n            <></>\n        )\n      ", Tsx: true},
+		{Code: "\n        foo ? (\n            <Foo />\n        )\n        :\n        (\n            <Bar />\n        )\n      ", Tsx: true},
+		{Code: "\n        foo ? (\n            <></>\n        )\n        :\n        (\n            <></>\n        )\n      ", Tsx: true},
+
+		// ---- Mixed test-on-first-line + paren second branch ----
+		{Code: "\n        foo ? <Foo /> : (\n            <Bar />\n        )\n      ", Tsx: true},
+		{Code: "\n        foo ? <></> : (\n            <></>\n        )\n      ", Tsx: true},
+		{Code: "\n        foo ? <Foo />\n        : (<Bar />)\n      ", Tsx: true},
+		{Code: "\n        foo ? <></>\n        : (<></>)\n      ", Tsx: true},
+		{Code: "\n        foo ? <Foo />\n        : (\n            <Bar />\n        )\n      ", Tsx: true},
+		{Code: "\n        foo ? <></>\n        : (\n            <></>\n        )\n      ", Tsx: true},
+
+		// ---- JsxExpression-wrapped ternary, JSX with attrs spanning
+		// multiple lines (opts [2]) ----
+		{
+			Code:    "\n        <span>\n          {condition ?\n            <Thing\n              foo={`bar`}\n            /> :\n            <Thing/>\n          }\n        </span>\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        <span>\n          {condition ?\n            <Thing\n              foo={\"bar\"}\n            /> :\n            <Thing/>\n          }\n        </span>\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        function foo() {\n          <span>\n            {condition ?\n              <Thing\n                foo={superFoo}\n              /> :\n              <Thing/>\n            }\n          </span>\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        function foo() {\n          <span>\n            {condition ?\n              <Thing\n                foo={superFoo}\n              /> :\n              <></>\n            }\n          </span>\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- do { } expression (stage-1) — tsgo has no native node;
+		// upstream uses the babel-eslint parser. Skip with reason. ----
+		{
+			Code: "\n        <span>\n            {do {\n                const num = rollDice();\n                <Thing num={num} />;\n            }}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {(do {\n                const num = rollDice();\n                <Thing num={num} />;\n            })}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {do {\n                const purposeOfLife = getPurposeOfLife();\n                if (purposeOfLife == 42) {\n                    <Thing />;\n                } else {\n                    <AnotherThing />;\n                }\n            }}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {(do {\n                const purposeOfLife = getPurposeOfLife();\n                if (purposeOfLife == 42) {\n                    <Thing />;\n                } else {\n                    <AnotherThing />;\n                }\n            })}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {do {\n                <Thing num={rollDice()} />;\n            }}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {(do {\n                <Thing num={rollDice()} />;\n            })}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {do {\n                <Thing num={rollDice()} />;\n                <Thing num={rollDice()} />;\n            }}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {(do {\n                <Thing num={rollDice()} />;\n                <Thing num={rollDice()} />;\n            })}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {do {\n                const purposeOfLife = 42;\n                <Thing num={purposeOfLife} />;\n                <Thing num={purposeOfLife} />;\n            }}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {(do {\n                const purposeOfLife = 42;\n                <Thing num={purposeOfLife} />;\n                <Thing num={purposeOfLife} />;\n            })}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+
+		// ---- Class component with deeply nested return ----
+		{
+			Code:    "\n        class Test extends React.Component {\n          render() {\n            return (\n              <div>\n                <div />\n                <div />\n              </div>\n            );\n          }\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        class Test extends React.Component {\n          render() {\n            return (\n              <>\n                <></>\n                <></>\n              </>\n            );\n          }\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Drift inside attribute is allowed by default (checkAttributes:false) ----
+		{
+			Code:    "\n        const Component = () => (\n          <View\n            ListFooterComponent={(\n              <View\n                rowSpan={3}\n                placeholder=\"placeholder text here\"\n              />\n        )}\n          />\n        );\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\nconst Component = () => (\n\t<View\n\t\tListFooterComponent={(\n\t\t\t<View\n\t\t\t\trowSpan={3}\n\t\t\t\tplaceholder=\"placeholder text here\"\n\t\t\t/>\n)}\n\t/>\n);\n    ",
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+		},
+		{
+			Code:    "\n        const Component = () => (\n          <View\n            ListFooterComponent={(\n              <View\n                rowSpan={3}\n                placeholder=\"placeholder text here\"\n              />\n        )}\n          />\n        );\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2), map[string]interface{}{"checkAttributes": false}},
+		},
+		{
+			Code:    "\nconst Component = () => (\n\t<View\n\t\tListFooterComponent={(\n\t\t\t<View\n\t\t\t\trowSpan={3}\n\t\t\t\tplaceholder=\"placeholder text here\"\n\t\t\t/>\n)}\n\t/>\n);\n    ",
+			Tsx:     true,
+			Options: []interface{}{"tab", map[string]interface{}{"checkAttributes": false}},
+		},
+
+		// ---- checkAttributes:true with already-correct indentation ----
+		{
+			Code:    "\n        function Foo() {\n          return (\n            <input\n              type=\"radio\"\n              defaultChecked\n            />\n          );\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2), map[string]interface{}{"checkAttributes": true}},
+		},
+
+		// ---- indentLogicalExpressions:true with already-correct nested indent ----
+		{
+			Code:    "\n        function Foo() {\n          return (\n            <div>\n              {condition && (\n                <p>Bar</p>\n              )}\n            </div>\n          );\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2), map[string]interface{}{"indentLogicalExpressions": true}},
+		},
+
+		// ---- JsxText content (default 4-space) ----
+		{Code: "\n        <App>\n            text\n        </App>\n      ", Tsx: true},
+		{Code: "\n        <App>\n            text\n            text\n            text\n        </App>\n      ", Tsx: true},
+
+		// ---- Tab + JsxText ----
+		{
+			Code:    "\n\t\t\t\t<App>\n\t\t\t\t\ttext\n\t\t\t\t</App>\n\t\t\t",
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+		},
+		{
+			Code:    "\n\t\t\t\t<App>\n\t\t\t\t\t{undefined}\n\t\t\t\t\t{null}\n\t\t\t\t\t{true}\n\t\t\t\t\t{false}\n\t\t\t\t\t{42}\n\t\t\t\t\t{NaN}\n\t\t\t\t\t{\"foo\"}\n\t\t\t\t</App>\n\t\t\t",
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+		},
+
+		// ---- Literals outside JSX must NOT be checked (#2563) ----
+		{Code: "\n        function foo() {\n          const a = `aa`;\n          const b = `b\nb`;\n        }\n      ", Tsx: true},
+
+		// ---- Arrow body returns / various function shapes ----
+		{
+			Code:    "\n        function App() {\n          return (\n            <App />\n          );\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        function App() {\n          return <App>\n            <Foo />\n          </App>;\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        const myFunction = () => (\n          [\n            <Tag\n              {...properties}\n            />,\n            <Tag\n              {...properties}\n            />,\n            <Tag\n              {...properties}\n            />,\n          ]\n        )\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code:    "\n        const Item = ({ id, name, onSelect }) => <div onClick={onSelect}>\n          {id}: {name}\n        </div>;\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Flow-typed prop pattern. Skip — Flow not supported. ----
+		{
+			Code: "\n        type Props = {\n          email: string,\n          password: string,\n          error: string,\n        }\n\n        const SomeFormComponent = ({\n          email,\n          password,\n          error,\n        }: Props) => (\n          // JSX\n        );\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: Flow type syntax is not supported by rslint's tsgo parser.
+		},
+
+		// ---- Multi-line opening tag with many attrs ----
+		{
+			Code:    "\n        <a role={'button'}\n          className={`navbar-burger ${open ? 'is-active' : ''}`}\n          href={'#'}\n          aria-label={'menu'}\n          aria-expanded={false}\n          onClick={openMenu}>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n        </a>\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Class component with class fields (TS supports the same shape) ----
+		{
+			Code:    "\n        export default class App extends React.Component {\n          state = {\n            name: '',\n          }\n\n          componentDidMount() {\n            this.fetchName()\n              .then(name => {\n                this.setState({name})\n              });\n          }\n\n          fetchName = () => {\n            const url = 'https://api.github.com/users/job13er'\n            return fetch(url)\n              .then(resp => resp.json())\n              .then(json => json.name)\n          }\n\n          render() {\n            const {name} = this.state\n            return (\n              <h1>Hello, {name}</h1>\n            )\n          }\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Large indentSize with non-JSX return body — must not flag. ----
+		{
+			Code:    "\n        function test (foo) {\n          return foo != null\n            ? Math.max(0, Math.min(1, 10))\n            : 0\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(99)},
+		},
+		{
+			Code:    "\n        function test (foo) {\n          return foo != null\n            ? <div>foo</div>\n            : <div>bar</div>\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// =================================================================
+		// Below: real-world / edge-shape coverage beyond the upstream
+		// suite. These exercise tsgo↔ESTree shape differences and common
+		// React patterns the upstream suite never gets to.
+		// =================================================================
+
+		// ---- TS `as` cast around a multi-line JSX expression — anchor
+		// for closing tag must skip the wrapping `(... as T)`. ----
+		{
+			Code: `var x = (
+  <App>
+    <Foo />
+  </App>
+) as React.ReactElement;
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- TS `satisfies` wrapper around JSX. Same structural shape
+		// — skipExpressionWrappers must transparently drop it. ----
+		{
+			Code: `var x = (
+  <App>
+    <Foo />
+  </App>
+) satisfies React.ReactElement;
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- TS non-null `!` on a JSX expression. tsgo represents this
+		// as `NonNullExpression` wrapping the JSX; the rule must treat
+		// it as transparent. ----
+		{
+			Code: `var x = (
+  <App>
+    <Foo />
+  </App>
+)!;
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- TS-`as` wrapper on the alternate of a `?:` — locks
+		// `walkUpThroughExprWrappers` cooperating with
+		// `isAlternateInConditionalExp`. ----
+		{
+			Code: `var x = condition ? (
+  <App>
+    <Foo />
+  </App>
+) : (
+  <Bar /> as React.ReactElement
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Generic JSX `<Foo<T>>...</Foo>` (TS-specific syntax). The
+		// `<T>` type-arguments list sits inside the opening tag but the
+		// opening tag's `<` is still at the line start; child indent
+		// follows the parent's line. ----
+		{
+			Code: `var x = (
+  <Foo<string>>
+    <Bar />
+  </Foo>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- JSX member-expression tag name (`<Foo.Bar>`). Tag-name
+		// shape is irrelevant to indentation arithmetic; this locks
+		// in that behaviour. ----
+		{
+			Code: `var x = (
+  <Foo.Bar>
+    <Foo.Baz />
+  </Foo.Bar>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Three-level JSX member expression. ----
+		{
+			Code: `var x = (
+  <Foo.Bar.Baz>
+    <Quux />
+  </Foo.Bar.Baz>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Namespaced JSX tag (`<svg:rect />`). ----
+		{
+			Code: `var x = (
+  <svg:svg>
+    <svg:rect />
+  </svg:svg>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- 6-level deeply nested element tree. Locks the
+		// jsxParentOpening anchor for arbitrary depth. ----
+		{
+			Code: `var x = (
+  <A>
+    <B>
+      <C>
+        <D>
+          <E>
+            <F />
+          </E>
+        </D>
+      </C>
+    </B>
+  </A>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Sibling fragment + element children at the same level. ----
+		{
+			Code: `var x = (
+  <App>
+    <>
+      <span />
+    </>
+    <span />
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Common React pattern: `React.memo(() => <jsx>)`. The JSX
+		// sits inside a CallExpression argument list; the anchor for
+		// `<App>` is the call argument's start line. ----
+		{
+			Code: `var Wrapped = React.memo(() => (
+  <App>
+    <Foo />
+  </App>
+));
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- React.forwardRef wrap. ----
+		{
+			Code: `var Wrapped = React.forwardRef((props, ref) => (
+  <App ref={ref}>
+    <Foo />
+  </App>
+));
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- map() returning JSX with a complex callback body. ----
+		{
+			Code: `var els = items.map((item, i) => (
+  <Item key={i}>
+    {item.name}
+  </Item>
+));
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Spread attribute in opening tag (`{...props}`). The
+		// JsxSpreadAttribute is treated like a normal attribute by the
+		// rule. ----
+		{
+			Code: `var x = (
+  <App
+    {...props}
+    foo="bar"
+  >
+    <Foo />
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- CRLF line endings, 2-space indent. The rule must treat
+		// `\r\n` like `\n` when locating start-of-line. ----
+		{
+			Code:    "var x = (\r\n  <App>\r\n    <Foo />\r\n  </App>\r\n);\r\n",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- HTML-entity content in a JsxText line. The entity is
+		// regular `\S` content — locks that the rule's literal scan
+		// doesn't mis-handle the `&`. ----
+		{
+			Code: `var x = (
+  <App>
+    Hello&nbsp;World
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- CJK content in a JsxText line. ----
+		{
+			Code: `var x = (
+  <App>
+    你好，世界
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Arrow function with parenthesized JSX body. ----
+		{
+			Code: `var Make = () => (
+  <App>
+    <Foo />
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- async function returning a JSX-only expression — not
+		// flagged by the ReturnStatement listener (it requires
+		// FunctionDeclaration/FunctionExpression, not async-arrow). ----
+		{
+			Code: `var f = async () => (
+  <App>
+    <Foo />
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- React.createContext + Provider with multi-line children. ----
+		{
+			Code: `var x = (
+  <ThemeContext.Provider value={theme}>
+    <App>
+      <Foo />
+    </App>
+  </ThemeContext.Provider>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- compose / HOC pattern: nested call expressions wrapping a
+		// JSX-returning arrow. ----
+		{
+			Code: `var Wrapped = compose(withRouter, connect(mapState))(({ items }) => (
+  <App>
+    <Foo />
+  </App>
+));
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Conditional rendering: ternary + nullish-coalesce mix. ----
+		{
+			Code: `var x = (
+  <App>
+    {loading
+      ? <Spinner />
+      : data ?? <Empty />}
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Multiple JsxText siblings separated by JsxExpressions. ----
+		{
+			Code: `var x = (
+  <App>
+    Hello
+    {", "}
+    World
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- JsxText that starts with non-whitespace (no leading
+		// newline). The first JsxText after an element opening with
+		// content directly inline. ----
+		{
+			Code: `var x = <App>inline-text<Foo />tail-text</App>;
+`,
+			Tsx: true,
+		},
+		// ---- Empty JsxElement / JsxFragment / no-attribute self-closing. ----
+		{
+			Code: `var x = (
+  <App>
+    <></>
+    <Foo />
+    <Bar></Bar>
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Multi-line comments INSIDE a multi-line JSX
+		// expression don't break anchor calculations. ----
+		{
+			Code: `var x = (
+  <App>
+    {/* block comment */}
+    <Foo />
+    {
+      // line comment
+      bar
+    }
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Tag with type-cast attribute value: `<Foo bar={x as number} />`.
+		// Type-cast wrapper inside the attr expression is irrelevant. ----
+		{
+			Code: `var x = (
+  <App>
+    <Foo bar={x as number} />
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- JSX as a default parameter value. ----
+		{
+			Code: `function Wrap(child = (
+  <Default>
+    <Foo />
+  </Default>
+)) {
+  return child;
+}
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- JSX as a value in an object literal. ----
+		{
+			Code: `var x = {
+  child: (
+    <App>
+      <Foo />
+    </App>
+  ),
+};
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- React.lazy + Suspense pattern. ----
+		{
+			Code: `var Page = React.lazy(() => import('./Page'));
+var x = (
+  <Suspense fallback={<Spinner />}>
+    <Page />
+  </Suspense>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Hooks / functional component pattern with useState. ----
+		{
+			Code: `function Counter() {
+  const [n, setN] = useState(0);
+  return (
+    <div>
+      <span>{n}</span>
+      <button onClick={() => setN(n + 1)}>+</button>
+    </div>
+  );
+}
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Tab option, deep nesting, mixed empty lines. ----
+		{
+			Code:    "var x = (\n\t<App>\n\n\t\t<Foo />\n\n\t</App>\n);\n",
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+		},
+		// ---- Switch case returning JSX (FunctionExpression context). ----
+		{
+			Code: `function pick(kind) {
+  switch (kind) {
+    case 'a':
+      return (
+        <A>
+          <Foo />
+        </A>
+      );
+    default:
+      return null;
+  }
+}
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Triple-nested ternary returning JSX. Locks colonAnchor
+		// + isAlternateInConditionalExp at multiple depths. ----
+		{
+			Code: `var x = (
+  a ?
+    <A />
+    : b ?
+      <B />
+      : c ?
+        <C />
+        : <D />
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- checkAttributes:true with deeply nested JSX inside the
+		// attribute value, plus matching indentation. ----
+		{
+			Code:    "\n        const x = (\n          <View\n            ListFooterComponent={(\n              <View\n                rowSpan={3}\n              />\n            )}\n          />\n        );\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2), map[string]interface{}{"checkAttributes": true}},
+		},
+		// ---- indentLogicalExpressions:true on nested logical chains.
+		// Locks that the rule still allows the inner JSX to align with
+		// the outer JSX when the option is on. ----
+		{
+			Code: `var x = (
+  <App>
+    {a && b && (
+      <p>both</p>
+    )}
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2), map[string]interface{}{"indentLogicalExpressions": true}},
+		},
+		// ---- Whitespace-only JsxText between sibling elements — must
+		// not produce diagnostics (no `\S` for the literal-line
+		// regex). ----
+		{
+			Code: "var x = (\n  <App>\n    <Foo />\n\n    <Bar />\n  </App>\n);\n",
+			Tsx:  true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Inline JSX as attribute prop value (no checkAttributes
+		// — drift not enforced). ----
+		{
+			Code: `var x = (
+  <App
+    icon={<Icon />}
+    title={<Title>foo</Title>}
+  >
+    <Foo />
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Both boolean options on at the same time. Locks that
+		// `checkAttributes` and `indentLogicalExpressions` cooperate
+		// rather than interfere. ----
+		{
+			Code: `var x = (
+  <App>
+    {condition && (
+      <View
+        Foo={(
+          <Inner />
+        )}
+      />
+    )}
+  </App>
+);
+`,
+			Tsx: true,
+			Options: []interface{}{
+				float64(2),
+				map[string]interface{}{
+					"checkAttributes":          true,
+					"indentLogicalExpressions": true,
+				},
+			},
+		},
+		// ---- Empty JsxExpression `{}` — JsxExpression with no inner
+		// expression. The handler must not panic; expected indent for
+		// the container `{` is the parent's line indent + indentSize. ----
+		{
+			Code: `var x = (
+  <App>
+    {}
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- `/* eslint-disable */` block at JS-top level suppresses
+		// diagnostics that would otherwise fire inside the JSX. Locks
+		// that the rule's emitted diagnostics route through the disable
+		// manager. JSX-internal `{/* */}` content is JsxText /
+		// JsxExpression, NOT a JS trivia comment — only JS-level
+		// comments are recognised. The bare-disable form is used here
+		// because rule_tester registers the rule under the name "test",
+		// not its real "react/jsx-indent" identifier; bare disable
+		// applies to all rules unconditionally. ----
+		{
+			Code: `/* eslint-disable */
+var x = (
+  <App>
+        <Foo />
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Comma in a SequenceExpression mustn't be treated like
+		// the array-sibling comma branch — anchor falls through to the
+		// non-comma case. ----
+		{
+			Code: `var x = (a, (
+  <App>
+    <Foo />
+  </App>
+));
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Boolean attribute (no value) — must not throw in the
+		// attribute handler under checkAttributes:true. ----
+		{
+			Code: `var x = (
+  <App>
+    <input
+      type="radio"
+      defaultChecked
+      disabled
+    />
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2), map[string]interface{}{"checkAttributes": true}},
+		},
+		// ---- Block comment inside an attribute value — anchor must
+		// land on the value, not the comment. ----
+		{
+			Code: `var x = (
+  <App>
+    <Foo bar={/* annotated */ 42} />
+  </App>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- A JsxText line containing only an NBSP-equivalent entity
+		// is treated as whitespace-only, mirroring upstream where
+		// `&nbsp;` decodes to U+00A0 and `\S` doesn't match. The
+		// surrounding lines indented "wrong" against the strict child
+		// expectation should NOT report — locks the entity-aware
+		// scanLiteralIndents branch. ----
+		{
+			Code: `var x = (
+  <>
+    <Link>hello</Link>
+    &nbsp;
+    <span>x</span>
+  </>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Numeric NBSP entity variants. ----
+		{
+			Code: `var x = (
+  <>
+    <Link>hello</Link>
+    &#160;
+    <span>x</span>
+  </>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		{
+			Code: `var x = (
+  <>
+    <Link>hello</Link>
+    &#xA0;
+    <span>x</span>
+  </>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- A JsxText line whose first non-whitespace content is a
+		// non-NBSP entity (e.g. `&amp;`, `&copy;`) DOES report — those
+		// decode to real `\S` chars. ----
+		{
+			Code: `var x = (
+  <>
+    <Link>a</Link>
+    &amp;
+    <span>b</span>
+  </>
+);
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- ReturnStatement gate alignment: TS `as` cast on a multi-line
+		// JSX argument with mismatched opening/closing column. Upstream's
+		// `jsxUtil.isJSX(node.argument)` rejects TSAsExpression so the
+		// ReturnStatement listener never enters; we mirror that with
+		// `ast.SkipParentheses` (paren-only, not TS-wrapper-stripping).
+		// Even though the closing `)` is over-indented relative to the
+		// `return`, NO diagnostic fires. ----
+		{
+			Code: `function App() {
+  return (
+    <App>
+      <Foo />
+    </App>
+    ) as React.ReactElement;
+}
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Same, with `satisfies`. ----
+		{
+			Code: `function App() {
+  return (
+    <App>
+      <Foo />
+    </App>
+    ) satisfies React.ReactElement;
+}
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// ---- Same, with non-null assertion `!`. ----
+		{
+			Code: `function App() {
+  return (
+    <App>
+      <Foo />
+    </App>
+    )!;
+}
+`,
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- JsxText + nested element drift. Multi-pass: pass 1 fixes
+		// outer/inner JsxText against the ORIGINAL parent indent (8); pass
+		// 2 re-evaluates with the new inner-`<div>` line indent (12) and
+		// pushes inner JsxText another 4 cols. Upstream's single-pass
+		// fixer stops after pass 1; rslint's multipass converges. ----
+		{
+			Code: "\n        <div>\n        bar <div>\n           bar\n           bar {foo}\n           bar </div>\n        </div>\n      ",
+			Output: []string{
+				"\n        <div>\n            bar <div>\n            bar\n            bar {foo}\n            bar </div>\n        </div>\n      ",
+				"\n        <div>\n            bar <div>\n                bar\n                bar {foo}\n                bar </div>\n        </div>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 11."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 11."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 11."},
+			},
+		},
+		// ---- Default 4-space, child under-indented ----
+		{
+			Code: "\n        <App>\n          <Foo />\n        </App>\n      ",
+			Output: []string{
+				"\n        <App>\n            <Foo />\n        </App>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10."},
+			},
+		},
+		// ---- Fragment variant ----
+		{
+			Code: "\n        <App>\n          <></>\n        </App>\n      ",
+			Output: []string{
+				"\n        <App>\n            <></>\n        </App>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10."},
+			},
+		},
+		{
+			Code: "\n        <>\n          <Foo />\n        </>\n      ",
+			Output: []string{
+				"\n        <>\n            <Foo />\n        </>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10."},
+			},
+		},
+		// ---- Over-indented child with 2-space option ----
+		{
+			Code: "\n        <App>\n            <Foo />\n        </App>\n      ",
+			Output: []string{
+				"\n        <App>\n          <Foo />\n        </App>\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 12."},
+			},
+		},
+		// ---- Tab option, child gets one tab ----
+		{
+			Code: "\n        <App>\n            <Foo />\n        </App>\n      ",
+			Output: []string{
+				"\n        <App>\n\t<Foo />\n        </App>\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 1 tab character but found 0."},
+			},
+		},
+		// ---- Closing tag mis-indented (return + closing — 2 errors) ----
+		{
+			Code: "\n        function App() {\n          return <App>\n            <Foo />\n                 </App>;\n        }\n      ",
+			Output: []string{
+				"\n        function App() {\n          return <App>\n            <Foo />\n          </App>;\n        }\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Line: 3, Message: "Expected indentation of 10 space characters but found 17."},
+				{MessageId: "wrongIndent", Line: 5, Message: "Expected indentation of 10 space characters but found 17."},
+			},
+		},
+		// ---- Parenthesized JSX with closing mis-indented ----
+		{
+			Code: "\n        function App() {\n          return (<App>\n            <Foo />\n            </App>);\n        }\n      ",
+			Output: []string{
+				"\n        function App() {\n          return (<App>\n            <Foo />\n          </App>);\n        }\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Line: 3, Message: "Expected indentation of 10 space characters but found 12."},
+				{MessageId: "wrongIndent", Line: 5, Message: "Expected indentation of 10 space characters but found 12."},
+			},
+		},
+		// ---- Upstream "only flags one of three lines" case (#608).
+		// Pass 1 reports just `<App>` mis-indent (the comment in the
+		// upstream source explains the diagnostic gap); pass 2 then
+		// catches `<Foo />` and `</App>` against the now-shifted parent
+		// — multipass converges to the fully aligned output. ----
+		{
+			Code: "\n        function App() {\n          return (\n        <App>\n          <Foo />\n        </App>\n          );\n        }\n      ",
+			Output: []string{
+				"\n        function App() {\n          return (\n            <App>\n          <Foo />\n        </App>\n          );\n        }\n      ",
+				"\n        function App() {\n          return (\n            <App>\n              <Foo />\n            </App>\n          );\n        }\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Three-space child JsxExpression ----
+		{
+			Code: "\n        <App>\n           {test}\n        </App>\n      ",
+			Output: []string{
+				"\n        <App>\n            {test}\n        </App>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 11."},
+			},
+		},
+		// ---- Three-space deeply nested JsxExpression ----
+		{
+			Code: "\n        <App>\n            {options.map((option, index) => (\n                <option key={index} value={option.key}>\n                   {option.name}\n                </option>\n            ))}\n        </App>\n      ",
+			Output: []string{
+				"\n        <App>\n            {options.map((option, index) => (\n                <option key={index} value={option.key}>\n                    {option.name}\n                </option>\n            ))}\n        </App>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 20 space characters but found 19."},
+			},
+		},
+		// ---- Tab option with JsxExpression at col 0 ----
+		{
+			Code: "\n        <App>\n        {test}\n        </App>\n      ",
+			Output: []string{
+				"\n        <App>\n\t{test}\n        </App>\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 1 tab character but found 0."},
+			},
+		},
+		// ---- Tab option, deeply nested JsxExpression ----
+		{
+			Code: "\n\t\t\t\t<App>\n\t\t\t\t\t{options.map((option, index) => (\n\t\t\t\t\t\t<option key={index} value={option.key}>\n\t\t\t\t\t\t{option.name}\n\t\t\t\t\t\t</option>\n\t\t\t\t\t))}\n\t\t\t\t</App>\n\t\t\t",
+			Output: []string{
+				"\n\t\t\t\t<App>\n\t\t\t\t\t{options.map((option, index) => (\n\t\t\t\t\t\t<option key={index} value={option.key}>\n\t\t\t\t\t\t\t{option.name}\n\t\t\t\t\t\t</option>\n\t\t\t\t\t))}\n\t\t\t\t</App>\n\t\t\t",
+			},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 7 tab characters but found 6."},
+			},
+		},
+		// ---- Tab option, JsxText literal containing escape `\n` ----
+		{
+			Code: "\n\t\t\t\t<App>\n\n\t\t\t\t<Foo />\n\n\t\t\t\t</App>\n\t\t\t",
+			Output: []string{
+				"\n\t\t\t\t<App>\n\n\t\t\t\t\t<Foo />\n\n\t\t\t\t</App>\n\t\t\t",
+			},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 5 tab characters but found 4."},
+			},
+		},
+		// ---- Array literal: 2nd element over-indented ----
+		{
+			Code: "\n        [\n          <div />,\n            <div />\n        ]\n      ",
+			Output: []string{
+				"\n        [\n          <div />,\n          <div />\n        ]\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 12."},
+			},
+		},
+		{
+			Code: "\n        [\n          <div />,\n            <></>\n        ]\n      ",
+			Output: []string{
+				"\n        [\n          <div />,\n          <></>\n        ]\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 12."},
+			},
+		},
+		// ---- Tab option, blank line between siblings ----
+		{
+			Code: "\n        <App>\n\n         <Foo />\n\n        </App>\n      ",
+			Output: []string{
+				"\n        <App>\n\n\t<Foo />\n\n        </App>\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 1 tab character but found 0."},
+			},
+		},
+		// ---- 2-space option, mixed tab/space child ----
+		{
+			Code: "\n        <App>\n\n        \t<Foo />\n\n        </App>\n      ",
+			Output: []string{
+				"\n        <App>\n\n          <Foo />\n\n        </App>\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 8."},
+			},
+		},
+		// ---- Default 4-space, deeply nested array under-indented ----
+		{
+			Code: "\n        <div>\n            {\n                [\n                    <Foo />,\n                <Bar />\n                ]\n            }\n        </div>\n      ",
+			Output: []string{
+				"\n        <div>\n            {\n                [\n                    <Foo />,\n                    <Bar />\n                ]\n            }\n        </div>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 20 space characters but found 16."},
+			},
+		},
+		// ---- Default 4-space, deeply nested array under `&&` ----
+		{
+			Code: "\n        <div>\n            {foo &&\n                [\n                    <Foo />,\n                <Bar />\n                ]\n            }\n        </div>\n      ",
+			Output: []string{
+				"\n        <div>\n            {foo &&\n                [\n                    <Foo />,\n                    <Bar />\n                ]\n            }\n        </div>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 20 space characters but found 16."},
+			},
+		},
+		// ---- Multiline ternary — alternate at col 0 ----
+		{
+			Code: "\n        foo ?\n            <Foo /> :\n        <Bar />\n      ",
+			Output: []string{
+				"\n        foo ?\n            <Foo /> :\n            <Bar />\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		{
+			Code: "\n        foo ?\n            <Foo /> :\n        <></>\n      ",
+			Output: []string{
+				"\n        foo ?\n            <Foo /> :\n            <></>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Multiline ternary — colon on its own line, alternate at col 0 ----
+		{
+			Code: "\n        foo ?\n            <Foo />\n        :\n        <Bar />\n      ",
+			Output: []string{
+				"\n        foo ?\n            <Foo />\n        :\n            <Bar />\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- First expr on test line, colon at end → alternate gets too much ----
+		{
+			Code: "\n        foo ? <Foo /> :\n            <Bar />\n      ",
+			Output: []string{
+				"\n        foo ? <Foo /> :\n        <Bar />\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 8 space characters but found 12."},
+			},
+		},
+		{
+			Code: "\n        foo ?\n            <Foo />\n        :\n        <></>\n      ",
+			Output: []string{
+				"\n        foo ?\n            <Foo />\n        :\n            <></>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Test on first line, colon on its own line, alternate over-indented ----
+		{
+			Code: "\n        foo ? <Foo />\n        :\n              <Bar />\n      ",
+			Output: []string{
+				"\n        foo ? <Foo />\n        :\n        <Bar />\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 8 space characters but found 14."},
+			},
+		},
+		// ---- Parenthesized first expr, colon at end ----
+		{
+			Code: "\n        foo ? (\n            <Foo />\n        ) :\n        <Bar />\n      ",
+			Output: []string{
+				"\n        foo ? (\n            <Foo />\n        ) :\n            <Bar />\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		{
+			Code: "\n        foo ? (\n            <Foo />\n        ) :\n        <></>\n      ",
+			Output: []string{
+				"\n        foo ? (\n            <Foo />\n        ) :\n            <></>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Parenthesized first expr, colon on own line ----
+		{
+			Code: "\n        foo ? (\n            <Foo />\n        )\n        :\n        <Bar />\n      ",
+			Output: []string{
+				"\n        foo ? (\n            <Foo />\n        )\n        :\n            <Bar />\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Parenthesized second expr, colon at end of consequent ----
+		{
+			Code: "\n        foo ?\n            <Foo /> : (\n            <Bar />\n            )\n      ",
+			Output: []string{
+				"\n        foo ?\n            <Foo /> : (\n                <Bar />\n            )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 16 space characters but found 12."},
+			},
+		},
+		{
+			Code: "\n        foo ?\n            <Foo /> : (\n            <></>\n            )\n      ",
+			Output: []string{
+				"\n        foo ?\n            <Foo /> : (\n                <></>\n            )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 16 space characters but found 12."},
+			},
+		},
+		// ---- Parenthesized second expr, colon on own line ----
+		{
+			Code: "\n        foo ?\n            <Foo />\n        : (\n        <Bar />\n        )\n      ",
+			Output: []string{
+				"\n        foo ?\n            <Foo />\n        : (\n            <Bar />\n        )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Parenthesized second expr, colon indented on its own line ----
+		{
+			Code: "\n        foo ?\n            <Foo />\n            : (\n            <Bar />\n            )\n      ",
+			Output: []string{
+				"\n        foo ?\n            <Foo />\n            : (\n                <Bar />\n            )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 16 space characters but found 12."},
+			},
+		},
+		{
+			Code: "\n        foo ?\n            <Foo />\n            : (\n            <></>\n            )\n      ",
+			Output: []string{
+				"\n        foo ?\n            <Foo />\n            : (\n                <></>\n            )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 16 space characters but found 12."},
+			},
+		},
+		// ---- Both branches parenthesized, colon at end ----
+		{
+			Code: "\n        foo ? (\n        <Foo />\n        ) : (\n        <Bar />\n        )\n      ",
+			Output: []string{
+				"\n        foo ? (\n            <Foo />\n        ) : (\n            <Bar />\n        )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		{
+			Code: "\n        foo ? (\n        <></>\n        ) : (\n        <></>\n        )\n      ",
+			Output: []string{
+				"\n        foo ? (\n            <></>\n        ) : (\n            <></>\n        )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Both parenthesized, colon on own line ----
+		{
+			Code: "\n        foo ? (\n        <Foo />\n        )\n        : (\n        <Bar />\n        )\n      ",
+			Output: []string{
+				"\n        foo ? (\n            <Foo />\n        )\n        : (\n            <Bar />\n        )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		{
+			Code: "\n        foo ? (\n        <Foo />\n        )\n        :\n        (\n        <Bar />\n        )\n      ",
+			Output: []string{
+				"\n        foo ? (\n            <Foo />\n        )\n        :\n        (\n            <Bar />\n        )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		{
+			Code: "\n        foo ? (\n        <></>\n        )\n        :\n        (\n        <></>\n        )\n      ",
+			Output: []string{
+				"\n        foo ? (\n            <></>\n        )\n        :\n        (\n            <></>\n        )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Test on first line, colon at end, parenthesized second expr ----
+		{
+			Code: "\n        foo ? <Foo /> : (\n        <Bar />\n        )\n      ",
+			Output: []string{
+				"\n        foo ? <Foo /> : (\n            <Bar />\n        )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		{
+			Code: "\n        foo ? <Foo /> : (\n        <></>\n        )\n      ",
+			Output: []string{
+				"\n        foo ? <Foo /> : (\n            <></>\n        )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Test on first line, colon on its own line, parenthesized second expr ----
+		{
+			Code: "\n        foo ? <Foo />\n        : (\n        <Bar />\n        )\n      ",
+			Output: []string{
+				"\n        foo ? <Foo />\n        : (\n            <Bar />\n        )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		{
+			Code: "\n        foo ? <Foo />\n        : (\n        <></>\n        )\n      ",
+			Output: []string{
+				"\n        foo ? <Foo />\n        : (\n            <></>\n        )\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Inline closing `</div>` after content; nested over-indented closing ----
+		{
+			Code: "\n        <p>\n            <div>\n                <SelfClosingTag />Text\n          </div>\n        </p>\n      ",
+			Output: []string{
+				"\n        <p>\n            <div>\n                <SelfClosingTag />Text\n            </div>\n        </p>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10."},
+			},
+		},
+		// ---- checkAttributes:true — `)}` realigned to attribute name ----
+		{
+			Code: "\n        const Component = () => (\n          <View\n            ListFooterComponent={(\n              <View\n                rowSpan={3}\n                placeholder=\"placeholder text here\"\n              />\n        )}\n          />\n        );\n      ",
+			Output: []string{
+				"\n        const Component = () => (\n          <View\n            ListFooterComponent={(\n              <View\n                rowSpan={3}\n                placeholder=\"placeholder text here\"\n              />\n            )}\n          />\n        );\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2), map[string]interface{}{"checkAttributes": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- checkAttributes:true with tab option ----
+		{
+			Code: "\nconst Component = () => (\n\t<View\n\t\tListFooterComponent={(\n\t\t\t<View\n\t\t\t\trowSpan={3}\n\t\t\t\tplaceholder=\"placeholder text here\"\n\t\t\t/>\n)}\n\t/>\n);\n    ",
+			Output: []string{
+				"\nconst Component = () => (\n\t<View\n\t\tListFooterComponent={(\n\t\t\t<View\n\t\t\t\trowSpan={3}\n\t\t\t\tplaceholder=\"placeholder text here\"\n\t\t\t/>\n\t\t)}\n\t/>\n);\n    ",
+			},
+			Tsx:     true,
+			Options: []interface{}{"tab", map[string]interface{}{"checkAttributes": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 2 tab characters but found 0."},
+			},
+		},
+		// ---- indentLogicalExpressions:true — inner JSX must indent past `&&` ----
+		{
+			Code: "\n        function Foo() {\n          return (\n            <div>\n              {condition && (\n              <p>Bar</p>\n              )}\n            </div>\n          );\n        }\n      ",
+			Output: []string{
+				"\n        function Foo() {\n          return (\n            <div>\n              {condition && (\n                <p>Bar</p>\n              )}\n            </div>\n          );\n        }\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2), map[string]interface{}{"indentLogicalExpressions": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 16 space characters but found 14."},
+			},
+		},
+		// ---- do-expression invalid cases (Skip — see valid skip block) ----
+		{
+			Code: "\n        <span>\n            {do {\n                const num = rollDice();\n                    <Thing num={num} />;\n            }}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {(do {\n                const num = rollDice();\n                    <Thing num={num} />;\n            })}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {do {\n            <Thing num={getPurposeOfLife()} />;\n            }}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		{
+			Code: "\n        <span>\n            {(do {\n            <Thing num={getPurposeOfLife()} />;\n            })}\n        </span>\n      ",
+			Tsx:  true,
+			Skip: true, // SKIP: rslint's tsgo parser does not support do-expressions.
+		},
+		// ---- JsxText fixer — single line of text mis-indented ----
+		{
+			Code: "\n        <div>\n        text\n        </div>\n      ",
+			Output: []string{
+				"\n        <div>\n            text\n        </div>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- JsxText fixer — multi-line text, all lines mis-indented ----
+		{
+			Code: "\n        <div>\n          text\n        text\n        </div>\n      ",
+			Output: []string{
+				"\n        <div>\n            text\n            text\n        </div>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- JsxText fixer — mixed tab + space ----
+		{
+			Code: "\n        <div>\n        \t  text\n          \t  text\n        </div>\n      ",
+			Output: []string{
+				"\n        <div>\n            text\n            text\n        </div>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10."},
+			},
+		},
+		// ---- Tab option, JsxText with tab characters ----
+		{
+			Code: "\n        <div>\n        \t\ttext\n        </div>\n      ",
+			Output: []string{
+				"\n        <div>\n\ttext\n        </div>\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 1 tab character but found 0."},
+			},
+		},
+		// ---- Fragment JsxText mis-indented ----
+		{
+			Code: "\n        <>\n        aaa\n        </>\n      ",
+			Output: []string{
+				"\n        <>\n            aaa\n        </>\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- Stateless component, return inside if(...) ----
+		{
+			Code: "\n        const StatelessComponent = () => {\n          if (new Date() % 2) {\n              return (\n        <div>Hello</div>\n              );\n          }\n          return null;\n        };\n      ",
+			Output: []string{
+				"\n        const StatelessComponent = () => {\n          if (new Date() % 2) {\n              return (\n                  <div>Hello</div>\n              );\n          }\n          return null;\n        };\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 18 space characters but found 8."},
+			},
+		},
+		// ---- Closing paren of return mis-indented (message text only) ----
+		{
+			Code: "\n        function App() {\n          return (\n            <App />\n            );\n        }\n      ",
+			Output: []string{
+				"\n        function App() {\n          return (\n            <App />\n          );\n        }\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 12."},
+			},
+		},
+		{
+			Code: "\n        function App() {\n          return (\n            <App />\n        );\n        }\n      ",
+			Output: []string{
+				"\n        function App() {\n          return (\n            <App />\n          );\n        }\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 8."},
+			},
+		},
+		// ---- Array of JSX with arrow-bodied callbacks ----
+		{
+			Code: "\n        {condition && [\n            <Tag key=\"a\" onClick={() => {\n              // some code\n            }} />,\n            <Tag key=\"b\" onClick={() => {\n              // some code\n            }} />,\n          ]\n        }\n      ",
+			Output: []string{
+				"\n        {condition && [\n          <Tag key=\"a\" onClick={() => {\n              // some code\n            }} />,\n          <Tag key=\"b\" onClick={() => {\n              // some code\n            }} />,\n          ]\n        }\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Line: 3, Message: "Expected indentation of 10 space characters but found 12."},
+				{MessageId: "wrongIndent", Line: 6, Message: "Expected indentation of 10 space characters but found 12."},
+			},
+		},
+		// ---- Mixed JsxExpression / JsxText / closing ----
+		{
+			Code: "\n        const IndexPage = () => (\n          <h1>\n        {\"Hi people\"}\n        <button/>\n        </h1>\n        );\n      ",
+			Output: []string{
+				"\n        const IndexPage = () => (\n          <h1>\n            {\"Hi people\"}\n            <button/>\n          </h1>\n        );\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 8."},
+			},
+		},
+		// ---- Multipass: mixed JsxText / JSX / closing — JsxText fix
+		// range overlaps with `<button/>` indent fix, so pass 1 only
+		// applies the JsxText + closing-tag fixes; pass 2 fixes
+		// `<button/>` once the overlap is gone. ----
+		{
+			Code: "\n        const IndexPage = () => (\n          <h1>\n        Hi people\n        <button/>\n        </h1>\n        );\n      ",
+			Output: []string{
+				"\n        const IndexPage = () => (\n          <h1>\n            Hi people\n        <button/>\n          </h1>\n        );\n      ",
+				"\n        const IndexPage = () => (\n          <h1>\n            Hi people\n            <button/>\n          </h1>\n        );\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 8."},
+			},
+		},
+		// ---- Followup pass: only the JsxElement child remains mis-indented ----
+		{
+			Code: "\n        const IndexPage = () => (\n          <h1>\n            Hi people\n        <button/>\n          </h1>\n        );\n      ",
+			Output: []string{
+				"\n        const IndexPage = () => (\n          <h1>\n            Hi people\n            <button/>\n          </h1>\n        );\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 8."},
+			},
+		},
+		// ---- import + multi-line indent (4-space option). Same overlap
+		// pattern as invalid-61: pass 1 fixes JsxText 1 + closing
+		// peer-anchor; pass 2 fixes `<p>` once the JsxText fix range
+		// no longer covers its line. Upstream's single-pass output is
+		// our pass 1; rslint's multipass yields the converged result. ----
+		{
+			Code: "\n        import React from 'react';\n\n        export default function () {\n            return (\n                <div>\n                            Test1\n\n                      <p>Test2</p>\n                </div>\n            );\n        }\n      ",
+			Output: []string{
+				"\n        import React from 'react';\n\n        export default function () {\n            return (\n                <div>\n                    Test1\n\n                      <p>Test2</p>\n                </div>\n            );\n        }\n      ",
+				"\n        import React from 'react';\n\n        export default function () {\n            return (\n                <div>\n                    Test1\n\n                    <p>Test2</p>\n                </div>\n            );\n        }\n      ",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(4)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// =================================================================
+		// Below: invalid-side coverage of the real-world / edge shapes.
+		// =================================================================
+
+		// ---- TS `as` cast: closing tag mis-indented. The wrapper must
+		// be transparent so the closing tag still reports against the
+		// parent's opening. ----
+		{
+			Code: `var x = (
+  <App>
+    <Foo />
+      </App>
+) as React.ReactElement;
+`,
+			Output: []string{`var x = (
+  <App>
+    <Foo />
+  </App>
+) as React.ReactElement;
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 2 space characters but found 6."},
+			},
+		},
+		// ---- TS `satisfies` wrapper: child mis-indented. ----
+		{
+			Code: `var x = (
+  <App>
+      <Foo />
+  </App>
+) satisfies React.ReactElement;
+`,
+			Output: []string{`var x = (
+  <App>
+    <Foo />
+  </App>
+) satisfies React.ReactElement;
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 6."},
+			},
+		},
+		// ---- Generic JSX with mis-indented child (`<Foo<T>><Bar />`). ----
+		{
+			Code: `var x = (
+  <Foo<string>>
+      <Bar />
+  </Foo>
+);
+`,
+			Output: []string{`var x = (
+  <Foo<string>>
+    <Bar />
+  </Foo>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 6."},
+			},
+		},
+		// ---- JSX member-expression tag with mis-indented child. ----
+		{
+			Code: `var x = (
+  <Foo.Bar>
+        <Foo.Baz />
+  </Foo.Bar>
+);
+`,
+			Output: []string{`var x = (
+  <Foo.Bar>
+    <Foo.Baz />
+  </Foo.Bar>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- Namespaced JSX with mis-indented closing. ----
+		{
+			Code: `var x = (
+  <svg:svg>
+    <svg:rect />
+      </svg:svg>
+);
+`,
+			Output: []string{`var x = (
+  <svg:svg>
+    <svg:rect />
+  </svg:svg>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 2 space characters but found 6."},
+			},
+		},
+		// ---- Deep nesting (5 levels) with one bad child mid-tree. The
+		// rule must report exactly that one mis-indent — not propagate
+		// to ancestors / descendants. ----
+		{
+			Code: `var x = (
+  <A>
+    <B>
+      <C>
+            <D>
+              <E />
+            </D>
+      </C>
+    </B>
+  </A>
+);
+`,
+			Output: []string{`var x = (
+  <A>
+    <B>
+      <C>
+        <D>
+              <E />
+            </D>
+      </C>
+    </B>
+  </A>
+);
+`,
+				`var x = (
+  <A>
+    <B>
+      <C>
+        <D>
+          <E />
+        </D>
+      </C>
+    </B>
+  </A>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Pass 1 sees only `<D>` over-indented at 12 (expected 8)
+				// — its closing tag still aligns with the (wrong) opening
+				// and `<E />` aligns one level deeper, so they're locally
+				// consistent. After pass 1 moves `<D>` to col 8, pass 2
+				// re-evaluates the children against the new parent indent
+				// and converges.
+				{MessageId: "wrongIndent", Message: "Expected indentation of 8 space characters but found 12."},
+			},
+		},
+		// ---- React.memo wrap with mis-indented child. ----
+		{
+			Code: `var Wrapped = React.memo(() => (
+  <App>
+        <Foo />
+  </App>
+));
+`,
+			Output: []string{`var Wrapped = React.memo(() => (
+  <App>
+    <Foo />
+  </App>
+));
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- forwardRef wrap with mis-indented closing. ----
+		{
+			Code: `var Wrapped = React.forwardRef((props, ref) => (
+  <App ref={ref}>
+    <Foo />
+        </App>
+));
+`,
+			Output: []string{`var Wrapped = React.forwardRef((props, ref) => (
+  <App ref={ref}>
+    <Foo />
+  </App>
+));
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 2 space characters but found 8."},
+			},
+		},
+		// ---- map() callback returning JSX, mis-indented child. ----
+		{
+			Code: `var els = items.map((item, i) => (
+  <Item key={i}>
+      {item.name}
+  </Item>
+));
+`,
+			Output: []string{`var els = items.map((item, i) => (
+  <Item key={i}>
+    {item.name}
+  </Item>
+));
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 6."},
+			},
+		},
+		// ---- CRLF line endings, mis-indented child. The rule must
+		// recognize `\r\n` so it locates the line start correctly. ----
+		{
+			Code: "var x = (\r\n  <App>\r\n      <Foo />\r\n  </App>\r\n);\r\n",
+			Output: []string{
+				"var x = (\r\n  <App>\r\n    <Foo />\r\n  </App>\r\n);\r\n",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 6."},
+			},
+		},
+		// ---- HTML-entity content with wrong line indent. ----
+		{
+			Code: `var x = (
+  <App>
+        Hello&nbsp;World
+  </App>
+);
+`,
+			Output: []string{`var x = (
+  <App>
+    Hello&nbsp;World
+  </App>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- CJK content with wrong indent. Locks UTF-8 byte
+		// arithmetic in lineIndentAt: leading whitespace counting must
+		// not get confused by multi-byte runes elsewhere on the line. ----
+		{
+			Code: `var x = (
+  <App>
+        你好世界
+  </App>
+);
+`,
+			Output: []string{`var x = (
+  <App>
+    你好世界
+  </App>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- Sibling-fragment-then-element pair, second child mis-indented. ----
+		{
+			Code: `var x = (
+  <App>
+    <>
+      <span />
+    </>
+        <span />
+  </App>
+);
+`,
+			Output: []string{`var x = (
+  <App>
+    <>
+      <span />
+    </>
+    <span />
+  </App>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- Spread attribute is mis-aligned and has nothing to do
+		// with this rule (the rule only checks attribute *value*
+		// indent under checkAttributes). Still no diagnostic. ----
+		{
+			Code: `var x = (
+  <App
+    {...props}
+    foo="bar"
+  >
+        <Foo />
+  </App>
+);
+`,
+			Output: []string{`var x = (
+  <App
+    {...props}
+    foo="bar"
+  >
+    <Foo />
+  </App>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- async arrow returning JSX with mis-indented child. ----
+		{
+			Code: `var f = async () => (
+  <App>
+        <Foo />
+  </App>
+);
+`,
+			Output: []string{`var f = async () => (
+  <App>
+    <Foo />
+  </App>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- Provider pattern with mis-indented inner child. ----
+		{
+			Code: `var x = (
+  <ThemeContext.Provider value={theme}>
+    <App>
+        <Foo />
+    </App>
+  </ThemeContext.Provider>
+);
+`,
+			Output: []string{`var x = (
+  <ThemeContext.Provider value={theme}>
+    <App>
+      <Foo />
+    </App>
+  </ThemeContext.Provider>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 6 space characters but found 8."},
+			},
+		},
+		// ---- compose / HOC double-call with mis-indented child. ----
+		{
+			Code: `var Wrapped = compose(withRouter, connect(mapState))(({ items }) => (
+  <App>
+        <Foo />
+  </App>
+));
+`,
+			Output: []string{`var Wrapped = compose(withRouter, connect(mapState))(({ items }) => (
+  <App>
+    <Foo />
+  </App>
+));
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- JSX in object literal value with mis-indented closing. ----
+		{
+			Code: `var x = {
+  child: (
+    <App>
+      <Foo />
+        </App>
+  ),
+};
+`,
+			Output: []string{`var x = {
+  child: (
+    <App>
+      <Foo />
+    </App>
+  ),
+};
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- React.lazy + Suspense with mis-indented child. ----
+		{
+			Code: `var x = (
+  <Suspense fallback={<Spinner />}>
+        <Page />
+  </Suspense>
+);
+`,
+			Output: []string{`var x = (
+  <Suspense fallback={<Spinner />}>
+    <Page />
+  </Suspense>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- Hooks pattern: function returning multi-line JSX, child
+		// mis-indented. Locks ReturnStatement listener vs jsxParentOpening
+		// interaction. ----
+		{
+			Code: `function Counter() {
+  const [n, setN] = useState(0);
+  return (
+    <div>
+        <span>{n}</span>
+      <button onClick={() => setN(n + 1)}>+</button>
+    </div>
+  );
+}
+`,
+			Output: []string{`function Counter() {
+  const [n, setN] = useState(0);
+  return (
+    <div>
+      <span>{n}</span>
+      <button onClick={() => setN(n + 1)}>+</button>
+    </div>
+  );
+}
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 6 space characters but found 8."},
+			},
+		},
+		// ---- switch case returning multi-line JSX, child mis-indented. ----
+		{
+			Code: `function pick(kind) {
+  switch (kind) {
+    case 'a':
+      return (
+        <A>
+            <Foo />
+        </A>
+      );
+    default:
+      return null;
+  }
+}
+`,
+			Output: []string{`function pick(kind) {
+  switch (kind) {
+    case 'a':
+      return (
+        <A>
+          <Foo />
+        </A>
+      );
+    default:
+      return null;
+  }
+}
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 12."},
+			},
+		},
+		// ---- Tab option with multi-line JSX, child mis-indented. ----
+		{
+			Code:    "var x = (\n\t<App>\n\t\t\t<Foo />\n\t</App>\n);\n",
+			Output:  []string{"var x = (\n\t<App>\n\t\t<Foo />\n\t</App>\n);\n"},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 2 tab characters but found 3."},
+			},
+		},
+		// ---- Block-comment between JSX siblings, second sibling
+		// mis-indented. The comment shouldn't affect anchor logic. ----
+		{
+			Code: `var x = (
+  <App>
+    {/* block comment */}
+        <Foo />
+  </App>
+);
+`,
+			Output: []string{`var x = (
+  <App>
+    {/* block comment */}
+    <Foo />
+  </App>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+			},
+		},
+		// ---- CRLF JsxText fix: the fixer must preserve `\r` carriage
+		// returns. Locks `replaceLeadingIndentInText` against the
+		// regression of stripping `\r` while it consumes leading
+		// whitespace. ----
+		{
+			Code:   "var x = (\r\n  <App>\r\nHello\r\n  </App>\r\n);\r\n",
+			Output: []string{"var x = (\r\n  <App>\r\n    Hello\r\n  </App>\r\n);\r\n"},
+			Tsx:    true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 0."},
+			},
+		},
+
+		// =================================================================
+		// Position-assertion suite. Each entry below pins
+		// Line + Column + EndLine + EndColumn so future range / Pos
+		// changes get caught. Containers covered: JsxOpeningElement,
+		// JsxClosingElement, JsxExpression, JsxText (multi-line range),
+		// ReturnStatement (multi-line range), JsxAttribute (custom
+		// anchor range).
+		// =================================================================
+
+		// ---- JsxOpeningElement at exact line+col, single-line node. ----
+		{
+			Code: "<App>\n  <Foo />\n</App>",
+			Output: []string{
+				"<App>\n    <Foo />\n</App>",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 4 space characters but found 2.",
+					Line:      2, Column: 3, EndLine: 2, EndColumn: 10,
+				},
+			},
+		},
+		// ---- JsxClosingElement at exact line+col. ----
+		{
+			Code: "<App>\n    <Foo />\n     </App>",
+			Output: []string{
+				"<App>\n    <Foo />\n</App>",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 0 space characters but found 5.",
+					Line:      3, Column: 6, EndLine: 3, EndColumn: 12,
+				},
+			},
+		},
+		// ---- JsxExpression `{...}` exact range. ----
+		{
+			Code: "<App>\n  {value}\n</App>",
+			Output: []string{
+				"<App>\n    {value}\n</App>",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 4 space characters but found 2.",
+					Line:      2, Column: 3, EndLine: 2, EndColumn: 10,
+				},
+			},
+		},
+		// ---- ReturnStatement multi-line: opening on its line, closing
+		// on a different line. The diagnostic range spans the whole
+		// statement (multi-line range). ----
+		{
+			Code: `function App() {
+  return <App>
+    <Foo />
+       </App>;
+}`,
+			Output: []string{
+				`function App() {
+  return <App>
+    <Foo />
+  </App>;
+}`,
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 2 space characters but found 7.",
+					Line:      2, Column: 3, EndLine: 4, EndColumn: 15,
+				},
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 2 space characters but found 7.",
+					Line:      4, Column: 8, EndLine: 4, EndColumn: 14,
+				},
+			},
+		},
+		// ---- JsxText multi-line raw range. The diagnostic anchors at
+		// the JsxText raw start (right after the parent's `>`) and
+		// ends at the next sibling's start. ----
+		{
+			Code: `<div>
+text
+text
+</div>`,
+			Output: []string{
+				`<div>
+    text
+    text
+</div>`,
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 4 space characters but found 0.",
+					// JsxText raw range: from `>` of `<div>` end to `<` of `</div>`.
+					Line: 1, Column: 6, EndLine: 4, EndColumn: 1,
+				},
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 4 space characters but found 0.",
+					Line:      1, Column: 6, EndLine: 4, EndColumn: 1,
+				},
+			},
+		},
+		// ---- Triple-nested ternary, deepest alternate on its OWN line at
+		// wrong indent. (Same line as `:` would NOT report — upstream's
+		// `isNodeFirstInLine` excludes the JSX from indent checking when
+		// the colon precedes it on the same line.) ----
+		{
+			Code: `var x = (
+  a ?
+    <A />
+    : b ?
+      <B />
+      : c ?
+        <C />
+        :
+            <D />
+);
+`,
+			Output: []string{`var x = (
+  a ?
+    <A />
+    : b ?
+      <B />
+      : c ?
+        <C />
+        :
+        <D />
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 8 space characters but found 12."},
+			},
+		},
+		// ---- indentLogicalExpressions:true on nested logical chain,
+		// inner JSX mis-indented. ----
+		{
+			Code: `var x = (
+  <App>
+    {a && b && (
+    <p>both</p>
+    )}
+  </App>
+);
+`,
+			Output: []string{`var x = (
+  <App>
+    {a && b && (
+      <p>both</p>
+    )}
+  </App>
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2), map[string]interface{}{"indentLogicalExpressions": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 6 space characters but found 4."},
+			},
+		},
+		// ---- checkAttributes:true with mis-indented `)}` after a
+		// multi-line attribute-value JSX. ----
+		{
+			Code: `const x = (
+  <View
+    Foo={(
+      <Inner />
+)}
+  />
+);
+`,
+			Output: []string{`const x = (
+  <View
+    Foo={(
+      <Inner />
+    )}
+  />
+);
+`},
+			Tsx:     true,
+			Options: []interface{}{float64(2), map[string]interface{}{"checkAttributes": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 0."},
+			},
+		},
+		// ---- JsxOpeningFragment mis-indented relative to its
+		// container's opening anchor. Pass 1 fixes `<>` against `<App>`
+		// (now col 4) AND `<Foo />` / `</>` against the *original* `<>`
+		// line indent (8) — they shift to 10 / 8. Pass 2 then
+		// re-evaluates against the moved `<>` (line indent 4) and
+		// converges on the final layout (6 / 4). ----
+		{
+			Code: `var x = (
+  <App>
+        <>
+      <Foo />
+    </>
+  </App>
+);
+`,
+			Output: []string{
+				"var x = (\n  <App>\n    <>\n          <Foo />\n        </>\n  </App>\n);\n",
+				"var x = (\n  <App>\n    <>\n      <Foo />\n    </>\n  </App>\n);\n",
+			},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 4 space characters but found 8."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 6."},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 8 space characters but found 4."},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -99,6 +99,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-filename-extension.test.ts',
     './tests/eslint-plugin-react/rules/jsx-first-prop-new-line.test.ts',
     './tests/eslint-plugin-react/rules/jsx-handler-names.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-indent.test.ts',
     './tests/eslint-plugin-react/rules/jsx-key.test.ts',
     './tests/eslint-plugin-react/rules/jsx-max-depth.test.ts',
     './tests/eslint-plugin-react/rules/jsx-max-props-per-line.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-indent.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-indent.test.ts
@@ -1,0 +1,181 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-indent', {} as never, {
+  valid: [
+    // ---- Single-line / multi-line element basics ----
+    { code: `<App></App>;` },
+    { code: `<></>;` },
+    { code: `<App>\n    <Foo />\n</App>;` },
+    {
+      code: `<App>\n  <Foo />\n</App>;`,
+      options: [2],
+    },
+    {
+      code: `<App>\n\t<Foo />\n</App>;`,
+      options: ['tab'],
+    },
+    {
+      code: `<App>\n<Foo />\n</App>;`,
+      options: [0],
+    },
+    // ---- Function/Arrow returns ----
+    {
+      code: `function App() {\n  return (\n    <App>\n      <Foo />\n    </App>\n  );\n}`,
+      options: [2],
+    },
+    {
+      code: `var x = () => (\n  <App>\n    <Foo />\n  </App>\n);`,
+      options: [2],
+    },
+    // ---- Logical / conditional renders ----
+    {
+      code: `var x = (\n  <div>\n    {condition && (\n    <p>Bar</p>\n    )}\n  </div>\n);`,
+      options: [2],
+    },
+    {
+      code: `var x = (\n  <div>\n    {condition && (\n      <p>Bar</p>\n    )}\n  </div>\n);`,
+      options: [2, { indentLogicalExpressions: true }],
+    },
+    {
+      code: `var x = foo ?\n    <Foo /> :\n    <Bar />;`,
+    },
+    // ---- TS wrappers (as / satisfies / non-null) on a return — must
+    // not enter the ReturnStatement check. ----
+    {
+      code: `function App() {\n  return (\n    <App>\n      <Foo />\n    </App>\n    ) as React.ReactElement;\n}`,
+      options: [2],
+    },
+    // ---- React.memo / forwardRef wrap ----
+    {
+      code: `var W = React.memo(() => (\n  <App>\n    <Foo />\n  </App>\n));`,
+      options: [2],
+    },
+    // ---- map render ----
+    {
+      code: `var els = items.map((it) => (\n  <Item key={it.id}>\n    {it.name}\n  </Item>\n));`,
+      options: [2],
+    },
+    // ---- Member / namespaced JSX tag names ----
+    {
+      code: `var x = (\n  <Foo.Bar.Baz>\n    <Quux />\n  </Foo.Bar.Baz>\n);`,
+      options: [2],
+    },
+    {
+      code: `var x = (\n  <svg:svg>\n    <svg:rect />\n  </svg:svg>\n);`,
+      options: [2],
+    },
+    // ---- Generic JSX (`<Foo<T>>`) ----
+    {
+      code: `var x = (\n  <Foo<string>>\n    <Bar />\n  </Foo>\n);`,
+      options: [2],
+    },
+    // ---- 6-level nesting ----
+    {
+      code: `var x = (\n  <A>\n    <B>\n      <C>\n        <D>\n          <E>\n            <F />\n          </E>\n        </D>\n      </C>\n    </B>\n  </A>\n);`,
+      options: [2],
+    },
+    // ---- Both boolean options on ----
+    {
+      code: `var x = (\n  <App>\n    {a && (\n      <View\n        Foo={(\n          <Inner />\n        )}\n      />\n    )}\n  </App>\n);`,
+      options: [2, { checkAttributes: true, indentLogicalExpressions: true }],
+    },
+  ],
+  invalid: [
+    // ---- Default 4-space, child under-indented ----
+    {
+      code: `<App>\n  <Foo />\n</App>;`,
+      output: `<App>\n    <Foo />\n</App>;`,
+      errors: [
+        { message: 'Expected indentation of 4 space characters but found 2.' },
+      ],
+    },
+    // ---- 2-space option, child over-indented ----
+    {
+      code: `<App>\n    <Foo />\n</App>;`,
+      output: `<App>\n  <Foo />\n</App>;`,
+      options: [2],
+      errors: [
+        { message: 'Expected indentation of 2 space characters but found 4.' },
+      ],
+    },
+    // ---- Tab option ----
+    {
+      code: `<App>\n    <Foo />\n</App>;`,
+      output: `<App>\n\t<Foo />\n</App>;`,
+      options: ['tab'],
+      errors: [
+        { message: 'Expected indentation of 1 tab character but found 0.' },
+      ],
+    },
+    // ---- Closing tag mis-indented ----
+    {
+      code: `<App>\n    <Foo />\n      </App>;`,
+      output: `<App>\n    <Foo />\n</App>;`,
+      errors: [
+        { message: 'Expected indentation of 0 space characters but found 6.' },
+      ],
+    },
+    // ---- JsxExpression mis-indented ----
+    {
+      code: `<App>\n   {test}\n</App>;`,
+      output: `<App>\n    {test}\n</App>;`,
+      errors: [
+        { message: 'Expected indentation of 4 space characters but found 3.' },
+      ],
+    },
+    // ---- JsxText mis-indented ----
+    {
+      code: `<div>\ntext\n</div>;`,
+      output: `<div>\n    text\n</div>;`,
+      errors: [
+        { message: 'Expected indentation of 4 space characters but found 0.' },
+      ],
+    },
+    // ---- indentLogicalExpressions:true forces deeper indent ----
+    {
+      code: `var x = (\n  <div>\n    {condition && (\n    <p>Bar</p>\n    )}\n  </div>\n);`,
+      output: `var x = (\n  <div>\n    {condition && (\n      <p>Bar</p>\n    )}\n  </div>\n);`,
+      options: [2, { indentLogicalExpressions: true }],
+      errors: [
+        { message: 'Expected indentation of 6 space characters but found 4.' },
+      ],
+    },
+    // ---- Multiline ternary alternate at wrong indent ----
+    {
+      code: `var x = foo ?\n    <Foo /> :\n<Bar />;`,
+      output: `var x = foo ?\n    <Foo /> :\n    <Bar />;`,
+      errors: [
+        { message: 'Expected indentation of 4 space characters but found 0.' },
+      ],
+    },
+    // ---- React.memo wrap with mis-indented child ----
+    {
+      code: `var W = React.memo(() => (\n  <App>\n        <Foo />\n  </App>\n));`,
+      output: `var W = React.memo(() => (\n  <App>\n    <Foo />\n  </App>\n));`,
+      options: [2],
+      errors: [
+        { message: 'Expected indentation of 4 space characters but found 8.' },
+      ],
+    },
+    // ---- Member expression tag with mis-indented child ----
+    {
+      code: `var x = (\n  <Foo.Bar>\n        <Foo.Baz />\n  </Foo.Bar>\n);`,
+      output: `var x = (\n  <Foo.Bar>\n    <Foo.Baz />\n  </Foo.Bar>\n);`,
+      options: [2],
+      errors: [
+        { message: 'Expected indentation of 4 space characters but found 8.' },
+      ],
+    },
+    // ---- checkAttributes:true — `)}` realigned to attribute name ----
+    {
+      code: `const x = (\n  <View\n    Foo={(\n      <Inner />\n)}\n  />\n);`,
+      output: `const x = (\n  <View\n    Foo={(\n      <Inner />\n    )}\n  />\n);`,
+      options: [2, { checkAttributes: true }],
+      errors: [
+        { message: 'Expected indentation of 4 space characters but found 0.' },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the [`react/jsx-indent`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md) rule from `eslint-plugin-react` to rslint. Enforces consistent JSX indentation; supports `'tab'` / non-negative integer for indent unit and the `checkAttributes` / `indentLogicalExpressions` boolean options.

Output is verified character-level identical to upstream:
- 100 valid + 75 invalid Go test cases (full upstream test suite migrated 1:1; do-expression / Flow cases marked \`Skip: true\` with reason).
- 19 valid + 11 invalid JS rule-tester cases.
- Differential validation on rsbuild + rspack: **345 \`react/jsx-indent\` diagnostics across 4 option configurations, line + column + message all character-level identical to upstream**; \`--fix\` output across 4 real files (172 fixes) byte-identical to ESLint \`--fix\`.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-indent.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).