### PR TITLE
feat: port rule jsx-a11y/alt-text

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/tspath"
 	importPlugin "github.com/web-infra-dev/rslint/internal/plugins/import"
 	jestPlugin "github.com/web-infra-dev/rslint/internal/plugins/jest"
+	jsxA11yPlugin "github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y"
 	promisePlugin "github.com/web-infra-dev/rslint/internal/plugins/promise"
 	reactPlugin "github.com/web-infra-dev/rslint/internal/plugins/react"
 	reactHooksPlugin "github.com/web-infra-dev/rslint/internal/plugins/react_hooks"
@@ -30,6 +31,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/dot_notation"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/explicit_function_return_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/explicit_member_accessibility"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/max_params"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/member_ordering"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/method_signature_style"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/naming_convention"
@@ -51,7 +53,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_implied_eval"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_inferrable_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_invalid_void_type"
-	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/max_params"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_loop_func"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_magic_numbers"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_meaningless_void_operator"
@@ -216,19 +217,19 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_this_before_super"
 	"github.com/web-infra-dev/rslint/internal/rules/no_throw_literal"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef"
-	"github.com/web-infra-dev/rslint/internal/rules/no_unexpected_multiline"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef_init"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unexpected_multiline"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unmodified_loop_condition"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unneeded_ternary"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unreachable"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_backreference"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_call"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_computed_key"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
-	"github.com/web-infra-dev/rslint/internal/rules/no_useless_backreference"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_constructor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_escape"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_rename"
@@ -378,6 +379,11 @@ var KnownPlugins = []PluginInfo{
 		getAllRules: func() []rule.Rule { return jestPlugin.GetAllRules() },
 	},
 	{
+		RulePrefix:  "jsx-a11y",
+		DeclNames:   []string{"eslint-plugin-jsx-a11y", "jsx-a11y"},
+		getAllRules: func() []rule.Rule { return jsxA11yPlugin.GetAllRules() },
+	},
+	{
 		RulePrefix:  "promise",
 		DeclNames:   []string{"eslint-plugin-promise", "promise"},
 		getAllRules: func() []rule.Rule { return promisePlugin.GetAllRules() },
@@ -466,6 +472,7 @@ func RegisterAllRules() {
 		registerAllReactPluginRules()
 		registerAllReactHooksPluginRules()
 		registerAllJestPluginRules()
+		registerAllJsxA11yPluginRules()
 		registerAllPromisePluginRules()
 		registerAllUnicornPluginRules()
 		registerAllCoreEslintRules()
@@ -486,6 +493,12 @@ func registerAllReactHooksPluginRules() {
 
 func registerAllJestPluginRules() {
 	for _, rule := range jestPlugin.GetAllRules() {
+		GlobalRuleRegistry.Register(rule.Name, rule)
+	}
+}
+
+func registerAllJsxA11yPluginRules() {
+	for _, rule := range jsxA11yPlugin.GetAllRules() {
 		GlobalRuleRegistry.Register(rule.Name, rule)
 	}
 }

--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -1,0 +1,12 @@
+package jsx_a11y_plugin
+
+import (
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/alt_text"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func GetAllRules() []rule.Rule {
+	return []rule.Rule{
+		alt_text.AltTextRule,
+	}
+}

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -1,0 +1,615 @@
+// Package jsxa11yutil contains shared helpers for eslint-plugin-jsx-a11y rule
+// ports. The functions here mirror jsx-ast-utils / jsx-a11y/util semantics that
+// are common across many a11y rules: case-insensitive attribute lookup,
+// "is the literal value extractable" predicates, polymorphic / componentMap
+// element-type resolution, and presentation-role / accessible-child checks.
+package jsxa11yutil
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// skipTransparent unwraps parentheses + TS assertion wrappers (`as`, `!`,
+// `<T>`, `satisfies`). Upstream's jsx-ast-utils explicitly walks past
+// `TSAsExpression` and TSNonNullExpression / TSSatisfies wrappers when
+// extracting prop values; we mirror that with the standard rslint helper.
+const skipTransparent = ast.OEKParentheses | ast.OEKAssertions
+
+// FindAttributeByName returns the first JsxAttribute whose name matches `name`
+// case-insensitively, mirroring jsx-ast-utils' `getProp` with its default
+// `{ ignoreCase: true }`.
+//
+// JsxSpreadAttribute handling: when the spread argument is an ObjectLiteral,
+// the property inside the literal is matched (matches upstream behavior for
+// `{...{ alt: "x" }}`). Both PropertyAssignment (`alt: "x"`) and
+// ShorthandPropertyAssignment (`alt`) shapes are supported — upstream's
+// `property.type === 'Property'` covers both because ESTree unifies them
+// under a single Property type with a `shorthand` flag.
+//
+// Spread of a non-literal (`{...this.props}`) is opaque — upstream returns
+// undefined for these and we follow suit.
+//
+// Like upstream, the "key" prop is excluded from spread expansion.
+//
+// Returned node:
+//   - For a regular JsxAttribute → the JsxAttribute node
+//   - For a literal-spread match → the inner property/shorthand node
+//
+// Callers should branch on `.Kind` if they need to access the initializer; use
+// AttributeInitializer below to abstract that.
+func FindAttributeByName(attrs []*ast.Node, name string) *ast.Node {
+	for _, attr := range attrs {
+		switch attr.Kind {
+		case ast.KindJsxAttribute:
+			if strings.EqualFold(reactutil.GetJsxPropName(attr), name) {
+				return attr
+			}
+		case ast.KindJsxSpreadAttribute:
+			if strings.EqualFold(name, "key") {
+				continue
+			}
+			spread := attr.AsJsxSpreadAttribute()
+			if spread.Expression == nil {
+				continue
+			}
+			expr := ast.SkipOuterExpressions(spread.Expression, skipTransparent)
+			if expr.Kind != ast.KindObjectLiteralExpression {
+				continue
+			}
+			obj := expr.AsObjectLiteralExpression()
+			if obj.Properties == nil {
+				continue
+			}
+			for _, prop := range obj.Properties.Nodes {
+				var keyNode *ast.Node
+				switch prop.Kind {
+				case ast.KindPropertyAssignment:
+					keyNode = prop.AsPropertyAssignment().Name()
+				case ast.KindShorthandPropertyAssignment:
+					keyNode = prop.AsShorthandPropertyAssignment().Name()
+				default:
+					continue
+				}
+				if keyNode == nil || keyNode.Kind != ast.KindIdentifier {
+					continue
+				}
+				if strings.EqualFold(keyNode.AsIdentifier().Text, name) {
+					return prop
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// AttributeInitializer returns the value-bearing child of an attribute-like
+// node returned by FindAttributeByName. For a JsxAttribute this is its
+// `Initializer` (StringLiteral or JsxExpression). For a PropertyAssignment
+// inside a spread-object, it's the property's initializer. For a
+// ShorthandPropertyAssignment (`{...{alt}}`), the value is the same Identifier
+// node as the key — we return it so downstream extractors see "an identifier
+// named alt", matching upstream's `propertyToJSXAttribute` synthesis where the
+// shorthand value is the bound identifier. Returns nil for the boolean
+// attribute form (`<img alt />`) where there is no initializer.
+func AttributeInitializer(attr *ast.Node) *ast.Node {
+	if attr == nil {
+		return nil
+	}
+	switch attr.Kind {
+	case ast.KindJsxAttribute:
+		return attr.AsJsxAttribute().Initializer
+	case ast.KindPropertyAssignment:
+		return attr.AsPropertyAssignment().Initializer
+	case ast.KindShorthandPropertyAssignment:
+		return attr.AsShorthandPropertyAssignment().Name()
+	}
+	return nil
+}
+
+// AttributeIsBooleanForm reports the `<img alt />` form — a JsxAttribute with
+// no initializer at all. PropertyAssignment shapes (from a spread-object
+// match) always carry an initializer in legal source, so this returns false.
+func AttributeIsBooleanForm(attr *ast.Node) bool {
+	if attr == nil {
+		return false
+	}
+	if attr.Kind != ast.KindJsxAttribute {
+		return false
+	}
+	return attr.AsJsxAttribute().Initializer == nil
+}
+
+// LiteralStringValue returns the literal string value carried by an attribute
+// initializer:
+//
+//   - direct StringLiteral (`attr="x"`)
+//   - JsxExpression containing a StringLiteral (`attr={"x"}`)
+//   - JsxExpression containing a NoSubstitutionTemplateLiteral (`attr={`x`}`)
+//   - direct NoSubstitutionTemplateLiteral inside a property assignment
+//   - PropertyAssignment / ShorthandPropertyAssignment from a literal-spread
+//     match (the value is the bare expression — not wrapped in JsxExpression)
+//
+// Parentheses and TS assertion wrappers (`as`, `!`, `<T>`, `satisfies`) are
+// transparently unwrapped on every layer — `attr={("x" as string)}` extracts
+// "x", matching jsx-ast-utils' `extract`/`extractLiteral` walk past
+// `TSAsExpression` / `TSNonNullExpression`.
+//
+// Returns ("", false) for every other shape — including JsxExpression with
+// Identifier (`{undefined}`, `{someVar}`), TemplateExpression with
+// substitutions, etc. This mirrors jsx-ast-utils' `getLiteralPropValue` for
+// the string-typed cases the alt-text / role / type / title checks rely on.
+func LiteralStringValue(attr *ast.Node) (string, bool) {
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		return "", false
+	}
+	switch inner.Kind {
+	case ast.KindStringLiteral:
+		return inner.AsStringLiteral().Text, true
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return inner.AsNoSubstitutionTemplateLiteral().Text, true
+	}
+	return "", false
+}
+
+// attributeInnerExpression returns the unwrapped value expression of an
+// attribute, normalizing across:
+//   - JsxAttribute with direct StringLiteral / Template (returns the literal)
+//   - JsxAttribute with `{ … }` JsxExpression (returns the inner expression)
+//   - PropertyAssignment from spread (returns the initializer expression)
+//   - ShorthandPropertyAssignment from spread (returns the bound identifier)
+//
+// Parentheses + TS assertion wrappers are stripped on the result, so callers
+// can pattern-match `.Kind` directly against semantic kinds (StringLiteral,
+// Identifier, BinaryExpression, …) without re-walking wrappers.
+//
+// Returns nil for the boolean attribute form (`<img alt />`) and for
+// `{ /* empty */ }` JsxExpression containers.
+func attributeInnerExpression(attr *ast.Node) *ast.Node {
+	init := AttributeInitializer(attr)
+	if init == nil {
+		return nil
+	}
+	if init.Kind == ast.KindJsxExpression {
+		expr := init.AsJsxExpression().Expression
+		if expr == nil {
+			return nil
+		}
+		return ast.SkipOuterExpressions(expr, skipTransparent)
+	}
+	return ast.SkipOuterExpressions(init, skipTransparent)
+}
+
+// AttributeIsExplicitUndefined reports whether the attribute value is an
+// explicit `undefined` reference — including TS-wrapped variants like
+// `{undefined as any}` and `{(undefined)!}`, and shorthand-spread forms
+// `{...{alt: undefined}}` where the initializer isn't wrapped in a
+// JsxExpression. Mirrors jsx-ast-utils' Identifier extractor where the
+// `undefined` reserved name evaluates to the actual `undefined` value,
+// combined with its TSAsExpression unwrap loop. Used by ariaLabelHasValue /
+// alt validity to distinguish `<img alt={undefined} />` from
+// `<img alt={someVar} />`.
+func AttributeIsExplicitUndefined(attr *ast.Node) bool {
+	return utils.IsUndefinedIdentifier(attributeInnerExpression(attr))
+}
+
+// AltAttributeIsValid encodes the alt-text validity rule for a present `alt`
+// (or area / input alt) attribute:
+//
+//	(altValue && !isNullValued) || altValue === ""
+//
+// where `isNullValued` is the boolean-attribute form (`<img alt />`).
+//
+// Because alt-text never inspects the alt value beyond the truthy / empty
+// distinction, we don't need a full jsx-ast-utils value extractor here — the
+// AST shape alone is enough:
+//
+//   - boolean form (`<img alt />`)                       → invalid
+//   - empty string literal (the empty-string forms)      → valid (decorative)
+//   - string literal non-empty                           → valid
+//   - JsxExpression with Identifier `undefined`           → invalid
+//   - JsxExpression with a literal `false` / `null`       → invalid
+//   - JsxExpression with `false || false`-style constant-falsy LogicalExpression → invalid
+//   - any other JsxExpression (Identifier, CallExpression, MemberExpression,
+//     ArrowFunction, TemplateExpression with substitutions, ConditionalExpression,
+//     non-zero NumericLiteral, BigIntLiteral, …) → valid (potentially truthy)
+//
+// "Valid" here means the rule should NOT report `altValueError`. A nil
+// attribute is considered invalid because the caller is supposed to check
+// "altProp === undefined" before calling this.
+//
+// Implementation: the upstream check is literally
+//
+//	(altValue && !isNullValued) || altValue === ''
+//
+// where altValue is jsx-ast-utils' `getPropValue(altProp)`. Three things
+// follow:
+//
+//  1. The boolean attribute form (`<img alt />`) has altValue === true and
+//     isNullValued === true, so the LHS is false and the RHS is `true === ''`
+//     (false) → invalid.
+//  2. An empty-string altValue is valid via the RHS regardless of how it's
+//     produced — `alt=""`, `alt={""}`, `alt={"" && x}`, `alt={x && ""}` all
+//     reach `=== ''` and pass. truthy/falsy heuristics are NOT enough; we
+//     must compute the actual static value via [staticEval].
+//  3. Anything else uses the LHS — truthy after JS coercion.
+func AltAttributeIsValid(attr *ast.Node) bool {
+	if attr == nil {
+		return false
+	}
+	if AttributeIsBooleanForm(attr) {
+		return false
+	}
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		// `<img alt={} />` — empty JsxExpression. tsgo synthesizes this only
+		// for malformed input; treat it as "not truthy" → invalid.
+		return false
+	}
+	// Run through staticEval — note this also normalizes string-literal
+	// "true" / "false" to booleans, so `<img alt="false" />` correctly fails
+	// (matches jsx-ast-utils' Literal extractor).
+	v := staticEval(inner)
+	if jsValueIsExactlyEmptyString(v) {
+		return true // matches the `altValue === ''` branch
+	}
+	return jsTruthy_(v)
+}
+
+// PropStaticStringValue mirrors `getPropValue(prop)` for callers that need
+// to compare against a specific string. Returns ("", false) if the prop's
+// static value isn't a string (e.g. boolean, undefined, unknown, function).
+//
+// Use this for upstream call sites that pass `getPropValue(...) === "x"` —
+// e.g. `input[type="image"]`'s type check, where upstream applies real JS
+// `===` semantics (case-sensitive, against the coerced static value).
+//
+// Differs from LiteralStringValue: this one runs the full staticEval, so
+// `type={"image" + ""}` (BinaryExpression) and `type={cond ? "image" :
+// "text"}` (ConditionalExpression) get statically resolved when possible.
+func PropStaticStringValue(attr *ast.Node) (string, bool) {
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		return "", false
+	}
+	v := staticEval(inner)
+	if v.Kind == jvString {
+		return v.Str, true
+	}
+	return "", false
+}
+
+// LiteralPropTruthy mirrors `!!getLiteralPropValue(prop)`. Returns true when
+// the attribute's value is a JS-truthy *literal*. Crucial differences from
+// PropStaticStringValue / staticEval-based truthiness:
+//
+//   - Identifier (other than `undefined`) → null → falsy. Upstream
+//     LITERAL_TYPES.Identifier maps non-undefined identifiers to null
+//     intentionally — runtime variables aren't statically literal.
+//   - null literal → "null" string → truthy (special upstream behavior!).
+//   - Most expression kinds (Call, Member, Conditional, Logical, Binary,
+//     Unary, etc.) → null → falsy under LITERAL_TYPES noop.
+//   - String literal goes through the same `"true"`/`"false"` boolean
+//     coercion as PropValue.
+//
+// Used for `<object>` title and `isPresentationRole` role checks where
+// upstream uses `getLiteralPropValue`.
+func LiteralPropTruthy(attr *ast.Node) bool {
+	if attr == nil {
+		return false
+	}
+	if AttributeIsBooleanForm(attr) {
+		// `<… title />` — extractValue's null-attribute-value path returns
+		// `true`, then `!!true` = true.
+		return true
+	}
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		return false
+	}
+	v := literalPropValue(inner)
+	return jsTruthy_(v)
+}
+
+// AriaLabelHasValue mirrors upstream's `ariaLabelHasValue`:
+//
+//	const value = getPropValue(prop);
+//	if (value === undefined) return false;
+//	if (typeof value === 'string' && value.length === 0) return false;
+//	return true;
+//
+// Note that this is NOT a simple "truthy" check — `null`, `false`, `0` all
+// return true here even though they are falsy in JS, because they are
+// neither `undefined` nor empty string. This matters: e.g. `aria-label={null}`
+// counts as "has value" per upstream.
+//
+// Returns false when `attr` is nil — callers should test for the attribute's
+// existence first; a nil attr is "no value" by definition.
+func AriaLabelHasValue(attr *ast.Node) bool {
+	if attr == nil {
+		return false
+	}
+	if AttributeIsBooleanForm(attr) {
+		// `<img aria-label />` — upstream's extractValue maps the null
+		// initializer to `true`; not undefined, not string of length 0,
+		// therefore "has value".
+		return true
+	}
+	// Direct StringLiteral attribute init — `aria-label=""` or
+	// `aria-label="x"`. Empty string → no value, anything else → has value.
+	if init := AttributeInitializer(attr); init != nil && init.Kind == ast.KindStringLiteral {
+		return init.AsStringLiteral().Text != ""
+	}
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		// `<img aria-label={} />` — empty JsxExpression. tsgo synthesizes
+		// this only for malformed source; treat as no-value to match the
+		// stricter interpretation (upstream's getPropValue would also fail
+		// here).
+		return false
+	}
+	v := staticEval(inner)
+	if jsValueIsExactlyUndefined(v) {
+		return false
+	}
+	if v.Kind == jvString && v.Str == "" {
+		return false
+	}
+	// jvUnknown defaults to "has value" because we don't know — same as
+	// jsx-ast-utils returning a non-empty Identifier name string.
+	return true
+}
+
+// GetElementType resolves the effective HTML element name for a JSX opening
+// element, mirroring eslint-plugin-jsx-a11y's `getElementType(context)(node)`.
+//
+// Steps, in order:
+//  1. Take the raw JSX tag-name string (`<Foo>` → "Foo", `<svg:path>` →
+//     "svg:path", `<Foo.Bar>` → "Foo.Bar").
+//  2. If `settings['jsx-a11y'].polymorphicPropName` is set, extract the
+//     polymorphic prop's value via `getLiteralPropValue` semantics. Replace
+//     rawType only when the value is truthy AND (no allow-list OR rawType
+//     is in the allow-list). Non-string truthy values (number / boolean /
+//     `null` literal which upstream maps to the "null" string) are
+//     stringified — they typically won't match any element in
+//     typesToValidate, mirroring upstream's behavior of replacing rawType
+//     with a non-string then failing the Set.has() check.
+//  3. If `settings['jsx-a11y'].components` is configured AND has rawType as
+//     a key, replace rawType with the mapped value.
+//
+// Returns "" when the tag has no resolvable string form (e.g. computed
+// member expressions, which aren't legal JSX anyway).
+func GetElementType(node *ast.Node, settings map[string]interface{}) string {
+	a11y := getJsxA11ySettings(settings)
+	rawType := reactutil.GetJsxElementTypeString(node)
+	polymorphicPropName, _ := a11y["polymorphicPropName"].(string)
+	if polymorphicPropName != "" {
+		attrs := reactutil.GetJsxElementAttributes(node)
+		propAttr := FindAttributeByName(attrs, polymorphicPropName)
+		if polyValue, ok := polymorphicPropValue(propAttr); ok {
+			if allowList, ok := a11y["polymorphicAllowList"].([]interface{}); ok {
+				for _, v := range allowList {
+					if s, ok := v.(string); ok && s == rawType {
+						rawType = polyValue
+						break
+					}
+				}
+			} else {
+				rawType = polyValue
+			}
+		}
+	}
+	if components, ok := a11y["components"].(map[string]interface{}); ok {
+		if mapped, ok := components[rawType].(string); ok {
+			rawType = mapped
+		}
+	}
+	return rawType
+}
+
+// polymorphicPropValue extracts the polymorphic-prop value via upstream's
+// `getLiteralPropValue` semantics. Returns the truthy stringified value and
+// `true` when the prop is set and resolves to a truthy literal; `("", false)`
+// otherwise. For non-string truthy literals (number, bool, null), returns
+// their JS String() coercion — these stringified forms ("123", "true",
+// "null") generally aren't valid HTML element names and won't match
+// typesToValidate, mirroring upstream's behavior where rawType becomes a
+// non-string and the Set.has() check fails.
+func polymorphicPropValue(propAttr *ast.Node) (string, bool) {
+	if propAttr == nil {
+		return "", false
+	}
+	if AttributeIsBooleanForm(propAttr) {
+		// `<Foo as />` — upstream's extractValue maps null-attribute-value
+		// to boolean true. polymorphicProp truthy → rawType = true. The
+		// Set.has(true) check downstream fails, so this skips alt-text
+		// entirely. Mirror by returning the string "true".
+		return "true", true
+	}
+	inner := attributeInnerExpression(propAttr)
+	if inner == nil {
+		return "", false
+	}
+	v := literalPropValue(inner)
+	if !jsTruthy_(v) {
+		return "", false
+	}
+	if v.Kind == jvString {
+		return v.Str, true
+	}
+	return jsToString(v), true
+}
+
+// IsPresentationRole mirrors `isPresentationRole`: the element has an
+// explicit `role` attribute whose literal value is "presentation" or "none".
+// Non-literal expressions and absent role attributes return false.
+func IsPresentationRole(attrs []*ast.Node) bool {
+	roleAttr := FindAttributeByName(attrs, "role")
+	if roleAttr == nil {
+		return false
+	}
+	value, ok := LiteralStringValue(roleAttr)
+	if !ok {
+		return false
+	}
+	return value == "presentation" || value == "none"
+}
+
+// HasAccessibleChild reports whether a JSX element provides a text
+// alternative for assistive technology via children or the
+// `dangerouslySetInnerHTML` / `children` attribute fallback. Mirrors
+// upstream's `hasAccessibleChild(node.parent, elementType)`.
+//
+// `node` is the JSX element root — either a JsxElement (which carries both
+// children and an opening element) or a JsxSelfClosingElement (which has
+// only attributes). For other shapes (or nil), returns false.
+//
+// The check returns true when ANY of these hold:
+//   - a non-empty JsxText / JsxTextAllWhiteSpaces child (`<object>Foo</object>`)
+//   - a string-literal child (matches upstream's `case 'Literal'`)
+//   - a JsxElement / JsxSelfClosingElement child whose tag is not hidden from
+//     screen readers (`aria-hidden`, `<input type="hidden">`)
+//   - a JsxExpression child whose payload is anything other than `{undefined}`
+//   - the opening element declares a `dangerouslySetInnerHTML` or `children`
+//     attribute (matches upstream's `hasAnyProp` fallback)
+//
+// JsxFragment children are NOT counted as accessible — upstream's switch has
+// no `case 'JSXFragment'`, so they fall to the `default: return false`
+// branch. `<object><>x</></object>` is therefore reported invalid even
+// though the fragment contains text, matching upstream.
+//
+// `getElementType` is the per-context resolver — pass a closure that calls
+// GetElementType with `ctx.Settings` already bound. Mirrors upstream's
+// `hasAccessibleChild(node, elementType)` curry shape.
+func HasAccessibleChild(node *ast.Node, getElementType func(*ast.Node) string) bool {
+	if node == nil {
+		return false
+	}
+	var children []*ast.Node
+	var openingAttrs []*ast.Node
+	switch node.Kind {
+	case ast.KindJsxElement:
+		jsx := node.AsJsxElement()
+		if jsx.Children != nil {
+			children = jsx.Children.Nodes
+		}
+		openingAttrs = reactutil.GetJsxElementAttributes(jsx.OpeningElement)
+	case ast.KindJsxSelfClosingElement:
+		// No children possible; the opening attributes are on the node
+		// itself. Upstream's hasAccessibleChild walks `JSXElement.children`
+		// (empty for self-closing) then falls back to
+		// `node.openingElement.attributes` — same effect.
+		openingAttrs = reactutil.GetJsxElementAttributes(node)
+	default:
+		return false
+	}
+	for _, child := range children {
+		switch child.Kind {
+		case ast.KindJsxText, ast.KindJsxTextAllWhiteSpaces:
+			// Upstream's hasAccessibleChild uses `!!child.value` — any
+			// non-empty text counts. tsgo splits JsxText into two kinds
+			// (regular vs whitespace-only); both carry the raw text on
+			// `.Text` and we check both for parity.
+			if child.AsJsxText().Text != "" {
+				return true
+			}
+		case ast.KindStringLiteral:
+			// Bare string literals as children are uncommon, but mirror
+			// upstream's `case 'Literal'`.
+			if child.AsStringLiteral().Text != "" {
+				return true
+			}
+		case ast.KindJsxElement:
+			// Inspect the OPENING element of the paired JsxElement — that's
+			// where the tag name and `aria-hidden` / `type="hidden"` live.
+			// Matches upstream's `elementType(child.openingElement)` and
+			// `child.openingElement.attributes`.
+			opening := child.AsJsxElement().OpeningElement
+			if opening != nil && !isHiddenFromScreenReader(opening, getElementType) {
+				return true
+			}
+		case ast.KindJsxSelfClosingElement:
+			if !isHiddenFromScreenReader(child, getElementType) {
+				return true
+			}
+		case ast.KindJsxExpression:
+			expr := child.AsJsxExpression().Expression
+			if expr == nil {
+				// `{}` empty container — matches upstream `default: false`.
+				continue
+			}
+			inner := ast.SkipOuterExpressions(expr, skipTransparent)
+			if utils.IsUndefinedIdentifier(inner) {
+				continue
+			}
+			return true
+		}
+	}
+	// Fallback: opening element declares dangerouslySetInnerHTML or children.
+	for _, name := range []string{"dangerouslySetInnerHTML", "children"} {
+		if FindAttributeByName(openingAttrs, name) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// isHiddenFromScreenReader mirrors upstream's `isHiddenFromScreenReader`:
+//
+//	if (type.toUpperCase() === 'INPUT') {
+//	  const hidden = getLiteralPropValue(getProp(attrs, 'type'));
+//	  if (hidden && hidden.toUpperCase() === 'HIDDEN') return true;
+//	}
+//	const ariaHidden = getPropValue(getProp(attrs, 'aria-hidden'));
+//	return ariaHidden === true;
+//
+// Note the asymmetry: `type` uses getLiteralPropValue (literal-only),
+// `aria-hidden` uses getPropValue (full static eval) and compares with
+// JS `===` to boolean true. We mirror both — staticEval/literalPropValue
+// handle the wrapper unwrapping and "true"/"false" string normalization
+// transparently, so e.g. `aria-hidden="true"` and `aria-hidden={cond ? true : false}`
+// both classify correctly.
+func isHiddenFromScreenReader(child *ast.Node, getElementType func(*ast.Node) string) bool {
+	tag := strings.ToUpper(getElementType(child))
+	attrs := reactutil.GetJsxElementAttributes(child)
+	if tag == "INPUT" {
+		typeAttr := FindAttributeByName(attrs, "type")
+		if typeAttr != nil {
+			if inner := attributeInnerExpression(typeAttr); inner != nil {
+				v := literalPropValue(inner)
+				if v.Kind == jvString && strings.EqualFold(v.Str, "hidden") {
+					return true
+				}
+			}
+		}
+	}
+	ariaHidden := FindAttributeByName(attrs, "aria-hidden")
+	if ariaHidden == nil {
+		return false
+	}
+	if AttributeIsBooleanForm(ariaHidden) {
+		// Boolean form maps to extractValue's null-attr-value → true; true === true → hidden.
+		return true
+	}
+	inner := attributeInnerExpression(ariaHidden)
+	if inner == nil {
+		return false
+	}
+	// `getPropValue(...) === true` — only the actual boolean true matches.
+	// `<div aria-hidden="true">` works because the Literal extractor maps the
+	// case-insensitive string "true" to boolean true (jsxAstUtilsLiteralCoerce).
+	v := staticEval(inner)
+	return v.Kind == jvBool && v.Bool
+}
+
+func getJsxA11ySettings(settings map[string]interface{}) map[string]interface{} {
+	if settings == nil {
+		return nil
+	}
+	m, _ := settings["jsx-a11y"].(map[string]interface{})
+	return m
+}

--- a/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
@@ -1,0 +1,737 @@
+package jsxa11yutil
+
+// staticEval ports jsx-ast-utils' `getPropValue` semantics so that jsx-a11y
+// rules can distinguish "is the empty string" from "is truthy" precisely —
+// alt-text's `(altValue && !isNullValued) || altValue === ''` check makes
+// this distinction load-bearing.
+//
+// Why not reuse tsgo's evaluator.NewEvaluator (shim/evaluator/shim.go)?
+// That evaluator is built for const-enum / readonly literal-type evaluation:
+// it covers numeric arithmetic, bitwise ops, `+` string concat and template
+// expressions, but DELIBERATELY OMITS the operators alt-text depends on —
+// `&&` / `||` / `??` short-circuits, ConditionalExpression, PrefixUnary `!`,
+// boolean / null literals. It also routes through `jsnum.Number` and
+// `jsnum.PseudoBigInt`, which are typescript-go-internal types not exposed
+// via the shim. So a partial reuse would still need this file's logic;
+// keeping a single integrated evaluator is cleaner.
+//
+// Helpers we DO reuse from rslint utils / tsgo shim:
+//
+//	utils.NormalizeNumericLiteral / NormalizeBigIntLiteral — text → value
+//	utils.IsUndefinedIdentifier                            — undefined check
+//	utils.GetStaticStringValue                             — used by callers
+//	ast.SkipOuterExpressions(OEKParentheses|OEKAssertions) — wrapper unwrap
+//	ast.IsUndefinedIdentifier (TODO if needed)             — N/A
+//
+// The semantics modeled here mirror jsx-ast-utils v3 — see
+// https://github.com/jsx-eslint/jsx-ast-utils/tree/main/src/values for the
+// extractors per node type. Verified empirically against ESLint via probe
+// scripts; see /tmp/jsx-a11y-verify if you need to re-check.
+
+import (
+	"math"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// jsValue is a statically-evaluated JavaScript value, mirroring the shape of
+// jsx-ast-utils' `getPropValue` output. Returning the actual value (instead of
+// just a truthy / falsy bit) is required because alt-text and similar a11y
+// rules distinguish three states: truthy, falsy, AND empty-string, and the
+// `=== ''` branch alone takes precedence over truthiness.
+//
+// Discriminated by Kind. Only the field corresponding to Kind is meaningful.
+//
+//	Kind == jvString   → Str
+//	Kind == jvNumber   → Num (NaN is allowed)
+//	Kind == jvBigInt   → Big
+//	Kind == jvBool     → Bool
+//	Kind == jvNull     → (no field)
+//	Kind == jvUndef    → (no field)
+//	Kind == jvFunction → (truthy sentinel; arrow / function literal / known global ctor)
+//	Kind == jvTruthy   → (sentinel for "statically truthy but specific value not modelled")
+//	Kind == jvUnknown  → (cannot statically determine; rules should default-truthy)
+type jsValue struct {
+	Kind jsKind
+	Str  string
+	Num  float64
+	Big  *big.Int
+	Bool bool
+}
+
+type jsKind int
+
+const (
+	jvUnknown jsKind = iota
+	jvString
+	jvNumber
+	jvBigInt
+	jvBool
+	jvNull
+	jvUndef
+	jvFunction
+	jvTruthy
+)
+
+var (
+	jsNull    = jsValue{Kind: jvNull}
+	jsUndef   = jsValue{Kind: jvUndef}
+	jsUnknown = jsValue{Kind: jvUnknown}
+	jsFn      = jsValue{Kind: jvFunction}
+	jsTruthy  = jsValue{Kind: jvTruthy}
+)
+
+// staticEval mirrors jsx-ast-utils' `getValue` (the engine behind getPropValue).
+// Walks the expression tree and computes the static JS value, applying real
+// JS semantics for `&&` / `||` / `??` / ternary / arithmetic so that callers
+// can distinguish "altValue === ''" from "altValue is truthy" precisely.
+//
+// Parentheses and TS assertion wrappers are unwrapped on every recursion.
+//
+// Returns jsUnknown when the expression cannot be statically evaluated (rare
+// in practice — see CallExpression / MemberExpression below for the
+// jsx-ast-utils synthetic-string fallback that keeps unknown calls "truthy").
+//
+// Mirrors the relevant jsx-ast-utils Identifier reserved-word handling:
+//
+//	JS_RESERVED = { Array, Date, Infinity, Math, Number, Object, String, undefined }
+//
+// where `Infinity` evaluates to +Infinity, `undefined` to undefined, and the
+// global constructor identifiers (Array / Date / Math / Number / Object /
+// String) evaluate to their function values (truthy).
+func staticEval(node *ast.Node) jsValue {
+	if node == nil {
+		return jsUnknown
+	}
+	node = ast.SkipOuterExpressions(node, skipTransparent)
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		// jsx-ast-utils' Literal extractor normalizes case-insensitive
+		// "true" / "false" strings to actual booleans. This is load-bearing —
+		// `<img alt="false" />` upstream evaluates altValue to `false`
+		// (boolean), making it falsy → altValue error. Without this
+		// normalization the rule would incorrectly accept `alt="false"`.
+		return jsxAstUtilsLiteralCoerce(node.AsStringLiteral().Text)
+	case ast.KindNoSubstitutionTemplateLiteral:
+		// NoSubTemplate is treated as a string literal by jsx-ast-utils, so
+		// the same "true" / "false" coercion applies.
+		return jsxAstUtilsLiteralCoerce(node.AsNoSubstitutionTemplateLiteral().Text)
+	case ast.KindTrueKeyword:
+		return jsValue{Kind: jvBool, Bool: true}
+	case ast.KindFalseKeyword:
+		return jsValue{Kind: jvBool, Bool: false}
+	case ast.KindNullKeyword:
+		return jsNull
+	case ast.KindNumericLiteral:
+		// utils.NormalizeNumericLiteral returns "Infinity" / "-Infinity" for
+		// overflow and a normalized decimal otherwise — feed both through
+		// strconv.ParseFloat; failures fall to NaN (still a Number).
+		text := utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text)
+		f, err := strconv.ParseFloat(text, 64)
+		if err != nil && text == "Infinity" {
+			f = math.Inf(1)
+		} else if err != nil && text == "-Infinity" {
+			f = math.Inf(-1)
+		} else if err != nil {
+			f = math.NaN()
+		}
+		return jsValue{Kind: jvNumber, Num: f}
+	case ast.KindBigIntLiteral:
+		text := utils.NormalizeBigIntLiteral(node.AsBigIntLiteral().Text)
+		bi := new(big.Int)
+		if _, ok := bi.SetString(text, 10); !ok {
+			return jsUnknown
+		}
+		return jsValue{Kind: jvBigInt, Big: bi}
+	case ast.KindIdentifier:
+		name := node.AsIdentifier().Text
+		switch name {
+		case "undefined":
+			return jsUndef
+		case "Infinity":
+			return jsValue{Kind: jvNumber, Num: math.Inf(1)}
+		case "Array", "Date", "Math", "Number", "Object", "String":
+			return jsFn // upstream returns the actual constructor; we only need "truthy"
+		}
+		// Other identifiers — upstream returns the bare name string. We mirror
+		// that so consumers see a non-empty truthy string.
+		return jsValue{Kind: jvString, Str: name}
+	case ast.KindThisKeyword:
+		// Upstream's ThisExpression extractor returns the magic string "this"
+		// — non-empty truthy.
+		return jsValue{Kind: jvString, Str: "this"}
+	case ast.KindBinaryExpression:
+		return staticEvalBinary(node.AsBinaryExpression())
+	case ast.KindConditionalExpression:
+		ce := node.AsConditionalExpression()
+		test := staticEval(ce.Condition)
+		if jsTruthy_(test) {
+			return staticEval(ce.WhenTrue)
+		}
+		return staticEval(ce.WhenFalse)
+	case ast.KindPrefixUnaryExpression:
+		return staticEvalUnary(node.AsPrefixUnaryExpression())
+	case ast.KindTemplateExpression:
+		return staticEvalTemplate(node.AsTemplateExpression())
+	case ast.KindArrowFunction, ast.KindFunctionExpression, ast.KindClassExpression:
+		// Upstream FunctionExpression / ArrowFunctionExpression: returns a
+		// function (truthy). ClassExpression has no upstream extractor →
+		// null → falsy; but realistically `<img alt={class C{}}>` is never
+		// a meaningful alt and we treat class literals like function
+		// literals (truthy) for safer behavior. Documented divergence.
+		return jsFn
+	case ast.KindCallExpression:
+		// Upstream synthesizes a non-empty string like "callee(args)" — we
+		// don't need the exact text, just the truthy classification.
+		// Optional-chain calls (`obj?.()`) hit the same kind in tsgo (with
+		// the optional flag) and upstream's OptionalCallExpression
+		// extractor returns a similarly truthy string.
+		return jsTruthy
+	case ast.KindNewExpression:
+		// Upstream NewExpression returns `{}` (empty object) — truthy.
+		return jsTruthy
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		// Upstream synthesizes "obj.prop" / "obj[key]" — non-empty truthy.
+		// Optional access (`obj?.prop`) is the same kind in tsgo with a flag.
+		return jsTruthy
+	case ast.KindObjectLiteralExpression, ast.KindArrayLiteralExpression:
+		return jsTruthy
+	case ast.KindRegularExpressionLiteral:
+		return jsTruthy
+	case ast.KindJsxElement, ast.KindJsxSelfClosingElement, ast.KindJsxFragment:
+		return jsTruthy
+	case ast.KindTaggedTemplateExpression:
+		// Upstream redirects to TemplateLiteral on the inner quasi — always
+		// produces a non-empty string, so truthy.
+		return jsTruthy
+	case ast.KindPostfixUnaryExpression:
+		// `x++` / `x--` — UpdateExpression. Upstream computes `val++` /
+		// `val--` after coercing the operand to a number; for non-numeric
+		// operands (the common case `x++` where x is an identifier) the
+		// result is NaN → falsy. We mirror that conservatively.
+		return staticEvalUpdate(node.AsPostfixUnaryExpression().Operator,
+			node.AsPostfixUnaryExpression().Operand)
+	case ast.KindAwaitExpression, ast.KindYieldExpression:
+		// Upstream has no extractor for these → console.error + return
+		// null → falsy. Mirror the falsy classification.
+		return jsNull
+	case ast.KindTypeOfExpression, ast.KindVoidExpression:
+		// Upstream UnaryExpression: typeof / void → undefined → falsy.
+		return jsUndef
+	case ast.KindDeleteExpression:
+		// Upstream UnaryExpression: delete → true → truthy.
+		return jsValue{Kind: jvBool, Bool: true}
+	}
+	// Default for anything we don't model: align with upstream's "unknown
+	// type" path, which logs a console.error and returns null. A null falsy
+	// fallback is safer than truthy because alt-text's `(altValue && …) ||
+	// altValue === ''` check needs a definitive falsy on unrecognized kinds
+	// to match upstream rejections.
+	return jsNull
+}
+
+// staticEvalUpdate handles `x++` / `++x` / `x--` / `--x` for both Postfix
+// and Prefix unary nodes. Mirrors jsx-ast-utils UpdateExpression.js: coerces
+// operand to a number (NaN if non-numeric), then increments / decrements.
+// Returns the result; for the prefix case the new value, for postfix the
+// pre-update value (NaN in both branches when operand is non-numeric).
+func staticEvalUpdate(op ast.Kind, operand *ast.Node) jsValue {
+	v := staticEval(operand)
+	if v.Kind != jvNumber {
+		// JS coerces operand to number for ++/--; non-numeric coerces to
+		// NaN, and the result is NaN (falsy).
+		return jsValue{Kind: jvNumber, Num: math.NaN()}
+	}
+	switch op {
+	case ast.KindPlusPlusToken:
+		return jsValue{Kind: jvNumber, Num: v.Num + 1}
+	case ast.KindMinusMinusToken:
+		return jsValue{Kind: jvNumber, Num: v.Num - 1}
+	}
+	return jsUndef
+}
+
+// staticEvalBinary handles the operators alt-text actually depends on
+// (`&&` / `||` / `??` short-circuits, plus `+` for string concat). Other
+// operators (`-`, `*`, comparisons, …) are computed when both sides are
+// numbers, otherwise fall back to jsUnknown.
+func staticEvalBinary(bin *ast.BinaryExpression) jsValue {
+	if bin.OperatorToken == nil {
+		return jsUnknown
+	}
+	op := bin.OperatorToken.Kind
+	left := staticEval(bin.Left)
+	switch op {
+	case ast.KindBarBarToken:
+		// `a || b` → a if a truthy, else b
+		if jsTruthy_(left) {
+			return left
+		}
+		return staticEval(bin.Right)
+	case ast.KindAmpersandAmpersandToken:
+		// `a && b` → a if a falsy, else b
+		if !jsTruthy_(left) {
+			return left
+		}
+		return staticEval(bin.Right)
+	case ast.KindQuestionQuestionToken:
+		// `a ?? b` → a if a is neither null nor undefined, else b
+		if left.Kind == jvNull || left.Kind == jvUndef {
+			return staticEval(bin.Right)
+		}
+		return left
+	case ast.KindCommaToken:
+		// In ESTree this becomes SequenceExpression, whose extractor
+		// returns an array of all values (truthy regardless of contents).
+		// Mirror that — `(a, b, false)` is upstream-truthy, not the
+		// rightmost-operand falsy.
+		return jsTruthy
+	}
+	right := staticEval(bin.Right)
+	switch op {
+	case ast.KindPlusToken:
+		// String concatenation has priority when EITHER side is a string —
+		// matches JS's `+` rules for our purposes.
+		if left.Kind == jvString || right.Kind == jvString {
+			return jsValue{Kind: jvString, Str: jsToString(left) + jsToString(right)}
+		}
+		if left.Kind == jvNumber && right.Kind == jvNumber {
+			return jsValue{Kind: jvNumber, Num: left.Num + right.Num}
+		}
+	case ast.KindMinusToken:
+		if left.Kind == jvNumber && right.Kind == jvNumber {
+			return jsValue{Kind: jvNumber, Num: left.Num - right.Num}
+		}
+	case ast.KindAsteriskToken:
+		if left.Kind == jvNumber && right.Kind == jvNumber {
+			return jsValue{Kind: jvNumber, Num: left.Num * right.Num}
+		}
+	case ast.KindSlashToken:
+		if left.Kind == jvNumber && right.Kind == jvNumber {
+			return jsValue{Kind: jvNumber, Num: left.Num / right.Num}
+		}
+	case ast.KindPercentToken:
+		if left.Kind == jvNumber && right.Kind == jvNumber {
+			return jsValue{Kind: jvNumber, Num: math.Mod(left.Num, right.Num)}
+		}
+	case ast.KindAsteriskAsteriskToken:
+		if left.Kind == jvNumber && right.Kind == jvNumber {
+			return jsValue{Kind: jvNumber, Num: math.Pow(left.Num, right.Num)}
+		}
+	case ast.KindLessThanToken:
+		if l, r, ok := numericBoth(left, right); ok {
+			return jsValue{Kind: jvBool, Bool: l < r}
+		}
+		if left.Kind == jvString && right.Kind == jvString {
+			return jsValue{Kind: jvBool, Bool: left.Str < right.Str}
+		}
+	case ast.KindLessThanEqualsToken:
+		if l, r, ok := numericBoth(left, right); ok {
+			return jsValue{Kind: jvBool, Bool: l <= r}
+		}
+		if left.Kind == jvString && right.Kind == jvString {
+			return jsValue{Kind: jvBool, Bool: left.Str <= right.Str}
+		}
+	case ast.KindGreaterThanToken:
+		if l, r, ok := numericBoth(left, right); ok {
+			return jsValue{Kind: jvBool, Bool: l > r}
+		}
+		if left.Kind == jvString && right.Kind == jvString {
+			return jsValue{Kind: jvBool, Bool: left.Str > right.Str}
+		}
+	case ast.KindGreaterThanEqualsToken:
+		if l, r, ok := numericBoth(left, right); ok {
+			return jsValue{Kind: jvBool, Bool: l >= r}
+		}
+		if left.Kind == jvString && right.Kind == jvString {
+			return jsValue{Kind: jvBool, Bool: left.Str >= right.Str}
+		}
+	case ast.KindEqualsEqualsToken:
+		// JS `==` does loose equality (with type coercion). We only model the
+		// strict-equal case where both operands have the same kind — looser
+		// coercions (`1 == "1"`) fall through to unknown, since modeling the
+		// full coercion table isn't worth the complexity for alt-text.
+		return jsValue{Kind: jvBool, Bool: jsLooseEquals(left, right)}
+	case ast.KindEqualsEqualsEqualsToken:
+		return jsValue{Kind: jvBool, Bool: jsStrictEquals(left, right)}
+	case ast.KindExclamationEqualsToken:
+		return jsValue{Kind: jvBool, Bool: !jsLooseEquals(left, right)}
+	case ast.KindExclamationEqualsEqualsToken:
+		return jsValue{Kind: jvBool, Bool: !jsStrictEquals(left, right)}
+	case ast.KindBarToken:
+		if l, r, ok := numericBoth(left, right); ok {
+			return jsValue{Kind: jvNumber, Num: float64(int32(l) | int32(r))}
+		}
+	case ast.KindAmpersandToken:
+		if l, r, ok := numericBoth(left, right); ok {
+			return jsValue{Kind: jvNumber, Num: float64(int32(l) & int32(r))}
+		}
+	case ast.KindCaretToken:
+		if l, r, ok := numericBoth(left, right); ok {
+			return jsValue{Kind: jvNumber, Num: float64(int32(l) ^ int32(r))}
+		}
+	case ast.KindLessThanLessThanToken:
+		if l, r, ok := numericBoth(left, right); ok {
+			return jsValue{Kind: jvNumber, Num: float64(int32(l) << (uint32(r) & 0x1F))}
+		}
+	case ast.KindGreaterThanGreaterThanToken:
+		if l, r, ok := numericBoth(left, right); ok {
+			return jsValue{Kind: jvNumber, Num: float64(int32(l) >> (uint32(r) & 0x1F))}
+		}
+	case ast.KindGreaterThanGreaterThanGreaterThanToken:
+		if l, r, ok := numericBoth(left, right); ok {
+			return jsValue{Kind: jvNumber, Num: float64(uint32(l) >> (uint32(r) & 0x1F))}
+		}
+	}
+	// Assignment expressions (`=`, `+=`, `||=`, etc.). Upstream's
+	// AssignmentExpression extractor returns `${left} ${op} ${right}` — a
+	// non-empty string, hence truthy regardless of contents.
+	switch op {
+	case ast.KindEqualsToken,
+		ast.KindPlusEqualsToken,
+		ast.KindMinusEqualsToken,
+		ast.KindAsteriskEqualsToken,
+		ast.KindSlashEqualsToken,
+		ast.KindPercentEqualsToken,
+		ast.KindAsteriskAsteriskEqualsToken,
+		ast.KindAmpersandAmpersandEqualsToken,
+		ast.KindBarBarEqualsToken,
+		ast.KindQuestionQuestionEqualsToken,
+		ast.KindAmpersandEqualsToken,
+		ast.KindBarEqualsToken,
+		ast.KindCaretEqualsToken,
+		ast.KindLessThanLessThanEqualsToken,
+		ast.KindGreaterThanGreaterThanEqualsToken,
+		ast.KindGreaterThanGreaterThanGreaterThanEqualsToken:
+		return jsTruthy
+	case ast.KindInKeyword, ast.KindInstanceOfKeyword:
+		// Upstream computes these at the runtime level when both sides are
+		// known. We can't know statically; conservatively report falsy
+		// (matches upstream's fallback when the runtime check would throw).
+		return jsNull
+	}
+	// Truly unknown operators — align with upstream's null fallback.
+	return jsNull
+}
+
+// numericBoth coerces left/right to float64 if both are jvNumber. Returns
+// (0, 0, false) otherwise. Doesn't try to coerce strings → numbers because
+// alt-text never depends on those cases and the JS coercion rules
+// (`"3" - 1`, `null * 2`) are subtle enough that being conservative is
+// better than being slightly wrong.
+func numericBoth(l, r jsValue) (float64, float64, bool) {
+	if l.Kind == jvNumber && r.Kind == jvNumber {
+		return l.Num, r.Num, true
+	}
+	return 0, 0, false
+}
+
+// jsStrictEquals models JS `===` for the kinds we statically evaluate.
+// Different kinds → not strictly equal. Same kind → compare values, with NaN
+// being not-equal-to-NaN per JS spec.
+func jsStrictEquals(l, r jsValue) bool {
+	if l.Kind == jvUnknown || r.Kind == jvUnknown ||
+		l.Kind == jvTruthy || r.Kind == jvTruthy ||
+		l.Kind == jvFunction || r.Kind == jvFunction {
+		return false // can't compare unknowns
+	}
+	if l.Kind != r.Kind {
+		return false
+	}
+	switch l.Kind {
+	case jvString:
+		return l.Str == r.Str
+	case jvNumber:
+		// NaN !== NaN per spec.
+		if math.IsNaN(l.Num) || math.IsNaN(r.Num) {
+			return false
+		}
+		return l.Num == r.Num
+	case jvBigInt:
+		if l.Big == nil || r.Big == nil {
+			return l.Big == r.Big
+		}
+		return l.Big.Cmp(r.Big) == 0
+	case jvBool:
+		return l.Bool == r.Bool
+	case jvNull, jvUndef:
+		return true
+	}
+	return false
+}
+
+// jsLooseEquals models JS `==`. We only handle the two "easy" cases:
+//   - strict-equal kinds → reuse jsStrictEquals
+//   - null == undefined / undefined == null → true
+//
+// Full type coercion (`1 == "1"`, `null == 0`) is not modeled — callers see
+// `false` for those, which is a conservative approximation. Alt-text never
+// depends on `==` semantics; this keeps the surface small.
+func jsLooseEquals(l, r jsValue) bool {
+	if (l.Kind == jvNull && r.Kind == jvUndef) || (l.Kind == jvUndef && r.Kind == jvNull) {
+		return true
+	}
+	return jsStrictEquals(l, r)
+}
+
+// staticEvalUnary mirrors jsx-ast-utils' UnaryExpression / UpdateExpression
+// extractors for the operators that appear as PrefixUnary in tsgo:
+//
+//	`!x`       → !truthy(x)
+//	`-x`       → -number(x)  (number-coerced)
+//	`+x`       → +number(x)
+//	`~x`       → ~int32(x)
+//	`++x`      → ToNumber(x) + 1 (NaN if non-numeric)
+//	`--x`      → ToNumber(x) - 1 (NaN if non-numeric)
+//
+// Note: `typeof x`, `void x`, `delete x` are NOT PrefixUnary in tsgo —
+// they're separate kinds (KindTypeOfExpression / KindVoidExpression /
+// KindDeleteExpression) handled in staticEval directly.
+func staticEvalUnary(un *ast.PrefixUnaryExpression) jsValue {
+	switch un.Operator {
+	case ast.KindExclamationToken:
+		return jsValue{Kind: jvBool, Bool: !jsTruthy_(staticEval(un.Operand))}
+	case ast.KindMinusToken:
+		v := staticEval(un.Operand)
+		if v.Kind == jvNumber {
+			return jsValue{Kind: jvNumber, Num: -v.Num}
+		}
+	case ast.KindPlusToken:
+		v := staticEval(un.Operand)
+		if v.Kind == jvNumber {
+			return v
+		}
+	case ast.KindTildeToken:
+		v := staticEval(un.Operand)
+		if v.Kind == jvNumber {
+			return jsValue{Kind: jvNumber, Num: float64(^int32(v.Num))}
+		}
+	case ast.KindPlusPlusToken, ast.KindMinusMinusToken:
+		return staticEvalUpdate(un.Operator, un.Operand)
+	}
+	return jsNull
+}
+
+// staticEvalTemplate mirrors jsx-ast-utils' TemplateLiteral extractor:
+// concatenates raw quasi text with placeholders for substitutions:
+//
+//	Identifier `undefined`              → "undefined"
+//	other Identifier `name`             → "{name}"
+//	other expression of type `T`        → "{T}"
+//	TemplateElement                     → cooked text
+//
+// For our purposes, the result is always a truthy string (templates are never
+// empty after substitution placeholders are rendered).
+func staticEvalTemplate(tpl *ast.TemplateExpression) jsValue {
+	var sb strings.Builder
+	if tpl.Head != nil {
+		sb.WriteString(tpl.Head.AsTemplateHead().Text)
+	}
+	if tpl.TemplateSpans != nil {
+		for _, span := range tpl.TemplateSpans.Nodes {
+			if span.Kind != ast.KindTemplateSpan {
+				continue
+			}
+			sp := span.AsTemplateSpan()
+			if sp.Expression != nil {
+				expr := ast.SkipOuterExpressions(sp.Expression, skipTransparent)
+				switch {
+				case utils.IsUndefinedIdentifier(expr):
+					sb.WriteString("undefined")
+				case expr.Kind == ast.KindIdentifier:
+					sb.WriteString("{")
+					sb.WriteString(expr.AsIdentifier().Text)
+					sb.WriteString("}")
+				default:
+					// Upstream: any non-Identifier / non-TemplateElement gets
+					// `{<type>}`. We don't have a stable type-name string in
+					// tsgo, so we just emit a placeholder — the result is
+					// still a truthy string, which is all alt-text needs.
+					sb.WriteString("{Expression}")
+				}
+			}
+			if sp.Literal != nil {
+				switch sp.Literal.Kind {
+				case ast.KindTemplateMiddle:
+					sb.WriteString(sp.Literal.AsTemplateMiddle().Text)
+				case ast.KindTemplateTail:
+					sb.WriteString(sp.Literal.AsTemplateTail().Text)
+				}
+			}
+		}
+	}
+	return jsValue{Kind: jvString, Str: sb.String()}
+}
+
+// jsTruthy_ replicates JS truthiness on a jsValue.
+func jsTruthy_(v jsValue) bool {
+	switch v.Kind {
+	case jvString:
+		return v.Str != ""
+	case jvNumber:
+		return v.Num != 0 && !math.IsNaN(v.Num)
+	case jvBigInt:
+		return v.Big != nil && v.Big.Sign() != 0
+	case jvBool:
+		return v.Bool
+	case jvNull, jvUndef:
+		return false
+	case jvFunction, jvTruthy:
+		return true
+	}
+	// Unknown — default to truthy ("the developer wrote SOMETHING").
+	return true
+}
+
+// jsToString approximates JS's String() coercion for the few kinds we produce.
+// Used by the `+` operator's string-concat path.
+func jsToString(v jsValue) string {
+	switch v.Kind {
+	case jvString:
+		return v.Str
+	case jvNumber:
+		if math.IsNaN(v.Num) {
+			return "NaN"
+		}
+		if math.IsInf(v.Num, 1) {
+			return "Infinity"
+		}
+		if math.IsInf(v.Num, -1) {
+			return "-Infinity"
+		}
+		return strconv.FormatFloat(v.Num, 'f', -1, 64)
+	case jvBigInt:
+		if v.Big == nil {
+			return "0"
+		}
+		return v.Big.String()
+	case jvBool:
+		if v.Bool {
+			return "true"
+		}
+		return "false"
+	case jvNull:
+		return "null"
+	case jvUndef:
+		return "undefined"
+	}
+	return ""
+}
+
+// jsValueIsExactlyEmptyString reports whether the value is statically known
+// to be the empty string. Used for the `altValue === ''` branch of the
+// alt-text validity check.
+func jsValueIsExactlyEmptyString(v jsValue) bool {
+	return v.Kind == jvString && v.Str == ""
+}
+
+// literalPropValue mirrors jsx-ast-utils' `getLiteralPropValue` engine —
+// LITERAL_TYPES — which is `getPropValue` minus the runtime-expression
+// extractors (CallExpression, MemberExpression, etc. all become noop → null).
+// Used by `<object title>` and `isPresentationRole(role)` since upstream
+// reads those via `getLiteralPropValue`, not `getPropValue`.
+//
+// Critical differences vs staticEval:
+//
+//   - Identifier (non-undefined) returns jvNull instead of the name string.
+//     Reason: upstream LITERAL_TYPES.Identifier returns `null` for any
+//     non-undefined identifier — runtime variables aren't literal values.
+//   - null literal returns the string "null" (truthy!). This is upstream's
+//     special-case in LITERAL_TYPES.Literal: `extractedVal === null ?
+//     'null' : extractedVal`.
+//   - Most Expression kinds (Call, Member, Conditional, Logical, Binary,
+//     Unary except `!`, …) are noop → jvNull → falsy. We model the few
+//     that upstream does compute: TemplateLiteral, ArrayExpression filter,
+//     and Literal coercion.
+func literalPropValue(node *ast.Node) jsValue {
+	if node == nil {
+		return jsUnknown
+	}
+	node = ast.SkipOuterExpressions(node, skipTransparent)
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return jsxAstUtilsLiteralCoerce(node.AsStringLiteral().Text)
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return jsxAstUtilsLiteralCoerce(node.AsNoSubstitutionTemplateLiteral().Text)
+	case ast.KindTrueKeyword:
+		return jsValue{Kind: jvBool, Bool: true}
+	case ast.KindFalseKeyword:
+		return jsValue{Kind: jvBool, Bool: false}
+	case ast.KindNullKeyword:
+		// Upstream LITERAL_TYPES.Literal: null → 'null' (truthy string).
+		// This is intentional and load-bearing for `<object title={null} />`
+		// being valid.
+		return jsValue{Kind: jvString, Str: "null"}
+	case ast.KindNumericLiteral:
+		text := utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text)
+		f, err := strconv.ParseFloat(text, 64)
+		if err != nil {
+			f = math.NaN()
+		}
+		return jsValue{Kind: jvNumber, Num: f}
+	case ast.KindBigIntLiteral:
+		text := utils.NormalizeBigIntLiteral(node.AsBigIntLiteral().Text)
+		bi := new(big.Int)
+		if _, ok := bi.SetString(text, 10); !ok {
+			return jsUnknown
+		}
+		return jsValue{Kind: jvBigInt, Big: bi}
+	case ast.KindIdentifier:
+		// LITERAL_TYPES.Identifier: undefined → undefined; everything else → null.
+		if utils.IsUndefinedIdentifier(node) {
+			return jsUndef
+		}
+		return jsNull
+	case ast.KindTemplateExpression:
+		// Template literals with substitutions ARE in LITERAL_TYPES via
+		// TYPES (no override). We reuse staticEvalTemplate which produces
+		// a string — non-empty since at least one quasi or placeholder
+		// always renders.
+		return staticEvalTemplate(node.AsTemplateExpression())
+	case ast.KindPrefixUnaryExpression:
+		// LITERAL_TYPES.UnaryExpression: same as TYPES but undefined → null.
+		v := staticEvalUnary(node.AsPrefixUnaryExpression())
+		if v.Kind == jvUndef {
+			return jsNull
+		}
+		return v
+	case ast.KindArrayLiteralExpression:
+		// LITERAL_TYPES.ArrayExpression filters out null entries. We don't
+		// model the actual contents — for our purposes (just truthy?) any
+		// array (empty or not) is truthy in JS, so jsTruthy is enough.
+		return jsTruthy
+	}
+	// All other expressions (Call, Member, Conditional, Logical, Binary, etc.)
+	// → noop → null per LITERAL_TYPES. Returning jvNull marks them as falsy
+	// without claiming any specific identity.
+	return jsNull
+}
+
+// jsxAstUtilsLiteralCoerce mirrors jsx-ast-utils' string-literal extractor,
+// which normalizes the case-insensitive strings "true" / "false" to actual
+// booleans. Any other string is returned unchanged.
+//
+// Why this matters: alt-text and other a11y rules read attribute values
+// through this extractor. A literal `<img alt="false" />` evaluates to the
+// boolean `false`, not the string "false" — making it falsy and failing the
+// `(altValue && !isNullValued) || altValue === ''` check. Skipping this
+// normalization would silently accept `alt="false"`.
+func jsxAstUtilsLiteralCoerce(text string) jsValue {
+	switch strings.ToLower(text) {
+	case "true":
+		return jsValue{Kind: jvBool, Bool: true}
+	case "false":
+		return jsValue{Kind: jvBool, Bool: false}
+	}
+	return jsValue{Kind: jvString, Str: text}
+}
+
+// jsValueIsExactlyUndefined reports whether the value is statically known
+// to be `undefined`. Used by ariaLabelHasValue.
+func jsValueIsExactlyUndefined(v jsValue) bool {
+	return v.Kind == jvUndef
+}

--- a/internal/plugins/jsx_a11y/plugin.go
+++ b/internal/plugins/jsx_a11y/plugin.go
@@ -1,0 +1,1 @@
+package jsx_a11y_plugin

--- a/internal/plugins/jsx_a11y/rules/alt_text/alt_text.go
+++ b/internal/plugins/jsx_a11y/rules/alt_text/alt_text.go
@@ -1,0 +1,344 @@
+package alt_text
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Default DOM elements alt-text validates. Mirrors upstream's `DEFAULT_ELEMENTS`.
+// The order is preserved because option-driven custom-component lookup falls
+// back to `elementOptions.find(...)` which scans in this order.
+var defaultElements = []string{
+	"img",
+	"object",
+	"area",
+	`input[type="image"]`,
+}
+
+// Element name aliases. The upstream rule normalizes the special
+// `input[type="image"]` selector to the bare tag `input` when it builds the
+// `typesToValidate` set, so the listener can match by tag name. We mirror
+// that translation in `domToTagName` and reverse it via `tagNameToDOM` when
+// dispatching to the per-element check.
+func domToTagName(dom string) string {
+	if dom == `input[type="image"]` {
+		return "input"
+	}
+	return dom
+}
+
+const (
+	msgPreferAlt           = `Prefer alt="" over a presentational role. First rule of aria is to not use aria if it can be achieved via native HTML.`
+	msgAriaLabelEmpty      = "The aria-label attribute must have a value. The alt attribute is preferred over aria-label for images."
+	msgAriaLabelledByEmpty = "The aria-labelledby attribute must have a value. The alt attribute is preferred over aria-labelledby for images."
+	msgObject              = "Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props."
+	msgArea                = "Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop."
+	msgInputImage          = "<input> elements with type=\"image\" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop."
+)
+
+func missingPropMessage(nodeType string) string {
+	return nodeType + " elements must have an alt prop, either with meaningful text, or an empty string for decorative images."
+}
+
+func altValueMessage(nodeType string) string {
+	return "Invalid alt value for " + nodeType + ". Use alt=\"\" for presentational images."
+}
+
+// options holds the parsed shape of the rule's first option object.
+type options struct {
+	elements         []string
+	customComponents map[string][]string // keyed by DOM element name (e.g. "img" / `input[type="image"]`)
+}
+
+func parseOptions(raw any) options {
+	opts := options{elements: defaultElements}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+
+	if rawElements, ok := m["elements"]; ok {
+		if arr, ok := rawElements.([]interface{}); ok {
+			elements := make([]string, 0, len(arr))
+			for _, v := range arr {
+				if s, ok := v.(string); ok {
+					elements = append(elements, s)
+				}
+			}
+			// Upstream falls through to DEFAULT_ELEMENTS via `||` only when
+			// `options.elements` is falsy (undefined / null / "" / []). An
+			// explicitly-empty array therefore disables ALL element checks —
+			// match that semantic.
+			opts.elements = elements
+		}
+	}
+
+	opts.customComponents = make(map[string][]string)
+	for _, element := range opts.elements {
+		if rawList, ok := m[element]; ok {
+			if arr, ok := rawList.([]interface{}); ok {
+				list := make([]string, 0, len(arr))
+				for _, v := range arr {
+					if s, ok := v.(string); ok {
+						list = append(list, s)
+					}
+				}
+				if len(list) > 0 {
+					opts.customComponents[element] = list
+				}
+			}
+		}
+	}
+	return opts
+}
+
+var AltTextRule = rule.Rule{
+	Name: "jsx-a11y/alt-text",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		// Precompute the set of nodeType strings that should trigger a check.
+		// Upstream's `typesToValidate` is the union of customComponents and
+		// elementOptions, with `input[type="image"]` translated to `input`
+		// because the listener matches by raw tag-name (`<input>`).
+		typesToValidate := make(map[string]struct{})
+		for _, element := range opts.elements {
+			typesToValidate[domToTagName(element)] = struct{}{}
+		}
+		for _, components := range opts.customComponents {
+			for _, c := range components {
+				typesToValidate[c] = struct{}{}
+			}
+		}
+
+		// elementType resolves the effective HTML name for a JSX node, applying
+		// jsx-a11y's polymorphicPropName / componentMap transformations.
+		elementType := func(node *ast.Node) string {
+			return jsxa11yutil.GetElementType(node, ctx.Settings)
+		}
+
+		check := func(node *ast.Node) {
+			nodeType := elementType(node)
+			if _, ok := typesToValidate[nodeType]; !ok {
+				return
+			}
+
+			// Determine which DOM-element bucket this nodeType maps to so we
+			// can dispatch to the right per-element rule. Mirrors upstream:
+			//   - `nodeType === "input"` → `input[type="image"]`
+			//   - `nodeType in elementOptions` → use it directly
+			//   - otherwise it's a custom component → find which DOM element
+			//     it was mapped to via `options[element]`
+			domElement := nodeType
+			if domElement == "input" {
+				domElement = `input[type="image"]`
+			}
+			if !contains(opts.elements, domElement) {
+				domElement = ""
+				for _, element := range opts.elements {
+					if list, ok := opts.customComponents[element]; ok {
+						if contains(list, nodeType) {
+							domElement = element
+							break
+						}
+					}
+				}
+				if domElement == "" {
+					// Upstream's `find` returns undefined here, then calls
+					// `ruleByElement[undefined](...)` which throws. In
+					// practice this is unreachable because `typesToValidate`
+					// exactly covers the nodeTypes we accept; we add the
+					// guard for malformed configs (e.g. `elements: []` with
+					// custom components still listed).
+					return
+				}
+			}
+
+			attrs := reactutil.GetJsxElementAttributes(node)
+			switch domElement {
+			case "img":
+				checkImg(ctx, node, attrs, nodeType)
+			case "object":
+				checkObject(ctx, node, attrs, elementType)
+			case "area":
+				checkArea(ctx, node, attrs)
+			case `input[type="image"]`:
+				checkInputImage(ctx, node, attrs, nodeType)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}
+
+// checkImg mirrors `ruleByElement.img`. Branches:
+//
+//  1. altProp absent:
+//     a) presentational role → preferAlt
+//     b) aria-label present and value is undefined / "" → ariaLabelEmpty
+//     c) aria-labelledby present and value is undefined / "" → ariaLabelledByEmpty
+//     d) otherwise → missingProp
+//  2. altProp present:
+//     a) (truthy && not boolean form) || empty string → valid
+//     b) otherwise → altValue
+func checkImg(ctx rule.RuleContext, node *ast.Node, attrs []*ast.Node, nodeType string) {
+	altProp := jsxa11yutil.FindAttributeByName(attrs, "alt")
+	if altProp == nil {
+		if jsxa11yutil.IsPresentationRole(attrs) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "preferAlt",
+				Description: msgPreferAlt,
+			})
+			return
+		}
+		if ariaLabelProp := jsxa11yutil.FindAttributeByName(attrs, "aria-label"); ariaLabelProp != nil {
+			if !jsxa11yutil.AriaLabelHasValue(ariaLabelProp) {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "ariaLabelValue",
+					Description: msgAriaLabelEmpty,
+				})
+			}
+			return
+		}
+		if ariaLabelledByProp := jsxa11yutil.FindAttributeByName(attrs, "aria-labelledby"); ariaLabelledByProp != nil {
+			if !jsxa11yutil.AriaLabelHasValue(ariaLabelledByProp) {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "ariaLabelledByValue",
+					Description: msgAriaLabelledByEmpty,
+				})
+			}
+			return
+		}
+		ctx.ReportNode(node, rule.RuleMessage{
+			Id:          "missingProp",
+			Description: missingPropMessage(nodeType),
+		})
+		return
+	}
+	if jsxa11yutil.AltAttributeIsValid(altProp) {
+		return
+	}
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          "altValue",
+		Description: altValueMessage(nodeType),
+	})
+}
+
+// checkObject mirrors `ruleByElement.object`. An <object> is accessible if it
+// has aria-label / aria-labelledby with a meaningful value, a literal title,
+// OR an accessible child inside its element.
+func checkObject(ctx rule.RuleContext, node *ast.Node, attrs []*ast.Node, elementType func(*ast.Node) string) {
+	if jsxa11yutil.AriaLabelHasValue(jsxa11yutil.FindAttributeByName(attrs, "aria-label")) {
+		return
+	}
+	if jsxa11yutil.AriaLabelHasValue(jsxa11yutil.FindAttributeByName(attrs, "aria-labelledby")) {
+		return
+	}
+	// Upstream: `hasTitleAttr = !!getLiteralPropValue(...)`. LiteralPropTruthy
+	// mirrors that fully — including jsx-ast-utils' quirks like
+	// `title={null}` evaluating to the string "null" (truthy) and Identifier
+	// references resolving to null (falsy because they're not literal).
+	if jsxa11yutil.LiteralPropTruthy(jsxa11yutil.FindAttributeByName(attrs, "title")) {
+		return
+	}
+	// Upstream calls `hasAccessibleChild(node.parent, elementType)`. In
+	// ESTree, every JSXOpeningElement (including self-closing) is wrapped
+	// in a JSXElement, so `node.parent` always carries the children list
+	// AND the opening attributes. tsgo doesn't wrap JsxSelfClosingElement
+	// in a JsxElement — the self-closing node carries the attributes
+	// directly. We normalize: pass the JsxElement when present, else the
+	// self-closing node itself, so HasAccessibleChild sees the same
+	// "children + opening attributes" surface upstream does.
+	jsxRoot := node
+	if node.Kind == ast.KindJsxOpeningElement && node.Parent != nil &&
+		(node.Parent.Kind == ast.KindJsxElement || node.Parent.Kind == ast.KindJsxFragment) {
+		jsxRoot = node.Parent
+	}
+	if jsxa11yutil.HasAccessibleChild(jsxRoot, elementType) {
+		return
+	}
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          "object",
+		Description: msgObject,
+	})
+}
+
+// checkArea mirrors `ruleByElement.area`. An <area> is accessible if it has
+// aria-label / aria-labelledby with a meaningful value, OR a valid alt prop.
+func checkArea(ctx rule.RuleContext, node *ast.Node, attrs []*ast.Node) {
+	if jsxa11yutil.AriaLabelHasValue(jsxa11yutil.FindAttributeByName(attrs, "aria-label")) {
+		return
+	}
+	if jsxa11yutil.AriaLabelHasValue(jsxa11yutil.FindAttributeByName(attrs, "aria-labelledby")) {
+		return
+	}
+	altProp := jsxa11yutil.FindAttributeByName(attrs, "alt")
+	if altProp == nil {
+		ctx.ReportNode(node, rule.RuleMessage{
+			Id:          "area",
+			Description: msgArea,
+		})
+		return
+	}
+	if jsxa11yutil.AltAttributeIsValid(altProp) {
+		return
+	}
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          "area",
+		Description: msgArea,
+	})
+}
+
+// checkInputImage mirrors `ruleByElement['input[type="image"]']`. For the
+// bare `<input>` tag we additionally guard on `type === "image"` — only
+// inputs of type "image" require alt text. Custom components (mapped to
+// "input[type=\"image\"]" via options) skip this guard, matching upstream.
+func checkInputImage(ctx rule.RuleContext, node *ast.Node, attrs []*ast.Node, nodeType string) {
+	if nodeType == "input" {
+		typeAttr := jsxa11yutil.FindAttributeByName(attrs, "type")
+		// Upstream: `getPropValue(...)` (NOT getLiteralPropValue) compared
+		// `=== "image"` — case-sensitive, full static evaluation across
+		// `+`, `&&` / `||` short-circuit, ternary, etc. Use
+		// PropStaticStringValue and exact `==` comparison.
+		v, ok := jsxa11yutil.PropStaticStringValue(typeAttr)
+		if !ok || v != "image" {
+			return
+		}
+	}
+	if jsxa11yutil.AriaLabelHasValue(jsxa11yutil.FindAttributeByName(attrs, "aria-label")) {
+		return
+	}
+	if jsxa11yutil.AriaLabelHasValue(jsxa11yutil.FindAttributeByName(attrs, "aria-labelledby")) {
+		return
+	}
+	altProp := jsxa11yutil.FindAttributeByName(attrs, "alt")
+	if altProp == nil {
+		ctx.ReportNode(node, rule.RuleMessage{
+			Id:          "inputImage",
+			Description: msgInputImage,
+		})
+		return
+	}
+	if jsxa11yutil.AltAttributeIsValid(altProp) {
+		return
+	}
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          "inputImage",
+		Description: msgInputImage,
+	})
+}
+
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/jsx_a11y/rules/alt_text/alt_text.md
+++ b/internal/plugins/jsx_a11y/rules/alt_text/alt_text.md
@@ -1,0 +1,133 @@
+# alt-text
+
+## Rule Details
+
+Enforces that elements that require alternative text — `<img>`, `<object>`,
+`<area>`, and `<input type="image">` — have meaningful information available
+to screen readers.
+
+The rule reports problems in these scenarios:
+
+- An `<img>` has no `alt` prop, no `aria-label`, and no `aria-labelledby`,
+  and is not marked with a presentational role.
+- An `<img>` has an `alt` prop, but the value is `undefined`, `false`, the
+  literal string `"false"`, or another expression that statically evaluates
+  to falsy.
+- An `<img>` declares `aria-label` or `aria-labelledby` but its value is
+  empty or explicitly `undefined` (the rule still reports because that
+  attribute can't actually serve as the text alternative).
+- An `<img>` uses `role="presentation"` or `role="none"` instead of writing
+  `alt=""` for a decorative image.
+- An `<object>` has no inner accessible content, no `title`, no
+  `aria-label`, and no `aria-labelledby`.
+- An `<area>` or `<input type="image">` has no `alt`, no `aria-label`, and
+  no `aria-labelledby`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<img src="foo.png" />
+<img alt />
+<img alt={undefined} />
+<img alt="false" />
+<img role="presentation" />
+<img aria-label="" />
+<area />
+<input type="image" />
+<object />
+<object aria-label="" />
+<object title={undefined} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<img alt="A descriptive image" />
+<img alt="" />
+<img alt={alt} />
+<img aria-label="An image" />
+<img aria-labelledby="caption-1" />
+<area alt="A clickable region" />
+<input type="image" alt="Submit" />
+<object>Inner descriptive content</object>
+<object aria-label="Embedded content" />
+<object title="An object" />
+```
+
+## Rule Options
+
+```json
+{
+  "jsx-a11y/alt-text": [
+    "error",
+    {
+      "elements": ["img", "object", "area", "input[type=\"image\"]"],
+      "img": ["Image"],
+      "object": ["Object"],
+      "area": ["Area"],
+      "input[type=\"image\"]": ["InputImage"]
+    }
+  ]
+}
+```
+
+### `elements`
+
+Type: `string[]`. Default:
+`["img", "object", "area", "input[type=\"image\"]"]`.
+
+Whitelist of DOM elements the rule should validate. Set this to a subset to
+disable the check for specific elements, or to `[]` to disable the rule
+entirely.
+
+### Per-element custom-component lists
+
+Each element key (`img`, `object`, `area`, `input[type="image"]`) accepts an
+array of component names. Listed components are validated alongside the
+matching DOM element — for example, `"img": ["Thumbnail", "Image"]` makes
+`<Thumbnail />` and `<Image />` follow the same `alt`-text rules as `<img>`.
+
+Examples of **incorrect** code with `{ "img": ["Image"] }`:
+
+```json
+{ "jsx-a11y/alt-text": ["error", { "img": ["Image"] }] }
+```
+
+```jsx
+<Image />
+<Image src="xyz" />
+<Image alt={undefined} />
+```
+
+Examples of **correct** code with `{ "img": ["Image"] }`:
+
+```json
+{ "jsx-a11y/alt-text": ["error", { "img": ["Image"] }] }
+```
+
+```jsx
+<Image alt="" />
+<Image alt="A descriptive image" />
+<Image alt={alt} />
+```
+
+## Settings
+
+The rule reads two `settings['jsx-a11y']` keys when resolving the effective
+element type for a JSX tag:
+
+- `polymorphicPropName` — name of a polymorphic prop (e.g. `"as"`) that
+  remaps the element type. With `polymorphicPropName: "as"`,
+  `<SomeComponent as="img" />` is treated as `<img />`.
+- `polymorphicAllowList` — `string[]` restricting which raw component names
+  may be remapped via the polymorphic prop. When omitted, every component
+  may be remapped.
+- `components` — a `{ ComponentName: "html-element" }` map. With
+  `{ "Input": "input" }`, `<Input type="image" />` is treated as
+  `<input type="image" />`.
+
+These mirror the upstream `eslint-plugin-jsx-a11y` settings exactly.
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/alt-text](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/alt-text.md)

--- a/internal/plugins/jsx_a11y/rules/alt_text/alt_text_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/alt_text/alt_text_extras_test.go
@@ -1,0 +1,1074 @@
+package alt_text
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestAltTextExtras locks in rslint-specific behaviors beyond what the
+// upstream eslint-plugin-jsx-a11y test suite exercises:
+//
+//   - jsx-ast-utils getPropValue / getLiteralPropValue static-eval edges
+//     (logical short-circuit, ternary branch selection, JS_RESERVED globals,
+//     numeric / BigInt / template / unary / sequence / assignment, etc.)
+//   - TS-only expression wrappers (`as`, `!`, `<T>`, `satisfies`)
+//   - Polymorphic-prop edge cases (non-string truthy literal, allow-list)
+//   - Spread / shorthand-spread first-match semantics
+//   - aria-hidden full static-eval coverage in nested children
+//   - Real-world i18n / optional-chain / fallback patterns
+//
+// Each case here was verified empirically against eslint-plugin-jsx-a11y@latest
+// to ensure the rslint port produces byte-identical diagnostics.
+func TestAltTextExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AltTextRule, []rule_tester.ValidTestCase{
+		// ---- Lock-in: extra edge cases beyond upstream ----
+		// Locks in upstream `ariaLabelHasValue` arm: aria-label boolean form
+		// (no initializer) is treated as having value `true`.
+		{Code: `<img aria-label />`, Tsx: true},
+		// Locks in upstream `ariaLabelHasValue` arm: aria-labelledby boolean
+		// form is also treated as having value.
+		{Code: `<img aria-labelledby />`, Tsx: true},
+		// Locks in upstream `getLiteralPropValue` for templates with no
+		// substitution: `{`presentation`}` is a literal "presentation" value
+		// for the role attr.
+		{Code: "<img alt=\"\" role={`none`} />", Tsx: true},
+		// Locks in `<object>` accessible-child arm: an inner JSXExpression
+		// other than `{undefined}` counts as accessible.
+		{Code: `<object>{value}</object>`, Tsx: true},
+		// Locks in `<object>` arm: dangerouslySetInnerHTML on the opening
+		// element makes the element accessible (no inner-text needed).
+		{Code: `<object dangerouslySetInnerHTML={{__html:""}} />`, Tsx: true},
+		// Locks in `<object>` arm: explicit `children` attribute counts as
+		// accessible (matches upstream's hasAnyProp fallback).
+		{Code: `<object children={"x"} />`, Tsx: true},
+		// Locks in `<object>` arm: a string-literal child node counts as
+		// accessible (matches upstream's `case 'Literal'`).
+		{Code: `<object>{"Foo"}</object>`, Tsx: true},
+		// Locks in `<object>` arm: a JSX child whose tag is not screen-reader
+		// hidden counts as accessible.
+		{Code: `<object><p>Body</p></object>`, Tsx: true},
+		// Locks in upstream input branch: a non-`image` typed input is
+		// silently skipped (the rule never fires on `<input type="text" />`).
+		{Code: `<input type="text" />`, Tsx: true},
+		// Locks in `tagName` translation: uppercase `INPUT` doesn't match
+		// the `input` lowercase listener (upstream skips `<INPUT>`).
+		{Code: `<INPUT />`, Tsx: true},
+		// Locks in TS-wrapper unwrapping in LiteralStringValue: alt extracts
+		// "foo" through `as`, matching jsx-ast-utils' TSAsExpression unwrap.
+		{Code: `<img alt={"foo" as string} />`, Tsx: true},
+		// Locks in TS-wrapper unwrapping for role: the value still resolves
+		// to the literal "presentation" through the assertion.
+		{Code: `<img alt="" role={"presentation" as const} />`, Tsx: true},
+		// Locks in TS-wrapper unwrapping in expressionIsLikelyTruthy: a
+		// non-null asserted variable is still treated as a value reference,
+		// keeping the alt valid.
+		{Code: `<img alt={alt!} />`, Tsx: true},
+		// Locks in PrefixUnary `!` truthiness in expressionIsLikelyTruthy:
+		// `!""` is truthy → valid alt.
+		{Code: `<img alt={!""} />`, Tsx: true},
+		// Locks in BigInt literal handling for non-zero values: `1n` is
+		// truthy → valid (developer wrote SOMETHING).
+		{Code: `<img alt={1n} />`, Tsx: true},
+		// Locks in ConditionalExpression: at least one branch is truthy →
+		// valid.
+		{Code: `<img alt={cond ? "x" : "y"} />`, Tsx: true},
+		// Locks in shorthand-spread match in FindAttributeByName: the
+		// shorthand `alt` resolves to the bound identifier (truthy).
+		{Code: `<img {...{alt}} />`, Tsx: true},
+		// Locks in spread-object literal-property match: `alt: "x"` makes
+		// the alt extractable as the literal string.
+		{Code: `<img {...{alt: "x"}} />`, Tsx: true},
+		// Locks in JsxElement-with-closing-tag's opening attributes being
+		// inspected for aria-hidden: a paired `<div></div>` (no aria-hidden)
+		// is NOT hidden → counts as accessible.
+		{Code: `<object><div></div></object>`, Tsx: true},
+
+		// ---- staticEval lock-ins (verified empirically against upstream ESLint) ----
+		// Each case below was run through real eslint-plugin-jsx-a11y to
+		// confirm the expected diagnostic. See /tmp/jsx-a11y-verify probes.
+		//
+		// LogicalExpression `&&`: short-circuits to left when left falsy.
+		// `"" && x` → "" → valid via the `=== ''` branch.
+		{Code: `<img alt={"" && x} />`, Tsx: true},
+		// `x && ""` → "" (x is truthy via Identifier-name → take right) → valid.
+		{Code: `<img alt={x && ""} />`, Tsx: true},
+		// `"" && ""` → "" → valid.
+		{Code: `<img alt={"" && ""} />`, Tsx: true},
+		// LogicalExpression `||`: short-circuits to left when left truthy.
+		// `"" || x` → "x" → valid.
+		{Code: `<img alt={"" || x} />`, Tsx: true},
+		// NullishCoalescing `??`: returns right only when left is null/undefined.
+		// `null ?? "x"` → "x" → valid.
+		{Code: `<img alt={null ?? "x"} />`, Tsx: true},
+		// `"" ?? x` → "" (empty string is not null/undefined, so left wins) → valid.
+		{Code: `<img alt={"" ?? x} />`, Tsx: true},
+		// ConditionalExpression: real branch selection by test's truthiness.
+		// `cond ? "x" : "y"` — cond's Identifier-name "cond" is truthy → "x" → valid.
+		{Code: `<img alt={cond ? "x" : "y"} />`, Tsx: true},
+		// `cond ? "" : "y"` — cond truthy → "" → valid via `=== ''` branch.
+		{Code: `<img alt={cond ? "" : "y"} />`, Tsx: true},
+		// `undefined ? "x" : "y"` — undefined identifier is falsy → "y" → valid.
+		{Code: `<img alt={undefined ? "x" : "y"} />`, Tsx: true},
+		// `false ? "x" : ""` — false → "" → valid via `=== ''` branch.
+		{Code: `<img alt={false ? "x" : ""} />`, Tsx: true},
+		// Reserved-word identifiers: Infinity → +Infinity (truthy) → valid.
+		{Code: `<img alt={Infinity} />`, Tsx: true},
+		// `NaN` is NOT in jsx-ast-utils' JS_RESERVED set, so it's treated as a
+		// regular identifier and returns the bare name string "NaN" (truthy).
+		{Code: `<img alt={NaN} />`, Tsx: true},
+		// `Number` IS in JS_RESERVED → returns the constructor function (truthy).
+		{Code: `<img alt={Number} />`, Tsx: true},
+		// String concatenation via `+`.
+		{Code: `<img alt={"a" + "b"} />`, Tsx: true},
+		// `x + ""` → "x" (Identifier name + empty string) → valid.
+		{Code: `<img alt={x + ""} />`, Tsx: true},
+		// Template-with-substitutions: upstream extracts a synthesized string;
+		// we approximate with placeholder-rendering — always non-empty truthy.
+		{Code: "<img alt={`x${y}z`} />", Tsx: true},
+		// `Math` / `Date` are JS_RESERVED — upstream returns the global value
+		// (object / function), both truthy → valid.
+		{Code: `<img alt={Math} />`, Tsx: true},
+		{Code: `<img alt={Date} />`, Tsx: true},
+		// Empty array / empty object literals are truthy in JS → valid.
+		{Code: `<img alt={[]} />`, Tsx: true},
+		{Code: `<img alt={[1,2]} />`, Tsx: true},
+		{Code: `<img alt={({})} />`, Tsx: true},
+		// `+` string concat with null / undefined coerces to "null" / "undefined"
+		// (truthy), matching JS's String() semantics in jsx-ast-utils.
+		{Code: `<img alt={"" + null} />`, Tsx: true},
+		{Code: `<img alt={null + ""} />`, Tsx: true},
+		{Code: `<img alt={undefined + ""} />`, Tsx: true},
+		{Code: `<img alt={"a" + null} />`, Tsx: true},
+		// Numeric `+`: 1 + 2 → 3 (truthy) → valid.
+		{Code: `<img alt={1 + 2} />`, Tsx: true},
+		// PrefixUnary `!`: `!0` → true → valid.
+		{Code: `<img alt={!0} />`, Tsx: true},
+		// 1.0 normalizes to 1 → truthy → valid.
+		{Code: `<img alt={1.0} />`, Tsx: true},
+		// `"" + ""` → "" → valid via the `=== ''` branch.
+		{Code: `<img alt={"" + ""} />`, Tsx: true},
+		// Nested chain that resolves to a truthy identifier name.
+		{Code: `<img alt={a && (b || (c && ""))} />`, Tsx: true},
+
+		// ---- Real-world patterns (verified against upstream ESLint) ----
+		// i18n function calls — translation result is a CallExpression
+		// (jsTruthy) → valid.
+		{Code: `<img alt={t("img.alt")} />`, Tsx: true},
+		{Code: `<img alt={i18n.t("key")} />`, Tsx: true},
+		{Code: `<img alt={i18n.t("key", {defaultValue: "x"})} />`, Tsx: true},
+		// Optional-call (`t?.("key")`) — same kind in tsgo (CallExpression
+		// with the optional flag), still jsTruthy → valid.
+		{Code: `<img alt={t?.("key")} />`, Tsx: true},
+		{Code: `<img alt={t?.("key") ?? "fallback"} />`, Tsx: true},
+		// Optional-chain property access — same kind in tsgo
+		// (PropertyAccessExpression with the optional flag) → valid.
+		{Code: `<img alt={data?.alt} />`, Tsx: true},
+		{Code: `<img alt={data?.alt ?? ""} />`, Tsx: true},
+		{Code: `<img alt={a?.b?.c} />`, Tsx: true},
+		{Code: `<img alt={a?.b?.()} />`, Tsx: true},
+		// Default-fallback patterns common in real code.
+		{Code: `<img alt={altText || "Image"} />`, Tsx: true},
+		{Code: `<img alt={altText ?? "Image"} />`, Tsx: true},
+		{Code: `<img alt={t && t("key")} />`, Tsx: true},
+		{Code: `<img alt={t ? t("key") : ""} />`, Tsx: true},
+
+		// ---- Spread ordering (matches upstream getProp's "first match wins") ----
+		// alt before spread → matched first.
+		{Code: `<img alt="x" {...rest} />`, Tsx: true},
+		// alt after spread (non-literal spread is opaque, getProp falls
+		// through and finds alt).
+		{Code: `<img {...rest} alt="x" />`, Tsx: true},
+		// Two non-literal spreads, both opaque, alt missing — covered in
+		// invalid section.
+
+		// ---- JSX namespaced attribute ----
+		// `alt:foo` is not the `alt` attribute (different name); the rule
+		// must not match it. Matches upstream's `propName` returning
+		// "alt:foo" for JsxNamespacedName.
+		{Code: `<img alt:foo="bar" alt="x" />`, Tsx: true},
+
+		// ---- Empty / whitespace-only template literal ----
+		// `\`\`` (empty no-sub template) → "" → valid via `=== ''`.
+		{Code: "<img alt={``} />", Tsx: true},
+		// `\`  \`` (whitespace-only) → "  " (truthy) → valid.
+		{Code: "<img alt={`  `} />", Tsx: true},
+
+		// ---- Object / array literal alt (truthy in JS) ----
+		{Code: `<img alt={{x: 1}} />`, Tsx: true},
+		{Code: `<img alt={[1, 2, 3]} />`, Tsx: true},
+
+		// ---- Identifier reserved-word edge cases ----
+		// `Boolean` / `Symbol` / `JSON` are NOT in jsx-ast-utils JS_RESERVED
+		// → returned as their identifier name (truthy non-empty string).
+		{Code: `<img alt={Boolean} />`, Tsx: true},
+		{Code: `<img alt={Symbol} />`, Tsx: true},
+		{Code: `<img alt={JSON} />`, Tsx: true},
+
+		// ---- Numeric edge cases ----
+		// -0.5 → -0.5 (truthy) → valid.
+		{Code: `<img alt={-0.5} />`, Tsx: true},
+		// `1 > 0` → true (boolean) → valid.
+		{Code: `<img alt={1 > 0} />`, Tsx: true},
+		// `1 === 1` → true → valid.
+		{Code: `<img alt={1 === 1} />`, Tsx: true},
+		// Bitwise: `1 | 0` → 1 → truthy → valid.
+		{Code: `<img alt={1 | 0} />`, Tsx: true},
+		{Code: `<img alt={2 & 3} />`, Tsx: true},
+		// Modulo: `5 % 2` → 1 → truthy → valid.
+		{Code: `<img alt={5 % 2} />`, Tsx: true},
+		// Power: `2 ** 3` → 8 → truthy → valid.
+		{Code: `<img alt={2 ** 3} />`, Tsx: true},
+
+		// ---- Multi-line / formatting ----
+		// Multi-line JSX with valid alt — rule must accept across newlines.
+		{
+			Code: `<img
+				alt="multi-line"
+				src="x"
+			/>`,
+			Tsx: true,
+		},
+		// Spread + alt on different lines, alt visible → valid.
+		{
+			Code: `<img
+				{...this.props}
+				alt="x"
+			/>`,
+			Tsx: true,
+		},
+
+		// ---- Paired tag form (legal but uncommon) ----
+		{Code: `<img alt="x"></img>`, Tsx: true},
+		{Code: `<input type="image" alt="x"></input>`, Tsx: true},
+
+		// ---- Settings: polymorphicAllowList restricts which raw types may
+		//     be remapped via the polymorphic prop. Component NOT in the
+		//     allow-list keeps its original tag — rule sees it as unknown
+		//     custom component, not validated by default → valid.
+		{
+			Code: `<NotAllowed as="img" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName":  "as",
+					"polymorphicAllowList": []interface{}{"OtherTag"},
+				},
+			},
+		},
+
+		// ---- Settings combination: polymorphic + componentMap ----
+		// `<X as="input" type="image" alt="x" />` — `as` rewrites to "input",
+		// then componentMap doesn't have "input" key, so it stays "input",
+		// then alt validation runs on input[type="image"].
+		{
+			Code: `<X as="input" type="image" alt="x" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"X": "div"},
+				},
+			},
+		},
+
+		// ---- Nested object accessible child (paired tags) ----
+		{Code: `<object><div><span>Description</span></div></object>`, Tsx: true},
+		// Multiple expression children — at least one non-undefined → valid.
+		{Code: `<object>{"prefix"}{value}{"suffix"}</object>`, Tsx: true},
+		// JsxExpression with nested JsxElement → counts as accessible.
+		{Code: `<object>{<span>x</span>}</object>`, Tsx: true},
+
+		// ---- Empty `elements` array → rule disabled (typesToValidate empty) ----
+		// Even `<img />` (which would normally be invalid) doesn't fire
+		// because the listener finds no matching tag.
+		{
+			Code:    `<img />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{}},
+		},
+
+		// ---- Multi-spread + ObjectLiteral ordering (verified via ESLint) ----
+		// First-match wins. `<img alt="y" {...{alt: "x"}} />` — direct alt
+		// found before the spread → "y" → valid.
+		{Code: `<img alt="y" {...{alt: "x"}} />`, Tsx: true},
+		// First match is the spread's inner property → "x" → valid.
+		{Code: `<img {...{alt: "x"}} alt="y" />`, Tsx: true},
+		// Two literal-spreads — first wins.
+		{Code: `<img {...{alt: "first"}} {...{alt: "second"}} />`, Tsx: true},
+		// Empty-string second spread doesn't matter; first wins.
+		{Code: `<img {...{alt: "first"}} {...{alt: ""}} />`, Tsx: true},
+		// First spread is empty string → valid via `=== ''`.
+		{Code: `<img {...{alt: ""}} {...{alt: "second"}} />`, Tsx: true},
+		// Spread alt with conditional value — staticEval picks the
+		// truthy-test consequent.
+		{Code: `<img {...{alt: x ? "" : "y"}} />`, Tsx: true},
+		// Spread alt with empty-string LITERAL → valid via `=== ''`.
+		{Code: `<img {...{alt: ""}} />`, Tsx: true},
+
+		// ---- Aria-hidden value variants in nested children ----
+		// `aria-hidden={false}` → NOT hidden → div counts as accessible →
+		// object valid.
+		{Code: `<object><div aria-hidden={false}>x</div></object>`, Tsx: true},
+		// `aria-hidden={"false"}` → string literal "false" → not "true",
+		// NOT hidden → valid.
+		{Code: `<object><div aria-hidden={"false"}>x</div></object>`, Tsx: true},
+		// `aria-hidden={someVar}` → unknown → NOT hidden (we only flag
+		// statically true) → valid. Matches upstream's getPropValue
+		// returning the identifier name (truthy non-bool) which then fails
+		// the `=== true` check in upstream's isHiddenFromScreenReader.
+		{Code: `<object><div aria-hidden={someVar}>x</div></object>`, Tsx: true},
+
+		// ---- TS-only wrappers (`as` / `!` / `satisfies`) — Go-impl specific ----
+		// Verified via real rslint binary. Each shape unwraps to its inner
+		// expression via OEKParentheses|OEKAssertions.
+		// `altText!` — non-null assertion on a value-bearing identifier.
+		{Code: `<img alt={altText!} />`, Tsx: true},
+		// `altText as string` — type assertion.
+		{Code: `<img alt={altText as string} />`, Tsx: true},
+		// Double TS wrapping `(altText as any)!`.
+		{Code: `<img alt={(altText as any)!} />`, Tsx: true},
+		// String literal under `as` — extracts to "foo" → truthy → valid.
+		{Code: `<img alt={"foo" as string} />`, Tsx: true},
+		// Empty string under `as` — extracts to "" → valid via `=== ''`.
+		{Code: `<img alt={"" as string} />`, Tsx: true},
+		// `satisfies` wrapping a string literal.
+		{Code: `<img alt={"foo" satisfies string} />`, Tsx: true},
+		// `as const` on a literal — still a literal "x" → valid.
+		{Code: `<img alt="" role={"presentation" as const} />`, Tsx: true},
+
+		// ---- input[type] case sensitivity (verified against ESLint) ----
+		// `type="IMAGE"` — upstream does case-sensitive `=== "image"`, so
+		// non-image inputs are correctly skipped (no alt error).
+		{Code: `<input type="IMAGE" />`, Tsx: true},
+		{Code: `<input type="Image" />`, Tsx: true},
+		// Non-string-literal type that doesn't statically resolve to "image" → skip.
+		{Code: `<input type={typeVar} />`, Tsx: true},
+		// Boolean form `<input type />` — upstream getPropValue returns
+		// boolean true, true !== "image" → skip.
+		{Code: `<input type />`, Tsx: true},
+		// Logical short-circuit: `"image" && ""` → "" → !== "image" → skip.
+		{Code: `<input type={"image" && ""} />`, Tsx: true},
+		// `?? "image"` only fires when left is null/undefined; `null ?? "x"` → "x" → != "image" → skip.
+		{Code: `<input type={null ?? "x"} />`, Tsx: true},
+		// type with TS wrapper around a non-image literal.
+		{Code: `<input type={"text" as string} />`, Tsx: true},
+
+		// ---- object title with literal non-string values (verified against ESLint) ----
+		// Upstream `getLiteralPropValue(null literal)` → "null" (string!) →
+		// truthy → title is sufficient, no error.
+		{Code: `<object title={null} />`, Tsx: true},
+		// Number literal → truthy if non-zero → no error.
+		{Code: `<object title={123} />`, Tsx: true},
+		// Boolean true literal → truthy → no error.
+		{Code: `<object title={true} />`, Tsx: true},
+		// Template literal with subs → upstream renders to a non-empty
+		// string → truthy → no error.
+		{Code: "<object title={`x${y}`} />", Tsx: true},
+
+		// ---- alt with `"true"` (string normalized to boolean true) ----
+		// Upstream Literal extractor: `"true".toLowerCase() === "true"` → bool true
+		// → truthy → valid.
+		{Code: `<img alt="true" />`, Tsx: true},
+		{Code: `<img alt="True" />`, Tsx: true},
+		{Code: `<img alt="TRUE" />`, Tsx: true},
+		{Code: `<img alt={"true"} />`, Tsx: true},
+		{Code: `<img alt={"True"} />`, Tsx: true},
+		// Non-bool string with content → string → truthy → valid.
+		{Code: `<img alt="null" />`, Tsx: true},
+		{Code: `<img alt="undefined" />`, Tsx: true},
+		{Code: `<img alt="0" />`, Tsx: true},
+
+		// ---- Pre-existing non-coverage corner-cases (verified against ESLint) ----
+		// AssignmentExpression — upstream returns "left op right" string
+		// (always non-empty truthy regardless of right's value).
+		{Code: `<img alt={(x = "foo")} />`, Tsx: true},
+		{Code: `<img alt={(x = "")} />`, Tsx: true},
+		{Code: `<img alt={(x = false)} />`, Tsx: true},
+		{Code: `<img alt={(x += 1)} />`, Tsx: true},
+		// SequenceExpression / comma — upstream returns array of all values
+		// (truthy regardless). My rsImpl handles `bin.OperatorToken.Kind ==
+		// CommaToken` as truthy.
+		{Code: `<img alt={(a, b, "foo")} />`, Tsx: true},
+		{Code: `<img alt={(a, b, false)} />`, Tsx: true},
+		{Code: `<img alt={(a, b, "")} />`, Tsx: true},
+		// NewExpression — upstream returns empty object → truthy.
+		{Code: `<img alt={new Date()} />`, Tsx: true},
+		{Code: `<img alt={new Image(800)} />`, Tsx: true},
+		// TaggedTemplateExpression — upstream redirects to TemplateLiteral
+		// extractor, returns the (always non-empty) template text.
+		{Code: "<img alt={tag`x`} />", Tsx: true},
+		{Code: "<img alt={tag`hello ${world}`} />", Tsx: true},
+		// Polymorphic with non-string truthy literal — upstream replaces
+		// rawType with the non-string value, which doesn't match
+		// typesToValidate. Mirror by coercing to a string form so the Set
+		// lookup misses.
+		{
+			Code: `<Img as={null} />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"Img": "img"},
+				},
+			},
+		},
+		{
+			Code: `<Img as={123} />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"Img": "img"},
+				},
+			},
+		},
+		{
+			Code: `<Img as={true} />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"Img": "img"},
+				},
+			},
+		},
+
+		// ---- aria-hidden in nested children — full static eval coverage ----
+		// `aria-hidden={cond ? false : false}` — both branches false →
+		// resolves to false → not hidden → div is accessible → object valid.
+		{Code: `<object><div aria-hidden={cond ? false : false}>x</div></object>`, Tsx: true},
+		// `aria-hidden={"true" && false}` — short-circuits to false → not hidden.
+		{Code: `<object><div aria-hidden={"true" && false}>x</div></object>`, Tsx: true},
+		// `aria-hidden={false || "x"}` — string "x" → not boolean true → not hidden.
+		{Code: `<object><div aria-hidden={false || "x"}>x</div></object>`, Tsx: true},
+		// `aria-hidden` inside TS wrapper — same.
+		{Code: `<object><div aria-hidden={false as any}>x</div></object>`, Tsx: true},
+
+		// ---- isHiddenFromScreenReader on `<input type="hidden">` (literal-only) ----
+		// `type="HIDDEN"` (case-insensitive comparison upstream) → hidden.
+		// We're matching that for the inner check, so this object reports
+		// invalid (no other accessible child).
+
+		// ---- jsx-ast-utils Literal extractor on direct attr value (not in expr) ----
+		// `aria-hidden=true` — JSX boolean form is parsed as Identifier, but
+		// `aria-hidden="true"` is parsed as StringLiteral "true".
+		// Both should classify the div as hidden, hence the object is invalid.
+		// Already covered with explicit invalid cases below.
+	}, []rule_tester.InvalidTestCase{
+		// ---- Lock-in: extra invalid edge cases beyond upstream ----
+		// Locks in upstream branch where alt is `<img alt={null} />` —
+		// LiteralValue null is not extracted as truthy → invalid.
+		{
+			Code: `<img alt={null} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Locks in upstream branch: `<img alt={false} />` is invalid (literal
+		// false is falsy and not the empty string).
+		{
+			Code: `<img alt={false} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Locks in img branch where presentation role short-circuits the
+		// aria-label / aria-labelledby checks.
+		{
+			Code: `<img role="presentation" aria-label="something" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferAlt", Message: msgPreferAlt, Line: 1, Column: 1},
+			},
+		},
+		// Locks in upstream area branch: `area` with `<area alt="" />` is
+		// valid; `<area alt={null} />` is invalid (alt validity logic).
+		{
+			Code: `<area alt={null} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		// Locks in input[type="image"] alt validity branch.
+		{
+			Code: `<input type="image" alt={null} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		// Locks in TS-wrapper unwrap in AttributeIsExplicitUndefined:
+		// `<img alt={undefined as any} />` still resolves to undefined →
+		// invalid (matches jsx-ast-utils TSAsExpression unwrap).
+		{
+			Code: `<img alt={undefined as any} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Locks in numeric falsy normalization: `<img alt={0.0} />` evaluates
+		// to 0 (falsy) → invalid. Without normalization, the raw token
+		// "0.0" wouldn't match "0".
+		{
+			Code: `<img alt={0.0} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Locks in numeric falsy normalization across hex: `<img alt={0x0} />`
+		// is 0 → falsy → invalid.
+		{
+			Code: `<img alt={0x0} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Locks in BigInt falsy: `<img alt={0n} />` is falsy → invalid.
+		{
+			Code: `<img alt={0n} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Locks in PrefixUnary `!` truthiness: `!"x"` is `false` → falsy →
+		// invalid.
+		{
+			Code: `<img alt={!"x"} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Locks in ConditionalExpression with both falsy branches: invalid.
+		{
+			Code: `<img alt={cond ? false : null} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Locks in JsxFragment-as-child NOT counting as accessible (matches
+		// upstream's missing `case 'JSXFragment'` falling to default false).
+		{
+			Code: `<object><>x</></object>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		// Locks in paired-tag aria-hidden inspection: `<div aria-hidden></div>`
+		// (paired, not self-closing) IS hidden → object reports invalid.
+		{
+			Code: `<object><div aria-hidden></div></object>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		// Locks in paired-tag `<input type="hidden">` short-circuit on
+		// isHiddenFromScreenReader.
+		{
+			Code: `<object><input type="hidden" /></object>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		// Locks in spread-object literal-property match for the negative
+		// case: `{...{alt: ""}}` → alt is the empty string → object error
+		// because alt extraction succeeds but the literal value, by upstream
+		// semantics, is "" — `(altValue && !isNullValued) || altValue === ''`
+		// makes empty string VALID. So this case is actually valid; we add
+		// the negative case via `aria-label: ""`.
+		{
+			Code: `<img {...{"aria-label": ""}} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 1},
+			},
+		},
+
+		// ---- staticEval lock-ins for INVALID cases ----
+		// `false && "x"` → false (left short-circuits) → falsy → invalid.
+		{
+			Code: `<img alt={false && "x"} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// `"x" && false` → false (left truthy → take right) → falsy → invalid.
+		{
+			Code: `<img alt={"x" && false} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// `null ?? false` → false (null is nullish → take right) → falsy → invalid.
+		{
+			Code: `<img alt={null ?? false} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Nested chain: `a && (b || (c && ""))` — c truthy → take "", then
+		// b || "" → b ("b" identifier name truthy → take "b"), then a && "b"
+		// → "b" (truthy) — actually VALID. Upstream confirmed: altValue="b".
+		// We'd need a chain that resolves to falsy/empty for an invalid case.
+		// Use `(a && false)` instead.
+		{
+			Code: `<img alt={(a && false) || false} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// PrefixUnary `!1` → false → invalid.
+		{
+			Code: `<img alt={!1} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Numeric arithmetic: `0 + 0` → 0 → falsy → invalid.
+		{
+			Code: `<img alt={0 + 0} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Comparison / bitwise (verified against upstream) ----
+		// `1 < 0` → false → invalid.
+		{
+			Code: `<img alt={1 < 0} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// `0 | 0` → 0 → falsy → invalid (this is the case that DID diverge
+		// before the staticEval rewrite — locks in the fix).
+		{
+			Code: `<img alt={0 | 0} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// `1 === 2` → false → invalid.
+		{
+			Code: `<img alt={1 === 2} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+
+		// ---- i18n falsy patterns ----
+		// `undefined && t("key")` short-circuits to undefined → invalid.
+		{
+			Code: `<img alt={undefined && t("key")} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Optional chain that resolves to undefined when receiver is
+		// undefined — but we don't track receiver state; OptionalAccess is
+		// modelled as truthy (matches upstream's `data?.alt` extraction
+		// returning a non-empty `"data?.alt"` string). The legitimate
+		// "missing alt because optional chain returns undefined" case
+		// needs a guarded fallback.
+
+		// ---- Multi-line invalid: error reports on the opening element ----
+		{
+			Code: `<img
+				src="x"
+			/>`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Two unrelated invalid elements in same source — independent
+		// reports.
+		{
+			Code: `<div><img /><object /></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 6},
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 13},
+			},
+		},
+
+		// ---- Paired-tag form invalid ----
+		{
+			Code: `<img></img>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 1},
+			},
+		},
+
+		// Subset elements: only check `img`, skip `<area />`.
+		// `<img />` → INVALID (still in elements), `<area />` → no report.
+		{
+			Code:    `<div><img /><area /></div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{"img"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 6},
+			},
+		},
+
+		// ---- Polymorphic NOT in allow-list: rule does NOT remap ----
+		// `<NotAllowed as="img" />` with `polymorphicAllowList: ["Allowed"]`
+		// — `NotAllowed` is not in the allow list, so `as` is ignored and
+		// the type stays "NotAllowed", which isn't in typesToValidate by
+		// default. So no error. (Already covered in valid above.)
+
+		// ---- Polymorphic IN allow-list: rule remaps to img → reports ----
+		// `<Allowed as="img" />` with allow list `["Allowed"]` — remaps to
+		// "img", then alt is missing → invalid.
+		{
+			Code: `<Allowed as="img" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName":  "as",
+					"polymorphicAllowList": []interface{}{"Allowed"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Spread inner alt: undefined → invalid ----
+		{
+			Code: `<img {...{alt: undefined}} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Aria-hidden literal-string "true" → invalid object ----
+		// `aria-hidden={"true"}` (StringLiteral inside JsxExpression) →
+		// upstream's getPropValue returns "true", isHiddenFromScreenReader
+		// uses `=== true` (boolean) so this would NOT match in upstream's
+		// strict check. But empirically ESLint reports invalid for this
+		// shape — meaning upstream actually compares loosely or extracts
+		// the string-literal "true" as the boolean true. We match upstream's
+		// observed behavior.
+		{
+			Code: `<object><div aria-hidden={"true"}>x</div></object>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		// Same but for direct StringLiteral attribute: `aria-hidden="true"`.
+		{
+			Code: `<object><div aria-hidden="true">x</div></object>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- TS-only wrappers preserving undefined → invalid ----
+		// `undefined as any` — assertion doesn't change the underlying
+		// undefined identifier; alt is still missing semantically.
+		{
+			Code: `<img alt={undefined as any} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// `(undefined as any)!` — double-wrapped, still undefined.
+		{
+			Code: `<img alt={(undefined as any)!} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// `undefined satisfies undefined` — same.
+		{
+			Code: `<img alt={undefined satisfies undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+
+		// ---- input[type] expression evaluation (uses getPropValue, not literal) ----
+		// `type={"image" + ""}` — staticEval resolves to "image" → enters
+		// inputImage check → no alt → error.
+		{
+			Code: `<input type={"image" + ""} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		// `type={cond ? "image" : "text"}` — cond is identifier "cond" →
+		// truthy → take consequent "image" → check alt → error.
+		{
+			Code: `<input type={cond ? "image" : "text"} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		// Logical `||` resolving to "image".
+		{
+			Code: `<input type={"" || "image"} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		// `&&` short-circuit resolving to "image".
+		{
+			Code: `<input type={"x" && "image"} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		// TS wrapper around "image".
+		{
+			Code: `<input type={"image" as string} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- object title falsy literals → invalid ----
+		{
+			Code: `<object title={false} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<object title={0} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<object title={NaN} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		// Identifier (non-undefined) — getLiteralPropValue returns null → falsy.
+		{
+			Code: `<object title={someVar} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		// `Math` is in JS_RESERVED but getLiteralPropValue still maps non-
+		// undefined identifiers to null → falsy → invalid (different from
+		// `<img alt={Math} />` which uses getPropValue and resolves to a fn).
+		{
+			Code: `<object title={Math} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		// Empty string title → not truthy → invalid.
+		{
+			Code: `<object title="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		// CallExpression / MemberExpression in title → noop in LITERAL_TYPES → null → falsy.
+		{
+			Code: `<object title={getTitle()} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<object title={obj.title} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- alt with `"false"` string normalized to boolean false → invalid ----
+		{
+			Code: `<img alt="false" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt="False" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt={"false"} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Verified: `<img alt={false}>` (boolean literal) is also invalid —
+		// already covered by the upstream test suite, locking in the
+		// downstream `"false"` string match too.
+
+		// ---- aria-hidden expression eval makes child hidden → object error ----
+		// `aria-hidden={cond ? true : true}` — both branches true → hidden →
+		// no accessible child → object error.
+		{
+			Code: `<object><div aria-hidden={cond ? true : true}>x</div></object>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		// `aria-hidden={"" || true}` — left falsy → right truthy bool → hidden.
+		{
+			Code: `<object><div aria-hidden={"" || true}>x</div></object>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		// `aria-hidden={true as any}` — TS-wrapped boolean true → hidden.
+		{
+			Code: `<object><div aria-hidden={true as any}>x</div></object>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- AwaitExpression / YieldExpression — upstream null → falsy → invalid ----
+		// (verified against ESLint with @babel parser)
+		{
+			Code: `async function fn() { return <img alt={await x} />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 30},
+			},
+		},
+		{
+			Code: `function* gen() { return <img alt={yield x} />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 26},
+			},
+		},
+
+		// ---- UpdateExpression (`x++`/`++x`/`x--`/`--x`) — upstream NaN → falsy ----
+		{
+			Code: `<img alt={x++} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt={++x} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt={x--} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt={--x} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+
+		// ---- typeof / void → undefined → falsy ----
+		{
+			Code: `<img alt={typeof x} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt={void 0} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Polymorphic resolves to undefined → no replacement → check fires ----
+		{
+			Code: `<Img as={undefined} />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"Img": "img"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// Polymorphic with literal "img" — replaces, then check fires (no alt).
+		{
+			Code: `<Img as={"img"} />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"Img": "img"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 1},
+			},
+		},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/alt_text/alt_text_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/alt_text/alt_text_upstream_test.go
@@ -1,0 +1,636 @@
+package alt_text
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// componentsSettings mirrors the upstream `componentsSettings` constant — the
+// `as` polymorphic prop and an `Input` → `input` component map. Used for the
+// settings-based valid/invalid cases from upstream's test file.
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+		"components": map[string]interface{}{
+			"Input": "input",
+		},
+	},
+}
+
+// arrayOpts mirrors the upstream `array` constant — custom-component options
+// mapping each DOM element to a list of accepted component names.
+var arrayOpts = map[string]interface{}{
+	"img":                 []interface{}{"Thumbnail", "Image"},
+	"object":              []interface{}{"Object"},
+	"area":                []interface{}{"Area"},
+	`input[type="image"]`: []interface{}{"InputImage"},
+}
+
+// TestAltTextUpstream covers the full valid/invalid suite migrated 1:1
+// from upstream eslint-plugin-jsx-a11y's `__tests__/src/rules/alt-text-test.js`.
+// rslint-specific lock-ins (staticEval coverage, TS wrappers, real-world
+// patterns, polymorphic edge cases, etc.) live in alt_text_extras_test.go.
+func TestAltTextUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AltTextRule, []rule_tester.ValidTestCase{
+		// ---- DEFAULT ELEMENT 'img' TESTS ----
+		{Code: `<img alt="foo" />;`, Tsx: true},
+		{Code: `<img alt={"foo"} />;`, Tsx: true},
+		{Code: `<img alt={alt} />;`, Tsx: true},
+		{Code: `<img ALT="foo" />;`, Tsx: true},
+		{Code: "<img ALT={`This is the ${alt} text`} />;", Tsx: true},
+		{Code: `<img ALt="foo" />;`, Tsx: true},
+		{Code: `<img alt="foo" salt={undefined} />;`, Tsx: true},
+		{Code: `<img {...this.props} alt="foo" />`, Tsx: true},
+		{Code: `<a />`, Tsx: true},
+		{Code: `<div />`, Tsx: true},
+		{Code: `<img alt={function(e) {} } />`, Tsx: true},
+		{Code: `<div alt={function(e) {} } />`, Tsx: true},
+		{Code: `<img alt={() => void 0} />`, Tsx: true},
+		{Code: `<IMG />`, Tsx: true},
+		{Code: `<UX.Layout>test</UX.Layout>`, Tsx: true},
+		{Code: `<img alt={alt || "Alt text" } />`, Tsx: true},
+		{Code: `<img alt={photo.caption} />;`, Tsx: true},
+		{Code: `<img alt={bar()} />;`, Tsx: true},
+		{Code: `<img alt={foo.bar || ""} />`, Tsx: true},
+		{Code: `<img alt={bar() || ""} />`, Tsx: true},
+		{Code: `<img alt={foo.bar() || ""} />`, Tsx: true},
+		{Code: `<img alt="" />`, Tsx: true},
+		{Code: "<img alt={`${undefined}`} />", Tsx: true},
+		{Code: `<img alt=" " />`, Tsx: true},
+		{Code: `<img alt="" role="presentation" />`, Tsx: true},
+		{Code: `<img alt="" role="none" />`, Tsx: true},
+		{Code: "<img alt=\"\" role={`presentation`} />", Tsx: true},
+		{Code: `<img alt="" role={"presentation"} />`, Tsx: true},
+		{Code: `<img alt="this is lit..." role="presentation" />`, Tsx: true},
+		{Code: `<img alt={error ? "not working": "working"} />`, Tsx: true},
+		{Code: `<img alt={undefined ? "working": "not working"} />`, Tsx: true},
+		{Code: `<img alt={plugin.name + " Logo"} />`, Tsx: true},
+		{Code: `<img aria-label="foo" />`, Tsx: true},
+		{Code: `<img aria-labelledby="id1" />`, Tsx: true},
+
+		// ---- DEFAULT <object> TESTS ----
+		{Code: `<object aria-label="foo" />`, Tsx: true},
+		{Code: `<object aria-labelledby="id1" />`, Tsx: true},
+		{Code: `<object>Foo</object>`, Tsx: true},
+		{Code: `<object><p>This is descriptive!</p></object>`, Tsx: true},
+		{Code: `<Object />`, Tsx: true},
+		{Code: `<object title="An object" />`, Tsx: true},
+
+		// ---- DEFAULT <area> TESTS ----
+		{Code: `<area aria-label="foo" />`, Tsx: true},
+		{Code: `<area aria-labelledby="id1" />`, Tsx: true},
+		{Code: `<area alt="" />`, Tsx: true},
+		{Code: `<area alt="This is descriptive!" />`, Tsx: true},
+		{Code: `<area alt={altText} />`, Tsx: true},
+		{Code: `<Area />`, Tsx: true},
+
+		// ---- DEFAULT <input type="image"> TESTS ----
+		{Code: `<input />`, Tsx: true},
+		{Code: `<input type="foo" />`, Tsx: true},
+		{Code: `<input type="image" aria-label="foo" />`, Tsx: true},
+		{Code: `<input type="image" aria-labelledby="id1" />`, Tsx: true},
+		{Code: `<input type="image" alt="" />`, Tsx: true},
+		{Code: `<input type="image" alt="This is descriptive!" />`, Tsx: true},
+		{Code: `<input type="image" alt={altText} />`, Tsx: true},
+		{Code: `<InputImage />`, Tsx: true},
+		{Code: `<Input type="image" alt="" />`, Tsx: true, Settings: componentsSettings},
+		{Code: `<SomeComponent as="input" type="image" alt="" />`, Tsx: true, Settings: componentsSettings},
+
+		// ---- CUSTOM ELEMENT TESTS FOR ARRAY OPTION TESTS ----
+		{Code: `<Thumbnail alt="foo" />;`, Tsx: true, Options: arrayOpts},
+		{Code: `<Thumbnail alt={"foo"} />;`, Tsx: true, Options: arrayOpts},
+		{Code: `<Thumbnail alt={alt} />;`, Tsx: true, Options: arrayOpts},
+		{Code: `<Thumbnail ALT="foo" />;`, Tsx: true, Options: arrayOpts},
+		{Code: "<Thumbnail ALT={`This is the ${alt} text`} />;", Tsx: true, Options: arrayOpts},
+		{Code: `<Thumbnail ALt="foo" />;`, Tsx: true, Options: arrayOpts},
+		{Code: `<Thumbnail alt="foo" salt={undefined} />;`, Tsx: true, Options: arrayOpts},
+		{Code: `<Thumbnail {...this.props} alt="foo" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<thumbnail />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Thumbnail alt={function(e) {} } />`, Tsx: true, Options: arrayOpts},
+		{Code: `<div alt={function(e) {} } />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Thumbnail alt={() => void 0} />`, Tsx: true, Options: arrayOpts},
+		{Code: `<THUMBNAIL />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Thumbnail alt={alt || "foo" } />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Image alt="foo" />;`, Tsx: true, Options: arrayOpts},
+		{Code: `<Image alt={"foo"} />;`, Tsx: true, Options: arrayOpts},
+		{Code: `<Image alt={alt} />;`, Tsx: true, Options: arrayOpts},
+		{Code: `<Image ALT="foo" />;`, Tsx: true, Options: arrayOpts},
+		{Code: "<Image ALT={`This is the ${alt} text`} />;", Tsx: true, Options: arrayOpts},
+		{Code: `<Image ALt="foo" />;`, Tsx: true, Options: arrayOpts},
+		{Code: `<Image alt="foo" salt={undefined} />;`, Tsx: true, Options: arrayOpts},
+		{Code: `<Image {...this.props} alt="foo" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<image />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Image alt={function(e) {} } />`, Tsx: true, Options: arrayOpts},
+		{Code: `<div alt={function(e) {} } />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Image alt={() => void 0} />`, Tsx: true, Options: arrayOpts},
+		{Code: `<IMAGE />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Image alt={alt || "foo" } />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Object aria-label="foo" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Object aria-labelledby="id1" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Object>Foo</Object>`, Tsx: true, Options: arrayOpts},
+		{Code: `<Object><p>This is descriptive!</p></Object>`, Tsx: true, Options: arrayOpts},
+		{Code: `<Object title="An object" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Area aria-label="foo" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Area aria-labelledby="id1" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Area alt="" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Area alt="This is descriptive!" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<Area alt={altText} />`, Tsx: true, Options: arrayOpts},
+		{Code: `<InputImage aria-label="foo" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<InputImage aria-labelledby="id1" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<InputImage alt="" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<InputImage alt="This is descriptive!" />`, Tsx: true, Options: arrayOpts},
+		{Code: `<InputImage alt={altText} />`, Tsx: true, Options: arrayOpts},
+	}, []rule_tester.InvalidTestCase{
+		// ---- DEFAULT ELEMENT 'img' TESTS ----
+		{
+			Code: `<img />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt={undefined} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img src="xyz" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img role />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img {...this.props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt={false || false} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt={undefined} role="presentation" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img alt role="presentation" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img role="presentation" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferAlt", Message: msgPreferAlt, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img role="none" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferAlt", Message: msgPreferAlt, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img aria-label={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ariaLabelValue", Message: msgAriaLabelEmpty, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img aria-labelledby={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ariaLabelledByValue", Message: msgAriaLabelledByEmpty, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img aria-label="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ariaLabelValue", Message: msgAriaLabelEmpty, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<img aria-labelledby="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ariaLabelledByValue", Message: msgAriaLabelledByEmpty, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:     `<SomeComponent as="img" aria-label="" />`,
+			Tsx:      true,
+			Settings: componentsSettings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "ariaLabelValue", Message: msgAriaLabelEmpty, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- DEFAULT ELEMENT 'object' TESTS ----
+		{
+			Code: `<object />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<object><div aria-hidden /></object>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<object title={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<object aria-label="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<object aria-labelledby="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<object aria-label={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<object aria-labelledby={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- DEFAULT ELEMENT 'area' TESTS ----
+		{
+			Code: `<area />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<area alt />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<area alt={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<area src="xyz" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<area {...this.props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<area aria-label="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<area aria-label={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<area aria-labelledby="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<area aria-labelledby={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- DEFAULT ELEMENT 'input type="image"' TESTS ----
+		{
+			Code: `<input type="image" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="image" alt />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="image" alt={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="image">Foo</input>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="image" {...this.props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="image" aria-label="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="image" aria-label={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="image" aria-labelledby="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="image" aria-labelledby={undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- CUSTOM ELEMENT TESTS FOR ARRAY OPTION TESTS ----
+		{
+			Code:    `<Thumbnail />;`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("Thumbnail"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Thumbnail alt />;`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("Thumbnail"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Thumbnail alt={undefined} />;`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("Thumbnail"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Thumbnail src="xyz" />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("Thumbnail"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Thumbnail {...this.props} />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("Thumbnail"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Image />;`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("Image"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Image alt />;`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("Image"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Image alt={undefined} />;`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("Image"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Image src="xyz" />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("Image"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Image {...this.props} />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProp", Message: missingPropMessage("Image"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Object />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Object><div aria-hidden /></Object>`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Object title={undefined} />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object", Message: msgObject, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Area />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Area alt />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Area alt={undefined} />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Area src="xyz" />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Area {...this.props} />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "area", Message: msgArea, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<InputImage />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<InputImage alt />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<InputImage alt={undefined} />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<InputImage>Foo</InputImage>`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<InputImage {...this.props} />`,
+			Tsx:     true,
+			Options: arrayOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:     `<Input type="image" />`,
+			Tsx:      true,
+			Settings: componentsSettings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "inputImage", Message: msgInputImage, Line: 1, Column: 1},
+			},
+		},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/fixtures/fixtures.go
+++ b/internal/plugins/jsx_a11y/rules/fixtures/fixtures.go
@@ -1,0 +1,11 @@
+package fixtures
+
+import (
+	"path"
+	"runtime"
+)
+
+func GetRootDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return path.Dir(filename)
+}

--- a/internal/plugins/jsx_a11y/rules/fixtures/tsconfig.json
+++ b/internal/plugins/jsx_a11y/rules/fixtures/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
+    "types": []
+  }
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -155,6 +155,9 @@ export default defineConfig({
     './tests/eslint-plugin-react-hooks/rules/rules-of-hooks.test.ts',
     './tests/eslint-plugin-react-hooks/rules/exhaustive-deps.test.ts',
 
+    // eslint-plugin-jsx-a11y
+    './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',
+
     // typescript-eslint
     './tests/typescript-eslint/rules/adjacent-overload-signatures.test.ts',
     './tests/typescript-eslint/rules/array-type.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rslint.config.mjs
@@ -1,0 +1,13 @@
+export default [
+  {
+    files: [],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: ['./tsconfig.files.json', './tsconfig.virtual.json'],
+      },
+    },
+    rules: {},
+    plugins: ['jsx-a11y'],
+  },
+];

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rule-tester.ts
@@ -1,0 +1,281 @@
+import { rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import util from 'node:util';
+
+import { lint } from '@rslint/core';
+import { loadConfigFile, normalizeConfig } from '@rslint/core/config-loader';
+
+// Per-test rslint config builder. The user-facing base config is
+// `rslint.config.mjs` (ESM, flat-config); we load it via `loadConfigFile`,
+// merge in any per-test `settings`, and serialize the result to a small
+// temporary file that `lint()` consumes.
+//
+// Why we still emit a temporary file: rslint's `lint()` JS API takes a
+// config path and the underlying Go binary parses it as hujson (a JSON
+// superset) — it does NOT execute JS/TS configs the way the CLI does
+// (the CLI pre-loads JS configs and pipes them to the binary via stdin,
+// see packages/rslint/dist/cli.js). Until `lint()` exposes the same
+// pre-load path or a `settings` override, a serialized intermediate is
+// the cleanest way to thread per-test `settings` through to the linter.
+//
+// Cached at module load so the .mjs is parsed exactly once per test run.
+let cachedBase: Record<string, unknown>[] | null = null;
+async function getBaseConfig(
+  baseConfigPath: string,
+): Promise<Record<string, unknown>[]> {
+  if (cachedBase) return cachedBase;
+  const raw = await loadConfigFile(baseConfigPath);
+  cachedBase = normalizeConfig(raw);
+  return cachedBase;
+}
+
+async function buildConfigForSettings(
+  baseConfigPath: string,
+  settings: Record<string, unknown> | undefined,
+): Promise<{ configPath: string; cleanup: () => void }> {
+  const base = await getBaseConfig(baseConfigPath);
+  const merged = base.map((entry) => ({
+    ...entry,
+    settings: {
+      ...((entry.settings as object | undefined) ?? {}),
+      ...(settings ?? {}),
+    },
+  }));
+  // Write the serialized config next to the base — rslint resolves the
+  // relative `tsconfig.*.json` paths inside each entry against the config
+  // file's directory, so the temp file must live in the same dir.
+  const baseDir = path.dirname(baseConfigPath);
+  const cfg = path.join(
+    baseDir,
+    `.rslint.test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`,
+  );
+  writeFileSync(cfg, JSON.stringify(merged), 'utf8');
+  return {
+    configPath: cfg,
+    cleanup: () => {
+      try {
+        rmSync(cfg, { force: true });
+      } catch {
+        /* best-effort cleanup; never fail a test on rmdir */
+      }
+    },
+  };
+}
+
+export interface ValidTestCase {
+  name?: string;
+  code: string;
+  options?: any;
+  filename?: string | undefined;
+  only?: boolean;
+  settings?: Record<string, any> | undefined;
+}
+
+interface SuggestionOutput {
+  messageId?: string;
+  desc?: string;
+  data?: Record<string, unknown> | undefined;
+  output: string;
+}
+
+export interface InvalidTestCase extends ValidTestCase {
+  errors: number | (TestCaseError | string)[];
+  output?: string | null | undefined;
+}
+
+interface TestCaseError {
+  message?: string | RegExp;
+  messageId?: string;
+  type?: string | undefined;
+  data?: any;
+  line?: number | undefined;
+  column?: number | undefined;
+  endLine?: number | undefined;
+  endColumn?: number | undefined;
+  suggestions?: SuggestionOutput[] | undefined;
+}
+
+export class RuleTester {
+  run(
+    ruleName: string,
+    rule: never,
+    cases: {
+      valid: ValidTestCase[];
+      invalid: InvalidTestCase[];
+    },
+  ) {
+    ruleName = 'jsx-a11y/' + ruleName;
+    describe(ruleName, () => {
+      const cwd = process.cwd();
+      const config = path.resolve(import.meta.dirname, './rslint.config.mjs');
+
+      let hasOnly =
+        cases.valid.some((x) => {
+          if (typeof x === 'object' && x.only) {
+            return true;
+          } else {
+            return false;
+          }
+        }) || cases.invalid.some((x) => x.only);
+
+      test('valid', async () => {
+        for (const validCase of cases.valid) {
+          if (hasOnly) {
+            if (typeof validCase === 'string') {
+              continue;
+            }
+            if (!validCase.only) {
+              continue;
+            }
+          }
+          const code =
+            typeof validCase === 'string' ? validCase : validCase.code;
+          const options =
+            typeof validCase === 'string' ? [] : validCase.options || [];
+          const settings =
+            typeof validCase === 'string' ? undefined : validCase.settings;
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof validCase === 'string'
+              ? defaultFilename
+              : (validCase.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+
+          const { configPath, cleanup } = await buildConfigForSettings(
+            config,
+            settings,
+          );
+          let diags;
+          try {
+            diags = await lint({
+              config: configPath,
+              workingDirectory: cwd,
+              fileContents: {
+                [absoluteFilename]: code,
+              },
+              ruleOptions: {
+                [ruleName]: options,
+              },
+            });
+          } finally {
+            cleanup();
+          }
+
+          assert(
+            diags.diagnostics?.length === 0,
+            `Expected no diagnostics for valid case, but got: ${JSON.stringify(diags)}\nCode: ${code}`,
+          );
+        }
+      });
+      test('invalid', async (t) => {
+        for (const item of cases.invalid) {
+          assert.ok(
+            item.errors || item.errors === 0,
+            `Did not specify errors for an invalid test of ${ruleName}`,
+          );
+          if (Array.isArray(item.errors) && item.errors.length === 0) {
+            assert.fail('Invalid cases must have at least one error');
+          }
+
+          const { code, only = false, options = [], settings } = item;
+          if (hasOnly && !only) {
+            continue;
+          }
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof item === 'string'
+              ? defaultFilename
+              : (item.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+          const { configPath, cleanup } = await buildConfigForSettings(
+            config,
+            settings,
+          );
+          let diags;
+          try {
+            diags = await lint({
+              config: configPath,
+              workingDirectory: cwd,
+              fileContents: {
+                [absoluteFilename]: code,
+              },
+              ruleOptions: {
+                [ruleName]: options,
+              },
+            });
+          } finally {
+            cleanup();
+          }
+
+          if (typeof item.errors === 'number') {
+            if (item.errors === 0) {
+              assert.fail(
+                "Invalid cases must have 'error' value greater than 0",
+              );
+            }
+
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors,
+                item.errors === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+          } else {
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors.length,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors.length,
+                item.errors.length === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+
+            const hasMessageOfThisRule = diags.diagnostics.some(
+              (d) => d.ruleName === ruleName,
+            );
+
+            for (let i = 0, l = item.errors.length; i < l; i++) {
+              const error = item.errors[i];
+              const message = diags.diagnostics[i];
+
+              assert(
+                hasMessageOfThisRule,
+                'Error rule name should be the same as the name of the rule being tested',
+              );
+              if (typeof error === 'string' || error instanceof RegExp) {
+                assertMessageMatches(message.message, error);
+                assert.ok(
+                  message.suggestions === void 0,
+                  `Error at index ${i} has suggestions. Please convert the test error into an object and specify 'suggestions' property on it to test suggestions.`,
+                );
+              } else if (typeof error === 'object' && error !== null) {
+                if (typeof error.message === 'string') {
+                  assertMessageMatches(message.message, error.message);
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  }
+}
+
+function assertMessageMatches(actual: string, expected: string | RegExp): void {
+  if (expected instanceof RegExp) {
+    assert.ok(
+      expected.test(actual),
+      `Expected '${actual}' to match ${expected}`,
+    );
+  } else {
+    assert.strictEqual(actual, expected);
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts
@@ -1,0 +1,762 @@
+import { RuleTester } from '../rule-tester';
+
+const componentsSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+    components: {
+      Input: 'input',
+    },
+  },
+};
+
+const arrayOpts = [
+  {
+    img: ['Thumbnail', 'Image'],
+    object: ['Object'],
+    area: ['Area'],
+    'input[type="image"]': ['InputImage'],
+  },
+];
+
+new RuleTester().run('alt-text', null as never, {
+  valid: [
+    // ---- DEFAULT ELEMENT 'img' TESTS ----
+    { code: '<img alt="foo" />;' },
+    { code: '<img alt={"foo"} />;' },
+    { code: '<img alt={alt} />;' },
+    { code: '<img ALT="foo" />;' },
+    { code: '<img ALT={`This is the ${alt} text`} />;' },
+    { code: '<img ALt="foo" />;' },
+    { code: '<img alt="foo" salt={undefined} />;' },
+    { code: '<img {...this.props} alt="foo" />' },
+    { code: '<a />' },
+    { code: '<div />' },
+    { code: '<img alt={function(e) {} } />' },
+    { code: '<div alt={function(e) {} } />' },
+    { code: '<img alt={() => void 0} />' },
+    { code: '<IMG />' },
+    { code: '<UX.Layout>test</UX.Layout>' },
+    { code: '<img alt={alt || "Alt text" } />' },
+    { code: '<img alt={photo.caption} />;' },
+    { code: '<img alt={bar()} />;' },
+    { code: '<img alt={foo.bar || ""} />' },
+    { code: '<img alt={bar() || ""} />' },
+    { code: '<img alt={foo.bar() || ""} />' },
+    { code: '<img alt="" />' },
+    { code: '<img alt={`${undefined}`} />' },
+    { code: '<img alt=" " />' },
+    { code: '<img alt="" role="presentation" />' },
+    { code: '<img alt="" role="none" />' },
+    { code: '<img alt="" role={`presentation`} />' },
+    { code: '<img alt="" role={"presentation"} />' },
+    { code: '<img alt="this is lit..." role="presentation" />' },
+    { code: '<img alt={error ? "not working": "working"} />' },
+    { code: '<img alt={undefined ? "working": "not working"} />' },
+    { code: '<img alt={plugin.name + " Logo"} />' },
+    { code: '<img aria-label="foo" />' },
+    { code: '<img aria-labelledby="id1" />' },
+
+    // ---- DEFAULT <object> TESTS ----
+    { code: '<object aria-label="foo" />' },
+    { code: '<object aria-labelledby="id1" />' },
+    { code: '<object>Foo</object>' },
+    { code: '<object><p>This is descriptive!</p></object>' },
+    { code: '<Object />' },
+    { code: '<object title="An object" />' },
+
+    // ---- DEFAULT <area> TESTS ----
+    { code: '<area aria-label="foo" />' },
+    { code: '<area aria-labelledby="id1" />' },
+    { code: '<area alt="" />' },
+    { code: '<area alt="This is descriptive!" />' },
+    { code: '<area alt={altText} />' },
+    { code: '<Area />' },
+
+    // ---- DEFAULT <input type="image"> TESTS ----
+    { code: '<input />' },
+    { code: '<input type="foo" />' },
+    { code: '<input type="image" aria-label="foo" />' },
+    { code: '<input type="image" aria-labelledby="id1" />' },
+    { code: '<input type="image" alt="" />' },
+    { code: '<input type="image" alt="This is descriptive!" />' },
+    { code: '<input type="image" alt={altText} />' },
+    { code: '<InputImage />' },
+    { code: '<Input type="image" alt="" />', settings: componentsSettings },
+    {
+      code: '<SomeComponent as="input" type="image" alt="" />',
+      settings: componentsSettings,
+    },
+
+    // ---- CUSTOM ELEMENT TESTS FOR ARRAY OPTION TESTS ----
+    { code: '<Thumbnail alt="foo" />;', options: arrayOpts },
+    { code: '<Thumbnail alt={"foo"} />;', options: arrayOpts },
+    { code: '<Thumbnail alt={alt} />;', options: arrayOpts },
+    { code: '<Thumbnail ALT="foo" />;', options: arrayOpts },
+    {
+      code: '<Thumbnail ALT={`This is the ${alt} text`} />;',
+      options: arrayOpts,
+    },
+    { code: '<Thumbnail ALt="foo" />;', options: arrayOpts },
+    { code: '<Thumbnail alt="foo" salt={undefined} />;', options: arrayOpts },
+    { code: '<Thumbnail {...this.props} alt="foo" />', options: arrayOpts },
+    { code: '<thumbnail />', options: arrayOpts },
+    { code: '<Thumbnail alt={function(e) {} } />', options: arrayOpts },
+    { code: '<div alt={function(e) {} } />', options: arrayOpts },
+    { code: '<Thumbnail alt={() => void 0} />', options: arrayOpts },
+    { code: '<THUMBNAIL />', options: arrayOpts },
+    { code: '<Thumbnail alt={alt || "foo" } />', options: arrayOpts },
+    { code: '<Image alt="foo" />;', options: arrayOpts },
+    { code: '<Image alt={"foo"} />;', options: arrayOpts },
+    { code: '<Image alt={alt} />;', options: arrayOpts },
+    { code: '<Image ALT="foo" />;', options: arrayOpts },
+    { code: '<Image ALT={`This is the ${alt} text`} />;', options: arrayOpts },
+    { code: '<Image ALt="foo" />;', options: arrayOpts },
+    { code: '<Image alt="foo" salt={undefined} />;', options: arrayOpts },
+    { code: '<Image {...this.props} alt="foo" />', options: arrayOpts },
+    { code: '<image />', options: arrayOpts },
+    { code: '<Image alt={function(e) {} } />', options: arrayOpts },
+    { code: '<div alt={function(e) {} } />', options: arrayOpts },
+    { code: '<Image alt={() => void 0} />', options: arrayOpts },
+    { code: '<IMAGE />', options: arrayOpts },
+    { code: '<Image alt={alt || "foo" } />', options: arrayOpts },
+    { code: '<Object aria-label="foo" />', options: arrayOpts },
+    { code: '<Object aria-labelledby="id1" />', options: arrayOpts },
+    { code: '<Object>Foo</Object>', options: arrayOpts },
+    {
+      code: '<Object><p>This is descriptive!</p></Object>',
+      options: arrayOpts,
+    },
+    { code: '<Object title="An object" />', options: arrayOpts },
+    { code: '<Area aria-label="foo" />', options: arrayOpts },
+    { code: '<Area aria-labelledby="id1" />', options: arrayOpts },
+    { code: '<Area alt="" />', options: arrayOpts },
+    { code: '<Area alt="This is descriptive!" />', options: arrayOpts },
+    { code: '<Area alt={altText} />', options: arrayOpts },
+    { code: '<InputImage aria-label="foo" />', options: arrayOpts },
+    { code: '<InputImage aria-labelledby="id1" />', options: arrayOpts },
+    { code: '<InputImage alt="" />', options: arrayOpts },
+    { code: '<InputImage alt="This is descriptive!" />', options: arrayOpts },
+    { code: '<InputImage alt={altText} />', options: arrayOpts },
+  ],
+  invalid: [
+    // ---- DEFAULT ELEMENT 'img' TESTS ----
+    {
+      code: '<img />;',
+      errors: [
+        {
+          message:
+            'img elements must have an alt prop, either with meaningful text, or an empty string for decorative images.',
+        },
+      ],
+    },
+    {
+      code: '<img alt />;',
+      errors: [
+        {
+          message:
+            'Invalid alt value for img. Use alt="" for presentational images.',
+        },
+      ],
+    },
+    {
+      code: '<img alt={undefined} />;',
+      errors: [
+        {
+          message:
+            'Invalid alt value for img. Use alt="" for presentational images.',
+        },
+      ],
+    },
+    {
+      code: '<img src="xyz" />',
+      errors: [
+        {
+          message:
+            'img elements must have an alt prop, either with meaningful text, or an empty string for decorative images.',
+        },
+      ],
+    },
+    {
+      code: '<img role />',
+      errors: [
+        {
+          message:
+            'img elements must have an alt prop, either with meaningful text, or an empty string for decorative images.',
+        },
+      ],
+    },
+    {
+      code: '<img {...this.props} />',
+      errors: [
+        {
+          message:
+            'img elements must have an alt prop, either with meaningful text, or an empty string for decorative images.',
+        },
+      ],
+    },
+    {
+      code: '<img alt={false || false} />',
+      errors: [
+        {
+          message:
+            'Invalid alt value for img. Use alt="" for presentational images.',
+        },
+      ],
+    },
+    {
+      code: '<img alt={undefined} role="presentation" />;',
+      errors: [
+        {
+          message:
+            'Invalid alt value for img. Use alt="" for presentational images.',
+        },
+      ],
+    },
+    {
+      code: '<img alt role="presentation" />;',
+      errors: [
+        {
+          message:
+            'Invalid alt value for img. Use alt="" for presentational images.',
+        },
+      ],
+    },
+    {
+      code: '<img role="presentation" />;',
+      errors: [
+        {
+          message:
+            'Prefer alt="" over a presentational role. First rule of aria is to not use aria if it can be achieved via native HTML.',
+        },
+      ],
+    },
+    {
+      code: '<img role="none" />;',
+      errors: [
+        {
+          message:
+            'Prefer alt="" over a presentational role. First rule of aria is to not use aria if it can be achieved via native HTML.',
+        },
+      ],
+    },
+    {
+      code: '<img aria-label={undefined} />',
+      errors: [
+        {
+          message:
+            'The aria-label attribute must have a value. The alt attribute is preferred over aria-label for images.',
+        },
+      ],
+    },
+    {
+      code: '<img aria-labelledby={undefined} />',
+      errors: [
+        {
+          message:
+            'The aria-labelledby attribute must have a value. The alt attribute is preferred over aria-labelledby for images.',
+        },
+      ],
+    },
+    {
+      code: '<img aria-label="" />',
+      errors: [
+        {
+          message:
+            'The aria-label attribute must have a value. The alt attribute is preferred over aria-label for images.',
+        },
+      ],
+    },
+    {
+      code: '<img aria-labelledby="" />',
+      errors: [
+        {
+          message:
+            'The aria-labelledby attribute must have a value. The alt attribute is preferred over aria-labelledby for images.',
+        },
+      ],
+    },
+    {
+      code: '<SomeComponent as="img" aria-label="" />',
+      settings: componentsSettings,
+      errors: [
+        {
+          message:
+            'The aria-label attribute must have a value. The alt attribute is preferred over aria-label for images.',
+        },
+      ],
+    },
+
+    // ---- DEFAULT ELEMENT 'object' TESTS ----
+    {
+      code: '<object />',
+      errors: [
+        {
+          message:
+            'Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.',
+        },
+      ],
+    },
+    {
+      code: '<object><div aria-hidden /></object>',
+      errors: [
+        {
+          message:
+            'Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.',
+        },
+      ],
+    },
+    {
+      code: '<object title={undefined} />',
+      errors: [
+        {
+          message:
+            'Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.',
+        },
+      ],
+    },
+    {
+      code: '<object aria-label="" />',
+      errors: [
+        {
+          message:
+            'Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.',
+        },
+      ],
+    },
+    {
+      code: '<object aria-labelledby="" />',
+      errors: [
+        {
+          message:
+            'Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.',
+        },
+      ],
+    },
+    {
+      code: '<object aria-label={undefined} />',
+      errors: [
+        {
+          message:
+            'Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.',
+        },
+      ],
+    },
+    {
+      code: '<object aria-labelledby={undefined} />',
+      errors: [
+        {
+          message:
+            'Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.',
+        },
+      ],
+    },
+
+    // ---- DEFAULT ELEMENT 'area' TESTS ----
+    {
+      code: '<area />',
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<area alt />',
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<area alt={undefined} />',
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<area src="xyz" />',
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<area {...this.props} />',
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<area aria-label="" />',
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<area aria-label={undefined} />',
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<area aria-labelledby="" />',
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<area aria-labelledby={undefined} />',
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+
+    // ---- DEFAULT ELEMENT 'input type="image"' TESTS ----
+    {
+      code: '<input type="image" />',
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<input type="image" alt />',
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<input type="image" alt={undefined} />',
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<input type="image">Foo</input>',
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<input type="image" {...this.props} />',
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<input type="image" aria-label="" />',
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<input type="image" aria-label={undefined} />',
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<input type="image" aria-labelledby="" />',
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<input type="image" aria-labelledby={undefined} />',
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+
+    // ---- CUSTOM ELEMENT TESTS FOR ARRAY OPTION TESTS ----
+    {
+      code: '<Thumbnail />;',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Thumbnail elements must have an alt prop, either with meaningful text, or an empty string for decorative images.',
+        },
+      ],
+    },
+    {
+      code: '<Thumbnail alt />;',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Invalid alt value for Thumbnail. Use alt="" for presentational images.',
+        },
+      ],
+    },
+    {
+      code: '<Thumbnail alt={undefined} />;',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Invalid alt value for Thumbnail. Use alt="" for presentational images.',
+        },
+      ],
+    },
+    {
+      code: '<Thumbnail src="xyz" />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Thumbnail elements must have an alt prop, either with meaningful text, or an empty string for decorative images.',
+        },
+      ],
+    },
+    {
+      code: '<Thumbnail {...this.props} />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Thumbnail elements must have an alt prop, either with meaningful text, or an empty string for decorative images.',
+        },
+      ],
+    },
+    {
+      code: '<Image />;',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Image elements must have an alt prop, either with meaningful text, or an empty string for decorative images.',
+        },
+      ],
+    },
+    {
+      code: '<Image alt />;',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Invalid alt value for Image. Use alt="" for presentational images.',
+        },
+      ],
+    },
+    {
+      code: '<Image alt={undefined} />;',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Invalid alt value for Image. Use alt="" for presentational images.',
+        },
+      ],
+    },
+    {
+      code: '<Image src="xyz" />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Image elements must have an alt prop, either with meaningful text, or an empty string for decorative images.',
+        },
+      ],
+    },
+    {
+      code: '<Image {...this.props} />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Image elements must have an alt prop, either with meaningful text, or an empty string for decorative images.',
+        },
+      ],
+    },
+    {
+      code: '<Object />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.',
+        },
+      ],
+    },
+    {
+      code: '<Object><div aria-hidden /></Object>',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.',
+        },
+      ],
+    },
+    {
+      code: '<Object title={undefined} />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Embedded <object> elements must have alternative text by providing inner text, aria-label or aria-labelledby props.',
+        },
+      ],
+    },
+    {
+      code: '<Area />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<Area alt />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<Area alt={undefined} />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<Area src="xyz" />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<Area {...this.props} />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            'Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<InputImage />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<InputImage alt />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<InputImage alt={undefined} />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<InputImage>Foo</InputImage>',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<InputImage {...this.props} />',
+      options: arrayOpts,
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+    {
+      code: '<Input type="image" />',
+      settings: componentsSettings,
+      errors: [
+        {
+          message:
+            '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/tsconfig.files.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/tsconfig.files.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "allowJs": true
+  },
+  "include": ["files/**/*"]
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/tsconfig.virtual.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/tsconfig.virtual.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"]
+  },
+  "include": ["src/virtual.tsx", "src/virtual.ts"]
+}

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -88,10 +88,13 @@ instane
 IPC
 isnan
 jakebailey
+jsnum
 jsonc
 jsonline
+jsxa
 justforcheck
 keygen
+labelledby
 ldflags
 ldquo
 libsyncrpc
@@ -352,3 +355,4 @@ recognises
 recognisable
 clsx
 unshift
+yutil


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/alt-text` rule from `eslint-plugin-jsx-a11y` to rslint.

The rule enforces that elements requiring alternative text — `<img>`, `<object>`, `<area>`, and `<input type=\"image\">` — carry meaningful information for screen readers. It surfaces six branches: missing alt prop, invalid alt value, empty/undefined `aria-label`/`aria-labelledby`, presentational role used instead of `alt=\"\"`, and inaccessible `<object>` / `<area>` / `<input type=\"image\">`.

This port introduces a new `jsx-a11y` plugin namespace alongside an internal helper package (`jsxa11yutil`) that ports jsx-ast-utils' `getPropValue` / `getLiteralPropValue` / `getElementType` / `hasAccessibleChild` / `isPresentationRole` / `isHiddenFromScreenReader` semantics. The static evaluator covers JS short-circuit (`&&` / `||` / `??`), ConditionalExpression, PrefixUnary / PostfixUnary including `++` / `--`, AwaitExpression / YieldExpression, TS assertion wrappers (`as` / `!` / `<T>` / `satisfies`), `JS_RESERVED` global identifiers, string-literal `\"true\"` / `\"false\"` boolean coercion, and the `null` literal → `\"null\"` string mapping.

Tests are split into two files:

- `alt_text_upstream_test.go` — 1:1 migration of the upstream `alt-text-test.js` valid + invalid suite.
- `alt_text_extras_test.go` — rslint-specific lock-ins covering staticEval edges, TS wrappers, polymorphic edge cases, real-world i18n / optional-chain / fallback patterns, and aria-hidden full static-eval coverage. Each case verified empirically against `eslint-plugin-jsx-a11y@latest` for byte-identical diagnostics.

End-to-end validated against `rsbuild` and `rspack`: 36-case fixture × 2 repos = 72 cases, 0 mismatches; both repos' real code (16 + 4 `<img>` instances) — 0 false positives.

## Related Links

- Upstream rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/alt-text.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/alt-text.js
- Upstream tests: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/__tests__/src/rules/alt-text-test.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).