### PR TITLE
feat: port rule react/display-name

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -3,6 +3,7 @@ package react_plugin
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/boolean_prop_naming"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/button_has_type"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/display_name"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_component_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_dom_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_elements"
@@ -75,6 +76,7 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		boolean_prop_naming.BooleanPropNamingRule,
 		button_has_type.ButtonHasTypeRule,
+		display_name.DisplayNameRule,
 		forbid_component_props.ForbidComponentPropsRule,
 		forbid_dom_props.ForbidDomPropsRule,
 		forbid_elements.ForbidElementsRule,

--- a/internal/plugins/react/rules/display_name/display_name.go
+++ b/internal/plugins/react/rules/display_name/display_name.go
@@ -1,0 +1,1455 @@
+package display_name
+
+import (
+	"sort"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Options carries the parsed rule options. Mirrors upstream's schema:
+//
+//	[{
+//	  type: 'object',
+//	  properties: {
+//	    ignoreTranspilerName: { type: 'boolean' },
+//	    checkContextObjects:  { type: 'boolean' },
+//	  },
+//	  additionalProperties: false,
+//	}]
+type Options struct {
+	IgnoreTranspilerName bool
+	CheckContextObjects  bool
+}
+
+func parseOptions(options any) Options {
+	opts := Options{}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["ignoreTranspilerName"].(bool); ok {
+			opts.IgnoreTranspilerName = v
+		}
+		if v, ok := optsMap["checkContextObjects"].(bool); ok {
+			opts.CheckContextObjects = v
+		}
+	}
+	return opts
+}
+
+// reactVersionAtLeast reports whether settings.react.version is >= the given
+// major.minor.patch. Uses the same parsing as ReactVersionLessThan.
+func reactVersionAtLeast(settings map[string]interface{}, major, minor, patch int) bool {
+	return !reactutil.ReactVersionLessThan(settings, major, minor, patch)
+}
+
+// supportsNestedMemo reports whether settings.react.version is in the range
+// `^0.14.10 || ^15.7.0 || >= 16.12.0`. Mirrors upstream's
+// `testReactVersion(context, '^0.14.10 || ^15.7.0 || >= 16.12.0')` gate that
+// suppresses the inner forwardRef-inside-memo report.
+func supportsNestedMemo(settings map[string]interface{}) bool {
+	major, minor, patch := reactutil.ParseReactVersion(settings)
+	// `^0.14.10` — 0.14.x with patch ≥ 10.
+	if major == 0 && minor == 14 && patch >= 10 {
+		return true
+	}
+	// `^15.7.0` — 15.x with minor ≥ 7.
+	if major == 15 && minor >= 7 {
+		return true
+	}
+	// `>= 16.12.0`.
+	return reactVersionAtLeast(settings, 16, 12, 0)
+}
+
+// detectedComponent pairs a registered component node with its sort key and
+// the running `hasDisplayName` flag mirrored from upstream's
+// `components.set(node, { hasDisplayName: ... })`. The sort key is the
+// node's trimmed source position so we can produce reports in the same order
+// as upstream's `components.list()` traversal.
+type detectedComponent struct {
+	node           *ast.Node
+	pos            int
+	hasDisplayName bool
+}
+
+// contextEntry mirrors upstream's `contextObjects.set(name, { node, hasDisplayName })`.
+// The `name` (binding identifier of the context variable) is the lookup key
+// used by the `MemberExpression` listener to flip `hasDisplayName`.
+type contextEntry struct {
+	node           *ast.Node
+	hasDisplayName bool
+}
+
+// nodeWalker carries per-source-file state for the display-name analysis.
+// A single walker fully owns the components / context maps and the helper
+// closures that mutate them; the rule's `Run` constructs one per file.
+type nodeWalker struct {
+	ctx                  rule.RuleContext
+	opts                 Options
+	pragma               string
+	createClass          string
+	wrappers             []reactutil.ComponentWrapperEntry
+	tc                   *checker.Checker
+	checkContextObjects  bool
+	nestedMemoSupported  bool
+
+	// Component registry. `byNode` is the source-of-truth for has-displayName
+	// state; `order` preserves discovery order for deterministic reporting.
+	byNode map[*ast.Node]*detectedComponent
+	order  []*detectedComponent
+
+	// nameToComponent indexes the registry by the binding identifier of the
+	// owning declaration / property assignment (string name → component).
+	// First-discovered wins; collides across scopes when the same name is
+	// bound multiple times. Used as the fallback when the TypeChecker
+	// can't resolve a reference precisely (or isn't available at all).
+	nameToComponent map[string]*detectedComponent
+
+	// Top-level binding map: identifier name → its initializer (the RHS of
+	// `var X = ...`, `let X = ...`, `const X = ...`). Used as the fallback
+	// for deep `Mixins.Greetings.Hello.displayName` resolution when the
+	// TypeChecker isn't available; with TC, the resolver prefers
+	// `reactutil.ResolveIdentifierInitializer` which works in any scope.
+	topBindings map[string]*ast.Node
+
+	// contextObjects mirrors upstream's `contextObjects` Map keyed by the
+	// binding identifier of the createContext target.
+	contextObjects map[string]*contextEntry
+}
+
+// addComponent registers `node` in the component registry, deduping on the
+// node pointer. Returns the entry so callers can flip `hasDisplayName`
+// inline. `bindingName` is optional — when non-empty it's also indexed in
+// `nameToComponent` so MemberExpression listeners can find the component
+// by the variable / class / function name that owns it.
+func (w *nodeWalker) addComponent(node *ast.Node, bindingName string) *detectedComponent {
+	if node == nil {
+		return nil
+	}
+	if existing, ok := w.byNode[node]; ok {
+		if bindingName != "" {
+			if _, exists := w.nameToComponent[bindingName]; !exists {
+				w.nameToComponent[bindingName] = existing
+			}
+		}
+		return existing
+	}
+	trimmed := utils.TrimNodeTextRange(w.ctx.SourceFile, node)
+	entry := &detectedComponent{node: node, pos: trimmed.Pos()}
+	w.byNode[node] = entry
+	w.order = append(w.order, entry)
+	if bindingName != "" {
+		if _, exists := w.nameToComponent[bindingName]; !exists {
+			w.nameToComponent[bindingName] = entry
+		}
+	}
+	return entry
+}
+
+// isDisplayNameKey reports whether `key` (a property/method/getter key node)
+// is the literal identifier or string `displayName`. Mirrors upstream's
+// `propsUtil.isDisplayNameDeclaration` — Identifier `displayName` and any
+// string-typed Literal `'displayName'`. Computed keys whose expression is a
+// string literal (`['displayName']`) collapse onto the same shape in tsgo
+// via the ComputedPropertyName wrapper, so we peek through it.
+func isDisplayNameKey(key *ast.Node) bool {
+	if key == nil {
+		return false
+	}
+	if key.Kind == ast.KindComputedPropertyName {
+		key = key.AsComputedPropertyName().Expression
+		if key == nil {
+			return false
+		}
+	}
+	switch key.Kind {
+	case ast.KindIdentifier:
+		return key.AsIdentifier().Text == "displayName"
+	case ast.KindStringLiteral:
+		return key.AsStringLiteral().Text == "displayName"
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return key.AsNoSubstitutionTemplateLiteral().Text == "displayName"
+	}
+	return false
+}
+
+// isModuleExportsLeft reports whether `expr` (the LHS of an
+// AssignmentExpression) is `module.exports`. Mirrors upstream's
+// `node.parent.parent.left.object.name !== 'module' || ... !== 'exports'`
+// check inside `hasTranspilerName`. Optional-chain / paren wrappers don't
+// occur in this position in real code; we still SkipParentheses for safety.
+func isModuleExportsLeft(expr *ast.Node) bool {
+	if expr == nil {
+		return false
+	}
+	expr = ast.SkipParentheses(expr)
+	if expr.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	pa := expr.AsPropertyAccessExpression()
+	obj := ast.SkipParentheses(pa.Expression)
+	if obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != "module" {
+		return false
+	}
+	name := pa.Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return false
+	}
+	return name.AsIdentifier().Text == "exports"
+}
+
+// skipParenParentsUp walks up through ParenthesizedExpression wrappers
+// starting from `node` and returns (resolvedNode, parentNode) — the
+// last node still inside the paren chain and its non-paren parent.
+// Mirrors upstream's implicit ESTree paren flattening for parent-walks.
+// Used by the binding / hasTranspilerName helpers that look at
+// `node.parent` after paren-flattening.
+func skipParenParentsUp(node *ast.Node) (*ast.Node, *ast.Node) {
+	cur := node
+	for cur.Parent != nil && cur.Parent.Kind == ast.KindParenthesizedExpression {
+		cur = cur.Parent
+	}
+	return cur, cur.Parent
+}
+
+// bindingFromOwner extracts the binding-identifier name from a parent
+// declaration / assignment, returning "" when `parent` is not a recognized
+// owner shape OR `cur` is not in the owner's RHS / Initializer slot.
+//
+// Recognized shapes (matching the cases upstream's `hasTranspilerName`
+// inspects via `node.parent.parent`):
+//
+//   - `var X = ...` / `const X = ...` / `let X = ...` (VariableDeclaration
+//     whose Initializer is `cur`).
+//   - `X = ...` (BinaryExpression `=` whose Right is `cur` and Left is a
+//     paren-stripped Identifier).
+//
+// `module.exports = ...` LHS is intentionally NOT filtered here — callers
+// that need the module.exports gate (`hasTranspilerNameForObject`) check it
+// separately to keep this helper single-purpose.
+func bindingFromOwner(parent, cur *ast.Node) string {
+	if parent == nil {
+		return ""
+	}
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		if parent.AsVariableDeclaration().Initializer != cur {
+			return ""
+		}
+		nm := parent.Name()
+		if nm != nil && nm.Kind == ast.KindIdentifier {
+			return nm.AsIdentifier().Text
+		}
+	case ast.KindBinaryExpression:
+		bin := parent.AsBinaryExpression()
+		if bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindEqualsToken || bin.Right != cur {
+			return ""
+		}
+		left := ast.SkipParentheses(bin.Left)
+		if left.Kind == ast.KindIdentifier {
+			return left.AsIdentifier().Text
+		}
+	}
+	return ""
+}
+
+// hasTranspilerNameForObject mirrors the ObjectExpression arm of upstream's
+// `hasTranspilerName`. Returns true when the object literal sits as the
+// argument of a createReactClass call whose enclosing context is a
+// VariableDeclaration or non-module-exports AssignmentExpression — i.e.
+// `var X = createReactClass({...})` / `X = createReactClass({...})`.
+// Upstream walks `node.parent.parent` from the ObjectExpression — the parent
+// is the createReactClass CallExpression, the parent.parent is the
+// VariableDeclarator / AssignmentExpression. Parenthesized wrappers around
+// either layer are transparent.
+func hasTranspilerNameForObject(node *ast.Node) bool {
+	cur, parent := skipParenParentsUp(node)
+	// Walk up through the createReactClass CallExpression; upstream reads
+	// `node.parent.parent` to find the VariableDeclarator / AssignmentExpression.
+	if parent != nil && parent.Kind == ast.KindCallExpression {
+		cur, parent = skipParenParentsUp(parent)
+	}
+	if parent == nil {
+		return false
+	}
+	// `var X = createReactClass({...})` / `const X = ...` / `let X = ...`
+	if parent.Kind == ast.KindVariableDeclaration && parent.AsVariableDeclaration().Initializer == cur {
+		return true
+	}
+	// `X = createReactClass({...})` — accepted unless LHS is `module.exports`.
+	if parent.Kind == ast.KindBinaryExpression {
+		bin := parent.AsBinaryExpression()
+		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == cur {
+			if !isModuleExportsLeft(bin.Left) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasTranspilerNameForFunctionLike mirrors the FunctionLike arms of
+// upstream's `hasTranspilerName`:
+//
+//   - FunctionDeclaration / FunctionExpression with own `id.name` → true
+//     (a generic capitalized id is enough; the rule checks for ANY name)
+//   - FunctionExpression / ArrowFunction whose direct effective parent is
+//     a VariableDeclarator (`var X = fn`), an object PropertyAssignment
+//     (`{ X: fn }`), or an ObjectLiteralExpression shorthand method
+//     (`{ X() { ... } }` — collapsed to MethodDeclaration in tsgo) — but
+//     only when that owner is NOT itself the argument of an ES5
+//     createReactClass call, since the createReactClass property names
+//     don't contribute a transpiler-derivable name.
+func (w *nodeWalker) hasTranspilerNameForFunctionLike(node *ast.Node) bool {
+	if name := functionExpressionOwnName(node); name != "" {
+		return true
+	}
+	if node.Kind != ast.KindFunctionExpression && node.Kind != ast.KindArrowFunction {
+		return false
+	}
+	cur, parent := skipParenParentsUp(node)
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		// `var X = fn` — qualifies. Upstream also walks parent.parent (the
+		// `VariableDeclaration`), but the createReactClass guard only fires
+		// when the FunctionLike's grandparent is itself a `Property`
+		// (object-literal value), not a VariableDeclaration.
+		return parent.AsVariableDeclaration().Initializer == cur
+	case ast.KindPropertyAssignment:
+		// `{ X: fn }` — disqualifies if the owning ObjectLiteralExpression
+		// is the argument of a createReactClass call (the property names
+		// inside an ES5 component object don't transpile to component names).
+		grand := parent.Parent
+		if grand != nil && grand.Kind == ast.KindObjectLiteralExpression && reactutil.IsCreateReactClassObjectArg(grand, w.pragma, w.createClass) {
+			return false
+		}
+		return true
+	}
+	// Object-literal shorthand method `{ X() { ... } }` collapses to a
+	// MethodDeclaration whose parent IS the ObjectLiteralExpression — but
+	// the AST kinds (FunctionExpression / ArrowFunction) we're checking
+	// here exclude shorthand methods anyway. Shorthand methods are handled
+	// directly by the MethodDeclaration arm of `collectComponents` /
+	// detection logic.
+	return false
+}
+
+// functionExpressionOwnName returns the FN's own id text (`function Foo()`
+// → "Foo") or "" when the FN is anonymous / not a FunctionDeclaration or
+// FunctionExpression. Used both for transpiler-name detection and binding
+// indexing.
+func functionExpressionOwnName(node *ast.Node) string {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		fn := node.AsFunctionDeclaration()
+		if name := fn.Name(); name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text != "" {
+			return name.AsIdentifier().Text
+		}
+	case ast.KindFunctionExpression:
+		fe := node.AsFunctionExpression()
+		if name := fe.Name(); name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text != "" {
+			return name.AsIdentifier().Text
+		}
+	}
+	return ""
+}
+
+// hasTranspilerNameForClass mirrors upstream's classNamed arm — true iff the
+// class has a non-empty `id.name`. Both ClassDeclaration and ClassExpression
+// expose `Name()` that returns the binding identifier.
+func hasTranspilerNameForClass(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		name := node.Name()
+		return name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text != ""
+	}
+	return false
+}
+
+// outermostWrapperCall walks up through nested pragma-wrapper calls and
+// returns the outer-most CallExpression that matches `wrappers`. Mirrors
+// upstream's `getPragmaComponentWrapper` loop. Used for the
+// `Components.detect` redirect from inner FunctionLike to its outer wrapper
+// call, so that the report node's range tracks upstream's
+// `getStatelessComponent` output.
+func (w *nodeWalker) outermostWrapperCall(fn *ast.Node) *ast.Node {
+	cur := reactutil.SkipExpressionWrappersUp(fn)
+	if cur == nil || cur.Kind != ast.KindCallExpression ||
+		!reactutil.MatchesAnyComponentWrapperWithChecker(cur, fn, w.wrappers, w.pragma, w.tc) {
+		return nil
+	}
+	for {
+		next := reactutil.SkipExpressionWrappersUp(cur)
+		if next == nil || next.Kind != ast.KindCallExpression {
+			return cur
+		}
+		if !reactutil.MatchesAnyComponentWrapperWithChecker(next, cur, w.wrappers, w.pragma, w.tc) {
+			return cur
+		}
+		cur = next
+	}
+}
+
+// bindingNameForFunctionLike returns the binding-identifier name of the
+// declaration that owns this FunctionLike, or "" when there isn't one.
+// Covers: own FN id (`function Foo()`), VariableDeclaration owner
+// (`var Foo = fn`), Identifier-LHS assignment (`Foo = fn`).
+func bindingNameForFunctionLike(node *ast.Node) string {
+	if name := functionExpressionOwnName(node); name != "" {
+		return name
+	}
+	cur, parent := skipParenParentsUp(node)
+	return bindingFromOwner(parent, cur)
+}
+
+// bindingNameForClass returns the binding-identifier name of a class
+// declaration / expression, or "" when none. ClassExpression in
+// `var Foo = class {}` doesn't have its own id (anonymous) — but its
+// VariableDeclaration parent does, so we walk up. Class*Declaration*
+// always carries its own id.
+func bindingNameForClass(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	if name := node.Name(); name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text != "" {
+		return name.AsIdentifier().Text
+	}
+	cur, parent := skipParenParentsUp(node)
+	// Class binding only flows from a VariableDeclaration. Identifier-LHS
+	// assignment (`Foo = class {}`) is upstream-rejected because
+	// `namedClass` requires `node.id.name`.
+	if parent != nil && parent.Kind == ast.KindVariableDeclaration && parent.AsVariableDeclaration().Initializer == cur {
+		nm := parent.Name()
+		if nm != nil && nm.Kind == ast.KindIdentifier {
+			return nm.AsIdentifier().Text
+		}
+	}
+	return ""
+}
+
+// bindingNameForObjectExpression returns the binding identifier of the
+// containing VariableDeclaration / Identifier-LHS assignment, or "" when
+// the object literal isn't directly bound. Mirrors the shape needed by
+// `Foo.displayName = ...` resolution for ES5 createReactClass components.
+func bindingNameForObjectExpression(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	cur, parent := skipParenParentsUp(node)
+	// For ES5 components, the object is the argument of createReactClass —
+	// walk up through the wrapping CallExpression to find the variable name.
+	if parent != nil && parent.Kind == ast.KindCallExpression {
+		cur, parent = skipParenParentsUp(parent)
+	}
+	return bindingFromOwner(parent, cur)
+}
+
+// bindingNameForCallExpression returns the binding identifier when the
+// pragma-wrapper call is directly bound (e.g. `const Foo = React.memo(...)`),
+// else "". Used so `Foo.displayName = 'Foo'` can find the wrapper-call
+// component. Skips TS expression wrappers on the way up so
+// `Comp = React.forwardRef(...) as SomeComponent` still resolves to `Comp`.
+func bindingNameForCallExpression(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	cur := node
+	for cur.Parent != nil {
+		switch cur.Parent.Kind {
+		case ast.KindParenthesizedExpression,
+			ast.KindAsExpression, ast.KindSatisfiesExpression,
+			ast.KindNonNullExpression, ast.KindTypeAssertionExpression:
+			cur = cur.Parent
+			continue
+		}
+		break
+	}
+	return bindingFromOwner(cur.Parent, cur)
+}
+
+// hasOwnDisplayNameProperty scans an ObjectLiteralExpression for an own
+// property whose key is `displayName`. Mirrors upstream's
+//
+//	node.properties.forEach((property) => {
+//	  if (!property.key || !propsUtil.isDisplayNameDeclaration(property.key)) return;
+//	  markDisplayNameAsDeclared(node);
+//	});
+//
+// Both PropertyAssignment and shorthand-method (MethodDeclaration) /
+// accessor (Get/SetAccessor) keys are recognized.
+func hasOwnDisplayNameProperty(obj *ast.Node) bool {
+	if obj == nil || obj.Kind != ast.KindObjectLiteralExpression {
+		return false
+	}
+	for _, prop := range obj.AsObjectLiteralExpression().Properties.Nodes {
+		key := prop.Name()
+		if isDisplayNameKey(key) {
+			return true
+		}
+	}
+	return false
+}
+
+// findClassMemberDisplayName scans a class body for any member whose key is
+// `displayName`. Mirrors the combined upstream `ClassProperty,
+// PropertyDefinition` and `MethodDefinition` listeners — both fire on
+// class-body members and call `markDisplayNameAsDeclared(node)`. The owning
+// class node is returned implicitly: callers iterate class declarations and
+// flip the displayName flag when this returns true.
+func findClassMemberDisplayName(class *ast.Node) bool {
+	if class == nil {
+		return false
+	}
+	members := class.Members()
+	if members == nil {
+		return false
+	}
+	for _, m := range members {
+		switch m.Kind {
+		case ast.KindPropertyDeclaration,
+			ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor:
+			if isDisplayNameKey(m.Name()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// resolveCreateContextCall reports whether `expr` (the RHS of a
+// VariableDeclaration initializer or AssignmentExpression) is a
+// `createContext(...)` or `<X>.createContext(...)` call. Mirrors upstream's
+// `isCreateContext` predicate, peeling parens / TS-wrappers off both the
+// call and its callee.
+func resolveCreateContextCall(expr *ast.Node) bool {
+	if expr == nil {
+		return false
+	}
+	expr = reactutil.SkipExpressionWrappers(expr)
+	if expr.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := reactutil.SkipExpressionWrappers(expr.AsCallExpression().Expression)
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		return callee.AsIdentifier().Text == "createContext"
+	case ast.KindPropertyAccessExpression:
+		name := callee.AsPropertyAccessExpression().Name()
+		return name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "createContext"
+	}
+	return false
+}
+
+// recordTopBinding remembers that `name` is bound to `init` at the
+// source-file top level. Subsequent calls with the same name are ignored
+// (first-binding-wins) so a re-assignment doesn't shadow the original
+// initializer for `Foo.Bar.displayName` resolution.
+func (w *nodeWalker) recordTopBinding(name string, init *ast.Node) {
+	if name == "" || init == nil {
+		return
+	}
+	if _, exists := w.topBindings[name]; !exists {
+		w.topBindings[name] = init
+	}
+}
+
+// resolveAndMarkComponentRef tries to resolve `obj` (the receiver of a
+// `.displayName` property access) to a registered component via the
+// TypeChecker, and marks the component's `hasDisplayName` when found.
+// Returns true on a successful match. Always returns false when the
+// TypeChecker is nil — callers must fall back to the syntactic indexes
+// (`nameToComponent` / `topBindings`) in that case, which is the design
+// for non-type-aware rule runs.
+//
+// Resolution rules — checked in order against `obj`'s value declaration:
+//
+//  1. The declaration node itself is a registered component (covers
+//     `function Foo() {}` and `class Foo {}` shapes).
+//  2. The declaration is a VariableDeclaration whose initializer (after
+//     `SkipExpressionWrappers`) is a registered component (covers
+//     `const Foo = arrow / FE / class-expression / wrapper-call`).
+//  3. ES5 indirection: the initializer is a `createReactClass({...})`
+//     CallExpression and the inner ObjectLiteralExpression argument is
+//     the registered component.
+//
+// All TC accesses are guarded — `w.tc == nil` short-circuits to false.
+func (w *nodeWalker) resolveAndMarkComponentRef(obj *ast.Node) bool {
+	if w.tc == nil || obj == nil || obj.Kind != ast.KindIdentifier {
+		return false
+	}
+	symbol := w.tc.GetSymbolAtLocation(obj)
+	if symbol == nil {
+		return false
+	}
+	decl := symbol.ValueDeclaration
+	if decl == nil {
+		return false
+	}
+	// Rule 1: declaration is the registered component.
+	if entry, ok := w.byNode[decl]; ok {
+		entry.hasDisplayName = true
+		return true
+	}
+	// Rule 2 & 3: VariableDeclaration → init.
+	if decl.Kind != ast.KindVariableDeclaration {
+		return false
+	}
+	init := decl.AsVariableDeclaration().Initializer
+	if init == nil {
+		return false
+	}
+	stripped := reactutil.SkipExpressionWrappers(init)
+	if entry, ok := w.byNode[stripped]; ok {
+		entry.hasDisplayName = true
+		return true
+	}
+	// ES5 indirection: `var X = createReactClass({...})`. The init is the
+	// call; the registered component is the inner ObjectLiteralExpression.
+	if stripped.Kind == ast.KindCallExpression {
+		call := stripped.AsCallExpression()
+		if call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+			arg := reactutil.SkipExpressionWrappers(call.Arguments.Nodes[0])
+			if entry, ok := w.byNode[arg]; ok {
+				entry.hasDisplayName = true
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// resolveDeepRelatedComponent mirrors a pragmatic subset of upstream's
+// `getRelatedComponent`. Given a MemberExpression like
+// `Mixins.Greetings.Hello.displayName`, it walks `Mixins`'s top-level
+// initializer through ObjectLiteralExpression properties (`Greetings`,
+// `Hello`) and returns the leaf node — typically a FunctionExpression or
+// ArrowFunction — so the caller can flip its component's `hasDisplayName`.
+//
+// The shallow case (`Foo.displayName = ...` where `Foo` is a directly
+// declared component) is handled by `nameToComponent` ahead of this; this
+// helper only kicks in for paths of length ≥ 2.
+func (w *nodeWalker) resolveDeepRelatedComponent(member *ast.Node) *ast.Node {
+	if member == nil || member.Kind != ast.KindPropertyAccessExpression {
+		return nil
+	}
+	// Walk down to the root identifier, collecting property names along
+	// the way (excluding the trailing `displayName`, which the caller
+	// already verified). Append-then-reverse keeps the slice ops O(N) —
+	// prepending in the loop would re-allocate every iteration.
+	var path []string
+	cur := ast.SkipParentheses(member.AsPropertyAccessExpression().Expression)
+	for cur.Kind == ast.KindPropertyAccessExpression {
+		pa := cur.AsPropertyAccessExpression()
+		name := pa.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return nil
+		}
+		path = append(path, name.AsIdentifier().Text)
+		cur = ast.SkipParentheses(pa.Expression)
+	}
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	if cur.Kind != ast.KindIdentifier {
+		return nil
+	}
+	if len(path) == 0 {
+		return nil
+	}
+	// TC-aware resolution (preferred): `ResolveIdentifierInitializer`
+	// uses `tc.GetSymbolAtLocation` when `tc` is non-nil, finding the
+	// initializer of the resolved binding regardless of scope. Falls
+	// back to a syntactic local-block / SourceFile scan when `tc` is
+	// nil — `reactutil` already encodes the defensive pattern, so we
+	// just call through. When even that fails, drop to `topBindings`.
+	init := reactutil.ResolveIdentifierInitializer(cur, w.tc)
+	if init == nil {
+		root := cur.AsIdentifier().Text
+		if v, ok := w.topBindings[root]; ok {
+			init = v
+		}
+	}
+	if init == nil {
+		return nil
+	}
+	node := init
+	for _, key := range path {
+		node = reactutil.SkipExpressionWrappers(node)
+		if node.Kind != ast.KindObjectLiteralExpression {
+			return nil
+		}
+		var found *ast.Node
+		for _, prop := range node.AsObjectLiteralExpression().Properties.Nodes {
+			pn := prop.Name()
+			if pn == nil {
+				continue
+			}
+			if pn.Kind == ast.KindIdentifier && pn.AsIdentifier().Text == key {
+				found = prop
+				break
+			}
+			if pn.Kind == ast.KindStringLiteral && pn.AsStringLiteral().Text == key {
+				found = prop
+				break
+			}
+		}
+		if found == nil {
+			return nil
+		}
+		switch found.Kind {
+		case ast.KindPropertyAssignment:
+			node = found.AsPropertyAssignment().Initializer
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+			node = found
+		default:
+			return nil
+		}
+	}
+	return reactutil.SkipExpressionWrappers(node)
+}
+
+// isAsyncGenerator reports whether `node` is a function expression /
+// declaration / shorthand method that is BOTH `async` AND a generator.
+// Mirrors upstream's `Components.detect` listener gate
+// `node.async && node.generator → components.add(node, 0)` — confidence 0
+// nodes are PERMANENTLY banned from `components.list()`. Arrow functions
+// cannot be generators (syntax) so this never fires on KindArrowFunction.
+//
+// In tsgo, the syntactic generator marker is `AsteriskToken` on the
+// FunctionDeclaration / FunctionExpression / MethodDeclaration; the
+// `async` modifier is in the modifiers list.
+func isAsyncGenerator(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	mods := node.Modifiers()
+	hasAsync := false
+	if mods != nil {
+		for _, m := range mods.Nodes {
+			if m.Kind == ast.KindAsyncKeyword {
+				hasAsync = true
+				break
+			}
+		}
+	}
+	if !hasAsync {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return node.AsFunctionDeclaration().AsteriskToken != nil
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().AsteriskToken != nil
+	case ast.KindMethodDeclaration:
+		return node.AsMethodDeclaration().AsteriskToken != nil
+	}
+	return false
+}
+
+// classifyAndRegisterFunctionLike runs the upstream FunctionLike component
+// classification (Branch 11 of `getStatelessComponent` plus the pragma
+// wrapper redirect) and registers the node. `componentNode` is the node
+// upstream `components.list()` would surface — either the FunctionLike
+// itself or the outer-most pragma-wrapper call when the FunctionLike sits
+// inside one.
+func (w *nodeWalker) classifyAndRegisterFunctionLike(n *ast.Node) {
+	// Async-generator ban — upstream's `Components.detect` adds these at
+	// confidence 0, which is permanently excluded from `components.list()`.
+	// Without this gate, `async function* Foo() { return <div/>; }` would
+	// silently classify here as a component and report. Arrow functions
+	// can't be generators by syntax, so the gate is naturally a no-op for
+	// KindArrowFunction.
+	if isAsyncGenerator(n) {
+		return
+	}
+	directParent := reactutil.SkipExpressionWrappersUp(n)
+	directInWrapper := directParent != nil && directParent.Kind == ast.KindCallExpression &&
+		reactutil.MatchesAnyComponentWrapperWithChecker(directParent, n, w.wrappers, w.pragma, w.tc)
+	// Wrap-known-sibling gate: when the outer wrapper call returns JSX
+	// whose root tag names a sibling/outer detected component, upstream's
+	// `isPragmaComponentWrapper` short-circuits to false. The inner
+	// FunctionLike is then NOT a component.
+	if directInWrapper && reactutil.WrapperWrapsKnownSiblingComponent(directParent, n) {
+		return
+	}
+	classifies := reactutil.IsStatelessReactComponentWithWrappers(n, w.pragma, w.tc, w.wrappers)
+	if !classifies {
+		// User-configured wrapper fallback — mirrors
+		// `IsDetectedComponent` FunctionLike arm. Some wrappers don't
+		// imply Branch 11 but still register the inner function as a
+		// component.
+		if directInWrapper && reactutil.FunctionReturnsJSXOrNullWithChecker(n, w.pragma, w.tc) {
+			outer := w.outermostWrapperCall(n)
+			if outer != nil {
+				w.addComponent(outer, bindingNameForCallExpression(outer))
+			}
+		}
+		return
+	}
+	// Pragma-wrapper redirect — mirrors upstream's
+	// `getStatelessComponent → getPragmaComponentWrapper` ascent.
+	if outer := w.outermostWrapperCall(n); outer != nil {
+		w.addComponent(outer, bindingNameForCallExpression(outer))
+		return
+	}
+	w.addComponent(n, bindingNameForFunctionLike(n))
+}
+
+// classifyAndRegisterCallExpression mirrors the CallExpression arm of
+// upstream's `Components.detect`. Registers a pragma-wrapper call as a
+// component when its first argument is a FunctionLike that classifies (or
+// the outer wrapper itself classifies) and the wrapper isn't wrapping a
+// known sibling component.
+func (w *nodeWalker) classifyAndRegisterCallExpression(n *ast.Node) {
+	call := n.AsCallExpression()
+	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+		return
+	}
+	inner := reactutil.SkipExpressionWrappers(call.Arguments.Nodes[0])
+	if inner == nil || !reactutil.IsFunctionLikeForComponent(inner) {
+		return
+	}
+	if !reactutil.MatchesAnyComponentWrapperWithChecker(n, inner, w.wrappers, w.pragma, w.tc) {
+		return
+	}
+	if reactutil.WrapperWrapsKnownSiblingComponent(n, inner) {
+		return
+	}
+	// When the call is itself nested inside another wrapper, redirect to
+	// the outer-most wrapper for component identity (matches the
+	// FunctionLike redirect).
+	if outer := w.outermostWrapperCall(inner); outer != nil && outer != n {
+		w.addComponent(outer, bindingNameForCallExpression(outer))
+		return
+	}
+	w.addComponent(n, bindingNameForCallExpression(n))
+}
+
+// collect walks the source file once and registers every component node /
+// context object, plus indexes top-level bindings for later
+// MemberExpression resolution. Mirrors the per-listener semantics of
+// upstream's `Components.detect` plus `display-name`'s context-tracking
+// listeners.
+func (w *nodeWalker) collect() {
+	sf := w.ctx.SourceFile
+
+	// First pass — top-level binding index. Used to resolve
+	// `Mixins.Greetings.Hello.displayName = ...`-style deep references.
+	for _, stmt := range sf.Statements.Nodes {
+		switch stmt.Kind {
+		case ast.KindVariableStatement:
+			vs := stmt.AsVariableStatement()
+			if vs.DeclarationList == nil {
+				continue
+			}
+			for _, decl := range vs.DeclarationList.AsVariableDeclarationList().Declarations.Nodes {
+				vd := decl.AsVariableDeclaration()
+				name := vd.Name()
+				if name == nil || name.Kind != ast.KindIdentifier {
+					continue
+				}
+				if vd.Initializer != nil {
+					w.recordTopBinding(name.AsIdentifier().Text, vd.Initializer)
+				}
+			}
+		case ast.KindFunctionDeclaration:
+			fd := stmt.AsFunctionDeclaration()
+			name := fd.Name()
+			if name != nil && name.Kind == ast.KindIdentifier {
+				w.recordTopBinding(name.AsIdentifier().Text, stmt)
+			}
+		case ast.KindClassDeclaration:
+			cd := stmt.AsClassDeclaration()
+			name := cd.Name()
+			if name != nil && name.Kind == ast.KindIdentifier {
+				w.recordTopBinding(name.AsIdentifier().Text, stmt)
+			}
+		}
+	}
+
+	// Second pass — visit every node, register components and contexts,
+	// and apply the various display-name-marker listeners.
+	var visit ast.Visitor
+	visit = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		switch n.Kind {
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			if reactutil.ExtendsReactComponent(n, w.pragma) {
+				entry := w.addComponent(n, bindingNameForClass(n))
+				if entry != nil {
+					if !w.opts.IgnoreTranspilerName && hasTranspilerNameForClass(n) {
+						entry.hasDisplayName = true
+					}
+					if findClassMemberDisplayName(n) {
+						entry.hasDisplayName = true
+					}
+				}
+			}
+
+		case ast.KindObjectLiteralExpression:
+			if reactutil.IsCreateReactClassObjectArg(n, w.pragma, w.createClass) {
+				entry := w.addComponent(n, bindingNameForObjectExpression(n))
+				if entry != nil {
+					if !w.opts.IgnoreTranspilerName && hasTranspilerNameForObject(n) {
+						entry.hasDisplayName = true
+					}
+					if hasOwnDisplayNameProperty(n) {
+						entry.hasDisplayName = true
+					}
+				}
+			}
+
+		case ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor:
+			// Object-literal shorthand-method classification — when the
+			// shorthand method itself classifies as a stateless React
+			// component (capitalized owner key, returns JSX, not in a
+			// disqualifying position). Excludes class-body members
+			// (handled by the ClassDeclaration / ClassExpression arm).
+			if n.Parent != nil && n.Parent.Kind != ast.KindObjectLiteralExpression {
+				break
+			}
+			if reactutil.IsStatelessReactComponentWithWrappers(n, w.pragma, w.tc, w.wrappers) {
+				w.classifyAndRegisterFunctionLike(n)
+				// Shorthand methods carry a transpiler-derivable name —
+				// upstream's `hasTranspilerName` recognizes
+				// `node.parent.method === true` (ESTree's shape for
+				// `{ Foo() { ... } }`). tsgo collapses that into a
+				// MethodDeclaration directly under the
+				// ObjectLiteralExpression; `parent.method` doesn't exist as
+				// a separate signal but the kind itself is the equivalent.
+				// Don't apply the `outermostWrapperCall == nil` gate here —
+				// shorthand methods can't be inside a pragma-wrapper call
+				// argument anyway (the wrapper would receive the surrounding
+				// ObjectLiteralExpression, not the bare method).
+				if !w.opts.IgnoreTranspilerName {
+					if entry, ok := w.byNode[n]; ok {
+						entry.hasDisplayName = true
+					}
+				}
+			}
+
+		case ast.KindFunctionDeclaration,
+			ast.KindFunctionExpression,
+			ast.KindArrowFunction:
+			w.classifyAndRegisterFunctionLike(n)
+			// Mark the FunctionLike's component when its transpiler-derivable
+			// name is in scope. Upstream's listener does
+			// `if (components.get(node)) markDisplayNameAsDeclared(node)` —
+			// `components.get(fn)` only resolves when `fn` itself was the
+			// registered component. When `getStatelessComponent(fn)`
+			// redirected to an outer pragma-wrapper, `components.get(fn)`
+			// returns undefined and no mark happens. Mirror that: only mark
+			// when the FunctionLike was registered without a wrapper redirect
+			// (i.e. `outermostWrapperCall` returned nil for this FN).
+			if !w.opts.IgnoreTranspilerName && w.hasTranspilerNameForFunctionLike(n) {
+				if w.outermostWrapperCall(n) == nil {
+					if entry, ok := w.byNode[n]; ok {
+						entry.hasDisplayName = true
+					}
+				}
+			}
+
+		case ast.KindCallExpression:
+			w.classifyAndRegisterCallExpression(n)
+			// Upstream CallExpression listener: when the wrapper's first
+			// argument is a FunctionLike, register the wrapper call as a
+			// component and flip displayName when:
+			//   - the wrapper is itself nested inside another wrapper, OR
+			//   - the inner FunctionLike has a transpiler name.
+			//
+			// The first arm fires ONLY when no outer wrapper triggers; if
+			// there IS an outer wrapper, upstream's listener returns early
+			// without flipping (so the outer wrapper's component, if any,
+			// is the one that needs the transpiler-name check).
+			call := n.AsCallExpression()
+			if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+				break
+			}
+			inner := reactutil.SkipExpressionWrappers(call.Arguments.Nodes[0])
+			if inner == nil {
+				break
+			}
+			if inner.Kind != ast.KindFunctionExpression && inner.Kind != ast.KindArrowFunction {
+				break
+			}
+			if !reactutil.MatchesAnyComponentWrapperWithChecker(n, inner, w.wrappers, w.pragma, w.tc) {
+				break
+			}
+			isWrappedInAnother := false
+			if outer := reactutil.SkipExpressionWrappersUp(n); outer != nil && outer.Kind == ast.KindCallExpression {
+				if reactutil.MatchesAnyComponentWrapperWithChecker(outer, n, w.wrappers, w.pragma, w.tc) {
+					isWrappedInAnother = true
+				}
+			}
+			if isWrappedInAnother || (!w.opts.IgnoreTranspilerName && w.hasTranspilerNameForFunctionLike(inner)) {
+				if entry, ok := w.byNode[n]; ok {
+					entry.hasDisplayName = true
+				}
+			}
+
+		case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+			// `foo.displayName` and `foo["displayName"]` references — mark
+			// the related component. Both AST kinds carry an Identifier
+			// (or string-literal) "name"; upstream's listener fires on
+			// ESTree's unified `MemberExpression` for both.
+			var memberKey *ast.Node
+			var memberObject *ast.Node
+			if n.Kind == ast.KindPropertyAccessExpression {
+				pa := n.AsPropertyAccessExpression()
+				memberKey = pa.Name()
+				memberObject = ast.SkipParentheses(pa.Expression)
+			} else {
+				ea := n.AsElementAccessExpression()
+				memberKey = ea.ArgumentExpression
+				memberObject = ast.SkipParentheses(ea.Expression)
+			}
+			if !isDisplayNameKey(memberKey) {
+				break
+			}
+			obj := memberObject
+			// Context-object case: `Hello.displayName = "..."` where
+			// `Hello = createContext(...)`.
+			if w.checkContextObjects && obj.Kind == ast.KindIdentifier {
+				if ctxEntry, ok := w.contextObjects[obj.AsIdentifier().Text]; ok {
+					ctxEntry.hasDisplayName = true
+				}
+			}
+			// Component case: `Foo.displayName = ...`. Try TC-aware
+			// resolution first (handles cross-scope bindings precisely);
+			// fall back to the syntactic indexes when TC is unavailable
+			// or doesn't resolve. The TC path mirrors upstream's
+			// `getRelatedComponent` ↔ ESLint scope manager interaction.
+			if w.resolveAndMarkComponentRef(obj) {
+				break
+			}
+			// Fallback 1 (syntactic): `nameToComponent` first-discovered
+			// match. Coarse but works without a TypeChecker.
+			if obj.Kind == ast.KindIdentifier {
+				if entry, ok := w.nameToComponent[obj.AsIdentifier().Text]; ok {
+					entry.hasDisplayName = true
+					break
+				}
+			}
+			// Fallback 2: deep path case (`Mixins.Greetings.Hello.displayName = ...`).
+			// Only the dot-access form is supported (mirrors upstream's
+			// `getRelatedComponent` MemberExpression walk through `.object`
+			// chains; bracket-access shapes don't appear in real-world
+			// React APIs and upstream doesn't probe them).
+			if n.Kind == ast.KindPropertyAccessExpression {
+				if leaf := w.resolveDeepRelatedComponent(n); leaf != nil {
+					if entry, ok := w.byNode[leaf]; ok {
+						entry.hasDisplayName = true
+					}
+				}
+			}
+
+		case ast.KindVariableDeclaration:
+			if !w.checkContextObjects {
+				break
+			}
+			vd := n.AsVariableDeclaration()
+			if vd.Initializer == nil {
+				break
+			}
+			name := vd.Name()
+			if name == nil || name.Kind != ast.KindIdentifier {
+				break
+			}
+			if resolveCreateContextCall(vd.Initializer) {
+				w.contextObjects[name.AsIdentifier().Text] = &contextEntry{node: n}
+			}
+
+		case ast.KindBinaryExpression:
+			if !w.checkContextObjects {
+				break
+			}
+			bin := n.AsBinaryExpression()
+			if bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindEqualsToken {
+				break
+			}
+			left := ast.SkipParentheses(bin.Left)
+			if left.Kind != ast.KindIdentifier {
+				break
+			}
+			if !resolveCreateContextCall(bin.Right) {
+				break
+			}
+			// Record only when the assignment is a top-level expression
+			// statement, mirroring upstream's `ExpressionStatement`
+			// listener entry point.
+			parent := n.Parent
+			if parent == nil || parent.Kind != ast.KindExpressionStatement {
+				break
+			}
+			w.contextObjects[left.AsIdentifier().Text] = &contextEntry{node: parent}
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	sf.Node.ForEachChild(visit)
+}
+
+// isShadowedComponent reports whether the wrapper identifier (`React`,
+// `memo`, or `forwardRef`) used by `node` (a CallExpression) is shadowed in
+// `node`'s lexical scope. Mirrors upstream's `isShadowedComponent` —
+// preventing false positives where users intentionally shadow the React
+// wrapper APIs in nested scopes (the canonical examples appear at the top
+// of upstream's `valid` block).
+func (w *nodeWalker) isShadowedComponent(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+	if callee.Kind == ast.KindPropertyAccessExpression {
+		obj := ast.SkipParentheses(callee.AsPropertyAccessExpression().Expression)
+		if obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == "React" {
+			return isIdentifierShadowed(node, "React")
+		}
+		return false
+	}
+	if callee.Kind == ast.KindIdentifier {
+		text := callee.AsIdentifier().Text
+		if text == "memo" || text == "forwardRef" {
+			return isIdentifierShadowed(node, text)
+		}
+	}
+	return false
+}
+
+// isIdentifierShadowed reports whether `name` is bound in any enclosing
+// function / block / parameter scope between `node` and the source-file
+// root. Deliberately NOT a thin wrapper over `utils.IsShadowed`:
+//
+//   - upstream's `isIdentifierShadowed` only looks for INNER bindings that
+//     would shadow the wrapper identifier in a nested scope (e.g. `const
+//     memo = …` inside a function body). It does not consider the
+//     SourceFile-level binding (the very import that BRINGS `memo` in)
+//     "shadowing" — which would invert the shadow-check's purpose and
+//     suppress every memo / forwardRef report against any file that
+//     actually imports React.
+//   - upstream uses a SHALLOW pattern scan (one level of object / array
+//     destructuring) — `{ a: { React } }` does NOT shadow `React`.
+//     `utils.IsShadowed` / `HasShadowingDeclaration` use
+//     `CollectBindingNames`, which recurses into nested patterns and
+//     would over-suppress.
+//
+// Keep the bespoke walk to preserve byte-for-byte alignment with upstream.
+func isIdentifierShadowed(node *ast.Node, name string) bool {
+	cur := node
+	for cur.Parent != nil {
+		cur = cur.Parent
+		if ast.IsFunctionLike(cur) {
+			if body := cur.Body(); body != nil && bodyHasVariableDeclaration(body, name) {
+				return true
+			}
+			if functionParamsBindName(cur, name) {
+				return true
+			}
+			continue
+		}
+		if cur.Kind == ast.KindBlock {
+			if bodyHasVariableDeclaration(cur, name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// bodyHasVariableDeclaration mirrors upstream's `hasVariableDeclaration`
+// recursive scan: a `var` / `let` / `const` declaration whose declarator id
+// (Identifier, ArrayPattern element, ObjectPattern key) names `name`,
+// recursively into BlockStatement children. tsgo wraps `let`/`const` in a
+// `VariableStatement` containing a `VariableDeclarationList`, while a
+// single arrow body might be an Expression — both shapes are covered.
+func bodyHasVariableDeclaration(body *ast.Node, name string) bool {
+	if body == nil {
+		return false
+	}
+	if body.Kind != ast.KindBlock {
+		return false
+	}
+	for _, stmt := range body.AsBlock().Statements.Nodes {
+		if statementHasVariableDeclaration(stmt, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// statementHasVariableDeclaration scans a single statement for an own
+// VariableDeclaration whose binding includes `name`. Block statements
+// recurse to mirror upstream's `node.body.some(...)`.
+func statementHasVariableDeclaration(stmt *ast.Node, name string) bool {
+	if stmt == nil {
+		return false
+	}
+	switch stmt.Kind {
+	case ast.KindVariableStatement:
+		vs := stmt.AsVariableStatement()
+		if vs.DeclarationList == nil {
+			return false
+		}
+		for _, decl := range vs.DeclarationList.AsVariableDeclarationList().Declarations.Nodes {
+			vd := decl.AsVariableDeclaration()
+			if bindingIncludesName(vd.Name(), name) {
+				return true
+			}
+		}
+	case ast.KindBlock:
+		for _, child := range stmt.AsBlock().Statements.Nodes {
+			if statementHasVariableDeclaration(child, name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// bindingIncludesName mirrors upstream's check across Identifier /
+// ArrayPattern / ObjectPattern bindings: returns true when `name` appears
+// at the top level of the binding (no recursion into nested patterns —
+// matches upstream's one-level-deep traversal).
+func bindingIncludesName(binding *ast.Node, name string) bool {
+	if binding == nil {
+		return false
+	}
+	switch binding.Kind {
+	case ast.KindIdentifier:
+		return binding.AsIdentifier().Text == name
+	case ast.KindArrayBindingPattern:
+		for _, el := range binding.AsBindingPattern().Elements.Nodes {
+			if el.Kind != ast.KindBindingElement {
+				continue
+			}
+			be := el.AsBindingElement()
+			if be.Name() != nil && be.Name().Kind == ast.KindIdentifier && be.Name().AsIdentifier().Text == name {
+				return true
+			}
+		}
+	case ast.KindObjectBindingPattern:
+		for _, el := range binding.AsBindingPattern().Elements.Nodes {
+			if el.Kind != ast.KindBindingElement {
+				continue
+			}
+			be := el.AsBindingElement()
+			// `{ name }` shorthand — the name node itself is the binding.
+			if be.Name() != nil && be.Name().Kind == ast.KindIdentifier && be.Name().AsIdentifier().Text == name {
+				return true
+			}
+			// `{ key: name }` — `PropertyName` is the source key, `Name()`
+			// is the local binding. Upstream matches on `prop.key.name`,
+			// which for the shorthand-form maps to the binding itself
+			// (already covered above). For renamed-form (`{ key: name }`),
+			// upstream's `prop.key.name` matches the SOURCE key, not the
+			// local — so a binding `{ React: r }` does NOT shadow `React`
+			// in upstream. Mirror that by only matching when there is no
+			// PropertyName (shorthand) OR when the PropertyName matches
+			// `name` (renamed case where the SOURCE key is `name`).
+			if be.PropertyName != nil {
+				if be.PropertyName.Kind == ast.KindIdentifier && be.PropertyName.AsIdentifier().Text == name {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// functionParamsBindName mirrors upstream's `currentNode.params.some(...)`
+// scan. Looks at the FunctionLike's parameters and returns true when any
+// parameter (or shallow destructured parameter property) binds `name`.
+// Uses tsgo's standard `node.Parameters()` accessor which covers every
+// FunctionLike kind uniformly.
+func functionParamsBindName(fn *ast.Node, name string) bool {
+	for _, p := range fn.Parameters() {
+		if p == nil || p.Kind != ast.KindParameter {
+			continue
+		}
+		if bindingIncludesName(p.AsParameterDeclaration().Name(), name) {
+			return true
+		}
+	}
+	return false
+}
+
+// isNestedMemo reports whether `node` is a `<wrapper>(<wrapper>(...))`
+// shape — specifically a CallExpression whose first argument is itself a
+// pragma-component-wrapper CallExpression. Mirrors upstream's `isNestedMemo`,
+// which suppresses the inner forwardRef-inside-memo report when the React
+// version supports nested memo (`^0.14.10 || ^15.7.0 || >= 16.12.0`).
+func (w *nodeWalker) isNestedMemo(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := node.AsCallExpression()
+	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+		return false
+	}
+	first := reactutil.SkipExpressionWrappers(call.Arguments.Nodes[0])
+	if first == nil || first.Kind != ast.KindCallExpression {
+		return false
+	}
+	// Both the outer and inner calls must be pragma-component-wrappers.
+	innerInnerArg := first.AsCallExpression()
+	if innerInnerArg.Arguments == nil || len(innerInnerArg.Arguments.Nodes) == 0 {
+		return false
+	}
+	innerFn := reactutil.SkipExpressionWrappers(innerInnerArg.Arguments.Nodes[0])
+	if !reactutil.MatchesAnyComponentWrapperWithChecker(first, innerFn, w.wrappers, w.pragma, w.tc) {
+		return false
+	}
+	return reactutil.MatchesAnyComponentWrapperWithChecker(node, first, w.wrappers, w.pragma, w.tc)
+}
+
+// DisplayNameRule is the registered rule. Use the `react/` prefix in
+// registration.
+var DisplayNameRule = rule.Rule{
+	Name: "react/display-name",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+		wrappers := reactutil.GetComponentWrapperFunctions(ctx.Settings, pragma)
+
+		// upstream: `(config.checkContextObjects || false) &&
+		// testReactVersion(context, '>= 16.3.0')` — the React-version gate
+		// is independent of the option and silently disables it on older
+		// configured versions.
+		checkContextObjects := opts.CheckContextObjects && reactVersionAtLeast(ctx.Settings, 16, 3, 0)
+		nestedMemoSupported := supportsNestedMemo(ctx.Settings)
+
+		w := &nodeWalker{
+			ctx:                 ctx,
+			opts:                opts,
+			pragma:              pragma,
+			createClass:         createClass,
+			wrappers:            wrappers,
+			tc:                  ctx.TypeChecker,
+			checkContextObjects: checkContextObjects,
+			nestedMemoSupported: nestedMemoSupported,
+			byNode:              map[*ast.Node]*detectedComponent{},
+			nameToComponent:     map[string]*detectedComponent{},
+			topBindings:         map[string]*ast.Node{},
+			contextObjects:      map[string]*contextEntry{},
+		}
+		w.collect()
+
+		// Report missing displayNames in source order — mirrors upstream's
+		// `values(list).filter(...).forEach(reportMissingDisplayName)`.
+		for _, comp := range w.order {
+			if comp.hasDisplayName {
+				continue
+			}
+			if w.nestedMemoSupported && w.isNestedMemo(comp.node) {
+				continue
+			}
+			if w.isShadowedComponent(comp.node) {
+				continue
+			}
+			ctx.ReportRange(reportRangeFor(ctx, comp.node), rule.RuleMessage{
+				Id:          "noDisplayName",
+				Description: "Component definition is missing display name",
+			})
+		}
+		// Report missing displayNames for context objects — preserve
+		// declaration order via a stable iteration (Go's `range` over map
+		// is intentionally randomized; we recover order by replaying the
+		// source-file walk).
+		if checkContextObjects {
+			reportContextObjects(ctx, w)
+		}
+
+		return rule.RuleListeners{}
+	},
+}
+
+// reportContextObjects emits the `noContextDisplayName` diagnostic for every
+// tracked context object whose `hasDisplayName` is false, in source-file
+// declaration order. Iterating Go's map directly would randomize the
+// reports; we replay the AST walk so the report order matches upstream's
+// `forEach(filter(contextObjects.values(), ...))`.
+func reportContextObjects(ctx rule.RuleContext, w *nodeWalker) {
+	type pendingContext struct {
+		node *ast.Node
+		pos  int
+	}
+	var pending []pendingContext
+	for _, e := range w.contextObjects {
+		if e.hasDisplayName {
+			continue
+		}
+		trimmed := utils.TrimNodeTextRange(ctx.SourceFile, e.node)
+		pending = append(pending, pendingContext{node: e.node, pos: trimmed.Pos()})
+	}
+	sort.SliceStable(pending, func(i, j int) bool {
+		return pending[i].pos < pending[j].pos
+	})
+	for _, p := range pending {
+		ctx.ReportRange(reportRangeFor(ctx, p.node), rule.RuleMessage{
+			Id:          "noContextDisplayName",
+			Description: "Context definition is missing display name",
+		})
+	}
+}
+
+// reportRangeFor returns the diagnostic range for `node`, aligned with
+// upstream's ESTree-style coordinates.
+//
+// For ClassDeclaration / ClassExpression: ESTree splits `export default
+// class …` into `ExportDefaultDeclaration > ClassDeclaration`, so the class
+// node's range starts past the `export default` flow modifiers but keeps
+// `abstract` / `declare` / decorators on the class itself. tsgo flattens
+// all modifiers onto the ClassDeclaration; we recover ESTree's range by
+// skipping `export` / `default` keywords only and stopping at the first
+// other modifier (or at the `class` keyword when there is none).
+//
+// For every other node, the standard trimmed-trivia range matches upstream.
+func reportRangeFor(ctx rule.RuleContext, node *ast.Node) core.TextRange {
+	defaultRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+	if node == nil {
+		return defaultRange
+	}
+	switch node.Kind {
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		text := ctx.SourceFile.Text()
+		mods := node.Modifiers()
+		pos := node.Pos()
+		if mods != nil {
+			for _, mod := range mods.Nodes {
+				switch mod.Kind {
+				case ast.KindExportKeyword, ast.KindDefaultKeyword:
+					pos = mod.End()
+				default:
+					// Decorators / abstract / declare — stop skipping but
+					// keep the modifier in the range. Anchor `pos` at the
+					// modifier's start so SkipTrivia lands on the modifier
+					// (matching ESTree, which keeps `abstract` / decorators
+					// on the ClassDeclaration node itself).
+					pos = mod.Pos()
+					start := scanner.SkipTrivia(text, pos)
+					return core.NewTextRange(start, node.End())
+				}
+			}
+		}
+		start := scanner.SkipTrivia(text, pos)
+		return core.NewTextRange(start, node.End())
+	}
+	return defaultRange
+}

--- a/internal/plugins/react/rules/display_name/display_name.md
+++ b/internal/plugins/react/rules/display_name/display_name.md
@@ -1,0 +1,161 @@
+# display-name
+
+## Rule Details
+
+Disallow missing `displayName` in a React component definition.
+
+`displayName` allows you to name your component. This name is used by React in debugging messages.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  render: function () {
+    return <div>Hello {this.props.name}</div>;
+  },
+});
+
+const Hello = React.memo(({ a }) => {
+  return <>{a}</>;
+});
+
+export default ({ a }) => {
+  return <>{a}</>;
+};
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  displayName: 'Hello',
+  render: function () {
+    return <div>Hello {this.props.name}</div>;
+  },
+});
+
+const Hello = React.memo(function Hello({ a }) {
+  return <>{a}</>;
+});
+```
+
+## Rule Options
+
+### `ignoreTranspilerName` (default: `false`)
+
+When `true` the rule will ignore the name set by the transpiler and require a `displayName` property in this case.
+
+Examples of **correct** code for this rule with `{ ignoreTranspilerName: true }`:
+
+```json
+{ "react/display-name": ["error", { "ignoreTranspilerName": true }] }
+```
+
+```jsx
+var Hello = createReactClass({
+  displayName: 'Hello',
+  render: function () {
+    return <div>Hello {this.props.name}</div>;
+  },
+});
+module.exports = Hello;
+```
+
+```jsx
+export default class Hello extends React.Component {
+  render() {
+    return <div>Hello {this.props.name}</div>;
+  }
+}
+Hello.displayName = 'Hello';
+```
+
+Examples of **incorrect** code for this rule with `{ ignoreTranspilerName: true }`:
+
+```json
+{ "react/display-name": ["error", { "ignoreTranspilerName": true }] }
+```
+
+```jsx
+var Hello = createReactClass({
+  render: function () {
+    return <div>Hello {this.props.name}</div>;
+  },
+});
+module.exports = Hello;
+```
+
+```jsx
+export default class Hello extends React.Component {
+  render() {
+    return <div>Hello {this.props.name}</div>;
+  }
+}
+```
+
+### `checkContextObjects` (default: `false`)
+
+When `true`, this rule will also warn on context objects (created via `React.createContext()` / `createContext()`) that don't have a `displayName` set.
+
+This option is silently disabled when `settings.react.version` is below `16.3.0`, since `Context.displayName` was introduced in React 16.3.
+
+Examples of **incorrect** code for this rule with `{ checkContextObjects: true }`:
+
+```json
+{ "react/display-name": ["error", { "checkContextObjects": true }] }
+```
+
+```jsx
+const Hello = React.createContext();
+```
+
+```jsx
+const Hello = createContext();
+```
+
+Examples of **correct** code for this rule with `{ checkContextObjects: true }`:
+
+```json
+{ "react/display-name": ["error", { "checkContextObjects": true }] }
+```
+
+```jsx
+const Hello = React.createContext();
+Hello.displayName = 'HelloContext';
+```
+
+```jsx
+const Hello = createContext();
+Hello.displayName = 'HelloContext';
+```
+
+## About component detection
+
+For this rule to work we need to detect React components, this could be very hard since components could be declared in a lot of ways.
+
+For now we detect components created with:
+
+- `createReactClass()`
+- an ES6 class that inherits from `React.Component` / `Component` / `PureComponent`
+- a stateless function that returns JSX or the result of a `React.createElement` call
+- `React.memo` / `React.forwardRef` (or destructured `memo` / `forwardRef`) wrapping any of the above
+
+## Settings
+
+This rule is influenced by the shared React settings:
+
+- `settings.react.pragma` — the `React` object name used for `<pragma>.Component` / `<pragma>.createContext` / `<pragma>.memo` / `<pragma>.forwardRef` matching (default: `"React"`).
+- `settings.react.createClass` — the `createReactClass` factory name used for ES5 component detection (default: `"createReactClass"`).
+- `settings.react.version` — gates the version-dependent behaviors:
+  - Nested `<pragma>.memo(<pragma>.forwardRef(...))` is allowed for `^0.14.10 || ^15.7.0 || >= 16.12.0` (default: latest).
+  - `checkContextObjects` is silently disabled when below `16.3.0`.
+- `settings.componentWrapperFunctions` — additional wrapper factories beyond `memo` / `forwardRef`. Accepts strings (`"observer"`) or `{ property, object }` entries. The `<pragma>` placeholder is substituted with the configured pragma.
+
+## When Not To Use It
+
+If you are not interested in giving every component a `displayName` and rely on bundler / transpiler-derived names for debugging, you can disable this rule.
+
+## Original Documentation
+
+- [eslint-plugin-react / display-name](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/display-name.js)

--- a/internal/plugins/react/rules/display_name/display_name_test.go
+++ b/internal/plugins/react/rules/display_name/display_name_test.go
@@ -1,0 +1,2363 @@
+package display_name
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	noDisplayName        = "noDisplayName"
+	noContextDisplayName = "noContextDisplayName"
+)
+
+func TestDisplayNameRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &DisplayNameRule, []rule_tester.ValidTestCase{
+		// ---- Shadowed wrapper identifiers (React/memo/forwardRef) ----
+		{Code: `
+        import React, { memo, forwardRef } from 'react'
+
+        const TestComponent = function () {
+          {
+            const memo = (cb) => cb()
+            const forwardRef = (cb) => cb()
+            const React = { memo, forwardRef }
+
+            const BlockMemo = memo(() => <div>shadowed</div>)
+            const BlockForwardRef = forwardRef(() => <div>shadowed</div>)
+            const BlockReactMemo = React.memo(() => <div>shadowed</div>)
+          }
+          return null
+        }
+      `, Tsx: true},
+		{Code: `
+        import React, { memo, forwardRef } from 'react'
+
+        const Test1 = function (memo) {
+          return memo(() => <div>param shadowed</div>)
+        }
+
+        const Test2 = function ({ forwardRef }) {
+          return forwardRef(() => <div>destructured param</div>)
+        }
+      `, Tsx: true},
+		{Code: `
+        import React, { memo, forwardRef } from 'react'
+
+        const TestComponent = function () {
+          function innerFunction() {
+            const memo = (cb) => cb()
+            const React = { forwardRef }
+
+            const Comp = memo(() => <div>nested</div>)
+            const ForwardComp = React.forwardRef(() => <div>nested</div>)
+            return [Comp, ForwardComp]
+          }
+          return innerFunction()
+        }
+      `, Tsx: true},
+		{Code: `
+        import React, { memo, forwardRef } from 'react'
+
+        const MixedShadowed = function () {
+          const memo = (cb) => cb()
+          const { forwardRef } = { forwardRef: () => null }
+          const [React] = [{ memo, forwardRef }]
+
+          const Comp = memo(() => <div>shadowed</div>)
+          const ReactMemo = React.memo(() => null)
+          const ReactForward = React.forwardRef((props, ref) => ` + "`${props} ${ref}`" + `)
+          const OtherComp = forwardRef((props, ref) => ` + "`${props} ${ref}`" + `)
+
+          return [Comp, ReactMemo, ReactForward, OtherComp]
+        }
+      `, Tsx: true},
+
+		// ---- ES5 createReactClass with displayName + ignoreTranspilerName ----
+		{Code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+		{Code: `
+        var Hello = React.createClass({
+          displayName: 'Hello',
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"createClass": "createClass"},
+			},
+		},
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+        Hello.displayName = 'Hello'
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Class without React heritage ----
+		{Code: `
+        class Hello {
+          render() {
+            return 'Hello World';
+          }
+        }
+      `, Tsx: true},
+		{Code: `
+        class Hello extends Greetings {
+          static text = 'Hello World';
+          render() {
+            return Hello.text;
+          }
+        }
+      `, Tsx: true},
+		{Code: `
+        class Hello {
+          method;
+        }
+      `, Tsx: true},
+
+		// ---- Class with displayName as static property / getter ----
+		{Code: `
+        class Hello extends React.Component {
+          static get displayName() {
+            return 'Hello';
+          }
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+		{Code: `
+        class Hello extends React.Component {
+          static displayName = 'Widget';
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- ES5 createReactClass — has transpiler name (default ignoreTranspilerName=false) ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true},
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- export default class with binding name ----
+		{Code: `
+        export default class Hello {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Reassignment of declared variable ----
+		{Code: `
+        var Hello;
+        Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- module.exports with displayName property ----
+		{Code: `
+        module.exports = createReactClass({
+          "displayName": "Hello",
+          "render": function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- ES5 + spread + ignoreTranspilerName ----
+		{Code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {
+            let { a, ...b } = obj;
+            let c = { ...d };
+            return <div />;
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Anonymous default-exported class ----
+		{Code: `
+        export default class {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Named function expression inside React.memo ----
+		{Code: `
+        export const Hello = React.memo(function Hello() {
+          return <p />;
+        })
+      `, Tsx: true},
+
+		// ---- Named function expressions / declarations / arrows with binding ----
+		{Code: `
+        var Hello = function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      `, Tsx: true},
+		{Code: `
+        function Hello() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      `, Tsx: true},
+		{Code: `
+        var Hello = () => {
+          return <div>Hello {this.props.name}</div>;
+        }
+      `, Tsx: true},
+		{Code: `
+        module.exports = function Hello() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      `, Tsx: true},
+
+		// ---- Functional + Hello.displayName + ignoreTranspilerName ----
+		{Code: `
+        function Hello() {
+          return <div>Hello {this.props.name}</div>;
+        }
+        Hello.displayName = 'Hello';
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+		{Code: `
+        var Hello = () => {
+          return <div>Hello {this.props.name}</div>;
+        }
+        Hello.displayName = 'Hello';
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+		{Code: `
+        var Hello = function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+        Hello.displayName = 'Hello';
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Deep MemberExpression displayName ----
+		{Code: `
+        var Mixins = {
+          Greetings: {
+            Hello: function() {
+              return <div>Hello {this.props.name}</div>;
+            }
+          }
+        }
+        Mixins.Greetings.Hello.displayName = 'Hello';
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- ES5 createReactClass with helper render ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>{this._renderHello()}</div>;
+          },
+          _renderHello: function() {
+            return <span>Hello {this.props.name}</span>;
+          }
+        });
+      `, Tsx: true},
+		{Code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {
+            return <div>{this._renderHello()}</div>;
+          },
+          _renderHello: function() {
+            return <span>Hello {this.props.name}</span>;
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Object literal with shorthand method (capitalized — Mixin button) ----
+		{Code: `
+        const Mixin = {
+          Button() {
+            return (
+              <button />
+            );
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Lowercase shorthand — not a component ----
+		{Code: `
+        var obj = {
+          pouf: function() {
+            return any
+          }
+        };
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+		{Code: `
+        var obj = {
+          pouf: function() {
+            return any
+          }
+        };
+      `, Tsx: true},
+
+		// ---- export default object literal with method that returns JSX ----
+		{Code: `
+        export default {
+          renderHello() {
+            let {name} = this.props;
+            return <div>{name}</div>;
+          }
+        };
+      `, Tsx: true},
+
+		// ---- import + createClass settings ----
+		{Code: `
+        import React, { createClass } from 'react';
+        export default createClass({
+          displayName: 'Foo',
+          render() {
+            return <h1>foo</h1>;
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"createClass": "createClass"},
+			},
+		},
+
+		// ---- Decorator-style class returned from a factory ----
+		{Code: `
+        import React, {Component} from "react";
+        function someDecorator(ComposedComponent) {
+          return class MyDecorator extends Component {
+            render() {return <ComposedComponent {...this.props} />;}
+          };
+        }
+        module.exports = someDecorator;
+      `, Tsx: true},
+
+		// ---- Capitalized SomeComponent with createElement (not a component) ----
+		{Code: `
+        import React, {createElement} from "react";
+        const SomeComponent = (props) => {
+          const {foo, bar} = props;
+          return someComponentFactory({
+            onClick: () => foo(bar("x"))
+          });
+        };
+      `, Tsx: true},
+
+		// ---- Render-prop arrow inside JSX (not a component) ----
+		{Code: `
+        const element = (
+          <Media query={query} render={() => {
+            renderWasCalled = true
+            return <div/>
+          }}/>
+        )
+      `, Tsx: true},
+		{Code: `
+        const element = (
+          <Media query={query} render={function() {
+            renderWasCalled = true
+            return <div/>
+          }}/>
+        )
+      `, Tsx: true},
+
+		// ---- Object method named createElement (not React.createElement) ----
+		{Code: `
+        module.exports = {
+          createElement: tagName => document.createElement(tagName)
+        };
+      `, Tsx: true},
+		{Code: `
+        const { createElement } = document;
+        createElement("a");
+      `, Tsx: true},
+
+		// ---- Component + propTypes + React.memo wrapping ----
+		{Code: `
+        import React from 'react'
+        import { string } from 'prop-types'
+
+        function Component({ world }) {
+          return <div>Hello {world}</div>
+        }
+
+        Component.propTypes = {
+          world: string,
+        }
+
+        export default React.memo(Component)
+      `, Tsx: true},
+
+		// ---- React.memo wrapping named function (transpiler name) ----
+		{Code: `
+        import React from 'react'
+
+        const ComponentWithMemo = React.memo(function Component({ world }) {
+          return <div>Hello {world}</div>
+        })
+      `, Tsx: true},
+		{Code: `
+        import React from 'react';
+
+        const Hello = React.memo(function Hello() {
+          return;
+        });
+      `, Tsx: true},
+
+		// ---- React.forwardRef wrapping named function ----
+		{Code: `
+        import React from 'react'
+
+        const ForwardRefComponentLike = React.forwardRef(function ComponentLike({ world }, ref) {
+          return <div ref={ref}>Hello {world}</div>
+        })
+      `, Tsx: true},
+
+		// ---- Loop / array helpers / unrelated displayName field ----
+		{Code: `
+        function F() {
+          let items = [];
+          let testData = [
+            {a: "test1", displayName: "test2"}, {a: "test1", displayName: "test2"}];
+          for (let item of testData) {
+              items.push({a: item.a, b: item.displayName});
+          }
+          return <div>{items}</div>;
+        }
+      `, Tsx: true},
+
+		// ---- Empty class body (Flow type imports) ----
+		// SKIP: rslint does not support Flow object type spreads.
+
+		// ---- Object literal Cell render ----
+		{Code: `
+        const x = {
+          title: "URL",
+          dataIndex: "url",
+          key: "url",
+          render: url => (
+            <a href={url} target="_blank" rel="noopener noreferrer">
+              <p>lol</p>
+            </a>
+          )
+        }
+      `, Tsx: true},
+
+		// ---- Higher-order arrow returning named function (issue #2920) ----
+		{Code: `
+        const renderer = a => function Component(listItem) {
+          return <div>{a} {listItem}</div>;
+        };
+      `, Tsx: true},
+
+		// ---- React.forwardRef + Comp.displayName ----
+		{Code: `
+        const Comp = React.forwardRef((props, ref) => <main />);
+        Comp.displayName = 'MyCompName';
+      `, Tsx: true},
+
+		// ---- React.forwardRef + TS as expression + Comp.displayName ----
+		{Code: `
+        const Comp = React.forwardRef((props, ref) => <main data-as="yes" />) as SomeComponent;
+        Comp.displayName = 'MyCompNameAs';
+      `, Tsx: true},
+
+		// ---- Cell column (issue #3300 / #3289 / #3329 / #3334 / #3346) ----
+		{Code: `
+        function Test() {
+          const data = [
+            {
+              name: 'Bob',
+            },
+          ];
+
+          const columns = [
+            {
+              Header: 'Name',
+              accessor: 'name',
+              Cell: ({ value }) => <div>{value}</div>,
+            },
+          ];
+
+          return <ReactTable columns={columns} data={data} />;
+        }
+      `, Tsx: true},
+
+		{Code: `
+        const f = (a) => () => {
+          if (a) {
+            return null;
+          }
+          return 1;
+        };
+      `, Tsx: true},
+		{Code: `
+        class Test {
+          render() {
+            const data = [
+              {
+                name: 'Bob',
+              },
+            ];
+
+            const columns = [
+              {
+                Header: 'Name',
+                accessor: 'name',
+                Cell: ({ value }) => <div>{value}</div>,
+              },
+            ];
+
+            return <ReactTable columns={columns} data={data} />;
+          }
+        }
+      `, Tsx: true},
+		{Code: `
+        export const demo = (a) => (b) => {
+          if (a == null) return null;
+          return b;
+        }
+      `, Tsx: true},
+		{Code: `
+        let demo = null;
+        demo = (a) => {
+          if (a == null) return null;
+          return f(a);
+        };
+      `, Tsx: true},
+		{Code: `
+        obj._property = (a) => {
+          if (a == null) return null;
+          return f(a);
+        };
+      `, Tsx: true},
+		{Code: `
+        _variable = (a) => {
+          if (a == null) return null;
+          return f(a);
+        };
+      `, Tsx: true},
+		{Code: `
+        demo = () => () => null;
+      `, Tsx: true},
+		{Code: `
+        demo = {
+          property: () => () => null
+        }
+      `, Tsx: true},
+		{Code: `
+        demo = function() {return function() {return null;};};
+      `, Tsx: true},
+		{Code: `
+        demo = {
+          property: function() {return function() {return null;};}
+        }
+      `, Tsx: true},
+
+		// ---- React.memo with multiple args (issue #3303) ----
+		{Code: `
+        function MyComponent(props) {
+          return <b>{props.name}</b>;
+        }
+
+        const MemoizedMyComponent = React.memo(
+          MyComponent,
+          (prevProps, nextProps) => prevProps.name === nextProps.name
+        )
+      `, Tsx: true},
+
+		// ---- Nested memo+forwardRef accepted in supported React versions ----
+		{Code: `
+        import React from 'react'
+
+        const MemoizedForwardRefComponentLike = React.memo(
+          React.forwardRef(function({ world }, ref) {
+            return <div ref={ref}>Hello {world}</div>
+        })
+        )
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "16.14.0"},
+			},
+		},
+		{Code: `
+        import React from 'react'
+
+        const MemoizedForwardRefComponentLike = React.memo(
+          React.forwardRef(({ world }, ref) => {
+            return <div ref={ref}>Hello {world}</div>
+          })
+        )
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "15.7.0"},
+			},
+		},
+		{Code: `
+        import React from 'react'
+
+        const MemoizedForwardRefComponentLike = React.memo(
+          React.forwardRef(function ComponentLike({ world }, ref) {
+            return <div ref={ref}>Hello {world}</div>
+          })
+        )
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "16.12.1"},
+			},
+		},
+		{Code: `
+        export const ComponentWithForwardRef = React.memo(
+          React.forwardRef(function Component({ world }) {
+            return <div>Hello {world}</div>
+          })
+        )
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "0.14.11"},
+			},
+		},
+		{Code: `
+        import React from 'react'
+
+        const MemoizedForwardRefComponentLike = React.memo(
+          React.forwardRef(function({ world }, ref) {
+            return <div ref={ref}>Hello {world}</div>
+          })
+        )
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "15.7.1"},
+			},
+		},
+
+		// ---- checkContextObjects: true with explicit displayName ----
+		{Code: `
+        import React from 'react';
+
+        const Hello = React.createContext();
+        Hello.displayName = "HelloContext"
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+		{Code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+        Hello.displayName = "HelloContext"
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+		{Code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+
+        const obj = {};
+        obj.displayName = "False positive";
+
+        Hello.displayName = "HelloContext"
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+		{Code: `
+        import * as React from 'react';
+
+        const Hello = React.createContext();
+
+        const obj = {};
+        obj.displayName = "False positive";
+
+        Hello.displayName = "HelloContext";
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+		{Code: `
+        const obj = {};
+        obj.displayName = "False positive";
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+
+		// ---- React version too old for context check (silently disabled) ----
+		{Code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+      `, Tsx: true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.2.0"}},
+			Options:  map[string]interface{}{"checkContextObjects": true},
+		},
+
+		// ---- React version >16.3.0 with context displayName ----
+		{Code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+        Hello.displayName = "HelloContext";
+      `, Tsx: true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": ">16.3.0"}},
+			Options:  map[string]interface{}{"checkContextObjects": true},
+		},
+
+		// ---- let / var assignments creating contexts ----
+		{Code: `
+        import { createContext } from 'react';
+
+        let Hello;
+        Hello = createContext();
+        Hello.displayName = "HelloContext";
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+
+		// ---- checkContextObjects: false leaves context unchecked ----
+		{Code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+      `, Tsx: true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": ">16.3.0"}},
+			Options:  map[string]interface{}{"checkContextObjects": false},
+		},
+
+		// ---- var Hello reassignment with createContext ----
+		{Code: `
+        import { createContext } from 'react';
+
+        var Hello;
+        Hello = createContext();
+        Hello.displayName = "HelloContext";
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+		{Code: `
+        import { createContext } from 'react';
+
+        var Hello;
+        Hello = React.createContext();
+        Hello.displayName = "HelloContext";
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+
+		// ---- Lock-in: bare options object (CLI-shape) for ignoreTranspilerName ----
+		// Locks in upstream config.go:414-420 single-element option-array
+		// unwrapping. Without GetOptionsMap this would silently fall back to
+		// defaults and the test would fail.
+		{Code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Lock-in: array-wrapped options shape ([{...}]) ----
+		// Locks in `utils.GetOptionsMap` array-form unwrap. The CLI sends
+		// `["error", {...}]` → after the level-1 unwrap, options arrives as
+		// an interface array; GetOptionsMap takes [0]. This shape exercises
+		// the same code path JS rule-tester uses.
+		{Code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `, Tsx: true, Options: []interface{}{map[string]interface{}{"ignoreTranspilerName": true}}},
+
+		// ---- Lock-in: bracket-access displayName property (tsgo ElementAccessExpression) ----
+		// `Foo['displayName'] = 'Foo'` is upstream's MemberExpression with
+		// `computed: true`. tsgo splits it into ElementAccessExpression
+		// (vs PropertyAccessExpression for dot-access). Both must mark the
+		// component — this case locks in the ElementAccessExpression arm.
+		{Code: `
+        function Hello() {
+          return <div>Hello</div>;
+        }
+        Hello['displayName'] = 'Hello';
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Lock-in: computed displayName key on class field (string literal) ----
+		// `class Foo extends React.Component { ['displayName'] = 'Foo' }` —
+		// tsgo wraps the string literal in a ComputedPropertyName. Upstream
+		// `propsUtil.isDisplayNameDeclaration` matches a string-literal
+		// `'displayName'` key. We must peek through ComputedPropertyName.
+		{Code: `
+        class Hello extends React.Component {
+          ['displayName'] = 'Hello';
+          render() { return <div>Hello</div>; }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Lock-in: TS abstract class extends React.Component ----
+		// Upstream's namedClass requires `node.id.name`. Both
+		// `abstract class Foo extends React.Component {}` and the TS-only
+		// abstract modifier are recognized. ESTree keeps `abstract` on the
+		// ClassDeclaration; rslint must too.
+		{Code: `
+        abstract class Hello extends React.Component {
+          render() { return <div>Hello</div>; }
+        }
+      `, Tsx: true},
+
+		// ---- Lock-in: declare class extends Component (body-absent) ----
+		// `declare` classes have no runtime body — upstream's component
+		// detection treats them like any other named class extending
+		// Component (named id → no diagnostic). Lock that in.
+		{Code: `
+        declare class Hello extends React.Component {
+          render(): JSX.Element;
+        }
+      `, Tsx: true},
+
+		// ---- Lock-in: forwardRef wrapping a known sibling component ----
+		// `nodeWrapsComponent` gate: when forwardRef wraps an arrow whose
+		// JSX root tag names an existing component, the forwardRef call is
+		// NOT itself a component (it's a passthrough). No diagnostic.
+		{Code: `
+        class StoreListItem extends React.PureComponent {
+          render() { return <div />; }
+        }
+        export default React.forwardRef((props, ref) => <StoreListItem {...props} forwardRef={ref} />);
+      `, Tsx: true},
+
+		// ---- Lock-in: triply-nested wrapper with all layers named ----
+		// `memo(memo(memo(named)))` — upstream's `getStatelessComponent`
+		// returns the OUTERMOST wrapper. With named inner FN, transpiler
+		// name is on the inner; the CallExpression listener for the
+		// outermost (no further outer wrapper, FunctionLike arg = inner
+		// memo, NOT FunctionLikeExpression in upstream's check) would
+		// behave differently. With this React version, all named → 0
+		// reports. Locks in component-identity dedup across multiple
+		// wrapper layers.
+		{Code: `
+        const MemoMemo = React.memo(React.memo(function Inner() { return <div/>; }));
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "16.14.0"},
+			},
+		},
+
+		// ---- Lock-in: TS satisfies / non-null wrappers around forwardRef call ----
+		// `React.forwardRef(...) satisfies SomeT` and `React.forwardRef(...)!`
+		// — both are TS-only expression wrappers that ESTree doesn't have.
+		// `bindingNameForCallExpression` walks past these so `Comp.displayName
+		// = ...` resolves through them.
+		{Code: `
+        const Comp = React.forwardRef((props, ref) => <main />) satisfies SomeT;
+        Comp.displayName = 'MyCompName';
+      `, Tsx: true},
+		{Code: `
+        const Comp = React.forwardRef((props, ref) => <main />)!;
+        Comp.displayName = 'MyCompName';
+      `, Tsx: true},
+
+		// ---- Lock-in: parenthesized createReactClass argument ----
+		// Upstream flattens parens; tsgo preserves them. The createReactClass
+		// detection must walk past parens around the object literal.
+		{Code: `
+        var Hello = createReactClass(({
+          displayName: 'Hello',
+          render: function() { return <div/>; }
+        }));
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Lock-in: getter / setter named displayName on class body ----
+		// Upstream's `MethodDefinition` listener marks a `displayName`
+		// getter / setter on class body as a displayName decl. tsgo splits
+		// these into KindGetAccessor / KindSetAccessor; both must qualify.
+		{Code: `
+        class Hello extends React.Component {
+          set displayName(v) {}
+          render() { return <div/>; }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Lock-in: MethodDeclaration shorthand inside ObjectLiteral ----
+		// `{ Hello() { return <div/> } }` — tsgo collapses ESTree's
+		// `Property { method: true, value: FunctionExpression }` into a
+		// MethodDeclaration directly under ObjectLiteralExpression. The
+		// method's transpiler name comes from the parent's key (uppercase
+		// → component candidate; matches `parent.method === true` arm).
+		{Code: `
+        const Mixin = {
+          Hello() {
+            return <div/>;
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Lock-in: non-React class doesn't classify (no extends) ----
+		// `class Foo {}` without React heritage is never a component.
+		{Code: `
+        class Hello {
+          render() { return <div/>; }
+        }
+      `, Tsx: true},
+
+		// ---- Lock-in: createReactClass without ignoreTranspilerName + reassignment ----
+		// `var X; X = createReactClass(...)` — Identifier-LHS assignment.
+		// `hasTranspilerNameForObject` must walk through the createReactClass
+		// CallExpression to reach the BinaryExpression and check that LHS
+		// is not module.exports.
+		{Code: `
+        var Hello;
+        Hello = createReactClass({
+          render: function() { return <div/>; }
+        });
+      `, Tsx: true},
+
+		// ---- Lock-in: deep MemberExpression with object-literal nesting ----
+		// Upstream's `getRelatedComponent` walks `Mixins.Greetings.Hello`
+		// through nested ObjectLiteralExpression properties. Lock in the
+		// path-resolution behavior — Hello inside Greetings inside Mixins.
+		{Code: `
+        var Mixins = {
+          Greetings: {
+            Hello: function() {
+              return <div>Hello</div>;
+            }
+          }
+        };
+        Mixins.Greetings.Hello.displayName = 'Hello';
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Lock-in: shadowing via let-rebinding inside the function ----
+		// Beyond const/var, `let memo = ...` also shadows.
+		{Code: `
+        import { memo } from 'react'
+        const TestComponent = function () {
+          let memo = (cb) => cb()
+          const X = memo(() => <div>shadowed</div>)
+          return X
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: TS generic arrow component ----
+		// `const Comp = <T,>(props: { v: T }) => <div/>` — a common TS
+		// pattern. Has transpiler name from the binding `Comp`. The
+		// `<T,>` syntax is parsed as a TypeParameter list; the arrow's
+		// classification must not be confused by it.
+		{Code: `
+        const Comp = <T,>(props: { value: T }) => <div>{props.value}</div>;
+      `, Tsx: true},
+
+		// ---- Real-world: TypeScript class with type parameters ----
+		// `class Foo<P> extends React.Component<P>` — generic class.
+		// `ExtendsReactComponent` reads through TypeArguments. Has id.
+		{Code: `
+        class Hello<P extends { name: string }> extends React.Component<P> {
+          render() { return <div>{this.props.name}</div>; }
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: React.FC type annotation ----
+		// `const Comp: React.FC = () => <div/>` — TS type annotation on the
+		// VariableDeclaration doesn't change the binding shape. Transpiler
+		// name still derives from `Comp`.
+		{Code: `
+        const Hello: React.FC = () => <div>Hello</div>;
+      `, Tsx: true},
+		{Code: `
+        const Hello: React.FC<{ name: string }> = ({ name }) => <div>Hello {name}</div>;
+      `, Tsx: true},
+
+		// ---- Real-world: arrow assigned via destructured rebinding ----
+		// `const { Foo } = { Foo: () => <div/> }` — the Foo binding is via
+		// destructuring, not a direct `var Foo = ...`. Upstream `Components.detect`
+		// won't classify the inner arrow on its own (parent is PropertyAssignment
+		// in a non-createReactClass object). Treat as no component → no report.
+		{Code: `
+        const { Hello } = { Hello: () => <div>Hello</div> };
+      `, Tsx: true},
+
+		// ---- Real-world: Component + propTypes + memo wrapping ----
+		// Common React + TypeScript pattern with named function. Upstream
+		// & rslint: function Component is named, transpiler name applies,
+		// React.memo doesn't add a separate component (first arg is
+		// Identifier, not FunctionLikeExpression).
+		{Code: `
+        function Hello({ name }: { name: string }) { return <div>{name}</div>; }
+        Hello.propTypes = { name: () => null };
+        export default React.memo(Hello);
+      `, Tsx: true},
+
+		// ---- Real-world: forwardRef with named inner function + type parameters ----
+		// Named inner FN `Inner` carries the transpiler name; the wrapper
+		// inherits it via `getStatelessComponent → outermostWrapper` redirect.
+		// Type arguments on forwardRef don't affect classification.
+		{Code: `
+        const Hello = React.forwardRef<HTMLDivElement, { world: string }>(
+          function Inner(props, ref) {
+            return <div ref={ref}>Hello {props.world}</div>;
+          }
+        );
+      `, Tsx: true},
+
+		// ---- Real-world: deeply nested wrapper with named inner ----
+		// `memo(forwardRef(memo(function Inner() {...})))` — three layers,
+		// inner is named. Outermost has transpiler name (from inner's id),
+		// no report.
+		{Code: `
+        const Hello = React.memo(
+          React.forwardRef(
+            React.memo(function Inner({ world }, ref) {
+              return <div ref={ref}>Hello {world}</div>;
+            })
+          )
+        );
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "16.14.0"},
+			},
+		},
+
+		// ---- Real-world: memo with displayName via assignment ----
+		// `const Comp = React.memo(...); Comp.displayName = '...'` — the
+		// wrapper-call component is identified via `Comp` binding name; the
+		// PropertyAccessExpression listener marks it.
+		{Code: `
+        const Hello = React.memo((props) => <div>{props.name}</div>);
+        Hello.displayName = 'HelloMemo';
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Real-world: ES5 + multiple property assignments to displayName ----
+		// `Foo.displayName = 'A'; Foo.displayName = 'B';` — both fire the
+		// MemberExpression listener; both mark. End state: marked.
+		{Code: `
+        var Hello = createReactClass({
+          render: function() { return <div/>; }
+        });
+        Hello.displayName = 'A';
+        Hello.displayName = 'B';
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Real-world: arrow in JSX render prop (not a component) ----
+		// `<Comp render={() => <div/>}/>` — the inner arrow is in JSX
+		// attribute position; not in an allowed component position.
+		// Branch 12 reject. No report.
+		{Code: `
+        const x = <Comp render={() => <div/>} renderItem={(item) => <span>{item}</span>}/>;
+      `, Tsx: true},
+
+		// ---- Real-world: arrow in array literal (not a component) ----
+		// `[() => <div/>]` — bare arrow in array literal isn't an allowed
+		// position. No detection.
+		{Code: `
+        const arr = [() => <div/>, function() { return <div/>; }];
+      `, Tsx: true},
+
+		// ---- Real-world: HOC pattern with bare Identifier arg ----
+		// `withRouter(SomeNamedFn)` — first arg is Identifier, not
+		// FunctionLike. The HOC call is NOT a component; the named SomeNamedFn
+		// is the component (if extended/etc.). Lock-in: no extra component
+		// added for the call.
+		{Code: `
+        function NamedComp({ x }) { return <div>{x}</div>; }
+        const Wrapped = withRouter(NamedComp);
+      `, Tsx: true},
+
+		// ---- Real-world: createContext with default value argument ----
+		// `createContext('defaultValue')` — first arg is a string, but
+		// upstream still treats this as createContext. With displayName set,
+		// no diagnostic.
+		{Code: `
+        import { createContext } from 'react';
+        const Hello = createContext('defaultValue');
+        Hello.displayName = 'HelloContext';
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+
+		// ---- Real-world: TypeScript abstract method with displayName ----
+		// `class Foo extends React.Component { abstract render(): JSX.Element; }`
+		// — abstract member has no body; class has id. Has transpiler name.
+		{Code: `
+        abstract class Hello extends React.Component {
+          abstract render(): JSX.Element;
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: PropertyAccess on `this` (NOT a component) ----
+		// `this.displayName = 'Foo'` inside a method — the receiver is
+		// `this`, not an Identifier matching a component. Should NOT mark
+		// any component (and not crash).
+		{Code: `
+        class Hello extends React.Component {
+          constructor(props) {
+            super(props);
+            this.displayName = 'Hello';
+          }
+          render() { return <div/>; }
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: optional-chain wrapper + named inner ----
+		// `React?.memo(function Inner() {...})` — both member-level optional
+		// AND named inner FN. Named inner gives transpiler name; the
+		// optional chain on the member access doesn't disrupt detection.
+		{Code: `
+        const Hello = React?.memo(function Inner(props) { return <div>{props.name}</div>; });
+      `, Tsx: true},
+
+		// ---- Real-world: wrapper assigned to module.exports ----
+		// `module.exports = React.memo(function Inner() {...})` — wrapper
+		// not directly bound to a variable, but inner FN has own id →
+		// transpiler name.
+		{Code: `
+        module.exports = React.memo(function Hello() { return <div/>; });
+      `, Tsx: true},
+
+		// ---- Real-world: ES5 createReactClass via React.createClass + setting ----
+		// `React.createClass({...})` requires `react.createClass: 'createClass'`
+		// setting — `IsCreateClassCall` matches `<pragma>.<createClass>` only
+		// when the configured createClass name matches.
+		{Code: `
+        var Hello = React.createClass({
+          render: function() { return <div/>; }
+        });
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"createClass": "createClass"},
+			},
+		},
+
+		// ---- Real-world: TS class with multiple modifiers (export default abstract) ----
+		// `export default abstract class Foo extends React.Component`
+		// — modifier list = [export, default, abstract]. Has id `Foo`,
+		// transpiler name. No diagnostic. Locks in modifier-skipping order.
+		{Code: `
+        export default abstract class Hello extends React.Component {
+          abstract render(): JSX.Element;
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: declaration merging — function + namespace ----
+		// `function Foo() {} namespace Foo { ... }` — only the FN classifies
+		// as a component (namespace doesn't contribute). FN is named, has
+		// transpiler name. No diagnostic.
+		{Code: `
+        function Hello(props: { name: string }) { return <div>{props.name}</div>; }
+        namespace Hello {
+          export const defaultProps = { name: 'World' };
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: import-then-extend (createReactClass aliased) ----
+		// `import { createClass as createReactClass } from 'react'` — TS
+		// import alias. Default `createClass` setting still matches
+		// `createReactClass` callee name. We're testing that aliasing
+		// doesn't break detection (same call shape after binding).
+		{Code: `
+        import { createClass as createReactClass } from 'react';
+        var Hello = createReactClass({
+          render: function() { return <div/>; }
+        });
+      `, Tsx: true},
+
+		// ---- Real-world: chained method-call wrapper ----
+		// `module.exports = React.memo()(component)` — confused chain that
+		// upstream's `isPragmaComponentWrapper` does NOT match (callee is
+		// CallExpression `React.memo()`, not MemberExpression / Identifier).
+		// Inner arrow is in CallExpression-arg position → Branch 12 reject.
+		// No detection. No diagnostic.
+		{Code: `
+        module.exports = React.memo()((props) => <div>{props.name}</div>);
+      `, Tsx: true},
+
+		// ---- Real-world: createContext with TS as wrapper ----
+		// `const X = createContext() as Context<T>` — `resolveCreateContextCall`
+		// SkipExpressionWrappers handles the outer `as`. Hello.displayName set
+		// → no diagnostic.
+		{Code: `
+        import { createContext } from 'react';
+        const Hello = (createContext() as React.Context<{ name: string }>);
+        Hello.displayName = 'HelloContext';
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+
+		// ---- Real-world: createContext via call-level TS satisfies ----
+		// Same shape as `as` but using `satisfies`. Both are TS-only
+		// expression wrappers; `SkipExpressionWrappers` peels both.
+		{Code: `
+        import { createContext } from 'react';
+        const Hello = (createContext() satisfies React.Context<unknown>);
+        Hello.displayName = 'HelloContext';
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true}},
+
+		// ---- Real-world: empty source file ----
+		// No content → no components → no errors.
+		{Code: ``, Tsx: true},
+
+		// ---- Real-world: pure-type code (no runtime components) ----
+		// Type-only declarations — none classify as components.
+		{Code: `
+        type Props = { name: string };
+        interface Helper { foo(): void; }
+        type Comp = React.FC<Props>;
+      `, Tsx: true},
+
+		// ---- Real-world: extreme nesting — class component containing arrow ----
+		// `class Outer { render() { const handleClick = () => {...}; return <div/>; } }`
+		// — handleClick is lowercase arrow inside a class method. NOT a component.
+		// Class is named → no diagnostic.
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            const handleClick = () => { console.log('click'); };
+            const renderHelper = () => <span>helper</span>;
+            return <div onClick={handleClick}>{renderHelper()}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: forwardRef + named inner inside TS `as` cast ----
+		// `const Comp = forwardRef(function Inner(...) {...}) as ForwardRefExoticComponent`
+		// — has TS `as` wrapper outside the wrapper call. Inner FN is named
+		// → transpiler name carries through.
+		{Code: `
+        const Hello = React.forwardRef(function Inner(props, ref) {
+          return <div ref={ref}>{props.name}</div>;
+        }) as React.ForwardRefExoticComponent<any>;
+      `, Tsx: true},
+
+		// ---- Real-world: parameter destructuring with default in shadowed wrapper ----
+		// `function f({memo = x} = {}) { memo(...) }` — destructured param
+		// with default value still binds `memo`. Shadowing applies.
+		{Code: `
+        import { memo } from 'react'
+        function Test({ memo: localMemo = (cb) => cb() } = {}) {
+          return localMemo(() => <div>shadowed</div>);
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: ignore lowercase function declaration ----
+		// `function helper() { return <div/>; }` — lowercase name. Even
+		// though it returns JSX, lowercase prefix excludes it from
+		// `isComponentName` checks. Branch 12 reject. NOT a component.
+		{Code: `
+        function helper() { return <div/>; }
+        export default function App() { return helper(); }
+      `, Tsx: true},
+
+		// ---- Real-world: class component with abstract render ----
+		// `abstract class Foo extends React.Component { abstract render(): JSX.Element }`
+		// — body-absent abstract method. Class has id `Foo`, has transpiler name.
+		{Code: `
+        abstract class Hello extends React.Component {
+          abstract render(): JSX.Element;
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: class with declare modifier ----
+		// `declare class Foo extends React.Component {}` — has id, no body.
+		// Type-only declaration but still classifies as a named component.
+		{Code: `
+        declare class Hello extends React.Component {
+          render(): JSX.Element;
+        }
+      `, Tsx: true},
+
+		// ---- Real-world: forwardRef inside a custom HOC factory ----
+		// `withHOC(forwardRef(...))` — the inner forwardRef has wrapper status
+		// only if `withHOC` is configured. With default settings, withHOC
+		// isn't a wrapper, so the forwardRef call is just a wrapped FN that
+		// classifies. Inner arrow anonymous → reports the forwardRef call.
+		// Wait, that would be invalid. Move to invalid section if so.
+		// Actually: the parent of forwardRef is CallExpression (withHOC(...)).
+		// `Components.detect`'s CallExpression arm classifies forwardRef IF its
+		// first arg is FunctionLike. Yes. Then redirect to outermost wrapper:
+		// `outermostWrapperCall(arrow)` returns forwardRef (since withHOC
+		// isn't a wrapper). Register forwardRef. No transpiler name, no
+		// displayName decl... → would report. So move to invalid.
+
+		// ---- Real-world: forwardRef + memo nested with named inner (backwards) ----
+		// `forwardRef(memo(function Inner() {...}))` — opposite nesting from
+		// usual `memo(forwardRef(...))`. Inner is named. With nested-memo
+		// React version, both layers redirect to outermost. Has transpiler
+		// name from inner.
+		{Code: `
+        const Hello = React.forwardRef(React.memo(function Inner({ x }, ref) {
+          return <div ref={ref}>{x}</div>;
+        }));
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "16.14.0"},
+			},
+		},
+
+		// ---- Real-world: forwardRef returning null ----
+		// `forwardRef((props, ref) => null)` — returns null, not JSX. With
+		// `IsStatelessReactComponentWithWrappers`, null-only return WITH
+		// pragma wrapper IS classified (via the special null-return path).
+		// Inner arrow has no transpiler name; the wrapper has no binding
+		// here either... add a binding to make it valid:
+		{Code: `
+        const Hello = React.forwardRef(function Inner(props, ref) {
+          return null;
+        });
+      `, Tsx: true},
+
+		// ---- Real-world: class with displayName via static block ----
+		// `class Foo extends React.Component { static { Foo.displayName = 'Foo'; } }`
+		// — static initialization block sets displayName at class init time.
+		// Upstream's `MemberExpression` listener catches `Foo.displayName = ...`
+		// regardless of where it appears; the deep / nameToComponent path
+		// resolves `Foo`.
+		{Code: `
+        class Hello extends React.Component {
+          static {
+            Hello.displayName = 'Hello';
+          }
+          render() { return <div/>; }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true}},
+
+		// ---- Lock-in: `(arrow) as Type` in default-export position is NOT classified ----
+		// `export default ((arrow) as React.FC)` — both upstream's
+		// `isInAllowedPositionForComponent` and rslint's parent-walk look
+		// at the IMMEDIATE parent (skipping ParenthesizedExpression only).
+		// TS expression wrappers (`as` / `satisfies` / `!`) sit between the
+		// arrow and the ExportAssignment, so the arrow doesn't classify
+		// as a component and the lint doesn't fire. Lock in this
+		// (admittedly conservative) behavior to align with upstream.
+		{Code: `
+        export default ((props: { name: string }) => <div>{props.name}</div>) as React.FC<any>;
+      `, Tsx: true},
+		{Code: `
+        export default ((props: { x: string }) => <div>{props.x}</div>) satisfies React.FC<any>;
+      `, Tsx: true},
+		{Code: `
+        export default (((props: { x: string }) => <div>{props.x}</div>)!);
+      `, Tsx: true},
+
+		// ---- Lock-in: async generator banned — never classifies as component ----
+		// `async function* X() { return <div/>; }` — upstream's
+		// `Components.detect` registers async generators at confidence 0,
+		// which is permanently banned from `components.list()`. Without
+		// our explicit gate, the generator's `return <div/>` would slip
+		// through as JSX-returning and the rule would falsely report.
+		// In real code generators are never React components.
+		{Code: `
+        async function* Hello() {
+          yield 1;
+          return <div>not a component</div>;
+        }
+        export const Real = () => <div/>;
+      `, Tsx: true},
+
+		// FunctionExpression form of async generator (also banned).
+		{Code: `
+        const gen = async function* () {
+          return <div>not a component</div>;
+        };
+        export const Hello = () => <div/>;
+      `, Tsx: true},
+
+		// MethodDeclaration shorthand form of async generator (also banned).
+		{Code: `
+        const obj = {
+          async *Hello() {
+            return <div/>;
+          }
+        };
+        export const Real = () => <div/>;
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Shadowed-but-only-some-paths shadowed: the un-shadowed ones report ----
+		{Code: `
+        import React, { memo, forwardRef } from 'react'
+
+        const TestComponent = function () {
+          {
+            const BlockReactMemo = React.memo(() => {
+              return <div>not shadowed</div>
+            })
+
+            const BlockMemo = memo(() => {
+              return <div>not shadowed</div>
+            })
+
+            const BlockForwardRef = forwardRef((props, ref) => {
+              return ` + "`${props} ${ref}`" + `
+            })
+          }
+
+          return null
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noDisplayName},
+				{MessageId: noDisplayName},
+				{MessageId: noDisplayName},
+			},
+		},
+		{Code: `
+        import React, { memo, forwardRef } from 'react'
+
+        const Test1 = function () {
+          const Comp = memo(() => <div>not param shadowed</div>)
+          return Comp
+        }
+
+        const Test2 = function () {
+          function innerFunction() {
+            const Comp = memo(() => <div>nested not shadowed</div>)
+            const ForwardComp = React.forwardRef(() => <div>nested</div>)
+            return [Comp, ForwardComp]
+          }
+          return innerFunction()
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noDisplayName},
+				{MessageId: noDisplayName},
+				{MessageId: noDisplayName},
+			},
+		},
+		{Code: `
+        import React, { memo, forwardRef } from 'react'
+
+        const MixedNotShadowed = function () {
+          const Comp = memo(() => {
+            return <div>not shadowed</div>
+          })
+          const ReactMemo = React.memo(() => null)
+          const ReactForward = React.forwardRef((props, ref) => {
+            return ` + "`${props} ${ref}`" + `
+          })
+          const OtherComp = forwardRef((props, ref) => ` + "`${props} ${ref}`" + `)
+
+          return [Comp, ReactMemo, ReactForward, OtherComp]
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noDisplayName},
+				{MessageId: noDisplayName},
+				{MessageId: noDisplayName},
+				{MessageId: noDisplayName},
+			},
+		},
+
+		// ---- ES5 createReactClass without displayName + ignoreTranspilerName ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return React.createElement("div", {}, "text content");
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        var Hello = React.createClass({
+          render: function() {
+            return React.createElement("div", {}, "text content");
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"createClass": "createClass"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Class without displayName + ignoreTranspilerName ----
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Function returning createReactClass result ----
+		{Code: `
+        function HelloComponent() {
+          return createReactClass({
+            render: function() {
+              return <div>Hello {this.props.name}</div>;
+            }
+          });
+        }
+        module.exports = HelloComponent();
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- module.exports anonymous arrow / function ----
+		{Code: `
+        module.exports = () => {
+          return <div>Hello {props.name}</div>;
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        module.exports = function() {
+          return <div>Hello {props.name}</div>;
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- module.exports of createReactClass without displayName ----
+		{Code: `
+        module.exports = createReactClass({
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- ES5 with helper render method ----
+		{Code: `
+        var Hello = createReactClass({
+          _renderHello: function() {
+            return <span>Hello {this.props.name}</span>;
+          },
+          render: function() {
+            return <div>{this._renderHello()}</div>;
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- ES5 with custom pragma + createClass ----
+		{Code: `
+        var Hello = Foo.createClass({
+          _renderHello: function() {
+            return <span>Hello {this.props.name}</span>;
+          },
+          render: function() {
+            return <div>{this._renderHello()}</div>;
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{
+					"pragma":      "Foo",
+					"createClass": "createClass",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        /** @jsx Foo */
+        var Hello = Foo.createClass({
+          _renderHello: function() {
+            return <span>Hello {this.props.name}</span>;
+          },
+          render: function() {
+            return <div>{this._renderHello()}</div>;
+          }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"createClass": "createClass"},
+			},
+			// SKIP: rslint does not support ESLint's `/** @jsx ... */` directive
+			// comments. The pragma is read solely from settings.react.pragma.
+			Skip:   true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Object literal shorthand method as component + ignoreTranspilerName ----
+		{Code: `
+        const Mixin = {
+          Button() {
+            return (
+              <button />
+            );
+          }
+        };
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Higher-order anonymous function returning JSX ----
+		{Code: `
+        function Hof() {
+          return function () {
+            return <div />
+          }
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Anonymous arrow exporting createElement ----
+		{Code: `
+        import React, { createElement } from "react";
+        export default (props) => {
+          return createElement("div", {}, "hello");
+        };
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- React.memo / React.forwardRef with anonymous arrow ----
+		{Code: `
+        import React from 'react'
+
+        const ComponentWithMemo = React.memo(({ world }) => {
+          return <div>Hello {world}</div>
+        })
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        import React from 'react'
+
+        const ComponentWithMemo = React.memo(function() {
+          return <div>Hello {world}</div>
+        })
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        import React from 'react'
+
+        const ForwardRefComponentLike = React.forwardRef(({ world }, ref) => {
+          return <div ref={ref}>Hello {world}</div>
+        })
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        import React from 'react'
+
+        const ForwardRefComponentLike = React.forwardRef(function({ world }, ref) {
+          return <div ref={ref}>Hello {world}</div>
+        })
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Nested memo+forwardRef NOT supported in older React versions ----
+		{Code: `
+        import React from 'react'
+
+        const MemoizedForwardRefComponentLike = React.memo(
+          React.forwardRef(({ world }, ref) => {
+            return <div ref={ref}>Hello {world}</div>
+          })
+        )
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "15.6.0"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        import React from 'react'
+
+        const MemoizedForwardRefComponentLike = React.memo(
+          React.forwardRef(function({ world }, ref) {
+            return <div ref={ref}>Hello {world}</div>
+          })
+        )
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "0.14.2"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        import React from 'react'
+
+        const MemoizedForwardRefComponentLike = React.memo(
+          React.forwardRef(function ComponentLike({ world }, ref) {
+            return <div ref={ref}>Hello {world}</div>
+          })
+        )
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "15.0.1"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Destructured createElement from React ----
+		{Code: `
+        import React from "react";
+        const { createElement } = React;
+        export default (props) => {
+          return createElement("div", {}, "hello");
+        };
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        import React from "react";
+        const createElement = React.createElement;
+        export default (props) => {
+          return createElement("div", {}, "hello");
+        };
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Inner non-component functions don't shadow outer report ----
+		{Code: `
+        module.exports = function () {
+          function a () {}
+          const b = function b () {}
+          const c = function () {}
+          const d = () => {}
+          const obj = {
+            a: function a () {},
+            b: function b () {},
+            c () {},
+            d: () => {},
+          }
+          return React.createElement("div", {}, "text content");
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        module.exports = () => {
+          function a () {}
+          const b = function b () {}
+          const c = function () {}
+          const d = () => {}
+          const obj = {
+            a: function a () {},
+            b: function b () {},
+            c () {},
+            d: () => {},
+          }
+
+          return React.createElement("div", {}, "text content");
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+		{Code: `
+        export default class extends React.Component {
+          render() {
+            function a () {}
+            const b = function b () {}
+            const c = function () {}
+            const d = () => {}
+            const obj = {
+              a: function a () {},
+              b: function b () {},
+              c () {},
+              d: () => {},
+            }
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Two unrelated anonymous components — line/column assertions ----
+		{Code: `
+        export default class extends React.PureComponent {
+          render() {
+            return <Card />;
+          }
+        }
+
+        const Card = (() => {
+          return React.memo(({ }) => (
+            <div />
+          ));
+        })();
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noDisplayName, Line: 2, Column: 24},
+				{MessageId: noDisplayName, Line: 9, Column: 18},
+			},
+		},
+
+		// ---- Curried arrow returning JSX (issue) ----
+		{Code: `
+        const renderer = a => listItem => (
+          <div>{a} {listItem}</div>
+        );
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noDisplayName, Message: "Component definition is missing display name"},
+			},
+		},
+
+		// ---- componentWrapperFunctions setting ----
+		{Code: `
+        const processData = (options?: { value: string }) => options?.value || 'no data';
+
+        export const Component = observer(() => {
+          const data = processData({ value: 'data' });
+          return <div>{data}</div>;
+        });
+
+        export const Component2 = observer(() => {
+          const data = processData();
+          return <div>{data}</div>;
+        });
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"componentWrapperFunctions": []interface{}{"observer"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noDisplayName, Message: "Component definition is missing display name", Line: 4},
+				{MessageId: noDisplayName, Message: "Component definition is missing display name", Line: 9},
+			},
+		},
+
+		// ---- checkContextObjects: missing context displayName ----
+		{Code: `
+        import React from 'react';
+
+        const Hello = React.createContext();
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noContextDisplayName, Line: 4},
+			},
+		},
+		{Code: `
+        import * as React from 'react';
+
+        const Hello = React.createContext();
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noContextDisplayName, Line: 4},
+			},
+		},
+		{Code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noContextDisplayName, Line: 4},
+			},
+		},
+		{Code: `
+        import { createContext } from 'react';
+
+        var Hello;
+        Hello = createContext();
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noContextDisplayName, Line: 5},
+			},
+		},
+		{Code: `
+        import { createContext } from 'react';
+
+        var Hello;
+        Hello = React.createContext();
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noContextDisplayName, Line: 5},
+			},
+		},
+
+		// ---- Lock-in: anonymous arrow returning createElement ----
+		// Reachable via Branch 12 path: Arrow whose immediate parent is
+		// `module.exports = ...`. Has no transpiler name (LHS is
+		// member-expression `module.exports`, not an Identifier). Returns
+		// JSX. Reports.
+		{Code: `
+        module.exports = (props) => React.createElement("div", {}, "hello");
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Lock-in: ignoreTranspilerName + ES5 reassignment ----
+		// `var X; X = createReactClass(...)` — has transpiler name from the
+		// assignment, but with ignoreTranspilerName we still require an
+		// explicit displayName property.
+		{Code: `
+        var Hello;
+        Hello = createReactClass({
+          render: function() { return <div/>; }
+        });
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Lock-in: nested triple-memo without inner name (older React) ----
+		// `memo(memo(() => <div/>))` on React 15.6 — three layers, none
+		// named, none in nested-memo-supported range. The outermost
+		// reports (single component identity preserved by
+		// outermostWrapperCall redirect; inner layers don't double-report).
+		{Code: `
+        import React from 'react'
+
+        const T = React.memo(React.memo(() => <div/>))
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "15.6.0"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Lock-in: ES5 module.exports with createReactClass ----
+		// LHS `module.exports` disqualifies the named-object-assignment arm.
+		// No transpiler name even though the right-hand side is recognized.
+		// With ignoreTranspilerName=false, still reports because the rule
+		// checks transpiler name AND module.exports gates it out.
+		{Code: `
+        module.exports = createReactClass({
+          render: function() { return <div/>; }
+        });
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Lock-in: bare-Identifier wrapper without import ----
+		// `memo(() => <div/>)` — `memo` is a bare identifier with no
+		// React import. `MatchesAnyComponentWrapperWithChecker` gates the
+		// hardcoded `{Property: "memo"}` default behind
+		// `IsDestructuredFromPragmaImport`. Without the import, this is
+		// NOT a wrapper call, so the arrow is in CallExpression-arg
+		// position (Branch 12 reject); it doesn't classify. Pair with a
+		// valid component to verify only the valid one would normally
+		// register — here neither classifies, no errors.
+		// SKIP — covered indirectly: when memo isn't imported,
+		// the arrow doesn't classify as a component, so there's nothing
+		// to report. Add to invalid only if/when reactutil's import
+		// detection mode changes.
+
+		// ---- Lock-in: CallExpression args is empty ----
+		// `React.memo()` — the call has zero arguments. Detection must
+		// not crash and must skip. Pair with an anonymous arrow assigned
+		// to module.exports so the run still has an expected error and
+		// the empty-call short-circuit gets exercised on the same file.
+		{Code: `
+        const empty = React.memo();
+        module.exports = () => <div/>;
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Lock-in: CallExpression first arg is non-FunctionLike literal ----
+		// `React.memo(SomeOtherComp)` where SomeOtherComp is an Identifier
+		// — first arg is NOT a FunctionLikeExpression, the CallExpression
+		// arm of Components.detect requires `IsFunctionLikeForComponent`.
+		// No detection on the memo call. Pair with a real invalid one.
+		{Code: `
+        const SomeComp = function () { return <div/>; }
+        const Memoized = React.memo(SomeComp);
+        const Anon = React.memo(() => <div/>);
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: anonymous arrow returned from function ----
+		// `function makeComp() { return () => <div/>; }` — the inner arrow
+		// is in ReturnStatement position, no transpiler name. The outer
+		// `makeComp` returns it. Reports the inner arrow.
+		{Code: `
+        function makeComp() {
+          return () => <div/>;
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: TS generic anonymous arrow without binding ----
+		// Without a binding, `<T,>(props) => <div/>` has no transpiler name.
+		// In ExportAssignment position, gets registered → reports.
+		{Code: `
+        export default <T,>(props: { value: T }) => <div>{props.value}</div>;
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: forwardRef anonymous arrow + propTypes only ----
+		// `const Comp = React.forwardRef((props, ref) => ...)` then
+		// `Comp.propTypes = {...}` — no displayName, only propTypes. Reports.
+		{Code: `
+        const Hello = React.forwardRef((props, ref) => <div ref={ref}>{props.x}</div>);
+        Hello.propTypes = { x: () => null };
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: shadowed wrapper inside fn, but not at top level ----
+		// Mixed: shadowed memo inside a component, but a top-level memo that
+		// IS the imported one. Top-level reports; shadowed doesn't.
+		{Code: `
+        import { memo } from 'react'
+        const Outer = memo(() => <div>top-level</div>);
+
+        function inner() {
+          const memo = (cb) => cb();
+          return memo(() => <div>shadowed</div>);
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: ignoreTranspilerName + memo.displayName ----
+		// `const Comp = React.memo(...); Comp.displayName = '...'` —
+		// even with ignoreTranspilerName, explicit displayName satisfies.
+		// Inverse case: forgot to set displayName → reports.
+		{Code: `
+        const Hello = React.memo((props) => <div>{props.name}</div>);
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: createContext registered both in valid & invalid ----
+		// Multiple createContext calls in one file. checkContextObjects: true.
+		// One has displayName, the other doesn't. Order in source is preserved.
+		{Code: `
+        import { createContext } from 'react';
+        const A = createContext();
+        A.displayName = 'A';
+        const B = createContext();
+        const C = createContext();
+        C.displayName = 'C';
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noContextDisplayName},
+			},
+		},
+
+		// ---- Real-world: createContext via React.X without displayName ----
+		// React 16.3+ — checkContextObjects fires.
+		{Code: `
+        const Hello = React.createContext();
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true},
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.3.0"}},
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: noContextDisplayName}},
+		},
+
+		// ---- Real-world: nested wrapper, NONE named, OLD React ----
+		// `memo(memo(memo(arrow)))` — three layers, none named, on React
+		// 15.6 (BEFORE nested-memo support). Outermost is reported once
+		// (inner layers redirect to outermost via `outermostWrapperCall`,
+		// preserving single-component identity).
+		{Code: `
+        const Hello = React.memo(React.memo(React.memo(() => <div/>)));
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "15.6.0"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: deep MemberExpression with displayName missing ----
+		// `Mixins.Greetings.Hello` inner FN — without displayName declared,
+		// upstream reports the inner FN. ignoreTranspilerName disables the
+		// transpiler-name fallback.
+		{Code: `
+        var Mixins = {
+          Greetings: {
+            Hello: function() {
+              return <div>Hello</div>;
+            }
+          }
+        };
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: arrow in IIFE result returned from arrow ----
+		// `const x = (() => () => <div/>)()` — outer IIFE, inner returns
+		// arrow. The innermost arrow has no binding, in ReturnStatement
+		// position of an arrow body, with capitalized binding `x`?
+		// Actually `x` is lowercase — Branch 12 reject? Let me check.
+		// `Comp` capitalized binding makes the inner arrow classify.
+		{Code: `
+        const Hello = (() => () => <div/>)();
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: anonymous class component with null-only render ----
+		// `class extends React.Component { render() { return null; } }` —
+		// classifies (extends Component). Anonymous → no transpiler name.
+		// `ignoreTranspilerName` doesn't matter; it's anonymous.
+		{Code: `
+        export default class extends React.Component {
+          render() { return null; }
+        }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: anonymous class assigned to identifier (no class id) ----
+		// `var Foo = class extends React.Component {}` — anonymous class,
+		// but `Foo` binding gives transpiler name? In upstream, namedClass
+		// requires `node.id.name`, which is absent. So no transpiler name.
+		// VARIABLE binding gives namedFunctionExpression-style name only for
+		// FE/Arrow, NOT classes. Reports.
+		{Code: `
+        var Hello = class extends React.Component {
+          render() { return <div/>; }
+        };
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: ES5 createReactClass via call to non-pragma ----
+		// `var X = MyOwnFactory({ render: ... })` — not the configured
+		// createClass. NOT classified as ES5. The arrow inside might still
+		// classify though… actually there's no arrow returning JSX directly
+		// here, just an object literal. Not a component. No report.
+		// Inverse: with no component pattern, no diagnostic.
+		// Use an actual real-world FN to keep this list invalid:
+		{Code: `
+        var Helper = MyOwnFactory({ render: function() { return <div/>; } });
+        export default function() { return <div>I am the only component</div>; }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: forwardRef with TS as wrapper outside the call ----
+		// `const Comp = React.forwardRef(...) as ForwardRefExoticComponent<P>`
+		// — inner arrow is anonymous; outer wrapper bound via VariableDeclaration
+		// `Comp`. Has transpiler name. NO error (this is in valid).
+		// Inverse: WITHOUT outer binding → report:
+		{Code: `
+        export default React.forwardRef((props, ref) => <main ref={ref} />) as React.ForwardRefExoticComponent<any>;
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: anonymous memo arg in CallExpression position ----
+		// `const X = memo(() => <div/>)` — wrapper bound to `X`, but
+		// anonymous arrow has no transpiler name. Wrapper is registered
+		// as component; no transpiler name to inherit. Reports.
+		{Code: `
+        import { memo } from 'react'
+        const Hello = memo(() => <div/>);
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: forwardRef anonymous bound to const ----
+		// Same shape as above. Component identity is the wrapper call;
+		// inner anonymous arrow doesn't transfer name to wrapper.
+		{Code: `
+        import { forwardRef } from 'react'
+        const Hello = forwardRef((props, ref) => <div ref={ref} />);
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: memo+forwardRef nested, both anonymous ----
+		// `memo(forwardRef(arrow))` — neither named, on React 15.0.0
+		// (before nested-memo support). Outermost reports.
+		{Code: `
+        const Hello = React.memo(React.forwardRef((props, ref) => <div ref={ref} />));
+      `, Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"version": "15.0.0"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: ES5 createReactClass without binding (immediate use) ----
+		// `(createReactClass({...})).propTypes = ...` — IIFE-style use,
+		// no binding. ES5 component IS detected (via `IsCreateReactClassObjectArg`).
+		// Without displayName property → reports.
+		{Code: `
+        export default createReactClass({
+          render: function() { return <div/>; }
+        }).someProp;
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: anonymous default-export arrow returning JSX ----
+		// `export default () => <div/>` — default export of anonymous arrow,
+		// no binding. Reports.
+		{Code: `
+        export default () => <div>Hello</div>;
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- TC-aware lock-in: cross-scope same-name binding disambiguation ----
+		// Two `Inner` bindings in sibling scopes — only outerB's gets a
+		// displayName assignment. Upstream's scope manager resolves the
+		// `Inner.displayName = 'B'` reference to outerB's Inner, marks it,
+		// and reports outerA's Inner (line 4). Without TC-aware resolution,
+		// the syntactic `nameToComponent` would map "Inner" to whichever
+		// was discovered first, leading to wrong-node reports. The TC path
+		// in `resolveAndMarkComponentRef` keeps both directions correct;
+		// the line/column assertion locks in the precise node.
+		{Code: `
+        function outerA() {
+          const Inner = function() { return <div>A</div>; };
+          return Inner;
+        }
+        function outerB() {
+          const Inner = function() { return <div>B</div>; };
+          Inner.displayName = 'B';
+          return Inner;
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noDisplayName, Line: 3},
+			},
+		},
+
+		// ---- Real-world: capitalized property-assignment arrow + anonymous default ----
+		// `NS.Bar = () => <div/>` — property-assignment with capitalized
+		// property name classifies (Branch 13). `export default function()`
+		// — anonymous default export classifies. Both report.
+		{Code: `
+        const NS: { Bar?: () => JSX.Element } = {};
+        NS.Bar = () => <div/>;
+        export default function() { return <div/>; }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: noDisplayName},
+				{MessageId: noDisplayName},
+			},
+		},
+
+		// ---- Real-world: exporting anonymous arrow ----
+		// `export default (props) => <div/>` — default export of anonymous
+		// arrow. No transpiler name, no displayName property. Reports.
+		{Code: `
+        export default (props) => <div>{props.name}</div>;
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: ignoreTranspilerName disables FN binding ----
+		// `var Foo = () => <div/>` — transpiler name from binding `Foo`,
+		// but `ignoreTranspilerName: true` requires explicit displayName.
+		{Code: `
+        var Hello = () => <div>Hello</div>;
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: ignoreTranspilerName disables class id ----
+		// `class Foo extends React.Component {}` — has class id, but
+		// `ignoreTranspilerName: true` requires explicit displayName.
+		{Code: `
+        class Hello extends React.Component {
+          render() { return <div/>; }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: anonymous Cell-style arrow in JSX prop ----
+		// `<Table cellRenderer={(value) => <div>{value}</div>}/>` — the
+		// arrow is in JSX-attribute position, NOT an allowed component
+		// position. NO detection. Pair with a real anonymous component.
+		{Code: `
+        const x = <Table cellRenderer={(value) => <div>{value}</div>}/>;
+        export default () => <div>main</div>;
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: anonymous arrow + propTypes assignment alone ----
+		// Without setting displayName, only propTypes — anonymous wrapper
+		// reports.
+		{Code: `
+        export const Hello = React.memo(({ x }) => <div>{x}</div>);
+        Hello.propTypes = { x: () => null };
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: anonymous CallExpression of factory ----
+		// `module.exports = createMyComponent({ render: () => <div/> })`
+		// — not a recognized createReactClass; no React extends; no
+		// pragma wrapper. The render callback's parent is PropertyAssignment
+		// in a non-createReactClass object → not a component. The outer
+		// shape isn't a component either. No detection on either.
+		// Without a fallback component, no errors at all → not invalid.
+		// Make this an invalid by adding a real anonymous arrow:
+		{Code: `
+        const helper = createMyComponent({ render: () => <div/> });
+        export default function() { return <div/>; }
+      `, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: createContext without React >= 16.3.0 setting falls back ----
+		// Default React version (`999.999.999`) — context check IS active.
+		// Without displayName, reports `noContextDisplayName`.
+		{Code: `
+        import { createContext } from 'react';
+        const Hello = createContext({ defaultValue: 'world' });
+      `, Tsx: true, Options: map[string]interface{}{"checkContextObjects": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noContextDisplayName}},
+		},
+
+		// ---- Real-world: displayName key with ignored case-mismatch ----
+		// `Foo.DisplayName = 'X'` — capitalized D doesn't match `displayName`.
+		// upstream's `isDisplayNameDeclaration` is exact match. Should
+		// NOT mark, so the component still reports.
+		{Code: `
+        function Hello() { return <div/>; }
+        Hello.DisplayName = 'Hello';
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: displayName via different identifier name ----
+		// `Foo.name = 'Foo'` — `name` ≠ `displayName`. Doesn't satisfy.
+		{Code: `
+        function Hello() { return <div/>; }
+        Hello.name = 'Hello';
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+
+		// ---- Real-world: createContext via aliased import ----
+		// `import { createContext as ctx } from 'react'; const X = ctx()`
+		// — upstream's `isCreateContext` matches by callee NAME, not by
+		// import resolution. Aliased `ctx` has callee.name = 'ctx', not
+		// 'createContext'. So it's NOT recognized as createContext.
+		// The X is just a value; not a context. With checkContextObjects
+		// the regular rule's report is also avoided.
+		// Make this valid (no diagnostic) to lock in the alias behavior:
+		// SKIP — this is a VALID case, not invalid. Move test out of this section.
+
+		// ---- Real-world: anonymous default-export class wrapping arrow ----
+		// `export default class { static comp = () => <div/>; }` — class
+		// is anonymous (no id), no displayName, extends nothing. Doesn't
+		// classify as React component. Inner arrow `comp` is lowercase →
+		// not a component either.
+		// To make this invalid, add a real anonymous arrow:
+		{Code: `
+        export default class { static x = 1; }
+        export const Hello = (props: any) => <div/>;
+      `, Tsx: true, Options: map[string]interface{}{"ignoreTranspilerName": true},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -124,6 +124,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-children-prop.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
     './tests/eslint-plugin-react/rules/no-danger-with-children.test.ts',
+    './tests/eslint-plugin-react/rules/display-name.test.ts',
     './tests/eslint-plugin-react/rules/no-deprecated.test.ts',
     './tests/eslint-plugin-react/rules/no-did-mount-set-state.test.ts',
     './tests/eslint-plugin-react/rules/no-did-update-set-state.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/display-name.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/display-name.test.ts
@@ -1,0 +1,593 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('display-name', {} as never, {
+  valid: [
+    // ---- Shadowed wrapper identifiers ----
+    {
+      code: `
+        import React, { memo, forwardRef } from 'react'
+
+        const TestComponent = function () {
+          {
+            const memo = (cb) => cb()
+            const forwardRef = (cb) => cb()
+            const React = { memo, forwardRef }
+
+            const BlockMemo = memo(() => <div>shadowed</div>)
+            const BlockForwardRef = forwardRef(() => <div>shadowed</div>)
+            const BlockReactMemo = React.memo(() => <div>shadowed</div>)
+          }
+          return null
+        }
+      `,
+    },
+    {
+      code: `
+        import React, { memo, forwardRef } from 'react'
+
+        const Test1 = function (memo) {
+          return memo(() => <div>param shadowed</div>)
+        }
+
+        const Test2 = function ({ forwardRef }) {
+          return forwardRef(() => <div>destructured param</div>)
+        }
+      `,
+    },
+
+    // ---- ES5 createReactClass with displayName + ignoreTranspilerName ----
+    {
+      code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+      options: [{ ignoreTranspilerName: true }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+        Hello.displayName = 'Hello'
+      `,
+      options: [{ ignoreTranspilerName: true }],
+    },
+
+    // ---- Class without React heritage ----
+    {
+      code: `
+        class Hello {
+          render() {
+            return 'Hello World';
+          }
+        }
+      `,
+    },
+
+    // ---- ES5 createReactClass — has transpiler name ----
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+    },
+
+    // ---- export default class with binding name ----
+    {
+      code: `
+        export default class Hello {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+    },
+
+    // ---- Reassignment of declared variable ----
+    {
+      code: `
+        var Hello;
+        Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+    },
+
+    // ---- module.exports with displayName property ----
+    {
+      code: `
+        module.exports = createReactClass({
+          "displayName": "Hello",
+          "render": function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+    },
+
+    // ---- Anonymous default-exported class ----
+    {
+      code: `
+        export default class {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+    },
+
+    // ---- Named function expression inside React.memo ----
+    {
+      code: `
+        export const Hello = React.memo(function Hello() {
+          return <p />;
+        })
+      `,
+    },
+
+    // ---- Named function expressions / declarations / arrows with binding ----
+    {
+      code: `
+        function Hello() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        var Hello = () => {
+          return <div>Hello {this.props.name}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        module.exports = function Hello() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      `,
+    },
+
+    // ---- Functional + Hello.displayName + ignoreTranspilerName ----
+    {
+      code: `
+        function Hello() {
+          return <div>Hello {this.props.name}</div>;
+        }
+        Hello.displayName = 'Hello';
+      `,
+      options: [{ ignoreTranspilerName: true }],
+    },
+
+    // ---- Deep MemberExpression displayName ----
+    {
+      code: `
+        var Mixins = {
+          Greetings: {
+            Hello: function() {
+              return <div>Hello {this.props.name}</div>;
+            }
+          }
+        }
+        Mixins.Greetings.Hello.displayName = 'Hello';
+      `,
+      options: [{ ignoreTranspilerName: true }],
+    },
+
+    // ---- ES5 createReactClass with helper render ----
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>{this._renderHello()}</div>;
+          },
+          _renderHello: function() {
+            return <span>Hello {this.props.name}</span>;
+          }
+        });
+      `,
+    },
+
+    // ---- Object literal with shorthand method (Mixin Button) ----
+    {
+      code: `
+        const Mixin = {
+          Button() {
+            return (
+              <button />
+            );
+          }
+        };
+      `,
+    },
+
+    // ---- Component + propTypes + React.memo wrapping ----
+    {
+      code: `
+        import React from 'react'
+        import { string } from 'prop-types'
+
+        function Component({ world }) {
+          return <div>Hello {world}</div>
+        }
+
+        Component.propTypes = {
+          world: string,
+        }
+
+        export default React.memo(Component)
+      `,
+    },
+
+    // ---- React.memo wrapping named function ----
+    {
+      code: `
+        import React from 'react'
+
+        const ComponentWithMemo = React.memo(function Component({ world }) {
+          return <div>Hello {world}</div>
+        })
+      `,
+    },
+
+    // ---- React.forwardRef wrapping named function ----
+    {
+      code: `
+        import React from 'react'
+
+        const ForwardRefComponentLike = React.forwardRef(function ComponentLike({ world }, ref) {
+          return <div ref={ref}>Hello {world}</div>
+        })
+      `,
+    },
+
+    // ---- Comp.displayName + React.forwardRef ----
+    {
+      code: `
+        const Comp = React.forwardRef((props, ref) => <main />);
+        Comp.displayName = 'MyCompName';
+      `,
+    },
+    {
+      code: `
+        const Comp = React.forwardRef((props, ref) => <main data-as="yes" />) as SomeComponent;
+        Comp.displayName = 'MyCompNameAs';
+      `,
+    },
+
+    // ---- Curried arrows / callbacks ----
+    {
+      code: `
+        const f = (a) => () => {
+          if (a) {
+            return null;
+          }
+          return 1;
+        };
+      `,
+    },
+
+    // ---- React.memo with two args ----
+    {
+      code: `
+        function MyComponent(props) {
+          return <b>{props.name}</b>;
+        }
+
+        const MemoizedMyComponent = React.memo(
+          MyComponent,
+          (prevProps, nextProps) => prevProps.name === nextProps.name
+        )
+      `,
+    },
+
+    // ---- Nested memo+forwardRef accepted in supported React versions ----
+    {
+      code: `
+        import React from 'react'
+
+        const MemoizedForwardRefComponentLike = React.memo(
+          React.forwardRef(({ world }, ref) => {
+            return <div ref={ref}>Hello {world}</div>
+          })
+        )
+      `,
+      settings: {
+        react: { version: '16.14.0' },
+      },
+    },
+
+    // ---- checkContextObjects: true with explicit displayName ----
+    {
+      code: `
+        import React from 'react';
+
+        const Hello = React.createContext();
+        Hello.displayName = "HelloContext"
+      `,
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+        Hello.displayName = "HelloContext"
+      `,
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        var Hello;
+        Hello = createContext();
+        Hello.displayName = "HelloContext";
+      `,
+      options: [{ checkContextObjects: true }],
+    },
+
+    // ---- React version too old for context check (silently disabled) ----
+    {
+      code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+      `,
+      settings: { react: { version: '16.2.0' } },
+      options: [{ checkContextObjects: true }],
+    },
+
+    // ---- checkContextObjects: false leaves context unchecked ----
+    {
+      code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+      `,
+      options: [{ checkContextObjects: false }],
+    },
+  ],
+
+  invalid: [
+    // ---- Shadowed-but-only-some-paths shadowed ----
+    {
+      code: `
+        import React, { memo, forwardRef } from 'react'
+
+        const TestComponent = function () {
+          {
+            const BlockReactMemo = React.memo(() => {
+              return <div>not shadowed</div>
+            })
+
+            const BlockMemo = memo(() => {
+              return <div>not shadowed</div>
+            })
+
+            const BlockForwardRef = forwardRef((props, ref) => {
+              return \`\${props} \${ref}\`
+            })
+          }
+
+          return null
+        }
+      `,
+      errors: [
+        { messageId: 'noDisplayName' },
+        { messageId: 'noDisplayName' },
+        { messageId: 'noDisplayName' },
+      ],
+    },
+
+    // ---- ES5 createReactClass without displayName + ignoreTranspilerName ----
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return React.createElement("div", {}, "text content");
+          }
+        });
+      `,
+      options: [{ ignoreTranspilerName: true }],
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+
+    // ---- Class without displayName + ignoreTranspilerName ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+      options: [{ ignoreTranspilerName: true }],
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+
+    // ---- module.exports anonymous arrow / function ----
+    {
+      code: `
+        module.exports = () => {
+          return <div>Hello {props.name}</div>;
+        }
+      `,
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+    {
+      code: `
+        module.exports = function() {
+          return <div>Hello {props.name}</div>;
+        }
+      `,
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+
+    // ---- module.exports of createReactClass without displayName ----
+    {
+      code: `
+        module.exports = createReactClass({
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+
+    // ---- Higher-order anonymous function returning JSX ----
+    {
+      code: `
+        function Hof() {
+          return function () {
+            return <div />
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+
+    // ---- React.memo / React.forwardRef with anonymous arrow ----
+    {
+      code: `
+        import React from 'react'
+
+        const ComponentWithMemo = React.memo(({ world }) => {
+          return <div>Hello {world}</div>
+        })
+      `,
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+    {
+      code: `
+        import React from 'react'
+
+        const ComponentWithMemo = React.memo(function() {
+          return <div>Hello {world}</div>
+        })
+      `,
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+    {
+      code: `
+        import React from 'react'
+
+        const ForwardRefComponentLike = React.forwardRef(({ world }, ref) => {
+          return <div ref={ref}>Hello {world}</div>
+        })
+      `,
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+
+    // ---- Nested memo+forwardRef NOT supported in older React versions ----
+    {
+      code: `
+        import React from 'react'
+
+        const MemoizedForwardRefComponentLike = React.memo(
+          React.forwardRef(({ world }, ref) => {
+            return <div ref={ref}>Hello {world}</div>
+          })
+        )
+      `,
+      settings: {
+        react: { version: '15.6.0' },
+      },
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+
+    // ---- Inner non-component functions don't shadow outer report ----
+    {
+      code: `
+        module.exports = function () {
+          function a () {}
+          const b = function b () {}
+          const c = function () {}
+          const d = () => {}
+          const obj = {
+            a: function a () {},
+            b: function b () {},
+            c () {},
+            d: () => {},
+          }
+          return React.createElement("div", {}, "text content");
+        }
+      `,
+      errors: [{ messageId: 'noDisplayName' }],
+    },
+
+    // ---- componentWrapperFunctions setting ----
+    {
+      code: `
+        const processData = (options?: { value: string }) => options?.value || 'no data';
+
+        export const Component = observer(() => {
+          const data = processData({ value: 'data' });
+          return <div>{data}</div>;
+        });
+
+        export const Component2 = observer(() => {
+          const data = processData();
+          return <div>{data}</div>;
+        });
+      `,
+      settings: {
+        componentWrapperFunctions: ['observer'],
+      },
+      errors: [{ messageId: 'noDisplayName' }, { messageId: 'noDisplayName' }],
+    },
+
+    // ---- checkContextObjects: missing context displayName ----
+    {
+      code: `
+        import React from 'react';
+
+        const Hello = React.createContext();
+      `,
+      options: [{ checkContextObjects: true }],
+      errors: [{ messageId: 'noContextDisplayName' }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+      `,
+      options: [{ checkContextObjects: true }],
+      errors: [{ messageId: 'noContextDisplayName' }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        var Hello;
+        Hello = createContext();
+      `,
+      options: [{ checkContextObjects: true }],
+      errors: [{ messageId: 'noContextDisplayName' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/display-name` rule from `eslint-plugin-react` to rslint.

The rule disallows missing `displayName` in a React component definition, helping debugging messages identify components correctly.

Supports both options from upstream:
- `ignoreTranspilerName` (default: `false`) — when `true`, requires an explicit `displayName` property even for components whose name can be inferred from the surrounding declaration.
- `checkContextObjects` (default: `false`) — when `true`, also warns on `React.createContext()` / `createContext()` results without a `displayName` (silently disabled when `settings.react.version` is below `16.3.0`).

Honors the shared React settings: `settings.react.pragma`, `settings.react.createClass`, `settings.react.version`, and `settings.componentWrapperFunctions`.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/display-name.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).