### PR TITLE
feat: port rule react/require-optimization

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -59,6 +59,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/prefer_es6_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/prefer_stateless_function"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/require_optimization"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/require_render_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/self_closing_comp"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/style_prop_object"
@@ -134,6 +135,7 @@ func GetAllRules() []rule.Rule {
 		prefer_es6_class.PreferEs6ClassRule,
 		prefer_stateless_function.PreferStatelessFunctionRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
+		require_optimization.RequireOptimizationRule,
 		require_render_return.RequireRenderReturnRule,
 		self_closing_comp.SelfClosingCompRule,
 		style_prop_object.StylePropObjectRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -3073,6 +3073,97 @@ func EnclosingClass(node *ast.Node) *ast.Node {
 	return nil
 }
 
+// ClassKeywordStart returns the report-anchor start position for a
+// ClassDeclaration / ClassExpression aligned with ESLint's `node.loc.start`
+// for that class.
+//
+// ESTree wraps `export class …` and `export default class …` in
+// `ExportNamedDeclaration` / `ExportDefaultDeclaration` and exposes the
+// inner `ClassDeclaration` starting at the `class` keyword. tsgo flattens
+// these — `export` / `default` end up as Modifier kinds on the class node
+// itself, shifting `node.Pos()` to the `export` token. We trim those two
+// modifier kinds back out to recover the upstream-aligned start.
+//
+// Decorators (`@dec`), TS `abstract` / `declare` / accessibility modifiers
+// are PART of the class's range upstream — TSESTree keeps them on the
+// ClassDeclaration. We stop trimming the moment a non-export/default
+// modifier appears so the report range still spans those.
+//
+// Pass `sourceFile.Text()` as `text` so trailing trivia after the
+// modifier list is properly skipped.
+func ClassKeywordStart(text string, node *ast.Node) int {
+	mods := node.Modifiers()
+	pos := node.Pos()
+	if mods != nil {
+		for _, mod := range mods.Nodes {
+			switch mod.Kind {
+			case ast.KindExportKeyword, ast.KindDefaultKeyword:
+				pos = mod.End()
+			default:
+				return scanner.SkipTrivia(text, mod.Pos())
+			}
+		}
+	}
+	return scanner.SkipTrivia(text, pos)
+}
+
+// IdentifierOrPrivateName mirrors ESLint's `node.name` lookup over a key /
+// member-name node: returns the Identifier text directly, or the
+// PrivateIdentifier text with the leading `#` stripped (per ESTree spec
+// `PrivateIdentifier.name` excludes the `#`). Returns "" for any other Kind
+// (StringLiteral, NumericLiteral, ComputedPropertyName, …) — those never
+// populate `.name` upstream and never match upstream's `key.name === 'X'`
+// gate.
+//
+// Use this when a rule's upstream form is `X.name === 'Y'`. tsgo's
+// PrivateIdentifier.Text retains the `#`, so a naive `.Text` compare would
+// require the caller to know which input is private — this helper hides
+// that.
+func IdentifierOrPrivateName(name *ast.Node) string {
+	if name == nil {
+		return ""
+	}
+	switch name.Kind {
+	case ast.KindIdentifier:
+		return name.AsIdentifier().Text
+	case ast.KindPrivateIdentifier:
+		return strings.TrimPrefix(name.AsPrivateIdentifier().Text, "#")
+	}
+	return ""
+}
+
+// ClassHasMethodNamed reports whether `classNode` has a method (regular
+// MethodDeclaration, GetAccessor, SetAccessor, or Constructor) whose key
+// resolves via IdentifierOrPrivateName to `methodName`. PropertyDeclaration
+// (class-field assignment like `name = () => {}`) does NOT count — upstream's
+// MethodDefinition listeners fire on real methods only, not class fields.
+//
+// Mirrors upstream `astUtil.getComponentProperties(node).some(p => getPropertyName(p) === '<methodName>')`
+// for the subset of properties that have method semantics.
+func ClassHasMethodNamed(classNode *ast.Node, methodName string) bool {
+	if classNode == nil {
+		return false
+	}
+	for _, m := range classNode.Members() {
+		if m == nil {
+			continue
+		}
+		switch m.Kind {
+		case ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor,
+			ast.KindConstructor:
+			// continue
+		default:
+			continue
+		}
+		if IdentifierOrPrivateName(m.Name()) == methodName {
+			return true
+		}
+	}
+	return false
+}
+
 // BindingIdentifierName returns the identifier text of a named declaration's
 // binding, or "" when the declaration is anonymous, the binding is a pattern
 // rather than a bare Identifier, or `n` is nil.

--- a/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.go
+++ b/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.go
@@ -1,8 +1,6 @@
 package no_redundant_should_component_update
 
 import (
-	"strings"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -11,30 +9,16 @@ import (
 // hasShouldComponentUpdate mirrors upstream's
 // `astUtil.getComponentProperties(node).some(p => getPropertyName(p) === 'shouldComponentUpdate')`.
 //
-// Upstream `getPropertyName` returns `nameNode.name`, which is populated for
-// Identifier and PrivateIdentifier (per spec, PrivateIdentifier exposes its
-// name without the leading `#`) — so `#shouldComponentUpdate` also matches,
-// matching upstream. Other key shapes (StringLiteral / NumericLiteral /
-// ComputedPropertyName) yield undefined `.name` upstream and never match.
+// Includes PropertyDeclaration (class field arrow `shouldComponentUpdate = () => {}`)
+// because upstream's `getComponentProperties` returns class fields too.
+// Contrast `reactutil.ClassHasMethodNamed`, which excludes PropertyDeclaration
+// to match MethodDefinition-listener semantics — wrong oracle for this rule.
 func hasShouldComponentUpdate(members []*ast.Node) bool {
 	for _, m := range members {
 		if m == nil {
 			continue
 		}
-		key := m.Name()
-		if key == nil {
-			continue
-		}
-		var name string
-		switch key.Kind {
-		case ast.KindIdentifier:
-			name = key.AsIdentifier().Text
-		case ast.KindPrivateIdentifier:
-			name = strings.TrimPrefix(key.AsPrivateIdentifier().Text, "#")
-		default:
-			continue
-		}
-		if name == "shouldComponentUpdate" {
+		if reactutil.IdentifierOrPrivateName(m.Name()) == "shouldComponentUpdate" {
 			return true
 		}
 	}

--- a/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function.go
+++ b/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function.go
@@ -6,7 +6,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
-	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -39,33 +38,6 @@ type componentFlags struct {
 	hasChildContextTypes bool
 	useDecorators        bool
 	hasSCU               bool
-}
-
-// classKeywordStart returns the start position of the `class` keyword for a
-// ClassDeclaration / ClassExpression, skipping any leading `export` /
-// `export default` modifiers tsgo inlines into the node's modifier list.
-//
-// ESTree wraps `export class …` in `ExportNamedDeclaration` /
-// `ExportDefaultDeclaration` and exposes the inner `ClassDeclaration`
-// starting at the `class` keyword. tsgo flattens this; we recover the same
-// position to match upstream's report range exactly. Decorators / TS
-// `abstract` / `declare` modifiers are PART of the class's range upstream
-// (they are kept on TSESTree's ClassDeclaration), so we stop trimming the
-// moment a non-export/default modifier appears.
-func classKeywordStart(text string, node *ast.Node) int {
-	mods := node.Modifiers()
-	pos := node.Pos()
-	if mods != nil {
-		for _, mod := range mods.Nodes {
-			switch mod.Kind {
-			case ast.KindExportKeyword, ast.KindDefaultKeyword:
-				pos = mod.End()
-			default:
-				return scanner.SkipTrivia(text, mod.Pos())
-			}
-		}
-	}
-	return scanner.SkipTrivia(text, pos)
 }
 
 // hasDecorators reports whether `node` carries one or more `@decorator`
@@ -1044,7 +1016,7 @@ var PreferStatelessFunctionRule = rule.Rule{
 				// tsgo inlines `export` into the ClassDeclaration's modifier
 				// list, so we trim it back out to match upstream's report
 				// position.
-				start := classKeywordStart(ctx.SourceFile.Text(), node)
+				start := reactutil.ClassKeywordStart(ctx.SourceFile.Text(), node)
 				ctx.ReportRange(core.NewTextRange(start, node.End()), rule.RuleMessage{
 					Id:          "componentShouldBePure",
 					Description: "Component should be written as a pure function",

--- a/internal/plugins/react/rules/require_optimization/require_optimization.go
+++ b/internal/plugins/react/rules/require_optimization/require_optimization.go
@@ -1,0 +1,463 @@
+package require_optimization
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Options mirrors upstream's schema:
+//
+//	[{
+//	  type: 'object',
+//	  properties: {
+//	    allowDecorators: {
+//	      type: 'array',
+//	      items: { type: 'string' },
+//	    },
+//	  },
+//	  additionalProperties: false,
+//	}]
+type Options struct {
+	AllowDecorators []string
+}
+
+func parseOptions(options any) Options {
+	opts := Options{}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowDecorators"].([]interface{}); ok {
+		for _, name := range v {
+			if s, ok := name.(string); ok {
+				opts.AllowDecorators = append(opts.AllowDecorators, s)
+			}
+		}
+	}
+	return opts
+}
+
+// hasPureRenderDecorator mirrors upstream's `hasPureRenderDecorator`: the
+// class carries a `@reactMixin.decorate(PureRenderMixin)` decorator. The
+// decorator expression must be a non-optional-chain CallExpression whose
+// callee is `reactMixin.decorate` and whose first argument is the Identifier
+// `PureRenderMixin`. Anything else (optional chain on the call or its
+// receiver, wrong member, missing args) doesn't match — same as upstream's
+// chained property accesses silently bailing on undefined.
+//
+// Parens are transparent on the call expression and its receiver (ESTree
+// flattens; tsgo preserves) so `(reactMixin.decorate)(...)` and
+// `(reactMixin).decorate(...)` still match.
+func hasPureRenderDecorator(classNode *ast.Node) bool {
+	mods := classNode.Modifiers()
+	if mods == nil {
+		return false
+	}
+	for _, mod := range mods.Nodes {
+		if mod.Kind != ast.KindDecorator {
+			continue
+		}
+		expr := ast.SkipParentheses(mod.AsDecorator().Expression)
+		if expr == nil || expr.Kind != ast.KindCallExpression {
+			continue
+		}
+		if ast.IsOptionalChain(expr) {
+			continue
+		}
+		call := expr.AsCallExpression()
+		callee := ast.SkipParentheses(call.Expression)
+		if callee == nil || callee.Kind != ast.KindPropertyAccessExpression {
+			continue
+		}
+		if ast.IsOptionalChain(callee) {
+			continue
+		}
+		pa := callee.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pa.Expression)
+		if obj == nil || obj.Kind != ast.KindIdentifier {
+			continue
+		}
+		if obj.AsIdentifier().Text != "reactMixin" {
+			continue
+		}
+		propName := pa.Name()
+		if propName == nil || propName.Kind != ast.KindIdentifier {
+			continue
+		}
+		if propName.AsIdentifier().Text != "decorate" {
+			continue
+		}
+		if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+			continue
+		}
+		firstArg := ast.SkipParentheses(call.Arguments.Nodes[0])
+		if firstArg == nil || firstArg.Kind != ast.KindIdentifier {
+			continue
+		}
+		if firstArg.AsIdentifier().Text == "PureRenderMixin" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasCustomDecorator mirrors upstream's `hasCustomDecorator`: any of the
+// class's decorators is a bare Identifier whose name appears in
+// `allowDecorators`. Decorators of any other shape (CallExpression,
+// PropertyAccess, etc.) do not match — matching upstream's `expression.name`
+// lookup, which is undefined on non-Identifier expressions.
+func hasCustomDecorator(classNode *ast.Node, allowDecorators []string) bool {
+	if len(allowDecorators) == 0 {
+		return false
+	}
+	mods := classNode.Modifiers()
+	if mods == nil {
+		return false
+	}
+	for _, mod := range mods.Nodes {
+		if mod.Kind != ast.KindDecorator {
+			continue
+		}
+		expr := ast.SkipParentheses(mod.AsDecorator().Expression)
+		if expr == nil || expr.Kind != ast.KindIdentifier {
+			continue
+		}
+		name := expr.AsIdentifier().Text
+		for _, allow := range allowDecorators {
+			if name == allow {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isPureRenderMixinsProperty mirrors upstream's `isPureRenderDeclared`: the
+// property is a `mixins: [..., PureRenderMixin, ...]` PropertyAssignment whose
+// initializer is an ArrayLiteralExpression containing at least one Identifier
+// element named `PureRenderMixin`. Other property forms (shorthand,
+// MethodDeclaration, accessors, spread) cannot satisfy this shape —
+// MethodDeclaration's body isn't an array, ShorthandPropertyAssignment has no
+// initializer, SpreadAssignment has no name. Upstream's `node.value.elements`
+// lookup naturally short-circuits the same way (undefined on
+// non-ArrayExpression values).
+func isPureRenderMixinsProperty(prop *ast.Node) bool {
+	if prop == nil || prop.Kind != ast.KindPropertyAssignment {
+		return false
+	}
+	pa := prop.AsPropertyAssignment()
+	if reactutil.IdentifierOrPrivateName(pa.Name()) != "mixins" {
+		return false
+	}
+	init := pa.Initializer
+	if init == nil || init.Kind != ast.KindArrayLiteralExpression {
+		return false
+	}
+	for _, el := range init.AsArrayLiteralExpression().Elements.Nodes {
+		el = ast.SkipParentheses(el)
+		if el == nil {
+			continue
+		}
+		if el.Kind == ast.KindIdentifier && el.AsIdentifier().Text == "PureRenderMixin" {
+			return true
+		}
+	}
+	return false
+}
+
+// objectDeclaresSCUOrMixin mirrors upstream's ObjectExpression listener gate:
+// any property whose key (Identifier / PrivateIdentifier) is
+// `shouldComponentUpdate`, OR a `mixins: [..., PureRenderMixin, ...]`
+// PropertyAssignment, marks the object as having SCU.
+func objectDeclaresSCUOrMixin(obj *ast.Node) bool {
+	for _, prop := range obj.AsObjectLiteralExpression().Properties.Nodes {
+		if prop == nil {
+			continue
+		}
+		if reactutil.IdentifierOrPrivateName(prop.Name()) == "shouldComponentUpdate" {
+			return true
+		}
+		if isPureRenderMixinsProperty(prop) {
+			return true
+		}
+	}
+	return false
+}
+
+// isInClassDeclarationMethodBody mirrors upstream's `isFunctionInClass`:
+// walks the parent chain looking for a ClassDeclaration scope. The function
+// must be reached via a body that ESLint's scope manager opens as a
+// function-like / class-static-block scope, anchored within a
+// ClassDeclaration (not a ClassExpression — upstream's `isFunctionInClass`
+// only matches `ClassDeclaration`).
+//
+// Note: class-field initializer arrows (PropertyDeclaration → ArrowFunction)
+// are NOT pre-rejected here. Their exclusion from SFC classification is
+// handled by `reactutil.IsStatelessReactComponent`'s
+// `isInAllowedPositionForComponent` gate (PropertyDeclaration is not in
+// the allowed-parent set), which keeps the boundary in one place. An
+// anonymous arrow nested INSIDE a class-field initializer (e.g.
+// `build = () => () => <div/>`) does live in a ClassDeclaration scope
+// upstream — its scope walk goes inner-arrow → outer-arrow → class — and
+// must be allowed to reach the ClassDeclaration here.
+//
+// Verified empirically against eslint-plugin-react:
+//
+//	class C extends React.Component {
+//	  build() { function Inner() { return <div />; } }   // Inner reported
+//	  build = () => () => <div/>;                         // inner arrow reported
+//	  build = () => <div />;                              // arrow not reported (small `build`)
+//	  Inner = (p) => <div />;                             // arrow not reported (PropertyDeclaration parent reject)
+//	  static { function Inner() { return <div />; } }    // Inner reported
+//	}
+//	const X = class extends React.Component {
+//	  build() { function Inner() { return <div />; } }   // Inner NOT reported
+//	};
+func isInClassDeclarationMethodBody(fn *ast.Node) bool {
+	sawMethodBody := false
+	for p := fn.Parent; p != nil; p = p.Parent {
+		switch p.Kind {
+		case ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor,
+			ast.KindConstructor,
+			ast.KindClassStaticBlockDeclaration:
+			sawMethodBody = true
+		case ast.KindPropertyDeclaration:
+			// A class-field initializer is also a scope under ESLint's
+			// scope manager whose enclosing scope is the class. Treat
+			// it as a method-like boundary so nested functions inside
+			// it can still reach the ClassDeclaration.
+			sawMethodBody = true
+		case ast.KindClassDeclaration:
+			return sawMethodBody
+		case ast.KindClassExpression:
+			// Enclosing class is not a ClassDeclaration —
+			// `isFunctionInClass` only matches `ClassDeclaration`.
+			return false
+		}
+	}
+	return false
+}
+
+// methodNameIsSCU returns true for a class member whose Kind is one of the
+// MethodDefinition equivalents (regular method, get/set accessor, constructor)
+// AND whose key resolves to "shouldComponentUpdate".
+//
+// Abstract methods are excluded: TSESTree maps `abstract foo()` to
+// `TSAbstractMethodDefinition`, NOT `MethodDefinition`, so upstream's
+// `MethodDefinition(node)` listener never fires on them. We mirror that by
+// rejecting members carrying the `abstract` modifier.
+func methodNameIsSCU(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor,
+		ast.KindConstructor:
+	default:
+		return false
+	}
+	if mods := node.Modifiers(); mods != nil {
+		for _, m := range mods.Nodes {
+			if m.Kind == ast.KindAbstractKeyword {
+				return false
+			}
+		}
+	}
+	return reactutil.IdentifierOrPrivateName(node.Name()) == "shouldComponentUpdate"
+}
+
+var RequireOptimizationRule = rule.Rule{
+	Name: "react/require-optimization",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+
+		msg := rule.RuleMessage{
+			Id:          "noShouldComponentUpdate",
+			Description: "Component is not optimized. Please add a shouldComponentUpdate method.",
+		}
+
+		// isDetectedComponent reports whether `node` is a node that upstream's
+		// `Components.detect` would register and that this rule would report
+		// when missing SCU. Three categories:
+		//
+		//  - ClassDeclaration / ClassExpression extending React.Component
+		//  - ObjectLiteralExpression that's the arg of a createReactClass call
+		//  - Stateless functional component inside a ClassDeclaration's
+		//    method body. Top-level / module-level SFCs are NOT detected
+		//    here because upstream's `mark-SCU-as-declared(self)` always
+		//    silences them (`isFunctionInClass` returns false), so they'd
+		//    be a no-op. SFCs inside a ClassExpression's methods are also
+		//    excluded — upstream's `isFunctionInClass` only matches
+		//    `ClassDeclaration`.
+		//
+		// SFC classification is delegated to
+		// `reactutil.IsStatelessReactComponentWithChecker` which mirrors
+		// upstream's full `Components.detect` SFC heuristic (binding-name
+		// resolution across VariableDeclaration / PropertyAssignment /
+		// AssignmentExpression / wrapper calls, returns-JSX-via-binding
+		// resolution, anonymous-arrow handling, …). The TypeChecker-aware
+		// variant resolves Identifier returns through symbol→declaration;
+		// it falls back to a local-block scan when `ctx.TypeChecker` is
+		// nil.
+		//
+		// Results are memoized per node: the same node is queried during
+		// the top-level `collect` walk AND during every enclosing
+		// component's `markedFromSubtree` skip-check, and SFC detection
+		// internally walks the function body looking for JSX returns —
+		// without memoization the rule degrades to O(N²) on large files.
+		detectionCache := make(map[*ast.Node]bool)
+		isDetectedComponent := func(node *ast.Node) bool {
+			if cached, ok := detectionCache[node]; ok {
+				return cached
+			}
+			var result bool
+			switch node.Kind {
+			case ast.KindClassDeclaration, ast.KindClassExpression:
+				result = reactutil.ExtendsReactComponent(node, pragma)
+			case ast.KindObjectLiteralExpression:
+				result = reactutil.IsCreateReactClassObjectArg(node, pragma, createClass)
+			case ast.KindFunctionDeclaration,
+				ast.KindFunctionExpression,
+				ast.KindArrowFunction:
+				if isInClassDeclarationMethodBody(node) {
+					result = reactutil.IsStatelessReactComponentWithChecker(node, pragma, ctx.TypeChecker)
+				}
+			}
+			detectionCache[node] = result
+			return result
+		}
+
+		// classSelfMarked covers upstream's `ClassDeclaration(node)` listener
+		// — it fires only on ClassDeclaration (NOT ClassExpression) and
+		// `mark-SCU-as-declared(node)` resolves to the class itself when the
+		// class is a detected component. So `extends PureComponent` /
+		// PureRender / custom-allow decorators silence the rule for
+		// ClassDeclaration only.
+		classSelfMarked := func(c *ast.Node) bool {
+			if c.Kind != ast.KindClassDeclaration {
+				return false
+			}
+			return hasPureRenderDecorator(c) ||
+				hasCustomDecorator(c, opts.AllowDecorators) ||
+				reactutil.ExtendsReactPureComponent(c, pragma)
+		}
+
+		// markedFromSubtree implements upstream's `mark-SCU-as-declared` walk-up
+		// resolution: any markSCU source node (ObjectExpression with
+		// SCU/PureRenderMixin, MethodDefinition with name SCU, ClassDeclaration
+		// with PureRender / custom-allow decorator) inside `self`'s subtree
+		// flows up the parent chain until it hits the nearest detected
+		// component. We mirror that with a pre-order subtree scan that
+		// PRUNES nested detected components — they would absorb the
+		// markSCU themselves before it reaches `self`.
+		//
+		// Verified empirically against eslint-plugin-react@latest:
+		//
+		//   class C extends React.Component {
+		//     init() {
+		//       const cfg = { shouldComponentUpdate() {} };  // marks C
+		//     }
+		//   }                                                  // not reported
+		//
+		//   class Outer extends React.Component {
+		//     build() {
+		//       class Inner extends React.Component { scu() {} }  // marks Inner
+		//     }
+		//   }                                                       // Outer reported
+		var markedFromSubtree func(self *ast.Node, current *ast.Node) bool
+		markedFromSubtree = func(self *ast.Node, current *ast.Node) bool {
+			// Skip the subtree of any OTHER detected component — its own
+			// markSCU events resolve to itself, not bubbling up to `self`.
+			if current != self && isDetectedComponent(current) {
+				return false
+			}
+
+			// markSCU source: any ObjectExpression with SCU/PureRenderMixin.
+			if current.Kind == ast.KindObjectLiteralExpression && objectDeclaresSCUOrMixin(current) {
+				return true
+			}
+			// markSCU source: any class member (MethodDef/Get/Set/Constructor)
+			// named shouldComponentUpdate.
+			if methodNameIsSCU(current) {
+				return true
+			}
+			// markSCU source: nested ClassDeclaration carrying PureRender or
+			// custom-allow decorator. Upstream's listener fires only on
+			// ClassDeclaration, so a nested ClassExpression with the same
+			// shape is NOT a markSCU source. Nested ClassDeclaration that
+			// itself extends PureComponent is already handled by the
+			// "skip detected component" guard above (it's a detected
+			// component, absorbs its own markSCU).
+			if current != self && current.Kind == ast.KindClassDeclaration {
+				if hasPureRenderDecorator(current) ||
+					hasCustomDecorator(current, opts.AllowDecorators) {
+					return true
+				}
+			}
+
+			found := false
+			current.ForEachChild(func(child *ast.Node) bool {
+				if markedFromSubtree(self, child) {
+					found = true
+					return true // early exit
+				}
+				return false
+			})
+			return found
+		}
+
+		report := func(c *ast.Node) {
+			switch c.Kind {
+			case ast.KindClassDeclaration, ast.KindClassExpression:
+				// Class report anchors at `class` keyword (or
+				// abstract/decorator/declare-equivalent), trimming
+				// `export` / `default` modifiers.
+				start := reactutil.ClassKeywordStart(ctx.SourceFile.Text(), c)
+				ctx.ReportRange(core.NewTextRange(start, c.End()), msg)
+			default:
+				// ObjectLiteralExpression / FunctionDeclaration /
+				// FunctionExpression / ArrowFunction — anchor at
+				// the node's start (function keyword, `{`, or
+				// `(` for parenless arrow).
+				ctx.ReportNode(c, msg)
+			}
+		}
+
+		// Single-pass collect-and-resolve. Done eagerly here (instead of via
+		// listeners + a SourceFile-exit hook) because rslint's visitor enters
+		// the SourceFile's children directly — the SourceFile node itself is
+		// never visited, so a `ListenerOnExit(KindSourceFile)` registration
+		// would silently never fire.
+		var collect func(*ast.Node)
+		collect = func(n *ast.Node) {
+			if n == nil {
+				return
+			}
+			if isDetectedComponent(n) {
+				if !classSelfMarked(n) && !markedFromSubtree(n, n) {
+					report(n)
+				}
+				// Continue walking — a detected component's subtree may
+				// contain further detected components (nested class /
+				// nested createReactClass) that need their own
+				// independent evaluation.
+			}
+			n.ForEachChild(func(c *ast.Node) bool {
+				collect(c)
+				return false
+			})
+		}
+		ctx.SourceFile.Node.ForEachChild(func(n *ast.Node) bool {
+			collect(n)
+			return false
+		})
+
+		return rule.RuleListeners{}
+	},
+}

--- a/internal/plugins/react/rules/require_optimization/require_optimization.md
+++ b/internal/plugins/react/rules/require_optimization/require_optimization.md
@@ -1,0 +1,83 @@
+# react/require-optimization
+
+Enforce React components to declare a `shouldComponentUpdate` method (or use an equivalent optimization mechanism such as extending `React.PureComponent` or applying a PureRender decorator/mixin).
+
+## Rule Details
+
+This rule prevents you from creating React components without declaring a `shouldComponentUpdate` method.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+class YourComponent extends React.Component {
+
+}
+```
+
+```jsx
+createReactClass({
+});
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+class YourComponent extends React.Component {
+  shouldComponentUpdate () {
+    return false;
+  }
+}
+```
+
+```jsx
+class YourComponent extends React.PureComponent {
+}
+```
+
+```jsx
+createReactClass({
+  shouldComponentUpdate: function () {
+    return false;
+  }
+});
+```
+
+```jsx
+createReactClass({
+  mixins: [PureRenderMixin]
+});
+```
+
+```jsx
+@reactMixin.decorate(PureRenderMixin)
+class YourComponent extends Component {
+}
+```
+
+## Rule Options
+
+```json
+{ "react/require-optimization": ["error", { "allowDecorators": [] }] }
+```
+
+- `allowDecorators`: optional array of decorator names. When a class is decorated with one of these decorators, the rule treats it as already optimized.
+
+### `allowDecorators`
+
+```json
+{ "react/require-optimization": ["error", { "allowDecorators": ["pureRender"] }] }
+```
+
+Examples of **correct** code with the option above:
+
+```jsx
+@pureRender
+class Hello extends React.Component {}
+```
+
+The decorator name must appear as a bare identifier in the class's decorator list. Call-form decorators (`@pureRender()`) and member-access forms (`@some.pureRender`) do not match this option — only the matching `@reactMixin.decorate(PureRenderMixin)` shape, which is recognized independently of `allowDecorators`, accepts a call form.
+
+## Original Documentation
+
+- [eslint-plugin-react: require-optimization](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-optimization.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/require-optimization.js)

--- a/internal/plugins/react/rules/require_optimization/require_optimization_extra_test.go
+++ b/internal/plugins/react/rules/require_optimization/require_optimization_extra_test.go
@@ -1,0 +1,2537 @@
+package require_optimization
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// TestRequireOptimizationRuleExtra collects rslint-specific edge cases that
+// extend coverage beyond the upstream eslint-plugin-react test suite (kept
+// intact in `require_optimization_test.go`):
+//
+//   - tsgo AST quirks (parens, optional chain, generic type args, satisfies,
+//     ClassExpression-vs-ClassDeclaration asymmetries, …)
+//   - Walk-up boundary lock-ins for the `mark-SCU-as-declared` semantics
+//     (nested detected components absorb the SCU; outer reports
+//     independently)
+//   - SFC detection branches (in-class-method body capitalized fns; class
+//     field arrow vs class method arrow; PropertyAssignment value arrow;
+//     anonymous nested arrows; class static block; …)
+//   - TS-specific syntax (abstract method gate, declare class, namespace /
+//     module, generic SCU, overload signatures, access modifiers)
+//   - Settings overrides (`react.pragma`, `react.createClass`)
+//   - Decorator boundary cases (deep member access, optional chain, spread
+//     args, factory call, paren-wrapped Identifier, multi-decorator chains)
+//   - Robustness (malformed options, null entries, options shape variations)
+//   - Real-codebase regressions (rspack class component, etc.)
+//
+// Each case here was verified against eslint-plugin-react@latest via
+// differential validation before being locked in.
+func TestRequireOptimizationRuleExtra(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RequireOptimizationRule, []rule_tester.ValidTestCase{
+		// ---- Edge: ClassExpression assigned to var — same React.Component check applies ----
+		{Code: `
+        const YourComponent = class extends React.Component {
+          shouldComponentUpdate() { return true; }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: PrivateIdentifier #shouldComponentUpdate — upstream strips '#' on .name ----
+		{Code: `
+        class YourComponent extends React.Component {
+          #shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: getter shouldComponentUpdate — MethodDefinition listener fires on accessors ----
+		{Code: `
+        class YourComponent extends React.Component {
+          get shouldComponentUpdate() { return () => true; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: setter shouldComponentUpdate — same ----
+		{Code: `
+        class YourComponent extends React.Component {
+          set shouldComponentUpdate(v) {}
+        }
+      `, Tsx: true},
+
+		// ---- Edge: static shouldComponentUpdate — upstream doesn't filter static, neither do we ----
+		{Code: `
+        class YourComponent extends React.Component {
+          static shouldComponentUpdate() {}
+        }
+      `, Tsx: true},
+
+		// ---- Edge: paren-wrapped extends — paren-transparent (matches ESTree) ----
+		{Code: `
+        class YourComponent extends (React.Component) {
+          shouldComponentUpdate() {}
+        }
+      `, Tsx: true},
+
+		// ---- Edge: parens around decorator receiver — `@(reactMixin).decorate(PureRenderMixin)` ----
+		{Code: `
+        @(reactMixin).decorate(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `, Tsx: true},
+
+		// ---- Edge: parens around PureRenderMixin argument — `[(PureRenderMixin)]` in mixins ----
+		{Code: `
+        createReactClass({
+          mixins: [(PureRenderMixin)]
+        })
+      `, Tsx: true},
+
+		// ---- Edge: createReactClass with ParenthesizedExpression around obj arg ----
+		{Code: `
+        createReactClass(({
+          mixins: [PureRenderMixin]
+        }))
+      `, Tsx: true},
+
+		// ---- Edge: createReactClass with shorthand `shouldComponentUpdate()` method ----
+		{Code: `
+        createReactClass({
+          shouldComponentUpdate() {}
+        })
+      `, Tsx: true},
+
+		// ---- Edge: React.createClass (pragma + createClass) qualified call ----
+		{Code: `
+        React.createClass({
+          shouldComponentUpdate: function () {}
+        })
+      `, Tsx: true},
+
+		// ---- Edge: createReactClass with mixins containing PureRenderMixin among others ----
+		{Code: `
+        createReactClass({
+          mixins: [SomeMixin, PureRenderMixin, AnotherMixin]
+        })
+      `, Tsx: true},
+
+		// ---- Edge: ObjectLiteral used outside createReactClass — never reported (not detected) ----
+		{Code: `
+        const config = {};
+      `, Tsx: true},
+
+		// ---- Edge: ObjectLiteral with shouldComponentUpdate in non-createReactClass position — never reported ----
+		{Code: `
+        const obj = {
+          // not a createReactClass arg, irrelevant whether SCU is here
+        };
+      `, Tsx: true},
+
+		// ---- Edge: empty `class X extends React.PureComponent {}` is allowed (PureComponent-only path) ----
+		{Code: `
+        class YourComponent extends React.PureComponent {}
+      `, Tsx: true},
+
+		// ---- Edge: anonymous default-exported ClassDeclaration with
+		// PureComponent. tsgo classifies `export default class …` as a
+		// ClassDeclaration (with export/default modifiers) so the
+		// PureComponent shortcut applies. Verified empirically against
+		// eslint-plugin-react. ----
+		{Code: `
+        export default class extends React.PureComponent {}
+      `, Tsx: true},
+
+		// ---- Edge: nested class — only the React-extending class is checked ----
+		{Code: `
+        class Outer {
+          method() {
+            class Inner extends React.Component {
+              shouldComponentUpdate() {}
+            }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: settings.react.pragma="Preact" + Preact.PureComponent ----
+		{Code: `
+        class YourComponent extends Preact.PureComponent {}
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}}},
+
+		// ---- Edge: settings.react.createClass="myCreateClass" custom factory ----
+		{Code: `
+        myCreateClass({
+          shouldComponentUpdate: function() {}
+        })
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "myCreateClass"}}},
+
+		// Locks in upstream `hasCustomDecorator` arm: empty allowDecorators must
+		// not match anything, so the rule reports plain-decorator classes.
+		// (This valid case proves the inverse — when allow contains the name, it passes.)
+		{Code: `
+        @custom
+        class DecoratedComponent extends Component {}
+      `, Tsx: true, Options: map[string]interface{}{"allowDecorators": []interface{}{"custom"}}},
+
+		// ---- Branch: allowDecorators item is the EXACT identifier name —
+		// CallExpression decorator like `@custom()` does NOT match (upstream's
+		// `expression.name` is undefined on CallExpression). Locked in here. ----
+		{Code: `
+        @custom
+        @customCall
+        class DecoratedComponent extends Component {}
+      `, Tsx: true, Options: map[string]interface{}{"allowDecorators": []interface{}{"customCall"}}},
+
+		// ---- Branch: ExtendsReactComponent matches `extends Component` from any source —
+		// classes extending PureComponent take the PureComponent shortcut. ----
+		{Code: `
+        class A extends PureComponent {}
+      `, Tsx: true},
+
+		// ---- Edge (TS): generic type args on PureComponent extends — type
+		// args are stripped via ExpressionWithTypeArguments wrapper. ----
+		{Code: `
+        class YourComponent extends React.PureComponent<Props, State> {}
+      `, Tsx: true},
+
+		// ---- Edge (TS): bare PureComponent with type args ----
+		{Code: `
+        class YourComponent extends PureComponent<Props> {
+          render() { return null; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge (TS): abstract React.Component subclass with SCU ----
+		{Code: `
+        abstract class YourComponent extends React.Component {
+          shouldComponentUpdate() {}
+        }
+      `, Tsx: true},
+
+		// ---- Edge (TS): TypeAssertion `(React.Component as any)` — text-regex
+		// would not match either, so we mirror that miss; the class is not
+		// detected as a React component and never reported. ----
+		{Code: `
+        class YourComponent extends (React.Component as any) {
+          // no SCU — NOT detected as a React component, so NOT reported
+        }
+      `, Tsx: true},
+
+		// ---- Edge: sibling components in same file — each evaluated independently ----
+		{Code: `
+        class A extends React.Component {
+          shouldComponentUpdate() {}
+        }
+        class B extends React.PureComponent {}
+      `, Tsx: true},
+
+		// ---- Edge: doubly-nested class — only inner extends React.Component, with SCU ----
+		{Code: `
+        class Outer {
+          method() {
+            class Middle {
+              another() {
+                class Inner extends React.Component {
+                  shouldComponentUpdate() { return true; }
+                }
+              }
+            }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: the SCU method is the LAST declared sibling — iteration
+		// must not stop early on a non-matching member. ----
+		{Code: `
+        class YourComponent extends React.Component {
+          a() {}
+          b() {}
+          render() { return null; }
+          shouldComponentUpdate() {}
+        }
+      `, Tsx: true},
+
+		// ---- Real user: `export default class extends React.PureComponent {}`
+		// (anonymous default-exported class). PureComponent shortcut applies. ----
+		{Code: `
+        export default class extends React.PureComponent {}
+      `, Tsx: true},
+
+		// ---- Real user: `export default class C extends React.Component { ... }`
+		// with shouldComponentUpdate. ----
+		{Code: `
+        export default class C extends React.Component {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Real user: `export class C extends React.Component { ... }` named
+		// export with shouldComponentUpdate. ----
+		{Code: `
+        export class C extends React.Component {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Real user: TS access modifiers on shouldComponentUpdate
+		// (`public` / `protected` / `private`) — modifier list does not
+		// change member name detection. ----
+		{Code: `
+        class C extends React.Component {
+          public shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+		{Code: `
+        class C extends React.Component {
+          protected shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+		{Code: `
+        class C extends React.Component {
+          private shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Real user: TS `override` modifier on SCU (TS 4.3+) ----
+		{Code: `
+        class C extends React.Component {
+          override shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Real user: SCU with parameter list (props, state) — body shape
+		// is irrelevant, only the name matters. ----
+		{Code: `
+        class C extends React.Component<P, S> {
+          shouldComponentUpdate(nextProps: P, nextState: S): boolean {
+            return true;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Real user: namespace-imported React (`import * as React from "react"`) ----
+		{Code: `
+        import * as React from "react";
+        class C extends React.PureComponent {}
+      `, Tsx: true},
+
+		// ---- Real user: PureRender decorator immediately above class with no
+		// blank line — whitespace is irrelevant. ----
+		{Code: `@reactMixin.decorate(PureRenderMixin)
+class C extends Component {}`, Tsx: true},
+
+		// ---- Real user: redux/mobx-style decorator factory with @observer
+		// allow-listed via call form — does NOT match (Identifier-only),
+		// so must extend PureComponent or have SCU. We test the bare-Identifier
+		// allow-list path here. ----
+		{Code: `
+        @observer
+        class Store extends React.Component {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Real user: connect HOC wrapping a class — the inner class still
+		// extends React.Component so SCU is required. SCU present → valid. ----
+		{Code: `
+        class Inner extends React.Component {
+          shouldComponentUpdate() { return true; }
+        }
+        const Connected = connect(mapStateToProps)(Inner);
+      `, Tsx: true},
+
+		// ---- Real user: TS declaration merging — class + namespace ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() { return true; }
+        }
+        namespace C {}
+      `, Tsx: true},
+
+		// ---- Real user: SCU defined on a class extending an aliased React
+		// (`import { Component as Comp } from "react"`) — upstream's regex
+		// ONLY matches "Component"/"PureComponent" via text, so an aliased
+		// `Comp` would not be detected as a React component → not reported.
+		// We mirror that miss. ----
+		{Code: `
+        import { Component as Comp } from "react";
+        class C extends Comp {}
+      `, Tsx: true},
+
+		// ---- Real user: settings-driven createClass + custom pragma ----
+		{Code: `
+        Preact.createClass({ shouldComponentUpdate() {} })
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}}},
+
+		// ---- Edge: createReactClass with mixins value being a CONST array
+		// reference — value isn't ArrayLiteral inline, gate fails. The
+		// createReactClass call still gets reported (counterexample below);
+		// here we add the mirror VALID — same call but inline mixins. ----
+		{Code: `
+        createReactClass({
+          mixins: [PureRenderMixin],
+          render() { return null; }
+        })
+      `, Tsx: true},
+
+		// ---- Edge: SCU defined as the very first member ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          render() { return null; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: SCU with TS overload signatures + implementation —
+		// any of the Identifier-keyed signatures matches. ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate(): boolean;
+          shouldComponentUpdate(nextProps: any): boolean;
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ===== Walk-up semantics (verified empirically against upstream) =====
+		// Upstream's `mark-SCU-as-declared(node)` calls `components.set(node, ...)`
+		// which walks up the parent chain to the nearest detected component
+		// and stamps `hasSCU=true`. So a SCU/PureRenderMixin signal
+		// ANYWHERE inside a component's subtree silences the report —
+		// even nested arbitrarily deep, even across non-React class /
+		// function boundaries.
+
+		// ---- walk-up: ObjectExpression with SCU inside class method body ----
+		{Code: `
+        class C extends React.Component {
+          init() {
+            const cfg = { shouldComponentUpdate() {} };
+          }
+        }
+      `, Tsx: true},
+
+		// ---- walk-up: ObjectExpression with SCU inside class field initializer ----
+		{Code: `
+        class C extends React.Component {
+          static defaults = {
+            shouldComponentUpdate: function() {}
+          };
+          render() { return null; }
+        }
+      `, Tsx: true},
+
+		// ---- walk-up: ObjectExpression with SCU inside arrow class field ----
+		{Code: `
+        class C extends React.Component {
+          build = () => ({ shouldComponentUpdate() {} });
+        }
+      `, Tsx: true},
+
+		// ---- walk-up: arrow returning object with SCU inside class method ----
+		{Code: `
+        class C extends React.Component {
+          build() {
+            return () => ({ shouldComponentUpdate() {} });
+          }
+        }
+      `, Tsx: true},
+
+		// ---- walk-up: PureRender decorator on non-React nested class
+		// silences the OUTER React component (the inner class isn't a
+		// detected component, so its markSCU walks up). ----
+		{Code: `
+        class C extends React.Component {
+          build() {
+            @reactMixin.decorate(PureRenderMixin)
+            class Helper extends NonReact {}
+          }
+        }
+      `, Tsx: true},
+
+		// ---- walk-up: PureRender decorator on inner class without extends ----
+		{Code: `
+        class C extends React.Component {
+          build() {
+            @reactMixin.decorate(PureRenderMixin)
+            class Helper {}
+          }
+        }
+      `, Tsx: true},
+
+		// ---- walk-up: SCU method on nested non-React class silences outer ----
+		{Code: `
+        class C extends React.Component {
+          build() {
+            class Helper {
+              shouldComponentUpdate() {}
+            }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- walk-up: SCU obj inside helper function body silences outer ----
+		{Code: `
+        class C extends React.Component {
+          build() {
+            function helper() {
+              return { shouldComponentUpdate() {} };
+            }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- walk-up: nested ObjectExpression containing SCU silences outer ----
+		{Code: `
+        createReactClass({
+          config: {
+            shouldComponentUpdate: function() {}
+          }
+        })
+      `, Tsx: true},
+
+		// ---- walk-up: nested mixins silences outer createReactClass ----
+		{Code: `
+        createReactClass({
+          config: {
+            mixins: [PureRenderMixin]
+          }
+        })
+      `, Tsx: true},
+
+		// ===== Stateless functional component (SFC) =====
+		// Top-level / module-level SFC function/arrow are auto-silenced by
+		// upstream's `mark-SCU-as-declared(self)` (only `isFunctionInClass`
+		// negative path); rslint achieves the same by simply not
+		// classifying them as detected components.
+
+		// ---- top-level FunctionDeclaration with capitalized name ----
+		{Code: `
+        function Comp(props) { return <div />; }
+      `, Tsx: true},
+
+		// ---- top-level arrow assigned to const ----
+		{Code: `
+        const Comp = (props) => <div />;
+      `, Tsx: true},
+
+		// ---- top-level FunctionExpression assigned to const ----
+		{Code: `
+        const Comp = function(props) { return <div />; };
+      `, Tsx: true},
+
+		// ---- top-level arrow returning null — markSCU(self) silences ----
+		{Code: `
+        const Comp = () => null;
+      `, Tsx: true},
+
+		// ---- top-level function returning non-JSX — markSCU(self) silences ----
+		{Code: `
+        function Comp() { return 1; }
+      `, Tsx: true},
+
+		// ---- lowercase-named function — never classified as SFC ----
+		{Code: `
+        function comp(props) { return <div />; }
+      `, Tsx: true},
+
+		// ---- nested top-level SFCs both auto-silenced ----
+		{Code: `
+        function Outer(props) {
+          function Inner(p) { return <div />; }
+          return <Inner />;
+        }
+      `, Tsx: true},
+
+		// ---- SFC + class component, class with SCU → both silenced ----
+		{Code: `
+        function Comp(props) { return <div />; }
+        class C extends React.Component { shouldComponentUpdate() {} }
+      `, Tsx: true},
+
+		// ---- export default function — top-level, silenced ----
+		{Code: `
+        export default function Comp(props) { return <div />; }
+      `, Tsx: true},
+
+		// ---- export default anonymous function — top-level, silenced ----
+		{Code: `
+        export default function(props) { return <div />; }
+      `, Tsx: true},
+
+		// ---- SFC inside ClassExpression's method is auto-silenced
+		// (upstream `isFunctionInClass` only matches ClassDeclaration).
+		// Outer ClassExpression silenced via `shouldComponentUpdate`. ----
+		{Code: `
+        const X = class extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            function Inner(p) { return <div />; }
+            return <Inner />;
+          }
+        };
+      `, Tsx: true},
+
+		// ---- class field arrow — even capitalized + returns JSX is NOT
+		// detected as SFC (Components.detect skips class-field initializer). ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          Inner = (p) => <div />;
+          render() { return <this.Inner />; }
+        }
+      `, Tsx: true},
+
+		// ---- in-class-method SFC with SCU obj inside it absorbs SCU
+		// to itself; outer class still reports separately (in invalid). ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            function Inner() {
+              const cfg = { shouldComponentUpdate() {} };
+              return <div />;
+            }
+          }
+        }
+      `, Tsx: true},
+
+		// ===== Settings overrides =====
+
+		// ---- pragma="Preact" + Preact.PureComponent — silences ----
+		{Code: `
+        class C extends Preact.PureComponent {}
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}}},
+
+		// ---- pragma="Preact" + Preact.createClass({...}) — recognized ----
+		{Code: `
+        Preact.createClass({});
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}}},
+
+		// ---- pragma="Preact" + React.Component — NOT recognized as React
+		// component anymore; not reported. ----
+		{Code: `
+        class C extends React.Component {}
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}}},
+
+		// ---- createClass="myCreateClass" + custom factory + SCU ----
+		{Code: `
+        myCreateClass({ shouldComponentUpdate() {} });
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "myCreateClass"}}},
+
+		// ---- createClass="myCreateClass" + default name `createReactClass`
+		// is no longer recognized → not detected → not reported. ----
+		{Code: `
+        createReactClass({});
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "myCreateClass"}}},
+
+		// ===== Misc verified-against-upstream edge cases =====
+
+		// ---- comma expression in extends — not a React component shape ----
+		{Code: `
+        class C extends (React, Component) {}
+      `, Tsx: true},
+
+		// ---- HOC mixin call in extends — not a React component shape ----
+		{Code: `
+        class C extends Mixin(Component) {}
+      `, Tsx: true},
+
+		// ---- multi-level member access in extends — regex anchors at start ----
+		{Code: `
+        class C extends MyLib.React.Component {}
+      `, Tsx: true},
+
+		// ---- extends a CallExpression — not a component ----
+		{Code: `
+        class C extends getBase() {
+          shouldComponentUpdate() {}
+        }
+      `, Tsx: true},
+
+		// ---- ObjectExpression in class field initializer with SCU silences class ----
+		{Code: `
+        class C extends React.Component {
+          cfg = { shouldComponentUpdate() {} };
+        }
+      `, Tsx: true},
+
+		// ---- ObjectExpression in static class field with SCU silences class ----
+		{Code: `
+        class C extends React.Component {
+          static cfg = { shouldComponentUpdate() {} };
+        }
+      `, Tsx: true},
+
+		// ---- nested ClassExpression with SCU silences itself; outer also has SCU ----
+		{Code: `
+        class Outer extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            return class extends React.Component { shouldComponentUpdate() {} };
+          }
+        }
+      `, Tsx: true},
+
+		// ---- export default class with PureRender decorator ----
+		{Code: `
+        @reactMixin.decorate(PureRenderMixin)
+        export default class extends Component {}
+      `, Tsx: true},
+
+		// ---- top-level export const arrow SFC auto-silenced ----
+		{Code: `
+        export const Comp = (props) => <div />;
+      `, Tsx: true},
+
+		// ---- multi-args to PureRender decorator — first arg matches → silences ----
+		{Code: `
+        @reactMixin.decorate(PureRenderMixin, OtherMixin)
+        class C extends Component {}
+      `, Tsx: true},
+
+		// ---- TS overload signature + concrete impl — concrete is the SCU. ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate(): boolean;
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- TS abstract `shouldComponentUpdate` alongside concrete — concrete
+		// satisfies the SCU shortcut; abstract is rejected by the gate. ----
+		{Code: `
+        abstract class C extends React.Component {
+          abstract shouldComponentUpdate(): boolean;
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- TS generic PureComponent extends — type args don't break detection. ----
+		{Code: `
+        class C<P> extends React.PureComponent<P> {}
+      `, Tsx: true},
+
+		// ---- TS satisfies in extends — non-Identifier wrapper, class is not
+		// detected as a React component → not reported. ----
+		{Code: `
+        class C extends (React.Component satisfies any) {
+          shouldComponentUpdate() {}
+        }
+      `, Tsx: true},
+
+		// ---- TS multi-overload signatures + concrete impl ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate(): boolean;
+          shouldComponentUpdate(p: any): boolean;
+          shouldComponentUpdate(p?: any) { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- TS generic SCU method ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate<T>(): boolean { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- TypeChecker-resolved binding: `let v; v = <div/>; return v;`
+		// — `v` has no initializer, so the resolver can't prove it returns
+		// JSX → Outer is NOT detected as SFC. ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          method() {
+            function Outer() {
+              let v;
+              v = <div />;
+              return v;
+            }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Named FunctionExpression assigned to a lowercase const —
+		// upstream resolves the binding name (`x`), not the inner function
+		// id, so `Inner` is not classified as an SFC. ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            const x = function Inner() { return <div />; };
+          }
+        }
+      `, Tsx: true},
+
+		// ---- ObjectExpression with SCU as JSX expression child silences
+		// outer class via walk-up. ----
+		{Code: `
+        class C extends React.Component {
+          render() {
+            return <div>{({ shouldComponentUpdate() {} })}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- ObjectExpression with SCU as JSX attribute value silences
+		// outer class via walk-up. ----
+		{Code: `
+        class C extends React.Component {
+          render() {
+            return <Comp config={{ shouldComponentUpdate() {} }} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- mixins: [...other, PureRenderMixin] — has Identifier element
+		// matching PureRenderMixin → silences. ----
+		{Code: `
+        createReactClass({
+          mixins: [...other, PureRenderMixin]
+        });
+      `, Tsx: true},
+
+		// ---- Multiple walk-up sources in same component: any one suffices. ----
+		{Code: `
+        class C extends React.Component {
+          build() {
+            const a = { shouldComponentUpdate() {} };
+            @reactMixin.decorate(PureRenderMixin)
+            class Helper {}
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Deeply nested ObjectExpression with SCU silences createReactClass. ----
+		{Code: `
+        createReactClass({
+          level1: { level2: { level3: { shouldComponentUpdate: function() {} } } }
+        });
+      `, Tsx: true},
+
+		// ---- Static block inside class: walk-up still bubbles SCU to outer class. ----
+		{Code: `
+        class C extends React.Component {
+          static {
+            const cfg = { shouldComponentUpdate() {} };
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Capitalized class-field arrow is NOT an SFC (class-field
+		// initializer position rejects). ----
+		{Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          Build = () => <div />;
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Edge: ClassExpression empty body extending React.Component ----
+		{
+			Code: `
+        const X = class extends React.Component {};
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 19},
+			},
+		},
+
+		// ---- Edge: anonymous ClassExpression as `module.exports = class extends React.Component { ... }` ----
+		{
+			Code: `
+        module.exports = class extends React.Component {};
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 26},
+			},
+		},
+
+		// ---- Edge: class with `shouldComponentUpdate = () => {}` class field —
+		// upstream's MethodDefinition listener does NOT fire on PropertyDefinition,
+		// so this still reports. Locks in upstream behavior. ----
+		{
+			Code: `
+        class YourComponent extends React.Component {
+          shouldComponentUpdate = () => true;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: shouldComponentUpdate as STRING-LITERAL key — upstream's
+		// `key.name` is undefined for non-Identifier keys, so still reports. ----
+		{
+			Code: `
+        class YourComponent extends React.Component {
+          "shouldComponentUpdate"() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: shouldComponentUpdate as COMPUTED key — same, no match ----
+		{
+			Code: "\n        class YourComponent extends React.Component {\n          [`shouldComponentUpdate`]() {}\n        }\n      ",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// Locks in upstream `hasPureRenderDecorator` arm: optional-chain
+		// `reactMixin?.decorate(PureRenderMixin)` does NOT match. tsgo flags
+		// the chain via QuestionDotToken; we explicitly reject it.
+		{
+			Code: `
+        @reactMixin?.decorate(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// Locks in upstream `hasPureRenderDecorator` arm: deeper member access
+		// `outer.reactMixin.decorate(PureRenderMixin)` does NOT match
+		// (`callee.object.name` is undefined on nested PropertyAccess).
+		{
+			Code: `
+        @outer.reactMixin.decorate(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// Locks in upstream `hasPureRenderDecorator` arm: zero-argument call
+		// `@reactMixin.decorate()` does NOT match (`arguments[0]` is undefined).
+		{
+			Code: `
+        @reactMixin.decorate()
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// Locks in upstream `hasPureRenderDecorator` arm: non-Identifier first
+		// arg (`@reactMixin.decorate(getMixin())`) does NOT match.
+		{
+			Code: `
+        @reactMixin.decorate(getMixin())
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// Locks in upstream `hasPureRenderDecorator` arm: wrong wrapper name
+		// `@otherWrapper.decorate(PureRenderMixin)` does NOT match.
+		{
+			Code: `
+        @otherWrapper.decorate(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// Locks in upstream `hasPureRenderDecorator` arm: wrong method name
+		// `@reactMixin.combine(PureRenderMixin)` does NOT match.
+		{
+			Code: `
+        @reactMixin.combine(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// Locks in upstream `hasCustomDecorator` arm: CallExpression decorator
+		// `@pureRender()` does NOT match (upstream `expression.name` is
+		// undefined on CallExpression — only bare Identifier matches).
+		{
+			Code: `
+        @pureRender()
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowDecorators": []interface{}{"pureRender"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// Locks in upstream `isPureRenderDeclared` arm: `mixins` value is NOT
+		// an ArrayExpression — `node.value.elements` is undefined → no match.
+		{
+			Code: `
+        createReactClass({
+          mixins: PureRenderMixin
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 26},
+			},
+		},
+
+		// Locks in upstream `isPureRenderDeclared` arm: array element is a
+		// CallExpression / non-Identifier — `element.name` is undefined → no match.
+		{
+			Code: `
+        createReactClass({
+          mixins: [resolveMixin()]
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 26},
+			},
+		},
+
+		// ---- Edge: settings.react.pragma="Preact" — `Preact.Component` IS
+		// detected as a component (pragma matches), but no SCU → reports. ----
+		{
+			Code: `
+        class YourComponent extends Preact.Component {}
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: nested `class extends React.Component` inside an outer non-
+		// component class body — listener fires per ClassDeclaration, so the
+		// inner class is independently checked. Locks in tree traversal. ----
+		{
+			Code: `
+        class Outer {
+          method() {
+            class Inner extends React.Component {}
+            return Inner;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: parens around obj arg — `createReactClass(({}))` is still
+		// detected (paren-transparent on createReactClass detection). ----
+		{
+			Code: `
+        createReactClass(({}))
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 27},
+			},
+		},
+
+		// ---- Edge: createReactClass with non-Identifier mixin element (template literal) ----
+		{
+			Code: "\n        createReactClass({\n          mixins: [`PureRenderMixin`]\n        })\n      ",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 26},
+			},
+		},
+
+		// ---- Edge: createReactClass with `shouldComponentUpdate` on COMPUTED key ----
+		{
+			Code: "\n        createReactClass({\n          [`shouldComponentUpdate`]: function() {}\n        })\n      ",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 26},
+			},
+		},
+
+		// ---- Edge: createReactClass with elision-only mixins array — no Identifier element ----
+		{
+			Code: `
+        createReactClass({
+          mixins: [,,,]
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 26},
+			},
+		},
+
+		// Locks in upstream `Components.detect` ClassExpression arm: anonymous
+		// ClassExpression in CallExpression argument position is still a
+		// React.Component subclass, still reported.
+		{
+			Code: `
+        register(class extends React.Component {});
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 18},
+			},
+		},
+
+		// ---- Options coverage: bare-object option shape (CLI-shaped) — locks
+		// in GetOptionsMap integration. Without GetOptionsMap (typed-struct-only)
+		// this would silently default and allow @pure to be reported. ----
+		{
+			Code: `
+        @pure
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowDecorators": []interface{}{"renderPure"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Options coverage: array-wrapped option shape (rule_tester / multi-element CLI shape) ----
+		{
+			Code: `
+        @pure
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"allowDecorators": []interface{}{"renderPure"}}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge (TS): generic type args + no SCU ----
+		{
+			Code: `
+        class YourComponent extends React.Component<Props, State> {
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge (TS): abstract React.Component subclass without SCU ----
+		{
+			Code: `
+        abstract class YourComponent extends React.Component {
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: SpreadElement first arg in decorator — `@reactMixin.decorate(...args)`
+		// — first argument is a SpreadAssignment, not an Identifier → does NOT match. ----
+		{
+			Code: `
+        @reactMixin.decorate(...args)
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: doubly-nested class — only inner extends React.Component, no SCU ----
+		{
+			Code: `
+        class Outer {
+          method() {
+            class Inner extends React.Component {
+              render() { return null; }
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: SpreadAssignment in createReactClass arg — has no key,
+		// must not match SCU/PureRenderMixin gate. ----
+		{
+			Code: `
+        createReactClass({
+          ...rest
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 26},
+			},
+		},
+
+		// ---- Edge: ShorthandPropertyAssignment `mixins` — no value, can't be
+		// an array, gate fails. ----
+		{
+			Code: `
+        const mixins = [PureRenderMixin];
+        createReactClass({
+          mixins
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 26},
+			},
+		},
+
+		// ---- Edge: multiple class components in same file — each is evaluated independently ----
+		{
+			Code: `
+        class A extends React.Component {}
+        class B extends React.Component {
+          shouldComponentUpdate() {}
+        }
+        class C extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+				{MessageId: "noShouldComponentUpdate", Line: 6, Column: 9},
+			},
+		},
+
+		// ---- Position: `export default class extends React.Component {}` —
+		// upstream ESTree puts ExportDefaultDeclaration outside ClassDeclaration,
+		// so the report anchors on `class`. Locks in ClassKeywordStart trim.
+		// `        export default class …` → Column 24. ----
+		{
+			Code: `
+        export default class extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- Position: `export class C extends React.Component {}` —
+		// `        export class …` → Column 16. ----
+		{
+			Code: `
+        export class YourComponent extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 16},
+			},
+		},
+
+		// ---- Position: `export default class C extends React.Component {}`
+		// (named default-exported) — same Column 24 as anonymous form. ----
+		{
+			Code: `
+        export default class C extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- Position: `abstract class …` — abstract IS part of ClassDeclaration's
+		// range upstream (TSESTree keeps it on the class), so report starts at
+		// `abstract`. `        abstract class …` → Column 9. ----
+		{
+			Code: `
+        abstract class YourComponent extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Position: `declare class …` — `declare` is also a TS modifier
+		// that belongs to the ClassDeclaration's range upstream. ----
+		// SKIP: tsgo errors out on a declare class with a body — this is a
+		// declare-only feature and the body content makes the input invalid.
+		// (Documented for completeness; no observable rule behavior.)
+
+		// ---- Position: `export default abstract class …` — export/default
+		// trimmed, `abstract` retained.
+		// `        export default abstract …` → `abstract` at Column 24. ----
+		{
+			Code: `
+        export default abstract class extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- Position: decorator + export default — decorator is BEFORE
+		// `export default`. tsgo orders modifiers by source position so the
+		// trim must walk all leading export/default and stop at decorator. ----
+		// Some bundlers / babel outputs emit `@dec\nexport default class`.
+		// In TS, decorators after `export default` are valid for class only
+		// in Stage-3 form; `@dec export default class` is the legacy form.
+		// We test only the normalized "decorator first" form (TS standard). ----
+		{
+			Code: `
+        @observer
+        export default class extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `@observer` decorator at Line 2 Column 9, included in the range.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Real user: connect HOC + inline ClassExpression without SCU ----
+		{
+			Code: `
+        const Connected = connect(mapStateToProps)(class extends React.Component {});
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `class extends React.Component {}` — `class` keyword position.
+				// `        const Connected = connect(mapStateToProps)(class …` →
+				// 8 + len("const Connected = connect(mapStateToProps)(") = 8 + 43 = 51 + 1 = Column 52.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 52},
+			},
+		},
+
+		// ---- Real user: ClassExpression in expression statement — `(class … {});` ----
+		{
+			Code: `
+        (class extends React.Component {});
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// ParenthesizedExpression wraps; ClassExpression itself starts
+				// at `class`. `        (class …` → 8 + 1 = Column 10.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 10},
+			},
+		},
+
+		// ---- Real user: multiple createReactClass calls in same file ----
+		{
+			Code: `
+        const A = createReactClass({});
+        const B = createReactClass({ shouldComponentUpdate() {} });
+        const C = createReactClass({ mixins: [RandomMixin] });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 36},
+				{MessageId: "noShouldComponentUpdate", Line: 4, Column: 36},
+			},
+		},
+
+		// ---- Real user: deeply nested class inside object inside class
+		// — listener fires on each ClassDeclaration independently. ----
+		{
+			Code: `
+        const factory = {
+          make() {
+            return class Inner extends React.Component {};
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `class Inner extends …` — class keyword position.
+				// `            return class …` → 12 + len("return ") = 19 + 1 = Column 20.
+				{MessageId: "noShouldComponentUpdate", Line: 4, Column: 20},
+			},
+		},
+
+		// ---- Real user: TS access modifier on SCU — modifier doesn't change name match.
+		// COUNTEREXAMPLE: `private otherMethod()` doesn't satisfy SCU. ----
+		{
+			Code: `
+        class C extends React.Component {
+          private otherMethod() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: class with computed-key static field that LOOKS like SCU
+		// — computed key is not Identifier, so doesn't match. ----
+		{
+			Code: "\n        class C extends React.Component {\n          static [`shouldComponentUpdate`] = () => true;\n        }\n      ",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Robustness: options malformed — `allowDecorators` is a string,
+		// not array → must fall back to default (empty) and report normally. ----
+		{
+			Code: `
+        @pure
+        class C extends Component {}
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowDecorators": "pure"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Robustness: options has null/non-string entries in
+		// allowDecorators — non-string elements ignored, valid ones still apply. ----
+		{
+			Code: `
+        @observer
+        class C extends Component {}
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowDecorators": []interface{}{nil, 42, "pure"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				// "observer" not in allow-list ("pure" is the only string), so reports.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Robustness: options is `[null]` — falls back to default. ----
+		{
+			Code: `
+        class C extends React.Component {}
+      `,
+			Tsx:     true,
+			Options: []interface{}{nil},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Robustness: options is `[{}]` empty object — defaults apply. ----
+		{
+			Code: `
+        @pure
+        class C extends Component {}
+      `,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Robustness: options is `[{ allowDecorators: [] }]` empty array
+		// — same as defaults. ----
+		{
+			Code: `
+        @pure
+        class C extends Component {}
+      `,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"allowDecorators": []interface{}{}}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Real user: ClassExpression assigned to module-level const,
+		// without SCU — class reports on its `class` keyword. ----
+		{
+			Code: `
+        const C = class extends React.Component {};
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        const C = class …` → 8 + len("const C = ") = 18 + 1 = Column 19.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 19},
+			},
+		},
+
+		// ---- Real user: deeply nested SIBLING component reports — outer
+		// is detected, inner is detected, both reported. ----
+		{
+			Code: `
+        function outer() {
+          class A extends React.Component {}
+          function inner() {
+            class B extends React.Component {}
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 11},
+				{MessageId: "noShouldComponentUpdate", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Locks in upstream behavior: ClassExpression extending
+		// React.PureComponent is REPORTED. Upstream registers
+		// `ClassDeclaration(node)` only — its PureComponent shortcut never
+		// fires for ClassExpression. Verified empirically against
+		// eslint-plugin-react. ----
+		{
+			Code: `
+        const X = class extends React.PureComponent {};
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        const X = class …` → 8 + len("const X = ") = 18 + 1 = Column 19.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 19},
+			},
+		},
+
+		// ---- Locks in upstream: ClassExpression PureComponent in CallExpression
+		// argument position — still reported. ----
+		{
+			Code: `
+        register(class extends React.PureComponent {});
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        register(class …` → 8 + len("register(") = 17 + 1 = Column 18.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 18},
+			},
+		},
+
+		// ---- Locks in upstream: ClassExpression PureComponent on RHS of
+		// `module.exports =` AssignmentExpression — still reported. ----
+		{
+			Code: `
+        module.exports = class extends React.PureComponent {};
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        module.exports = class …` → 8 + len("module.exports = ") = 25 + 1 = Column 26.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 26},
+			},
+		},
+
+		// ---- Locks in upstream: ClassExpression PureComponent as object
+		// property value — still reported. ----
+		{
+			Code: `
+        const obj = { Comp: class extends React.PureComponent {} };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        const obj = { Comp: class …` → 8 + len("const obj = { Comp: ") = 28 + 1 = Column 29.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 29},
+			},
+		},
+
+		// ---- Locks in upstream: ClassExpression PureComponent wrapped in HOC
+		// (real-world Redux `connect(...)(Component)` pattern) — still reported. ----
+		{
+			Code: `
+        const Connected = connect(mapStateToProps)(class extends React.PureComponent {});
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        const Connected = connect(mapStateToProps)(class …` →
+				// 8 + len("const Connected = connect(mapStateToProps)(") = 8 + 43 = 51 + 1 = Column 52.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 52},
+			},
+		},
+
+		// ---- Locks in upstream: bare ClassExpression PureComponent — same
+		// `<bare>PureComponent` regex match, still reported. ----
+		{
+			Code: `
+        const X = class extends PureComponent {};
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        const X = class …` → Column 19.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 19},
+			},
+		},
+
+		// ---- Locks in upstream: ClassExpression with allow-listed decorator
+		// — `hasCustomDecorator` shortcut also gated to ClassDeclaration only,
+		// so decorated ClassExpression still reports. ----
+		// SKIP: tsgo's parser rejects `@dec class` decorator syntax on
+		// ClassExpression (legacy decorators are class-statement only).
+		// `const X = @dec class extends Component {}` is a parse error.
+		// Documented for completeness; no observable rule case.
+
+		// ===== Walk-up boundary: nested detected component absorbs the markSCU =====
+
+		// ---- nested React.Component class with SCU absorbs SCU; outer
+		// React.Component still reports because outer has no SCU of its own. ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          build() {
+            class Inner extends React.Component {
+              shouldComponentUpdate() {}
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Outer at 'class' keyword.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- nested PureComponent absorbs its own (self) SCU; outer
+		// React.Component still reports. ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          build() {
+            class Inner extends React.PureComponent {}
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- nested obj-with-SCU inside nested React.Component absorbs the
+		// SCU into INNER, so OUTER still reports. ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          build() {
+            class Inner extends React.Component {
+              method() {
+                return { shouldComponentUpdate() {} };
+              }
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- inner createReactClass absorbs its own SCU; outer class
+		// still reports. ----
+		{
+			Code: `
+        class C extends React.Component {
+          init() {
+            const cfg = { shouldComponentUpdate() {} };
+            createReactClass({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// outer has cfg with SCU → C is silenced
+				// createReactClass({}) without SCU → reported at the {} object.
+				// `            createReactClass({})` → 12 + len("createReactClass(") = 29 + 1 = Column 30.
+				{MessageId: "noShouldComponentUpdate", Line: 5, Column: 30},
+			},
+		},
+
+		// ---- two ClassDeclaration components, one with walk-up obj scu,
+		// one without — only the second reports. ----
+		{
+			Code: `
+        class A extends React.Component {
+          init() {
+            const cfg = { shouldComponentUpdate() {} };
+          }
+        }
+        class B extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        class B extends …` at Line 7 Column 9.
+				{MessageId: "noShouldComponentUpdate", Line: 7, Column: 9},
+			},
+		},
+
+		// ---- top-level obj with SCU does NOT walk up (no enclosing
+		// component); class A is still reported. ----
+		{
+			Code: `
+        const cfg = { shouldComponentUpdate() {} };
+        class A extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 9},
+			},
+		},
+
+		// ---- ClassExpression PureComponent inside class field static —
+		// inner ClassExpression reports (not silenced by PureComponent — it's
+		// ClassExpression), outer C also reports (no SCU of its own). ----
+		{
+			Code: `
+        class C extends React.Component {
+          static Inner = class extends React.PureComponent {};
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+				// Inner ClassExpression at `class` keyword: 18 col
+				// (`          static Inner = class …` → 10 + len("static Inner = ") = 25 + 1 = Col 26).
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 26},
+			},
+		},
+
+		// ---- inner ClassExpression with SCU silences itself, outer C still
+		// reports. ----
+		{
+			Code: `
+        class C extends React.Component {
+          static Inner = class extends React.Component {
+            shouldComponentUpdate() {}
+          };
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- ClassExpression returned from helper function inside class
+		// method — Inner is detected (extends React.PureComponent), but
+		// PureComponent shortcut doesn't fire (ClassExpression), so Inner
+		// reports. Outer C also reports. ----
+		{
+			Code: `
+        class C extends React.Component {
+          build() {
+            function inner() {
+              return class extends React.PureComponent {};
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+				// Inner ClassExpression: `              return class …` → 14 + len("return ") = 21 + 1 = Col 22.
+				{MessageId: "noShouldComponentUpdate", Line: 5, Column: 22},
+			},
+		},
+
+		// ---- inner class with @PureRender decorator absorbs SCU; outer
+		// React.Component still reports. ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          build() {
+            @reactMixin.decorate(PureRenderMixin)
+            class Inner extends Component {}
+            return Inner;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- createReactClass with nested ClassExpression that has SCU
+		// — outer createReactClass has no SCU of its own, ClassExpression
+		// absorbs its SCU, so only outer reports. ----
+		{
+			Code: `
+        createReactClass({
+          inner: class extends React.Component {
+            shouldComponentUpdate() {}
+          }
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        createReactClass({...` → 8 + len("createReactClass(") = 25 + 1 = Col 26.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 26},
+			},
+		},
+
+		// ---- top-level mixins var doesn't walk up to createReactClass({})
+		// — Identifier path; createReactClass has empty obj, reports. ----
+		{
+			Code: `
+        const x = { mixins: [PureRenderMixin] };
+        createReactClass({});
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        createReactClass({})` → 8 + len("createReactClass(") = 25 + 1 = Col 26.
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 26},
+			},
+		},
+
+		// ---- outer class method with empty createReactClass — both
+		// outer and inner have no SCU, both report. ----
+		{
+			Code: `
+        class C extends React.Component {
+          buildConfig() {
+            return createReactClass({});
+          }
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+				// inner createReactClass({}) at the {} object position:
+				// `            return createReactClass({})` → 12 + len("return createReactClass(") = 36 + 1 = Col 37.
+				{MessageId: "noShouldComponentUpdate", Line: 4, Column: 37},
+			},
+		},
+
+		// ===== SFC inside ClassDeclaration method body =====
+		// upstream's `isFunctionInClass` blocks `mark-SCU-as-declared(self)`,
+		// so a SFC inside a ClassDeclaration method body falls into
+		// `components.list()` without being silenced and reports.
+
+		// ---- function declaration inside class method ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            function Inner(p) { return <div />; }
+            return <Inner />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `            function Inner …` → 12 + 1 = Column 13.
+				{MessageId: "noShouldComponentUpdate", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- arrow assigned to const inside class method ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            const Inner = (p) => <div />;
+            return <Inner />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// arrow ReportNode anchors at `(p) =>` — `            const Inner = (p) => …` →
+				// 12 + len("const Inner = ") = 26 + 1 = Column 27.
+				{MessageId: "noShouldComponentUpdate", Line: 5, Column: 27},
+			},
+		},
+
+		// ---- function declaration inside block scope inside method ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            {
+              function Inner() { return <div />; }
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `              function Inner …` → 14 + 1 = Column 15.
+				{MessageId: "noShouldComponentUpdate", Line: 6, Column: 15},
+			},
+		},
+
+		// ---- in-class-method SFC absorbs an obj-with-SCU sibling
+		// (Inner.something = { scu() {} }) → the sibling assigns SCU to
+		// outer C (walk-up to nearest detected). Inner itself has no SCU
+		// inside its body, so Inner reports. ----
+		{
+			Code: `
+        class C extends React.Component {
+          build() {
+            function Inner() {
+              return <div />;
+            }
+            Inner.something = { shouldComponentUpdate() {} };
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Inner reports: `            function Inner …` → 12 + 1 = Col 13, Line 4.
+				{MessageId: "noShouldComponentUpdate", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- class with no SCU + SFC inside method body — both report ----
+		{
+			Code: `
+        class C extends React.Component {
+          build() {
+            function Inner() { return <div />; }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+				// `            function Inner …` → Col 13, Line 4.
+				{MessageId: "noShouldComponentUpdate", Line: 4, Column: 13},
+			},
+		},
+
+		// ===== Settings: pragma + bare component =====
+		// ---- pragma="Preact" + Preact.Component without SCU ----
+		{
+			Code: `
+        class C extends Preact.Component {}
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- pragma="Preact" + bare Component matches (regex `(Preact\.)?Component`) ----
+		{
+			Code: `
+        class C extends Component {}
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- createClass="myCreateClass" + custom factory empty obj ----
+		{
+			Code: `
+        myCreateClass({});
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "myCreateClass"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        myCreateClass({})` → 8 + len("myCreateClass(") = 22 + 1 = Col 23.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 23},
+			},
+		},
+
+		// ---- ClassExpression with SFC inside method — outer ClassExpression
+		// still reports (PureComponent shortcut doesn't apply to
+		// ClassExpression and there's no SCU). Inner SFC is auto-silenced
+		// because upstream's `isFunctionInClass` doesn't match ClassExpression. ----
+		{
+			Code: `
+        const X = class extends React.Component {
+          build() {
+            function Inner(p) { return <div />; }
+            return <Inner />;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// `        const X = class …` → 8 + len("const X = ") = 18 + 1 = Col 19.
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 19},
+			},
+		},
+
+		// ===== Misc verified-against-upstream invalid cases =====
+
+		// ---- IIFE in class method body containing SFC reports both C and Inner ----
+		{
+			Code: `
+        class C extends React.Component {
+          build() {
+            (function() {
+              function Inner() { return <div />; }
+            })();
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- nested function chain in class method body — all 3 report ----
+		{
+			Code: `
+        class C extends React.Component {
+          method() {
+            function Outer() {
+              function Inner() { return <div />; }
+              return <Inner />;
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+				{MessageId: "noShouldComponentUpdate"},
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- arrow callback in class method (no name binding) — not detected
+		// as SFC; outer C still reports (no SCU). ----
+		{
+			Code: `
+        class C extends React.Component {
+          build() {
+            return list.map((item) => <div key={item} />);
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- nested class with PureRender decorator extending React.Component
+		// (Helper is detected, self-marked); outer reports. ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          build() {
+            @reactMixin.decorate(PureRenderMixin)
+            class Helper extends React.Component {}
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- array of 3 ClassExpressions, all 3 report ----
+		{
+			Code: `[class A extends React.Component {}, class B extends React.PureComponent {}, class C extends Component {}];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+				{MessageId: "noShouldComponentUpdate"},
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- top-level obj-with-SCU bound to const, used as class field
+		// initializer — does not walk up through binding. ----
+		{
+			Code: `
+        const obj = { shouldComponentUpdate: () => true };
+        class C extends React.Component {
+          use = obj;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- helper SFC declared inside render method body reports ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          render() {
+            function Helper() { return <span />; }
+            return <div><Helper /></div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- class field arrow returning JSX is NOT detected as SFC,
+		// outer class still reports (no SCU). ----
+		{
+			Code: `
+        class C extends React.Component {
+          render = () => <div />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- nested ClassExpression PureComponent inside ClassDecl method
+		// (outer has SCU, inner reports because PureComponent shortcut
+		// doesn't apply to ClassExpression). ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            return class extends React.PureComponent {};
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- decorator factory (CallExpression) with PureRenderMixin arg —
+		// not the recognized `@reactMixin.decorate(PureRenderMixin)` shape. ----
+		{
+			Code: `
+        @createDecorator(PureRenderMixin)
+        class C extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- decorator with PropertyAccess first argument — not bare Identifier
+		// `PureRenderMixin`, doesn't silence. ----
+		{
+			Code: `
+        @reactMixin.decorate(MyMixin.PureRenderMixin)
+        class C extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- TS abstract shouldComponentUpdate-only (no concrete impl) —
+		// upstream's TSESTree maps `abstract foo()` to
+		// `TSAbstractMethodDefinition` (not `MethodDefinition`), so the
+		// MethodDefinition listener never fires. We mirror the rejection
+		// via the abstract-modifier gate. ----
+		{
+			Code: `
+        abstract class C extends React.Component {
+          abstract shouldComponentUpdate(): boolean;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- TS declare class — no body, no SCU, still reports. ----
+		{
+			Code: `
+        declare class C extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- TS abstract class without SCU — still reports. ----
+		{
+			Code: `
+        abstract class C extends React.Component {
+          abstract render(): JSX.Element;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- TS namespace-wrapped class — detected, no SCU, reports. ----
+		{
+			Code: `
+        namespace Foo {
+          export class C extends React.Component {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- TS module-wrapped class (legacy `module Foo { ... }`). ----
+		{
+			Code: `
+        module Foo {
+          class C extends React.Component {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- TS interface extending React.Component is NOT a class component;
+		// the sibling class still reports. ----
+		{
+			Code: `
+        interface I extends React.Component {}
+        class C extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 9},
+			},
+		},
+
+		// ---- PropertyDeclaration named SCU with no initializer is NOT a method;
+		// class still reports. ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- decorator with nested member access deeper than the matched
+		// `<Identifier>.<name>` shape — does NOT match. ----
+		{
+			Code: `
+        @reactMixin.decorate.fn(PureRenderMixin)
+        class C extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- paren-wrapped bare-Identifier decorator — not a CallExpression,
+		// so `hasPureRenderDecorator` doesn't match. ----
+		{
+			Code: `
+        @(PureRenderMixin)
+        class C extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- class with only a constructor — constructor key is "constructor",
+		// not SCU; reports. ----
+		{
+			Code: `
+        class C extends React.Component {
+          constructor() { super(); }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- TypeChecker-resolved binding: `const view = <div/>; return view;`
+		// — `view` initializer is JSX, resolver classifies Outer as SFC,
+		// Outer is in class method body → reports. Lock-in for the
+		// `FunctionReturnsJSXOrNullWithChecker` path. ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          method() {
+            function Outer() {
+              const view = <div />;
+              return view;
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Outer at `function` keyword:
+				// `            function Outer() {` → 12 + 1 = Col 13.
+				{MessageId: "noShouldComponentUpdate", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- TypeChecker-resolved cross-scope binding: `view` declared in
+		// outer method scope, referenced from `Outer` body. Without a
+		// TypeChecker, the local-block scan misses it; with the
+		// TypeChecker, the symbol resolves to its declaration in the
+		// outer scope and Outer classifies as SFC. ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          method() {
+            const view = <div />;
+            function Outer() {
+              return view;
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Outer at `function` keyword:
+				// `            function Outer() {` → 12 + 1 = Col 13.
+				{MessageId: "noShouldComponentUpdate", Line: 6, Column: 13},
+			},
+		},
+
+		// ---- SFC inside class static block — reaches ClassDeclaration via
+		// ClassStaticBlockDeclaration sentinel. ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          static {
+            function Inner() { return <div />; }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- Named FunctionExpression returned from method body, no
+		// outer binding — Inner reported via its own id. ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            return function Inner() { return <div />; };
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- Anonymous arrow as object property value with capitalized
+		// key (Inner) — reported via PropertyAssignment-key binding name. ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            const obj = { Inner: () => <div /> };
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- Anonymous nested arrow as outer arrow's body inside a
+		// class field — inner arrow's enclosing scope walks through the
+		// class field (PropertyDeclaration sentinel) up to the class. ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build = () => () => <div />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- Anonymous arrow returned from method body — reported. ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            return () => <div />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+
+		// ---- Double anonymous arrow returned from method body — inner-most
+		// reported. ----
+		{
+			Code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            return () => () => <div />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate"},
+			},
+		},
+	})
+}
+
+// TestRequireOptimizationRule_NilTypeChecker verifies the rule operates
+// without panicking when the TypeChecker is unavailable. rslint schedules
+// rules without `RequiresTypeInfo: true` against "gap files" (files in the
+// program but not in `typeInfoFiles`) with a nil checker; the rule must
+// degrade gracefully — the only TC-aware path (SFC classification via
+// `reactutil.IsStatelessReactComponentWithChecker`) falls back to a
+// local-block scan when `tc == nil`.
+//
+// The fixture below covers every detection path of the rule:
+//   - ClassDeclaration extending React.Component (no SCU → reports)
+//   - ClassExpression extending React.PureComponent (no SCU shortcut, reports)
+//   - createReactClass({}) ObjectLiteralExpression
+//   - SFC inside ClassDeclaration method body (TC-aware classification)
+//   - obj-with-SCU walk-up (silences class)
+//   - decorator + extends Component
+//
+// Success criterion: the rule's Run callback executes end-to-end without
+// panicking. Reports may differ from the TC-enabled path; we don't assert
+// specific messages, only non-panic behavior.
+func TestRequireOptimizationRule_NilTypeChecker(t *testing.T) {
+	t.Parallel()
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir, "react.tsx")
+	code := `
+class A extends React.Component {}
+class B extends React.PureComponent { shouldComponentUpdate() {} }
+class C extends React.Component {
+  shouldComponentUpdate() {}
+  build() {
+    function Inner() { return <div />; }
+    const Sibling = (p) => <div />;
+    return <Inner />;
+  }
+}
+class D extends React.Component {
+  static cfg = { shouldComponentUpdate() {} };
+}
+const E = class extends React.Component {
+  shouldComponentUpdate() {}
+};
+createReactClass({});
+createReactClass({ shouldComponentUpdate: function () {} });
+createReactClass({ mixins: [PureRenderMixin] });
+@reactMixin.decorate(PureRenderMixin)
+class F extends Component {}
+function TopLevelComp(props) { return <div />; }
+const ArrowComp = (p) => <div />;
+`
+	fs := utils.NewOverlayVFSForFile(filePath, code)
+	program, err := utils.CreateProgram(
+		true, fs, rootDir, "tsconfig.json", utils.CreateCompilerHost(rootDir, fs),
+	)
+	if err != nil {
+		t.Fatalf("CreateProgram: %v", err)
+	}
+	sourceFile := program.GetSourceFile(filePath)
+	if sourceFile == nil {
+		t.Fatalf("source file not found for %s", filePath)
+		return
+	}
+
+	ctx := rule.RuleContext{
+		SourceFile:  sourceFile,
+		Program:     program,
+		Settings:    map[string]interface{}{},
+		TypeChecker: nil, // explicitly nil — this is the path under test
+		ReportNode: func(node *ast.Node, msg rule.RuleMessage) {
+			// noop — we only care that nothing panics.
+		},
+		ReportRange: func(_ core.TextRange, _ rule.RuleMessage) {
+		},
+		ReportNodeWithFixes: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleFix) {
+		},
+		ReportRangeWithFixes: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleFix) {
+		},
+		ReportNodeWithSuggestions: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
+		},
+		ReportRangeWithSuggestions: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
+		},
+		ReportNodeWithFixesAndSuggestions: func(_ *ast.Node, _ rule.RuleMessage, _ []rule.RuleFix, _ []rule.RuleSuggestion) {
+		},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RequireOptimizationRule.Run() panicked with nil TypeChecker: %v", r)
+		}
+	}()
+
+	// The rule does its full walk inside Run() (single-pass collect-and-
+	// report) and returns an empty listener map. Calling Run() is enough
+	// to exercise every code path against the fixture.
+	_ = RequireOptimizationRule.Run(ctx, nil)
+}

--- a/internal/plugins/react/rules/require_optimization/require_optimization_test.go
+++ b/internal/plugins/react/rules/require_optimization/require_optimization_test.go
@@ -1,0 +1,244 @@
+package require_optimization
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestRequireOptimizationRule mirrors the upstream eslint-plugin-react test
+// suite for `react/require-optimization` 1:1. Each case here corresponds
+// to a valid/invalid entry from
+// https://github.com/jsx-eslint/eslint-plugin-react/blob/master/tests/lib/rules/require-optimization.js.
+//
+// Additional rslint-specific edge cases (TypeScript-only syntax, tsgo AST
+// quirks, walk-up boundary lock-ins, real-codebase regressions, nil-
+// TypeChecker safety) live in `require_optimization_extra_test.go`.
+func TestRequireOptimizationRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RequireOptimizationRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid: plain class without React extension is not a component ----
+		{Code: `
+        class A {}
+      `, Tsx: true},
+
+		// ---- Upstream valid: React.Component with shouldComponentUpdate ----
+		{Code: `
+        import React from "react";
+        class YourComponent extends React.Component {
+          shouldComponentUpdate () {}
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: bare Component with shouldComponentUpdate ----
+		{Code: `
+        import React, {Component} from "react";
+        class YourComponent extends Component {
+          shouldComponentUpdate () {}
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: PureRender decorator on bare Component ----
+		{Code: `
+        import React, {Component} from "react";
+        @reactMixin.decorate(PureRenderMixin)
+        class YourComponent extends Component {
+          componentDidMount () {}
+          render() {}
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: createReactClass with shouldComponentUpdate property ----
+		{Code: `
+        import React from "react";
+        createReactClass({
+          shouldComponentUpdate: function () {}
+        })
+      `, Tsx: true},
+
+		// ---- Upstream valid: createReactClass with PureRenderMixin ----
+		{Code: `
+        import React from "react";
+        createReactClass({
+          mixins: [PureRenderMixin]
+        })
+      `, Tsx: true},
+
+		// ---- Upstream valid: PureRender decorator alone ----
+		{Code: `
+        @reactMixin.decorate(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `, Tsx: true},
+
+		// ---- Upstream valid: stateless functional component as FunctionExpression ----
+		{Code: `
+        const FunctionalComponent = function (props) {
+          return <div />;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: stateless functional component as FunctionDeclaration ----
+		{Code: `
+        function FunctionalComponent(props) {
+          return <div />;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: stateless functional component as ArrowFunction ----
+		{Code: `
+        const FunctionalComponent = (props) => {
+          return <div />;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: custom decorator allow-listed ----
+		{Code: `
+        @bar
+        @pureRender
+        @foo
+        class DecoratedComponent extends Component {}
+      `, Tsx: true, Options: map[string]interface{}{"allowDecorators": []interface{}{"renderPure", "pureRender"}}},
+
+		// ---- Upstream valid: React.PureComponent (allow option still applies) ----
+		{Code: `
+        import React from "react";
+        class YourComponent extends React.PureComponent {}
+      `, Tsx: true, Options: map[string]interface{}{"allowDecorators": []interface{}{"renderPure", "pureRender"}}},
+
+		// ---- Upstream valid: bare PureComponent ----
+		{Code: `
+        import React, {PureComponent} from "react";
+        class YourComponent extends PureComponent {}
+      `, Tsx: true, Options: map[string]interface{}{"allowDecorators": []interface{}{"renderPure", "pureRender"}}},
+
+		// ---- Upstream valid: object with elision-padded array — not a createReactClass call ----
+		{Code: `
+        const obj = { prop: [,,,,,] }
+      `, Tsx: true},
+
+		// ---- Upstream valid: class with class-field handler + shouldComponentUpdate method ----
+		{Code: `
+        import React from "react";
+        class YourComponent extends React.Component {
+          handleClick = () => {}
+          shouldComponentUpdate(){
+            return true;
+          }
+          render() {
+            return <div onClick={this.handleClick}>123</div>
+          }
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid: empty React.Component class ----
+		{
+			Code: `
+        import React from "react";
+        class YourComponent extends React.Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: methods without shouldComponentUpdate ----
+		{
+			Code: `
+        import React from "react";
+        class YourComponent extends React.Component {
+          handleClick() {}
+          render() {
+            return <div onClick={this.handleClick}>123</div>
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: class field arrow handler, no SCU ----
+		{
+			Code: `
+        import React from "react";
+        class YourComponent extends React.Component {
+          handleClick = () => {}
+          render() {
+            return <div onClick={this.handleClick}>123</div>
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: bare Component, empty body ----
+		{
+			Code: `
+        import React, {Component} from "react";
+        class YourComponent extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: empty createReactClass ----
+		{
+			Code: `
+        import React from "react";
+        createReactClass({})
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 26},
+			},
+		},
+
+		// ---- Upstream invalid: createReactClass with non-PureRender mixin ----
+		{
+			Code: `
+        import React from "react";
+        createReactClass({
+          mixins: [RandomMixin]
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 3, Column: 26},
+			},
+		},
+
+		// ---- Upstream invalid: decorator with non-PureRender mixin argument ----
+		{
+			Code: `
+        @reactMixin.decorate(SomeOtherMixin)
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: decorators not in allow-list ----
+		{
+			Code: `
+        @bar
+        @pure
+        @foo
+        class DecoratedComponent extends Component {}
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowDecorators": []interface{}{"renderPure", "pureRender"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -149,6 +149,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-will-update-set-state.test.ts',
     './tests/eslint-plugin-react/rules/prefer-es6-class.test.ts',
     './tests/eslint-plugin-react/rules/prefer-stateless-function.test.ts',
+    './tests/eslint-plugin-react/rules/require-optimization.test.ts',
     './tests/eslint-plugin-react/rules/require-render-return.test.ts',
 
     // eslint-plugin-react-hooks

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/require-optimization.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/require-optimization.test.ts
@@ -1,0 +1,845 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('require-optimization', {} as never, {
+  valid: [
+    // ---- Upstream valid: plain class without React extension is not a component ----
+    {
+      code: `
+        class A {}
+      `,
+    },
+    // ---- Upstream valid: React.Component with shouldComponentUpdate ----
+    {
+      code: `
+        import React from "react";
+        class YourComponent extends React.Component {
+          shouldComponentUpdate () {}
+        }
+      `,
+    },
+    // ---- Upstream valid: bare Component with shouldComponentUpdate ----
+    {
+      code: `
+        import React, {Component} from "react";
+        class YourComponent extends Component {
+          shouldComponentUpdate () {}
+        }
+      `,
+    },
+    // ---- Upstream valid: PureRender decorator on bare Component ----
+    {
+      code: `
+        import React, {Component} from "react";
+        @reactMixin.decorate(PureRenderMixin)
+        class YourComponent extends Component {
+          componentDidMount () {}
+          render() {}
+        }
+      `,
+    },
+    // ---- Upstream valid: createReactClass with shouldComponentUpdate property ----
+    {
+      code: `
+        import React from "react";
+        createReactClass({
+          shouldComponentUpdate: function () {}
+        })
+      `,
+    },
+    // ---- Upstream valid: createReactClass with PureRenderMixin ----
+    {
+      code: `
+        import React from "react";
+        createReactClass({
+          mixins: [PureRenderMixin]
+        })
+      `,
+    },
+    // ---- Upstream valid: PureRender decorator alone ----
+    {
+      code: `
+        @reactMixin.decorate(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `,
+    },
+    // ---- Upstream valid: stateless functional components are never reported ----
+    {
+      code: `
+        const FunctionalComponent = function (props) {
+          return <div />;
+        }
+      `,
+    },
+    {
+      code: `
+        function FunctionalComponent(props) {
+          return <div />;
+        }
+      `,
+    },
+    {
+      code: `
+        const FunctionalComponent = (props) => {
+          return <div />;
+        }
+      `,
+    },
+    // ---- Upstream valid: custom decorator allow-listed ----
+    {
+      code: `
+        @bar
+        @pureRender
+        @foo
+        class DecoratedComponent extends Component {}
+      `,
+      options: [{ allowDecorators: ['renderPure', 'pureRender'] }],
+    },
+    // ---- Upstream valid: React.PureComponent (allow option still applies) ----
+    {
+      code: `
+        import React from "react";
+        class YourComponent extends React.PureComponent {}
+      `,
+      options: [{ allowDecorators: ['renderPure', 'pureRender'] }],
+    },
+    // ---- Upstream valid: bare PureComponent ----
+    {
+      code: `
+        import React, {PureComponent} from "react";
+        class YourComponent extends PureComponent {}
+      `,
+      options: [{ allowDecorators: ['renderPure', 'pureRender'] }],
+    },
+    // ---- Upstream valid: object with elision-padded array — not a createReactClass call ----
+    {
+      code: `
+        const obj = { prop: [,,,,,] }
+      `,
+    },
+    // ---- Upstream valid: class with class-field handler + shouldComponentUpdate method ----
+    {
+      code: `
+        import React from "react";
+        class YourComponent extends React.Component {
+          handleClick = () => {}
+          shouldComponentUpdate(){
+            return true;
+          }
+          render() {
+            return <div onClick={this.handleClick}>123</div>
+          }
+        }
+      `,
+    },
+    // ---- Edge: ClassExpression assigned to var — same React.Component check applies ----
+    {
+      code: `
+        const YourComponent = class extends React.Component {
+          shouldComponentUpdate() { return true; }
+        };
+      `,
+    },
+    // ---- Edge: PrivateIdentifier #shouldComponentUpdate — '#' is stripped on .name ----
+    {
+      code: `
+        class YourComponent extends React.Component {
+          #shouldComponentUpdate() { return true; }
+        }
+      `,
+    },
+    // ---- Edge: getter / setter / static shouldComponentUpdate ----
+    {
+      code: `
+        class YourComponent extends React.Component {
+          get shouldComponentUpdate() { return () => true; }
+        }
+      `,
+    },
+    {
+      code: `
+        class YourComponent extends React.Component {
+          set shouldComponentUpdate(v) {}
+        }
+      `,
+    },
+    {
+      code: `
+        class YourComponent extends React.Component {
+          static shouldComponentUpdate() {}
+        }
+      `,
+    },
+    // ---- Edge: paren-wrapped extends ----
+    {
+      code: `
+        class YourComponent extends (React.Component) {
+          shouldComponentUpdate() {}
+        }
+      `,
+    },
+    // ---- Edge: parens around decorator receiver — `@(reactMixin).decorate(PureRenderMixin)` ----
+    {
+      code: `
+        @(reactMixin).decorate(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `,
+    },
+    // ---- Edge: createReactClass with shorthand `shouldComponentUpdate()` ----
+    {
+      code: `
+        createReactClass({
+          shouldComponentUpdate() {}
+        })
+      `,
+    },
+    // ---- Edge: React.createClass (pragma + createClass) qualified call ----
+    {
+      code: `
+        React.createClass({
+          shouldComponentUpdate: function () {}
+        })
+      `,
+    },
+    // ---- Edge: createReactClass with PureRenderMixin among other mixins ----
+    {
+      code: `
+        createReactClass({
+          mixins: [SomeMixin, PureRenderMixin, AnotherMixin]
+        })
+      `,
+    },
+    // ---- Edge: paren-wrapped PureRenderMixin in mixins array ----
+    {
+      code: `
+        createReactClass({
+          mixins: [(PureRenderMixin)]
+        })
+      `,
+    },
+    // ---- Edge: createReactClass with ParenthesizedExpression around obj arg ----
+    {
+      code: `
+        createReactClass(({
+          mixins: [PureRenderMixin]
+        }))
+      `,
+    },
+    // ---- Edge: settings.react.createClass="myCreateClass" custom factory ----
+    {
+      code: `
+        myCreateClass({
+          shouldComponentUpdate: function() {}
+        })
+      `,
+      settings: { react: { createClass: 'myCreateClass' } },
+    },
+    // ---- Edge: nested class — only the React-extending class is checked ----
+    {
+      code: `
+        class Outer {
+          method() {
+            class Inner extends React.Component {
+              shouldComponentUpdate() {}
+            }
+          }
+        }
+      `,
+    },
+    // ---- Edge: settings.react.pragma="Preact" + Preact.PureComponent ----
+    {
+      code: `
+        class YourComponent extends Preact.PureComponent {}
+      `,
+      settings: { react: { pragma: 'Preact' } },
+    },
+    // ---- Real user: export default class extends React.PureComponent ----
+    {
+      code: `
+        export default class extends React.PureComponent {}
+      `,
+    },
+    // ---- Real user: export default class with SCU ----
+    {
+      code: `
+        export default class C extends React.Component {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+    },
+    // ---- Real user: export class ... with SCU ----
+    {
+      code: `
+        export class C extends React.Component {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+    },
+    // ---- Real user: TS access modifiers on SCU ----
+    {
+      code: `
+        class C extends React.Component {
+          public shouldComponentUpdate() { return true; }
+        }
+      `,
+    },
+    {
+      code: `
+        class C extends React.Component {
+          protected shouldComponentUpdate() { return true; }
+        }
+      `,
+    },
+    // ---- Real user: TS override modifier on SCU ----
+    {
+      code: `
+        class C extends React.Component {
+          override shouldComponentUpdate() { return true; }
+        }
+      `,
+    },
+    // ---- Real user: SCU with explicit parameters and types ----
+    {
+      code: `
+        class C extends React.Component<P, S> {
+          shouldComponentUpdate(nextProps: P, nextState: S): boolean {
+            return true;
+          }
+        }
+      `,
+    },
+    // ---- Real user: namespace-imported React ----
+    {
+      code: `
+        import * as React from "react";
+        class C extends React.PureComponent {}
+      `,
+    },
+    // ---- Real user: connect HOC wrapping a class with SCU ----
+    {
+      code: `
+        class Inner extends React.Component {
+          shouldComponentUpdate() { return true; }
+        }
+        const Connected = connect(mapStateToProps)(Inner);
+      `,
+    },
+    // ---- Real user: TS overload signatures + implementation for SCU ----
+    {
+      code: `
+        class C extends React.Component {
+          shouldComponentUpdate(): boolean;
+          shouldComponentUpdate(nextProps: any): boolean;
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+    },
+    // ---- Edge: TS abstract class with SCU ----
+    {
+      code: `
+        abstract class C extends React.Component {
+          shouldComponentUpdate() {}
+        }
+      `,
+    },
+    // ---- Edge: generic type args + SCU ----
+    {
+      code: `
+        class C extends React.PureComponent<Props, State> {}
+      `,
+    },
+    // ---- Walk-up: ObjectExpression with SCU inside class method ----
+    {
+      code: `
+        class C extends React.Component {
+          init() {
+            const cfg = { shouldComponentUpdate() {} };
+          }
+        }
+      `,
+    },
+    // ---- Walk-up: nested obj scu inside createReactClass ----
+    {
+      code: `
+        createReactClass({
+          config: {
+            shouldComponentUpdate: function() {}
+          }
+        })
+      `,
+    },
+    // ---- Walk-up: PureRender decorator on inner non-React class
+    // silences outer React component. ----
+    {
+      code: `
+        class C extends React.Component {
+          build() {
+            @reactMixin.decorate(PureRenderMixin)
+            class Helper {}
+          }
+        }
+      `,
+    },
+    // ---- Top-level SFC auto-silenced ----
+    {
+      code: `
+        function Comp(props) { return <div />; }
+      `,
+    },
+    {
+      code: `
+        export default function Comp(props) { return <div />; }
+      `,
+    },
+    {
+      code: `
+        const Comp = (props) => <div />;
+      `,
+    },
+    // ---- Settings: pragma=Preact, Preact.PureComponent silenced ----
+    {
+      code: `
+        class C extends Preact.PureComponent {}
+      `,
+      settings: { react: { pragma: 'Preact' } },
+    },
+    // ---- Settings: pragma=Preact, React.Component no longer recognized ----
+    {
+      code: `
+        class C extends React.Component {}
+      `,
+      settings: { react: { pragma: 'Preact' } },
+    },
+    // ---- Settings: createClass=myCreateClass + SCU ----
+    {
+      code: `
+        myCreateClass({ shouldComponentUpdate() {} });
+      `,
+      settings: { react: { createClass: 'myCreateClass' } },
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid: empty React.Component class ----
+    {
+      code: `
+        import React from "react";
+        class YourComponent extends React.Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Upstream invalid: methods without shouldComponentUpdate ----
+    {
+      code: `
+        import React from "react";
+        class YourComponent extends React.Component {
+          handleClick() {}
+          render() {
+            return <div onClick={this.handleClick}>123</div>
+          }
+        }
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Upstream invalid: class field arrow handler, no SCU ----
+    {
+      code: `
+        import React from "react";
+        class YourComponent extends React.Component {
+          handleClick = () => {}
+          render() {
+            return <div onClick={this.handleClick}>123</div>
+          }
+        }
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Upstream invalid: bare Component, empty body ----
+    {
+      code: `
+        import React, {Component} from "react";
+        class YourComponent extends Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Upstream invalid: empty createReactClass ----
+    {
+      code: `
+        import React from "react";
+        createReactClass({})
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Upstream invalid: createReactClass with non-PureRender mixin ----
+    {
+      code: `
+        import React from "react";
+        createReactClass({
+          mixins: [RandomMixin]
+        })
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Upstream invalid: decorator with non-PureRender mixin argument ----
+    {
+      code: `
+        @reactMixin.decorate(SomeOtherMixin)
+        class DecoratedComponent extends Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Upstream invalid: decorators not in allow-list ----
+    {
+      code: `
+        @bar
+        @pure
+        @foo
+        class DecoratedComponent extends Component {}
+      `,
+      options: [{ allowDecorators: ['renderPure', 'pureRender'] }],
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: anonymous ClassExpression — no name, still reported ----
+    {
+      code: `
+        module.exports = class extends React.Component {};
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: shouldComponentUpdate as class field (not a method) — still reported ----
+    {
+      code: `
+        class YourComponent extends React.Component {
+          shouldComponentUpdate = () => true;
+        }
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: shouldComponentUpdate as STRING-LITERAL key — non-Identifier never matches ----
+    {
+      code: `
+        class YourComponent extends React.Component {
+          "shouldComponentUpdate"() {}
+        }
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: optional chain in decorator — does NOT match the PureRender shape ----
+    {
+      code: `
+        @reactMixin?.decorate(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: deeper member access in decorator — does NOT match ----
+    {
+      code: `
+        @outer.reactMixin.decorate(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: zero-arg decorate() — does NOT match ----
+    {
+      code: `
+        @reactMixin.decorate()
+        class DecoratedComponent extends Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: non-Identifier first arg — does NOT match ----
+    {
+      code: `
+        @reactMixin.decorate(getMixin())
+        class DecoratedComponent extends Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: wrong wrapper name — does NOT match ----
+    {
+      code: `
+        @otherWrapper.decorate(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: wrong method name — does NOT match ----
+    {
+      code: `
+        @reactMixin.combine(PureRenderMixin)
+        class DecoratedComponent extends Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: CallExpression form decorator with allowDecorators — does NOT match ----
+    {
+      code: `
+        @pureRender()
+        class DecoratedComponent extends Component {}
+      `,
+      options: [{ allowDecorators: ['pureRender'] }],
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: createReactClass mixins is NOT an ArrayExpression ----
+    {
+      code: `
+        createReactClass({
+          mixins: PureRenderMixin
+        })
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: createReactClass mixins element is a CallExpression ----
+    {
+      code: `
+        createReactClass({
+          mixins: [resolveMixin()]
+        })
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: settings.react.pragma="Preact" + Preact.Component without SCU ----
+    {
+      code: `
+        class YourComponent extends Preact.Component {}
+      `,
+      settings: { react: { pragma: 'Preact' } },
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: nested ClassDeclaration inside non-component class body ----
+    {
+      code: `
+        class Outer {
+          method() {
+            class Inner extends React.Component {}
+            return Inner;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: createReactClass with paren-wrapped object arg, empty body ----
+    {
+      code: `
+        createReactClass(({}))
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: createReactClass with elision-only mixins array ----
+    {
+      code: `
+        createReactClass({
+          mixins: [,,,]
+        })
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Edge: anonymous ClassExpression in CallExpression arg position ----
+    {
+      code: `
+        register(class extends React.Component {});
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Real user: export default class without SCU ----
+    {
+      code: `
+        export default class extends React.Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Real user: export class without SCU ----
+    {
+      code: `
+        export class YourComponent extends React.Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Real user: export default abstract class without SCU ----
+    {
+      code: `
+        export default abstract class extends React.Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Real user: connect HOC wrapping inline ClassExpression without SCU ----
+    {
+      code: `
+        const Connected = connect(mapStateToProps)(class extends React.Component {});
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Real user: ClassExpression in expression statement ----
+    {
+      code: `
+        (class extends React.Component {});
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Real user: multiple createReactClass calls — only the missing
+    // ones report. ----
+    {
+      code: `
+        const A = createReactClass({});
+        const B = createReactClass({ shouldComponentUpdate() {} });
+        const C = createReactClass({ mixins: [RandomMixin] });
+      `,
+      errors: [
+        { messageId: 'noShouldComponentUpdate' },
+        { messageId: 'noShouldComponentUpdate' },
+      ],
+    },
+    // ---- Real user: TS access modifier on a non-SCU method — class still
+    // missing SCU, reports. ----
+    {
+      code: `
+        class C extends React.Component {
+          private otherMethod() {}
+        }
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Real user: const C = class extends React.Component {} without SCU ----
+    {
+      code: `
+        const C = class extends React.Component {};
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Real user: nested sibling components, both missing SCU ----
+    {
+      code: `
+        function outer() {
+          class A extends React.Component {}
+          function inner() {
+            class B extends React.Component {}
+          }
+        }
+      `,
+      errors: [
+        { messageId: 'noShouldComponentUpdate' },
+        { messageId: 'noShouldComponentUpdate' },
+      ],
+    },
+    // ---- Robustness: malformed allowDecorators (non-array) — falls back to defaults ----
+    {
+      code: `
+        @pure
+        class C extends Component {}
+      `,
+      options: [{ allowDecorators: 'pure' as any }],
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Locks in upstream: ClassExpression PureComponent variants are
+    // ALWAYS reported. Upstream's PureComponent/decorator shortcut runs only
+    // on ClassDeclaration. ----
+    {
+      code: `
+        const X = class extends React.PureComponent {};
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    {
+      code: `
+        register(class extends React.PureComponent {});
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    {
+      code: `
+        module.exports = class extends React.PureComponent {};
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    {
+      code: `
+        const obj = { Comp: class extends React.PureComponent {} };
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    {
+      code: `
+        const Connected = connect(mapStateToProps)(class extends React.PureComponent {});
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Walk-up: nested class scu absorbs SCU on inner; outer reports ----
+    {
+      code: `
+        class Outer extends React.Component {
+          build() {
+            class Inner extends React.Component {
+              shouldComponentUpdate() {}
+            }
+          }
+        }
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Walk-up: createReactClass with nested ClassExpression that has
+    // SCU. Inner ClassExpression absorbs SCU; outer createReactClass empty,
+    // reports. ----
+    {
+      code: `
+        createReactClass({
+          inner: class extends React.Component {
+            shouldComponentUpdate() {}
+          }
+        })
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Walk-up: top-level obj-with-SCU does NOT walk up to a class
+    // declared in module scope. ----
+    {
+      code: `
+        const cfg = { shouldComponentUpdate() {} };
+        class A extends React.Component {}
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- SFC inside ClassDeclaration method body is reported (not auto-
+    // silenced because `isFunctionInClass` blocks markSCU(self)). ----
+    {
+      code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            function Inner(p) { return <div />; }
+            return <Inner />;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    {
+      code: `
+        class C extends React.Component {
+          shouldComponentUpdate() {}
+          build() {
+            const Inner = (p) => <div />;
+            return <Inner />;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Settings: pragma=Preact + Preact.Component without SCU ----
+    {
+      code: `
+        class C extends Preact.Component {}
+      `,
+      settings: { react: { pragma: 'Preact' } },
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+    // ---- Settings: createClass=myCreateClass empty obj ----
+    {
+      code: `
+        myCreateClass({});
+      `,
+      settings: { react: { createClass: 'myCreateClass' } },
+      errors: [{ messageId: 'noShouldComponentUpdate' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/require-optimization` rule from eslint-plugin-react to rslint.

The rule enforces that React components either declare a `shouldComponentUpdate` method, extend `React.PureComponent`, apply the `@reactMixin.decorate(PureRenderMixin)` decorator, use a `mixins: [PureRenderMixin]` config in `createReactClass`, or carry a custom decorator listed in the `allowDecorators` option.

The implementation aligns with upstream's `Components.detect` semantics, including the walk-up resolution where any SCU / `PureRenderMixin` signal anywhere in a component's subtree silences the report on the nearest ancestor detected component, and the SFC detection branch where capitalized + JSX-returning functions inside a `ClassDeclaration`'s method body are reported.

Behavior was verified against eslint-plugin-react@latest via differential validation across 80+ boundary fixtures (class form variants, decorator shapes, options edges, walk-up boundaries, TS-specific syntax, real codebase fixture from `rspack/tests/e2e/cases/react/class-component`).

Three helpers extracted into `internal/plugins/react/reactutil/`:
- `IdentifierOrPrivateName` — ESLint `node.name` semantic for Identifier / PrivateIdentifier (replaces inline duplication across 5+ rules)
- `ClassHasMethodNamed` — class-member iteration for the MethodDefinition-listener semantics
- `ClassKeywordStart` — report-anchor trim that strips `export` / `default` modifiers (matches ESTree `ClassDeclaration.loc.start`)

`no_redundant_should_component_update` and `prefer_stateless_function` refactored to use the new helpers.

## Related Links

- ESLint plugin rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-optimization.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/require-optimization.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).