### PR TITLE
docs(website): enable llms generation and ssg

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -30,9 +30,14 @@ export default defineConfig({
     exclude: ['**/zh/shared/**', '**/en/shared/**', './theme'],
   },
   globalStyles: path.join(__dirname, 'styles/index.css'),
-  // TODO: enable llms when SSG issues had been fixed
-  // llms: true,
-  ssg: false,
+  llms: {
+    remarkSplitMdxOptions: {
+      excludes: [[['Playground'], '@/theme/components/Playground']],
+    },
+  },
+  ssg: {
+    experimentalExcludeRoutePaths: ['/playground/'],
+  },
   themeConfig: {
     socialLinks: [
       {


### PR DESCRIPTION
## Summary

exclude paths unsuitable for server-side rendering to enable SSG and LLMs generation.