### PR TITLE
feat: port rule react/jsx-indent-props

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -18,6 +18,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_first_prop_new_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_handler_names"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_indent"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_indent_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_key"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_depth"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_props_per_line"
@@ -92,6 +93,7 @@ func GetAllRules() []rule.Rule {
 		jsx_first_prop_new_line.JsxFirstPropNewLineRule,
 		jsx_handler_names.JsxHandlerNamesRule,
 		jsx_indent.JsxIndentRule,
+		jsx_indent_props.JsxIndentPropsRule,
 		jsx_key.JsxKeyRule,
 		jsx_max_depth.JsxMaxDepthRule,
 		jsx_max_props_per_line.JsxMaxPropsPerLineRule,

--- a/internal/plugins/react/reactutil/indent.go
+++ b/internal/plugins/react/reactutil/indent.go
@@ -1,0 +1,125 @@
+package reactutil
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// IndentLineStart returns the byte offset of the first character on the
+// line containing pos, derived from the source file's ECMA line map.
+func IndentLineStart(lineMap []core.TextPos, pos int) int {
+	line := scanner.ComputeLineOfPosition(lineMap, pos)
+	return int(lineMap[line])
+}
+
+// IndentLeading counts consecutive `indentChar` bytes at the start of the
+// line containing pos. Mirrors upstream ESLint's
+// `getText(node, node.loc.start.column).match(/^[ ]+|^[\t]+/)` slice that
+// every eslint-plugin-react indent-style rule uses to read a line's leading
+// indent.
+func IndentLeading(text string, lineMap []core.TextPos, pos int, indentChar byte) int {
+	start := IndentLineStart(lineMap, pos)
+	count := 0
+	for i := start; i < len(text); i++ {
+		if text[i] != indentChar {
+			break
+		}
+		count++
+	}
+	return count
+}
+
+// NodeStartIndent returns the leading indent (count of `indentChar`) on
+// the line containing the trimmed start of `node`.
+func NodeStartIndent(sf *ast.SourceFile, node *ast.Node, indentChar byte) int {
+	trimmed := utils.TrimNodeTextRange(sf, node)
+	return IndentLeading(sf.Text(), sf.ECMALineMap(), trimmed.Pos(), indentChar)
+}
+
+// NodeEndIndent returns the leading indent (count of `indentChar`) on
+// the line containing the trimmed end of `node`. Steps one byte back from
+// `End()` to land inside the node so that a node ending exactly at a
+// newline is still attributed to its own last line.
+func NodeEndIndent(sf *ast.SourceFile, node *ast.Node, indentChar byte) int {
+	trimmed := utils.TrimNodeTextRange(sf, node)
+	pos := trimmed.End()
+	if pos > 0 {
+		pos--
+	}
+	return IndentLeading(sf.Text(), sf.ECMALineMap(), pos, indentChar)
+}
+
+// IsNodeFirstInLine reports whether node is the first non-whitespace
+// (and non-comma) source character on its line. Walks back from the
+// trimmed start over spaces, tabs, commas and CR; a leading newline (or
+// start-of-file) means yes, anything else means no. The comma skip
+// mirrors upstream's `getFirstNodeInLine` behaviour for array-literal
+// siblings.
+func IsNodeFirstInLine(sf *ast.SourceFile, node *ast.Node) bool {
+	text := sf.Text()
+	trimmed := utils.TrimNodeTextRange(sf, node)
+	i := trimmed.Pos() - 1
+	for i >= 0 {
+		c := text[i]
+		if c == '\n' {
+			return true
+		}
+		if c == ' ' || c == '\t' || c == ',' || c == '\r' {
+			i--
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// WrongIndentMessage builds the standard `wrongIndent` rule message used
+// by indent-style rules ported from eslint-plugin-react. The message text
+// matches the upstream
+// `Expected indentation of {needed} {type} {characters} but found {gotten}.`
+// template; `characters` switches between "character" and "characters"
+// based on whether `needed` is 1.
+func WrongIndentMessage(needed, gotten int, indentType string) rule.RuleMessage {
+	characters := "characters"
+	if needed == 1 {
+		characters = "character"
+	}
+	return rule.RuleMessage{
+		Id: "wrongIndent",
+		Description: fmt.Sprintf(
+			"Expected indentation of %d %s %s but found %d.",
+			needed, indentType, characters, gotten,
+		),
+		Data: map[string]string{
+			"needed":     strconv.Itoa(needed),
+			"type":       indentType,
+			"characters": characters,
+			"gotten":     strconv.Itoa(gotten),
+		},
+	}
+}
+
+// ReportIndentReplaceLeading emits a `wrongIndent` diagnostic anchored at
+// `node` and provides an autofix that replaces the whitespace from the
+// start of the node's line up to the node's trimmed start with `needed`
+// repetitions of `indentChar`. This is the default fix shape used by
+// upstream's
+// `replaceTextRange([node.range[0] - node.loc.start.column, node.range[0]], …)`
+// pattern.
+func ReportIndentReplaceLeading(ctx rule.RuleContext, node *ast.Node, needed, gotten int, indentChar byte, indentType string) {
+	indent := strings.Repeat(string(indentChar), needed)
+	trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+	startPos := trimmed.Pos()
+	lineStart := IndentLineStart(ctx.SourceFile.ECMALineMap(), startPos)
+	ctx.ReportNodeWithFixes(node, WrongIndentMessage(needed, gotten, indentType), rule.RuleFix{
+		Text:  indent,
+		Range: core.NewTextRange(lineStart, startPos),
+	})
+}

--- a/internal/plugins/react/reactutil/indent.go
+++ b/internal/plugins/react/reactutil/indent.go
@@ -56,6 +56,18 @@ func NodeEndIndent(sf *ast.SourceFile, node *ast.Node, indentChar byte) int {
 	return IndentLeading(sf.Text(), sf.ECMALineMap(), pos, indentChar)
 }
 
+// NodeStartUTF16Column returns the 0-based UTF-16 character column of
+// the trimmed start of `node`. Used by indent-style rules whose option
+// semantics are character-based (e.g. eslint-plugin-react's
+// `jsx-indent-props` `'first'` mode, which aligns to the visual column of
+// the first prop). Counting bytes here would diverge from upstream ESLint
+// when the source contains multi-byte characters before the node.
+func NodeStartUTF16Column(sf *ast.SourceFile, node *ast.Node) int {
+	trimmed := utils.TrimNodeTextRange(sf, node)
+	_, char := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, trimmed.Pos())
+	return int(char)
+}
+
 // IsNodeFirstInLine reports whether node is the first non-whitespace
 // (and non-comma) source character on its line. Walks back from the
 // trimmed start over spaces, tabs, commas and CR; a leading newline (or
@@ -113,12 +125,26 @@ func WrongIndentMessage(needed, gotten int, indentType string) rule.RuleMessage 
 // upstream's
 // `replaceTextRange([node.range[0] - node.loc.start.column, node.range[0]], …)`
 // pattern.
+//
+// When `needed` is negative (only reachable via a negative `indentSize`
+// option such as `[-2]`), the diagnostic is emitted WITHOUT a fix. The
+// message still reports the negative `needed` verbatim — that matches
+// upstream ESLint, which calls `' '.repeat(needed)` inside its fix
+// lambda; the lambda throws `RangeError`, ESLint discards the fix but
+// keeps the diagnostic intact. Skipping the fix here avoids the
+// `strings: negative Repeat count` panic in Go (which would crash the
+// whole linter, not just this one rule).
 func ReportIndentReplaceLeading(ctx rule.RuleContext, node *ast.Node, needed, gotten int, indentChar byte, indentType string) {
+	msg := WrongIndentMessage(needed, gotten, indentType)
+	if needed < 0 {
+		ctx.ReportNode(node, msg)
+		return
+	}
 	indent := strings.Repeat(string(indentChar), needed)
 	trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
 	startPos := trimmed.Pos()
 	lineStart := IndentLineStart(ctx.SourceFile.ECMALineMap(), startPos)
-	ctx.ReportNodeWithFixes(node, WrongIndentMessage(needed, gotten, indentType), rule.RuleFix{
+	ctx.ReportNodeWithFixes(node, msg, rule.RuleFix{
 		Text:  indent,
 		Range: core.NewTextRange(lineStart, startPos),
 	})

--- a/internal/plugins/react/rules/jsx_indent/jsx_indent.go
+++ b/internal/plugins/react/rules/jsx_indent/jsx_indent.go
@@ -1,8 +1,6 @@
 package jsx_indent
 
 import (
-	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -39,104 +37,10 @@ var JsxIndentRule = rule.Rule{
 		text := ctx.SourceFile.Text()
 		lineMap := ctx.SourceFile.ECMALineMap()
 
+		// lineOfPos is the only line-number helper kept local; the indent
+		// / first-in-line / message helpers live in `reactutil`.
 		lineOfPos := func(pos int) int {
 			return scanner.ComputeLineOfPosition(lineMap, pos)
-		}
-
-		// lineStartOfPos returns the byte offset of the first char of the
-		// line containing pos, using the line map.
-		lineStartOfPos := func(pos int) int {
-			line := lineOfPos(pos)
-			return int(lineMap[line])
-		}
-
-		// lineIndentAt returns the count of leading `indentChar` runs at
-		// the start of the line containing pos. Mirrors upstream's
-		// `^[ ]+` / `^[\t]+` slice on `getText(node, node.loc.start.column)`.
-		lineIndentAt := func(pos int) int {
-			start := lineStartOfPos(pos)
-			count := 0
-			for i := start; i < len(text); i++ {
-				if text[i] != indentChar {
-					break
-				}
-				count++
-			}
-			return count
-		}
-
-		nodeStartIndent := func(node *ast.Node) int {
-			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
-			return lineIndentAt(trimmed.Pos())
-		}
-		nodeEndIndent := func(node *ast.Node) int {
-			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
-			pos := trimmed.End()
-			if pos > 0 {
-				pos--
-			}
-			return lineIndentAt(pos)
-		}
-
-		// isNodeFirstInLine reports whether node is the first non-whitespace
-		// (and non-comma) source character on its line. Walks back from the
-		// trimmed start over spaces, tabs, commas and CR; a leading newline
-		// (or start-of-file) means yes, anything else means no. The comma
-		// skip mirrors upstream's `getFirstNodeInLine` behaviour for
-		// array-literal siblings.
-		isNodeFirstInLine := func(node *ast.Node) bool {
-			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
-			i := trimmed.Pos() - 1
-			for i >= 0 {
-				c := text[i]
-				if c == '\n' {
-					return true
-				}
-				if c == ' ' || c == '\t' || c == ',' || c == '\r' {
-					i--
-					continue
-				}
-				return false
-			}
-			return true
-		}
-
-		// makeMsg builds the wrongIndent diagnostic message.
-		makeMsg := func(needed, gotten int) rule.RuleMessage {
-			characters := "characters"
-			if needed == 1 {
-				characters = "character"
-			}
-			return rule.RuleMessage{
-				Id: "wrongIndent",
-				Description: fmt.Sprintf(
-					"Expected indentation of %d %s %s but found %d.",
-					needed, indentType, characters, gotten,
-				),
-				Data: map[string]string{
-					"needed":     strconv.Itoa(needed),
-					"type":       indentType,
-					"characters": characters,
-					"gotten":     strconv.Itoa(gotten),
-				},
-			}
-		}
-
-		// reportIndent emits a wrongIndent diagnostic with the upstream
-		// "default" fix (replace whitespace from start-of-line to node
-		// start with the expected indent). Used for JsxOpeningElement /
-		// JsxClosingElement / JsxExpression. JsxText, ReturnStatement and
-		// JsxAttribute take dedicated paths via reportLiteral /
-		// reportReturn / reportAttribute below.
-		reportIndent := func(node *ast.Node, needed, gotten int) {
-			indent := strings.Repeat(string(indentChar), needed)
-			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
-			startCol := trimmed.Pos()
-			lineStart := lineStartOfPos(startCol)
-			ctx.ReportNodeWithFixes(node, makeMsg(needed, gotten), rule.RuleFix{
-				Text:  indent,
-				Range: core.NewTextRange(lineStart, startCol),
-			})
 		}
 
 		// reportLiteral emits one diagnostic per mis-indented line of a
@@ -147,7 +51,7 @@ var JsxIndentRule = rule.Rule{
 		// of the parent's opening tag).
 		reportLiteral := func(node *ast.Node, needed, gotten int, fixed string) {
 			rawRange := core.NewTextRange(node.Pos(), node.End())
-			ctx.ReportRangeWithFixes(rawRange, makeMsg(needed, gotten), rule.RuleFix{
+			ctx.ReportRangeWithFixes(rawRange, reactutil.WrongIndentMessage(needed, gotten, indentType), rule.RuleFix{
 				Text:  fixed,
 				Range: rawRange,
 			})
@@ -163,14 +67,15 @@ var JsxIndentRule = rule.Rule{
 			start := trimmed.Pos()
 			end := trimmed.End()
 			raw := text[start:end]
+			msg := reactutil.WrongIndentMessage(needed, gotten, indentType)
 			if !strings.Contains(raw, "\n") {
-				ctx.ReportNode(node, makeMsg(needed, gotten))
+				ctx.ReportNode(node, msg)
 				return
 			}
 			lastNL := strings.LastIndex(raw, "\n")
 			lastLine := raw[lastNL:]
 			fixedLast := replaceFirstLeadingIndent(lastLine, indent)
-			ctx.ReportNodeWithFixes(node, makeMsg(needed, gotten), rule.RuleFix{
+			ctx.ReportNodeWithFixes(node, msg, rule.RuleFix{
 				Text:  fixedLast,
 				Range: core.NewTextRange(start+lastNL, end),
 			})
@@ -183,7 +88,7 @@ var JsxIndentRule = rule.Rule{
 		// the anchor token, NOT on the JsxAttribute.
 		reportAttribute := func(anchorPos int, needed, gotten int, fixRange core.TextRange, fixText string) {
 			anchorRange := core.NewTextRange(anchorPos, anchorPos+1)
-			ctx.ReportRangeWithFixes(anchorRange, makeMsg(needed, gotten), rule.RuleFix{
+			ctx.ReportRangeWithFixes(anchorRange, reactutil.WrongIndentMessage(needed, gotten, indentType), rule.RuleFix{
 				Text:  fixText,
 				Range: fixRange,
 			})
@@ -284,14 +189,14 @@ var JsxIndentRule = rule.Rule{
 		}
 
 		checkNodesIndent := func(node *ast.Node, indent int) {
-			nodeIndent := nodeStartIndent(node)
+			nodeIndent := reactutil.NodeStartIndent(ctx.SourceFile, node, indentChar)
 			isCorrectRightInLogicalExp := isRightInLogicalExp(node) && (nodeIndent-indent) == indentSize
 			isCorrectAlternateInCondExp := isAlternateInConditionalExp(node) && (nodeIndent-indent) == 0
 			if nodeIndent != indent &&
-				isNodeFirstInLine(node) &&
+				reactutil.IsNodeFirstInLine(ctx.SourceFile, node) &&
 				!isCorrectRightInLogicalExp &&
 				!isCorrectAlternateInCondExp {
-				reportIndent(node, indent, nodeIndent)
+				reactutil.ReportIndentReplaceLeading(ctx, node, indent, nodeIndent, indentChar, indentType)
 			}
 		}
 
@@ -433,7 +338,7 @@ var JsxIndentRule = rule.Rule{
 			if opening := jsxParentOpening(node); opening != nil {
 				openingTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, opening)
 				sameLine := lineOfPos(openingTrimmed.Pos()) == lineOfPos(startPos)
-				return lineIndentAt(openingTrimmed.Pos()), sameLine, true
+				return reactutil.IndentLeading(text, lineMap, openingTrimmed.Pos(), indentChar), sameLine, true
 			}
 
 			i := startPos - 1
@@ -448,7 +353,7 @@ var JsxIndentRule = rule.Rule{
 				if container != nil {
 					containerTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, container)
 					sameLine := lineOfPos(containerTrimmed.Pos()) == lineOfPos(startPos)
-					return lineIndentAt(containerTrimmed.Pos()), sameLine, true
+					return reactutil.IndentLeading(text, lineMap, containerTrimmed.Pos(), indentChar), sameLine, true
 				}
 				i--
 				for i >= 0 && (text[i] == ' ' || text[i] == '\t' || text[i] == '\r' || text[i] == '\n') {
@@ -457,20 +362,20 @@ var JsxIndentRule = rule.Rule{
 				if i < 0 {
 					return 0, false, true
 				}
-				return lineIndentAt(i), false, true
+				return reactutil.IndentLeading(text, lineMap, i, indentChar), false, true
 			}
 			if text[i] == ':' {
 				anchor := colonAnchor(node)
 				if anchor != nil {
 					anchorTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, anchor)
 					sameLine := lineOfPos(anchorTrimmed.Pos()) == lineOfPos(startPos)
-					return lineIndentAt(anchorTrimmed.Pos()), sameLine, true
+					return reactutil.IndentLeading(text, lineMap, anchorTrimmed.Pos(), indentChar), sameLine, true
 				}
 				// Fall through: no enclosing conditional — use the `:`
 				// position.
 			}
 			sameLine := lineOfPos(i) == lineOfPos(startPos)
-			return lineIndentAt(i), sameLine, true
+			return reactutil.IndentLeading(text, lineMap, i, indentChar), sameLine, true
 		}
 
 		handleOpeningElement := func(node *ast.Node) {
@@ -501,7 +406,7 @@ var JsxIndentRule = rule.Rule{
 			default:
 				return
 			}
-			peerIndent := nodeStartIndent(openingNode)
+			peerIndent := reactutil.NodeStartIndent(ctx.SourceFile, openingNode, indentChar)
 			checkNodesIndent(node, peerIndent)
 		}
 
@@ -536,7 +441,7 @@ var JsxIndentRule = rule.Rule{
 				return
 			}
 			anchorPos := i
-			lineStart := lineStartOfPos(anchorPos)
+			lineStart := reactutil.IndentLineStart(lineMap, anchorPos)
 			actualIndent := 0
 			for j := lineStart; j < anchorPos; j++ {
 				if text[j] != indentChar {
@@ -560,7 +465,7 @@ var JsxIndentRule = rule.Rule{
 			}
 			nameLine := lineOfPos(nameNode.Pos())
 			anchorLine := lineOfPos(anchorPos)
-			expectedIndent := nodeStartIndent(nameNode)
+			expectedIndent := reactutil.NodeStartIndent(ctx.SourceFile, nameNode, indentChar)
 			if nameLine == anchorLine {
 				expectedIndent = 0
 			}
@@ -577,7 +482,7 @@ var JsxIndentRule = rule.Rule{
 			if parent == nil {
 				return
 			}
-			parentIndent := nodeStartIndent(parent)
+			parentIndent := reactutil.NodeStartIndent(ctx.SourceFile, parent, indentChar)
 			checkNodesIndent(node, parentIndent+indentSize)
 		}
 
@@ -589,7 +494,7 @@ var JsxIndentRule = rule.Rule{
 			if parent.Kind != ast.KindJsxElement && parent.Kind != ast.KindJsxFragment {
 				return
 			}
-			parentIndent := nodeStartIndent(parent)
+			parentIndent := reactutil.NodeStartIndent(ctx.SourceFile, parent, indentChar)
 			checkLiteralNodeIndent(node, parentIndent+indentSize)
 		}
 
@@ -617,8 +522,8 @@ var JsxIndentRule = rule.Rule{
 			if fn == nil {
 				return
 			}
-			openingIndent := nodeStartIndent(node)
-			closingIndent := nodeEndIndent(node)
+			openingIndent := reactutil.NodeStartIndent(ctx.SourceFile, node, indentChar)
+			closingIndent := reactutil.NodeEndIndent(ctx.SourceFile, node, indentChar)
 			if openingIndent != closingIndent {
 				reportReturn(node, openingIndent, closingIndent)
 			}

--- a/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props.go
+++ b/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props.go
@@ -117,8 +117,12 @@ var JsxIndentPropsRule = rule.Rule{
 
 			var propIndent int
 			if indentIsFirst {
-				firstPropTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, props[0])
-				propIndent = firstPropTrimmed.Pos() - reactutil.IndentLineStart(lineMap, firstPropTrimmed.Pos())
+				// 'first' mode aligns to the visual column of the
+				// first prop. Use UTF-16 character column (matches
+				// ESLint's `loc.start.column`) instead of byte
+				// offset so multi-byte characters preceding the
+				// first prop don't inflate the expected indent.
+				propIndent = reactutil.NodeStartUTF16Column(ctx.SourceFile, props[0])
 			} else {
 				propIndent = elementIndent + indentSize
 			}

--- a/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props.go
+++ b/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props.go
@@ -1,0 +1,225 @@
+package jsx_indent_props
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// JsxIndentPropsRule enforces JSX prop indentation.
+//
+// Ported from eslint-plugin-react's `jsx-indent-props` rule. The rule walks
+// every JsxOpeningElement / JsxSelfClosingElement, computes the expected
+// prop indent (either `<element-indent> + indentSize` for the numeric / tab
+// modes, or the column of the first prop for `'first'`), and reports each
+// attribute whose leading-whitespace count differs.
+//
+// tsgo↔ESTree shape adjustments (vs the upstream JS rule):
+//   - Self-closing `<Foo />` is `JsxSelfClosingElement` with no wrapping
+//     `JsxElement`, so both `JsxOpeningElement` and `JsxSelfClosingElement`
+//     share the same listener.
+//   - Source-line scans (line-start, leading whitespace, first non-WS char)
+//     run against `SourceFile.Text()`; line numbers come from the
+//     ECMA line map via `scanner.ComputeLineOfPosition`.
+//
+// Ternary operator handling: upstream maintains a `line.isUsingOperator`
+// flag that is set when the line containing the JSX `<` starts with `?` or
+// `:` after whitespace. When that flag is on (and `'first'` mode is off and
+// `ignoreTernaryOperator` is off), the FIRST prop that sits first-in-line
+// receives an extra `indentSize` bump, after which the flag is cleared.
+// We replicate that behaviour with a per-element `bumpApplied` boolean and
+// a per-prop bracket reset (mirrors upstream's `useBracket` reset inside
+// `getNodeIndent` — any prop whose first source line contains `<` cancels
+// the pending bump, exactly the same way upstream's per-call side effect
+// would).
+var JsxIndentPropsRule = rule.Rule{
+	Name: "react/jsx-indent-props",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		indentType, indentSize, indentChar, indentIsFirst, ignoreTernaryOperator := parseOptions(options)
+
+		text := ctx.SourceFile.Text()
+		lineMap := ctx.SourceFile.ECMALineMap()
+
+		// firstNonWhitespaceCharOnLine returns the first non space / tab
+		// character on the line containing pos, or 0 if none.
+		firstNonWhitespaceCharOnLine := func(pos int) byte {
+			start := reactutil.IndentLineStart(lineMap, pos)
+			for i := start; i < len(text); i++ {
+				c := text[i]
+				if c == ' ' || c == '\t' {
+					continue
+				}
+				if c == '\n' || c == '\r' {
+					return 0
+				}
+				return c
+			}
+			return 0
+		}
+
+		// firstLineContainsBracket reports whether the first source line
+		// of node (from line-start of trimmed start to the next newline
+		// or the trimmed end, whichever comes first) contains a `<`.
+		// Mirrors upstream's `useBracket` check inside `getNodeIndent`,
+		// which resets `isUsingOperator` whenever the scanned line
+		// includes a `<` (i.e. the prop is on the same line as the
+		// element's opening `<`, or carries an inline JSX-literal value).
+		firstLineContainsBracket := func(node *ast.Node) bool {
+			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			lineStart := reactutil.IndentLineStart(lineMap, trimmed.Pos())
+			end := trimmed.End()
+			for i := lineStart; i < end && i < len(text); i++ {
+				c := text[i]
+				if c == '\n' {
+					break
+				}
+				if c == '<' {
+					return true
+				}
+			}
+			return false
+		}
+
+		check := func(node *ast.Node) {
+			var props []*ast.Node
+			switch node.Kind {
+			case ast.KindJsxOpeningElement:
+				opening := node.AsJsxOpeningElement()
+				if opening.Attributes != nil {
+					attrs := opening.Attributes.AsJsxAttributes()
+					if attrs != nil && attrs.Properties != nil {
+						props = attrs.Properties.Nodes
+					}
+				}
+			case ast.KindJsxSelfClosingElement:
+				self := node.AsJsxSelfClosingElement()
+				if self.Attributes != nil {
+					attrs := self.Attributes.AsJsxAttributes()
+					if attrs != nil && attrs.Properties != nil {
+						props = attrs.Properties.Nodes
+					}
+				}
+			}
+			if len(props) == 0 {
+				return
+			}
+
+			openingTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			openingStart := openingTrimmed.Pos()
+
+			// isUsingOperator: line containing the opening `<` starts
+			// with `?` or `:` after whitespace.
+			leadChar := firstNonWhitespaceCharOnLine(openingStart)
+			isUsingOperator := leadChar == '?' || leadChar == ':'
+
+			elementIndent := reactutil.IndentLeading(text, lineMap, openingStart, indentChar)
+
+			var propIndent int
+			if indentIsFirst {
+				firstPropTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, props[0])
+				propIndent = firstPropTrimmed.Pos() - reactutil.IndentLineStart(lineMap, firstPropTrimmed.Pos())
+			} else {
+				propIndent = elementIndent + indentSize
+			}
+
+			nestedIndent := propIndent
+			bumpApplied := false
+
+			for _, prop := range props {
+				// Mirror upstream: `getNodeIndent(node)` is called per
+				// prop regardless of first-in-line status, and resets
+				// `isUsingOperator` when the scanned line contains a
+				// `<`. Apply the same reset here so a prop whose first
+				// source line includes `<` (e.g. on the element's own
+				// `<` line, or carrying an inline JSX-literal value)
+				// cancels the bump.
+				if firstLineContainsBracket(prop) {
+					isUsingOperator = false
+				}
+
+				if !reactutil.IsNodeFirstInLine(ctx.SourceFile, prop) {
+					continue
+				}
+
+				if !bumpApplied && isUsingOperator && !indentIsFirst && !ignoreTernaryOperator {
+					nestedIndent += indentSize
+					bumpApplied = true
+					isUsingOperator = false
+				}
+
+				actualIndent := reactutil.NodeStartIndent(ctx.SourceFile, prop, indentChar)
+				if actualIndent != nestedIndent {
+					reactutil.ReportIndentReplaceLeading(ctx, prop, nestedIndent, actualIndent, indentChar, indentType)
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}
+
+// parseOptions parses the rule options. The first positional option may be:
+//   - "tab"                     → tab indent, size 1
+//   - "first"                   → align with first prop's column
+//   - integer N                 → N-space indent
+//   - object { indentMode, ignoreTernaryOperator } → use indentMode as
+//     above, plus optional ignoreTernaryOperator boolean
+//
+// Default: 4-space indent, ignoreTernaryOperator off.
+func parseOptions(options any) (indentType string, indentSize int, indentChar byte, indentIsFirst bool, ignoreTernaryOperator bool) {
+	indentType = "space"
+	indentSize = 4
+	indentChar = ' '
+
+	var first any
+	if options == nil {
+		return indentType, indentSize, indentChar, indentIsFirst, ignoreTernaryOperator
+	}
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) > 0 {
+			first = arr[0]
+		}
+	} else {
+		first = options
+	}
+	if first == nil {
+		return indentType, indentSize, indentChar, indentIsFirst, ignoreTernaryOperator
+	}
+
+	var indentMode any
+	if m, ok := first.(map[string]interface{}); ok {
+		indentMode = m["indentMode"]
+		if v, ok := m["ignoreTernaryOperator"].(bool); ok {
+			ignoreTernaryOperator = v
+		}
+	} else {
+		indentMode = first
+	}
+
+	switch v := indentMode.(type) {
+	case string:
+		switch v {
+		case "first":
+			indentIsFirst = true
+			indentType = "space"
+			indentChar = ' '
+		case "tab":
+			indentType = "tab"
+			indentSize = 1
+			indentChar = '\t'
+		}
+	case float64:
+		indentType = "space"
+		indentSize = int(v)
+		indentChar = ' '
+	case int:
+		indentType = "space"
+		indentSize = v
+		indentChar = ' '
+	}
+	return indentType, indentSize, indentChar, indentIsFirst, ignoreTernaryOperator
+}

--- a/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props.md
+++ b/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props.md
@@ -1,0 +1,140 @@
+# jsx-indent-props
+
+## Rule Details
+
+This rule enforces a consistent indentation style for JSX props. The default style is `4 spaces`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<Hello
+  firstName="John"
+/>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<Hello
+    firstName="John"
+/>
+```
+
+## Rule Options
+
+The first option accepts:
+
+- `"tab"` — tab-based indentation.
+- a non-negative integer — N-space indentation.
+- `"first"` — align each prop with the column of the first prop.
+- an object with these keys:
+  - `indentMode` — same value space as the positional option above (`"tab"`, `"first"`, or an integer).
+  - `ignoreTernaryOperator` — boolean (default `false`). When `true`, props inside a JSX element nested in a `?:` consequent / alternate are NOT given an extra `indentMode` bump.
+
+Examples of **incorrect** code for this rule with `["error", 2]`:
+
+```json
+{ "react/jsx-indent-props": ["error", 2] }
+```
+
+```jsx
+<Hello
+    firstName="John"
+/>
+```
+
+Examples of **correct** code for this rule with `["error", 2]`:
+
+```json
+{ "react/jsx-indent-props": ["error", 2] }
+```
+
+```jsx
+<Hello
+  firstName="John"
+/>
+```
+
+Examples of **correct** code for this rule with `["error", "tab"]`:
+
+```json
+{ "react/jsx-indent-props": ["error", "tab"] }
+```
+
+```jsx
+<Hello
+	firstName="John"
+/>
+```
+
+Examples of **correct** code for this rule with `["error", 0]`:
+
+```json
+{ "react/jsx-indent-props": ["error", 0] }
+```
+
+```jsx
+<Hello
+firstName="John"
+/>
+```
+
+Examples of **incorrect** code for this rule with `["error", "first"]`:
+
+```json
+{ "react/jsx-indent-props": ["error", "first"] }
+```
+
+```jsx
+<Hello firstName="John"
+  lastName="Doe"
+/>
+```
+
+Examples of **correct** code for this rule with `["error", "first"]`:
+
+```json
+{ "react/jsx-indent-props": ["error", "first"] }
+```
+
+```jsx
+<Hello firstName="John"
+       lastName="Doe"
+/>
+```
+
+Examples of **correct** code for this rule with `["error", { "indentMode": 2, "ignoreTernaryOperator": false }]` (default — props inside a `?:` branch receive an extra `indentMode` bump):
+
+```json
+{ "react/jsx-indent-props": ["error", { "indentMode": 2, "ignoreTernaryOperator": false }] }
+```
+
+```jsx
+{condition
+  ? <Hello
+      firstName="John"
+    />
+  : null}
+```
+
+Examples of **correct** code for this rule with `["error", { "indentMode": 2, "ignoreTernaryOperator": true }]` (no extra bump inside `?:`):
+
+```json
+{ "react/jsx-indent-props": ["error", { "indentMode": 2, "ignoreTernaryOperator": true }] }
+```
+
+```jsx
+{condition
+  ? <Hello
+    firstName="John"
+  />
+  : null}
+```
+
+## When Not To Use It
+
+If you are not using JSX, you can disable this rule. If you use a code formatter (e.g. Prettier) that already enforces JSX prop indentation, prefer relying on the formatter instead.
+
+## Original Documentation
+
+- [react/jsx-indent-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md)

--- a/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props_test.go
+++ b/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props_test.go
@@ -1,0 +1,745 @@
+package jsx_indent_props
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestJsxIndentPropsRule mirrors the upstream eslint-plugin-react test suite
+// at `tests/lib/rules/jsx-indent-props.js`. Each upstream case is migrated
+// 1:1; cases that exercise non-tsgo features are kept as `Skip: true` with a
+// short reason so the file still maps to the upstream layout.
+//
+// Layout note: upstream's tagged-template-literal cases anchor their JSX
+// with an 8-space outer indent that the template literal itself injects
+// (the source of the test file is indented inside the JS module). We keep
+// the same 8-space prefix verbatim so the indent arithmetic continues to
+// match upstream's expectations.
+func TestJsxIndentPropsRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxIndentPropsRule, []rule_tester.ValidTestCase{
+		// ---- Default 4-space indent (no options) ----
+		{
+			Code: "\n        <App foo\n        />\n      ",
+			Tsx:  true,
+		},
+
+		// ---- 2-space indent ----
+		{
+			Code:    "\n        <App\n          foo\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- Complex multi-element array literal (options: [2]) ----
+		{
+			Code:    "\n        const Test = () => ([\n          (x\n            ? <div key=\"1\" />\n            : <div key=\"2\" />),\n          <div\n            key=\"3\"\n            align=\"left\"\n          />,\n          <div\n            key=\"4\"\n            align=\"left\"\n          />,\n        ]);\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// ---- 0-indent (props flush to column 0) ----
+		{
+			Code:    "\n        <App\n        foo\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(0)},
+		},
+
+		// ---- Negative indent (props sit two cols to the LEFT of `<App`) ----
+		{
+			Code:    "\n          <App\n        foo\n          />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(-2)},
+		},
+
+		// ---- Tab indentation ----
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+		},
+
+		// ---- 'first' option, no props ----
+		{
+			Code:    "\n        <App/>\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+
+		// ---- 'first' option, props aligned with first prop's column ----
+		{
+			Code:    "\n        <App aaa\n             b\n             cc\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+		{
+			Code:    "\n        <App   aaa\n               b\n               cc\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+		{
+			Code:    "\n        const test = <App aaa\n                          b\n                          cc\n                     />\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+		{
+			Code:    "\n        <App aaa x\n             b y\n             cc\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+		{
+			Code:    "\n        const test = <App aaa x\n                          b y\n                          cc\n                     />\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+		{
+			Code:    "\n        <App aaa\n             b\n        >\n            <Child c\n                   d/>\n        </App>\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+		{
+			Code:    "\n        <Fragment>\n          <App aaa\n               b\n               cc\n          />\n          <OtherApp a\n                    bbb\n                    c\n          />\n        </Fragment>\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+
+		// ---- 'first' with all props on new lines: each prop must match
+		// the first prop's column (which is the open-tag's own line indent
+		// plus the gap before the first prop). ----
+		{
+			Code:    "\n        <App\n          a\n          b\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+
+		// ---- ignoreTernaryOperator: false (default), input already has
+		// the bump applied. ----
+		{
+			Code:    "\n        {this.props.ignoreTernaryOperatorFalse\n          ? <span\n              className=\"value\"\n              some={{aaa}}\n            />\n          : null}\n      ",
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": false}},
+		},
+
+		// ---- Function returning JSX nested in conditional, default
+		// indentMode=2, ignoreTernaryOperator=false. ----
+		{
+			Code:    "\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n            id=\"id\"\n          >\n            test\n          </div>\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": false}},
+		},
+
+		// ---- Same shape, ignoreTernaryOperator=true — single-line JSX
+		// inside the conditional doesn't trigger a bump either way. ----
+		{
+			Code:    "\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n            id=\"id\"\n          >\n            test\n          </div>\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": true}},
+		},
+
+		// ---- Tab indent with conditional + return JSX ----
+		{
+			Code:    "\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n",
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": "tab", "ignoreTernaryOperator": false}},
+		},
+		{
+			Code:    "\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n",
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": "tab", "ignoreTernaryOperator": true}},
+		},
+
+		// ---- ignoreTernaryOperator: true — props inside ternary alternate/
+		// consequent do NOT receive an extra indent bump. ----
+		{
+			Code:    "\n        {this.props.ignoreTernaryOperatorTrue\n          ? <span\n            className=\"value\"\n            some={{aaa}}\n            />\n          : null}\n      ",
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": true}},
+		},
+
+		// ---- Realistic anchor element with mixed prop kinds (object form
+		// with only indentMode). ----
+		{
+			Code:    "\n        <a\n          role={'button'}\n          className={`navbar-burger ${open ? 'is-active' : ''}`}\n          href={'#'}\n          aria-label={'menu'}\n          aria-expanded={false}\n          onClick={openMenu}>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n        </a>\n      ",
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": float64(2)}},
+		},
+
+		// ---- Same realistic element under 'first' alignment ----
+		{
+			Code:    "\n        <a role={'button'}\n           className={`navbar-burger ${open ? 'is-active' : ''}`}\n           href={'#'}\n           aria-label={'menu'}\n           aria-expanded={false}\n           onClick={openMenu}>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n        </a>\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+
+		// ---- tsgo-specific lock-ins (NOT in upstream) ----
+		// Spread attribute as the first prop under default 4-space:
+		// `{...rest}` is a JsxSpreadAttribute and must obey the same
+		// indent contract as a JsxAttribute.
+		{
+			Code: "\n        <App\n            {...rest}\n            foo\n        />\n      ",
+			Tsx:  true,
+		},
+
+		// Spread attribute as first prop with 'first' alignment — column
+		// of the first prop is the column of the leading `{`, and the
+		// second prop must match.
+		{
+			Code:    "\n        <App {...rest}\n             foo\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+
+		// Single-line JSX inside a ternary must NOT trigger the bump —
+		// upstream's `useOperator` regex only fires when the `<` line
+		// itself starts with `?`/`:` after WS, not when the `?` sits
+		// upstream on the same line.
+		{
+			Code:    "\n        const x = cond ? <App foo bar /> : null\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// Adjacent ternary JSX + non-ternary JSX in the same source —
+		// the per-element state reset must prevent `isUsingOperator`
+		// from leaking across elements (the state was set by the first
+		// element's `?` line, but the second element's `<App` line is
+		// not a ternary side and must NOT pick up the bump).
+		{
+			Code:    "\n        const a = c1\n          ? <X\n              a\n            /> : null;\n        const b = <App\n          foo\n        />;\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// Multi-line JSX literal as an attr value, first line of the
+		// prop does NOT contain `<` (it ends with `={`), so upstream's
+		// `useBracket` reset does NOT fire and the ternary bump still
+		// applies to subsequent props.
+		{
+			Code:    "\n        c\n          ? <App\n              foo={\n                <Inner/>\n              }\n              bar\n            />\n          : null\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// Single-line attr value containing a JSX literal: first line
+		// of the prop contains `<`, which cancels the ternary bump
+		// (upstream's `useBracket` reset). Both `foo={...}` and the
+		// following `bar` must align WITHOUT the bump.
+		{
+			Code:    "\n        c\n          ? <App\n            foo={<Inner/>}\n            bar\n          />\n          : null\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// TS wrappers around the ternary side (`as`, `satisfies`, `!`,
+		// type assertion) are explicit nodes in tsgo — but the
+		// `useOperator` check is line-content-based, so wrappers don't
+		// change which line `?` sits on, and the bump still applies.
+		{
+			Code:    "\n        const x = c\n          ? (<App\n              foo\n            />) as React.ReactElement\n          : null\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// Generic JSX tag `<Foo<T>>` — type arguments don't appear in
+		// `Attributes.Properties.Nodes`, so prop processing must ignore
+		// them and treat the multi-line props normally.
+		{
+			Code:    "\n        <Foo<string>\n            a\n            b\n        />\n      ",
+			Tsx:     true,
+		},
+
+		// Member-expression tag `<Foo.Bar>` — the dotted name must not
+		// disturb prop processing.
+		{
+			Code: "\n        <Foo.Bar\n            a\n            b\n        />\n      ",
+			Tsx:  true,
+		},
+
+		// Namespaced tag `<svg:rect>` — same shape as member, should be
+		// transparent to prop processing.
+		{
+			Code: "\n        <svg:rect\n            a\n            b\n        />\n      ",
+			Tsx:  true,
+		},
+
+		// ---- Real user scenarios (valid) ----
+		// Inline arrow event handler with a multi-line body. The first
+		// source line of `onClick` ends with `={() => {` — no `<` — so
+		// the bracket-reset is a no-op (and there's no ternary anyway).
+		{
+			Code:    "\n        <button\n          onClick={() => {\n            setX(true);\n            log();\n          }}\n          disabled\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// className with template literal interpolation that itself
+		// contains a `?:` — the `?` is inside `${ ... }`, not at line
+		// start, so it must NOT trigger the operator bump.
+		{
+			Code:    "\n        <div\n          className={`foo ${cond ? 'a' : 'b'} bar`}\n          id=\"x\"\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// Spread + named override pattern (`<Input {...props} value={x} />`)
+		// — both forms of attribute share the same indent contract.
+		{
+			Code:    "\n        <Input\n          {...props}\n          value={localValue}\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// Multiple consecutive spread attributes followed by named.
+		{
+			Code:    "\n        <Input\n          {...props1}\n          {...props2}\n          value={x}\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// Render-prop / children-as-function — JSX nested inside a JSX
+		// expression container that itself sits in JSX children.
+		{
+			Code:    "\n        <Query>\n          {(data) => <Result\n            value={data}\n            onClick={handler}\n          />}\n        </Query>\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// Conditional rendering with `&&` (logical-and) wrapping a
+		// multi-line JSX. Same as map / IIFE — line of `<Modal` is not
+		// led by `?`/`:`, so no bump.
+		{
+			Code:    "\n        {isOpen && (\n          <Modal\n            onClose={close}\n            title=\"Welcome\"\n          />\n        )}\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// `.map(...)` render with a multi-line JSX body.
+		{
+			Code:    "\n        {items.map((item) => (\n          <Item\n            key={item.id}\n            value={item.value}\n          />\n        ))}\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// `ref` is just an attribute — no special handling. Combined
+		// with hyphenated and dotted attribute names that exercise the
+		// JSX identifier parser.
+		{
+			Code:    "\n        <input\n          ref={inputRef}\n          type=\"text\"\n          aria-label=\"name\"\n          data-testid=\"input\"\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// Realistic full-form component: function declaration, return
+		// statement, multi-line opening tag, hyphenated and template-
+		// literal-valued props.
+		{
+			Code:    "\n        function Form({ submit }) {\n          return (\n            <form\n              onSubmit={submit}\n              noValidate\n              autoComplete=\"off\"\n              className={`form ${variant}`}\n            >\n              <input\n                ref={inputRef}\n                type=\"text\"\n              />\n            </form>\n          );\n        }\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// Comment between attributes — leading trivia on the second
+		// attr; trimmed.Pos() must skip the comment so the line-indent
+		// reading lands on `b`'s line, not the comment's line.
+		{
+			Code:    "\n        <App\n          a={1}\n          // separator\n          b={2}\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+
+		// `'first'` mode with a SPREAD as the first prop — column
+		// anchor must come from the leading `{` of `{...rest}`, not
+		// from any inner identifier.
+		{
+			Code:    "\n        <App {...rest}\n             id=\"x\"\n             onClick={fn}\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+
+		// `'first'` mode with a BOOLEAN attribute as the first prop —
+		// column anchor must come from the boolean's identifier start.
+		{
+			Code:    "\n        <App disabled\n             onClick={fn}\n             id=\"x\"\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{"first"},
+		},
+
+		// ---- Configuration edge cases ----
+		// Object form with ONLY `ignoreTernaryOperator` (no
+		// `indentMode`): should fall back to default 4-space, and the
+		// flag must still take effect (no bump on ternary side).
+		{
+			Code:    "\n        {cond\n          ? <App\n              foo\n            />\n          : null}\n      ",
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"ignoreTernaryOperator": true}},
+		},
+
+		// Object form with `indentMode: 'first'` — string value inside
+		// the object form must work the same as the bare `'first'`.
+		{
+			Code:    "\n        <App aaa\n             b\n             cc\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": "first"}},
+		},
+
+		// Large indent (8-space) — option size only feeds arithmetic
+		// and string repeat, must work regardless of magnitude.
+		{
+			Code:    "\n        <App\n                foo\n                bar\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(8)},
+		},
+
+		// Empty options array — equivalent to default 4-space.
+		{
+			Code:    "\n        <App\n            foo\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{},
+		},
+
+		// Unrecognised string in object form (`indentMode: 'spaces'`)
+		// silently falls through to default 4-space — must not crash
+		// or produce false reports.
+		{
+			Code:    "\n        <App\n            foo\n        />\n      ",
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": "spaces"}},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Default 4-space indent — child at 10 must be 12. ----
+		{
+			Code:   "\n        <App\n          foo\n        />\n      ",
+			Output: []string{"\n        <App\n            foo\n        />\n      "},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- 2-space indent — child at 12 must be 10. ----
+		{
+			Code:    "\n        <App\n            foo\n        />\n      ",
+			Output:  []string{"\n        <App\n          foo\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Conditional with JSX in both branches — bump applies on
+		// each ternary side. ----
+		{
+			Code:    "\n        const test = true\n          ? <span\n            attr=\"value\"\n            />\n          : <span\n            attr=\"otherValue\"\n            />\n      ",
+			Output:  []string{"\n        const test = true\n          ? <span\n              attr=\"value\"\n            />\n          : <span\n              attr=\"otherValue\"\n            />\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Alternate wrapped in its own parens — indent expected
+		// without ternary bump because the `(` resets context. ----
+		{
+			Code:    "\n        const test = true\n          ? <span attr=\"value\" />\n          : (\n            <span\n                attr=\"otherValue\"\n            />\n          )\n      ",
+			Output:  []string{"\n        const test = true\n          ? <span attr=\"value\" />\n          : (\n            <span\n              attr=\"otherValue\"\n            />\n          )\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Ternary alternate: only one prop. ----
+		{
+			Code:    "\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n            some={aaa}/>\n        }\n      ",
+			Output:  []string{"\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n              some={aaa}/>\n        }\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Ternary alternate: two props, both bumped. ----
+		{
+			Code:    "\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n            some={aaa}\n            other={bbb}/>\n        }\n      ",
+			Output:  []string{"\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n              some={aaa}\n              other={bbb}/>\n        }\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Ternary consequent inside JSXExpressionContainer: bump
+		// applies. ----
+		{
+			Code:    "\n        {this.props.test\n          ? <span\n            className=\"value\"\n            some={{aaa}}\n            />\n          : null}\n      ",
+			Output:  []string{"\n        {this.props.test\n          ? <span\n              className=\"value\"\n              some={{aaa}}\n            />\n          : null}\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Tab option, prop has no leading tab — needed=1 character. ----
+		{
+			Code:    "\n        <App1\n            foo\n        />\n      ",
+			Output:  []string{"\n        <App1\n\tfoo\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Tab option, too many tabs — needed=5 characters. ----
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t"},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- 'first': prop at col 10 must match firstPropCol=13. ----
+		{
+			Code:    "\n        <App a\n          b\n        />\n      ",
+			Output:  []string{"\n        <App a\n             b\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- 'first': prop at col 11 must match firstPropCol=14. ----
+		{
+			Code:    "\n        <App  a\n           b\n        />\n      ",
+			Output:  []string{"\n        <App  a\n              b\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- 'first', first prop on new line: subsequent props must
+		// match the FIRST prop's column. ----
+		{
+			Code:    "\n        <App\n              a\n           b\n        />\n      ",
+			Output:  []string{"\n        <App\n              a\n              b\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- 'first', three props with two mis-aligned. ----
+		{
+			Code:    "\n        <App\n          a\n         b\n           c\n        />\n      ",
+			Output:  []string{"\n        <App\n          a\n          b\n          c\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- ignoreTernaryOperator:false, return JSX one indent off. ----
+		{
+			Code:    "\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n              id=\"id\"\n          >\n            test\n          </div>\n        }\n      ",
+			Output:  []string{"\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n            id=\"id\"\n          >\n            test\n          </div>\n        }\n      "},
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": false}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Same shape, ignoreTernaryOperator:true (return JSX is not in
+		// a ternary so behaviour is identical). ----
+		{
+			Code:    "\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n              id=\"id\"\n          >\n            test\n          </div>\n        }\n      ",
+			Output:  []string{"\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n            id=\"id\"\n          >\n            test\n          </div>\n        }\n      "},
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Tab indent + return JSX off by one tab. ----
+		{
+			Code:    "\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n",
+			Output:  []string{"\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n"},
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": "tab", "ignoreTernaryOperator": false}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+		{
+			Code:    "\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n",
+			Output:  []string{"\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n"},
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": "tab", "ignoreTernaryOperator": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- tsgo-specific lock-ins (NOT in upstream) ----
+		// Spread + named prop both at wrong indent — both must report.
+		{
+			Code:   "\n        <App\n          {...rest}\n          foo\n        />\n      ",
+			Output: []string{"\n        <App\n            {...rest}\n            foo\n        />\n      "},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// Bracket-reset cancels the ternary bump: actual props are
+		// indented as if the bump applied, but because the first prop's
+		// first source line contains `<`, upstream's `useBracket` reset
+		// fires and the expected indent is propIndent (NOT
+		// propIndent + indentSize). Locks in: without the reset, this
+		// would silently accept props at indent 10.
+		{
+			Code:    "\n        c\n          ? <App\n              foo={<Inner/>}\n              bar\n            />\n          : null\n      ",
+			Output:  []string{"\n        c\n          ? <App\n            foo={<Inner/>}\n            bar\n            />\n          : null\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// State-leak lock-in: ternary state from the first JSX must NOT
+		// affect the second JSX. The first element's `?` line sets
+		// `isUsingOperator` upstream, but the second element's own `<`
+		// line doesn't lead with `?`/`:` — it should fall back to the
+		// non-bumped expected indent.
+		{
+			Code:    "\n        const a = c1 ? <X\n          a\n        /> : null;\n        <Y\n            foo\n        />\n      ",
+			Output:  []string{"\n        const a = c1 ? <X\n          a\n        /> : null;\n        <Y\n          foo\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Message text + diagnostic position lock-ins ----
+		// Default 4-space, foo at indent 10 must be 12. Asserts the
+		// FULL diagnostic shape: messageId, exact message text
+		// ("12 space characters"), and 1-based Line/Column/EndLine/
+		// EndColumn anchored at the JsxAttribute's trimmed range.
+		{
+			Code:   "\n        <App\n          foo\n        />\n      ",
+			Output: []string{"\n        <App\n            foo\n        />\n      "},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 12 space characters but found 10.",
+					Line:      3,
+					Column:    11,
+					EndLine:   3,
+					EndColumn: 14,
+				},
+			},
+		},
+
+		// Tab option, prop has zero leading tabs — needed=1 must use
+		// the SINGULAR "character" (not "characters"); locks in the
+		// pluralization branch in the message.
+		{
+			Code:    "\n        <App1\n            foo\n        />\n      ",
+			Output:  []string{"\n        <App1\n\tfoo\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 1 tab character but found 0.",
+					Line:      3,
+					Column:    13,
+					EndLine:   3,
+					EndColumn: 16,
+				},
+			},
+		},
+
+		// 'first' alignment mismatch — expected indent is computed from
+		// the first prop's column (here `a` sits at byte column 13,
+		// which becomes the expected indent count).
+		{
+			Code:    "\n        <App a\n          b\n        />\n      ",
+			Output:  []string{"\n        <App a\n             b\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 13 space characters but found 10.",
+					Line:      3,
+					Column:    11,
+					EndLine:   3,
+					EndColumn: 12,
+				},
+			},
+		},
+
+		// Multi-error sequencing — two mis-indented props on different
+		// lines must each report on their OWN line, not on a single
+		// merged location.
+		{
+			Code:   "\n        <App\n          foo\n          bar\n        />\n      ",
+			Output: []string{"\n        <App\n            foo\n            bar\n        />\n      "},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 12 space characters but found 10.",
+					Line:      3,
+					Column:    11,
+				},
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 12 space characters but found 10.",
+					Line:      4,
+					Column:    11,
+				},
+			},
+		},
+
+		// 'first' with three mismatched props — Line increments must
+		// stay in source order; locks in that the iteration follows
+		// `Attributes.Properties.Nodes` order, not visit order.
+		{
+			Code:    "\n        <App\n          a\n         b\n           c\n        />\n      ",
+			Output:  []string{"\n        <App\n          a\n          b\n          c\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Line: 4, Column: 10},
+				{MessageId: "wrongIndent", Line: 5, Column: 12},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props_test.go
+++ b/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props_test.go
@@ -741,5 +741,74 @@ func TestJsxIndentPropsRule(t *testing.T) {
 				{MessageId: "wrongIndent", Line: 5, Column: 12},
 			},
 		},
+
+		// Negative indent option — `[-2]` makes propIndent < 0. Locks in:
+		//   1. The rule MUST NOT panic (early `strings.Repeat(' ', -2)`
+		//      crash before fix). The omitted `Output` field asserts no
+		//      fix was applied (matching upstream ESLint, whose `repeat()`
+		//      throws and is silently dropped).
+		//   2. The diagnostic message preserves the negative `needed`
+		//      verbatim — same shape upstream produces before its fix
+		//      lambda blows up.
+		{
+			Code:    "<App\nfoo\n/>",
+			Tsx:     true,
+			Options: []interface{}{float64(-2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of -2 space characters but found 0.",
+					Line:      2,
+					Column:    1,
+					EndLine:   2,
+					EndColumn: 4,
+				},
+			},
+		},
+
+		// Multi-byte tag name in `'first'` mode — `<中Foo>` adds 1 UTF-16
+		// code unit but 3 UTF-8 bytes. Locks in that propIndent uses
+		// UTF-16 character column (matches ESLint's `loc.start.column`),
+		// not byte offset. Without the UTF-16 fix, this case would
+		// erroneously expect indent 16 (byte offset) instead of 14.
+		{
+			Code:    "\n        <中Foo a=\"x\"\n           b=\"y\"\n        />\n      ",
+			Output:  []string{"\n        <中Foo a=\"x\"\n              b=\"y\"\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 14 space characters but found 11.",
+					Line:      3,
+					Column:    12,
+					EndLine:   3,
+					EndColumn: 17,
+				},
+			},
+		},
+
+		// Multi-line attribute value position assertion (PORT_RULE.md
+		// Phase 4 Step 6 requires ≥1 multi-line case with full
+		// Line+Column+EndLine+EndColumn). The `beforeNav` attribute
+		// spans 4 lines; the diagnostic's end-of-range must land on the
+		// CLOSING line/column of the JsxAttribute, not on its first line.
+		{
+			Code: "\n        <BaseLayout\n          beforeNav={\n            <Banner />\n          }\n        />\n      ",
+			Output: []string{
+				"\n        <BaseLayout\n            beforeNav={\n            <Banner />\n          }\n        />\n      ",
+			},
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "wrongIndent",
+					Message:   "Expected indentation of 12 space characters but found 10.",
+					Line:      3,
+					Column:    11,
+					EndLine:   5,
+					EndColumn: 12,
+				},
+			},
+		},
 	})
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -102,6 +102,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-first-prop-new-line.test.ts',
     './tests/eslint-plugin-react/rules/jsx-handler-names.test.ts',
     './tests/eslint-plugin-react/rules/jsx-indent.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-indent-props.test.ts',
     './tests/eslint-plugin-react/rules/jsx-key.test.ts',
     './tests/eslint-plugin-react/rules/jsx-max-depth.test.ts',
     './tests/eslint-plugin-react/rules/jsx-max-props-per-line.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-indent-props.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-indent-props.test.ts
@@ -1,0 +1,252 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-indent-props', {} as never, {
+  valid: [
+    // ---- Default 4-space indent ----
+    { code: `\n        <App foo\n        />\n      ` },
+
+    // ---- 2-space indent ----
+    {
+      code: `\n        <App\n          foo\n        />\n      `,
+      options: [2],
+    },
+
+    // ---- Complex array literal with multiple JSX elements ----
+    {
+      code: `\n        const Test = () => ([\n          (x\n            ? <div key="1" />\n            : <div key="2" />),\n          <div\n            key="3"\n            align="left"\n          />,\n          <div\n            key="4"\n            align="left"\n          />,\n        ]);\n      `,
+      options: [2],
+    },
+
+    // ---- 0-indent ----
+    {
+      code: `\n        <App\n        foo\n        />\n      `,
+      options: [0],
+    },
+
+    // ---- Negative indent ----
+    {
+      code: `\n          <App\n        foo\n          />\n      `,
+      options: [-2],
+    },
+
+    // ---- Tab indent ----
+    {
+      code: `\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t`,
+      options: ['tab'],
+    },
+
+    // ---- 'first' option, no props ----
+    {
+      code: `\n        <App/>\n      `,
+      options: ['first'],
+    },
+
+    // ---- 'first' option, props aligned with first prop's column ----
+    {
+      code: `\n        <App aaa\n             b\n             cc\n        />\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        <App   aaa\n               b\n               cc\n        />\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        const test = <App aaa\n                          b\n                          cc\n                     />\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        <App aaa x\n             b y\n             cc\n        />\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        const test = <App aaa x\n                          b y\n                          cc\n                     />\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        <App aaa\n             b\n        >\n            <Child c\n                   d/>\n        </App>\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        <Fragment>\n          <App aaa\n               b\n               cc\n          />\n          <OtherApp a\n                    bbb\n                    c\n          />\n        </Fragment>\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        <App\n          a\n          b\n        />\n      `,
+      options: ['first'],
+    },
+
+    // ---- ignoreTernaryOperator: false (default) — props inside the
+    // ternary side already have the bump applied. ----
+    {
+      code: `\n        {this.props.ignoreTernaryOperatorFalse\n          ? <span\n              className="value"\n              some={{aaa}}\n            />\n          : null}\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: false }],
+    },
+
+    // ---- Function returning JSX in conditional, both flag values. ----
+    {
+      code: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n            id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: false }],
+    },
+    {
+      code: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n            id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: true }],
+    },
+
+    // ---- Tab indent with conditional + return JSX ----
+    {
+      code: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      options: [{ indentMode: 'tab', ignoreTernaryOperator: false }],
+    },
+    {
+      code: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      options: [{ indentMode: 'tab', ignoreTernaryOperator: true }],
+    },
+
+    // ---- ignoreTernaryOperator:true — no bump applied. ----
+    {
+      code: `\n        {this.props.ignoreTernaryOperatorTrue\n          ? <span\n            className="value"\n            some={{aaa}}\n            />\n          : null}\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: true }],
+    },
+
+    // ---- Realistic anchor element, indentMode-only object form ----
+    {
+      code: `\n        <a\n          role={'button'}\n          className={\`navbar-burger \${open ? 'is-active' : ''}\`}\n          href={'#'}\n          aria-label={'menu'}\n          aria-expanded={false}\n          onClick={openMenu}>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n        </a>\n      `,
+      options: [{ indentMode: 2 }],
+    },
+
+    // ---- Same realistic element, 'first' alignment ----
+    {
+      code: `\n        <a role={'button'}\n           className={\`navbar-burger \${open ? 'is-active' : ''}\`}\n           href={'#'}\n           aria-label={'menu'}\n           aria-expanded={false}\n           onClick={openMenu}>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n        </a>\n      `,
+      options: ['first'],
+    },
+  ],
+  invalid: [
+    // ---- Default 4-space indent — child at 10 must be 12. ----
+    {
+      code: `\n        <App\n          foo\n        />\n      `,
+      output: `\n        <App\n            foo\n        />\n      `,
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- 2-space indent — child at 12 must be 10. ----
+    {
+      code: `\n        <App\n            foo\n        />\n      `,
+      output: `\n        <App\n          foo\n        />\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- Conditional with JSX in both branches — bump applies. ----
+    {
+      code: `\n        const test = true\n          ? <span\n            attr="value"\n            />\n          : <span\n            attr="otherValue"\n            />\n      `,
+      output: `\n        const test = true\n          ? <span\n              attr="value"\n            />\n          : <span\n              attr="otherValue"\n            />\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }, { messageId: 'wrongIndent' }],
+    },
+
+    // ---- Alternate wrapped in its own parens — no ternary bump. ----
+    {
+      code: `\n        const test = true\n          ? <span attr="value" />\n          : (\n            <span\n                attr="otherValue"\n            />\n          )\n      `,
+      output: `\n        const test = true\n          ? <span attr="value" />\n          : (\n            <span\n              attr="otherValue"\n            />\n          )\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- Ternary alternate, single prop. ----
+    {
+      code: `\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n            some={aaa}/>\n        }\n      `,
+      output: `\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n              some={aaa}/>\n        }\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- Ternary alternate, two props bumped. ----
+    {
+      code: `\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n            some={aaa}\n            other={bbb}/>\n        }\n      `,
+      output: `\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n              some={aaa}\n              other={bbb}/>\n        }\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }, { messageId: 'wrongIndent' }],
+    },
+
+    // ---- Ternary consequent inside JSXExpressionContainer. ----
+    {
+      code: `\n        {this.props.test\n          ? <span\n            className="value"\n            some={{aaa}}\n            />\n          : null}\n      `,
+      output: `\n        {this.props.test\n          ? <span\n              className="value"\n              some={{aaa}}\n            />\n          : null}\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }, { messageId: 'wrongIndent' }],
+    },
+
+    // ---- Tab option, prop has no leading tab. ----
+    {
+      code: `\n        <App1\n            foo\n        />\n      `,
+      output: `\n        <App1\n\tfoo\n        />\n      `,
+      options: ['tab'],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- Tab option, too many tabs. ----
+    {
+      code: `\n\t\t\t\t<App\n\t\t\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t`,
+      output: `\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t`,
+      options: ['tab'],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- 'first' alignment failures. ----
+    {
+      code: `\n        <App a\n          b\n        />\n      `,
+      output: `\n        <App a\n             b\n        />\n      `,
+      options: ['first'],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+    {
+      code: `\n        <App  a\n           b\n        />\n      `,
+      output: `\n        <App  a\n              b\n        />\n      `,
+      options: ['first'],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+    {
+      code: `\n        <App\n              a\n           b\n        />\n      `,
+      output: `\n        <App\n              a\n              b\n        />\n      `,
+      options: ['first'],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+    {
+      code: `\n        <App\n          a\n         b\n           c\n        />\n      `,
+      output: `\n        <App\n          a\n          b\n          c\n        />\n      `,
+      options: ['first'],
+      errors: [{ messageId: 'wrongIndent' }, { messageId: 'wrongIndent' }],
+    },
+
+    // ---- Return JSX off by one indent unit, both ignoreTernaryOperator
+    // values (return JSX is not in a ternary so behaviour matches). ----
+    {
+      code: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n              id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      output: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n            id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: false }],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+    {
+      code: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n              id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      output: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n            id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: true }],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- Tab indent + return JSX off by one. ----
+    {
+      code: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      output: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      options: [{ indentMode: 'tab', ignoreTernaryOperator: false }],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+    {
+      code: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      output: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      options: [{ indentMode: 'tab', ignoreTernaryOperator: true }],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/jsx-indent-props` rule from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-indent-props.js) to rslint.

The rule enforces a consistent indentation style for JSX props. Supported option shapes (full upstream parity):

- `"tab"` — tab-based indentation
- non-negative / negative integer — N-space indentation
- `"first"` — align each prop with the column of the first prop
- object form `{ indentMode, ignoreTernaryOperator }` — `indentMode` accepts the same values as the positional option; `ignoreTernaryOperator` (default `false`) disables the extra `indentMode` bump for props inside a `?:` consequent / alternate.

This PR also extracts a shared indent-helper module to `internal/plugins/react/reactutil/indent.go` (`IndentLineStart`, `IndentLeading`, `NodeStartIndent`, `NodeEndIndent`, `IsNodeFirstInLine`, `WrongIndentMessage`, `ReportIndentReplaceLeading`) and refactors `jsx-indent` to use it, so the two indent-style rules in the React plugin share a single source of truth.

## Related Links

- Upstream rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-indent-props.js
- Upstream tests: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/tests/lib/rules/jsx-indent-props.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).