### PR TITLE
feat: port rule jsx-a11y/anchor-is-valid

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -3,6 +3,7 @@ package jsx_a11y_plugin
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/alt_text"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/anchor_has_content"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/anchor_is_valid"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_unsupported_elements"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/autocomplete_valid"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/img_redundant_alt"
@@ -13,6 +14,7 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		alt_text.AltTextRule,
 		anchor_has_content.AnchorHasContentRule,
+		anchor_is_valid.AnchorIsValidRule,
 		aria_unsupported_elements.AriaUnsupportedElementsRule,
 		autocomplete_valid.AutocompleteValidRule,
 		img_redundant_alt.ImgRedundantAltRule,

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -19,6 +19,41 @@ import (
 // extracting prop values; we mirror that with the standard rslint helper.
 const skipTransparent = ast.OEKParentheses | ast.OEKAssertions
 
+// StringSliceOption coerces a JSON-decoded option value into `[]string`,
+// silently dropping any non-string entries. It is the standard helper for
+// the `components: string[]` / `elements: string[]` / `specialLink:
+// string[]` / `<element>: string[]` shapes that appear across jsx-a11y
+// rule options (anchor-has-content, anchor-is-valid, alt-text, …).
+//
+// Returns:
+//   - `nil` when `v` is not a `[]interface{}` (absent option, wrong type).
+//     Callers should treat `nil` the same as upstream's `||` fallback —
+//     i.e. apply the rule's default. An EXPLICIT empty array is a
+//     deliberate "disable all" signal and is returned as a non-nil
+//     zero-length slice; this matters for rules whose semantics differ
+//     between "absent" and "explicit []".
+//   - a freshly-allocated `[]string` containing only the string entries
+//     of `v`, in order. Non-string entries (numbers, nested arrays,
+//     objects) are dropped — upstream's options validate via JSON schema
+//     so we only see well-typed values in practice; the filter is purely
+//     defensive.
+//
+// Single source of truth for this pattern; do NOT inline-loop a fresh copy
+// in a new rule.
+func StringSliceOption(v interface{}) []string {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 // FindAttributeByName returns the first JsxAttribute whose name matches `name`
 // case-insensitively, mirroring jsx-ast-utils' `getProp` with its default
 // `{ ignoreCase: true }`.
@@ -378,6 +413,50 @@ func LiteralPropStringValue(attr *ast.Node) (string, bool) {
 		return v.Str, true
 	}
 	return "", false
+}
+
+// PropValueIsNullish mirrors the upstream `getPropValue(prop) == null` check
+// (loose equality with `null`, true for both `null` and `undefined`). Used by
+// rules that distinguish "no usable href" (absent prop, `prop={null}`,
+// `prop={undefined}`) from "href provided" (anything else, including boolean
+// `<a href />`, `prop={true}`, `prop={"foo"}`, `prop={someVar}`, calls,
+// member access, etc.).
+//
+// Returns true when:
+//   - `attr` is nil — `getProp` would have returned a missing prop, and
+//     `getPropValue(undefined)` evaluates to `undefined`.
+//   - the prop's value statically resolves to `null` or `undefined`. This
+//     covers `prop={null}`, `prop={undefined}`, and the TS-wrapped variants
+//     `prop={null as any}` / `prop={undefined!}` (skipTransparent unwraps
+//     parens + assertion wrappers per jsx-ast-utils' extract loop).
+//
+// Returns false for:
+//   - boolean form `<a prop />` — upstream maps the null-attribute-value to
+//     boolean `true`, which is `!= null`.
+//   - any non-nullish static value (string, number, boolean, function,
+//     truthy synthesized strings for member access / calls, etc.).
+//   - any expression staticEval can't resolve — these get jvUnknown, which
+//     upstream's getPropValue would have approximated with a non-null
+//     synthesized string. Treating jvUnknown as non-nullish matches the
+//     "value != null" branch upstream would take.
+func PropValueIsNullish(attr *ast.Node) bool {
+	if attr == nil {
+		return true
+	}
+	if AttributeIsBooleanForm(attr) {
+		return false
+	}
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		// Empty `{}` JsxExpression — tsgo synthesizes this only for malformed
+		// source. Upstream's parser would have errored out earlier; we treat
+		// it conservatively as non-nullish so the element still routes
+		// through the hasAnyHref branch (matches the "we don't know, but
+		// the developer wrote SOMETHING" default of staticEval's jvUnknown).
+		return false
+	}
+	v := staticEval(inner)
+	return v.Kind == jvNull || v.Kind == jvUndef
 }
 
 // LiteralPropTruthy mirrors `!!getLiteralPropValue(prop)`. Returns true when

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -425,20 +425,25 @@ func LiteralPropStringValue(attr *ast.Node) (string, bool) {
 // Returns true when:
 //   - `attr` is nil — `getProp` would have returned a missing prop, and
 //     `getPropValue(undefined)` evaluates to `undefined`.
+//   - the prop's value is an empty JsxExpression (`prop={}`) — tsgo accepts
+//     this for error-recovery, but jsx-ast-utils' expressions extractor has
+//     no entry for `JSXEmptyExpression` and falls through to its
+//     `TYPES[type] === undefined → return null` path, which is `== null`.
 //   - the prop's value statically resolves to `null` or `undefined`. This
 //     covers `prop={null}`, `prop={undefined}`, and the TS-wrapped variants
 //     `prop={null as any}` / `prop={undefined!}` (skipTransparent unwraps
 //     parens + assertion wrappers per jsx-ast-utils' extract loop).
+//   - staticEval cannot resolve the expression at all (`jvUnknown`). This
+//     mirrors jsx-ast-utils returning `null` for unrecognized expression
+//     types via the same fallback path. Producing this state is rare in
+//     practice (most "I don't know" arms in staticEval fall through to
+//     jsNull explicitly); kept here for defensive parity.
 //
 // Returns false for:
 //   - boolean form `<a prop />` — upstream maps the null-attribute-value to
 //     boolean `true`, which is `!= null`.
 //   - any non-nullish static value (string, number, boolean, function,
 //     truthy synthesized strings for member access / calls, etc.).
-//   - any expression staticEval can't resolve — these get jvUnknown, which
-//     upstream's getPropValue would have approximated with a non-null
-//     synthesized string. Treating jvUnknown as non-nullish matches the
-//     "value != null" branch upstream would take.
 func PropValueIsNullish(attr *ast.Node) bool {
 	if attr == nil {
 		return true
@@ -448,15 +453,15 @@ func PropValueIsNullish(attr *ast.Node) bool {
 	}
 	inner := attributeInnerExpression(attr)
 	if inner == nil {
-		// Empty `{}` JsxExpression — tsgo synthesizes this only for malformed
-		// source. Upstream's parser would have errored out earlier; we treat
-		// it conservatively as non-nullish so the element still routes
-		// through the hasAnyHref branch (matches the "we don't know, but
-		// the developer wrote SOMETHING" default of staticEval's jvUnknown).
-		return false
+		// Empty `{}` JsxExpression (or expression-container holding only
+		// trivia). jsx-ast-utils routes JSXEmptyExpression through its
+		// "type not in TYPES" fallback → returns null. We mirror that —
+		// `null != null` is false, so the prop contributes nothing to
+		// `hasAnyHref` and the element correctly trips the noHref aspect.
+		return true
 	}
 	v := staticEval(inner)
-	return v.Kind == jvNull || v.Kind == jvUndef
+	return v.Kind == jvNull || v.Kind == jvUndef || v.Kind == jvUnknown
 }
 
 // LiteralPropTruthy mirrors `!!getLiteralPropValue(prop)`. Returns true when

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -13,11 +13,26 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// skipTransparent unwraps parentheses + TS assertion wrappers (`as`, `!`,
-// `<T>`, `satisfies`). Upstream's jsx-ast-utils explicitly walks past
-// `TSAsExpression` and TSNonNullExpression / TSSatisfies wrappers when
-// extracting prop values; we mirror that with the standard rslint helper.
-const skipTransparent = ast.OEKParentheses | ast.OEKAssertions
+// skipTransparent is the wrapper mask used by `staticEval` (the
+// `getPropValue` / TYPES path). Strips parentheses, type assertions
+// (`as` / `<T>x` / `TypeCastExpression`), and non-null assertions (`!`),
+// because upstream's jsx-ast-utils does the equivalent:
+//
+//   - parens are flattened by ESTree's parser; tsgo preserves them, so
+//     stripping is needed for parity.
+//   - `TSAsExpression` is unwrapped via the while-loop in
+//     `extractValueFromExpression`.
+//   - `TSNonNullExpression` has its own TYPES extractor that recurses
+//     into `.expression`, equivalent to stripping.
+//
+// `OEKSatisfies` is INTENTIONALLY EXCLUDED. Upstream's `TYPES` table has
+// no entry for `TSSatisfiesExpression`, so it falls to the
+// `TYPES[type] === undefined → return null` branch. Keeping satisfies
+// opaque here makes it land on `staticEval`'s default `jsNull` arm,
+// matching upstream's null exactly. Used only by `staticEval`; the
+// `getLiteralPropValue` (`literalPropValue`) and `getProp` paths strip
+// parens only — see those callers.
+const skipTransparent = ast.OEKParentheses | ast.OEKTypeAssertions | ast.OEKNonNullAssertions
 
 // StringSliceOption coerces a JSON-decoded option value into `[]string`,
 // silently dropping any non-string entries. It is the standard helper for

--- a/internal/plugins/jsx_a11y/rules/alt_text/alt_text.go
+++ b/internal/plugins/jsx_a11y/rules/alt_text/alt_text.go
@@ -61,35 +61,21 @@ func parseOptions(raw any) options {
 	}
 
 	if rawElements, ok := m["elements"]; ok {
-		if arr, ok := rawElements.([]interface{}); ok {
-			elements := make([]string, 0, len(arr))
-			for _, v := range arr {
-				if s, ok := v.(string); ok {
-					elements = append(elements, s)
-				}
-			}
-			// Upstream falls through to DEFAULT_ELEMENTS via `||` only when
-			// `options.elements` is falsy (undefined / null / "" / []). An
-			// explicitly-empty array therefore disables ALL element checks —
-			// match that semantic.
+		// Upstream falls through to DEFAULT_ELEMENTS via `||` only when
+		// `options.elements` is falsy (undefined / null / "" / []). An
+		// explicitly-empty array IS truthy in JS, so it replaces the
+		// default and disables ALL element checks. The `ok` guard is the
+		// "absent vs present" distinction; StringSliceOption returns a
+		// (possibly empty) `[]string` for any present `[]interface{}`.
+		if elements := jsxa11yutil.StringSliceOption(rawElements); elements != nil {
 			opts.elements = elements
 		}
 	}
 
 	opts.customComponents = make(map[string][]string)
 	for _, element := range opts.elements {
-		if rawList, ok := m[element]; ok {
-			if arr, ok := rawList.([]interface{}); ok {
-				list := make([]string, 0, len(arr))
-				for _, v := range arr {
-					if s, ok := v.(string); ok {
-						list = append(list, s)
-					}
-				}
-				if len(list) > 0 {
-					opts.customComponents[element] = list
-				}
-			}
+		if list := jsxa11yutil.StringSliceOption(m[element]); len(list) > 0 {
+			opts.customComponents[element] = list
 		}
 	}
 	return opts

--- a/internal/plugins/jsx_a11y/rules/alt_text/alt_text_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/alt_text/alt_text_extras_test.go
@@ -320,9 +320,11 @@ func TestAltTextExtras(t *testing.T) {
 		// the `=== true` check in upstream's isHiddenFromScreenReader.
 		{Code: `<object><div aria-hidden={someVar}>x</div></object>`, Tsx: true},
 
-		// ---- TS-only wrappers (`as` / `!` / `satisfies`) — Go-impl specific ----
+		// ---- TS-only wrappers (`as` / `!`) — Go-impl specific ----
 		// Verified via real rslint binary. Each shape unwraps to its inner
-		// expression via OEKParentheses|OEKAssertions.
+		// expression via skipTransparent (parens + type assertions +
+		// non-null assertions). `satisfies` is intentionally EXCLUDED — see
+		// the invalid section below for the lock-in.
 		// `altText!` — non-null assertion on a value-bearing identifier.
 		{Code: `<img alt={altText!} />`, Tsx: true},
 		// `altText as string` — type assertion.
@@ -333,8 +335,6 @@ func TestAltTextExtras(t *testing.T) {
 		{Code: `<img alt={"foo" as string} />`, Tsx: true},
 		// Empty string under `as` — extracts to "" → valid via `=== ''`.
 		{Code: `<img alt={"" as string} />`, Tsx: true},
-		// `satisfies` wrapping a string literal.
-		{Code: `<img alt={"foo" satisfies string} />`, Tsx: true},
 		// `as const` on a literal — still a literal "x" → valid.
 		{Code: `<img alt="" role={"presentation" as const} />`, Tsx: true},
 
@@ -812,6 +812,19 @@ func TestAltTextExtras(t *testing.T) {
 		// `undefined satisfies undefined` — same.
 		{
 			Code: `<img alt={undefined satisfies undefined} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
+			},
+		},
+		// `"foo" satisfies string` — even a truthy literal under `satisfies`
+		// is null per upstream's TYPES table (no `TSSatisfiesExpression`
+		// extractor). staticEval excludes `OEKSatisfies` from
+		// skipTransparent, so satisfies-wrapped values fall to the default
+		// `jsNull` arm. Locks in alignment after the satisfies-stripping
+		// fix.
+		{
+			Code: `<img alt={"foo" satisfies string} />`,
 			Tsx:  true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},

--- a/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content.go
@@ -31,17 +31,7 @@ func parseOptions(raw any) options {
 	if m == nil {
 		return opts
 	}
-	if rawComponents, ok := m["components"]; ok {
-		if arr, ok := rawComponents.([]interface{}); ok {
-			comps := make([]string, 0, len(arr))
-			for _, v := range arr {
-				if s, ok := v.(string); ok {
-					comps = append(comps, s)
-				}
-			}
-			opts.components = comps
-		}
-	}
+	opts.components = jsxa11yutil.StringSliceOption(m["components"])
 	return opts
 }
 

--- a/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.go
@@ -1,0 +1,243 @@
+// Package anchor_is_valid ports eslint-plugin-jsx-a11y's `anchor-is-valid`
+// rule. The rule enforces that <a> elements (and any configured custom
+// components) function as proper hyperlinks — every anchor should either
+// carry a valid, navigable href, or be replaced with a <button> when used
+// as a click target.
+//
+// Three independent aspects can be enabled / disabled via options:
+//
+//   - noHref         — require an href-like prop to be present.
+//   - invalidHref    — reject `""`, `"#"`, and `javascript:` URL strings.
+//   - preferButton   — when an onClick is present, recommend <button>.
+//
+// All three are active by default. The rule reports at most one diagnostic
+// per element; aspect ordering and the onClick interaction follow upstream
+// (see the comments inside the listener for the exact precedence).
+package anchor_is_valid
+
+import (
+	"regexp"
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	preferButtonErrorMessage = "Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md"
+	noHrefErrorMessage       = "The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md"
+	invalidHrefErrorMessage  = "The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md"
+)
+
+// jsHrefPattern mirrors upstream's `safeRegexTest(/^\W*?javascript:/)`. The
+// lazy `\W*?` lets a stray non-word prefix (whitespace, `#`, etc.) precede
+// `javascript:` and still match — this is what catches obfuscation attempts
+// like ` javascript:void(0)` while still accepting plain identifiers
+// such as `javascriptFoo`. Both JS and Go default `\W` to ASCII (`[^A-Za-z0-9_]`),
+// so the matched character class is identical.
+var jsHrefPattern = regexp.MustCompile(`^\W*?javascript:`)
+
+const (
+	aspectNoHref       = "noHref"
+	aspectInvalidHref  = "invalidHref"
+	aspectPreferButton = "preferButton"
+)
+
+// options mirrors the upstream JSON shape. Each field maps directly to the
+// schema entry of the same name; defaults are applied at use-sites because
+// upstream's per-aspect default depends on whether `aspects` was provided
+// at all (an empty / absent `aspects` enables all three; an explicit list
+// enables only the listed names).
+type options struct {
+	components  []string
+	specialLink []string
+	// activeAspects mirrors upstream's `activeAspects[name] = aspects.indexOf(name) !== -1`
+	// after defaulting. We pre-compute the booleans during options parsing
+	// so the listener never needs to re-walk the `aspects` array.
+	activeAspects map[string]bool
+}
+
+func parseOptions(raw any) options {
+	opts := options{
+		activeAspects: map[string]bool{
+			aspectNoHref:       true,
+			aspectInvalidHref:  true,
+			aspectPreferButton: true,
+		},
+	}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	opts.components = jsxa11yutil.StringSliceOption(m["components"])
+	opts.specialLink = jsxa11yutil.StringSliceOption(m["specialLink"])
+	if rawAspects, ok := m["aspects"]; ok {
+		// An explicit aspects array — including an empty one — replaces the
+		// default. Upstream's schema requires `minItems: 1`, but the rule
+		// itself doesn't re-validate, so we mirror the runtime behavior:
+		// any provided array, including an empty one, deactivates all
+		// aspects until names are listed.
+		//
+		// Distinguishing "absent" vs "explicit []" is what the outer `ok`
+		// guards: absent → keep the all-true default; present → start
+		// from all-false and re-enable the listed names. StringSliceOption
+		// flattens both cases into a (possibly empty) `[]string`, so the
+		// `ok` check remains the single source of the absent/present
+		// distinction.
+		if aspects := jsxa11yutil.StringSliceOption(rawAspects); aspects != nil {
+			opts.activeAspects = map[string]bool{
+				aspectNoHref:       false,
+				aspectInvalidHref:  false,
+				aspectPreferButton: false,
+			}
+			for _, name := range aspects {
+				if _, known := opts.activeAspects[name]; known {
+					opts.activeAspects[name] = true
+				}
+			}
+		}
+	}
+	return opts
+}
+
+var AnchorIsValidRule = rule.Rule{
+	Name: "jsx-a11y/anchor-is-valid",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		// typeCheck = ['a'].concat(componentOptions). Resolved against the
+		// element's effective name via `jsxa11yutil.GetElementType` so both
+		// `settings['jsx-a11y'].components` remap (Link → a) and the
+		// `polymorphicPropName` setting are honored — same as upstream's
+		// `getElementType(context)(node)` curry.
+		typeCheck := append([]string{"a"}, opts.components...)
+		// propsToValidate = ['href'].concat(propOptions). Each prop is
+		// looked up case-insensitively via FindAttributeByName and walked
+		// through any literal-spread, mirroring `getProp(attrs, name)`.
+		propsToValidate := append([]string{"href"}, opts.specialLink...)
+
+		check := func(node *ast.Node) {
+			nodeType := jsxa11yutil.GetElementType(node, ctx.Settings)
+			if !slices.Contains(typeCheck, nodeType) {
+				return
+			}
+
+			attrs := reactutil.GetJsxElementAttributes(node)
+
+			// First pass: walk every href-like prop, classify each as
+			// "missing/null", "invalid string", or "present and OK".
+			//
+			// Upstream's logic is:
+			//
+			//   const values = propsToValidate.map(p => getPropValue(getProp(attrs, p)));
+			//   const hasAnyHref = values.some(v => v != null);
+			//   const invalidHrefValues = values.filter(v =>
+			//     v != null && typeof v === 'string' &&
+			//     (!v.length || v === '#' || /^\W*?javascript:/.test(v)));
+			//
+			// We don't need to materialize the values array — a single
+			// pass tracking the two flags is equivalent.
+			hasAnyHref := false
+			hasInvalidHref := false
+			for _, propName := range propsToValidate {
+				attr := jsxa11yutil.FindAttributeByName(attrs, propName)
+				if jsxa11yutil.PropValueIsNullish(attr) {
+					// `attr == nil` (absent prop), `prop={null}`,
+					// `prop={undefined}`, and TS-wrapped variants of those
+					// all collapse to `value == null` in upstream — they
+					// contribute nothing to hasAnyHref.
+					continue
+				}
+				hasAnyHref = true
+				if val, ok := jsxa11yutil.PropStaticStringValue(attr); ok {
+					// Only string values are eligible for the invalid-href
+					// check. Booleans (`prop={true}`, boolean form), numbers,
+					// and any non-string truthy synthesized values (member
+					// access, calls, etc.) all skip the typeof === 'string'
+					// guard upstream and stay valid.
+					if val == "" || val == "#" || jsHrefPattern.MatchString(val) {
+						hasInvalidHref = true
+					}
+				}
+			}
+
+			// `attributes.some(a => a.type === 'JSXSpreadAttribute')` — any
+			// spread, literal or not, suppresses the noHref / preferButton
+			// branches when there is no explicit href. Crucially, this is
+			// independent from FindAttributeByName's literal-spread walk:
+			// `<a {...{href: ''}}/>` has hasSpread=true AND will populate
+			// the href-prop branch via the literal walk.
+			hasSpread := false
+			for _, a := range attrs {
+				if a.Kind == ast.KindJsxSpreadAttribute {
+					hasSpread = true
+					break
+				}
+			}
+			onClick := jsxa11yutil.FindAttributeByName(attrs, "onClick")
+
+			if !hasAnyHref {
+				// Upstream:
+				//
+				//   if (!hasSpreadOperator && activeAspects.noHref
+				//     && (!onClick || (onClick && !activeAspects.preferButton))) {
+				//     report noHref
+				//   }
+				//   if (!hasSpreadOperator && onClick && activeAspects.preferButton) {
+				//     report preferButton
+				//   }
+				//
+				// The `(onClick && !preferButton)` arm is reachable: when
+				// only `noHref` is enabled and an onClick is present, the
+				// element should still be flagged as missing href (because
+				// preferButton is off, the onClick doesn't redirect the
+				// report into a button-recommendation). Lock-in tests exist
+				// upstream for this combination — see __tests__/.../anchor-is-valid-test.js.
+				if !hasSpread && opts.activeAspects[aspectNoHref] &&
+					(onClick == nil || !opts.activeAspects[aspectPreferButton]) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "noHref",
+						Description: noHrefErrorMessage,
+					})
+				}
+				if !hasSpread && onClick != nil && opts.activeAspects[aspectPreferButton] {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "preferButton",
+						Description: preferButtonErrorMessage,
+					})
+				}
+				return
+			}
+
+			if !hasInvalidHref {
+				return
+			}
+			// Hrefs are present but at least one is invalid. preferButton
+			// takes precedence over invalidHref when both are active and an
+			// onClick exists — upstream's `if (onClick && activeAspects.preferButton)`
+			// followed by `else if (activeAspects.invalidHref)`.
+			if onClick != nil && opts.activeAspects[aspectPreferButton] {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "preferButton",
+					Description: preferButtonErrorMessage,
+				})
+			} else if opts.activeAspects[aspectInvalidHref] {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "invalidHref",
+					Description: invalidHrefErrorMessage,
+				})
+			}
+		}
+
+		// Listen on both opening kinds. tsgo splits ESTree's
+		// JSXOpeningElement into KindJsxOpeningElement (paired tags) and
+		// KindJsxSelfClosingElement (`<a/>`); upstream's single
+		// `JSXOpeningElement` listener fires on both forms.
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.md
+++ b/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.md
@@ -1,0 +1,105 @@
+# anchor-is-valid
+
+## Rule Details
+
+This rule enforces that `<a>` elements (and any configured custom anchor
+components) function as proper hyperlinks. An anchor without a usable
+`href`, with a non-navigable `href` such as `""`, `"#"`, or `javascript:…`,
+or used purely for click handling, is reported.
+
+The rule runs three independent aspects, all enabled by default:
+
+- **noHref** — reports when no usable href is provided.
+- **invalidHref** — reports when the `href` value is empty, the literal
+  `"#"`, or matches `^\W*?javascript:` (e.g. `"javascript:void(0)"`).
+- **preferButton** — when an `onClick` is present, reports that the element
+  should be a `<button>` instead of an anchor.
+
+A spread attribute (`{...props}`, including a literal-object spread
+without a usable href) suppresses the `noHref` and `preferButton` reports
+when no explicit href is found, because the spread may carry one at
+runtime.
+
+When more than one aspect would trigger on the same element,
+`preferButton` takes precedence over `invalidHref` (and `preferButton`
+takes precedence over `noHref` in the no-href branch).
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<a />
+<a href={undefined} />
+<a href={null} />
+<a href="" />
+<a href="#" />
+<a href={"#"} />
+<a href="javascript:void(0)" />
+<a href={"javascript:void(0)"} />
+<a onClick={() => void 0} />
+<a href="#" onClick={() => void 0} />
+<a href="javascript:void(0)" onClick={() => void 0} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<a href="https://example.com" />
+<a href="/foo" />
+<a href="#section" />
+<a href={url} />
+<a href="foo" onClick={() => void 0} />
+<a {...props} />
+```
+
+## Rule Options
+
+The rule accepts an options object with the following properties:
+
+- `components` — array of additional component names (besides the built-in
+  `a`) that should be checked.
+- `specialLink` — array of additional prop names (besides the built-in
+  `href`) that should be treated as href-like for the purposes of this
+  rule.
+- `aspects` — array of which sub-checks to run; one or more of `noHref`,
+  `invalidHref`, `preferButton`. When omitted, all three are active.
+
+Examples of **incorrect** code with `{ "components": ["Anchor", "Link"] }`:
+
+```json
+{ "anchor-is-valid": ["error", { "components": ["Anchor", "Link"] }] }
+```
+
+```jsx
+<Link />
+<Anchor href="#" />
+```
+
+Examples of **incorrect** code with `{ "specialLink": ["hrefLeft"] }`:
+
+```json
+{ "anchor-is-valid": ["error", { "specialLink": ["hrefLeft"] }] }
+```
+
+```jsx
+<a hrefLeft="" />
+<a hrefLeft="javascript:void(0)" />
+```
+
+Examples of **incorrect** code with `{ "aspects": ["noHref"] }`:
+
+```json
+{ "anchor-is-valid": ["error", { "aspects": ["noHref"] }] }
+```
+
+```jsx
+<a />
+<a onClick={() => void 0} />
+```
+
+With `aspects` set to `["noHref"]`, an anchor that carries an `onClick`
+but no `href` is still reported as `noHref` — `preferButton` is off, so
+the `onClick` does not redirect the report.
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/anchor-is-valid](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md)

--- a/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid_extras_test.go
@@ -56,14 +56,15 @@ func TestAnchorIsValidExtras(t *testing.T) {
 		{Code: `<a href />`, Tsx: true},
 
 		// ---- Dimension 4: TS expression wrappers on the value (parens +
-		//      `as` + `!`). attributeInnerExpression strips these via
-		//      ast.SkipOuterExpressions(skipTransparent), so the inner
-		//      string literal "foo" is what staticEval sees. ----
+		//      `as` + `!`). staticEval strips these via skipTransparent
+		//      (parens + type assertions + non-null), so the inner string
+		//      literal "foo" is what staticEval sees. NOTE: `satisfies` is
+		//      intentionally NOT in skipTransparent — see the satisfies
+		//      lock-in in the invalid section below. ----
 		{Code: `<a href={("foo")} />`, Tsx: true},
 		{Code: `<a href={"foo" as string} />`, Tsx: true},
 		{Code: `<a href={"foo" as const} />`, Tsx: true},
 		{Code: `<a href={"foo"!} />`, Tsx: true},
-		{Code: `<a href={"foo" satisfies string} />`, Tsx: true},
 
 		// ---- Dimension 4: spread attribute — non-literal spread is opaque,
 		//      hasSpread=true suppresses the noHref/preferButton branches. ----
@@ -488,6 +489,16 @@ func TestAnchorIsValidExtras(t *testing.T) {
 		//      fallback. `null != null` is false → no href → noHref. Locks
 		//      in PropValueIsNullish's `inner == nil` branch alignment. ----
 		{Code: `<a href={} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- TS `satisfies` wrapper — upstream's TYPES table has NO
+		//      `TSSatisfiesExpression` extractor, so `getPropValue` returns
+		//      null for `<a href={"foo" satisfies string}/>`. staticEval
+		//      mirrors by EXCLUDING `OEKSatisfies` from skipTransparent;
+		//      satisfies-wrapped values land on the default `jsNull` arm
+		//      and PropValueIsNullish reports nullish → noHref. Catches
+		//      what would otherwise be silent under-reporting. ----
+		{Code: `<a href={"foo" satisfies string} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)" satisfies string} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
 		// JsxExpression containing only a comment is the same shape as
 		// empty: tsgo strips trivia, leaving Expression nil. Same outcome.
 		{Code: `<a href={/* todo */} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},

--- a/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid_extras_test.go
@@ -1,0 +1,544 @@
+package anchor_is_valid
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// polymorphicSettings exercises the `polymorphicPropName` jsx-a11y setting —
+// `<Foo as="a">` should be treated as `<a>` after getElementType resolution.
+// Locks in jsxa11yutil.GetElementType's polymorphic-prop branch which
+// upstream's own test file doesn't directly exercise on this rule.
+var polymorphicSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+	},
+}
+
+// TestAnchorIsValidExtras locks in branches that upstream's test file
+// doesn't directly exercise but are reachable through the rule's listener
+// gate. Each case carries an inline comment pointing at the specific
+// upstream branch / Dimension 4 edge shape it covers.
+func TestAnchorIsValidExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AnchorIsValidRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: paired form (KindJsxOpeningElement listener) ----
+		// Upstream's `JSXOpeningElement` fires for both self-closing AND
+		// paired tags. tsgo splits these into two kinds; we listen on
+		// both. `<a href="foo">x</a>` exercises the paired form.
+		{Code: `<a href="foo">x</a>`, Tsx: true},
+
+		// ---- Dimension 4: tag-name forms — case-sensitive HTML matching ----
+		// `typeCheck.indexOf(nodeType)` is case-sensitive. `<A />` resolves
+		// to nodeType "A" which is NOT in ['a'] → rule short-circuits and
+		// does NOT report, even with no href.
+		{Code: `<A />`, Tsx: true},
+
+		// ---- Dimension 4: namespaced JSX names → not matched ----
+		{Code: `<svg:a />`, Tsx: true},
+
+		// ---- Dimension 4: member-access tag → not matched ----
+		// Even when the member's last segment is "a", the resolved type is
+		// "Foo.a" — distinct from "a". Skipped.
+		{Code: `<Foo.a />`, Tsx: true},
+
+		// ---- Dimension 4: case-insensitive prop matching (jsx-ast-utils
+		//      `getProp` default `ignoreCase: true`) ----
+		// `HREF`, `Href`, etc. all match. Locks in FindAttributeByName's
+		// strings.EqualFold lookup.
+		{Code: `<a HREF="foo" />`, Tsx: true},
+		{Code: `<a Href="foo" />`, Tsx: true},
+
+		// ---- Dimension 4: boolean-attribute form — value is boolean true,
+		//      not null/undefined. hasAnyHref=true; not a string so not in
+		//      invalid list. Result: passes. ----
+		{Code: `<a href />`, Tsx: true},
+
+		// ---- Dimension 4: TS expression wrappers on the value (parens +
+		//      `as` + `!`). attributeInnerExpression strips these via
+		//      ast.SkipOuterExpressions(skipTransparent), so the inner
+		//      string literal "foo" is what staticEval sees. ----
+		{Code: `<a href={("foo")} />`, Tsx: true},
+		{Code: `<a href={"foo" as string} />`, Tsx: true},
+		{Code: `<a href={"foo" as const} />`, Tsx: true},
+		{Code: `<a href={"foo"!} />`, Tsx: true},
+		{Code: `<a href={"foo" satisfies string} />`, Tsx: true},
+
+		// ---- Dimension 4: spread attribute — non-literal spread is opaque,
+		//      hasSpread=true suppresses the noHref/preferButton branches. ----
+		{Code: `<a {...props} />`, Tsx: true},
+		{Code: `<a {...props} onClick={() => 0} />`, Tsx: true},
+
+		// ---- Dimension 4: spread of literal object that supplies a valid
+		//      href. FindAttributeByName walks the literal-spread to find
+		//      the property; staticEval extracts "foo" from the
+		//      PropertyAssignment initializer. hasAnyHref=true,
+		//      hasInvalidHref=false → no report. ----
+		{Code: `<a {...{href: "foo"}} />`, Tsx: true},
+		{Code: `<a {...{href: "/foo"}} />`, Tsx: true},
+
+		// ---- Locks in upstream regex /^\W*?javascript:/ negative cases ----
+		// Word-char prefix prevents the lazy `\W*?` from consuming, so the
+		// pattern fails to anchor at "javascript:". These must remain valid.
+		{Code: `<a href="xjavascript:" />`, Tsx: true},
+		// "javascript" without the trailing colon never matches.
+		{Code: `<a href="javascript" />`, Tsx: true},
+		{Code: `<a href="javascript;" />`, Tsx: true},
+		// "##" is not the exact "#" string upstream rejects.
+		{Code: `<a href="##" />`, Tsx: true},
+		// Non-empty whitespace-only strings are NOT rejected — they pass
+		// every disjunct of the invalid filter (length>0, !== "#", no
+		// "javascript:" anywhere). Locks in the literal value comparison.
+		{Code: `<a href=" " />`, Tsx: true},
+
+		// ---- Locks in upstream Identifier extractor → string of name.
+		//      `href={foo}` ⇒ jsx-ast-utils returns "foo" (truthy non-empty
+		//      non-"#" non-"javascript:" string) ⇒ valid. ----
+		{Code: `<a href={someVar} />`, Tsx: true},
+
+		// ---- Locks in upstream MemberExpression / CallExpression / etc.
+		//      → synthesized non-empty string (or jsTruthy in our impl).
+		//      typeof-string check upstream still passes for these because
+		//      jsx-ast-utils returns "obj.prop" / "callee()" — but the
+		//      synthesized strings don't match the invalid disjuncts. Our
+		//      staticEval returns jsTruthy (Kind != jvString) so the typeof
+		//      check fails. Same end result: not invalid. ----
+		{Code: `<a href={obj.prop} />`, Tsx: true},
+		{Code: `<a href={getUrl()} />`, Tsx: true},
+
+		// ---- Polymorphic settings: `<Foo as="a">` resolves to "a" ----
+		// FindAttributeByName + GetElementType's polymorphic step.
+		{Code: `<Foo as="a" href="x" />`, Tsx: true, Settings: polymorphicSettings},
+
+		// ---- Numeric / boolean values are non-string, so they bypass the
+		//      typeof-string invalid filter. hasAnyHref=true. ----
+		{Code: `<a href={5} />`, Tsx: true},
+		{Code: `<a href={true} />`, Tsx: true},
+		{Code: `<a href={false} />`, Tsx: true},
+
+		// ---- One valid + one missing href-like prop → hasAnyHref=true via
+		//      the valid one, hasInvalidHref=false. Locks in the OR-merge
+		//      across propsToValidate. ----
+		{Code: `<a href="foo" hrefLeft={null} />`, Tsx: true, Options: specialLinkOption},
+
+		// ---- Empty aspects array: upstream's runtime treats this as "no
+		//      aspects active", so even no-href elements pass. Locks in
+		//      our explicit-aspects-array deactivation logic. ----
+		{Code: `<a />`, Tsx: true, Options: []interface{}{
+			map[string]interface{}{"aspects": []interface{}{}},
+		}},
+
+		// ---- staticEval `||` short-circuit: falsy left → take right ----
+		// Upstream's jsx-ast-utils LogicalExpression extractor evaluates
+		// `getValue(left) || getValue(right)`. Empty string is falsy → use
+		// the truthy right value. Our staticEval mirrors via
+		// `if !jsTruthy_(left) return staticEval(right)`.
+		{Code: `<a href={"" || "/foo"} />`, Tsx: true},
+		{Code: `<a href={null || "/foo"} />`, Tsx: true},
+		{Code: `<a href={undefined || "/foo"} />`, Tsx: true},
+
+		// ---- staticEval `||` short-circuit: truthy left → take left ----
+		// `someVar || "/fallback"` — Identifier extractor returns "someVar"
+		// (truthy) → returns "someVar". Not invalid. Realistic pattern.
+		{Code: `<a href={someVar || "/fallback"} />`, Tsx: true},
+
+		// ---- staticEval `&&` short-circuit with non-nullish falsy left ----
+		// `false && "#"` — left is jvBool false (falsy but NOT null/undef)
+		// → returns false. PropValueIsNullish=false → hasAnyHref=true.
+		// PropStaticStringValue: jvBool != jvString → not invalid. Result:
+		// passes. Lock in the boolean-false / number-zero distinction from
+		// the null/undef cases below (which produce noHref reports).
+		{Code: `<a href={false && "#"} />`, Tsx: true},
+		// `0 && "#"` — number 0 (falsy, not null/undef) → returns 0. Same
+		// classification as boolean false: contributes to hasAnyHref, not
+		// a string, not invalid.
+		{Code: `<a href={0 && "#"} />`, Tsx: true},
+
+		// ---- staticEval `??` nullish coalescing: non-null left → take left ----
+		// `"/" ?? "#"` — left is jvString "/" (not null/undef) → take left.
+		// Valid.
+		{Code: `<a href={"/" ?? "#"} />`, Tsx: true},
+		// `someVar ?? "#"` — Identifier extractor returns string "someVar"
+		// (non-null) → take left. Valid.
+		{Code: `<a href={someVar ?? "#"} />`, Tsx: true},
+
+		// ---- staticEval ConditionalExpression: take consequent or alternate
+		//      based on test ----
+		// `true ? "foo" : "#"` → "foo". `cond ? "foo" : "#"` where cond is
+		// Identifier "cond" → truthy string → "foo".
+		{Code: `<a href={true ? "/foo" : "#"} />`, Tsx: true},
+		{Code: `<a href={cond ? "/foo" : "#"} />`, Tsx: true},
+
+		// ---- staticEval string concatenation `+` ----
+		// `"prefix-" + suffix` → "prefix-{suffix-name-string}" — synthesized
+		// string, not invalid (no js: prefix, not "#" exactly, length>0).
+		{Code: `<a href={"https://" + domain} />`, Tsx: true},
+		{Code: `<a href={base + "/path"} />`, Tsx: true},
+
+		// ---- staticEval TemplateExpression with variable substitutions ----
+		// `` `/users/${id}` `` — staticEval emits "/users/{id}" placeholder.
+		// Length > 0, not invalid. Realistic pattern.
+		{Code: "<a href={`/users/${id}`} />", Tsx: true},
+		{Code: "<a href={`${prefix}/${path}`} />", Tsx: true},
+
+		// ---- Numeric / regex / new-expression / object literal as href
+		//      values. None are strings → bypass typeof-string filter →
+		//      contribute to hasAnyHref but never invalid. ----
+		{Code: `<a href={5} />`, Tsx: true},
+		{Code: `<a href={0} />`, Tsx: true},
+		{Code: `<a href={5n} />`, Tsx: true},
+		{Code: `<a href={new URL("/")} />`, Tsx: true},
+		{Code: `<a href={["/foo"]} />`, Tsx: true},
+		{Code: `<a href={{toString: () => "/"}} />`, Tsx: true},
+
+		// ---- Optional chain on href value (`obj?.url`). tsgo flags this as
+		//      a PropertyAccessExpression with the optional flag — same kind
+		//      as plain `obj.prop`. staticEval returns jsTruthy → contributes
+		//      to hasAnyHref, not invalid. ----
+		{Code: `<a href={obj?.url} />`, Tsx: true},
+		{Code: `<a href={fns.getUrl?.()} />`, Tsx: true},
+
+		// ---- onClick prop case-insensitivity. jsx-ast-utils' getProp default
+		//      `ignoreCase: true` matches the standard `onClick` against the
+		//      PascalCase variant and the legacy lowercase HTML attribute. ----
+		{Code: `<a href="/" OnClick={() => 0} />`, Tsx: true},
+		{Code: `<a href="/" onclick={() => 0} />`, Tsx: true},
+
+		// ---- onClick={undefined} still counts as "has onClick". The presence
+		//      of the prop matters, not its value. With href present this
+		//      passes (not invalid + hasAnyHref). ----
+		{Code: `<a href="/" onClick={undefined} />`, Tsx: true},
+		{Code: `<a href="/" onClick={null} />`, Tsx: true},
+
+		// ---- Spread + onClick only: `<a {...{onClick: fn}}/>` — hasSpread
+		//      from JsxSpreadAttribute, onClick found via literal-spread
+		//      walk. !hasSpread is false → both noHref and preferButton
+		//      gates suppressed in the no-href branch. Result: passes. ----
+		{Code: `<a {...{onClick: () => 0}} />`, Tsx: true},
+
+		// ---- Components option is case-sensitive — `["link"]` does NOT
+		//      match JSX `<Link/>`. Locks in upstream's
+		//      `typeCheck.indexOf(nodeType) === -1` exact-match behavior. ----
+		{Code: `<Link />`, Tsx: true, Options: []interface{}{
+			map[string]interface{}{"components": []interface{}{"link"}},
+		}},
+
+		// ---- specialLink with prop names not present on element — fall back
+		//      to the default 'href' lookup. Locks in propsToValidate
+		//      iteration when a configured prop is absent. ----
+		{Code: `<a href="/foo" />`, Tsx: true, Options: []interface{}{
+			map[string]interface{}{"specialLink": []interface{}{"hrefBottom"}},
+		}},
+
+		// ---- aspects array with an unknown name — silently ignored,
+		//      matching upstream's `aspects.indexOf(aspect) !== -1`
+		//      mechanism. All three known aspects stay false → no report. ----
+		{Code: `<a />`, Tsx: true, Options: []interface{}{
+			map[string]interface{}{"aspects": []interface{}{"madeUpAspect"}},
+		}},
+
+		// ---- aspects with all three names = same as default (all active) ----
+		// Locks in the explicit-vs-default symmetry: same outcome.
+		{Code: `<a href="/foo" />`, Tsx: true, Options: []interface{}{
+			map[string]interface{}{"aspects": []interface{}{"noHref", "invalidHref", "preferButton"}},
+		}},
+
+		// ---- Real-world Nav-component flow: multiple anchors of varying
+		//      states. Per-element listener firing must not bleed; valid
+		//      anchors stay valid. ----
+		{
+			Code: `<nav>
+  <a href="/">Home</a>
+  <a href="/about">About</a>
+</nav>`,
+			Tsx: true,
+		},
+
+		// ---- Anchor inside Array.map callback — each rendered element gets
+		//      its own listener invocation, with no shared state. ----
+		{Code: `<ul>{items.map(it => <a key={it.id} href={it.url}>{it.label}</a>)}</ul>`, Tsx: true},
+
+		// ---- Shorthand property in literal-spread: `{...{href}}` ≡
+		//      `{...{href: href}}`. FindAttributeByName resolves the
+		//      ShorthandPropertyAssignment via AttributeInitializer →
+		//      bound Identifier "href" → staticEval returns jvString
+		//      "href" (truthy non-empty) → not invalid. ----
+		{Code: `<a {...{href}} />`, Tsx: true},
+
+		// ---- Spread literal carries nullish href: `{...{href: null}}` ----
+		// FindAttributeByName walks the spread, finds `href: null`,
+		// PropValueIsNullish returns true (jsNull). hasAnyHref=false.
+		// hasSpread=true (because the JsxSpreadAttribute is present). The
+		// !hasSpread gate suppresses both noHref and preferButton in the
+		// no-href branch → no report. Same shape as `<a href={null} {...x}/>`
+		// upstream — the spread is opaque-enough to suppress.
+		{Code: `<a {...{href: null}} />`, Tsx: true},
+		{Code: `<a {...{href: undefined}} />`, Tsx: true},
+
+		// ---- Wrapper-component pattern: explicit href={undefined} +
+		//      spread that supplies a valid href. At runtime the spread
+		//      overrides; getProp / FindAttributeByName return the FIRST
+		//      match (the explicit one with undefined). hasAnyHref=false
+		//      via the explicit, hasSpread=true → suppressed → no report.
+		//      Locks in upstream's first-match quirk for a realistic
+		//      higher-order-component wrapper shape. ----
+		{Code: `<a href={undefined} {...{href: "/"}} />`, Tsx: true},
+
+		// ---- Two spread attributes (non-literal + literal) — common in
+		//      composition: `<a {...rest} {...defaults}/>`. hasSpread=true,
+		//      no explicit href. Suppressed regardless of literal payload. ----
+		{Code: `<a {...rest} {...{className: "x"}} />`, Tsx: true},
+
+		// ---- Options as bare-object (single-option CLI shape) — exercises
+		//      utils.GetOptionsMap's non-array branch. Without this case
+		//      the suite would only cover the array-wrapped rule_tester
+		//      shape, leaving the CLI-facing wiring untested. ----
+		{Code: `<Anchor href="/foo" />`, Tsx: true, Options: map[string]interface{}{
+			"components": []interface{}{"Anchor"},
+		}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Locks in paired-form coverage (KindJsxOpeningElement) ----
+		{Code: `<a>x</a>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Locks in upstream regex /^\W*?javascript:/ positive cases ----
+		// 1+ non-word prefix (whitespace, `#`, etc.) still matches.
+		{Code: `<a href=" javascript:void(0)" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="	javascript:void(0)" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// `#` is non-word in `\W`, so `#javascript:foo` matches the regex
+		// after the lazy quantifier consumes the `#`. Locks in the
+		// non-zero-prefix branch.
+		{Code: `<a href="#javascript:foo" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Dimension 4: TS expression wrappers around invalid values
+		//      must still be rejected. `("#" as const)` should reach the
+		//      `value === '#'` disjunct. ----
+		{Code: `<a href={("#")} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"#" as string} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"" as const} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Locks in NoSubstitutionTemplateLiteral coverage. tsgo splits
+		//      template literals into a separate kind from StringLiteral;
+		//      both must be staticEval-able to a string. `` `#` `` should
+		//      hit the `value === '#'` disjunct. ----
+		{Code: "<a href={`#`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: "<a href={`javascript:void(0)`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Locks in spread-of-literal walking. `<a {...{href: ""}}/>`
+		//      has hasSpread=true AND populates hasAnyHref via the literal
+		//      spread walk. The hrefs-found branch then fires invalidHref. ----
+		{Code: `<a {...{href: ""}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a {...{href: "#"}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Mixed-validity props: one prop is a valid href, another is
+		//      invalid. Upstream's filter takes ANY invalid in the array →
+		//      report. Locks in the OR-merge across propsToValidate. ----
+		{Code: `<a href="foo" hrefLeft="" />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="" hrefLeft="foo" />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Polymorphic-as-a: `<Foo as="a" />` resolves to "a" → checked.
+		//      Locks in the GetElementType polymorphic-prop branch with no
+		//      href → noHref report. ----
+		{Code: `<Foo as="a" />`, Tsx: true, Settings: polymorphicSettings, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Two consecutive anchors → both reported independently. Locks
+		//      in the per-element listener firing (no state leak). ----
+		{
+			Code: `<><a /><a href="#" /></>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 3},
+				{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 8},
+			},
+		},
+
+		// ---- Nested anchors: outer and inner both invalid (illegal HTML
+		//      but legal JSX). Locks in the absence of bleed-through; both
+		//      should be reported. ----
+		{
+			Code: `<a><a /></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1},
+				{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 4},
+			},
+		},
+
+		// ---- staticEval `||` short-circuit: truthy left = invalid value ----
+		// `"javascript:" || "/foo"` — left is truthy (non-empty string) →
+		// take left = "javascript:" → matches /^\W*?javascript:/ → invalid.
+		// Locks in the BinaryExpression-`||` arm of staticEvalBinary.
+		{Code: `<a href={"javascript:" || "/foo"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// `"" || "#"` — left is falsy → take right = "#" → invalid.
+		{Code: `<a href={"" || "#"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// `null || ""` — left null (falsy) → take right = "" → invalid.
+		{Code: `<a href={null || ""} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- staticEval `&&` short-circuit: truthy left → take right ----
+		// `"foo" && "#"` — left truthy → take right = "#" → invalid.
+		{Code: `<a href={"foo" && "#"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// `1 && "javascript:void(0)"` — number 1 truthy → take right →
+		// invalid. Locks in non-string truthy left.
+		{Code: `<a href={1 && "javascript:void(0)"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- staticEval `??` nullish coalescing: null left → take right ----
+		// `null ?? "#"` and `undefined ?? "javascript:foo"` — both fall to
+		// the right operand. Locks in the null-or-undefined detection arm.
+		{Code: `<a href={null ?? "#"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={undefined ?? "javascript:foo"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// `"" ?? "#"` — empty string is NOT null/undef → take left = "" →
+		// invalid (length 0). Lock in distinction between `??` and `||`.
+		{Code: `<a href={"" ?? "#"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- `&&` short-circuit producing nullish result → noHref ----
+		// `null && X` returns null per JS semantics (and staticEval mirrors
+		// via "if !jsTruthy_(left) return left"). null is nullish →
+		// PropValueIsNullish=true → hasAnyHref=false → noHref. Same path
+		// for `undefined && X`. Crucially distinct from `false && X` and
+		// `0 && X` which produce non-nullish falsy values (covered in
+		// valid above).
+		{Code: `<a href={null && "/foo"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={undefined && "/foo"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- ConditionalExpression: literal true → consequent ----
+		// `true ? "javascript:" : "/foo"` → "javascript:" → invalid.
+		{Code: `<a href={true ? "javascript:foo" : "/"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// `false ? "/" : "javascript:..."` → take alternate → invalid.
+		{Code: `<a href={false ? "/" : "javascript:foo"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// `cond ? "#" : "/"` — cond is Identifier (truthy string per
+		// jsx-ast-utils Identifier extractor) → take consequent = "#" →
+		// invalid.
+		{Code: `<a href={cond ? "#" : "/"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- staticEval string concatenation: result matches js: prefix ----
+		// `"java" + "script:" + "alert(1)"` — concatenated to
+		// "javascript:alert(1)" → matches regex → invalid. Locks in the
+		// `+` BinaryExpression arm with same-side string operands.
+		{Code: `<a href={"java" + "script:" + "alert(1)"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// String concat producing exact "#" — `"#" + ""` → "#" → invalid.
+		{Code: `<a href={"#" + ""} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Multi-line code: position assertions on each line. Verifies
+		//      Line/Column report at the opening `<` of each anchor. ----
+		{
+			Code: `<div>
+  <a />
+  <a href="#" />
+</div>`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noHref", Message: noHrefErrorMessage, Line: 2, Column: 3},
+				{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 3, Column: 3},
+			},
+		},
+
+		// ---- Real-world Nav-component flow with mixed states. Locks in
+		//      independent per-element classification across a realistic
+		//      structure. ----
+		{
+			Code: `<nav>
+  <a href="/">Home</a>
+  <a href="/about">About</a>
+  <a href="#" onClick={() => 0}>Click</a>
+  <a>Empty</a>
+</nav>`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 4, Column: 3},
+				{MessageId: "noHref", Message: noHrefErrorMessage, Line: 5, Column: 3},
+			},
+		},
+
+		// ---- Mixed valid + invalid with onClick → preferButton wins ----
+		// `<a href="/" hrefLeft="" onClick={fn}/>` with specialLink=
+		// ['hrefLeft']. hasAnyHref=true (via /), hasInvalidHref=true (via
+		// hrefLeft=""), onClick + preferButton active → preferButton report.
+		{Code: `<a href="/" hrefLeft="" onClick={() => 0} />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Spread + explicit invalid href: hasSpread=true does NOT
+		//      suppress the invalidHref report (spread suppression only
+		//      applies to the no-href branch). ----
+		{Code: `<a {...props} href="" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a {...props} href="javascript:void(0)" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Spread literal walk + onClick via spread: `<a {...{href: "#",
+		//      onClick: fn}}/>` — both found via single literal-spread
+		//      walk. hasAnyHref=true, hasInvalidHref=true, onClick present,
+		//      preferButton active → preferButton report. ----
+		{Code: `<a {...{href: "#", onClick: () => 0}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Attribute order: literal-spread BEFORE explicit href —
+		//      FindAttributeByName returns the FIRST match (the spread one),
+		//      mirroring upstream's `getProp` first-match behavior. The
+		//      spread's invalid value drives the report even though the
+		//      runtime override would set href="foo". This is upstream's
+		//      known quirk and we mirror it. ----
+		{Code: `<a {...{href: "#"}} href="foo" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- staticEval Identifier extractor: bare `<a href={undefined}/>`
+		//      vs identifier whose name happens to be a known-truthy global.
+		//      The `undefined` Identifier returns jsUndef → nullish → no
+		//      href → noHref report. Locks in the special-cased Identifier
+		//      handling. ----
+		{Code: `<a href={undefined} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- onClick prop case-insensitive lookup. With no href, the
+		//      lowercase legacy HTML attribute should still trigger
+		//      preferButton (per jsx-ast-utils ignoreCase=true). ----
+		{Code: `<a onclick={() => 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Boolean form for special link: `<a hrefLeft />` with
+		//      specialLink=['hrefLeft']. Boolean form maps to value `true`
+		//      (per upstream's null-attribute-value handling) → hasAnyHref
+		//      = true, not a string → not invalid. But what about pure
+		//      `<a hrefLeft/>` with NO other href? Should be valid (we have
+		//      a href-like prop with a non-null/non-string-invalid value).
+		//      No invalid case here — moved to valid section actually.
+		//      Below is a different shape that IS invalid:
+		//      `<a hrefLeft="" />` — explicit empty string, length 0,
+		//      invalid. Already covered in upstream tests.
+
+		// ---- aspects array with both ON and unknown — unknown silently
+		//      ignored, "noHref" still triggers reports. ----
+		{Code: `<a />`, Tsx: true, Options: []interface{}{
+			map[string]interface{}{"aspects": []interface{}{"noHref", "madeUpAspect"}},
+		}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Bare-object options shape (single-option CLI / lint() API
+		//      shape) for the invalid path. Without an array wrap, the
+		//      rule must still parse `components` correctly — exercises
+		//      GetOptionsMap's `map[string]interface{}` branch. ----
+		{Code: `<Link />`, Tsx: true, Options: map[string]interface{}{
+			"components": []interface{}{"Link"},
+		}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Bare-object options with aspects override ----
+		// Locks in the CLI-shape parse for the aspects path too: only
+		// `noHref` active should still report on a bare anchor.
+		{Code: `<a />`, Tsx: true, Options: map[string]interface{}{
+			"aspects": []interface{}{"noHref"},
+		}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- Two onClick reports across same parent: each anchor's
+		//      listener invocation is independent. Locks in the absence
+		//      of cross-element shared state in the rule. ----
+		{
+			Code: `<div><a onClick={() => 0} /><a href="#" onClick={() => 0} /></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 6},
+				{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 29},
+			},
+		},
+
+		// ---- Anchor inside a conditional render expression. The listener
+		//      fires regardless of the surrounding container. ----
+		{
+			Code: `function App({cond}) { return cond && <a />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noHref", Message: noHrefErrorMessage},
+			},
+		},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid_extras_test.go
@@ -482,6 +482,16 @@ func TestAnchorIsValidExtras(t *testing.T) {
 		//      handling. ----
 		{Code: `<a href={undefined} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
 
+		// ---- Empty JsxExpression `<a href={}/>` — tsgo accepts this for
+		//      error-recovery; jsx-ast-utils routes JSXEmptyExpression
+		//      through its `TYPES[type] === undefined → return null`
+		//      fallback. `null != null` is false → no href → noHref. Locks
+		//      in PropValueIsNullish's `inner == nil` branch alignment. ----
+		{Code: `<a href={} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		// JsxExpression containing only a comment is the same shape as
+		// empty: tsgo strips trivia, leaving Expression nil. Same outcome.
+		{Code: `<a href={/* todo */} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+
 		// ---- onClick prop case-insensitive lookup. With no href, the
 		//      lowercase legacy HTML attribute should still trigger
 		//      preferButton (per jsx-ast-utils ignoreCase=true). ----

--- a/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid_upstream_test.go
@@ -1,0 +1,409 @@
+package anchor_is_valid
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// componentsOption mirrors upstream's `[{ components: ['Anchor', 'Link'] }]`.
+var componentsOption = []interface{}{
+	map[string]interface{}{
+		"components": []interface{}{"Anchor", "Link"},
+	},
+}
+
+// specialLinkOption mirrors upstream's `[{ specialLink: ['hrefLeft', 'hrefRight'] }]`.
+var specialLinkOption = []interface{}{
+	map[string]interface{}{
+		"specialLink": []interface{}{"hrefLeft", "hrefRight"},
+	},
+}
+
+var noHrefAspectOption = []interface{}{
+	map[string]interface{}{
+		"aspects": []interface{}{"noHref"},
+	},
+}
+
+var invalidHrefAspectOption = []interface{}{
+	map[string]interface{}{
+		"aspects": []interface{}{"invalidHref"},
+	},
+}
+
+var preferButtonAspectOption = []interface{}{
+	map[string]interface{}{
+		"aspects": []interface{}{"preferButton"},
+	},
+}
+
+var noHrefInvalidHrefAspectOption = []interface{}{
+	map[string]interface{}{
+		"aspects": []interface{}{"noHref", "invalidHref"},
+	},
+}
+
+var noHrefPreferButtonAspectOption = []interface{}{
+	map[string]interface{}{
+		"aspects": []interface{}{"noHref", "preferButton"},
+	},
+}
+
+var preferButtonInvalidHrefAspectOption = []interface{}{
+	map[string]interface{}{
+		"aspects": []interface{}{"preferButton", "invalidHref"},
+	},
+}
+
+var componentsAndSpecialLinkOption = []interface{}{
+	map[string]interface{}{
+		"components":  []interface{}{"Anchor"},
+		"specialLink": []interface{}{"hrefLeft"},
+	},
+}
+
+var componentsAndSpecialLinkAndInvalidHrefAspectOption = []interface{}{
+	map[string]interface{}{
+		"components":  []interface{}{"Anchor"},
+		"specialLink": []interface{}{"hrefLeft"},
+		"aspects":     []interface{}{"invalidHref"},
+	},
+}
+
+var componentsAndSpecialLinkAndNoHrefAspectOption = []interface{}{
+	map[string]interface{}{
+		"components":  []interface{}{"Anchor"},
+		"specialLink": []interface{}{"hrefLeft"},
+		"aspects":     []interface{}{"noHref"},
+	},
+}
+
+// componentsSettings mirrors upstream's
+// `{ 'jsx-a11y': { components: { Anchor: 'a', Link: 'a' } } }`.
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Anchor": "a",
+			"Link":   "a",
+		},
+	},
+}
+
+// TestAnchorIsValidUpstream covers the full valid/invalid suite migrated
+// 1:1 from upstream eslint-plugin-jsx-a11y's
+// `__tests__/src/rules/anchor-is-valid-test.js`. rslint-specific lock-ins
+// (semantic-walk branches, Dimension 4 universal edge shapes, tsgo AST
+// quirks) live in anchor_is_valid_extras_test.go.
+func TestAnchorIsValidUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AnchorIsValidRule, []rule_tester.ValidTestCase{
+		// ---- DEFAULT ELEMENT 'a' TESTS ----
+		{Code: `<Anchor />`, Tsx: true},
+		{Code: `<a {...props} />`, Tsx: true},
+		{Code: `<a href="foo" />`, Tsx: true},
+		{Code: `<a href={foo} />`, Tsx: true},
+		{Code: `<a href="/foo" />`, Tsx: true},
+		{Code: `<a href="https://foo.bar.com" />`, Tsx: true},
+		{Code: `<div href="foo" />`, Tsx: true},
+		{Code: `<a href="javascript" />`, Tsx: true},
+		{Code: `<a href="javascriptFoo" />`, Tsx: true},
+		{Code: "<a href={`#foo`}/>", Tsx: true},
+		{Code: `<a href={"foo"}/>`, Tsx: true},
+		{Code: `<a href={"javascript"}/>`, Tsx: true},
+		{Code: "<a href={`#javascript`}/>", Tsx: true},
+		{Code: `<a href="#foo" />`, Tsx: true},
+		{Code: `<a href="#javascript" />`, Tsx: true},
+		{Code: `<a href="#javascriptFoo" />`, Tsx: true},
+		{Code: `<UX.Layout>test</UX.Layout>`, Tsx: true},
+		{Code: `<a href={this} />`, Tsx: true},
+
+		// ---- CUSTOM ELEMENT TEST FOR ARRAY OPTION ----
+		{Code: `<Anchor {...props} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href="foo" />`, Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href={foo} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href="/foo" />`, Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href="https://foo.bar.com" />`, Tsx: true, Options: componentsOption},
+		{Code: `<div href="foo" />`, Tsx: true, Options: componentsOption},
+		{Code: "<Anchor href={`#foo`}/>", Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href={"foo"}/>`, Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href="#foo" />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link {...props} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href="foo" />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href={foo} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href="/foo" />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href="https://foo.bar.com" />`, Tsx: true, Options: componentsOption},
+		{Code: `<div href="foo" />`, Tsx: true, Options: componentsOption},
+		{Code: "<Link href={`#foo`}/>", Tsx: true, Options: componentsOption},
+		{Code: `<Link href={"foo"}/>`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href="#foo" />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href="#foo" />`, Tsx: true, Settings: componentsSettings},
+
+		// ---- CUSTOM PROP TESTS ----
+		{Code: `<a {...props} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft="foo" />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft={foo} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft="/foo" />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft="https://foo.bar.com" />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<div hrefLeft="foo" />`, Tsx: true, Options: specialLinkOption},
+		{Code: "<a hrefLeft={`#foo`}/>", Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft={"foo"}/>`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft="#foo" />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<UX.Layout>test</UX.Layout>`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight={this} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a {...props} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight="foo" />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight={foo} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight="/foo" />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight="https://foo.bar.com" />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<div hrefRight="foo" />`, Tsx: true, Options: specialLinkOption},
+		{Code: "<a hrefRight={`#foo`}/>", Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight={"foo"}/>`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight="#foo" />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<UX.Layout>test</UX.Layout>`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight={this} />`, Tsx: true, Options: specialLinkOption},
+
+		// ---- CUSTOM BOTH COMPONENTS AND SPECIAL LINK TESTS ----
+		{Code: `<Anchor {...props} />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft="foo" />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft={foo} />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft="/foo" />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft="https://foo.bar.com" />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<div hrefLeft="foo" />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: "<Anchor hrefLeft={`#foo`}/>", Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft={"foo"}/>`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft="#foo" />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<UX.Layout>test</UX.Layout>`, Tsx: true, Options: componentsAndSpecialLinkOption},
+
+		// ---- WITH ON CLICK — DEFAULT ELEMENT 'a' TESTS ----
+		{Code: `<a {...props} onClick={() => void 0} />`, Tsx: true},
+		{Code: `<a href="foo" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<a href={foo} onClick={() => void 0} />`, Tsx: true},
+		{Code: `<a href="/foo" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<a href="https://foo.bar.com" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<div href="foo" onClick={() => void 0} />`, Tsx: true},
+		{Code: "<a href={`#foo`} onClick={() => void 0} />", Tsx: true},
+		{Code: `<a href={"foo"} onClick={() => void 0} />`, Tsx: true},
+		{Code: `<a href="#foo" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<a href={this} onClick={() => void 0} />`, Tsx: true},
+
+		// ---- WITH ON CLICK — CUSTOM ELEMENT TEST FOR ARRAY OPTION ----
+		{Code: `<Anchor {...props} onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href="foo" onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href={foo} onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href="/foo" onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href="https://foo.bar.com" onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: "<Anchor href={`#foo`} onClick={() => void 0} />", Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href={"foo"} onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Anchor href="#foo" onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link {...props} onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href="foo" onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href={foo} onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href="/foo" onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href="https://foo.bar.com" onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<div href="foo" onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: "<Link href={`#foo`} onClick={() => void 0} />", Tsx: true, Options: componentsOption},
+		{Code: `<Link href={"foo"} onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+		{Code: `<Link href="#foo" onClick={() => void 0} />`, Tsx: true, Options: componentsOption},
+
+		// ---- WITH ON CLICK — CUSTOM PROP TESTS ----
+		{Code: `<a {...props} onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft="foo" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft={foo} onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft="/foo" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft href="https://foo.bar.com" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<div hrefLeft="foo" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: "<a hrefLeft={`#foo`} onClick={() => void 0} />", Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft={"foo"} onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefLeft="#foo" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight={this} onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a {...props} onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight="foo" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight={foo} onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight="/foo" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight href="https://foo.bar.com" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<div hrefRight="foo" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: "<a hrefRight={`#foo`} onClick={() => void 0} />", Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight={"foo"} onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight="#foo" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+		{Code: `<a hrefRight={this} onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption},
+
+		// ---- WITH ON CLICK — CUSTOM BOTH COMPONENTS AND SPECIAL LINK TESTS ----
+		{Code: `<Anchor {...props} onClick={() => void 0} />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft="foo" onClick={() => void 0} />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft={foo} onClick={() => void 0} />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft="/foo" onClick={() => void 0} />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft href="https://foo.bar.com" onClick={() => void 0} />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: "<Anchor hrefLeft={`#foo`} onClick={() => void 0} />", Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft={"foo"} onClick={() => void 0} />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+		{Code: `<Anchor hrefLeft="#foo" onClick={() => void 0} />`, Tsx: true, Options: componentsAndSpecialLinkOption},
+
+		// ---- WITH ASPECTS TESTS — NO HREF ----
+		{Code: `<a />`, Tsx: true, Options: invalidHrefAspectOption},
+		{Code: `<a href={undefined} />`, Tsx: true, Options: invalidHrefAspectOption},
+		{Code: `<a href={null} />`, Tsx: true, Options: invalidHrefAspectOption},
+		{Code: `<a />`, Tsx: true, Options: preferButtonAspectOption},
+		{Code: `<a href={undefined} />`, Tsx: true, Options: preferButtonAspectOption},
+		{Code: `<a href={null} />`, Tsx: true, Options: preferButtonAspectOption},
+		{Code: `<a />`, Tsx: true, Options: preferButtonInvalidHrefAspectOption},
+		{Code: `<a href={undefined} />`, Tsx: true, Options: preferButtonInvalidHrefAspectOption},
+		{Code: `<a href={null} />`, Tsx: true, Options: preferButtonInvalidHrefAspectOption},
+
+		// ---- WITH ASPECTS TESTS — INVALID HREF ----
+		{Code: `<a href="" />;`, Tsx: true, Options: preferButtonAspectOption},
+		{Code: `<a href="#" />`, Tsx: true, Options: preferButtonAspectOption},
+		{Code: `<a href={"#"} />`, Tsx: true, Options: preferButtonAspectOption},
+		{Code: `<a href="javascript:void(0)" />`, Tsx: true, Options: preferButtonAspectOption},
+		{Code: `<a href={"javascript:void(0)"} />`, Tsx: true, Options: preferButtonAspectOption},
+		{Code: `<a href="" />;`, Tsx: true, Options: noHrefAspectOption},
+		{Code: `<a href="#" />`, Tsx: true, Options: noHrefAspectOption},
+		{Code: `<a href={"#"} />`, Tsx: true, Options: noHrefAspectOption},
+		{Code: `<a href="javascript:void(0)" />`, Tsx: true, Options: noHrefAspectOption},
+		{Code: `<a href={"javascript:void(0)"} />`, Tsx: true, Options: noHrefAspectOption},
+		{Code: `<a href="" />;`, Tsx: true, Options: noHrefPreferButtonAspectOption},
+		{Code: `<a href="#" />`, Tsx: true, Options: noHrefPreferButtonAspectOption},
+		{Code: `<a href={"#"} />`, Tsx: true, Options: noHrefPreferButtonAspectOption},
+		{Code: `<a href="javascript:void(0)" />`, Tsx: true, Options: noHrefPreferButtonAspectOption},
+		{Code: `<a href={"javascript:void(0)"} />`, Tsx: true, Options: noHrefPreferButtonAspectOption},
+
+		// ---- WITH ASPECTS TESTS — SHOULD BE BUTTON ----
+		{Code: `<a onClick={() => void 0} />`, Tsx: true, Options: invalidHrefAspectOption},
+		{Code: `<a href="#" onClick={() => void 0} />`, Tsx: true, Options: noHrefAspectOption},
+		{Code: `<a href="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Options: noHrefAspectOption},
+		{Code: `<a href={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Options: noHrefAspectOption},
+
+		// ---- CUSTOM COMPONENTS AND SPECIAL LINK AND ASPECT ----
+		{Code: `<Anchor hrefLeft={undefined} />`, Tsx: true, Options: componentsAndSpecialLinkAndInvalidHrefAspectOption},
+		{Code: `<Anchor hrefLeft={null} />`, Tsx: true, Options: componentsAndSpecialLinkAndInvalidHrefAspectOption},
+	}, []rule_tester.InvalidTestCase{
+		// ---- DEFAULT ELEMENT 'a' TESTS — NO HREF ----
+		{Code: `<a />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={undefined} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={null} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		// ---- DEFAULT ELEMENT 'a' TESTS — INVALID HREF ----
+		{Code: `<a href="" />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="#" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"#"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="javascript:void(0)" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// ---- DEFAULT ELEMENT 'a' TESTS — SHOULD BE BUTTON ----
+		{Code: `<a onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="#" onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- CUSTOM ELEMENT TEST FOR ARRAY OPTION — NO HREF ----
+		{Code: `<Link />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Link href={undefined} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Link href={null} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		// ---- CUSTOM ELEMENT TEST FOR ARRAY OPTION — INVALID HREF ----
+		{Code: `<Link href="" />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Link href="#" />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Link href={"#"} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Link href="javascript:void(0)" />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Link href={"javascript:void(0)"} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor href="" />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor href="#" />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor href={"#"} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor href="javascript:void(0)" />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor href={"javascript:void(0)"} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// ---- CUSTOM ELEMENT TEST FOR ARRAY OPTION — SHOULD BE BUTTON ----
+		{Code: `<Link onClick={() => void 0} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Link href="#" onClick={() => void 0} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Link href="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Link href={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor onClick={() => void 0} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor href="#" onClick={() => void 0} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor href="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor href={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Options: componentsOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Link href="#" onClick={() => void 0} />`, Tsx: true, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- CUSTOM PROP TESTS — NO HREF ----
+		{Code: `<a hrefLeft={undefined} />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a hrefLeft={null} />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		// ---- CUSTOM PROP TESTS — INVALID HREF ----
+		{Code: `<a hrefLeft="" />;`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a hrefLeft="#" />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a hrefLeft={"#"} />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a hrefLeft="javascript:void(0)" />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a hrefLeft={"javascript:void(0)"} />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// ---- CUSTOM PROP TESTS — SHOULD BE BUTTON ----
+		{Code: `<a hrefLeft="#" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a hrefLeft="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a hrefLeft={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Options: specialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- CUSTOM BOTH COMPONENTS AND SPECIAL LINK TESTS — NO HREF ----
+		// Upstream's curious `Anchor={undefined}` (note: not hrefLeft) — tests
+		// that the rule treats unrelated props as no-href (Anchor doesn't
+		// match propsToValidate, so values is [undefined, undefined] for
+		// [href, hrefLeft] → noHref).
+		{Code: `<Anchor Anchor={undefined} />`, Tsx: true, Options: componentsAndSpecialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor hrefLeft={null} />`, Tsx: true, Options: componentsAndSpecialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		// ---- CUSTOM BOTH COMPONENTS AND SPECIAL LINK TESTS — INVALID HREF ----
+		{Code: `<Anchor hrefLeft="" />;`, Tsx: true, Options: componentsAndSpecialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor hrefLeft="#" />`, Tsx: true, Options: componentsAndSpecialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor hrefLeft={"#"} />`, Tsx: true, Options: componentsAndSpecialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor hrefLeft="javascript:void(0)" />`, Tsx: true, Options: componentsAndSpecialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor hrefLeft={"javascript:void(0)"} />`, Tsx: true, Options: componentsAndSpecialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		// ---- CUSTOM BOTH COMPONENTS AND SPECIAL LINK TESTS — SHOULD BE BUTTON ----
+		{Code: `<Anchor hrefLeft="#" onClick={() => void 0} />`, Tsx: true, Options: componentsAndSpecialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor hrefLeft="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Options: componentsAndSpecialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor hrefLeft={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Options: componentsAndSpecialLinkOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- WITH ASPECTS TESTS — NO HREF ----
+		{Code: `<a />`, Tsx: true, Options: noHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a />`, Tsx: true, Options: noHrefPreferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a />`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={undefined} />`, Tsx: true, Options: noHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={undefined} />`, Tsx: true, Options: noHrefPreferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={undefined} />`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={null} />`, Tsx: true, Options: noHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={null} />`, Tsx: true, Options: noHrefPreferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={null} />`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- WITH ASPECTS TESTS — INVALID HREF ----
+		{Code: `<a href="" />;`, Tsx: true, Options: invalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="" />;`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="" />;`, Tsx: true, Options: preferButtonInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="#" />;`, Tsx: true, Options: invalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="#" />;`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="#" />;`, Tsx: true, Options: preferButtonInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"#"} />;`, Tsx: true, Options: invalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"#"} />;`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"#"} />;`, Tsx: true, Options: preferButtonInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="javascript:void(0)" />;`, Tsx: true, Options: invalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="javascript:void(0)" />;`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="javascript:void(0)" />;`, Tsx: true, Options: preferButtonInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)"} />;`, Tsx: true, Options: invalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)"} />;`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)"} />;`, Tsx: true, Options: preferButtonInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- WITH ASPECTS TESTS — SHOULD BE BUTTON ----
+		{Code: `<a onClick={() => void 0} />`, Tsx: true, Options: preferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a onClick={() => void 0} />`, Tsx: true, Options: preferButtonInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a onClick={() => void 0} />`, Tsx: true, Options: noHrefPreferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		// onClick + only-noHref: the `(onClick && !preferButton)` arm of the
+		// `||` gates the noHref report; preferButton off → noHref reported.
+		{Code: `<a onClick={() => void 0} />`, Tsx: true, Options: noHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a onClick={() => void 0} />`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="#" onClick={() => void 0} />`, Tsx: true, Options: preferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="#" onClick={() => void 0} />`, Tsx: true, Options: noHrefPreferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="#" onClick={() => void 0} />`, Tsx: true, Options: preferButtonInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="#" onClick={() => void 0} />`, Tsx: true, Options: invalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="#" onClick={() => void 0} />`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Options: preferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Options: noHrefPreferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Options: preferButtonInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Options: invalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href="javascript:void(0)" onClick={() => void 0} />`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Options: preferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Options: noHrefPreferButtonAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Options: preferButtonInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferButton", Message: preferButtonErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Options: invalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<a href={"javascript:void(0)"} onClick={() => void 0} />`, Tsx: true, Options: noHrefInvalidHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidHref", Message: invalidHrefErrorMessage, Line: 1, Column: 1}}},
+
+		// ---- CUSTOM COMPONENTS AND SPECIAL LINK AND ASPECT ----
+		{Code: `<Anchor hrefLeft={undefined} />`, Tsx: true, Options: componentsAndSpecialLinkAndNoHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+		{Code: `<Anchor hrefLeft={null} />`, Tsx: true, Options: componentsAndSpecialLinkAndNoHrefAspectOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -159,6 +159,7 @@ export default defineConfig({
     // eslint-plugin-jsx-a11y
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/anchor-has-content.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/anchor-is-valid.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/aria-unsupported-elements.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/img-redundant-alt.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/anchor-is-valid.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/anchor-is-valid.test.ts
@@ -1,0 +1,898 @@
+import { RuleTester } from '../rule-tester';
+
+const preferButtonErrorMessage =
+  'Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md';
+
+const noHrefErrorMessage =
+  'The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md';
+
+const invalidHrefErrorMessage =
+  'The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md';
+
+const components = [{ components: ['Anchor', 'Link'] }];
+const specialLink = [{ specialLink: ['hrefLeft', 'hrefRight'] }];
+const noHrefAspect = [{ aspects: ['noHref'] }];
+const invalidHrefAspect = [{ aspects: ['invalidHref'] }];
+const preferButtonAspect = [{ aspects: ['preferButton'] }];
+const noHrefInvalidHrefAspect = [{ aspects: ['noHref', 'invalidHref'] }];
+const noHrefPreferButtonAspect = [{ aspects: ['noHref', 'preferButton'] }];
+const preferButtonInvalidHrefAspect = [
+  { aspects: ['preferButton', 'invalidHref'] },
+];
+const componentsAndSpecialLink = [
+  { components: ['Anchor'], specialLink: ['hrefLeft'] },
+];
+const componentsAndSpecialLinkAndInvalidHrefAspect = [
+  {
+    components: ['Anchor'],
+    specialLink: ['hrefLeft'],
+    aspects: ['invalidHref'],
+  },
+];
+const componentsAndSpecialLinkAndNoHrefAspect = [
+  { components: ['Anchor'], specialLink: ['hrefLeft'], aspects: ['noHref'] },
+];
+
+const componentsSettings = {
+  'jsx-a11y': {
+    components: {
+      Anchor: 'a',
+      Link: 'a',
+    },
+  },
+};
+
+new RuleTester().run('anchor-is-valid', null as never, {
+  valid: [
+    // ---- DEFAULT ELEMENT 'a' TESTS ----
+    { code: '<Anchor />' },
+    { code: '<a {...props} />' },
+    { code: '<a href="foo" />' },
+    { code: '<a href={foo} />' },
+    { code: '<a href="/foo" />' },
+    { code: '<a href="https://foo.bar.com" />' },
+    { code: '<div href="foo" />' },
+    { code: '<a href="javascript" />' },
+    { code: '<a href="javascriptFoo" />' },
+    { code: '<a href={`#foo`}/>' },
+    { code: '<a href={"foo"}/>' },
+    { code: '<a href={"javascript"}/>' },
+    { code: '<a href={`#javascript`}/>' },
+    { code: '<a href="#foo" />' },
+    { code: '<a href="#javascript" />' },
+    { code: '<a href="#javascriptFoo" />' },
+    { code: '<UX.Layout>test</UX.Layout>' },
+    { code: '<a href={this} />' },
+
+    // ---- CUSTOM ELEMENT TEST FOR ARRAY OPTION ----
+    { code: '<Anchor {...props} />', options: components },
+    { code: '<Anchor href="foo" />', options: components },
+    { code: '<Anchor href={foo} />', options: components },
+    { code: '<Anchor href="/foo" />', options: components },
+    { code: '<Anchor href="https://foo.bar.com" />', options: components },
+    { code: '<div href="foo" />', options: components },
+    { code: '<Anchor href={`#foo`}/>', options: components },
+    { code: '<Anchor href={"foo"}/>', options: components },
+    { code: '<Anchor href="#foo" />', options: components },
+    { code: '<Link {...props} />', options: components },
+    { code: '<Link href="foo" />', options: components },
+    { code: '<Link href={foo} />', options: components },
+    { code: '<Link href="/foo" />', options: components },
+    { code: '<Link href="https://foo.bar.com" />', options: components },
+    { code: '<div href="foo" />', options: components },
+    { code: '<Link href={`#foo`}/>', options: components },
+    { code: '<Link href={"foo"}/>', options: components },
+    { code: '<Link href="#foo" />', options: components },
+    { code: '<Link href="#foo" />', settings: componentsSettings },
+
+    // ---- CUSTOM PROP TESTS ----
+    { code: '<a {...props} />', options: specialLink },
+    { code: '<a hrefLeft="foo" />', options: specialLink },
+    { code: '<a hrefLeft={foo} />', options: specialLink },
+    { code: '<a hrefLeft="/foo" />', options: specialLink },
+    { code: '<a hrefLeft="https://foo.bar.com" />', options: specialLink },
+    { code: '<div hrefLeft="foo" />', options: specialLink },
+    { code: '<a hrefLeft={`#foo`}/>', options: specialLink },
+    { code: '<a hrefLeft={"foo"}/>', options: specialLink },
+    { code: '<a hrefLeft="#foo" />', options: specialLink },
+    { code: '<UX.Layout>test</UX.Layout>', options: specialLink },
+    { code: '<a hrefRight={this} />', options: specialLink },
+    { code: '<a hrefRight="foo" />', options: specialLink },
+    { code: '<a hrefRight={foo} />', options: specialLink },
+    { code: '<a hrefRight="/foo" />', options: specialLink },
+    { code: '<a hrefRight="https://foo.bar.com" />', options: specialLink },
+    { code: '<div hrefRight="foo" />', options: specialLink },
+    { code: '<a hrefRight={`#foo`}/>', options: specialLink },
+    { code: '<a hrefRight={"foo"}/>', options: specialLink },
+    { code: '<a hrefRight="#foo" />', options: specialLink },
+
+    // ---- CUSTOM BOTH COMPONENTS AND SPECIALLINK TESTS ----
+    { code: '<Anchor {...props} />', options: componentsAndSpecialLink },
+    { code: '<Anchor hrefLeft="foo" />', options: componentsAndSpecialLink },
+    { code: '<Anchor hrefLeft={foo} />', options: componentsAndSpecialLink },
+    { code: '<Anchor hrefLeft="/foo" />', options: componentsAndSpecialLink },
+    {
+      code: '<Anchor hrefLeft="https://foo.bar.com" />',
+      options: componentsAndSpecialLink,
+    },
+    { code: '<div hrefLeft="foo" />', options: componentsAndSpecialLink },
+    {
+      code: '<Anchor hrefLeft={`#foo`}/>',
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft={"foo"}/>',
+      options: componentsAndSpecialLink,
+    },
+    { code: '<Anchor hrefLeft="#foo" />', options: componentsAndSpecialLink },
+    {
+      code: '<UX.Layout>test</UX.Layout>',
+      options: componentsAndSpecialLink,
+    },
+
+    // ---- WITH ONCLICK — DEFAULT ELEMENT 'a' TESTS ----
+    { code: '<a {...props} onClick={() => void 0} />' },
+    { code: '<a href="foo" onClick={() => void 0} />' },
+    { code: '<a href={foo} onClick={() => void 0} />' },
+    { code: '<a href="/foo" onClick={() => void 0} />' },
+    { code: '<a href="https://foo.bar.com" onClick={() => void 0} />' },
+    { code: '<div href="foo" onClick={() => void 0} />' },
+    { code: '<a href={`#foo`} onClick={() => void 0} />' },
+    { code: '<a href={"foo"} onClick={() => void 0} />' },
+    { code: '<a href="#foo" onClick={() => void 0} />' },
+    { code: '<a href={this} onClick={() => void 0} />' },
+
+    // ---- WITH ONCLICK — CUSTOM ELEMENT TEST FOR ARRAY OPTION ----
+    {
+      code: '<Anchor {...props} onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Anchor href="foo" onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Anchor href={foo} onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Anchor href="/foo" onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Anchor href="https://foo.bar.com" onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Anchor href={`#foo`} onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Anchor href={"foo"} onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Anchor href="#foo" onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Link {...props} onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Link href="foo" onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Link href={foo} onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Link href="/foo" onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Link href="https://foo.bar.com" onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<div href="foo" onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Link href={`#foo`} onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Link href={"foo"} onClick={() => void 0} />',
+      options: components,
+    },
+    {
+      code: '<Link href="#foo" onClick={() => void 0} />',
+      options: components,
+    },
+
+    // ---- WITH ONCLICK — CUSTOM PROP TESTS ----
+    {
+      code: '<a {...props} onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft="foo" onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft={foo} onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft="/foo" onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft href="https://foo.bar.com" onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<div hrefLeft="foo" onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft={`#foo`} onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft={"foo"} onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft="#foo" onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefRight={this} onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefRight="foo" onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefRight={foo} onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefRight="/foo" onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefRight href="https://foo.bar.com" onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<div hrefRight="foo" onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefRight={`#foo`} onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefRight={"foo"} onClick={() => void 0} />',
+      options: specialLink,
+    },
+    {
+      code: '<a hrefRight="#foo" onClick={() => void 0} />',
+      options: specialLink,
+    },
+
+    // ---- WITH ONCLICK — CUSTOM BOTH COMPONENTS AND SPECIALLINK TESTS ----
+    {
+      code: '<Anchor {...props} onClick={() => void 0} />',
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft="foo" onClick={() => void 0} />',
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft={foo} onClick={() => void 0} />',
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft="/foo" onClick={() => void 0} />',
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft href="https://foo.bar.com" onClick={() => void 0} />',
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft={`#foo`} onClick={() => void 0} />',
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft={"foo"} onClick={() => void 0} />',
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft="#foo" onClick={() => void 0} />',
+      options: componentsAndSpecialLink,
+    },
+
+    // ---- WITH ASPECTS TESTS — NO HREF ----
+    { code: '<a />', options: invalidHrefAspect },
+    { code: '<a href={undefined} />', options: invalidHrefAspect },
+    { code: '<a href={null} />', options: invalidHrefAspect },
+    { code: '<a />', options: preferButtonAspect },
+    { code: '<a href={undefined} />', options: preferButtonAspect },
+    { code: '<a href={null} />', options: preferButtonAspect },
+    { code: '<a />', options: preferButtonInvalidHrefAspect },
+    { code: '<a href={undefined} />', options: preferButtonInvalidHrefAspect },
+    { code: '<a href={null} />', options: preferButtonInvalidHrefAspect },
+
+    // ---- WITH ASPECTS TESTS — INVALID HREF ----
+    { code: '<a href="" />;', options: preferButtonAspect },
+    { code: '<a href="#" />', options: preferButtonAspect },
+    { code: '<a href={"#"} />', options: preferButtonAspect },
+    { code: '<a href="javascript:void(0)" />', options: preferButtonAspect },
+    {
+      code: '<a href={"javascript:void(0)"} />',
+      options: preferButtonAspect,
+    },
+    { code: '<a href="" />;', options: noHrefAspect },
+    { code: '<a href="#" />', options: noHrefAspect },
+    { code: '<a href={"#"} />', options: noHrefAspect },
+    { code: '<a href="javascript:void(0)" />', options: noHrefAspect },
+    { code: '<a href={"javascript:void(0)"} />', options: noHrefAspect },
+    { code: '<a href="" />;', options: noHrefPreferButtonAspect },
+    { code: '<a href="#" />', options: noHrefPreferButtonAspect },
+    { code: '<a href={"#"} />', options: noHrefPreferButtonAspect },
+    {
+      code: '<a href="javascript:void(0)" />',
+      options: noHrefPreferButtonAspect,
+    },
+    {
+      code: '<a href={"javascript:void(0)"} />',
+      options: noHrefPreferButtonAspect,
+    },
+
+    // ---- WITH ASPECTS TESTS — SHOULD BE BUTTON ----
+    {
+      code: '<a onClick={() => void 0} />',
+      options: invalidHrefAspect,
+    },
+    {
+      code: '<a href="#" onClick={() => void 0} />',
+      options: noHrefAspect,
+    },
+    {
+      code: '<a href="javascript:void(0)" onClick={() => void 0} />',
+      options: noHrefAspect,
+    },
+    {
+      code: '<a href={"javascript:void(0)"} onClick={() => void 0} />',
+      options: noHrefAspect,
+    },
+
+    // ---- CUSTOM COMPONENTS AND SPECIAL LINK AND ASPECT ----
+    {
+      code: '<Anchor hrefLeft={undefined} />',
+      options: componentsAndSpecialLinkAndInvalidHrefAspect,
+    },
+    {
+      code: '<Anchor hrefLeft={null} />',
+      options: componentsAndSpecialLinkAndInvalidHrefAspect,
+    },
+  ],
+  invalid: [
+    // ---- DEFAULT ELEMENT 'a' TESTS — NO HREF ----
+    { code: '<a />', errors: [{ message: noHrefErrorMessage }] },
+    {
+      code: '<a href={undefined} />',
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a href={null} />',
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    // ---- DEFAULT ELEMENT 'a' TESTS — INVALID HREF ----
+    {
+      code: '<a href="" />;',
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="#" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href={"#"} />',
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="javascript:void(0)" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href={"javascript:void(0)"} />',
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    // ---- DEFAULT ELEMENT 'a' TESTS — SHOULD BE BUTTON ----
+    {
+      code: '<a onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href="#" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href="javascript:void(0)" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href={"javascript:void(0)"} onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+
+    // ---- CUSTOM ELEMENT TEST FOR ARRAY OPTION — NO HREF ----
+    {
+      code: '<Link />',
+      errors: [{ message: noHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Link href={undefined} />',
+      errors: [{ message: noHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Link href={null} />',
+      errors: [{ message: noHrefErrorMessage }],
+      options: components,
+    },
+    // ---- CUSTOM ELEMENT TEST FOR ARRAY OPTION — INVALID HREF ----
+    {
+      code: '<Link href="" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Link href="#" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Link href={"#"} />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Link href="javascript:void(0)" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Link href={"javascript:void(0)"} />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Anchor href="" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Anchor href="#" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Anchor href={"#"} />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Anchor href="javascript:void(0)" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Anchor href={"javascript:void(0)"} />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: components,
+    },
+    // ---- CUSTOM ELEMENT TEST FOR ARRAY OPTION — SHOULD BE BUTTON ----
+    {
+      code: '<Link onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Link href="#" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Link href="javascript:void(0)" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Link href={"javascript:void(0)"} onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Anchor onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Anchor href="#" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Anchor href="javascript:void(0)" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Anchor href={"javascript:void(0)"} onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: components,
+    },
+    {
+      code: '<Link href="#" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      settings: componentsSettings,
+    },
+
+    // ---- CUSTOM PROP TESTS — NO HREF ----
+    {
+      code: '<a hrefLeft={undefined} />',
+      errors: [{ message: noHrefErrorMessage }],
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft={null} />',
+      errors: [{ message: noHrefErrorMessage }],
+      options: specialLink,
+    },
+    // ---- CUSTOM PROP TESTS — INVALID HREF ----
+    {
+      code: '<a hrefLeft="" />;',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft="#" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft={"#"} />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft="javascript:void(0)" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft={"javascript:void(0)"} />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: specialLink,
+    },
+    // ---- CUSTOM PROP TESTS — SHOULD BE BUTTON ----
+    {
+      code: '<a hrefLeft="#" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft="javascript:void(0)" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: specialLink,
+    },
+    {
+      code: '<a hrefLeft={"javascript:void(0)"} onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: specialLink,
+    },
+
+    // ---- CUSTOM BOTH COMPONENTS AND SPECIAL LINK TESTS — NO HREF ----
+    {
+      code: '<Anchor Anchor={undefined} />',
+      errors: [{ message: noHrefErrorMessage }],
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft={null} />',
+      errors: [{ message: noHrefErrorMessage }],
+      options: componentsAndSpecialLink,
+    },
+    // ---- CUSTOM BOTH COMPONENTS AND SPECIAL LINK TESTS — INVALID HREF ----
+    {
+      code: '<Anchor hrefLeft="" />;',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft="#" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft={"#"} />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft="javascript:void(0)" />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft={"javascript:void(0)"} />',
+      errors: [{ message: invalidHrefErrorMessage }],
+      options: componentsAndSpecialLink,
+    },
+    // ---- CUSTOM BOTH COMPONENTS AND SPECIAL LINK TESTS — SHOULD BE BUTTON ----
+    {
+      code: '<Anchor hrefLeft="#" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft="javascript:void(0)" onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: componentsAndSpecialLink,
+    },
+    {
+      code: '<Anchor hrefLeft={"javascript:void(0)"} onClick={() => void 0} />',
+      errors: [{ message: preferButtonErrorMessage }],
+      options: componentsAndSpecialLink,
+    },
+
+    // ---- WITH ASPECTS TESTS — NO HREF ----
+    {
+      code: '<a />',
+      options: noHrefAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a />',
+      options: noHrefPreferButtonAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a />',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a href={undefined} />',
+      options: noHrefAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a href={undefined} />',
+      options: noHrefPreferButtonAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a href={undefined} />',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a href={null} />',
+      options: noHrefAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a href={null} />',
+      options: noHrefPreferButtonAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a href={null} />',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+
+    // ---- WITH ASPECTS TESTS — INVALID HREF ----
+    {
+      code: '<a href="" />;',
+      options: invalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="" />;',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="" />;',
+      options: preferButtonInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="#" />;',
+      options: invalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="#" />;',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="#" />;',
+      options: preferButtonInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href={"#"} />;',
+      options: invalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href={"#"} />;',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href={"#"} />;',
+      options: preferButtonInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="javascript:void(0)" />;',
+      options: invalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="javascript:void(0)" />;',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="javascript:void(0)" />;',
+      options: preferButtonInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href={"javascript:void(0)"} />;',
+      options: invalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href={"javascript:void(0)"} />;',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href={"javascript:void(0)"} />;',
+      options: preferButtonInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+
+    // ---- WITH ASPECTS TESTS — SHOULD BE BUTTON ----
+    {
+      code: '<a onClick={() => void 0} />',
+      options: preferButtonAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a onClick={() => void 0} />',
+      options: preferButtonInvalidHrefAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a onClick={() => void 0} />',
+      options: noHrefPreferButtonAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a onClick={() => void 0} />',
+      options: noHrefAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a onClick={() => void 0} />',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<a href="#" onClick={() => void 0} />',
+      options: preferButtonAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href="#" onClick={() => void 0} />',
+      options: noHrefPreferButtonAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href="#" onClick={() => void 0} />',
+      options: preferButtonInvalidHrefAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href="#" onClick={() => void 0} />',
+      options: invalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="#" onClick={() => void 0} />',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="javascript:void(0)" onClick={() => void 0} />',
+      options: preferButtonAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href="javascript:void(0)" onClick={() => void 0} />',
+      options: noHrefPreferButtonAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href="javascript:void(0)" onClick={() => void 0} />',
+      options: preferButtonInvalidHrefAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href="javascript:void(0)" onClick={() => void 0} />',
+      options: invalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href="javascript:void(0)" onClick={() => void 0} />',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href={"javascript:void(0)"} onClick={() => void 0} />',
+      options: preferButtonAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href={"javascript:void(0)"} onClick={() => void 0} />',
+      options: noHrefPreferButtonAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href={"javascript:void(0)"} onClick={() => void 0} />',
+      options: preferButtonInvalidHrefAspect,
+      errors: [{ message: preferButtonErrorMessage }],
+    },
+    {
+      code: '<a href={"javascript:void(0)"} onClick={() => void 0} />',
+      options: invalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+    {
+      code: '<a href={"javascript:void(0)"} onClick={() => void 0} />',
+      options: noHrefInvalidHrefAspect,
+      errors: [{ message: invalidHrefErrorMessage }],
+    },
+
+    // ---- CUSTOM COMPONENTS AND SPECIAL LINK AND ASPECT ----
+    {
+      code: '<Anchor hrefLeft={undefined} />',
+      options: componentsAndSpecialLinkAndNoHrefAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+    {
+      code: '<Anchor hrefLeft={null} />',
+      options: componentsAndSpecialLinkAndNoHrefAspect,
+      errors: [{ message: noHrefErrorMessage }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -136,6 +136,7 @@ NOTX
 Nullishness
 objectbindingpattern
 objectliteralexpression
+onclick
 optionable
 osvfs
 parenless


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/anchor-is-valid` rule from eslint-plugin-jsx-a11y to rslint, with full upstream parity plus tsgo / staticEval edge-case lock-ins.

The rule enforces that `<a>` elements (and any configured custom anchor components) function as proper hyperlinks — every anchor should either carry a valid, navigable href, or be replaced with a `<button>` when used as a click target. Three independent aspects (`noHref` / `invalidHref` / `preferButton`) are enabled by default.

Two helpers also extracted to `jsxa11yutil` along the way (per the duplicate-across-rules rule):

- `PropValueIsNullish` — mirrors upstream's `getPropValue(prop) == null` check.
- `StringSliceOption` — JSON-decoded `[]interface{}` → `[]string` coercion. Replaces inline duplicates in `anchor_has_content` + `alt_text` (2 sites).

## Related Links

- ESLint rule docs: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/anchor-is-valid.js
- Upstream tests: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/__tests__/src/rules/anchor-is-valid-test.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).