### PR TITLE
feat: port rule react/destructuring-assignment

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -2,6 +2,7 @@ package react_plugin
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/boolean_prop_naming"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/destructuring_assignment"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/button_has_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/display_name"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_component_props"
@@ -76,6 +77,7 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		boolean_prop_naming.BooleanPropNamingRule,
 		button_has_type.ButtonHasTypeRule,
+		destructuring_assignment.DestructuringAssignmentRule,
 		display_name.DisplayNameRule,
 		forbid_component_props.ForbidComponentPropsRule,
 		forbid_dom_props.ForbidDomPropsRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -1686,6 +1686,32 @@ func GetParentReactComponentScopeBasedOrStateless(node *ast.Node, pragma, create
 	return nil
 }
 
+// GetParentStatelessComponent mirrors eslint-plugin-react's
+// `utils.getParentStatelessComponent(node)`: walk up enclosing FunctionLike
+// scopes from `node` and return the first one classified as a stateless
+// functional component. A non-component function does NOT stop the walk —
+// the next outer FunctionLike still gets a chance, matching upstream's
+// `scope.upper` traversal.
+//
+// ES6 class scopes / class field initializers / module scope are
+// non-FunctionLike nodes that are simply skipped during the walk.
+//
+// Pass empty `pragma` to default to `DefaultReactPragma`. `wrappers` should
+// be the resolved `settings.componentWrapperFunctions` list (plus the
+// built-in `memo` / `forwardRef` defaults) so user-configured HOCs are
+// recognized as component-wrapping calls.
+func GetParentStatelessComponent(node *ast.Node, pragma string, wrappers []ComponentWrapperEntry) *ast.Node {
+	for p := node.Parent; p != nil; p = p.Parent {
+		if !ast.IsFunctionLike(p) {
+			continue
+		}
+		if IsStatelessReactComponentWithWrappers(p, pragma, nil, wrappers) {
+			return p
+		}
+	}
+	return nil
+}
+
 // IsStatelessReactComponent reports whether `fn` (a FunctionLike) looks like a
 // React functional component. Mirrors eslint-plugin-react's
 // `getStatelessComponent` decision tree:
@@ -3089,6 +3115,65 @@ func FunctionParameters(fn *ast.Node) []*ast.Node {
 			return nil
 		}
 		return af.Parameters.Nodes
+	case ast.KindMethodDeclaration:
+		// Object-literal shorthand methods (`{ Foo(props) {...} }`) and class
+		// methods both use this kind in tsgo. ESTree wraps the former as a
+		// `FunctionExpression`, so callers iterating "function-like
+		// components" need MethodDeclaration to participate too.
+		md := fn.AsMethodDeclaration()
+		if md.Parameters == nil {
+			return nil
+		}
+		return md.Parameters.Nodes
+	case ast.KindGetAccessor:
+		ga := fn.AsGetAccessorDeclaration()
+		if ga.Parameters == nil {
+			return nil
+		}
+		return ga.Parameters.Nodes
+	case ast.KindSetAccessor:
+		sa := fn.AsSetAccessorDeclaration()
+		if sa.Parameters == nil {
+			return nil
+		}
+		return sa.Parameters.Nodes
+	case ast.KindConstructor:
+		c := fn.AsConstructorDeclaration()
+		if c.Parameters == nil {
+			return nil
+		}
+		return c.Parameters.Nodes
+	}
+	return nil
+}
+
+// FunctionBody returns the body of a function-like node, mirroring
+// `FunctionParameters`'s coverage. Returns nil when the kind is not
+// function-like, or when the body is absent (overload signatures, abstract
+// methods, ambient declarations).
+//
+// Arrow expression bodies (`() => expr`) are returned as the expression node
+// itself — callers that distinguish block bodies from expression bodies
+// should branch on `body.Kind == ast.KindBlock`.
+func FunctionBody(fn *ast.Node) *ast.Node {
+	if fn == nil {
+		return nil
+	}
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		return fn.AsFunctionDeclaration().Body
+	case ast.KindFunctionExpression:
+		return fn.AsFunctionExpression().Body
+	case ast.KindArrowFunction:
+		return fn.AsArrowFunction().Body
+	case ast.KindMethodDeclaration:
+		return fn.AsMethodDeclaration().Body
+	case ast.KindGetAccessor:
+		return fn.AsGetAccessorDeclaration().Body
+	case ast.KindSetAccessor:
+		return fn.AsSetAccessorDeclaration().Body
+	case ast.KindConstructor:
+		return fn.AsConstructorDeclaration().Body
 	}
 	return nil
 }

--- a/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment.go
+++ b/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment.go
@@ -705,7 +705,17 @@ var DestructuringAssignmentRule = rule.Rule{
 					}
 					pd := param.AsParameterDeclaration()
 					paramName := pd.Name()
-					if paramName == nil {
+					// SFC's first parameter must be an Identifier literally
+					// named `props` for this gate to apply. Mirrors upstream's
+					// `getScope(node).set.get('props')` lookup, which only
+					// succeeds when `props` is bound in the enclosing function
+					// scope. Without this guard, an SFC whose parameter is
+					// renamed (e.g. `function Foo(myProps)`) but whose body
+					// references an outer `props` would trigger an autofix
+					// that rewrites the parameter and silently changes the
+					// reference target.
+					if paramName == nil || paramName.Kind != ast.KindIdentifier ||
+						paramName.AsIdentifier().Text != "props" {
 						return
 					}
 					// Use TypeChecker Symbol comparison when available so

--- a/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment.go
+++ b/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment.go
@@ -1,0 +1,752 @@
+package destructuring_assignment
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// sfcParam mirrors upstream's `evalParams` output: one entry per SFC parameter
+// position. Either `destructuring` is true (param is an `ObjectPattern`,
+// e.g. `({a, b})`) or `name` is non-empty (param is an `Identifier`,
+// e.g. `props`). For other shapes (rest, default, identifier-with-default
+// pattern) we leave both zero — upstream's `param.type === 'Identifier'`
+// equality also misses those.
+//
+// `symbol` carries the TypeChecker-resolved Symbol for the parameter binding,
+// when a TypeChecker is available. handleSFCUsage uses it to verify that an
+// Identifier with a name-matching `obj.Text == propsName` actually refers to
+// THIS SFC's parameter — without it, an inner `let props = …` shadow would
+// be misreported as a missed destructure (upstream has this same false
+// positive; rslint resolves it when a TypeChecker is present).
+type sfcParam struct {
+	destructuring bool
+	name          string
+	symbol        *ast.Symbol
+}
+
+// sfcParamsStack mirrors upstream's `createSFCParams()` queue: an
+// unshift-on-enter / shift-on-exit stack of the current SFC chain's param
+// shapes. `propsName` / `contextName` walk inner-to-outer for the first
+// non-destructuring identifier-named param at position 0 / 1 respectively.
+type sfcParamsStack struct {
+	queue [][]sfcParam
+}
+
+func (s *sfcParamsStack) push(params []sfcParam) {
+	s.queue = append([][]sfcParam{params}, s.queue...)
+}
+
+func (s *sfcParamsStack) pop() {
+	if len(s.queue) > 0 {
+		s.queue = s.queue[1:]
+	}
+}
+
+func (s *sfcParamsStack) propsName() string {
+	for _, p := range s.queue {
+		if len(p) > 0 && !p[0].destructuring && p[0].name != "" {
+			return p[0].name
+		}
+	}
+	return ""
+}
+
+// propsSymbol returns the TypeChecker Symbol of the active props parameter,
+// matching the same stack entry that `propsName` selects. Returns nil when no
+// TypeChecker was available at push time, or when the entry's parameter shape
+// doesn't carry a Symbol.
+func (s *sfcParamsStack) propsSymbol() *ast.Symbol {
+	for _, p := range s.queue {
+		if len(p) > 0 && !p[0].destructuring && p[0].name != "" {
+			return p[0].symbol
+		}
+	}
+	return nil
+}
+
+func (s *sfcParamsStack) contextName() string {
+	for _, p := range s.queue {
+		if len(p) > 1 && !p[1].destructuring && p[1].name != "" {
+			return p[1].name
+		}
+	}
+	return ""
+}
+
+func (s *sfcParamsStack) contextSymbol() *ast.Symbol {
+	for _, p := range s.queue {
+		if len(p) > 1 && !p[1].destructuring && p[1].name != "" {
+			return p[1].symbol
+		}
+	}
+	return nil
+}
+
+// evalParams maps a function's parameter list to upstream's
+// `evalParams(node.params)` output. Only top-level shapes the rule cares about
+// are recorded — `KindObjectBindingPattern` for `{a, b}` and `KindIdentifier`
+// for a named parameter. Other shapes (rest element, array binding, parameters
+// with type-only annotations) leave the entry zero, matching upstream's
+// `param.type === 'Identifier'` / `param.type === 'ObjectPattern'` strict
+// equality on the raw param node.
+//
+// Default-valued parameters are skipped to mirror upstream. ESTree wraps
+// `(props = {})` and `({id} = {})` in an `AssignmentPattern`, whose
+// `param.type` matches neither `'Identifier'` nor `'ObjectPattern'`, so
+// upstream silently leaves both `destructuring` and `name` falsy. tsgo
+// represents the same shapes as a `ParameterDeclaration` with a non-nil
+// `Initializer`, so we explicitly skip that case to stay aligned.
+//
+// Rest parameters are intentionally skipped — `function Foo(...rest)` binds
+// an array, and ESTree's `RestElement.type` likewise fails the strict
+// equality checks above.
+//
+// When `tc` is non-nil, each Identifier-named parameter additionally carries
+// its TypeChecker-resolved Symbol so handleSFCUsage can verify that a
+// name-matching reference actually resolves to *this* parameter and not an
+// inner shadow.
+func evalParams(params []*ast.Node, tc *checker.Checker) []sfcParam {
+	out := make([]sfcParam, len(params))
+	for i, p := range params {
+		if p == nil || p.Kind != ast.KindParameter {
+			continue
+		}
+		pd := p.AsParameterDeclaration()
+		if pd.DotDotDotToken != nil || pd.Initializer != nil {
+			continue
+		}
+		name := pd.Name()
+		if name == nil {
+			continue
+		}
+		switch name.Kind {
+		case ast.KindObjectBindingPattern:
+			out[i].destructuring = true
+		case ast.KindIdentifier:
+			out[i].name = name.AsIdentifier().Text
+			if tc != nil {
+				out[i].symbol = tc.GetSymbolAtLocation(name)
+			}
+		}
+	}
+	return out
+}
+
+// getEnclosingSFCComponent mirrors upstream's
+// `components.get(getScope(context, node).block)` semantics — the
+// **enclosing-only** check used in `VariableDeclarator` listeners.
+//
+// Unlike `reactutil.GetParentStatelessComponent` (which walks the entire
+// ancestor chain looking for any SFC), this helper inspects only the
+// nearest enclosing FunctionLike scope. If that scope is not classified
+// as an SFC, returns nil — even if a further-out ancestor happens to be
+// one. This matters for `const {x} = props` inside an inner non-SFC
+// helper of an outer SFC: upstream's `scope.block` is the inner helper,
+// `components.get(inner)` is undefined, and the rule stays silent.
+func getEnclosingSFCComponent(node *ast.Node, pragma string, wrappers []reactutil.ComponentWrapperEntry) *ast.Node {
+	for p := node.Parent; p != nil; p = p.Parent {
+		if !ast.IsFunctionLike(p) {
+			continue
+		}
+		if reactutil.IsStatelessReactComponentWithWrappers(p, pragma, nil, wrappers) {
+			return p
+		}
+		return nil
+	}
+	return nil
+}
+
+// isAssignmentLHS mirrors upstream's `isAssignmentLHS(node)`: true when `node`
+// is the left-hand side of a BinaryExpression with an assignment operator
+// (`=`, `+=`, etc.). Used to suppress `useDestructAssignment` reports on
+// `props.x = …` — the access there is a write target, not a read.
+func isAssignmentLHS(node *ast.Node) bool {
+	parent := node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parent = parent.Parent
+	}
+	if parent == nil || parent.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	bin := parent.AsBinaryExpression()
+	if bin.OperatorToken == nil || !ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
+		return false
+	}
+	left := bin.Left
+	for left != nil && left.Kind == ast.KindParenthesizedExpression {
+		left = left.AsParenthesizedExpression().Expression
+	}
+	target := node
+	for target != nil && target.Kind == ast.KindParenthesizedExpression {
+		target = target.AsParenthesizedExpression().Expression
+	}
+	return left == target
+}
+
+// isOptionalMember mirrors ESTree's `node.optional` flag for member
+// expressions. tsgo encodes `foo?.bar` via the `QuestionDotToken` field on
+// PropertyAccessExpression / ElementAccessExpression — there is no
+// `ChainExpression` wrapper.
+func isOptionalMember(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		return node.AsPropertyAccessExpression().QuestionDotToken != nil
+	case ast.KindElementAccessExpression:
+		return node.AsElementAccessExpression().QuestionDotToken != nil
+	}
+	return false
+}
+
+// isInClassProperty walks up looking for a class field (PropertyDeclaration
+// in tsgo, which collapses ESTree's `ClassProperty` and `PropertyDefinition`
+// into one kind). Mirrors upstream's `isInClassProperty(node)`.
+func isInClassProperty(node *ast.Node) bool {
+	for p := node.Parent; p != nil; p = p.Parent {
+		if p.Kind == ast.KindPropertyDeclaration {
+			return true
+		}
+	}
+	return false
+}
+
+// isParentClassProperty mirrors upstream's
+// `node.parent.type === 'ClassProperty' || 'PropertyDefinition'` test on the
+// VariableDeclarator. For `node` = VariableDeclarator, `node.parent` is a
+// VariableDeclaration, never a class field — so this guard is dead code in
+// upstream and always evaluates to false. We preserve that exact behavior
+// here so `ignoreClassFields` does NOT suppress `const {x} = this.props`
+// reports under `'never'`. (Class-field-internal IIFE cases reach this via
+// `isInClassProperty` from `handleClassUsage`, which IS a real ancestor
+// walk; that path is unchanged.)
+func isParentClassProperty(_ *ast.Node) bool {
+	return false
+}
+
+// findEnclosingTypeQuery mirrors upstream's `findParent(n, n.type === 'TSTypeQuery')`.
+// Returns true when any ancestor is a `typeof T` type query.
+func findEnclosingTypeQuery(node *ast.Node) bool {
+	for p := node.Parent; p != nil; p = p.Parent {
+		if p.Kind == ast.KindTypeQuery {
+			return true
+		}
+	}
+	return false
+}
+
+// countPropsRefsExcludingDecl approximates upstream's
+// `getScope(context, node).set.get('props').references.length` for the
+// `destructureInSignature: 'always'` gate.
+//
+// One up-front decision selects the counting strategy:
+//
+//   - **Symbol path** (TypeChecker + parameter Symbol both resolved):
+//     count Identifiers whose Symbol matches the SFC parameter. Inner
+//     `let props = …` shadows have a different Symbol and are excluded —
+//     scope-aware, matching ESLint's scopeManager exactly.
+//
+//   - **Name path** (anything required for the Symbol path missing):
+//     count every `props` Identifier that isn't an obvious binding /
+//     property name. Over-counts on shadows → conservative no-report.
+//
+// The decision happens once below; the walker calls `shouldCount` directly
+// without re-testing the TypeChecker on each Identifier.
+func countPropsRefsExcludingDecl(fn *ast.Node, exclude *ast.Node, tc *checker.Checker, paramName *ast.Node) int {
+	body := reactutil.FunctionBody(fn)
+	if body == nil {
+		return 0
+	}
+
+	var paramSymbol *ast.Symbol
+	if tc != nil && paramName != nil && paramName.Kind == ast.KindIdentifier {
+		paramSymbol = tc.GetSymbolAtLocation(paramName)
+	}
+
+	var shouldCount func(n *ast.Node) bool
+	if paramSymbol != nil {
+		// Symbol path — `tc` is guaranteed non-nil because paramSymbol was
+		// only assigned when `tc != nil`.
+		shouldCount = func(n *ast.Node) bool {
+			sym := tc.GetSymbolAtLocation(n)
+			return sym != nil && sym == paramSymbol
+		}
+	} else {
+		shouldCount = isPropsReference
+	}
+
+	count := 0
+	var walk func(n *ast.Node) bool
+	walk = func(n *ast.Node) bool {
+		if n == nil || n == exclude {
+			return false
+		}
+		if n.Kind == ast.KindIdentifier && n.AsIdentifier().Text == "props" && shouldCount(n) {
+			count++
+		}
+		n.ForEachChild(walk)
+		return false
+	}
+	body.ForEachChild(walk)
+	return count
+}
+
+// isPropsReference is the no-checker fallback predicate for
+// `countPropsRefsExcludingDecl`. Returns true when the Identifier `n` is
+// *probably* a value reference (not a binding name, member key, label, etc.).
+// Without a TypeChecker we can't tell whether the reference resolves to the
+// outer SFC's `props` or an inner shadow — we conservatively count every
+// suspect occurrence so the rule errs on "don't autofix" in ambiguous cases.
+func isPropsReference(n *ast.Node) bool {
+	parent := n.Parent
+	if parent == nil {
+		return true
+	}
+	switch parent.Kind {
+	case ast.KindParameter:
+		if parent.AsParameterDeclaration().Name() == n {
+			return false
+		}
+	case ast.KindBindingElement:
+		if parent.AsBindingElement().Name() == n {
+			return false
+		}
+	case ast.KindVariableDeclaration:
+		if parent.AsVariableDeclaration().Name() == n {
+			return false
+		}
+	case ast.KindPropertyAccessExpression:
+		if parent.AsPropertyAccessExpression().Name() == n {
+			return false
+		}
+	case ast.KindQualifiedName:
+		if parent.AsQualifiedName().Right == n {
+			return false
+		}
+	case ast.KindPropertyAssignment:
+		if parent.Name() == n {
+			return false
+		}
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindPropertyDeclaration:
+		if parent.Name() == n {
+			return false
+		}
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindClassDeclaration, ast.KindClassExpression:
+		if parent.Name() == n {
+			return false
+		}
+	case ast.KindLabeledStatement, ast.KindBreakStatement, ast.KindContinueStatement:
+		return false
+	}
+	return true
+}
+
+
+type ruleOptions struct {
+	configuration          string
+	ignoreClassFields      bool
+	destructureInSignature string
+}
+
+// buildSFCMatcher returns a `(receiver, paramSymbol) → bool` closure used by
+// handleSFCUsage. The closure is constructed ONCE per rule invocation based
+// on whether a TypeChecker is available:
+//
+//   - `tc == nil` → returns a closure that always answers true. The
+//     caller's name comparison alone gates the report — equivalent to
+//     upstream's name-only behavior. The closure has no reference to `tc`,
+//     so a nil checker can never be dereferenced downstream.
+//
+//   - `tc != nil` → returns a closure that compares Symbols. A
+//     name-matching but scope-shadowed reference is correctly rejected.
+//     `paramSymbol == nil` (Symbol resolution failed at push time) falls
+//     back to "accept" so a transient resolver miss never suppresses a
+//     legitimate report.
+func buildSFCMatcher(tc *checker.Checker) func(obj *ast.Node, paramSymbol *ast.Symbol) bool {
+	if tc == nil {
+		return func(_ *ast.Node, _ *ast.Symbol) bool { return true }
+	}
+	return func(obj *ast.Node, paramSymbol *ast.Symbol) bool {
+		if paramSymbol == nil {
+			return true
+		}
+		sym := tc.GetSymbolAtLocation(obj)
+		return sym != nil && sym == paramSymbol
+	}
+}
+
+// parseOptions handles both the array-wrapped shape the rule_tester emits
+// (`["always", {...}]`) and the bare-string / bare-object shapes the CLI
+// can deliver after `internal/config/config.go` unwraps a single-option
+// array. Defaults: `configuration="always"`, `ignoreClassFields=false`,
+// `destructureInSignature="ignore"` — matching upstream.
+func parseOptions(options any) ruleOptions {
+	opts := ruleOptions{
+		configuration:          "always",
+		ignoreClassFields:      false,
+		destructureInSignature: "ignore",
+	}
+	if options == nil {
+		return opts
+	}
+	var arr []interface{}
+	switch v := options.(type) {
+	case []interface{}:
+		arr = v
+	case string:
+		opts.configuration = v
+		return opts
+	default:
+		return opts
+	}
+	if len(arr) > 0 {
+		if s, ok := arr[0].(string); ok {
+			opts.configuration = s
+		}
+	}
+	if len(arr) > 1 {
+		if m, ok := arr[1].(map[string]interface{}); ok {
+			if v, ok := m["ignoreClassFields"].(bool); ok {
+				opts.ignoreClassFields = v
+			}
+			if v, ok := m["destructureInSignature"].(string); ok {
+				opts.destructureInSignature = v
+			}
+		}
+	}
+	return opts
+}
+
+var DestructuringAssignmentRule = rule.Rule{
+	Name: "react/destructuring-assignment",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+		wrappers := reactutil.GetComponentWrapperFunctions(ctx.Settings, pragma)
+		stack := &sfcParamsStack{}
+
+		reportUseDestruct := func(node *ast.Node, t string) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "useDestructAssignment",
+				Description: "Must use destructuring " + t + " assignment",
+				Data:        map[string]string{"type": t},
+			})
+		}
+
+		reportNoDestruct := func(node *ast.Node, t string) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noDestructAssignment",
+				Description: "Must never use destructuring " + t + " assignment",
+				Data:        map[string]string{"type": t},
+			})
+		}
+
+		// handleStatelessComponent enters an SFC: push its params onto the
+		// stack so nested member-expression listeners can see the active
+		// `props` / `context` names, then in `never` mode emit the
+		// destructured-arg diagnostic.
+		handleStatelessComponent := func(node *ast.Node) {
+			if !reactutil.IsStatelessReactComponentWithWrappers(node, pragma, nil, wrappers) {
+				return
+			}
+			params := evalParams(reactutil.FunctionParameters(node), ctx.TypeChecker)
+			stack.push(params)
+			if opts.configuration != "never" {
+				return
+			}
+			if len(params) > 0 && params[0].destructuring {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "noDestructPropsInSFCArg",
+					Description: "Must never use destructuring props assignment in SFC argument",
+				})
+			} else if len(params) > 1 && params[1].destructuring {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "noDestructContextInSFCArg",
+					Description: "Must never use destructuring context assignment in SFC argument",
+				})
+			}
+		}
+
+		handleStatelessComponentExit := func(node *ast.Node) {
+			if !reactutil.IsStatelessReactComponentWithWrappers(node, pragma, nil, wrappers) {
+				return
+			}
+			stack.pop()
+		}
+
+		// matchesSFCParam returns true when the receiver Identifier `obj`
+		// (name-matched by the caller) actually refers to the SFC parameter
+		// recorded with `paramSymbol`. The closure is built ONCE based on
+		// whether a TypeChecker is wired up:
+		//
+		//   - **No TypeChecker**: closure always returns true. Only the
+		//     caller's name comparison gates the report — equivalent to
+		//     upstream's name-only behavior. The closure never touches
+		//     `ctx.TypeChecker`, so nil-deref is impossible.
+		//
+		//   - **TypeChecker present**: closure compares Symbols. A
+		//     name-matching but scope-shadowed reference is correctly
+		//     rejected. `paramSymbol == nil` (Symbol resolution failed at
+		//     push time) still falls back to "accept" so the rule never
+		//     loses a legitimate report due to a transient resolver miss.
+		matchesSFCParam := buildSFCMatcher(ctx.TypeChecker)
+
+		// handleSFCUsage reports `props.X` / `context.X` accesses on `always`
+		// mode. The receiver must be a bare Identifier matching the active
+		// `propsName` / `contextName`; `(props).x` is unwrapped via
+		// SkipParentheses (tsgo preserves what ESTree flattens).
+		// Optional-chain accesses (`props?.x`) do NOT trigger — upstream's
+		// `!node.optional` guard.
+		handleSFCUsage := func(node *ast.Node) {
+			propsName := stack.propsName()
+			contextName := stack.contextName()
+			var objNode *ast.Node
+			switch node.Kind {
+			case ast.KindPropertyAccessExpression:
+				objNode = node.AsPropertyAccessExpression().Expression
+			case ast.KindElementAccessExpression:
+				objNode = node.AsElementAccessExpression().Expression
+			default:
+				return
+			}
+			obj := ast.SkipParentheses(objNode)
+			if obj.Kind != ast.KindIdentifier {
+				return
+			}
+			objName := obj.AsIdentifier().Text
+
+			matched := false
+			if propsName != "" && objName == propsName &&
+				matchesSFCParam(obj, stack.propsSymbol()) {
+				matched = true
+			} else if contextName != "" && objName == contextName &&
+				matchesSFCParam(obj, stack.contextSymbol()) {
+				matched = true
+			}
+			if !matched {
+				return
+			}
+			if isAssignmentLHS(node) {
+				return
+			}
+			if opts.configuration != "always" || isOptionalMember(node) {
+				return
+			}
+			reportUseDestruct(node, objName)
+		}
+
+		// handleClassUsage reports `this.props.X` / `this.state.X` /
+		// `this.context.X` accesses on `always` mode. The receiver chain must
+		// match exactly: outer member's object is itself a member with `this`
+		// as its receiver and one of the three known property names. Other
+		// `this.X.Y` shapes are left alone.
+		handleClassUsage := func(node *ast.Node) {
+			var objNode *ast.Node
+			switch node.Kind {
+			case ast.KindPropertyAccessExpression:
+				objNode = node.AsPropertyAccessExpression().Expression
+			case ast.KindElementAccessExpression:
+				objNode = node.AsElementAccessExpression().Expression
+			default:
+				return
+			}
+			obj := ast.SkipParentheses(objNode)
+			if obj.Kind != ast.KindPropertyAccessExpression {
+				return
+			}
+			inner := obj.AsPropertyAccessExpression()
+			if ast.SkipParentheses(inner.Expression).Kind != ast.KindThisKeyword {
+				return
+			}
+			name := reactutil.EsTreeName(inner.Name())
+			if name != "props" && name != "state" && name != "context" {
+				return
+			}
+			if isAssignmentLHS(node) {
+				return
+			}
+			if opts.configuration != "always" {
+				return
+			}
+			if opts.ignoreClassFields && isInClassProperty(node) {
+				return
+			}
+			reportUseDestruct(node, name)
+		}
+
+		memberExprListener := func(node *ast.Node) {
+			if reactutil.GetParentStatelessComponent(node, pragma, wrappers) != nil {
+				handleSFCUsage(node)
+			}
+			if reactutil.GetParentReactComponentScopeBasedOrStateless(node, pragma, createClass, wrappers) != nil {
+				handleClassUsage(node)
+			}
+		}
+
+		return rule.RuleListeners{
+			// MethodDeclaration is included so object-literal shorthand
+			// methods (`{ Foo(props) {...} }`) participate in the SFC stack
+			// — ESTree wraps these as FunctionExpression, tsgo doesn't.
+			// `IsStatelessReactComponent`'s MethodDeclaration arm then
+			// classifies them when the parent is ObjectLiteralExpression and
+			// the key is a capitalized Identifier returning JSX.
+			ast.KindFunctionDeclaration:                      handleStatelessComponent,
+			ast.KindFunctionExpression:                       handleStatelessComponent,
+			ast.KindArrowFunction:                            handleStatelessComponent,
+			ast.KindMethodDeclaration:                        handleStatelessComponent,
+			rule.ListenerOnExit(ast.KindFunctionDeclaration): handleStatelessComponentExit,
+			rule.ListenerOnExit(ast.KindFunctionExpression):  handleStatelessComponentExit,
+			rule.ListenerOnExit(ast.KindArrowFunction):       handleStatelessComponentExit,
+			rule.ListenerOnExit(ast.KindMethodDeclaration):   handleStatelessComponentExit,
+
+			ast.KindPropertyAccessExpression: memberExprListener,
+			ast.KindElementAccessExpression:  memberExprListener,
+
+			// Upstream `TSQualifiedName` listener: report `typeof props.X` in
+			// SFC `always` mode. Only the leftmost QualifiedName in a chain
+			// matches (its `Left` is an Identifier); outer wrappers in
+			// `props.a.b` have a QualifiedName as `Left` and are skipped.
+			ast.KindQualifiedName: func(node *ast.Node) {
+				if opts.configuration != "always" {
+					return
+				}
+				qn := node.AsQualifiedName()
+				if qn.Left == nil || qn.Left.Kind != ast.KindIdentifier {
+					return
+				}
+				propsName := stack.propsName()
+				if propsName == "" || qn.Left.AsIdentifier().Text != propsName {
+					return
+				}
+				if !findEnclosingTypeQuery(node) {
+					return
+				}
+				if reactutil.GetParentStatelessComponent(node, pragma, wrappers) == nil {
+					return
+				}
+				reportUseDestruct(node, "props")
+			},
+
+			// Upstream `VariableDeclarator` listener: covers three reports:
+			//   - `never` mode SFC `const {a} = props|context`
+			//   - `never` mode class `const {a} = this.props|state|context`
+			//   - `always` + `destructureInSignature: 'always'` SFC props
+			ast.KindVariableDeclaration: func(node *ast.Node) {
+				vd := node.AsVariableDeclaration()
+				if vd.Initializer == nil {
+					return
+				}
+				name := vd.Name()
+				if name == nil || name.Kind != ast.KindObjectBindingPattern {
+					return
+				}
+				init := ast.SkipParentheses(vd.Initializer)
+
+				var sfcType string
+				var classType string
+				switch init.Kind {
+				case ast.KindIdentifier:
+					nm := init.AsIdentifier().Text
+					if nm == "props" || nm == "context" {
+						sfcType = nm
+					}
+				case ast.KindPropertyAccessExpression:
+					pa := init.AsPropertyAccessExpression()
+					if ast.SkipParentheses(pa.Expression).Kind == ast.KindThisKeyword {
+						propName := reactutil.EsTreeName(pa.Name())
+						if propName == "props" || propName == "context" || propName == "state" {
+							classType = propName
+						}
+					}
+				}
+
+				// Mirror upstream's `components.get(getScope(context, node).block)`:
+				// enclosing-only semantics. A `const {x} = props` inside an
+				// inner non-SFC helper of an outer SFC must NOT report —
+				// upstream's `scope.block` is the inner helper, `components.
+				// get(inner) === undefined`, and the rule stays silent.
+				// `GetParentStatelessComponent` (ancestor walk) would
+				// over-report here.
+				sfcComp := getEnclosingSFCComponent(node, pragma, wrappers)
+				// Mirror upstream's `utils.getParentComponent(node)` =
+				// `getParentES6Component || getParentES5Component
+				// || getParentStatelessComponent`. The OrStateless tail
+				// matters: when a SFC body contains `const {x} = this.props`
+				// (semantically nonsensical but legal syntax), upstream's
+				// `classComponent` falls back to the SFC and reports under
+				// `'never'`. Using only `GetEnclosingReactComponent` (class-
+				// only) would silently drop that report.
+				classComp := reactutil.GetParentReactComponentScopeBasedOrStateless(node, pragma, createClass, wrappers)
+
+				if opts.configuration == "never" {
+					if sfcComp != nil && sfcType != "" {
+						reportNoDestruct(node, sfcType)
+					}
+					if classComp != nil && classType != "" {
+						if !opts.ignoreClassFields || !isParentClassProperty(node) {
+							reportNoDestruct(node, classType)
+						}
+					}
+				}
+
+				if sfcComp != nil &&
+					sfcType == "props" &&
+					opts.configuration == "always" &&
+					opts.destructureInSignature == "always" {
+					params := reactutil.FunctionParameters(sfcComp)
+					if len(params) == 0 {
+						return
+					}
+					param := params[0]
+					if param == nil || param.Kind != ast.KindParameter {
+						return
+					}
+					pd := param.AsParameterDeclaration()
+					paramName := pd.Name()
+					if paramName == nil {
+						return
+					}
+					// Use TypeChecker Symbol comparison when available so
+					// inner `let props = …` shadows are correctly excluded;
+					// otherwise fall back to a name+parent-shape walk.
+					if countPropsRefsExcludingDecl(sfcComp, vd.Initializer, ctx.TypeChecker, paramName) > 0 {
+						return
+					}
+
+					// Replace the parameter binding name span with the
+					// destructure pattern. The trimmed range is identical to
+					// upstream's `[param.range[0], param.typeAnnotation
+					// ? param.typeAnnotation.range[0] : param.range[1]]` —
+					// when a type annotation exists, ESTree's `param.range[1]`
+					// includes it, while tsgo's `paramName.End()` is the bare
+					// identifier end, so this branch falls out naturally.
+					replaceRange := utils.TrimNodeTextRange(ctx.SourceFile, paramName)
+					patternText := utils.TrimmedNodeText(ctx.SourceFile, name)
+
+					// Remove the surrounding VariableStatement so the body
+					// loses the `const {a} = props;` line. tsgo's
+					// VariableDeclaration parent chain is
+					// VariableDeclarationList → VariableStatement, while
+					// ESTree's VariableDeclarator parent is VariableDeclaration
+					// (which carries the trailing semicolon directly).
+					removeTarget := node
+					if node.Parent != nil && node.Parent.Kind == ast.KindVariableDeclarationList {
+						list := node.Parent
+						if list.Parent != nil && list.Parent.Kind == ast.KindVariableStatement {
+							removeTarget = list.Parent
+						}
+					}
+					ctx.ReportNodeWithFixes(node, rule.RuleMessage{
+						Id:          "destructureInSignature",
+						Description: "Must destructure props in the function signature.",
+					},
+						rule.RuleFixReplaceRange(replaceRange, patternText),
+						rule.RuleFixRemove(ctx.SourceFile, removeTarget),
+					)
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment.md
+++ b/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment.md
@@ -1,0 +1,133 @@
+# destructuring-assignment
+
+Enforce consistent usage of destructuring assignment of props, state, and context.
+
+## Rule Details
+
+This rule has two configurations:
+
+- `"always"` (default): always require destructuring of `props`, `state`, and `context` inside React components.
+- `"never"`: forbid destructuring of `props`, `state`, and `context` inside React components.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const MyComponent = (props) => {
+  return <div id={props.id} />;
+};
+```
+
+```javascript
+class Foo extends React.Component {
+  render() {
+    return <div>{this.props.foo}</div>;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const MyComponent = ({ id }) => (
+  <div id={id} />
+);
+```
+
+```javascript
+const MyComponent = (props) => {
+  const { id } = props;
+  return <div id={id} />;
+};
+```
+
+```javascript
+class Foo extends React.Component {
+  render() {
+    const { foo } = this.props;
+    return <div>{foo}</div>;
+  }
+}
+```
+
+Examples of **incorrect** code for this rule with `"never"`:
+
+```json
+{ "react/destructuring-assignment": ["error", "never"] }
+```
+
+```javascript
+const MyComponent = ({ id, className }) => (
+  <div id={id} className={className} />
+);
+```
+
+```javascript
+const Foo = class extends React.PureComponent {
+  render() {
+    const { foo } = this.props;
+    return <div>{foo}</div>;
+  }
+};
+```
+
+Examples of **correct** code for this rule with `"never"`:
+
+```json
+{ "react/destructuring-assignment": ["error", "never"] }
+```
+
+```javascript
+const MyComponent = (props) => (
+  <div id={props.id} className={props.className} />
+);
+```
+
+### `ignoreClassFields`
+
+When this option is set to `true`, accessing `this.props` / `this.state` / `this.context` directly inside a class field initializer is allowed even when the rule is configured as `"always"`. The example below would normally be reported, but is permitted with this option:
+
+```json
+{ "react/destructuring-assignment": ["error", "always", { "ignoreClassFields": true }] }
+```
+
+```javascript
+class Foo extends React.Component {
+  bar = this.props.bar;
+}
+```
+
+### `destructureInSignature`
+
+When this option is set to `"always"`, a destructuring `const { … } = props` whose `props` parameter is not used elsewhere must instead be destructured directly in the function signature. Has no effect when the rule is configured as `"never"` or when the parameter is referenced more than once.
+
+```json
+{ "react/destructuring-assignment": ["error", "always", { "destructureInSignature": "always" }] }
+```
+
+Examples of **incorrect** code with `destructureInSignature: "always"`:
+
+```javascript
+function Foo(props) {
+  const {a} = props;
+  return <p>{a}</p>;
+}
+```
+
+Examples of **correct** code with `destructureInSignature: "always"`:
+
+```javascript
+function Foo({a}) {
+  return <p>{a}</p>;
+}
+```
+
+```javascript
+function Foo(props) {
+  const {a} = props;
+  return <Goo {...props}>{a}</Goo>;
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-react `destructuring-assignment`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md)

--- a/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment_test.go
+++ b/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment_test.go
@@ -1,0 +1,1636 @@
+package destructuring_assignment
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestDestructuringAssignmentRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &DestructuringAssignmentRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: arrow that does not return JSX is not a component ----
+		{Code: `
+        export const revisionStates2 = {
+            [A.b]: props => {
+              return props.editor !== null
+                ? 'xyz'
+                : 'abc'
+            },
+        };
+      `, Tsx: true},
+
+		// ---- Upstream: HOF returning a component that destructures props inside ----
+		{Code: `
+        export function hof(namespace) {
+          const initialState = {
+            bounds: null,
+            search: false,
+          };
+          return (props) => {
+            const {x, y} = props
+            if (y) {
+              return <span>{y}</span>;
+            }
+            return <span>{x}</span>
+          };
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: non-component reducer-like callback ----
+		{Code: `
+        export function hof(namespace) {
+          const initialState = {
+            bounds: null,
+            search: false,
+          };
+
+          return (state = initialState, action) => {
+            if (action.type === 'ABC') {
+              return {...state, bounds: stuff ? action.x : null};
+            }
+
+            if (action.namespace !== namespace) {
+              return state;
+            }
+
+            return null
+          };
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: SFC with destructured-arg (default 'always' allows it) ----
+		{Code: `
+        const MyComponent = ({ id, className }) => (
+          <div id={id} className={className} />
+        );
+      `, Tsx: true},
+
+		// ---- Upstream: SFC with destructured-arg + explicit 'always' ----
+		{Code: `
+        const MyComponent = ({ id, className }) => (
+          <div id={id} className={className} />
+        );
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Upstream: SFC body destructures from props ----
+		{Code: `
+        const MyComponent = (props) => {
+          const { id, className } = props;
+          return <div id={id} className={className} />
+        };
+      `, Tsx: true},
+
+		// ---- Upstream: same with explicit 'always' ----
+		{Code: `
+        const MyComponent = (props) => {
+          const { id, className } = props;
+          return <div id={id} className={className} />
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Upstream: passing entire props prop is allowed ----
+		{Code: `
+        const MyComponent = (props) => (
+          <div id={id} props={props} />
+        );
+      `, Tsx: true},
+
+		{Code: `
+        const MyComponent = (props) => (
+          <div id={id} props={props} />
+        );
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Upstream: destructured second arg + first-arg-as-whole-spread ----
+		{Code: `
+        const MyComponent = (props, { color }) => (
+          <div id={id} props={props} color={color} />
+        );
+      `, Tsx: true},
+
+		{Code: `
+        const MyComponent = (props, { color }) => (
+          <div id={id} props={props} color={color} />
+        );
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Upstream: 'never' allows class direct access ----
+		{Code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        };
+      `, Tsx: true, Options: []interface{}{"never"}},
+
+		{Code: `
+        class Foo extends React.Component {
+          doStuff() {}
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true, Options: []interface{}{"never"}},
+
+		// ---- Upstream: class destructuring under 'always' ----
+		{Code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            const { foo } = this.props;
+            return <div>{foo}</div>;
+          }
+        };
+      `, Tsx: true},
+
+		{Code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            const { foo } = this.props;
+            return <div>{foo}</div>;
+          }
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Upstream: 'never' on non-`props` destructure is fine ----
+		{Code: `
+        const MyComponent = (props) => {
+          const { h, i } = hi;
+          return <div id={props.id} className={props.className} />
+        };
+      `, Tsx: true, Options: []interface{}{"never"}},
+
+		// ---- Upstream: constructor `this.state` direct access ----
+		{Code: `
+        const Foo = class extends React.PureComponent {
+          constructor() {
+            this.state = {};
+            this.state.foo = 'bar';
+          }
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Upstream: tagged template literal (styled-component) is not a component ----
+		{Code: "\n        const div = styled.div`\n          & .button {\n            border-radius: ${props => props.borderRadius}px;\n          }\n        `\n      ", Tsx: true},
+
+		// ---- Upstream: typed context arg (not an SFC, returns object) ----
+		{Code: `
+        export default (context: $Context) => ({
+          foo: context.bar
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: regular non-React class ----
+		{Code: `
+        class Foo {
+          bar(context) {
+            return context.baz;
+          }
+        }
+      `, Tsx: true},
+
+		{Code: `
+        class Foo {
+          bar(props) {
+            return props.baz;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: ignoreClassFields option ----
+		{Code: `
+        class Foo extends React.Component {
+          bar = this.props.bar
+        }
+      `, Tsx: true, Options: []interface{}{"always", map[string]interface{}{"ignoreClassFields": true}}},
+
+		{Code: `
+        class Input extends React.Component {
+          id = ` + "`${this.props.name}`" + `;
+          render() {
+            return <div />;
+          }
+        }
+      `, Tsx: true, Options: []interface{}{"always", map[string]interface{}{"ignoreClassFields": true}}},
+
+		// ---- Upstream: https://github.com/jsx-eslint/eslint-plugin-react/issues/2911
+		// destructured arg shadowing — `context` here is local, not React context. ----
+		{Code: `
+        function Foo({ context }) {
+          const d = context.describe();
+          return <div>{d}</div>;
+        }
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Upstream: arrow as object-method value, not a component ----
+		{Code: `
+        const obj = {
+          foo(arg) {
+            const a = arg.func();
+            return null;
+          },
+        };
+      `, Tsx: true},
+
+		// ---- Upstream: render-callback patterns inside data arrays ----
+		{Code: `
+        const columns = [
+          {
+            render: (val) => {
+              if (val.url) {
+                return (
+                  <a href={val.url}>
+                    {val.test}
+                  </a>
+                );
+              }
+              return null;
+            },
+          },
+        ];
+      `, Tsx: true},
+
+		{Code: `
+        const columns = [
+          {
+            render: val => <span>{val}</span>,
+          },
+          {
+            someRenderFunc: function(val) {
+              if (val.url) {
+                return (
+                  <a href={val.url}>
+                    {val.test}
+                  </a>
+                );
+              }
+              return null;
+            },
+          },
+        ];
+      `, Tsx: true},
+
+		// ---- Upstream: default export of a non-component arrow ----
+		{Code: `
+        export default (fileName) => {
+          const match = fileName.match(/some expression/);
+          if (match) {
+            return fn;
+          }
+          return null;
+        };
+      `, Tsx: true},
+
+		// ---- Upstream: this.props destructuring in a class method ----
+		{Code: `
+        class C extends React.Component {
+          componentDidMount() {
+            const { forwardRef } = this.props;
+
+            this.ref.current.focus();
+
+            if (typeof forwardRef === 'function') {
+              forwardRef(this.ref);
+            }
+          }
+          render() {
+            return <div />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: destructureInSignature 'always' but `props` referenced more than once ----
+		{Code: `
+        function Foo(props) {
+          const {a} = props;
+          return <Goo {...props}>{a}</Goo>;
+        }
+      `, Tsx: true, Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}}},
+
+		{Code: `
+        function Foo(props) {
+          const {a} = props;
+          return <Goo f={() => props}>{a}</Goo>;
+        }
+      `, Tsx: true, Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}}},
+
+		// ---- Upstream: useContext destructured / non-destructured combinations ----
+		{Code: `
+        import { useContext } from 'react';
+
+        const MyComponent = (props) => {
+          const {foo} = useContext(aContext);
+          return <div>{foo}</div>
+        };
+      `, Tsx: true, Options: []interface{}{"always"}, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.9.0"}}},
+
+		{Code: `
+        import { useContext } from 'react';
+
+        const MyComponent = (props) => {
+          const foo = useContext(aContext);
+          return <div>{foo.test}</div>
+        };
+      `, Tsx: true, Options: []interface{}{"never"}, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.9.0"}}},
+
+		{Code: `
+        import { useContext } from 'react';
+
+        const MyComponent = (props) => {
+          const foo = useContext(aContext);
+          return <div>{foo.test}</div>
+        };
+      `, Tsx: true, Options: []interface{}{"always"}, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.9.0"}}},
+
+		{Code: `
+        const MyComponent = (props) => {
+          const foo = useContext(aContext);
+          return <div>{foo.test}</div>
+        };
+      `, Tsx: true, Options: []interface{}{"always"}, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.8.999"}}},
+
+		{Code: `
+        const MyComponent = (props) => {
+          const {foo} = useContext(aContext);
+          return <div>{foo}</div>
+        };
+      `, Tsx: true, Options: []interface{}{"never"}, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.8.999"}}},
+
+		{Code: `
+        const MyComponent = (props) => {
+          const {foo} = useContext(aContext);
+          return <div>{foo}</div>
+        };
+      `, Tsx: true, Options: []interface{}{"always"}, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.8.999"}}},
+
+		{Code: `
+        const MyComponent = (props) => {
+          const foo = useContext(aContext);
+          return <div>{foo.test}</div>
+        };
+      `, Tsx: true, Options: []interface{}{"never"}, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.8.999"}}},
+
+		// ---- Upstream: optional chain on useContext result is allowed (no `.optional` member trigger) ----
+		{Code: `
+        import { useContext } from 'react';
+
+        const MyComponent = (props) => {
+          const foo = useContext(aContext);
+          return <div>{foo?.test}</div>
+        };
+      `, Tsx: true},
+
+		// ---- Locks in: optional-chain access on props is exempt under 'always' ----
+		// Mirrors upstream's `!node.optional` guard inside handleSFCUsage.
+		{Code: `
+        const MyComponent = (props) => {
+          return <div id={props?.id} />;
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Edge: shadowed `props` inside nested function — outer SFC's stack
+		// entry is still the active one for the inner non-SFC callback that uses
+		// its own local `props` parameter. ----
+		{Code: `
+        const MyComponent = ({foo}) => {
+          const handler = (props) => props.bar();
+          return <div onClick={handler}>{foo}</div>;
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Edge: nested SFC inside class method — class method body is not
+		// an SFC, the inner arrow IS, and its destructured arg satisfies 'always'. ----
+		{Code: `
+        class Outer extends React.Component {
+          render() {
+            const Inner = ({x}) => <span>{x}</span>;
+            const { y } = this.props;
+            return <Inner x={y} />;
+          }
+        }
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Edge: 'never' allows destructuring from non-`props|state|context`. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            const { foo } = this.unrelated;
+            return <div>{foo}</div>;
+          }
+        }
+      `, Tsx: true, Options: []interface{}{"never"}},
+
+		// ---- Edge: 'never' allows destructuring from a Call/non-member init. ----
+		{Code: `
+        const MyComponent = (props) => {
+          const { foo } = props.normalize();
+          return <div>{foo}</div>;
+        };
+      `, Tsx: true, Options: []interface{}{"never"}},
+
+		// ---- Edge: 'never' permits SFC body's `props` reference (only destructure is forbidden). ----
+		{Code: `
+        const MyComponent = (props) => {
+          return <div id={props.id} className={props.className} />;
+        };
+      `, Tsx: true, Options: []interface{}{"never"}},
+
+		// ---- Edge: 'always' SFC body's `props` access through receiver-cast is
+		// not flagged — the receiver after SkipParentheses is not a bare
+		// Identifier so it shouldn't fire. ----
+		{Code: `
+        const MyComponent = (props) => {
+          return <div id={(props as any).id} />;
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: TS non-null assertion on receiver matches upstream's
+		// `node.object.type === 'TSNonNullExpression'` non-match. ----
+		// `props!.x` — receiver after paren-strip is NonNullExpression, not
+		// Identifier; upstream's `node.object.name` is undefined → silent.
+		{Code: `
+        const MyComponent = (props: any) => {
+          return <div id={props!.id} />;
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: TS satisfies operator on receiver — same shape as as-cast. ----
+		{Code: `
+        const MyComponent = (props) => {
+          return <div id={(props satisfies any).id} />;
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: rest parameter is not treated as propsName. ----
+		// `function Foo(...rest)` binds an array; `rest[0]` is element access
+		// on a tuple, not a missed destructure.
+		{Code: `
+        function Foo(...rest: any[]) {
+          return <div>{rest[0]}</div>;
+        }
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: default-valued parameter is NOT identified as propsName.
+		// Mirrors upstream behavior: ESTree wraps `(props = {})` in an
+		// `AssignmentPattern` whose `param.type` matches neither
+		// `'Identifier'` nor `'ObjectPattern'`, so upstream's `evalParams`
+		// emits a zero entry. We mirror this by skipping
+		// ParameterDeclarations whose `Initializer` is non-nil.
+		// Verified against eslint-plugin-react@7.37.5: the snippet below is
+		// silent under both rules. ----
+		{Code: `
+        const MyComponent = (props = {}) => {
+          const { id } = props;
+          return <div id={id} />;
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock (default param + body access): even when `props.id` is
+		// accessed directly in the body, the default value disables
+		// propsName recognition, so the rule stays silent. ----
+		{Code: `
+        const MyComponent = (props = {}) => <div id={props.id} />;
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock (default destructured param under 'never'): an
+		// AssignmentPattern wrapping ObjectPattern (`({id} = {})`) is
+		// likewise skipped — upstream does not flag it. ----
+		{Code: `
+        const Foo = ({ id } = {}) => <div id={id} />;
+      `, Tsx: true, Options: []interface{}{"never"}},
+
+		// ---- Lock: nested non-SFC callback inside SFC sees outer `props`
+		// through the active stack entry, but accesses are still flagged when
+		// they touch the outer parameter. ----
+		// (This valid case shows: when the inner callback uses its OWN local
+		// `props` parameter, no upstream stack entry should leak through.)
+		{Code: `
+        const Foo = ({foo}) => {
+          const helper = (props) => props.bar();
+          return <div>{foo}{helper({bar: () => 0})}</div>;
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: 'never' allows non-`props|context` named first arg in SFC
+		// when destructured? No — destructuring at SFC arg always reports
+		// regardless of name (upstream evalParams emits `destructuring=true`
+		// without checking name). ----
+		// This is a positive control showing 'never' permits `Identifier` first
+		// arg with any name, matching `params[0].name && !params[0].destructuring`.
+		{Code: `
+        const Foo = (renamedProps) => (
+          <div id={renamedProps.id} />
+        );
+      `, Tsx: true, Options: []interface{}{"never"}},
+
+		// ---- Lock: assignment to `this.props` itself (constructor pattern) is exempt. ----
+		// `this.props = X` would be `this.props` as LHS — outer MemberExpression
+		// on receiver `this` doesn't match `this.props.X` shape, so no report.
+		{Code: `
+        class Foo extends React.Component {
+          constructor(p) {
+            super(p);
+            this.props = p;
+          }
+          render() { return <div /> }
+        }
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: useContext with `?.` chain on the result is not a `props`
+		// access (already in upstream), and the outer member is optional. ----
+		{Code: `
+        function Foo(props) {
+          const ctx = useContext(C);
+          return <div>{ctx?.x}</div>;
+        }
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: 'this[\"props\"].x' is NOT flagged (inner is ElementAccess,
+		// upstream only matches dotted .props/.state/.context). ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this['props'].foo}</div>;
+          }
+        }
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: spread destructure in SFC arg under 'always'. ----
+		{Code: `
+        const Foo = ({...rest}) => <div {...rest} />;
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: 'always' SFC body destructure consumed in JSX child. ----
+		{Code: `
+        const Foo = (props) => {
+          const {children} = props;
+          return <div>{children}</div>;
+        };
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: TS generic SFC with destructured arg under 'always'. ----
+		{Code: `
+        const Foo = <T,>(p: { x: T }) => <div>{p.x}</div>;
+      `, Tsx: true, Options: []interface{}{"never"}},
+
+		// ---- Real-world: forwardRef with destructured args under 'always'. ----
+		// Inner arrow is recognized by IsStatelessReactComponent (memo /
+		// forwardRef wrapper), and the destructured param is allowed.
+		{Code: `
+        const Foo = React.forwardRef(({x}: any, ref: any) => (
+          <div ref={ref}>{x}</div>
+        ));
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Real-world: memo + forwardRef nested. ----
+		{Code: `
+        const Foo = React.memo(React.forwardRef(({x}: any, ref: any) => (
+          <div ref={ref}>{x}</div>
+        )));
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: TypeChecker path — outer `props` referenced beyond the
+		// destructure suppresses destructureInSignature. Control case paired
+		// with the shadow test in invalid: same shape but without scope
+		// shadow, the second `props` IS the outer parameter, so the rule
+		// must stay silent. ----
+		{Code: `
+        function Foo(props) {
+          const {a} = props;
+          const cached = props;
+          return <p>{a}{cached}</p>;
+        }
+      `, Tsx: true, Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}}},
+
+		// ---- Lock (custom HOC parity): a function wrapped by a user-defined
+		// HOC that is NOT in the built-in wrapper list (memo / forwardRef) and
+		// not configured via `settings.componentWrapperFunctions` is treated
+		// as a non-component by both ESLint and rslint, so `props.id` access
+		// is silent. Verified against eslint-plugin-react@7.37.5. ----
+		{Code: `
+        const withLogging = (fn) => fn;
+        const Foo = withLogging((props) => <div id={props.id} />);
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock (shadow false positive fix): a local `props` declared
+		// inside an inner function is unrelated to the component's props,
+		// so accesses on it must NOT be flagged. ESLint's name-only check
+		// reports this as a missed destructure (a known false positive in
+		// upstream); rslint resolves the actual binding via type info and
+		// stays silent. The outer SFC parameter is named `props` so the
+		// name-only path WOULD match — only Symbol comparison rejects.
+		// 'always' mode is required to exercise handleSFCUsage. ----
+		{Code: `
+        function Foo(props) {
+          function helper() {
+            let props = { b: 1 };
+            return props.b;
+          }
+          return <p>{helper()}</p>;
+        }
+      `, Tsx: true, Options: []interface{}{"always"}},
+
+		// ---- Lock: VariableDeclaration uses ENCLOSING-only SFC check (not
+		// ancestor walk). `const {x} = props` inside an inner non-SFC helper
+		// of an outer SFC must NOT report under 'never' — upstream's
+		// `components.get(scope.block)` returns undefined for the inner
+		// helper, and the rule stays silent. Earlier ancestor-walk
+		// implementation over-reported here. ----
+		{Code: `
+        const Foo = (props) => {
+          function helper() {
+            const {x} = props;
+            return x;
+          }
+          return <div>{helper()}</div>;
+        };
+      `, Tsx: true, Options: []interface{}{"never"}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: SFC accessing `props.id` directly ----
+		{
+			Code: `
+        const MyComponent = (props) => {
+          return (<div id={props.id} />)
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: 'never' rejects destructured props in SFC arg ----
+		{
+			Code: `
+        const MyComponent = ({ id, className }) => (
+          <div id={id} className={className} />
+        );
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructPropsInSFCArg"},
+			},
+		},
+
+		// ---- Upstream: 'never' rejects destructured context in SFC arg ----
+		{
+			Code: `
+        const MyComponent = (props, { color }) => (
+          <div id={props.id} className={props.className} />
+        );
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructContextInSFCArg"},
+			},
+		},
+
+		// ---- Upstream: class accessing `this.props.foo` ----
+		{
+			Code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: class `this.state` direct access ----
+		{
+			Code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            return <div>{this.state.foo}</div>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: class `this.context` direct access ----
+		{
+			Code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            return <div>{this.context.foo}</div>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: this.props in a method called by render ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() { return this.foo(); }
+          foo() {
+            return this.props.children;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: createReactClass + this.props.foo ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <Text>{this.props.foo}</Text>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: SFC inside object literal (module.exports = { Foo(props) {...} }) ----
+		{
+			Code: `
+        module.exports = {
+          Foo(props) {
+            return <p>{props.a}</p>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: export default function form ----
+		{
+			Code: `
+        export default function Foo(props) {
+          return <p>{props.a}</p>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: HOF returning an arrow component ----
+		{
+			Code: `
+        function hof() {
+          return (props) => <p>{props.a}</p>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: const-init from this.props in render ----
+		{
+			Code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            const foo = this.props.foo;
+            return <div>{foo}</div>;
+          }
+        };
+        `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: 'never' rejects class const-destructuring of this.props ----
+		{
+			Code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            const { foo } = this.props;
+            return <div>{foo}</div>;
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: 'never' rejects SFC const-destructuring of props ----
+		{
+			Code: `
+        const MyComponent = (props) => {
+          const { id, className } = props;
+          return <div id={id} className={className} />
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: 'never' rejects class const-destructuring of this.state ----
+		{
+			Code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            const { foo } = this.state;
+            return <div>{foo}</div>;
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: multi-line columns config — 3 reports on different lines ----
+		{
+			Code: `
+        const columns = [
+          {
+            CustomComponentName: function(props) {
+              if (props.url) {
+                return (
+                  <a href={props.url}>
+                    {props.test}
+                  </a>
+                );
+              }
+              return null;
+            },
+          },
+        ];
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment", Line: 5},
+				{MessageId: "useDestructAssignment", Line: 7},
+				{MessageId: "useDestructAssignment", Line: 8},
+			},
+		},
+
+		// ---- Upstream: SFC second arg accessed but not destructured ----
+		{
+			Code: `
+        function Foo(props, context) {
+          const d = context.describe();
+          return <div>{d}</div>;
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: chained access props.str.match ----
+		{
+			Code: `
+        export default (props) => {
+          const match = props.str.match(/some expression/);
+          if (match) {
+            return <span>jsx</span>;
+          }
+          return null;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: nested arrow callback observing props ----
+		{
+			Code: `
+        import React from 'react';
+
+        const TestComp = (props) => {
+          props.onClick3102();
+
+          return (
+            <div
+              onClick={(evt) => {
+                if (props.onClick3102) {
+                  props.onClick3102(evt);
+                }
+              }}
+            >
+              <div />
+            </div>
+          );
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment", Line: 5},
+				{MessageId: "useDestructAssignment", Line: 10},
+				{MessageId: "useDestructAssignment", Line: 11},
+			},
+		},
+
+		// ---- Upstream: arrow inside object literal — JSX-returning ----
+		{
+			Code: `
+        export const revisionStates2 = {
+            [A.b]: props => {
+              return props.editor !== null
+                ? <span>{props.editor}</span>
+                : null
+            },
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment", Line: 4},
+				{MessageId: "useDestructAssignment", Line: 5},
+			},
+		},
+
+		// ---- Upstream: HOF returning component with three props refs ----
+		{
+			Code: `
+        export function hof(namespace) {
+          const initialState = {
+            bounds: null,
+            search: false,
+          };
+          return (props) => {
+            if (props.y) {
+              return <span>{props.y}</span>;
+            }
+            return <span>{props.x}</span>
+          };
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment", Line: 8},
+				{MessageId: "useDestructAssignment", Line: 9},
+				{MessageId: "useDestructAssignment", Line: 11},
+			},
+		},
+
+		// ---- Upstream: destructureInSignature 'always' — fix to signature destructure ----
+		{
+			Code: `
+          function Foo(props) {
+            const {a} = props;
+            return <p>{a}</p>;
+          }
+        `,
+			Tsx:     true,
+			Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "destructureInSignature", Line: 3},
+			},
+			Output: []string{"\n          function Foo({a}) {\n            \n            return <p>{a}</p>;\n          }\n        "},
+		},
+
+		// ---- Upstream: destructureInSignature with type annotation preserved ----
+		{
+			Code: `
+          function Foo(props: FooProps) {
+            const {a} = props;
+            return <p>{a}</p>;
+          }
+        `,
+			Tsx:     true,
+			Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "destructureInSignature", Line: 3},
+			},
+			Output: []string{"\n          function Foo({a}: FooProps) {\n            \n            return <p>{a}</p>;\n          }\n        "},
+		},
+
+		// ---- Upstream: TSQualifiedName `typeof props.text` and member `props.text` ----
+		{
+			Code: `
+        type Props = { text: string };
+        export const MyComponent: React.FC<Props> = (props) => {
+          type MyType = typeof props.text;
+          return <div>{props.text as MyType}</div>;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: only TSQualifiedName triggers when body already destructured ----
+		{
+			Code: `
+        type Props = { text: string };
+        export const MyOtherComponent: React.FC<Props> = (props) => {
+          const { text } = props;
+          type MyType = typeof props.text;
+          return <div>{text as MyType}</div>;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Upstream: void / typeof prop access ----
+		{
+			Code: `
+        function C(props: Props) {
+          void props.a
+          typeof props.b
+          return <div />
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: `props['x']` is also a member expression with Identifier receiver ----
+		// Locks in: tsgo's ElementAccessExpression triggers handleSFCUsage when the receiver is `props`.
+		{
+			Code: `
+        const MyComponent = (props) => {
+          return <div id={props['id']} />;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: parenthesized receiver — `(props).id` ----
+		// Locks in: SkipParentheses unwrapping the access receiver.
+		{
+			Code: `
+        const MyComponent = (props) => {
+          return <div id={(props).id} />;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: assignment LHS is suppressed, but the inner `props.x` chain is reported ----
+		// Locks in: outer `props.foo.bar = 1` suppresses the outer, but `props.foo` (inner) still reports.
+		{
+			Code: `
+        const MyComponent = (props) => {
+          props.foo.bar = 1;
+          return <div />;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: parenthesized assignment LHS is also suppressed ----
+		// Locks in: SkipParentheses on `node.parent` chain inside isAssignmentLHS.
+		{
+			Code: `
+        const MyComponent = (props) => {
+          (props.foo.bar) = 1;
+          return <div />;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: compound-assignment LHS is suppressed ----
+		// Locks in: ast.IsAssignmentOperator covers `+=`, `||=`, etc.
+		{
+			Code: `
+        const MyComponent = (props) => {
+          props.foo += 1;
+          return <div />;
+        };
+      `,
+			Tsx: true,
+			// Outer `props.foo += 1` is LHS — suppressed. No nested member to
+			// report. Only triggered if `props` is read elsewhere; here it
+			// isn't, so this case has zero diagnostics.
+			Errors: nil,
+		},
+
+		// ---- Edge: ++props.x is reported (UpdateExpression isn't an assignment) ----
+		// Locks in: prefix unary on member is not isAssignmentLHS — matches upstream.
+		{
+			Code: `
+        const MyComponent = (props) => {
+          ++props.x;
+          return <div />;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: `let {a} = props` under 'never' — still reported (binding kind doesn't matter). ----
+		{
+			Code: `
+        const MyComponent = (props) => {
+          let { foo } = props;
+          return <div>{foo}</div>;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: `var {a} = props` under 'never' — still reported. ----
+		{
+			Code: `
+        const MyComponent = (props) => {
+          var { foo } = props;
+          return <div>{foo}</div>;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: nested QualifiedName — only the leftmost (left=Identifier) reports. ----
+		// `typeof props.a.b` becomes `QN(QN(props, a), b)`; outer's `Left` is a
+		// QualifiedName, not Identifier, so only the inner one fires.
+		{
+			Code: `
+        const MyComponent = (props) => {
+          type T = typeof props.a.b;
+          return <div />;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: ignoreClassFields=true under 'always' still reports
+		// `this.props.x` outside class fields. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          bar = this.props.bar;
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always", map[string]interface{}{"ignoreClassFields": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: shorthand-method SFC value (object literal) — both
+		// `useDestructAssignment` reports trigger the props.X chain. ----
+		{
+			Code: `
+        const obj = {
+          MyComp(props) {
+            return <p id={props.id}>{props.name}</p>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: `this.props` element-access OUTER (e.g. `this.props['foo']`)
+		// matches: outer is ElementAccess, inner (object) is `this.props`
+		// PropertyAccess. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props['foo']}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: optional chain on `this.props?.x` IS reported in 'always'.
+		// Upstream's `!node.optional` guard only applies to handleSFCUsage, NOT
+		// handleClassUsage — class access reports regardless of optionality. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props?.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: parenthesized this — `(this).props.x` still reports. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{(this).props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: nested non-SFC inner callback inside SFC reads outer
+		// `props` — should still report (upstream's `propsName()` walks the
+		// full SFC stack, the inner callback's local scope doesn't shadow). ----
+		{
+			Code: `
+        const Foo = (props) => {
+          const handler = () => props.x;
+          return <div onClick={handler} />;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: SFC inside ConditionalExpression (init position) — when
+		// recognized, props.x should report. (If our SFC detector rejects this
+		// position, the case becomes a no-error scenario; either way the lock
+		// is on the rule's behavior, not the detector's.) ----
+		// We assert no panic / consistent classification; let's keep it
+		// pragmatic and skip if detector disagrees.
+		{
+			Code: `
+        const A = (props: any) => <div>{props.foo}</div>;
+        const B = (props: any) => <div>{props.bar}</div>;
+        const C = condition ? A : B;
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: SFC body uses `props` as RHS of an assignment to a local. ----
+		{
+			Code: `
+        const Foo = (props) => {
+          let cached;
+          cached = props.value;
+          return <div>{cached}</div>;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: chained `props.a.b` reports inner only. ----
+		// Outer's object is PropertyAccess(props, a), not Identifier → no match
+		// for outer. Inner's object is Identifier props → match.
+		{
+			Code: `
+        const Foo = (props) => {
+          return <div>{props.a.b}</div>;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: nested member with element-access outer:
+		// `props['a'].b` — inner `props['a']` matches (Identifier receiver). ----
+		{
+			Code: `
+        const Foo = (props) => {
+          return <div>{props['a'].b}</div>;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: 'never' + class field initializer destructure WITHOUT
+		// ignoreClassFields — should report (default behavior). ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          state = { count: 0 };
+          init = (() => { const { count } = this.state; return count; })();
+          render() { return <div /> }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructAssignment"},
+			},
+		},
+
+		// ---- Edge: destructureInSignature 'always' with multi-property
+		// destructure — fix preserves the full pattern. ----
+		{
+			Code: `
+          function Foo(props) {
+            const {a, b, c} = props;
+            return <p>{a}{b}{c}</p>;
+          }
+        `,
+			Tsx:     true,
+			Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "destructureInSignature"},
+			},
+			Output: []string{"\n          function Foo({a, b, c}) {\n            \n            return <p>{a}{b}{c}</p>;\n          }\n        "},
+		},
+
+		// ---- Edge: destructureInSignature 'always' with rename. ----
+		{
+			Code: `
+          function Foo(props) {
+            const {a: x} = props;
+            return <p>{x}</p>;
+          }
+        `,
+			Tsx:     true,
+			Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "destructureInSignature"},
+			},
+			Output: []string{"\n          function Foo({a: x}) {\n            \n            return <p>{x}</p>;\n          }\n        "},
+		},
+
+		// ---- Edge: 'never' SFC param renamed (Identifier) shape destructure
+		// of `props` is NOT possible (would need rename to be the SFC param,
+		// but destructuring binds locals, not the param itself). The reverse —
+		// destructured first param under any name — still reports. ----
+		{
+			Code: `
+        const Foo = ({a}: any) => (
+          <div>{a}</div>
+        );
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructPropsInSFCArg"},
+			},
+		},
+
+		// ---- Real-world: useEffect closure over outer SFC props. ----
+		// Inner arrow callback ancestor walk must reach the outer SFC.
+		{
+			Code: `
+        const Foo = (props) => {
+          React.useEffect(() => {
+            console.log(props.id);
+          }, [props.id]);
+          return <div />;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Real-world: switch on `props.type` returns JSX. ----
+		{
+			Code: `
+        const Foo = (props) => {
+          switch (props.type) {
+            case 'a': return <A />;
+            default: return null;
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Real-world: JSX spread attribute receiving `props.X`. ----
+		{
+			Code: `
+        const Foo = (props) => <div {...props.styles} />;
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Real-world: short-circuit and ternary mixing props references. ----
+		{
+			Code: `
+        const Foo = (props) => (
+          <div>{props.show && <span>{props.text}</span>}</div>
+        );
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Real-world: forwardRef inner arrow with non-destructured props. ----
+		{
+			Code: `
+        const Foo = React.forwardRef((props: any, ref: any) => (
+          <div ref={ref}>{props.x}</div>
+        ));
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Real-world: useState init with `props.X`. ----
+		{
+			Code: `
+        const Foo = (props) => {
+          const [x] = React.useState(props.initial);
+          return <div>{x}</div>;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Real-world: nested SFC stack — outer SFC's props is reachable
+		// from an inner SFC's body when the inner SFC's first param is
+		// destructured (so `propsName()` skips B and falls through to A's
+		// 'props' name). ----
+		{
+			Code: `
+        const A = (props) => {
+          const B = ({x}: any) => <div>{x}{props.y}</div>;
+          return <B />;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDestructAssignment"},
+			},
+		},
+
+		// ---- Lock: 'never' + SFC body with `const {x} = this.props` (nonsensical
+		// but legal syntax) — upstream's getParentComponent falls back to the
+		// SFC, so destructuringClass + classComponent triggers a noDestructAssignment
+		// report. We must mirror that fallback. ----
+		{
+			Code: `
+        const Foo = (props) => {
+          const { x } = this.props;
+          return <div>{x}</div>;
+        };
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructAssignment"},
+			},
+		},
+
+		// ---- Lock: 'never' + ignoreClassFields=true does NOT suppress
+		// `const {x} = this.props` even when nested inside a class field
+		// initializer IIFE. Upstream's `node.parent.type === 'ClassProperty'`
+		// check is dead code (node.parent is always VariableDeclaration), so
+		// the guard never fires. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          state = { count: 0 };
+          field = (() => { const { count } = this.state; return count; })();
+          render() { return <div /> }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never", map[string]interface{}{"ignoreClassFields": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDestructAssignment"},
+			},
+		},
+
+		// ---- Lock: TypeChecker scope-aware path resolves shadow correctly.
+		// The inner `helper` declares its own `let props`, whose Symbol differs
+		// from the outer SFC parameter. Both gates use Symbol comparison:
+		//
+		//   - `destructureInSignature` count: inner occurrences excluded →
+		//     outer has only the init reference → count==0 → REPORT.
+		//   - `handleSFCUsage` SFC report: inner `props.b`'s Symbol does NOT
+		//     match the SFC parameter's Symbol → NO useDestructAssignment.
+		//
+		// This is strictly more precise than upstream, which uses name-only
+		// matching everywhere and would emit both reports. The improvement
+		// is documented in the rule's `.md` Differences section.
+		// ----
+		{
+			Code: `
+          function Foo(props) {
+            const {a} = props;
+            function helper() {
+              let props = { b: 1 };
+              return props.b;
+            }
+            return <p>{a}{helper()}</p>;
+          }
+        `,
+			Tsx:     true,
+			Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "destructureInSignature", Line: 3},
+			},
+			Output: []string{"\n          function Foo({a}) {\n            \n            function helper() {\n              let props = { b: 1 };\n              return props.b;\n            }\n            return <p>{a}{helper()}</p>;\n          }\n        "},
+		},
+	})
+}

--- a/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment_test.go
+++ b/internal/plugins/react/rules/destructuring_assignment/destructuring_assignment_test.go
@@ -602,6 +602,22 @@ func TestDestructuringAssignmentRule(t *testing.T) {
         }
       `, Tsx: true, Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}}},
 
+		// ---- Lock (destructureInSignature scope guard): when the SFC's
+		// first parameter is renamed and the body destructures from an
+		// outer `props` (different binding), upstream's scope manager
+		// returns undefined for `getScope().set.get('props')` and stays
+		// silent. We mirror that with a name guard on the parameter so an
+		// autofix never rewrites a param it doesn't actually own.
+		// Verified against eslint-plugin-react@7.37.5: silent on this
+		// snippet under the same options. ----
+		{Code: `
+        const props: any = { b: 1 };
+        function Foo(myProps: any) {
+          const {b} = props;
+          return <p>{b}</p>;
+        }
+      `, Tsx: true, Options: []interface{}{"always", map[string]interface{}{"destructureInSignature": "always"}}},
+
 		// ---- Lock (custom HOC parity): a function wrapped by a user-defined
 		// HOC that is NOT in the built-in wrapper list (memo / forwardRef) and
 		// not configured via `settings.componentWrapperFunctions` is treated

--- a/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.go
+++ b/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.go
@@ -6,36 +6,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
-// getParentStatelessComponent mirrors eslint-plugin-react's
-// `Components.detect`-paired helper of the same name: walk up enclosing
-// FunctionLike scopes from `node` and return the first one classified as a
-// stateless functional component. A non-component function does NOT stop the
-// walk — the next outer FunctionLike still gets a chance, matching upstream's
-// `scope.upper` traversal.
-//
-// ES6 class scopes / class field initializers / module scope are non-FunctionLike
-// nodes that are simply skipped during the walk; `this` inside a class field
-// thus resolves to the nearest enclosing function-like (matching upstream's
-// `getScope` + `scope.upper` chain, which also walks past class scope without
-// classifying it as a component).
-//
-// `wrappers` is the resolved `settings.componentWrapperFunctions` list (plus
-// the built-in `memo` / `forwardRef` defaults) — passing it through to
-// `IsStatelessReactComponentWithWrappers` lets user-configured HOCs be
-// recognized as component-wrapping calls (e.g. `mobx.observer(fn)`,
-// `styled(fn)`).
-func getParentStatelessComponent(node *ast.Node, pragma string, wrappers []reactutil.ComponentWrapperEntry) *ast.Node {
-	for p := node.Parent; p != nil; p = p.Parent {
-		if !ast.IsFunctionLike(p) {
-			continue
-		}
-		if reactutil.IsStatelessReactComponentWithWrappers(p, pragma, nil, wrappers) {
-			return p
-		}
-	}
-	return nil
-}
-
 // isPropertyOwnedSFC mirrors upstream's
 // `component.node.parent.type === 'Property'` filter. ESTree wraps every
 // object-literal entry in a `Property` node, so any FunctionExpression /
@@ -90,7 +60,7 @@ var NoThisInSfcRule = rule.Rule{
 			if ast.SkipParentheses(expr).Kind != ast.KindThisKeyword {
 				return
 			}
-			component := getParentStatelessComponent(node, pragma, wrappers)
+			component := reactutil.GetParentStatelessComponent(node, pragma, wrappers)
 			if component == nil {
 				return
 			}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -84,6 +84,7 @@ export default defineConfig({
     './tests/eslint-plugin-import/rules/no-webpack-loader-syntax.test.ts',
 
     // eslint-plugin-react
+    './tests/eslint-plugin-react/rules/destructuring-assignment.test.ts',
     './tests/eslint-plugin-react/rules/boolean-prop-naming.test.ts',
     './tests/eslint-plugin-react/rules/button-has-type.test.ts',
     './tests/eslint-plugin-react/rules/forbid-component-props.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/destructuring-assignment.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/destructuring-assignment.test.ts
@@ -1,0 +1,112 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('destructuring-assignment', {} as never, {
+  valid: [
+    {
+      code: `
+        const MyComponent = ({ id, className }) => (
+          <div id={id} className={className} />
+        );
+      `,
+    },
+    {
+      code: `
+        const MyComponent = (props) => {
+          const { id, className } = props;
+          return <div id={id} className={className} />
+        };
+      `,
+      options: ['always'],
+    },
+    {
+      code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        };
+      `,
+      options: ['never'],
+    },
+    {
+      code: `
+        class Foo extends React.Component {
+          bar = this.props.bar
+        }
+      `,
+      options: ['always', { ignoreClassFields: true }],
+    },
+    {
+      code: `
+        function Foo(props) {
+          const {a} = props;
+          return <Goo {...props}>{a}</Goo>;
+        }
+      `,
+      options: ['always', { destructureInSignature: 'always' }],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const MyComponent = (props) => {
+          return (<div id={props.id} />)
+        };
+      `,
+      errors: [{ messageId: 'useDestructAssignment' }],
+    },
+    {
+      code: `
+        const MyComponent = ({ id, className }) => (
+          <div id={id} className={className} />
+        );
+      `,
+      options: ['never'],
+      errors: [{ messageId: 'noDestructPropsInSFCArg' }],
+    },
+    {
+      code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        };
+      `,
+      errors: [{ messageId: 'useDestructAssignment' }],
+    },
+    {
+      code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            return <div>{this.state.foo}</div>;
+          }
+        };
+      `,
+      errors: [{ messageId: 'useDestructAssignment' }],
+    },
+    {
+      code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            const { foo } = this.props;
+            return <div>{foo}</div>;
+          }
+        };
+      `,
+      options: ['never'],
+      errors: [{ messageId: 'noDestructAssignment' }],
+    },
+    {
+      code: `
+        function Foo(props) {
+          const {a} = props;
+          return <p>{a}</p>;
+        }
+      `,
+      options: ['always', { destructureInSignature: 'always' }],
+      errors: [{ messageId: 'destructureInSignature' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -351,3 +351,4 @@ ZWNBSP
 recognises
 recognisable
 clsx
+unshift


### PR DESCRIPTION
## Summary

Port the `react/destructuring-assignment` rule from `eslint-plugin-react` to rslint.

This rule enforces consistent usage of destructuring assignment of `props`, `state`, and `context` in React components. It supports two modes (`always` / `never`) and two extra options (`ignoreClassFields`, `destructureInSignature` with autofix).

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/destructuring-assignment.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).