### PR TITLE
feat: port rule jsx-a11y/autocomplete-valid

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/alt_text"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/anchor_has_content"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_unsupported_elements"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/autocomplete_valid"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -12,5 +13,6 @@ func GetAllRules() []rule.Rule {
 		alt_text.AltTextRule,
 		anchor_has_content.AnchorHasContentRule,
 		aria_unsupported_elements.AriaUnsupportedElementsRule,
+		autocomplete_valid.AutocompleteValidRule,
 	}
 }

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -315,6 +315,46 @@ func PropStaticStringValue(attr *ast.Node) (string, bool) {
 	return "", false
 }
 
+// LiteralPropStringValue mirrors `getLiteralPropValue(prop)` filtered to the
+// string-typed result. Returns ("", false) when the prop's literal-typed
+// value isn't a string under jsx-ast-utils' LITERAL_TYPES rules:
+//
+//   - Boolean attribute form (`<input autocomplete />`) → upstream returns
+//     boolean true, not a string → ("", false).
+//   - Identifier (`<input autocomplete={x} />`) → noop in LITERAL_TYPES → null
+//     → ("", false).
+//   - LogicalExpression / ConditionalExpression / CallExpression /
+//     MemberExpression / BinaryExpression — all noop in LITERAL_TYPES → null
+//     → ("", false).
+//
+// Differs from LiteralStringValue (which only handles direct StringLiteral
+// / NoSubstitutionTemplateLiteral) in two ways:
+//  1. Routes through literalPropValue, which special-cases the `null`
+//     literal to the string `"null"` (LITERAL_TYPES.Literal override).
+//  2. Synthesizes a placeholder string for TemplateExpression with
+//     substitutions (matches jsx-ast-utils' TemplateLiteral extractor).
+//
+// Used by autocomplete-valid (upstream calls `getLiteralPropValue` and gates
+// on `typeof === 'string'`) — anything other than a literal-typed string
+// makes the rule return early without checking validity.
+func LiteralPropStringValue(attr *ast.Node) (string, bool) {
+	if attr == nil {
+		return "", false
+	}
+	if AttributeIsBooleanForm(attr) {
+		return "", false
+	}
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		return "", false
+	}
+	v := literalPropValue(inner)
+	if v.Kind == jvString {
+		return v.Str, true
+	}
+	return "", false
+}
+
 // LiteralPropTruthy mirrors `!!getLiteralPropValue(prop)`. Returns true when
 // the attribute's value is a JS-truthy *literal*. Crucial differences from
 // PropStaticStringValue / staticEval-based truthiness:

--- a/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
@@ -539,19 +539,29 @@ func staticEvalTemplate(tpl *ast.TemplateExpression) jsValue {
 			sp := span.AsTemplateSpan()
 			if sp.Expression != nil {
 				expr := ast.SkipOuterExpressions(sp.Expression, skipTransparent)
+				// Upstream wraps every substitution in `${<value>}` (the
+				// inner template literal `\${${getValue(expr)}}` evaluates
+				// to literal `"${" + String(getValue(expr)) + "}"`). The
+				// `$` prefix is load-bearing for autocomplete-valid: without
+				// it, `<input autocomplete={`${undefined}`} />` would
+				// synthesize the bare string "undefined", which matches
+				// axe-core's extended `stateTerms` and produces a false
+				// "valid" verdict. Mirror the `${...}` wrapping verbatim.
 				switch {
 				case utils.IsUndefinedIdentifier(expr):
-					sb.WriteString("undefined")
+					sb.WriteString("${undefined}")
 				case expr.Kind == ast.KindIdentifier:
-					sb.WriteString("{")
+					sb.WriteString("${")
 					sb.WriteString(expr.AsIdentifier().Text)
 					sb.WriteString("}")
 				default:
-					// Upstream: any non-Identifier / non-TemplateElement gets
-					// `{<type>}`. We don't have a stable type-name string in
-					// tsgo, so we just emit a placeholder — the result is
-					// still a truthy string, which is all alt-text needs.
-					sb.WriteString("{Expression}")
+					// Upstream computes `getValue(expr)` and JS-coerces to
+					// string. We don't replicate every TYPES branch; a
+					// placeholder is sufficient because alt-text only needs
+					// truthiness and autocomplete-valid only checks that
+					// the synthesized string isn't a known token (the `$`
+					// prefix guarantees no accidental token match).
+					sb.WriteString("${Expression}")
 				}
 			}
 			if sp.Literal != nil {

--- a/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid.go
+++ b/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid.go
@@ -1,0 +1,342 @@
+// cspell:words bday impp
+
+package autocomplete_valid
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// failMessage is the message axe-core's `autocomplete-valid` check emits when
+// the autocomplete attribute fails validation. The upstream ESLint rule reads
+// `violations[0].nodes[0].all[0].message` directly from axe-core; the message
+// text comes from `lib/checks/forms/autocomplete-valid.json`'s `messages.fail`.
+// Source: https://github.com/dequelabs/axe-core/blob/develop/lib/checks/forms/autocomplete-valid.json
+const failMessage = "the autocomplete attribute is incorrectly formatted"
+
+// Token sets mirror axe-core's `autocomplete` constant in
+// `lib/commons/text/is-valid-autocomplete.js`, plus the `stateTerms` and
+// `ignoredValues` extensions defined in `lib/checks/forms/autocomplete-valid.json`.
+//
+// stateTerms: terms whose presence ALONE (without any other tokens) makes the
+// autocomplete value valid. The base `["on", "off"]` come from the WHATWG HTML
+// spec; axe-core's autocomplete-valid.json extends with eight more pragmatic
+// extras (`none`, `false`, `true`, etc.) to accept common author misuses.
+var stateTerms = map[string]struct{}{
+	// axe-core base
+	"on":  {},
+	"off": {},
+	// axe-core autocomplete-valid.json extension
+	"none":      {},
+	"false":     {},
+	"true":      {},
+	"disabled":  {},
+	"enabled":   {},
+	"undefined": {},
+	"null":      {},
+	"xoff":      {},
+	"xon":       {},
+}
+
+// standaloneTerms — the autofill field-name tokens that are valid on their
+// own (without a contact qualifier). Source: WHATWG HTML autofill detail
+// tokens, mirrored from axe-core's `autocomplete.standaloneTerms`.
+var standaloneTerms = map[string]struct{}{
+	"name":               {},
+	"honorific-prefix":   {},
+	"given-name":         {},
+	"additional-name":    {},
+	"family-name":        {},
+	"honorific-suffix":   {},
+	"nickname":           {},
+	"username":           {},
+	"new-password":       {},
+	"current-password":   {},
+	"organization-title": {},
+	"organization":       {},
+	"street-address":     {},
+	"address-line1":      {},
+	"address-line2":      {},
+	"address-line3":      {},
+	"address-level4":     {},
+	"address-level3":     {},
+	"address-level2":     {},
+	"address-level1":     {},
+	"country":            {},
+	"country-name":       {},
+	"postal-code":        {},
+	"cc-name":            {},
+	"cc-given-name":      {},
+	"cc-additional-name": {},
+	"cc-family-name":     {},
+	"cc-number":          {},
+	"cc-exp":             {},
+	"cc-exp-month":       {},
+	"cc-exp-year":        {},
+	"cc-csc":             {},
+	"cc-type":            {},
+	"transaction-currency": {},
+	"transaction-amount":   {},
+	"language":             {},
+	"bday":                 {},
+	"bday-day":             {},
+	"bday-month":           {},
+	"bday-year":            {},
+	"sex":                  {},
+	"url":                  {},
+	"photo":                {},
+	"one-time-code":        {},
+}
+
+// qualifiers — contact-channel qualifiers that may precede a qualifiedTerm
+// (e.g. `home email`, `work tel`). Mirrors axe-core's `autocomplete.qualifiers`.
+var qualifiers = map[string]struct{}{
+	"home":   {},
+	"work":   {},
+	"mobile": {},
+	"fax":    {},
+	"pager":  {},
+}
+
+// qualifiedTerms — autofill field-name tokens that are valid only AFTER a
+// qualifier (and also valid on their own, since they're additionally accepted
+// in the no-qualifier case). Mirrors axe-core's `autocomplete.qualifiedTerms`.
+var qualifiedTerms = map[string]struct{}{
+	"tel":              {},
+	"tel-country-code": {},
+	"tel-national":     {},
+	"tel-area-code":    {},
+	"tel-local":        {},
+	"tel-local-prefix": {},
+	"tel-local-suffix": {},
+	"tel-extension":    {},
+	"email":            {},
+	"impp":             {},
+}
+
+// locations — address grouping tokens (`billing` / `shipping`) that may
+// optionally precede the rest of the value. Mirrors axe-core's
+// `autocomplete.locations`.
+var locations = map[string]struct{}{
+	"billing":  {},
+	"shipping": {},
+}
+
+// ignoredValues — tokens that axe-core's autocomplete-valid extension marks
+// as "incomplete" (returns `undefined`) rather than failing. The ESLint rule
+// only reports violations (`false` returns), so these effectively pass.
+// Source: `lib/checks/forms/autocomplete-valid.json` `options.ignoredValues`.
+var ignoredValues = map[string]struct{}{
+	"text":     {},
+	"pronouns": {},
+	"gender":   {},
+	"message":  {},
+	"content":  {},
+}
+
+// excludedInputTypes — input `type` values that axe-core's
+// `autocomplete-matches` (lib/commons/forms/autocomplete-matches.js) filters
+// out before running any check. For these, the rule produces no violation
+// regardless of the autocomplete value. Source comparison is
+// case-insensitive: axe-core's SerialVirtualNode lowercases `attributes.type`
+// into `virtualNode.props.type`.
+//
+// The other gates in autocomplete-matches (`readonly`, `disabled`,
+// `aria-readonly`, `aria-disabled`, `tabindex`+role) are unreachable in this
+// port because the upstream ESLint rule passes ONLY `{autocomplete, type}`
+// into `runVirtualRule` — every other attribute lookup in matches sees
+// `null` and falls through. Only the `type` filter affects observable
+// behavior here.
+var excludedInputTypes = map[string]struct{}{
+	"submit": {},
+	"reset":  {},
+	"button": {},
+	"hidden": {},
+}
+
+type options struct {
+	inputComponents []string
+}
+
+func parseOptions(raw any) options {
+	opts := options{}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	opts.inputComponents = utils.ToStringSlice(m["inputComponents"])
+	return opts
+}
+
+var AutocompleteValidRule = rule.Rule{
+	Name: "jsx-a11y/autocomplete-valid",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		// inputTypes is the union of `["input"]` and the user-provided
+		// inputComponents. Upstream builds this fresh inside the listener;
+		// hoisting it here is a no-op semantically because options can't
+		// change during a single run.
+		inputTypes := map[string]struct{}{"input": {}}
+		for _, c := range opts.inputComponents {
+			inputTypes[c] = struct{}{}
+		}
+
+		check := func(node *ast.Node) {
+			elType := jsxa11yutil.GetElementType(node, ctx.Settings)
+			if _, ok := inputTypes[elType]; !ok {
+				return
+			}
+
+			attrs := reactutil.GetJsxElementAttributes(node)
+			autocompleteAttr := jsxa11yutil.FindAttributeByName(attrs, "autocomplete")
+			if autocompleteAttr == nil {
+				return
+			}
+			// Upstream gates on `typeof autocomplete !== 'string'` after
+			// `getLiteralPropValue`. LiteralPropStringValue mirrors that —
+			// boolean form, dynamic identifiers, logical / conditional
+			// expressions, etc. all return ("", false) and we exit early.
+			autocompleteValue, ok := jsxa11yutil.LiteralPropStringValue(autocompleteAttr)
+			if !ok {
+				return
+			}
+
+			// Mirror axe-core's `autocomplete-matches` filter
+			// (lib/commons/forms/autocomplete-matches.js): when the literal
+			// `type` value is in `excludedInputTypes` (submit / reset /
+			// button / hidden), the rule must NOT report. axe-core's
+			// matches() runs before evaluate(), so the violation list is
+			// empty for these inputs regardless of the autocomplete value.
+			//
+			// Applies to every element that passed the inputTypes gate —
+			// the ESLint plugin always hardcodes `nodeName: 'input'` when
+			// calling `runVirtualRule`, so the matches gate `nodeName !==
+			// 'input'` upstream never fires for custom inputComponents or
+			// components-map entries; the type filter is the only matches
+			// branch that affects observable behavior here.
+			//
+			// Comparison is case-insensitive because axe-core's
+			// SerialVirtualNode lowercases `attributes.type` into
+			// `virtualNode.props.type`.
+			if typeAttr := jsxa11yutil.FindAttributeByName(attrs, "type"); typeAttr != nil {
+				if typeValue, ok := jsxa11yutil.LiteralPropStringValue(typeAttr); ok {
+					if _, excluded := excludedInputTypes[strings.ToLower(typeValue)]; excluded {
+						return
+					}
+				}
+			}
+
+			if isValidAutocomplete(autocompleteValue) {
+				return
+			}
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "autocompleteValid",
+				Description: failMessage,
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}
+
+// isValidAutocomplete ports axe-core's `isValidAutocomplete` from
+// `lib/commons/text/is-valid-autocomplete.js`, with the extended `stateTerms`
+// and `ignoredValues` from the rule's check options baked in.
+//
+// Returns true when the value matches one of:
+//   - empty string (after trim)
+//   - a stateTerm (e.g. "on", "off", or one of the autocomplete-valid extras)
+//   - the autofill detail-token grammar:
+//     [section-*]? [billing|shipping]? [home|work|mobile|fax|pager]? <field-name> [webauthn]?
+//     where <field-name> is in standaloneTerms when no qualifier was used,
+//     OR in qualifiedTerms when a qualifier was used.
+//   - any value whose final token (after stripping the optional `webauthn`,
+//     section-, location, qualifier prefixes) is in `ignoredValues` —
+//     axe-core returns `undefined` here, treated as "incomplete" by the rule
+//     engine and therefore not a violation.
+//
+// Returns false for any value that doesn't fit the grammar.
+func isValidAutocomplete(value string) bool {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if _, ok := stateTerms[value]; ok {
+		return true
+	}
+	if value == "" {
+		return true
+	}
+
+	// `\s+` split per axe-core; strings.Fields collapses any whitespace run.
+	terms := strings.Fields(value)
+	if len(terms) == 0 {
+		return true // unreachable: covered by `value == ""` above, but kept defensive
+	}
+
+	// Optional trailing `webauthn`. After popping, if no terms remain the
+	// value was just `"webauthn"` alone — that's invalid.
+	if terms[len(terms)-1] == "webauthn" {
+		terms = terms[:len(terms)-1]
+		if len(terms) == 0 {
+			return false
+		}
+	}
+
+	// Optional `section-*` prefix. Upstream guards on length > 8 so that the
+	// bare token `"section-"` (8 chars) is NOT treated as a prefix. Mirror
+	// that exactly to lock the boundary.
+	if len(terms[0]) > 8 && strings.HasPrefix(terms[0], "section-") {
+		terms = terms[1:]
+	}
+	if len(terms) == 0 {
+		return false
+	}
+
+	// Optional `billing` / `shipping` location.
+	if _, ok := locations[terms[0]]; ok {
+		terms = terms[1:]
+	}
+	if len(terms) == 0 {
+		return false
+	}
+
+	// Optional contact qualifier. When present, the field name must come from
+	// qualifiedTerms — standaloneTerms become invalid (matches upstream's
+	// `standaloneTerms = []` reset).
+	qualifierUsed := false
+	if _, ok := qualifiers[terms[0]]; ok {
+		terms = terms[1:]
+		qualifierUsed = true
+	}
+
+	// Exactly one term must remain — the field-name purpose.
+	if len(terms) != 1 {
+		return false
+	}
+	purposeTerm := terms[0]
+
+	// `ignoredValues` short-circuit: axe-core returns `undefined` (incomplete);
+	// the rule treats anything other than `false` (violation) as passing.
+	if _, ok := ignoredValues[purposeTerm]; ok {
+		return true
+	}
+
+	if qualifierUsed {
+		_, ok := qualifiedTerms[purposeTerm]
+		return ok
+	}
+	if _, ok := standaloneTerms[purposeTerm]; ok {
+		return true
+	}
+	if _, ok := qualifiedTerms[purposeTerm]; ok {
+		return true
+	}
+	return false
+}

--- a/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid.md
+++ b/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid.md
@@ -1,0 +1,118 @@
+# autocomplete-valid
+
+The `autocomplete` attribute on form controls follows a strict grammar from
+the [WHATWG HTML autofill detail tokens](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens).
+Values that don't match the grammar give browsers no useful hint and break
+autofill for users who rely on it — this rule reports such values.
+
+## Rule Details
+
+This rule applies to `<input>` elements (plus any custom components opted
+in via the `inputComponents` option or the `jsx-a11y` `components` /
+`polymorphicPropName` settings). It accepts:
+
+- the empty string, `on`, `off`, and a few state-like aliases (`none`,
+  `null`, `disabled`, `enabled`, `undefined`, `true`, `false`, `xon`,
+  `xoff`);
+- a single autofill field-name token (e.g. `name`, `email`, `street-address`,
+  `current-password`);
+- a token sequence of the form
+  `[section-* ]? [billing|shipping]? [home|work|mobile|fax|pager]? <field-name> [webauthn]?`
+  where `<field-name>` must be drawn from the qualified list when a
+  contact qualifier (`home`, `work`, …) is present.
+
+Comparison is case-insensitive and surrounding whitespace is trimmed.
+Dynamic values (`autocomplete={someVar}`) are not checked.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<input type="text" autocomplete="foo" />
+<input type="text" autocomplete="name invalid" />
+<input type="text" autocomplete="invalid name" />
+<input type="text" autocomplete="home url" />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<input type="text" autocomplete="name" />
+<input type="text" autocomplete="" />
+<input type="text" autocomplete="off" />
+<input type="text" autocomplete="on" />
+<input type="text" autocomplete="billing family-name" />
+<input type="text" autocomplete="section-blue shipping street-address" />
+<input type="text" autocomplete="section-somewhere shipping work email" />
+<input type="text" autocomplete />
+<input type="text" autocomplete={dynamicValue} />
+<Foo autocomplete="bar" />
+```
+
+The rule does not run on inputs whose `type` is `submit`, `reset`,
+`button`, or `hidden` — those controls don't carry autofill data:
+
+```jsx
+<input type="hidden" autocomplete="foo" />
+<input type="submit" autocomplete="foo" />
+```
+
+## Rule Options
+
+```json
+{
+  "jsx-a11y/autocomplete-valid": [
+    "error",
+    {
+      "inputComponents": ["MyInput"]
+    }
+  ]
+}
+```
+
+### `inputComponents`
+
+Type: `string[]`. Default: `[]`.
+
+Component names that should be validated as if they were `<input>` elements.
+Components not listed are ignored.
+
+Examples of **incorrect** code with `{ "inputComponents": ["MyInput"] }`:
+
+```json
+{ "jsx-a11y/autocomplete-valid": ["error", { "inputComponents": ["MyInput"] }] }
+```
+
+```jsx
+<MyInput autocomplete="foo" />
+```
+
+Examples of **correct** code with `{ "inputComponents": ["MyInput"] }`:
+
+```json
+{ "jsx-a11y/autocomplete-valid": ["error", { "inputComponents": ["MyInput"] }] }
+```
+
+```jsx
+<MyInput autocomplete="name" />
+<MyInput autocomplete={dynamicValue} />
+```
+
+## Settings
+
+The rule reads `settings['jsx-a11y']` to resolve the effective element
+type for a JSX tag:
+
+- `polymorphicPropName` — name of a polymorphic prop (e.g. `"as"`) that
+  remaps the element type. With `polymorphicPropName: "as"`,
+  `<Box as="input" />` is validated as `<input />`.
+- `polymorphicAllowList` — `string[]` restricting which raw component
+  names may be remapped via the polymorphic prop. When omitted, every
+  component may be remapped.
+- `components` — a `{ ComponentName: "html-element" }` map. With
+  `{ "Input": "input" }`, `<Input />` is validated as `<input />`.
+
+These mirror the upstream `eslint-plugin-jsx-a11y` settings exactly.
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/autocomplete-valid](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/autocomplete-valid.md)

--- a/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid_extras_test.go
@@ -1,0 +1,897 @@
+// cspell:words bday impp
+
+package autocomplete_valid
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestAutocompleteValidExtras covers behavior beyond the upstream
+// `__tests__/src/rules/autocomplete-valid-test.js` suite — primarily:
+//
+//   - axe-core grammar boundaries that upstream's tests don't probe
+//     (section-* length boundary, qualifier+standalone exclusion, double
+//     qualifier / location, webauthn alone, ignoredValues, every stateTerm
+//     extension, every standalone-term we ship, …)
+//   - JSX-shape variants (paired vs self-closing, JsxExpression wrappers,
+//     spread-of-literal, multi-line, deeply nested in map/conditionals/
+//     hooks/class methods, etc.)
+//   - tsgo-specific lock-ins (satisfies / `as const` / non-null
+//     unwrapping, OEKAssertions bits, optional-chain noop, template-literal
+//     `${undefined}` synthesis fix, …)
+//   - axe-core matches() type filter on every excluded type, with literal
+//     and JsxExpression-wrapped type forms, plus the negative direction
+//     (non-excluded types still report)
+//   - rslint-vs-upstream call-shape parity — runVirtualRule only forwards
+//     `{autocomplete, type}`, so the rule must NOT skip on `disabled` /
+//     `readonly` / `aria-*` / `tabindex` / `role` (negative tests in the
+//     invalid block)
+//   - Diagnostic position locking (single-line, multi-line, paired form,
+//     siblings, fragments)
+//
+// The upstream-replica suite lives in `autocomplete_valid_upstream_test.go`.
+// `componentsSettings` is shared from that file via the same package.
+func TestAutocompleteValidExtras(t *testing.T) {
+	validCases := []rule_tester.ValidTestCase{
+		// ---- Upstream-walk lock-ins ----
+		// stateTerms — the axe-core extras (none, false, true, disabled,
+		// enabled, undefined, null, xoff, xon) must each be accepted.
+		// Exercising every entry guards against accidental list edits.
+		{Code: `<input autocomplete="none" />;`, Tsx: true},
+		{Code: `<input autocomplete="false" />;`, Tsx: true},
+		{Code: `<input autocomplete="true" />;`, Tsx: true},
+		{Code: `<input autocomplete="disabled" />;`, Tsx: true},
+		{Code: `<input autocomplete="enabled" />;`, Tsx: true},
+		{Code: `<input autocomplete="undefined" />;`, Tsx: true},
+		{Code: `<input autocomplete="null" />;`, Tsx: true},
+		{Code: `<input autocomplete="xoff" />;`, Tsx: true},
+		{Code: `<input autocomplete="xon" />;`, Tsx: true},
+		// Case-insensitivity: the axe-core algorithm lowercases before any
+		// term matching, so uppercase / mixed-case values must still pass.
+		{Code: `<input autocomplete="NAME" />;`, Tsx: true},
+		{Code: `<input autocomplete="OFF" />;`, Tsx: true},
+		{Code: `<input autocomplete="Section-Blue Shipping Street-Address" />;`, Tsx: true},
+		// Whitespace handling: trim before stateTerms check, then \s+ split.
+		// Multiple spaces between tokens collapse via strings.Fields.
+		{Code: `<input autocomplete="   name   " />;`, Tsx: true},
+		{Code: `<input autocomplete="  " />;`, Tsx: true},
+		{Code: `<input autocomplete="billing  family-name" />;`, Tsx: true},
+		// webauthn alone is invalid (terms empty after pop) — tested below.
+		// webauthn AFTER a valid token pops then re-validates the rest.
+		{Code: `<input autocomplete="name webauthn" />;`, Tsx: true},
+		{Code: `<input autocomplete="shipping street-address webauthn" />;`, Tsx: true},
+		{Code: `<input autocomplete="home email webauthn" />;`, Tsx: true},
+		// ignoredValues — axe-core returns `undefined` (incomplete), not a
+		// violation, so the ESLint plugin reports nothing. Lock each entry.
+		{Code: `<input autocomplete="text" />;`, Tsx: true},
+		{Code: `<input autocomplete="pronouns" />;`, Tsx: true},
+		{Code: `<input autocomplete="gender" />;`, Tsx: true},
+		{Code: `<input autocomplete="message" />;`, Tsx: true},
+		{Code: `<input autocomplete="content" />;`, Tsx: true},
+		// Qualified term combinations: every qualifier × every qualifiedTerm
+		// representative should pass. Sample a few.
+		{Code: `<input autocomplete="home tel" />;`, Tsx: true},
+		{Code: `<input autocomplete="work email" />;`, Tsx: true},
+		{Code: `<input autocomplete="mobile tel-extension" />;`, Tsx: true},
+		{Code: `<input autocomplete="fax impp" />;`, Tsx: true},
+		{Code: `<input autocomplete="pager tel-country-code" />;`, Tsx: true},
+		// All three optional prefixes used at once: section + location + qualifier + qualified term.
+		{Code: `<input autocomplete="section-payment billing home tel" />;`, Tsx: true},
+		// Boundary on the section- length check: upstream requires
+		// `length > 8`, so the 8-character bare token "section-" is NOT
+		// stripped — it's treated as the purpose token, which doesn't match
+		// anything → the value is invalid. Conversely "section-x" (9 chars)
+		// IS stripped. Lock both sides of the boundary; the invalid case is
+		// in the invalid block.
+		{Code: `<input autocomplete="section-x name" />;`, Tsx: true},
+		// JSX shape variants — locks that the listener fires on both
+		// JsxOpeningElement (paired) and JsxSelfClosingElement (no children).
+		{Code: `<input autocomplete="name"></input>`, Tsx: true},
+		// Self-closing without space before `/>`.
+		{Code: `<input autocomplete="name"/>`, Tsx: true},
+		// Spread props mixed with literal autocomplete — spread is opaque,
+		// the named attr still resolves to the literal "name" → valid.
+		{Code: `<input {...rest} autocomplete="name" />;`, Tsx: true},
+		// Explicit JsxExpression wrapping a literal — not technically common
+		// but legal. Both StringLiteral and NoSubstitutionTemplateLiteral
+		// inside a JsxExpression must resolve via LiteralPropStringValue.
+		{Code: `<input autocomplete={"name"} />;`, Tsx: true},
+		{Code: "<input autocomplete={`name`} />;", Tsx: true},
+		// TS wrappers around the autocomplete literal. literalPropValue
+		// goes through SkipOuterExpressions which strips parens / `as` / `!`.
+		{Code: `<input autocomplete={"name" as const} />;`, Tsx: true},
+		{Code: `<input autocomplete={("name")} />;`, Tsx: true},
+		// Settings: components map points at a non-input HTML tag. The
+		// element resolves to "div", which isn't in inputTypes → rule
+		// returns early. Locks the components-map path.
+		{
+			Code: `<Block autocomplete="foo" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"Block": "div"},
+				},
+			},
+		},
+		// polymorphicPropName resolves a polymorphic component to a
+		// non-input element. Locks the polymorphic + non-input path.
+		{
+			Code: `<Box as="div" autocomplete="foo" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+		// Non-input elements with autocomplete are silently passed through
+		// per upstream's `inputTypes.includes(elType)` gate.
+		{Code: `<select autocomplete="foo" />;`, Tsx: true},
+		{Code: `<textarea autocomplete="foo" />;`, Tsx: true},
+		{Code: `<button autocomplete="foo" />;`, Tsx: true},
+		// Member-expression / namespaced tag names — neither matches "input"
+		// directly, so no validation runs.
+		{Code: `<Foo.input autocomplete="foo" />;`, Tsx: true},
+		{Code: `<svg:input autocomplete="foo" />;`, Tsx: true},
+		// inputComponents option as the array-wrapped JSON shape (matches
+		// the rule_tester multi-element shape vs. CLI bare-object shape).
+		{
+			Code:    `<MyInput autocomplete="name" />`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"inputComponents": []interface{}{"MyInput"}}},
+		},
+		// Empty inputComponents array — no extra components, only "input"
+		// is checked. <Foo> remains unchecked.
+		{
+			Code:    `<Foo autocomplete="foo" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"inputComponents": []interface{}{}},
+		},
+		// Nil options — defaults to just ["input"].
+		{Code: `<Foo autocomplete="foo" />;`, Tsx: true},
+		// Malformed option (non-array inputComponents) — tolerated by
+		// GetOptionsMap path, falls through to defaults.
+		{
+			Code:    `<Foo autocomplete="foo" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"inputComponents": "MyInput"},
+		},
+		// `<input autocomplete={undefined} />` — getLiteralPropValue returns
+		// undefined; typeof !== string → return early.
+		{Code: `<input autocomplete={undefined} />;`, Tsx: true},
+		// Literal `null` autocomplete — LITERAL_TYPES.Literal special-cases
+		// null to the string "null"; "null" is in the extended stateTerms
+		// → valid. Locks the null-literal coercion path.
+		{Code: `<input autocomplete={null} />;`, Tsx: true},
+		// CallExpression inside a JsxExpression — noop in LITERAL_TYPES →
+		// rule returns early.
+		{Code: `<input autocomplete={getValue()} />;`, Tsx: true},
+		// MemberExpression inside a JsxExpression — noop in LITERAL_TYPES.
+		{Code: `<input autocomplete={config.autocomplete} />;`, Tsx: true},
+		// Conditional expression — noop in LITERAL_TYPES.
+		{Code: `<input autocomplete={cond ? "name" : "foo"} />;`, Tsx: true},
+		// `<input>` inside common React patterns — listener must fire but
+		// the value is valid. Locks the listener-shape coverage.
+		{Code: `function F() { return <input autocomplete="name" />; }`, Tsx: true},
+		{Code: `class C { render() { return <input autocomplete="name" />; } }`, Tsx: true},
+		// Multi-line JSX with a valid literal autocomplete — must not fire.
+		{Code: "<input\n  type=\"text\"\n  autocomplete=\"name\"\n/>", Tsx: true},
+
+		// ---- axe-core matches() type-filter lockdowns ----
+		// Each of the four excluded types skips the check entirely — even
+		// with an obviously invalid autocomplete value. Locks parity with
+		// `lib/commons/forms/autocomplete-matches.js` excludedInputTypes.
+		{Code: `<input type="hidden" autocomplete="foo" />;`, Tsx: true},
+		{Code: `<input type="submit" autocomplete="foo" />;`, Tsx: true},
+		{Code: `<input type="reset" autocomplete="invalid garbage" />;`, Tsx: true},
+		{Code: `<input type="button" autocomplete="bogus" />;`, Tsx: true},
+		// Case-insensitivity on the type comparison: axe-core's
+		// SerialVirtualNode lowercases `attributes.type`. Locks the lower-
+		// case normalization on rslint's side.
+		{Code: `<input type="HIDDEN" autocomplete="foo" />;`, Tsx: true},
+		{Code: `<input type="Submit" autocomplete="foo" />;`, Tsx: true},
+		// JsxExpression-wrapped literal type — should still resolve via
+		// LITERAL_TYPES.Literal extraction.
+		{Code: `<input type={"hidden"} autocomplete="foo" />;`, Tsx: true},
+		{Code: "<input type={`hidden`} autocomplete=\"foo\" />;", Tsx: true},
+		// TS wrappers around the literal type: stripped before comparison.
+		{Code: `<input type={"hidden" as const} autocomplete="foo" />;`, Tsx: true},
+		// Custom inputComponent with excluded type — the ESLint plugin
+		// hardcodes `nodeName: 'input'` in runVirtualRule so the type
+		// filter applies to inputComponents too.
+		{
+			Code:    `<MyInput type="hidden" autocomplete="foo" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"inputComponents": []interface{}{"MyInput"}},
+		},
+		// Components-map mapping with excluded type — same path.
+		{
+			Code:     `<Input type="submit" autocomplete="baz" />`,
+			Tsx:      true,
+			Settings: componentsSettings,
+		},
+
+		// ---- Spread-of-literal lockdowns ----
+		// `<input {...{autocomplete: "name"}} />` — FindAttributeByName
+		// inspects literal-spread arguments per jsx-ast-utils' getProp
+		// behavior. Locks that the literal-spread path produces the same
+		// validation result as a direct named attribute.
+		{Code: `<input {...{autocomplete: "name"}} />;`, Tsx: true},
+		// Shorthand inside a literal spread — `{...{autocomplete}}` — the
+		// shorthand value is the bound identifier, not a literal string,
+		// so LiteralPropStringValue returns ("", false) → rule returns
+		// early → valid (matches upstream where Identifier is noop in
+		// LITERAL_TYPES).
+		{Code: `<input {...{autocomplete}} />;`, Tsx: true},
+
+		// ---- Logical short-circuit lockdowns ----
+		// `&&` short-circuit — same noop in LITERAL_TYPES as `||`, so the
+		// rule must return early without inspecting either side.
+		{Code: `<input autocomplete={cond && "name"} />;`, Tsx: true},
+		// Nullish coalescing — also noop in LITERAL_TYPES.
+		{Code: `<input autocomplete={x ?? "name"} />;`, Tsx: true},
+
+		// ---- Deeply-nested JSX patterns ----
+		// JSX inside Array.map callback — common React pattern. Listener
+		// must fire on the inner <input>; outer expression doesn't matter.
+		{Code: `function L({xs}) { return xs.map(x => <input autocomplete="name" key={x} />); }`, Tsx: true},
+		// Conditional render via && inside parent JSX — inner <input> fires.
+		{Code: `function F() { return <div>{cond && <input autocomplete="name" />}</div>; }`, Tsx: true},
+		// JSX inside generic function — locks that surrounding TS
+		// constructs don't affect listener firing.
+		{Code: `function f<T>(x: T) { return <input autocomplete="name" />; }`, Tsx: true},
+		// Nested forms / fragments — each <input> fires independently.
+		{Code: `<form><input autocomplete="name" /></form>`, Tsx: true},
+		{Code: `<><><input autocomplete="name" /></></>`, Tsx: true},
+		// JSX inside hook callback.
+		{Code: `function F() { useEffect(() => { renderer(<input autocomplete="name" />); }); }`, Tsx: true},
+		// Tab / newline as whitespace separator: strings.Fields collapses
+		// any whitespace run, mirroring axe-core's `\s+` split.
+		{Code: "<input autocomplete=\"home\ttel\" />", Tsx: true},
+		// String concatenation here splits the literal "\nwebauthn" so the
+		// spell-checker doesn't see one fused token; the actual JSX value
+		// still contains a newline followed by the webauthn keyword.
+		{Code: "<input autocomplete=\"name\n" + "webauthn\" />", Tsx: true},
+		{Code: "<input autocomplete=\"shipping\tstreet-address\" />", Tsx: true},
+
+		// ---- Attribute-name case-insensitive matching ----
+		// jsx-ast-utils' getProp uses { ignoreCase: true } by default;
+		// FindAttributeByName mirrors via strings.EqualFold. Real JSX has
+		// authors using both `autocomplete` (HTML-correct) and
+		// `autoComplete` (React's camelCase prop). Both must trigger the
+		// rule. Locks the case-folded match path on both literal and
+		// JsxExpression initializer forms.
+		{Code: `<input autoComplete="name" />;`, Tsx: true},
+		{Code: `<input AUTOCOMPLETE="name" />;`, Tsx: true},
+		{Code: `<input AutoComplete="name" />;`, Tsx: true},
+		{Code: `<input autoComplete={dynamicValue} />;`, Tsx: true},
+
+		// ---- Real-world login form patterns ----
+		// All standalone-term entries we ship — covers the sub-list
+		// we copied from axe-core. Explicitly exercising each guards
+		// against accidental list edits.
+		{Code: `<input type="text" autocomplete="username" />;`, Tsx: true},
+		{Code: `<input type="password" autocomplete="current-password" />;`, Tsx: true},
+		{Code: `<input type="password" autocomplete="new-password" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="one-time-code" />;`, Tsx: true},
+		// Address form — the "address-line*"/"address-level*" family.
+		{Code: `<input type="text" autocomplete="street-address" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="address-line1" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="address-line2" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="address-line3" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="address-level1" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="address-level2" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="address-level3" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="address-level4" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="country" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="country-name" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="postal-code" />;`, Tsx: true},
+		// Personal — name family + birthday family.
+		{Code: `<input type="text" autocomplete="honorific-prefix" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="given-name" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="additional-name" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="family-name" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="honorific-suffix" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="nickname" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="organization-title" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="organization" />;`, Tsx: true},
+		{Code: `<input type="date" autocomplete="bday" />;`, Tsx: true},
+		{Code: `<input type="number" autocomplete="bday-day" />;`, Tsx: true},
+		{Code: `<input type="number" autocomplete="bday-month" />;`, Tsx: true},
+		{Code: `<input type="number" autocomplete="bday-year" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="sex" />;`, Tsx: true},
+		// Credit card form.
+		{Code: `<input type="text" autocomplete="cc-name" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="cc-given-name" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="cc-additional-name" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="cc-family-name" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="cc-number" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="cc-exp" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="cc-exp-month" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="cc-exp-year" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="cc-csc" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="cc-type" />;`, Tsx: true},
+		// Misc standalone.
+		{Code: `<input type="text" autocomplete="transaction-currency" />;`, Tsx: true},
+		{Code: `<input type="number" autocomplete="transaction-amount" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="language" />;`, Tsx: true},
+		{Code: `<input type="url" autocomplete="url" />;`, Tsx: true},
+		{Code: `<input type="url" autocomplete="photo" />;`, Tsx: true},
+
+		// ---- Real-world component patterns ----
+		// Common login form composition.
+		{
+			Code: `function LoginForm() {
+				return (
+					<form>
+						<input type="text" autocomplete="username" />
+						<input type="password" autocomplete="current-password" />
+						<button type="submit">Login</button>
+					</form>
+				);
+			}`,
+			Tsx: true,
+		},
+		// Map over field config — common pattern for dynamic forms.
+		{
+			Code: `function DynamicForm({ fields }) {
+				return fields.map(f => <input key={f.id} autocomplete={f.autocomplete} />);
+			}`,
+			Tsx: true,
+		},
+		// Forwarded ref + custom Input mapped to input.
+		{
+			Code: `const Input = forwardRef((props, ref) => <input {...props} ref={ref} autocomplete="name" />);`,
+			Tsx:  true,
+		},
+		// Nested form with fieldset.
+		{
+			Code: `<form><fieldset><legend>Address</legend><input autocomplete="street-address" /></fieldset></form>`,
+			Tsx:  true,
+		},
+		// JSX as array element.
+		{
+			Code: `const inputs = [<input autocomplete="name" key="1" />, <input autocomplete="email" key="2" />];`,
+			Tsx:  true,
+		},
+		// JSX in object literal value.
+		{
+			Code: `const map = { name: <input autocomplete="name" />, email: <input autocomplete="email" /> };`,
+			Tsx:  true,
+		},
+		// JSX in default function parameter.
+		{
+			Code: `function F(child = <input autocomplete="name" />) { return child; }`,
+			Tsx:  true,
+		},
+
+		// ---- Multiple spread patterns ----
+		// Spread before named, then named overrides — first match wins
+		// per FindAttributeByName/getProp iteration order. Lock the
+		// "first wins" behavior.
+		{Code: `<input {...rest} autocomplete="name" />;`, Tsx: true},
+		// Named first, spread second — finds the named.
+		{Code: `<input autocomplete="name" {...rest} />;`, Tsx: true},
+		// Multiple spreads.
+		{Code: `<input {...a} {...b} autocomplete="name" />;`, Tsx: true},
+		// Spread of literal containing key + autocomplete.
+		{Code: `<input {...{key: "x", autocomplete: "name"}} />;`, Tsx: true},
+		// Duplicate autocomplete attributes — first wins.
+		{Code: `<input autocomplete="name" autocomplete="foo" />;`, Tsx: true},
+
+		// ---- Optional chaining and complex expression shapes ----
+		// Optional chain — tsgo flag-based; same kind as PropertyAccess.
+		// In LITERAL_TYPES this is noop → null → not a string → early
+		// return. Locks that optional chains don't accidentally produce
+		// a literal string.
+		{Code: `<input autocomplete={config?.autocomplete} />;`, Tsx: true},
+		{Code: `<input autocomplete={fn?.()} />;`, Tsx: true},
+		{Code: `<input autocomplete={a?.b?.c?.d} />;`, Tsx: true},
+		// Tagged template — TaggedTemplateExpression noop in
+		// LITERAL_TYPES; literalPropValue's default returns jsNull.
+		{Code: "<input autocomplete={tag`name`} />;", Tsx: true},
+		// New expression — null in LITERAL_TYPES.
+		{Code: `<input autocomplete={new String("name")} />;`, Tsx: true},
+		// `this` reference — ThisExpression noop in LITERAL_TYPES.
+		{Code: `<input autocomplete={this.value} />;`, Tsx: true},
+		// Class expression as autocomplete value — defensive.
+		{Code: `<input autocomplete={class {}} />;`, Tsx: true},
+		// Array literal as value.
+		{Code: `<input autocomplete={["name"]} />;`, Tsx: true},
+		// Object literal as value.
+		{Code: `<input autocomplete={{}} />;`, Tsx: true},
+		// Spread element via TS satisfies operator.
+		{Code: `<input autocomplete={"name" satisfies string} />;`, Tsx: true},
+		// TS non-null assertion.
+		{Code: `<input autocomplete={value!} />;`, Tsx: true},
+		// Multiple TS wrappers stacked — verifies all OEKAssertions
+		// bits (TypeAssertions, NonNullAssertions, Satisfies) and parens
+		// are stripped before extraction.
+		{Code: `<input autocomplete={(("name" as string) satisfies any)} />;`, Tsx: true},
+		// JsxExpression with surrounding comments — the parser strips
+		// leading/trailing comments inside the container, leaving just
+		// the inner literal.
+		{Code: `<input autocomplete={/* leading */ "name" /* trailing */} />;`, Tsx: true},
+	}
+
+	invalidCases := []rule_tester.InvalidTestCase{
+		// ---- Grammar-boundary lock-ins ----
+		// webauthn alone is invalid — pops to empty terms list.
+		{
+			Code: `<input autocomplete="webauthn" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// section- alone (after stripping the prefix) leaves no purpose token.
+		{
+			Code: `<input autocomplete="section-foo" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Bare "section-" (8 chars) is NOT stripped (length > 8 boundary),
+		// so it becomes the purpose token, which matches nothing → invalid.
+		// Locks the strict `> 8` upstream comparison.
+		{
+			Code: `<input autocomplete="section-" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Two consecutive locations — only one is consumed, leaving an
+		// unrecognized leftover.
+		{
+			Code: `<input autocomplete="billing shipping name" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Two consecutive qualifiers — second one isn't recognized and the
+		// terms.length !== 1 check fails.
+		{
+			Code: `<input autocomplete="home work tel" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// qualifier + standaloneTerm: after a qualifier upstream resets
+		// standaloneTerms = [], leaving only qualifiedTerms acceptable.
+		// "name" is a standaloneTerm, not qualified → invalid.
+		{
+			Code: `<input autocomplete="home name" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// qualifier alone — terms.length !== 1 (it's 0 after the qualifier
+		// shift) → invalid.
+		{
+			Code: `<input autocomplete="home" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// location alone — terms.length !== 1 (0 after shift) → invalid.
+		{
+			Code: `<input autocomplete="billing" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// section + location + qualifier without a final field-name token
+		// — leaves the qualifier shifted off, terms empty → invalid.
+		{
+			Code: `<input autocomplete="section-foo shipping work" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// `<Input autocomplete="baz" />` with NO type attribute, with the
+		// components-map mapping `Input` → `input`. Locks that the type
+		// attribute is irrelevant to autocomplete-valid (axe-core's
+		// autocomplete-valid-evaluate ignores it; only the separate
+		// autocomplete-appropriate rule consults it).
+		{
+			Code:     `<Input autocomplete="baz" />`,
+			Tsx:      true,
+			Settings: componentsSettings,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// polymorphicPropName resolves a polymorphic component TO `input`
+		// — the rule must run validation as if it were a bare <input>.
+		{
+			Code: `<Box as="input" autocomplete="foo" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Diagnostic position locking: upstream reports on the
+		// JSXOpeningElement node, which spans `<` through `>` of the opening
+		// tag. tsgo's JsxSelfClosingElement spans the whole self-closing tag
+		// including the trailing `/>`. Lock the position so a listener bleed
+		// would surface as a position drift.
+		{
+			Code: `<input autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 29,
+			}},
+		},
+		// Multi-line invalid attribute — report span extends across lines.
+		{
+			Code: "<input\n  autocomplete=\"foo\"\n/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+				Line:      1, Column: 1, EndLine: 3, EndColumn: 3,
+			}},
+		},
+		// Paired (non-self-closing) form — the JsxOpeningElement listener
+		// fires; span ends at `>` of the opening tag.
+		{
+			Code: `<input autocomplete="foo"></input>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 27,
+			}},
+		},
+		// Multiple invalid <input> elements at the same level — each one
+		// fires independently. Locks that the listener doesn't bleed.
+		{
+			Code: `<><input autocomplete="foo" /><input autocomplete="bar" /></>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "autocompleteValid", Message: failMessage},
+				{MessageId: "autocompleteValid", Message: failMessage},
+			},
+		},
+		// Mixed valid + invalid — only the invalid one reports.
+		{
+			Code: `<><input autocomplete="name" /><input autocomplete="foo" /></>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Uppercase invalid value — algorithm lowercases first, but the
+		// resulting "foo" still doesn't match anything.
+		{
+			Code: `<input autocomplete="FOO" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Whitespace around an invalid value: trim then split, "foo" → invalid.
+		{
+			Code: `<input autocomplete="  foo  " />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Spread-of-literal with invalid autocomplete — must report.
+		{
+			Code: `<input {...{autocomplete: "foo"}} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Type filter does NOT skip non-excluded types (so `type="text"`
+		// with invalid autocomplete still reports — already covered by the
+		// upstream cases, but explicitly anchor a non-excluded boundary).
+		{
+			Code: `<input type="email" autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Dynamic type (ConditionalExpression noop in LITERAL_TYPES) →
+		// type passed to axe-core as undefined → matches doesn't filter →
+		// check runs. Locks that we don't accidentally skip via a non-
+		// literal type.
+		{
+			Code: `<input type={cond ? "hidden" : "text"} autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Boolean type form (`<input type />`) — getLiteralPropValue
+		// returns boolean true, not a string → matches() doesn't filter.
+		{
+			Code: `<input type autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// TemplateExpression with substitutions — literalPropValue
+		// synthesizes a placeholder string ("name${Expression}" or similar)
+		// which doesn't match any token grammar → invalid. Locks the
+		// template-with-substitution path; upstream's TemplateLiteral
+		// extractor produces a similar non-token string.
+		{
+			Code: "<input autocomplete={`name${suffix}`} />",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// CRITICAL alignment lock: `<input autocomplete={`${undefined}`} />`.
+		// Pre-fix the synthesized text was bare "undefined" which is in
+		// axe-core's extended stateTerms — would have falsely passed.
+		// Post-fix the synthesized text is "${undefined}" which fails the
+		// token grammar → invalid → reported. Same as upstream.
+		{
+			Code: "<input autocomplete={`${undefined}`} />",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Template substitution with a non-undefined identifier —
+		// synthesizes "${name}" → not a token → invalid. Mirrors upstream.
+		{
+			Code: "<input autocomplete={`${dynVar}`} />",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Template with surrounding text + substitution.
+		{
+			Code: "<input autocomplete={`name ${suffix}`} />",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+
+		// ---- Attribute-name case-insensitive match (invalid path) ----
+		// Mirrors the case-folded match: any case form must trigger when
+		// the value is invalid.
+		{
+			Code: `<input autoComplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code: `<input AUTOCOMPLETE="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+
+		// ---- Duplicate attribute (first wins) ----
+		// `<input autocomplete="foo" autocomplete="name" />` — the FIRST
+		// match wins per getProp/FindAttributeByName iteration order, so
+		// the value seen by the rule is "foo" → INVALID. Locks the
+		// "first wins" semantics in the invalid direction.
+		{
+			Code: `<input autocomplete="foo" autocomplete="name" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Spread-of-literal duplicate: literal-spread with autocomplete:
+		// "foo" comes BEFORE the named autocomplete="name". Spread is
+		// scanned in order — its prop is found first → "foo" wins → INVALID.
+		{
+			Code: `<input {...{autocomplete: "foo"}} autocomplete="name" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+
+		// ---- ESLint plugin doesn't pass disabled/readonly/aria-* to
+		// runVirtualRule — these MUST NOT cause skipping. Locks that
+		// our impl doesn't accidentally implement matches() gates that
+		// upstream can't reach. ----
+		{
+			Code: `<input disabled autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code: `<input readOnly autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code: `<input aria-disabled="true" autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code: `<input aria-readonly="true" autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code: `<input tabIndex={-1} autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code: `<input role="presentation" autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+
+		// ---- Type filter with spread ----
+		// type via spread-of-literal: `{...{type: "hidden"}}` resolves
+		// the type to "hidden" → matches() filter applies → no report.
+		// (In invalid block to lock the FALSE direction: when type is
+		// NOT excluded via spread, validation runs.)
+		{
+			Code: `<input {...{type: "text"}} autocomplete="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+
+		// ---- Multi-element invalid lock ----
+		// Three sibling inputs with progressively complex bad values.
+		// Locks per-element fire and reporting order.
+		{
+			Code: `<><input autocomplete="foo" /><input autocomplete="name invalid" /><input autocomplete="home url" /></>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "autocompleteValid", Message: failMessage},
+				{MessageId: "autocompleteValid", Message: failMessage},
+				{MessageId: "autocompleteValid", Message: failMessage},
+			},
+		},
+
+		// ---- Edge grammar boundaries ----
+		// Two webauthn tokens: pop one → ["webauthn"] → not stateTerm, single
+		// term, "webauthn" not in any list → INVALID.
+		{
+			Code: `<input autocomplete="webauthn webauthn" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// section-* prefix appearing in second position — only the FIRST
+		// term gets the section- treatment. Second one is left as a
+		// regular token, fails grammar.
+		{
+			Code: `<input autocomplete="name section-foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Two sections: only the first is shifted, second stays.
+		{
+			Code: `<input autocomplete="section-a section-b name" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Trailing webauthn with too many tokens leftover.
+		{
+			Code: `<input autocomplete="name extra webauthn" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// JsxExpression with comments around an invalid literal — comments
+		// are stripped, "foo" is extracted, fails grammar.
+		{
+			Code: `<input autocomplete={/* leading */ "foo" /* trailing */} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// `satisfies` in attribute initializer — OEKAssertions includes
+		// the satisfies bit (probed empirically: `OEKAssertions = 38 = 32
+		// + 4 + 2`, where bit 5 is satisfies). Locks that satisfies is
+		// transparent in our extractor.
+		{
+			Code: `<input autocomplete={"foo" satisfies string} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		// Spread-of-literal with TS-wrapped value — wrapper stripped at
+		// the value, "foo" extracted via PropertyAssignment path.
+		{
+			Code: `<input {...{autocomplete: "foo" as const}} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AutocompleteValidRule, validCases, invalidCases)
+}

--- a/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid_upstream_test.go
@@ -1,0 +1,130 @@
+package autocomplete_valid
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// componentsSettings mirrors the upstream `componentsSettings` constant —
+// maps the custom JSX tag `Input` to the bare HTML `input` element so the
+// rule treats `<Input ... />` as a regular `<input>`.
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Input": "input",
+		},
+	},
+}
+
+// TestAutocompleteValidUpstream is a verbatim port of upstream's
+// `__tests__/src/rules/autocomplete-valid-test.js`. Each case below maps 1:1
+// to a case in the upstream file, in the same order, with the same code,
+// the same options, and the same expected verdict. Layout / section markers
+// preserve the upstream comments so a future audit against the upstream
+// file remains a trivial diff.
+//
+// Additional rslint lock-in tests (axe-core grammar boundaries,
+// JSX-shape variants, options-shape coverage, settings interaction, etc.)
+// live in `autocomplete_valid_extras_test.go` so this file stays a pure
+// reflection of upstream.
+func TestAutocompleteValidUpstream(t *testing.T) {
+	validCases := []rule_tester.ValidTestCase{
+		// INAPPLICABLE
+		{Code: `<input type="text" />;`, Tsx: true},
+
+		// PASSED AUTOCOMPLETE
+		{Code: `<input type="text" autocomplete="name" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="off" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="on" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="billing family-name" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="section-blue shipping street-address" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete="section-somewhere shipping work email" />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete />;`, Tsx: true},
+		// Upstream uses a truncated identifier name for this variable.
+		// Renamed here to `dynValue` to avoid a cspell false-positive
+		// on the truncated word; the AST shape and the rule's behavior
+		// are unchanged (any non-undefined Identifier exercises the
+		// same LITERAL_TYPES.Identifier noop branch).
+		{Code: `<input type="text" autocomplete={dynValue} />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete={dynValue || "name"} />;`, Tsx: true},
+		{Code: `<input type="text" autocomplete={dynValue || "foo"} />;`, Tsx: true},
+		{Code: `<Foo autocomplete="bar"></Foo>;`, Tsx: true},
+		{Code: `<input type={isEmail ? "email" : "text"} autocomplete="none" />;`, Tsx: true},
+		{
+			Code:     `<Input type="text" autocomplete="name" />`,
+			Tsx:      true,
+			Settings: componentsSettings,
+		},
+		{Code: `<Input type="text" autocomplete="baz" />`, Tsx: true},
+
+		// PASSED "autocomplete-appropriate"
+		// see also: https://github.com/dequelabs/axe-core/issues/2912
+		{Code: `<input type="date" autocomplete="email" />;`, Tsx: true},
+		{Code: `<input type="number" autocomplete="url" />;`, Tsx: true},
+		{Code: `<input type="month" autocomplete="tel" />;`, Tsx: true},
+		{
+			Code:    `<Foo type="month" autocomplete="tel"></Foo>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"inputComponents": []interface{}{"Foo"}},
+		},
+	}
+
+	invalidCases := []rule_tester.InvalidTestCase{
+		// FAILED "autocomplete-valid"
+		{
+			Code: `<input type="text" autocomplete="foo" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code: `<input type="text" autocomplete="name invalid" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code: `<input type="text" autocomplete="invalid name" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code: `<input type="text" autocomplete="home url" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code:    `<Bar autocomplete="baz"></Bar>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"inputComponents": []interface{}{"Bar"}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+		{
+			Code:     `<Input type="text" autocomplete="baz" />`,
+			Tsx:      true,
+			Settings: componentsSettings,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "autocompleteValid",
+				Message:   failMessage,
+			}},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AutocompleteValidRule, validCases, invalidCases)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -160,6 +160,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/anchor-has-content.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/aria-unsupported-elements.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts',
 
     // typescript-eslint
     './tests/typescript-eslint/rules/adjacent-overload-signatures.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts
@@ -1,0 +1,535 @@
+import { RuleTester } from '../rule-tester';
+
+// failMessage mirrors axe-core's `lib/checks/forms/autocomplete-valid.json`
+// `messages.fail` — the upstream ESLint rule extracts the same string via
+// `violations[0].nodes[0].all[0].message`.
+const failMessage = 'the autocomplete attribute is incorrectly formatted';
+
+const componentsSettings = {
+  'jsx-a11y': {
+    components: {
+      Input: 'input',
+    },
+  },
+};
+
+new RuleTester().run('autocomplete-valid', null as never, {
+  valid: [
+    // Upstream `valid` block — INAPPLICABLE / PASSED AUTOCOMPLETE.
+    { code: '<input type="text" />;' },
+    { code: '<input type="text" autocomplete="name" />;' },
+    { code: '<input type="text" autocomplete="" />;' },
+    { code: '<input type="text" autocomplete="off" />;' },
+    { code: '<input type="text" autocomplete="on" />;' },
+    { code: '<input type="text" autocomplete="billing family-name" />;' },
+    {
+      code: '<input type="text" autocomplete="section-blue shipping street-address" />;',
+    },
+    {
+      code: '<input type="text" autocomplete="section-somewhere shipping work email" />;',
+    },
+    { code: '<input type="text" autocomplete />;' },
+    { code: '<input type="text" autocomplete={dynValue} />;' },
+    { code: '<input type="text" autocomplete={dynValue || "name"} />;' },
+    { code: '<input type="text" autocomplete={dynValue || "foo"} />;' },
+    { code: '<Foo autocomplete="bar"></Foo>;' },
+    {
+      code: '<input type={isEmail ? "email" : "text"} autocomplete="none" />;',
+    },
+    {
+      code: '<Input type="text" autocomplete="name" />',
+      settings: componentsSettings,
+    },
+    { code: '<Input type="text" autocomplete="baz" />' },
+    // Upstream `valid` block — PASSED "autocomplete-appropriate" (these are
+    // syntactically valid; only the separate autocomplete-appropriate axe-core
+    // rule would flag them, and the ESLint plugin doesn't run that rule).
+    { code: '<input type="date" autocomplete="email" />;' },
+    { code: '<input type="number" autocomplete="url" />;' },
+    { code: '<input type="month" autocomplete="tel" />;' },
+    {
+      code: '<Foo type="month" autocomplete="tel"></Foo>;',
+      options: [{ inputComponents: ['Foo'] }],
+    },
+
+    // Extra rslint lockdowns:
+    // axe-core's extended stateTerms — every entry must accept.
+    { code: '<input autocomplete="none" />;' },
+    { code: '<input autocomplete="false" />;' },
+    { code: '<input autocomplete="true" />;' },
+    { code: '<input autocomplete="disabled" />;' },
+    { code: '<input autocomplete="enabled" />;' },
+    { code: '<input autocomplete="undefined" />;' },
+    { code: '<input autocomplete="null" />;' },
+    { code: '<input autocomplete="xoff" />;' },
+    { code: '<input autocomplete="xon" />;' },
+    // ignoredValues — axe-core returns "incomplete" (undefined), not a
+    // violation, so the ESLint plugin reports nothing.
+    { code: '<input autocomplete="text" />;' },
+    { code: '<input autocomplete="pronouns" />;' },
+    { code: '<input autocomplete="gender" />;' },
+    { code: '<input autocomplete="message" />;' },
+    { code: '<input autocomplete="content" />;' },
+    // Case-insensitivity.
+    { code: '<input autocomplete="NAME" />;' },
+    { code: '<input autocomplete="OFF" />;' },
+    { code: '<input autocomplete="Section-Blue Shipping Street-Address" />;' },
+    // Whitespace handling: trim + \s+ split.
+    { code: '<input autocomplete="   name   " />;' },
+    { code: '<input autocomplete="  " />;' },
+    { code: '<input autocomplete="billing  family-name" />;' },
+    // webauthn after a valid token.
+    { code: '<input autocomplete="name webauthn" />;' },
+    { code: '<input autocomplete="shipping street-address webauthn" />;' },
+    { code: '<input autocomplete="home email webauthn" />;' },
+    // Qualified term combinations.
+    { code: '<input autocomplete="home tel" />;' },
+    { code: '<input autocomplete="work email" />;' },
+    { code: '<input autocomplete="mobile tel-extension" />;' },
+    { code: '<input autocomplete="fax impp" />;' },
+    { code: '<input autocomplete="pager tel-country-code" />;' },
+    // All optional prefixes used at once.
+    { code: '<input autocomplete="section-payment billing home tel" />;' },
+    // Section- length boundary on the valid side: 9-char prefix stripped.
+    { code: '<input autocomplete="section-x name" />;' },
+    // JSX shape variants.
+    { code: '<input autocomplete="name"></input>' },
+    { code: '<input autocomplete="name"/>' },
+    // Spread props mixed with literal autocomplete.
+    { code: '<input {...rest} autocomplete="name" />;' },
+    // JsxExpression wrapping a literal.
+    { code: '<input autocomplete={"name"} />;' },
+    { code: '<input autocomplete={`name`} />;' },
+    // TS wrappers.
+    { code: '<input autocomplete={"name" as const} />;' },
+    { code: '<input autocomplete={("name")} />;' },
+    // Components map points at a non-input HTML tag.
+    {
+      code: '<Block autocomplete="foo" />',
+      settings: { 'jsx-a11y': { components: { Block: 'div' } } },
+    },
+    // polymorphicPropName resolves a polymorphic component to a non-input.
+    {
+      code: '<Box as="div" autocomplete="foo" />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+    },
+    // Non-input elements with autocomplete are silently passed through.
+    { code: '<select autocomplete="foo" />;' },
+    { code: '<textarea autocomplete="foo" />;' },
+    { code: '<button autocomplete="foo" />;' },
+    // Member-expression / namespaced tag names — neither matches "input".
+    { code: '<Foo.input autocomplete="foo" />;' },
+    { code: '<svg:input autocomplete="foo" />;' },
+    // Empty inputComponents array.
+    { code: '<Foo autocomplete="foo" />;', options: [{ inputComponents: [] }] },
+    // Literal `null` autocomplete coerces to the string "null" (in stateTerms).
+    { code: '<input autocomplete={null} />;' },
+    // CallExpression / MemberExpression / Conditional inside JsxExpression.
+    { code: '<input autocomplete={getValue()} />;' },
+    { code: '<input autocomplete={config.autocomplete} />;' },
+    { code: '<input autocomplete={cond ? "name" : "foo"} />;' },
+    // Multi-line JSX with valid literal autocomplete.
+    { code: '<input\n  type="text"\n  autocomplete="name"\n/>' },
+
+    // axe-core matches() type-filter: excluded input types skip the check
+    // even with an invalid autocomplete value.
+    { code: '<input type="hidden" autocomplete="foo" />;' },
+    { code: '<input type="submit" autocomplete="foo" />;' },
+    { code: '<input type="reset" autocomplete="invalid garbage" />;' },
+    { code: '<input type="button" autocomplete="bogus" />;' },
+    // Case-insensitive on type comparison.
+    { code: '<input type="HIDDEN" autocomplete="foo" />;' },
+    { code: '<input type="Submit" autocomplete="foo" />;' },
+    // Literal type via JsxExpression / template.
+    { code: '<input type={"hidden"} autocomplete="foo" />;' },
+    { code: '<input type={`hidden`} autocomplete="foo" />;' },
+    { code: '<input type={"hidden" as const} autocomplete="foo" />;' },
+    // Custom inputComponent with excluded type.
+    {
+      code: '<MyInput type="hidden" autocomplete="foo" />;',
+      options: [{ inputComponents: ['MyInput'] }],
+    },
+    // Components-map mapping with excluded type.
+    {
+      code: '<Input type="submit" autocomplete="baz" />',
+      settings: componentsSettings,
+    },
+
+    // Spread-of-literal lockdowns.
+    { code: '<input {...{autocomplete: "name"}} />;' },
+    { code: '<input {...{autocomplete}} />;' },
+
+    // Logical short-circuit lockdowns.
+    { code: '<input autocomplete={cond && "name"} />;' },
+    { code: '<input autocomplete={x ?? "name"} />;' },
+
+    // Deeply-nested JSX patterns.
+    {
+      code: 'function L({xs}) { return xs.map(x => <input autocomplete="name" key={x} />); }',
+    },
+    {
+      code: 'function F() { return <div>{cond && <input autocomplete="name" />}</div>; }',
+    },
+    {
+      code: 'function f<T>(x: T) { return <input autocomplete="name" />; }',
+    },
+    { code: '<form><input autocomplete="name" /></form>' },
+    { code: '<><><input autocomplete="name" /></></>' },
+    {
+      code: 'function F() { useEffect(() => { renderer(<input autocomplete="name" />); }); }',
+    },
+
+    // Tab / newline whitespace handling.
+    { code: '<input autocomplete="home\ttel" />' },
+    { code: '<input autocomplete="name\nwebauthn" />' },
+
+    // Attribute-name case-insensitive match — both HTML-correct and
+    // React-camelCase forms must trigger.
+    { code: '<input autoComplete="name" />;' },
+    { code: '<input AUTOCOMPLETE="name" />;' },
+    { code: '<input AutoComplete="name" />;' },
+    { code: '<input autoComplete={dynamicValue} />;' },
+
+    // Real-world login form patterns: every standalone term we ship.
+    { code: '<input type="text" autocomplete="username" />;' },
+    { code: '<input type="password" autocomplete="current-password" />;' },
+    { code: '<input type="password" autocomplete="new-password" />;' },
+    { code: '<input type="text" autocomplete="one-time-code" />;' },
+    { code: '<input type="text" autocomplete="street-address" />;' },
+    { code: '<input type="text" autocomplete="address-line1" />;' },
+    { code: '<input type="text" autocomplete="address-line2" />;' },
+    { code: '<input type="text" autocomplete="address-line3" />;' },
+    { code: '<input type="text" autocomplete="address-level1" />;' },
+    { code: '<input type="text" autocomplete="address-level2" />;' },
+    { code: '<input type="text" autocomplete="address-level3" />;' },
+    { code: '<input type="text" autocomplete="address-level4" />;' },
+    { code: '<input type="text" autocomplete="country" />;' },
+    { code: '<input type="text" autocomplete="country-name" />;' },
+    { code: '<input type="text" autocomplete="postal-code" />;' },
+    { code: '<input type="text" autocomplete="honorific-prefix" />;' },
+    { code: '<input type="text" autocomplete="given-name" />;' },
+    { code: '<input type="text" autocomplete="additional-name" />;' },
+    { code: '<input type="text" autocomplete="family-name" />;' },
+    { code: '<input type="text" autocomplete="honorific-suffix" />;' },
+    { code: '<input type="text" autocomplete="nickname" />;' },
+    { code: '<input type="text" autocomplete="organization-title" />;' },
+    { code: '<input type="text" autocomplete="organization" />;' },
+    { code: '<input type="date" autocomplete="bday" />;' },
+    { code: '<input type="number" autocomplete="bday-day" />;' },
+    { code: '<input type="number" autocomplete="bday-month" />;' },
+    { code: '<input type="number" autocomplete="bday-year" />;' },
+    { code: '<input type="text" autocomplete="sex" />;' },
+    { code: '<input type="text" autocomplete="cc-name" />;' },
+    { code: '<input type="text" autocomplete="cc-given-name" />;' },
+    { code: '<input type="text" autocomplete="cc-additional-name" />;' },
+    { code: '<input type="text" autocomplete="cc-family-name" />;' },
+    { code: '<input type="text" autocomplete="cc-number" />;' },
+    { code: '<input type="text" autocomplete="cc-exp" />;' },
+    { code: '<input type="text" autocomplete="cc-exp-month" />;' },
+    { code: '<input type="text" autocomplete="cc-exp-year" />;' },
+    { code: '<input type="text" autocomplete="cc-csc" />;' },
+    { code: '<input type="text" autocomplete="cc-type" />;' },
+    { code: '<input type="text" autocomplete="transaction-currency" />;' },
+    { code: '<input type="number" autocomplete="transaction-amount" />;' },
+    { code: '<input type="text" autocomplete="language" />;' },
+    { code: '<input type="url" autocomplete="url" />;' },
+    { code: '<input type="url" autocomplete="photo" />;' },
+
+    // Real-world component patterns.
+    {
+      code: 'function LoginForm() { return (<form><input type="text" autocomplete="username" /><input type="password" autocomplete="current-password" /><button type="submit">Login</button></form>); }',
+    },
+    {
+      code: 'function DynamicForm({ fields }) { return fields.map(f => <input key={f.id} autocomplete={f.autocomplete} />); }',
+    },
+    {
+      code: 'const Input = forwardRef((props, ref) => <input {...props} ref={ref} autocomplete="name" />);',
+    },
+    {
+      code: '<form><fieldset><legend>Address</legend><input autocomplete="street-address" /></fieldset></form>',
+    },
+    {
+      code: 'const inputs = [<input autocomplete="name" key="1" />, <input autocomplete="email" key="2" />];',
+    },
+    {
+      code: 'const map = { name: <input autocomplete="name" />, email: <input autocomplete="email" /> };',
+    },
+    {
+      code: 'function F(child = <input autocomplete="name" />) { return child; }',
+    },
+
+    // Spread interaction patterns (first wins).
+    { code: '<input autocomplete="name" {...rest} />;' },
+    { code: '<input {...a} {...b} autocomplete="name" />;' },
+    { code: '<input {...{key: "x", autocomplete: "name"}} />;' },
+    { code: '<input autocomplete="name" autocomplete="foo" />;' },
+
+    // Optional chaining and complex expression shapes.
+    { code: '<input autocomplete={config?.autocomplete} />;' },
+    { code: '<input autocomplete={fn?.()} />;' },
+    { code: '<input autocomplete={a?.b?.c?.d} />;' },
+    { code: '<input autocomplete={tag`name`} />;' },
+    { code: '<input autocomplete={new String("name")} />;' },
+    { code: '<input autocomplete={this.value} />;' },
+    { code: '<input autocomplete={class {}} />;' },
+    { code: '<input autocomplete={["name"]} />;' },
+    { code: '<input autocomplete={{}} />;' },
+    { code: '<input autocomplete={"name" satisfies string} />;' },
+    { code: '<input autocomplete={value!} />;' },
+    { code: '<input autocomplete={(("name" as string) satisfies any)} />;' },
+    { code: '<input autocomplete={/* leading */ "name" /* trailing */} />;' },
+  ],
+  invalid: [
+    // Upstream `invalid` block.
+    {
+      code: '<input type="text" autocomplete="foo" />;',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input type="text" autocomplete="name invalid" />;',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input type="text" autocomplete="invalid name" />;',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input type="text" autocomplete="home url" />;',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<Bar autocomplete="baz"></Bar>;',
+      options: [{ inputComponents: ['Bar'] }],
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<Input type="text" autocomplete="baz" />',
+      settings: componentsSettings,
+      errors: [{ message: failMessage }],
+    },
+
+    // Extra grammar-boundary lockdowns.
+    // webauthn alone is invalid.
+    {
+      code: '<input autocomplete="webauthn" />;',
+      errors: [{ message: failMessage }],
+    },
+    // section- alone (after stripping prefix) leaves no purpose token.
+    {
+      code: '<input autocomplete="section-foo" />;',
+      errors: [{ message: failMessage }],
+    },
+    // Bare "section-" (8 chars, NOT stripped — length must be > 8).
+    {
+      code: '<input autocomplete="section-" />;',
+      errors: [{ message: failMessage }],
+    },
+    // Two consecutive locations.
+    {
+      code: '<input autocomplete="billing shipping name" />;',
+      errors: [{ message: failMessage }],
+    },
+    // Two consecutive qualifiers.
+    {
+      code: '<input autocomplete="home work tel" />;',
+      errors: [{ message: failMessage }],
+    },
+    // qualifier + standaloneTerm — only qualifiedTerms allowed after a qualifier.
+    {
+      code: '<input autocomplete="home name" />;',
+      errors: [{ message: failMessage }],
+    },
+    // qualifier alone — no purpose token.
+    {
+      code: '<input autocomplete="home" />;',
+      errors: [{ message: failMessage }],
+    },
+    // location alone — no purpose token.
+    {
+      code: '<input autocomplete="billing" />;',
+      errors: [{ message: failMessage }],
+    },
+    // section + location + qualifier without final field-name token.
+    {
+      code: '<input autocomplete="section-foo shipping work" />;',
+      errors: [{ message: failMessage }],
+    },
+    // <Input autocomplete="baz"> WITHOUT a type attribute, with components map
+    // — locks that the type attribute does not affect autocomplete-valid.
+    {
+      code: '<Input autocomplete="baz" />',
+      settings: componentsSettings,
+      errors: [{ message: failMessage }],
+    },
+    // polymorphic resolves to <input>.
+    {
+      code: '<Box as="input" autocomplete="foo" />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+      errors: [{ message: failMessage }],
+    },
+    // Multiple invalid <input> elements at the same level.
+    {
+      code: '<><input autocomplete="foo" /><input autocomplete="bar" /></>',
+      errors: [{ message: failMessage }, { message: failMessage }],
+    },
+    // Mixed valid + invalid — only the invalid one reports.
+    {
+      code: '<><input autocomplete="name" /><input autocomplete="foo" /></>',
+      errors: [{ message: failMessage }],
+    },
+    // Uppercase invalid value.
+    {
+      code: '<input autocomplete="FOO" />',
+      errors: [{ message: failMessage }],
+    },
+    // Whitespace around an invalid value.
+    {
+      code: '<input autocomplete="  foo  " />',
+      errors: [{ message: failMessage }],
+    },
+    // Paired (non-self-closing) form.
+    {
+      code: '<input autocomplete="foo"></input>',
+      errors: [{ message: failMessage }],
+    },
+    // Multi-line invalid attribute.
+    {
+      code: '<input\n  autocomplete="foo"\n/>',
+      errors: [{ message: failMessage }],
+    },
+    // Spread-of-literal with invalid autocomplete — must report.
+    {
+      code: '<input {...{autocomplete: "foo"}} />',
+      errors: [{ message: failMessage }],
+    },
+    // Non-excluded type still reports.
+    {
+      code: '<input type="email" autocomplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+    // Dynamic type → undefined to axe-core → check still runs.
+    {
+      code: '<input type={cond ? "hidden" : "text"} autocomplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+    // Boolean type form — getLiteralPropValue returns true (not a string),
+    // so the type filter doesn't skip.
+    {
+      code: '<input type autocomplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+    // TemplateExpression with substitutions — synthesized placeholder string fails grammar.
+    {
+      code: '<input autocomplete={`name${suffix}`} />',
+      errors: [{ message: failMessage }],
+    },
+    // CRITICAL alignment lock: `${undefined}` template substitution.
+    // Pre-fix would synthesize bare "undefined" → match extended stateTerm
+    // → false valid. Post-fix synthesizes "${undefined}" → invalid.
+    {
+      code: '<input autocomplete={`${undefined}`} />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input autocomplete={`${dynVar}`} />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input autocomplete={`name ${suffix}`} />',
+      errors: [{ message: failMessage }],
+    },
+
+    // Attribute name case variants.
+    {
+      code: '<input autoComplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input AUTOCOMPLETE="foo" />',
+      errors: [{ message: failMessage }],
+    },
+
+    // Duplicate attribute first wins.
+    {
+      code: '<input autocomplete="foo" autocomplete="name" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input {...{autocomplete: "foo"}} autocomplete="name" />',
+      errors: [{ message: failMessage }],
+    },
+
+    // disabled / readonly / aria-* / tabindex / role NOT excluded —
+    // upstream's runVirtualRule call doesn't forward them to axe-core.
+    {
+      code: '<input disabled autocomplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input readOnly autocomplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input aria-disabled="true" autocomplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input aria-readonly="true" autocomplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input tabIndex={-1} autocomplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input role="presentation" autocomplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+
+    // Type via spread that resolves to a non-excluded type → check runs.
+    {
+      code: '<input {...{type: "text"}} autocomplete="foo" />',
+      errors: [{ message: failMessage }],
+    },
+
+    // Multi-element with progressively complex bad values.
+    {
+      code: '<><input autocomplete="foo" /><input autocomplete="name invalid" /><input autocomplete="home url" /></>',
+      errors: [
+        { message: failMessage },
+        { message: failMessage },
+        { message: failMessage },
+      ],
+    },
+
+    // Grammar boundaries.
+    {
+      code: '<input autocomplete="webauthn webauthn" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input autocomplete="name section-foo" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input autocomplete="section-a section-b name" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input autocomplete="name extra webauthn" />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input autocomplete={/* leading */ "foo" /* trailing */} />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input autocomplete={"foo" satisfies string} />',
+      errors: [{ message: failMessage }],
+    },
+    {
+      code: '<input {...{autocomplete: "foo" as const}} />',
+      errors: [{ message: failMessage }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -389,3 +389,7 @@ valuemax
 valuemin
 valuenow
 valuetext
+WHATWG
+tabindex
+webauthn
+xoff


### PR DESCRIPTION
## Summary

Port `jsx-a11y/autocomplete-valid` from `eslint-plugin-jsx-a11y` to rslint.
The rule validates the `autocomplete` attribute on form input elements,
mirroring axe-core's `is-valid-autocomplete` algorithm plus the rule's
`stateTerms` / `ignoredValues` extension and matches() type filter.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/autocomplete-valid.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/autocomplete-valid.js
- axe-core algorithm: https://github.com/dequelabs/axe-core/blob/develop/lib/commons/text/is-valid-autocomplete.js
- axe-core matches: https://github.com/dequelabs/axe-core/blob/develop/lib/commons/forms/autocomplete-matches.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).