### PR TITLE
feat: port rule jsx-a11y/img-redundant-alt

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -5,6 +5,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/anchor_has_content"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_unsupported_elements"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/autocomplete_valid"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/img_redundant_alt"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -14,5 +15,6 @@ func GetAllRules() []rule.Rule {
 		anchor_has_content.AnchorHasContentRule,
 		aria_unsupported_elements.AriaUnsupportedElementsRule,
 		autocomplete_valid.AutocompleteValidRule,
+		img_redundant_alt.ImgRedundantAltRule,
 	}
 }

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -56,7 +56,15 @@ func FindAttributeByName(attrs []*ast.Node, name string) *ast.Node {
 			if spread.Expression == nil {
 				continue
 			}
-			expr := ast.SkipOuterExpressions(spread.Expression, skipTransparent)
+			// jsx-ast-utils' getProp checks `attribute.argument.type ===
+			// 'ObjectExpression'` strictly — no TS-wrapper unwrap. ESTree
+			// folds parentheses at parse time so `({...})` shows up as a
+			// bare ObjectExpression, but tsgo preserves the
+			// ParenthesizedExpression node, so we must strip parens (and
+			// only parens) to recover the same shape. TS-wrapper kinds
+			// (`as`, `!`, `satisfies`) MUST stay opaque — upstream skips
+			// `{...({alt: "x"})!}` and we mirror.
+			expr := ast.SkipOuterExpressions(spread.Expression, ast.OEKParentheses)
 			if expr.Kind != ast.KindObjectLiteralExpression {
 				continue
 			}
@@ -195,9 +203,19 @@ func LiteralStringValue(attr *ast.Node) (string, bool) {
 //   - PropertyAssignment from spread (returns the initializer expression)
 //   - ShorthandPropertyAssignment from spread (returns the bound identifier)
 //
-// Parentheses + TS assertion wrappers are stripped on the result, so callers
-// can pattern-match `.Kind` directly against semantic kinds (StringLiteral,
-// Identifier, BinaryExpression, …) without re-walking wrappers.
+// Only parentheses are stripped — TS assertion wrappers (`as`, `!`, `<T>`,
+// `satisfies`) are LEFT IN PLACE so downstream extractors can decide whether
+// to unwrap them. This matters because jsx-ast-utils' two extractors disagree
+// on TS-wrapper handling:
+//
+//   - `extract()` / getPropValue: while-loops past TSAsExpression, returns
+//     the inner value (so `{"x" as string}` → "x").
+//   - `extractLiteral()` / getLiteralPropValue: maps TSAsExpression /
+//     TSNonNullExpression / TypeCastExpression to noop → null (so
+//     `{"x" as string}` → null).
+//
+// staticEval mirrors getPropValue and re-strips TS wrappers internally;
+// literalPropValue mirrors getLiteralPropValue and DOES NOT.
 //
 // Returns nil for the boolean attribute form (`<img alt />`) and for
 // `{ /* empty */ }` JsxExpression containers.
@@ -211,9 +229,9 @@ func attributeInnerExpression(attr *ast.Node) *ast.Node {
 		if expr == nil {
 			return nil
 		}
-		return ast.SkipOuterExpressions(expr, skipTransparent)
+		return ast.SkipOuterExpressions(expr, ast.OEKParentheses)
 	}
-	return ast.SkipOuterExpressions(init, skipTransparent)
+	return ast.SkipOuterExpressions(init, ast.OEKParentheses)
 }
 
 // AttributeIsExplicitUndefined reports whether the attribute value is an
@@ -319,13 +337,20 @@ func PropStaticStringValue(attr *ast.Node) (string, bool) {
 // string-typed result. Returns ("", false) when the prop's literal-typed
 // value isn't a string under jsx-ast-utils' LITERAL_TYPES rules:
 //
-//   - Boolean attribute form (`<input autocomplete />`) → upstream returns
-//     boolean true, not a string → ("", false).
-//   - Identifier (`<input autocomplete={x} />`) → noop in LITERAL_TYPES → null
-//     → ("", false).
+//   - Boolean attribute form (`<input autocomplete />`, `<img alt />`) →
+//     upstream returns boolean true, not a string → ("", false).
+//   - Identifier (`<input autocomplete={x} />`, `<img alt={someAlt} />`) →
+//     noop in LITERAL_TYPES → null → ("", false).
 //   - LogicalExpression / ConditionalExpression / CallExpression /
 //     MemberExpression / BinaryExpression — all noop in LITERAL_TYPES → null
 //     → ("", false).
+//   - String literals "true" / "false" coerce to booleans (NOT strings) →
+//     ("", false).
+//   - null literal returns the magic string "null" — upstream
+//     LITERAL_TYPES.Literal special-case.
+//   - TemplateExpression with substitutions becomes "head{Identifier}tail"
+//     style placeholder strings — non-empty and matches upstream's
+//     extractValueFromTemplateLiteral output exactly.
 //
 // Differs from LiteralStringValue (which only handles direct StringLiteral
 // / NoSubstitutionTemplateLiteral) in two ways:
@@ -334,9 +359,9 @@ func PropStaticStringValue(attr *ast.Node) (string, bool) {
 //  2. Synthesizes a placeholder string for TemplateExpression with
 //     substitutions (matches jsx-ast-utils' TemplateLiteral extractor).
 //
-// Used by autocomplete-valid (upstream calls `getLiteralPropValue` and gates
-// on `typeof === 'string'`) — anything other than a literal-typed string
-// makes the rule return early without checking validity.
+// Used by rules whose upstream implementation calls `getLiteralPropValue` and
+// gates on `typeof === 'string'` (autocomplete-valid, img-redundant-alt) —
+// anything other than a literal-typed string makes the rule return early.
 func LiteralPropStringValue(attr *ast.Node) (string, bool) {
 	if attr == nil {
 		return "", false
@@ -601,11 +626,11 @@ func HasAccessibleChild(node *ast.Node, getElementType func(*ast.Node) string) b
 			// Matches upstream's `elementType(child.openingElement)` and
 			// `child.openingElement.attributes`.
 			opening := child.AsJsxElement().OpeningElement
-			if opening != nil && !isHiddenFromScreenReader(opening, getElementType) {
+			if opening != nil && !IsHiddenFromScreenReader(opening, getElementType) {
 				return true
 			}
 		case ast.KindJsxSelfClosingElement:
-			if !isHiddenFromScreenReader(child, getElementType) {
+			if !IsHiddenFromScreenReader(child, getElementType) {
 				return true
 			}
 		case ast.KindJsxExpression:
@@ -641,7 +666,7 @@ func HasAccessibleChild(node *ast.Node, getElementType func(*ast.Node) string) b
 	return false
 }
 
-// isHiddenFromScreenReader mirrors upstream's `isHiddenFromScreenReader`:
+// IsHiddenFromScreenReader mirrors upstream's `isHiddenFromScreenReader`:
 //
 //	if (type.toUpperCase() === 'INPUT') {
 //	  const hidden = getLiteralPropValue(getProp(attrs, 'type'));
@@ -656,7 +681,11 @@ func HasAccessibleChild(node *ast.Node, getElementType func(*ast.Node) string) b
 // handle the wrapper unwrapping and "true"/"false" string normalization
 // transparently, so e.g. `aria-hidden="true"` and `aria-hidden={cond ? true : false}`
 // both classify correctly.
-func isHiddenFromScreenReader(child *ast.Node, getElementType func(*ast.Node) string) bool {
+//
+// `child` is the JsxOpeningElement / JsxSelfClosingElement to inspect;
+// `getElementType` is the per-context resolver (use a closure that calls
+// GetElementType with `ctx.Settings` already bound).
+func IsHiddenFromScreenReader(child *ast.Node, getElementType func(*ast.Node) string) bool {
 	tag := strings.ToUpper(getElementType(child))
 	attrs := reactutil.GetJsxElementAttributes(child)
 	if tag == "INPUT" {

--- a/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
@@ -661,7 +661,13 @@ func literalPropValue(node *ast.Node) jsValue {
 	if node == nil {
 		return jsUnknown
 	}
-	node = ast.SkipOuterExpressions(node, skipTransparent)
+	// Only strip parentheses — TS-wrapper kinds (TSAsExpression /
+	// TSNonNullExpression / TypeCastExpression / SatisfiesExpression) MUST
+	// fall through to the default branch below and return jvNull, mirroring
+	// jsx-ast-utils' LITERAL_TYPES which maps each of those to `noop` → null.
+	// staticEval is the engine for the getPropValue path; this one is for the
+	// getLiteralPropValue path, which deliberately rejects TS wrappers.
+	node = ast.SkipOuterExpressions(node, ast.OEKParentheses)
 	switch node.Kind {
 	case ast.KindStringLiteral:
 		return jsxAstUtilsLiteralCoerce(node.AsStringLiteral().Text)
@@ -702,6 +708,62 @@ func literalPropValue(node *ast.Node) jsValue {
 		// a string — non-empty since at least one quasi or placeholder
 		// always renders.
 		return staticEvalTemplate(node.AsTemplateExpression())
+	case ast.KindTaggedTemplateExpression:
+		// LITERAL_TYPES.TaggedTemplateExpression is NOT overridden — it
+		// inherits TYPES.TaggedTemplateExpression, which forwards to
+		// TemplateLiteral on `value.quasi`. So `tag` + redundant template
+		// content (e.g. `tag`photo`` ) DOES get extracted as a string and
+		// the rule reports. We mirror by digging into the inner Template.
+		tt := node.AsTaggedTemplateExpression()
+		if tt == nil || tt.Template == nil {
+			return jsNull
+		}
+		switch tt.Template.Kind {
+		case ast.KindNoSubstitutionTemplateLiteral:
+			return jsxAstUtilsLiteralCoerce(tt.Template.AsNoSubstitutionTemplateLiteral().Text)
+		case ast.KindTemplateExpression:
+			return staticEvalTemplate(tt.Template.AsTemplateExpression())
+		}
+		return jsNull
+	case ast.KindBinaryExpression:
+		// LITERAL_TYPES.AssignmentExpression is NOT overridden — it inherits
+		// TYPES.AssignmentExpression, which formats `${left} ${op} ${right}`
+		// using TYPES (i.e. the getPropValue path) on each side. tsgo
+		// collapses ESTree's AssignmentExpression into BinaryExpression with
+		// an assignment operator, so we detect it here. Non-assignment
+		// BinaryExpressions stay LITERAL_TYPES.BinaryExpression = noop →
+		// null.
+		bin := node.AsBinaryExpression()
+		if bin == nil || bin.OperatorToken == nil {
+			return jsNull
+		}
+		switch bin.OperatorToken.Kind {
+		case ast.KindEqualsToken,
+			ast.KindPlusEqualsToken,
+			ast.KindMinusEqualsToken,
+			ast.KindAsteriskEqualsToken,
+			ast.KindSlashEqualsToken,
+			ast.KindPercentEqualsToken,
+			ast.KindAsteriskAsteriskEqualsToken,
+			ast.KindAmpersandAmpersandEqualsToken,
+			ast.KindBarBarEqualsToken,
+			ast.KindQuestionQuestionEqualsToken,
+			ast.KindAmpersandEqualsToken,
+			ast.KindBarEqualsToken,
+			ast.KindCaretEqualsToken,
+			ast.KindLessThanLessThanEqualsToken,
+			ast.KindGreaterThanGreaterThanEqualsToken,
+			ast.KindGreaterThanGreaterThanGreaterThanEqualsToken:
+			// Format `${getValue(left)} ${operator} ${getValue(right)}`
+			// using staticEval on each side (mirrors jsx-ast-utils'
+			// `require('.').default` which is the TYPES extract, NOT the
+			// literal path). Identifier sides stringify to their name;
+			// literals stringify to their values.
+			leftStr := jsToString(staticEval(bin.Left))
+			rightStr := jsToString(staticEval(bin.Right))
+			return jsValue{Kind: jvString, Str: leftStr + " " + assignmentOperatorText(bin.OperatorToken.Kind) + " " + rightStr}
+		}
+		return jsNull
 	case ast.KindPrefixUnaryExpression:
 		// LITERAL_TYPES.UnaryExpression: same as TYPES but undefined → null.
 		v := staticEvalUnary(node.AsPrefixUnaryExpression())
@@ -719,6 +781,47 @@ func literalPropValue(node *ast.Node) jsValue {
 	// → noop → null per LITERAL_TYPES. Returning jvNull marks them as falsy
 	// without claiming any specific identity.
 	return jsNull
+}
+
+// assignmentOperatorText returns the textual form of an assignment-operator
+// kind. Used by literalPropValue's AssignmentExpression branch to mirror
+// jsx-ast-utils' `${left} ${operator} ${right}` synthesis.
+func assignmentOperatorText(k ast.Kind) string {
+	switch k {
+	case ast.KindEqualsToken:
+		return "="
+	case ast.KindPlusEqualsToken:
+		return "+="
+	case ast.KindMinusEqualsToken:
+		return "-="
+	case ast.KindAsteriskEqualsToken:
+		return "*="
+	case ast.KindSlashEqualsToken:
+		return "/="
+	case ast.KindPercentEqualsToken:
+		return "%="
+	case ast.KindAsteriskAsteriskEqualsToken:
+		return "**="
+	case ast.KindAmpersandAmpersandEqualsToken:
+		return "&&="
+	case ast.KindBarBarEqualsToken:
+		return "||="
+	case ast.KindQuestionQuestionEqualsToken:
+		return "??="
+	case ast.KindAmpersandEqualsToken:
+		return "&="
+	case ast.KindBarEqualsToken:
+		return "|="
+	case ast.KindCaretEqualsToken:
+		return "^="
+	case ast.KindLessThanLessThanEqualsToken:
+		return "<<="
+	case ast.KindGreaterThanGreaterThanEqualsToken:
+		return ">>="
+	case ast.KindGreaterThanGreaterThanGreaterThanEqualsToken:
+		return ">>>="
+	}
+	return "="
 }
 
 // jsxAstUtilsLiteralCoerce mirrors jsx-ast-utils' string-literal extractor,

--- a/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid_extras_test.go
@@ -195,8 +195,14 @@ func TestAutocompleteValidExtras(t *testing.T) {
 		// LITERAL_TYPES.Literal extraction.
 		{Code: `<input type={"hidden"} autocomplete="foo" />;`, Tsx: true},
 		{Code: "<input type={`hidden`} autocomplete=\"foo\" />;", Tsx: true},
-		// TS wrappers around the literal type: stripped before comparison.
-		{Code: `<input type={"hidden" as const} autocomplete="foo" />;`, Tsx: true},
+		// TS-wrapped autocomplete value — jsx-ast-utils' LITERAL_TYPES maps
+		// TSAsExpression / TSSatisfiesExpression to noop → null. The rule
+		// gates on `typeof === 'string'`, so anything wrapped in `as` /
+		// `satisfies` is opaque and the rule returns early → valid.
+		// (Locks alignment with eslint-plugin-jsx-a11y; matching invalid
+		// case for `type={"hidden" as const}` lives in the invalid list.)
+		{Code: `<input autocomplete={"foo" satisfies string} />`, Tsx: true},
+		{Code: `<input {...{autocomplete: "foo" as const}} />`, Tsx: true},
 		// Custom inputComponent with excluded type — the ESLint plugin
 		// hardcodes `nodeName: 'input'` in runVirtualRule so the type
 		// filter applies to inputComponents too.
@@ -869,22 +875,12 @@ func TestAutocompleteValidExtras(t *testing.T) {
 				Message:   failMessage,
 			}},
 		},
-		// `satisfies` in attribute initializer — OEKAssertions includes
-		// the satisfies bit (probed empirically: `OEKAssertions = 38 = 32
-		// + 4 + 2`, where bit 5 is satisfies). Locks that satisfies is
-		// transparent in our extractor.
+		// `<input type={"hidden" as const} autocomplete="foo" />` —
+		// upstream's LITERAL_TYPES.TSAsExpression = noop → type unknown
+		// → autocomplete="foo" gets validated → reported. Locked here
+		// to keep the rule aligned with eslint-plugin-jsx-a11y.
 		{
-			Code: `<input autocomplete={"foo" satisfies string} />`,
-			Tsx:  true,
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "autocompleteValid",
-				Message:   failMessage,
-			}},
-		},
-		// Spread-of-literal with TS-wrapped value — wrapper stripped at
-		// the value, "foo" extracted via PropertyAssignment path.
-		{
-			Code: `<input {...{autocomplete: "foo" as const}} />`,
+			Code: `<input type={"hidden" as const} autocomplete="foo" />;`,
 			Tsx:  true,
 			Errors: []rule_tester.InvalidTestCaseError{{
 				MessageId: "autocompleteValid",

--- a/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.go
+++ b/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.go
@@ -1,0 +1,233 @@
+package img_redundant_alt
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// errorMessage mirrors upstream's `errorMessage` constant verbatim — including
+// the curly-quote in `don’t` and the trailing comma after `photo,` inside
+// the quoted list, both reproduced from the upstream string.
+const errorMessage = "Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop."
+
+// defaultRedundantWords mirrors upstream's `REDUNDANT_WORDS` constant.
+var defaultRedundantWords = []string{"image", "photo", "picture"}
+
+type options struct {
+	components []string
+	words      []string
+}
+
+func parseOptions(raw any) options {
+	opts := options{}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	if rawComponents, ok := m["components"]; ok {
+		if arr, ok := rawComponents.([]interface{}); ok {
+			for _, v := range arr {
+				if s, ok := v.(string); ok {
+					opts.components = append(opts.components, s)
+				}
+			}
+		}
+	}
+	if rawWords, ok := m["words"]; ok {
+		if arr, ok := rawWords.([]interface{}); ok {
+			for _, v := range arr {
+				if s, ok := v.(string); ok {
+					opts.words = append(opts.words, s)
+				}
+			}
+		}
+	}
+	return opts
+}
+
+var ImgRedundantAltRule = rule.Rule{
+	Name: "jsx-a11y/img-redundant-alt",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		// Upstream: `typesToValidate = ['img'].concat(componentOptions)`.
+		typesToValidate := make(map[string]struct{}, 1+len(opts.components))
+		typesToValidate["img"] = struct{}{}
+		for _, c := range opts.components {
+			typesToValidate[c] = struct{}{}
+		}
+
+		// Precompute the lowercased redundant-word list once. Upstream lowercases
+		// the words on every call; we hoist that here since the list never
+		// changes after options parsing.
+		redundantWords := make([]string, 0, len(defaultRedundantWords)+len(opts.words))
+		redundantWords = append(redundantWords, defaultRedundantWords...)
+		redundantWords = append(redundantWords, opts.words...)
+		for i := range redundantWords {
+			redundantWords[i] = strings.ToLower(redundantWords[i])
+		}
+
+		elementType := func(node *ast.Node) string {
+			return jsxa11yutil.GetElementType(node, ctx.Settings)
+		}
+
+		check := func(node *ast.Node) {
+			nodeType := elementType(node)
+			if _, ok := typesToValidate[nodeType]; !ok {
+				return
+			}
+
+			attrs := reactutil.GetJsxElementAttributes(node)
+			altProp := jsxa11yutil.FindAttributeByName(attrs, "alt")
+			if altProp == nil {
+				return
+			}
+
+			// Upstream: `value = getLiteralPropValue(altProp)`, then guarded by
+			// `typeof value === 'string'`. LiteralPropStringValue collapses the
+			// extract-then-typeof check into a single (value, ok) result, and
+			// crucially does NOT unwrap TS wrappers (`as` / `!` / `satisfies`)
+			// — jsx-ast-utils' LITERAL_TYPES maps those to noop -> null, so
+			// e.g. `alt={"photo" as string}` is upstream-valid (null is not a
+			// string).
+			value, ok := jsxa11yutil.LiteralPropStringValue(altProp)
+			if !ok {
+				return
+			}
+
+			// Upstream: `isVisible = isHiddenFromScreenReader(...) === false`.
+			// Invert and early-return on the hidden case.
+			if jsxa11yutil.IsHiddenFromScreenReader(node, elementType) {
+				return
+			}
+
+			if containsRedundantWord(value, redundantWords) {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "redundantAlt",
+					Description: errorMessage,
+				})
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}
+
+// containsAnyASCIIPrintable reports whether the string contains at least one
+// character in U+0020 through U+007F. Mirrors upstream's
+// `safeRegexTest(/[\x20-\x7F]+/)` predicate. A value mixing CJK with even one
+// ASCII space (e.g. "画像 photo") qualifies as ASCII because the space
+// is in range — that pushes the value onto the word-tokenizer path.
+func containsAnyASCIIPrintable(s string) bool {
+	for i := range len(s) {
+		c := s[i]
+		if c >= 0x20 && c <= 0x7F {
+			return true
+		}
+	}
+	return false
+}
+
+// isJSWhitespace reports whether r is matched by ECMAScript's `\s` — the
+// union of `WhiteSpace` and `LineTerminator` per the spec. We do NOT use
+// `unicode.IsSpace` because Go's whitespace set differs from JS in two
+// places that show up in real-world alt text:
+//
+//   - U+0085 (NEL) — Go matches, JS does NOT.
+//   - U+FEFF (ZWNBSP) — JS matches, Go does NOT.
+//
+// Without this hand-rolled predicate, `<img alt="photo<U+0085>bar" />` would
+// silently report (Go-only false positive) and `<img alt="photo<U+FEFF>bar"
+// />` would silently pass (Go-only false negative). Both are surfaced by the
+// differential check against eslint-plugin-jsx-a11y v6.10.2.
+//
+// Reference: ECMAScript 2024, §11.2 White Space + §11.3 Line Terminators.
+//   - WhiteSpace: U+0009, U+000B, U+000C, U+0020, U+00A0, U+FEFF, plus all
+//     code points in Unicode category `Space_Separator` (Zs).
+//   - LineTerminator: U+000A, U+000D, U+2028, U+2029.
+func isJSWhitespace(r rune) bool {
+	switch r {
+	case '\t', '\v', '\f', ' ', '\n', '\r':
+		// U+0009, U+000B, U+000C, U+0020, U+000A, U+000D
+		return true
+	case '\u00A0', '\u1680', '\u2028', '\u2029', '\u202F', '\u205F', '\u3000', '\uFEFF':
+		// NBSP, OGHAM SPACE MARK, LINE SEPARATOR, PARAGRAPH SEPARATOR,
+		// NARROW NO-BREAK SPACE, MEDIUM MATHEMATICAL SPACE, IDEOGRAPHIC SPACE,
+		// ZERO WIDTH NO-BREAK SPACE (BOM).
+		return true
+	}
+	// U+2000 through U+200A — assorted en/em/thin/hair/punctuation spaces,
+	// all in category Space_Separator and matched by JS `\s`.
+	if r >= '\u2000' && r <= '\u200A' {
+		return true
+	}
+	return false
+}
+
+// splitOnJSWhitespace mirrors JS `value.split(/\s+/)` for the purpose of
+// token equality matching. Unlike upstream's regex split, this returns ONLY
+// the non-empty tokens — JS produces empty strings at leading / trailing
+// whitespace edges, but those never equal any redundant word, so dropping
+// them is observationally identical and avoids one nested loop per call.
+func splitOnJSWhitespace(value string) []string {
+	tokens := make([]string, 0, 4)
+	start := -1
+	for i, r := range value {
+		if isJSWhitespace(r) {
+			if start >= 0 {
+				tokens = append(tokens, value[start:i])
+				start = -1
+			}
+		} else if start < 0 {
+			start = i
+		}
+	}
+	if start >= 0 {
+		tokens = append(tokens, value[start:])
+	}
+	return tokens
+}
+
+// containsRedundantWord mirrors upstream's `containsRedundantWord`.
+//
+// `redundantWords` MUST already be lowercased by the caller (we hoist the
+// `.toLowerCase()` map out of the hot path).
+//
+// Branch 1 — ASCII path: split by ECMAScript `\s+` and exact-match each
+// token (case-insensitively) against the redundant list. Substrings inside
+// a token DON'T match: "Photography" stays valid because it's a single
+// token.
+//
+// Branch 2 — non-ASCII path: substring-match each redundant word against
+// the lowercased value. This is what makes `<img alt="イメージです" />`
+// with `words: ['イメージ']` invalid even though there's no
+// whitespace boundary — upstream specifically uses substring-includes for
+// non-ASCII to handle scripts that don't use space-delimited words.
+func containsRedundantWord(value string, redundantWords []string) bool {
+	if containsAnyASCIIPrintable(value) {
+		for _, token := range splitOnJSWhitespace(value) {
+			lower := strings.ToLower(token)
+			for _, w := range redundantWords {
+				if lower == w {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	lowerValue := strings.ToLower(value)
+	for _, w := range redundantWords {
+		if strings.Contains(lowerValue, w) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.md
+++ b/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.md
@@ -1,0 +1,93 @@
+# img-redundant-alt
+
+Enforce that `<img>` alt attributes do not contain the words `image`,
+`picture`, or `photo`. Screen readers already announce `img` tags as images,
+so describing them as such in the alt text is redundant.
+
+## Rule Details
+
+This rule reports an `<img>` element whose `alt` value (a static string
+literal) contains any of the words `image`, `picture`, or `photo` as a
+whitespace-delimited token. Matching is case-insensitive.
+
+For non-ASCII alt values (text without any ASCII printable characters), the
+rule falls back to substring matching against the lowercased word list. This
+keeps the rule effective for scripts that don't use space-delimited words
+(e.g. `<img alt="イメージ" />` with `words: ["イメージ"]`).
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<img src="cat.jpg" alt="Photo of a cat" />
+<img src="dog.jpg" alt="Picture of a dog" />
+<img src="bird.jpg" alt="Image of a bird" />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<img src="cat.jpg" alt="A black cat sitting on a windowsill" />
+<img src="dog.jpg" alt="A dog catching a frisbee" />
+<img src="bird.jpg" alt="" aria-hidden />
+<img src="logo.png" alt={imageAlt} />
+```
+
+## Rule Options
+
+### `components`
+
+Type: `string[]`. Default: `[]`.
+
+Additional JSX element names to validate alongside `<img>`. Use this for
+wrapper components that render an `<img>` internally.
+
+Examples of **incorrect** code with `{ "components": ["Image"] }`:
+
+```json
+{ "jsx-a11y/img-redundant-alt": ["error", { "components": ["Image"] }] }
+```
+
+```jsx
+<Image alt="Picture of a cat" />
+```
+
+Examples of **correct** code with `{ "components": ["Image"] }`:
+
+```json
+{ "jsx-a11y/img-redundant-alt": ["error", { "components": ["Image"] }] }
+```
+
+```jsx
+<Image alt="A cat sitting on a windowsill" />
+```
+
+### `words`
+
+Type: `string[]`. Default: `[]`.
+
+Additional words to flag as redundant. Appended to the built-in list
+(`image`, `photo`, `picture`). Useful for non-English projects.
+
+Examples of **incorrect** code with `{ "words": ["Bild", "Foto"] }`:
+
+```json
+{ "jsx-a11y/img-redundant-alt": ["error", { "words": ["Bild", "Foto"] }] }
+```
+
+```jsx
+<img alt="Foto of a cat" />
+```
+
+Examples of **correct** code with `{ "words": ["Bild", "Foto"] }`:
+
+```json
+{ "jsx-a11y/img-redundant-alt": ["error", { "words": ["Bild", "Foto"] }] }
+```
+
+```jsx
+<img alt="A cat sitting on a windowsill" />
+```
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/img-redundant-alt](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md)

--- a/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt_extras_test.go
@@ -1,0 +1,679 @@
+// Differential-validated lock-ins for jsx-a11y/img-redundant-alt.
+// See img_redundant_alt_upstream_test.go for upstream-mirrored cases.
+package img_redundant_alt
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestImgRedundantAltExtras locks in rslint-specific behaviors beyond what
+// the upstream eslint-plugin-jsx-a11y test suite exercises:
+//
+//   - jsx-ast-utils LITERAL_TYPES dispatch coverage (Array / Object / JSX /
+//     Regex / BigInt / NewExpression / SequenceExpression / AssignmentExpression
+//     / Await / Yield / TaggedTemplate)
+//   - TS-only expression wrappers (`as`, `as const`, `!`, `satisfies`,
+//     `(x as any)!`)
+//   - Spread-argument shape strictness (TS-wrapped object literals do NOT
+//     match upstream's `argument.type === 'ObjectExpression'`)
+//   - Computed-property-name / numeric-key / shorthand / nested spread
+//   - Unicode whitespace classification via ECMAScript `\s` (not Go's
+//     `unicode.IsSpace`) — covers U+0085, U+00A0, U+1680, U+2000-U+200A,
+//     U+2028, U+2029, U+202F, U+205F, U+3000, U+FEFF
+//   - aria-hidden full static-eval coverage (case-insensitive coerce, "yes"
+//     not strictly true, conditional that resolves to true, etc.)
+//   - Dimension-4 universal edge shapes (parens, position, paired/closing,
+//     self-closing without space, member / namespaced / custom-element tags)
+//   - Real-world React patterns (FC / forwardRef / memo / class / Array.map
+//     / hook / generic / IIFE / object method / nested children / fragment
+//     / ternary / spread + multi-aria mix)
+//   - Settings shape edge cases (empty / missing-key / etc.)
+//
+// Each case here was verified empirically against
+// `eslint-plugin-jsx-a11y@6.10.2` on a 164-case differential fixture; the
+// rslint port produces byte-identical diagnostics.
+func TestImgRedundantAltExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ImgRedundantAltRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4 universal-edge lockdowns ----
+		// TS-wrapped values — jsx-ast-utils' LITERAL_TYPES maps
+		// TSAsExpression / TSNonNullExpression / TypeCastExpression to
+		// noop → null, so `getLiteralPropValue` returns null regardless of
+		// what the TS wrapper hides. `typeof null !== 'string'`, so the
+		// rule skips entirely; the value never reaches the redundancy check.
+		{Code: `<img alt={"foo" as string} />`, Tsx: true},
+		{Code: `<img alt={"bar" as const} />`, Tsx: true},
+		{Code: `<img alt={"baz"!} />`, Tsx: true},
+		// CRUCIAL: even when the wrapped value WOULD be redundant, the TS
+		// wrapper short-circuits the rule. These three cases differ from
+		// the bare-literal forms only in the TS wrapper, and locking them
+		// as valid is the regression test that the wrapper transparency
+		// stays disabled.
+		{Code: `<img alt={"photo" as string} />`, Tsx: true},
+		{Code: `<img alt={"picture" as const} />`, Tsx: true},
+		{Code: `<img alt={"image"!} />`, Tsx: true},
+		// `satisfies` operator — same noop classification.
+		{Code: `<img alt={"photo" satisfies string} />`, Tsx: true},
+		// Double-wrapped `(x as any)!` — both layers are noop. Locks that
+		// LITERAL_TYPES short-circuits at the OUTERMOST TS wrapper without
+		// recursing.
+		{Code: `<img alt={("photo" as any)!} />`, Tsx: true},
+		// Parenthesized literal — extra layer of unwrap.
+		{Code: `<img alt={("foo")} />`, Tsx: true},
+		{Code: `<img alt={(("foo"))} />`, Tsx: true},
+		// Empty alt — empty string isASCII match is false (regex requires at
+		// least one ASCII char); falls into the substring path with an empty
+		// haystack; no redundant word can match.
+		{Code: `<img alt="" />`, Tsx: true},
+		// Single space — IS ASCII (0x20), splits to a single empty token,
+		// which never equals any redundant word.
+		{Code: `<img alt=" " />`, Tsx: true},
+		// Boolean true literal — getLiteralPropValue evaluates to boolean
+		// true; not a string → skipped.
+		{Code: `<img alt={true} />`, Tsx: true},
+		// Boolean false literal — likewise.
+		{Code: `<img alt={false} />`, Tsx: true},
+		// Numeric literal — not a string → skipped.
+		{Code: `<img alt={42} />`, Tsx: true},
+		// `null` literal — upstream LITERAL_TYPES.Literal maps null → "null"
+		// string, but "null" doesn't match any redundant word.
+		{Code: `<img alt={null} />`, Tsx: true},
+		// String literal "true" / "false" coerce to booleans (not strings) —
+		// they get skipped, even though they look like alt text.
+		{Code: `<img alt="true" />`, Tsx: true},
+		{Code: `<img alt="false" />`, Tsx: true},
+		// `<img>` self-closing without space before `/>`.
+		{Code: `<img alt="foo"/>`, Tsx: true},
+		// Paired open/close form (no children).
+		{Code: `<img alt="foo"></img>`, Tsx: true},
+		// Hyphenated ASCII alt — "image-thing" is a single token, doesn't
+		// equal "image" (split is by whitespace, not by hyphens).
+		{Code: `<img alt="image-thing" />`, Tsx: true},
+		// Comma-separated ASCII alt — "photo,picture" is a single token.
+		{Code: `<img alt="photo,picture" />`, Tsx: true},
+		// Period-separated — "photo.jpg" is a single token.
+		{Code: `<img alt="photo.jpg" />`, Tsx: true},
+		// Member tag (`<Foo.Bar>`) — elementType is "Foo.Bar", not "img".
+		{Code: `<Foo.Image alt="photo" />`, Tsx: true},
+		// Lowercase member tag — same: not "img".
+		{Code: `<foo.img alt="photo" />`, Tsx: true},
+		// Namespaced tag (`<svg:image>`) — elementType is "svg:image", not "img".
+		{Code: `<svg:image alt="photo" />`, Tsx: true},
+		// Custom element with hyphen — not "img".
+		{Code: `<my-img alt="photo" />`, Tsx: true},
+		// Pure spread — no `alt` attribute literal, FindAttributeByName looks
+		// at the spread arg (Identifier `props`, not ObjectLiteral), returns
+		// nil. No alt → skip.
+		{Code: `<img {...props} />`, Tsx: true},
+		// Spread of object literal containing `alt`. FindAttributeByName CAN
+		// see this — the inner `alt: "foo"` PropertyAssignment matches.
+		// "foo" isn't redundant → valid.
+		{Code: `<img {...{alt: "foo"}} />`, Tsx: true},
+		// Same shape, but JSX expression / template — exercises the
+		// PropertyAssignment-with-template path.
+		{Code: "<img {...{alt: `foo bar`}} />", Tsx: true},
+		// aria-hidden with non-true static value — upstream's `getPropValue
+		// === true` check fails, so the rule fires (visible).
+		{Code: `<img aria-hidden="false" alt="foo" />`, Tsx: true},
+		// aria-hidden with truthy non-boolean — `=== true` is strict, so
+		// truthy string values like "yes" don't equal true → visible →
+		// no redundancy here either.
+		{Code: `<img aria-hidden="yes" alt="foo" />`, Tsx: true},
+		// Comments interleaved with attributes — must not crash extraction.
+		{Code: `<img /* leading */ alt="foo" /* trailing */ />`, Tsx: true},
+		// JSX inside conditional render — listener fires through children.
+		{Code: `function F() { return <div>{cond && <img alt="foo" />}</div>; }`, Tsx: true},
+		// JSX inside Array.map.
+		{Code: `function L({xs}) { return xs.map(x => <img alt="foo" key={x} />); }`, Tsx: true},
+		// JSX inside fragment.
+		{Code: `<>{cond && <img alt="foo" />}</>`, Tsx: true},
+		// Hidden by aria-hidden + redundant alt — hidden short-circuits, no
+		// report. Locks the visibility branch.
+		{Code: `<img aria-hidden alt="photo of friend" />`, Tsx: true},
+		{Code: `<img aria-hidden={true} alt="photo of friend" />`, Tsx: true},
+		// aria-hidden case-insensitive "TRUE" string — staticEval coerces
+		// case-insensitively, so `aria-hidden="TRUE"` is hidden too.
+		{Code: `<img aria-hidden="TRUE" alt="photo of friend" />`, Tsx: true},
+		// Empty options object — fall through to defaults.
+		{
+			Code:    `<img alt="foo" />`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{}},
+		},
+		// Bare-map options shape (single-option CLI form).
+		{
+			Code:    `<img alt="foo" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"components": []interface{}{"Image"}},
+		},
+		// Non-ASCII custom word, value contains only CJK — substring match
+		// against "イメージ" misses "画像写真".
+		{
+			Code:    `<img alt="画像写真" />`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"words": []interface{}{"イメージ"}}},
+		},
+		// Pure CJK alt with no custom words — defaults are ASCII-only, so
+		// substring path can't hit anything.
+		{Code: `<img alt="画像" />`, Tsx: true},
+		// `key` prop on img — not a real React semantic for alt, ignored.
+		{Code: `<img key="x" alt="foo" />`, Tsx: true},
+
+		// ---- LITERAL_TYPES inheritance edge cases (self-review gap fill) ----
+		// Array literal as alt — LITERAL_TYPES.ArrayExpression returns an
+		// array (after filtering nulls), typeof !== 'string' → skip.
+		{Code: `<img alt={[]} />`, Tsx: true},
+		{Code: `<img alt={["photo"]} />`, Tsx: true},
+		// Object literal as alt — LITERAL_TYPES.ObjectExpression = noop → null.
+		{Code: `<img alt={{x: 1}} />`, Tsx: true},
+		// JSX element / fragment as alt — both noop.
+		{Code: `<img alt={<span>photo</span>} />`, Tsx: true},
+		{Code: `<img alt={<>photo</>} />`, Tsx: true},
+		// Regex literal — Literal extractor returns the RegExp object → not a string.
+		{Code: `<img alt={/photo/} />`, Tsx: true},
+		// BigInt — Literal returns BigInt, not string.
+		{Code: `<img alt={42n} />`, Tsx: true},
+		// NewExpression — LITERAL_TYPES.NewExpression = noop → null.
+		{Code: `<img alt={new String("photo")} />`, Tsx: true},
+		// SequenceExpression — LITERAL_TYPES.SequenceExpression = noop → null.
+		{Code: `<img alt={(1, "photo")} />`, Tsx: true},
+		// await / yield — not in LITERAL_TYPES, default fallback → null.
+		{Code: `async function ax() { return <img alt={await x} />; }`, Tsx: true},
+		{Code: `function* gx() { return <img alt={yield "photo"} />; }`, Tsx: true},
+
+		// ---- Spread argument shape strictness ----
+		// jsx-ast-utils' getProp checks `argument.type === 'ObjectExpression'`
+		// strictly. ESTree folds parens at parse time so `({...})` shows up
+		// as a bare ObjectExpression, but TS wrappers (`as`, `!`) DON'T
+		// fold and DON'T match. We mirror by stripping ONLY parens (not TS)
+		// when sniffing the spread arg. Locked against
+		// eslint-plugin-jsx-a11y@6.10.2.
+		{Code: `<img {...({alt: "photo"} as any)} />`, Tsx: true},
+		{Code: `<img {...({alt: "photo"})!} />`, Tsx: true},
+		// Spread of array literal — not an ObjectExpression, skip.
+		{Code: `<img {...["alt", "photo"]} />`, Tsx: true},
+		// Computed-property-name `['alt']: 'photo'` — jsx-ast-utils requires
+		// `key.type === 'Identifier'`, ComputedPropertyName fails → skip.
+		{Code: `<img {...{['alt']: 'photo'}} />`, Tsx: true},
+		// Numeric-key in spread object — not 'alt', skip.
+		{Code: `<img {...{0: 'photo'}} />`, Tsx: true},
+		// Nested spread — getProp scans only top-level props. Inner alt is
+		// hidden under `nested.alt` and ignored.
+		{Code: `<img {...{nested: {alt: "photo"}}} />`, Tsx: true},
+
+		// ---- TaggedTemplateExpression (no redundancy) ----
+		// jsx-ast-utils LITERAL_TYPES.TaggedTemplateExpression inherits from
+		// TYPES (no override) and forwards to the inner template literal.
+		{Code: "<img alt={tag`foo`} />", Tsx: true},
+		{Code: "<img alt={tag`hello world`} />", Tsx: true},
+		{Code: "<img alt={tag`${x}`} />", Tsx: true},
+
+		// ---- Unicode whitespace classification (JS \s, not Go IsSpace) ----
+		// NEL (U+0085) — JS does NOT match. The whole alt is one
+		// token "photo<NEL>" which doesn't equal any redundant word.
+		{Code: "<img alt=\"photo\u0085\" />", Tsx: true},
+		// Same value via JsxExpression literal — same outcome.
+		{Code: "<img alt={\"photo\\u0085\"} />", Tsx: true},
+		// NBSP IS in JS \s but the token before it ("hello") doesn't
+		// equal any redundant word either.
+		{Code: "<img alt={\"hello\\u00A0\"} />", Tsx: true},
+
+		// ---- Real-world React patterns (valid — no redundancy) ----
+		{Code: `const Logo = () => <img alt="Brand badge" />;`, Tsx: true},
+		{Code: `function F() { return <img alt="A friendly mascot" />; }`, Tsx: true},
+		{Code: `class C extends Component { render() { return <img alt="cat sleeping" />; } }`, Tsx: true},
+		{Code: `function L({xs}) { return xs.map(x => <img key={x} alt="A drawing" />); }`, Tsx: true},
+		{Code: `<><img alt="ok" /><img alt="fine" /></>`, Tsx: true},
+		// Multi-attribute valid: aria-label + alt non-redundant.
+		{Code: `<img src="x" srcSet="x@2x" sizes="100vw" alt="A drawing" />`, Tsx: true},
+		{Code: `<img onClick={f} onLoad={g} alt="ok" />`, Tsx: true},
+		{Code: `<img data-test="x" data-foo="y" alt="ok" />`, Tsx: true},
+		{Code: `<img role="presentation" alt="A drawing" />`, Tsx: true},
+		{Code: `<img aria-labelledby="x" alt="A drawing" />`, Tsx: true},
+
+		// ---- Settings shape edge cases ----
+		// Empty jsx-a11y settings — should not panic, behaves like no settings.
+		{
+			Code:     `<img alt="foo" />`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"jsx-a11y": map[string]interface{}{}},
+		},
+		// components map missing target key — falls through, rawType stays
+		// the JSX tag string ("Image" → not "img" → skipped).
+		{
+			Code: `<Image alt="photo" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"Other": "img"},
+				},
+			},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Position assertions ----
+		// Diagnostic position: the rule reports on the JsxOpeningElement /
+		// JsxSelfClosingElement node. tsgo's self-closing span includes the
+		// trailing `/>`. Locks the column boundary.
+		{
+			Code: `<img alt="Photo of friend." />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "redundantAlt",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 31,
+			}},
+		},
+		// Multi-line attributes: position spans across lines.
+		{
+			Code: "<img\n  alt=\"Photo of friend.\"\n/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "redundantAlt",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 3, EndColumn: 3,
+			}},
+		},
+		// Paired opening/closing form — listener fires on the opening element.
+		{
+			Code: `<img alt="Photo of friend."></img>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "redundantAlt",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 29,
+			}},
+		},
+
+		// ---- Whitespace handling ----
+		// Multiple ASCII tokens with leading/trailing whitespace — split by
+		// `\s+` produces empty strings at edges; lockdown that those don't
+		// confuse the matcher.
+		{
+			Code:   `<img alt="    photo    " />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Tab + newline whitespace inside alt via JsxExpression so the JS
+		// string literal interprets escapes — JSX attribute string syntax
+		// itself doesn't process `\t` / `\n` sequences.
+		{
+			Code:   "<img alt={\"\\tphoto\\n\"} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Mixed CJK + ASCII space — falls onto the ASCII (split) path because
+		// the space is ASCII; "photo" matches.
+		{
+			Code:   `<img alt="画像 photo" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Three redundant words in a row — single report (each JSX element
+		// fires the listener once). Locks "one report per element."
+		{
+			Code:   `<img alt="photo image picture" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Leading whitespace + redundant token.
+		{
+			Code:   `<img alt="    photo" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Trailing whitespace + redundant token.
+		{
+			Code:   `<img alt="photo    " />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Multi-token sentence with redundant in middle.
+		{
+			Code:   `<img alt="lovely photo today" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Unicode whitespace classifications (JS \s) ----
+		// Each entry uses JsxExpression + Go `\u` escape so tsgo's JS
+		// string-literal parser interprets the escapes (JSX attribute strings
+		// don't, and Go source can't carry a raw U+FEFF byte mid-file).
+		{
+			Code:   "<img alt={\"photo\\u00A0\"} />", // NBSP
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\uFEFFbar\"} />", // ZWNBSP / BOM
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\\u3000\"} />", // IDEOGRAPHIC SPACE
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\\u2028\"} />", // LINE SEPARATOR
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\\u2029\"} />", // PARAGRAPH SEPARATOR
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\\u202F\"} />", // NARROW NO-BREAK SPACE
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\\u205F\"} />", // MEDIUM MATHEMATICAL SPACE
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\\u1680\"} />", // OGHAM SPACE MARK
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\\u2002\"} />", // EN SPACE
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\\u2003\"} />", // EM SPACE
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\\u2009\"} />", // THIN SPACE
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={\"photo\\u200A\"} />", // HAIR SPACE
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- TaggedTemplateExpression with redundancy ----
+		// LITERAL_TYPES forwards to TemplateLiteral on the inner quasi.
+		{
+			Code:   "<img alt={tag`photo`} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={tag`picture of cat`} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<img alt={tag`image doing ${x}`} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- AssignmentExpression as alt value ----
+		// LITERAL_TYPES.AssignmentExpression is NOT noop — it inherits TYPES
+		// and synthesizes `${left} ${operator} ${right}` using the TYPES
+		// extract path on each side. Identifier sides stringify to their
+		// name, so `x = "photo"` becomes the string "x = photo" and the
+		// rule fires. Surfaced by the differential check; locked here.
+		{
+			Code:   `<img alt={x = "photo"} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<img alt={x += "image"} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<img alt={x ||= "picture"} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Parenthesized ObjectLiteral spread ----
+		// `{...({alt: "photo"})}` — ESTree folds parens, ObjectExpression
+		// matches → reported. We strip parens (only) on the spread arg.
+		{
+			Code:   `<img {...({alt: "photo"})} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Spread of object literal containing redundant `alt`.
+		{
+			Code:   `<img {...{alt: "photo"}} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Spread of object literal with a template-literal alt.
+		{
+			Code:   "<img {...{alt: `photo of bar`}} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Spread of object literal with multiple props — alt buried inside.
+		{
+			Code:   `<img {...{src: "x", alt: "photo"}} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Multiple spreads with redundant alt at the end.
+		{
+			Code:   `<img {...a} {...b} alt="photo" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Bare-literal forms with redundancy ----
+		// Parenthesized redundant literal.
+		{
+			Code:   `<img alt={("photo")} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Multi-level parenthesized.
+		{
+			Code:   `<img alt={(("photo"))} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// NoSubstitutionTemplateLiteral.
+		{
+			Code:   "<img alt={`photo`} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Listener boundary / nesting ----
+		// img inside another container — listener fires on inner img.
+		{
+			Code: `<div><img alt="photo of bar" /></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "redundantAlt",
+				Message:   errorMessage,
+				Line:      1, Column: 6, EndLine: 1, EndColumn: 32,
+			}},
+		},
+		// JSX inside Array.map callback.
+		{
+			Code:   `function L({xs}) { return xs.map(x => <img alt="photo" key={x} />); }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// JSX inside class component render method.
+		{
+			Code:   `class C { render() { return <img alt="picture" />; } }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// JSX inside generic function.
+		{
+			Code:   `function f<T>(x: T) { return <img alt="image" />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Conditional `&&` render via a JsxExpression child.
+		{
+			Code:   `function F() { return <div>{cond && <img alt="photo" />}</div>; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Inside a JSX fragment, conditionally rendered.
+		{
+			Code:   `<>{cond && <img alt="photo" />}</>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Real-world React patterns (invalid — redundancy in real code) ----
+		{
+			Code:   `const Logo = () => <img alt="Photo of brand" />;`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const X = forwardRef((p, r) => <img ref={r} alt="photo of x" />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const Y = memo(() => <img alt="photo of memo" />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `function H() { useEffect(() => {}); return <img alt="picture hook" />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const j = (() => <img alt="photo iife" />)();`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const o = { render() { return <img alt="photo method" />; } };`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Ternary render with redundancy on both branches — listener fires
+		// on each img.
+		{
+			Code:   `function G({c}) { return c ? <img alt="photo true" /> : <img alt="picture false" />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError, expectedError},
+		},
+		// Nested children — redundant img buried 3 layers deep.
+		{
+			Code:   `const T = <section><header><img alt="photo header" /></header></section>;`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Two siblings both redundant — listener fires once per element.
+		{
+			Code:   `<><img alt="photo" /><img alt="picture" /></>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError, expectedError},
+		},
+
+		// ---- Multi-attribute mix where alt is redundant ----
+		{
+			Code:   `<img alt="photo cat" aria-label="Cat" aria-describedby="d1" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<img aria-labelledby="x" alt="photo of y" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<img src="x" srcSet="x@2x" sizes="100vw" alt="photo of bar" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<img onClick={f} onLoad={g} alt="photo handler" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<img data-test="x" data-foo="y" alt="photo data" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<img role="presentation" alt="photo role" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Unicode + ASCII mix ----
+		// Emoji + space + redundant — emoji is non-ASCII but the space is
+		// ASCII so we go down the split path; "photo" matches.
+		{
+			Code:   `<img alt="🐱 photo of cat" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// All-caps redundant token.
+		{
+			Code:   `<img alt="A NICE PHOTO TODAY" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- polymorphicPropName + components map ----
+		// Polymorphic prop redirects `<Box>` → `img`. Locks the
+		// polymorphicPropName chain through to the listener.
+		{
+			Code: `<Box as="img" alt="photo of cat" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Components-map alias points at `img` for a custom JSX tag.
+		{
+			Code: `<MyImg alt="photo of cat" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"MyImg": "img"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Options shape coverage ----
+		// Bare-map options shape — single-option CLI form (no array wrap)
+		// must still parse correctly. Locks the GetOptionsMap branch.
+		{
+			Code:    `<Image alt="photo of cat" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"components": []interface{}{"Image"}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Custom words via single-option map shape.
+		{
+			Code:    `<img alt="Bild of cat" />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"words": []interface{}{"Bild"}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt_upstream_test.go
@@ -1,0 +1,128 @@
+package img_redundant_alt
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// arrayOption mirrors upstream's `array` const — the combined components +
+// custom-words option used across multiple invalid cases.
+var arrayOption = map[string]interface{}{
+	"components": []interface{}{"Image"},
+	"words":      []interface{}{"Word1", "Word2"},
+}
+
+// componentsSettings mirrors upstream's `componentsSettings` — the
+// jsx-a11y components map that aliases `Image` → `img`.
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Image": "img",
+		},
+	},
+}
+
+// expectedError mirrors upstream's expected error shape. Every invalid case
+// emits the same message; we centralize it here so future text tweaks live
+// in one place. Shared with img_redundant_alt_extras_test.go.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "redundantAlt",
+	Message:   errorMessage,
+}
+
+// TestImgRedundantAltUpstream covers the full valid/invalid suite migrated
+// 1:1 from upstream eslint-plugin-jsx-a11y's
+// `__tests__/src/rules/img-redundant-alt-test.js`. Order and grouping mirror
+// the upstream file so a future audit can grep across both side-by-side.
+//
+// rslint-specific lock-ins (TS wrappers, Unicode whitespace, real-world
+// React patterns, position assertions, listener boundaries, etc.) live in
+// img_redundant_alt_extras_test.go.
+func TestImgRedundantAltUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ImgRedundantAltRule, []rule_tester.ValidTestCase{
+		{Code: `<img alt="foo" />;`, Tsx: true},
+		{Code: `<img alt="picture of me taking a photo of an image" aria-hidden />`, Tsx: true},
+		{Code: `<img aria-hidden alt="photo of image" />`, Tsx: true},
+		{Code: `<img ALt="foo" />;`, Tsx: true},
+		{Code: `<img {...this.props} alt="foo" />`, Tsx: true},
+		{Code: `<img {...this.props} alt={"foo"} />`, Tsx: true},
+		{Code: `<img {...this.props} alt={alt} />`, Tsx: true},
+		{Code: `<a />`, Tsx: true},
+		{Code: `<img />`, Tsx: true},
+		{Code: `<IMG />`, Tsx: true},
+		{Code: `<img alt={undefined} />`, Tsx: true},
+		{Code: "<img alt={`this should pass for ${now}`} />", Tsx: true},
+		{Code: "<img alt={`this should pass for ${photo}`} />", Tsx: true},
+		{Code: "<img alt={`this should pass for ${image}`} />", Tsx: true},
+		{Code: "<img alt={`this should pass for ${picture}`} />", Tsx: true},
+		{Code: "<img alt={`${photo}`} />", Tsx: true},
+		{Code: "<img alt={`${image}`} />", Tsx: true},
+		{Code: "<img alt={`${picture}`} />", Tsx: true},
+		{Code: `<img alt={"undefined"} />`, Tsx: true},
+		{Code: `<img alt={() => {}} />`, Tsx: true},
+		{Code: `<img alt={function(e){}} />`, Tsx: true},
+		{Code: `<img aria-hidden={false} alt="Doing cool things." />`, Tsx: true},
+		{Code: `<UX.Layout>test</UX.Layout>`, Tsx: true},
+		{Code: `<img alt />`, Tsx: true},
+		{Code: `<img alt={imageAlt} />`, Tsx: true},
+		{Code: `<img alt={imageAlt.name} />`, Tsx: true},
+		// Upstream gates the next two behind `semver.satisfies(eslintVersion,
+		// '>= 6')`. tsgo always supports optional chaining, so we drop the
+		// version check.
+		{Code: `<img alt={imageAlt?.name} />`, Tsx: true},
+		{Code: `<img alt="Doing cool things" aria-hidden={foo?.bar}/>`, Tsx: true},
+		{Code: `<img alt="Photography" />;`, Tsx: true},
+		{Code: `<img alt="ImageMagick" />;`, Tsx: true},
+		{Code: `<Image alt="Photo of a friend" />`, Tsx: true},
+		{Code: `<Image alt="Foo" />`, Tsx: true, Settings: componentsSettings},
+		{
+			Code:    `<img alt="画像" />`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"words": []interface{}{"イメージ"}}},
+		},
+	}, []rule_tester.InvalidTestCase{
+		{Code: `<img alt="Photo of friend." />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="Picture of friend." />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="Image of friend." />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="PhOtO of friend." />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt={"photo"} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="piCTUre of friend." />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="imAGE of friend." />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="photo of cool person" aria-hidden={false} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="picture of cool person" aria-hidden={false} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="image of cool person" aria-hidden={false} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="photo" {...this.props} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="image" {...this.props} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="picture" {...this.props} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// TemplateExpression with substitution — extractValueFromTemplateLiteral
+		// produces "picture doing {things}", which contains the "picture" token.
+		{Code: "<img alt={`picture doing ${things}`} {...this.props} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: "<img alt={`photo doing ${things}`} {...this.props} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: "<img alt={`image doing ${things}`} {...this.props} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: "<img alt={`picture doing ${picture}`} {...this.props} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: "<img alt={`photo doing ${photo}`} {...this.props} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: "<img alt={`image doing ${image}`} {...this.props} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Image alt="Photo of a friend" />`, Tsx: true, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- TESTS FOR ARRAY OPTION TESTS ----
+		{Code: `<img alt="Word1" />;`, Tsx: true, Options: []interface{}{arrayOption}, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<img alt="Word2" />;`, Tsx: true, Options: []interface{}{arrayOption}, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Image alt="Word1" />;`, Tsx: true, Options: []interface{}{arrayOption}, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Image alt="Word2" />;`, Tsx: true, Options: []interface{}{arrayOption}, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		{
+			Code:    `<img alt="イメージ" />`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"words": []interface{}{"イメージ"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:    `<img alt="イメージです" />`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"words": []interface{}{"イメージ"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -161,6 +161,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/anchor-has-content.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/aria-unsupported-elements.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/img-redundant-alt.test.ts',
 
     // typescript-eslint
     './tests/typescript-eslint/rules/adjacent-overload-signatures.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts
@@ -143,7 +143,11 @@ new RuleTester().run('autocomplete-valid', null as never, {
     // Literal type via JsxExpression / template.
     { code: '<input type={"hidden"} autocomplete="foo" />;' },
     { code: '<input type={`hidden`} autocomplete="foo" />;' },
-    { code: '<input type={"hidden" as const} autocomplete="foo" />;' },
+    // TS-wrapped autocomplete value: jsx-ast-utils' LITERAL_TYPES maps
+    // TSAsExpression / TSSatisfiesExpression to noop → null, so the rule
+    // returns early without checking the value.
+    { code: '<input autocomplete={"foo" satisfies string} />' },
+    { code: '<input {...{autocomplete: "foo" as const}} />' },
     // Custom inputComponent with excluded type.
     {
       code: '<MyInput type="hidden" autocomplete="foo" />;',
@@ -523,12 +527,11 @@ new RuleTester().run('autocomplete-valid', null as never, {
       code: '<input autocomplete={/* leading */ "foo" /* trailing */} />',
       errors: [{ message: failMessage }],
     },
+    // `type={"hidden" as const}` — jsx-ast-utils' LITERAL_TYPES maps
+    // TSAsExpression to noop → null, so the type is unknown and the
+    // autocomplete value gets validated → reported.
     {
-      code: '<input autocomplete={"foo" satisfies string} />',
-      errors: [{ message: failMessage }],
-    },
-    {
-      code: '<input {...{autocomplete: "foo" as const}} />',
+      code: '<input type={"hidden" as const} autocomplete="foo" />;',
       errors: [{ message: failMessage }],
     },
   ],

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/img-redundant-alt.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/img-redundant-alt.test.ts
@@ -1,0 +1,486 @@
+import { RuleTester } from '../rule-tester';
+
+const arrayOpts = [
+  {
+    components: ['Image'],
+    words: ['Word1', 'Word2'],
+  },
+];
+
+const componentsSettings = {
+  'jsx-a11y': {
+    components: {
+      Image: 'img',
+    },
+  },
+};
+
+const errorMessage =
+  'Redundant alt attribute. Screen-readers already announce `img` tags as an image. ' +
+  'You don’t need to use the words `image`, `photo,` or `picture` ' +
+  '(or any specified custom words) in the alt prop.';
+
+new RuleTester().run('img-redundant-alt', null as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    { code: '<img alt="foo" />;' },
+    {
+      code: '<img alt="picture of me taking a photo of an image" aria-hidden />',
+    },
+    { code: '<img aria-hidden alt="photo of image" />' },
+    { code: '<img ALt="foo" />;' },
+    { code: '<img {...this.props} alt="foo" />' },
+    { code: '<img {...this.props} alt={"foo"} />' },
+    { code: '<img {...this.props} alt={alt} />' },
+    { code: '<a />' },
+    { code: '<img />' },
+    { code: '<IMG />' },
+    { code: '<img alt={undefined} />' },
+    { code: '<img alt={`this should pass for ${now}`} />' },
+    { code: '<img alt={`this should pass for ${photo}`} />' },
+    { code: '<img alt={`this should pass for ${image}`} />' },
+    { code: '<img alt={`this should pass for ${picture}`} />' },
+    { code: '<img alt={`${photo}`} />' },
+    { code: '<img alt={`${image}`} />' },
+    { code: '<img alt={`${picture}`} />' },
+    { code: '<img alt={"undefined"} />' },
+    { code: '<img alt={() => {}} />' },
+    { code: '<img alt={function(e){}} />' },
+    { code: '<img aria-hidden={false} alt="Doing cool things." />' },
+    { code: '<UX.Layout>test</UX.Layout>' },
+    { code: '<img alt />' },
+    { code: '<img alt={imageAlt} />' },
+    { code: '<img alt={imageAlt.name} />' },
+    { code: '<img alt={imageAlt?.name} />' },
+    { code: '<img alt="Doing cool things" aria-hidden={foo?.bar}/>' },
+    { code: '<img alt="Photography" />;' },
+    { code: '<img alt="ImageMagick" />;' },
+    { code: '<Image alt="Photo of a friend" />' },
+    { code: '<Image alt="Foo" />', settings: componentsSettings },
+    {
+      code: '<img alt="画像" />',
+      options: [{ words: ['イメージ'] }],
+    },
+
+    // ---- rslint extras: edge-shape lock-ins ----
+    // TS wrappers (`as`, `as const`, `!`, `satisfies`) — jsx-ast-utils'
+    // LITERAL_TYPES treats these as noop → null, so the rule skips
+    // regardless of whether the wrapped value would be redundant.
+    { code: '<img alt={"foo" as string} />' },
+    { code: '<img alt={"bar" as const} />' },
+    { code: '<img alt={"baz"!} />' },
+    { code: '<img alt={"photo" as string} />' },
+    { code: '<img alt={"picture" as const} />' },
+    { code: '<img alt={"image"!} />' },
+    { code: '<img alt={"photo" satisfies string} />' },
+    { code: '<img alt={("photo" as any)!} />' },
+    { code: '<img alt={("foo")} />' },
+    { code: '<img alt={(("foo"))} />' },
+    { code: '<img alt="" />' },
+    { code: '<img alt=" " />' },
+    { code: '<img alt={true} />' },
+    { code: '<img alt={false} />' },
+    { code: '<img alt={42} />' },
+    { code: '<img alt={null} />' },
+    { code: '<img alt="true" />' },
+    { code: '<img alt="false" />' },
+    { code: '<img alt="foo"/>' },
+    { code: '<img alt="foo"></img>' },
+    { code: '<img alt="image-thing" />' },
+    { code: '<img alt="photo,picture" />' },
+    { code: '<img alt="photo.jpg" />' },
+    { code: '<Foo.Image alt="photo" />' },
+    { code: '<foo.img alt="photo" />' },
+    { code: '<svg:image alt="photo" />' },
+    { code: '<my-img alt="photo" />' },
+    { code: '<img {...props} />' },
+    { code: '<img {...{alt: "foo"}} />' },
+    { code: '<img {...{alt: `foo bar`}} />' },
+    { code: '<img aria-hidden="false" alt="foo" />' },
+    { code: '<img aria-hidden="yes" alt="foo" />' },
+    { code: '<img /* leading */ alt="foo" /* trailing */ />' },
+    { code: 'function F() { return <div>{cond && <img alt="foo" />}</div>; }' },
+    {
+      code: 'function L({xs}) { return xs.map(x => <img alt="foo" key={x} />); }',
+    },
+    { code: '<>{cond && <img alt="foo" />}</>' },
+    { code: '<img aria-hidden alt="photo of friend" />' },
+    { code: '<img aria-hidden={true} alt="photo of friend" />' },
+    { code: '<img aria-hidden="TRUE" alt="photo of friend" />' },
+    { code: '<img alt="画像" />' },
+    {
+      code: '<img alt="画像写真" />',
+      options: [{ words: ['イメージ'] }],
+    },
+    { code: '<img key="x" alt="foo" />' },
+    {
+      code: '<img alt="foo" />',
+      settings: { 'jsx-a11y': {} },
+    },
+    // TaggedTemplateExpression with non-redundant content — LITERAL_TYPES
+    // forwards to TemplateLiteral but the inner text doesn't match.
+    { code: '<img alt={tag`foo`} />' },
+    { code: '<img alt={tag`hello world`} />' },
+    { code: '<img alt={tag`${x}`} />' },
+    // NEL (U+0085) is NOT in JS \s — single token "photo<NEL>bar".
+    { code: '<img alt="photobar" />' },
+    { code: '<img alt={"photobar"} />' },
+    // Real-world React patterns (no redundancy).
+    { code: 'const Logo = () => <img alt="Brand badge" />;' },
+    { code: 'function F() { return <img alt="A friendly mascot" />; }' },
+    {
+      code: 'class C extends Component { render() { return <img alt="cat sleeping" />; } }',
+    },
+    {
+      code: 'function L({xs}) { return xs.map(x => <img key={x} alt="A drawing" />); }',
+    },
+    { code: '<><img alt="ok" /><img alt="fine" /></>' },
+    {
+      code: '<img src="x" srcSet="x@2x" sizes="100vw" alt="A drawing" />',
+    },
+    { code: '<img onClick={f} onLoad={g} alt="ok" />' },
+    { code: '<img data-test="x" data-foo="y" alt="ok" />' },
+    { code: '<img role="presentation" alt="A drawing" />' },
+    { code: '<img aria-labelledby="x" alt="A drawing" />' },
+    {
+      code: '<Image alt="photo" />',
+      settings: { 'jsx-a11y': { components: { Other: 'img' } } },
+    },
+
+    // LITERAL_TYPES inheritance edge cases (differential gap fill).
+    { code: '<img alt={[]} />' },
+    { code: '<img alt={["photo"]} />' },
+    { code: '<img alt={{x: 1}} />' },
+    { code: '<img alt={<span>photo</span>} />' },
+    { code: '<img alt={<>photo</>} />' },
+    { code: '<img alt={/photo/} />' },
+    { code: '<img alt={42n} />' },
+    { code: '<img alt={new String("photo")} />' },
+    { code: '<img alt={(1, "photo")} />' },
+    { code: 'async function ax() { return <img alt={await x} />; }' },
+    { code: 'function* gx() { return <img alt={yield "photo"} />; }' },
+    // Spread argument shape strictness — TS-wrapped object literal does NOT
+    // match upstream's `argument.type === 'ObjectExpression'` check.
+    { code: '<img {...({alt: "photo"} as any)} />' },
+    { code: '<img {...({alt: "photo"})!} />' },
+    { code: '<img {...["alt", "photo"]} />' },
+    { code: "<img {...{['alt']: 'photo'}} />" },
+    { code: "<img {...{0: 'photo'}} />" },
+    { code: '<img {...{nested: {alt: "photo"}}} />' },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: '<img alt="Photo of friend." />;',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="Picture of friend." />;',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="Image of friend." />;',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="PhOtO of friend." />;',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={"photo"} />;',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="piCTUre of friend." />;',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="imAGE of friend." />;',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="photo of cool person" aria-hidden={false} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="picture of cool person" aria-hidden={false} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="image of cool person" aria-hidden={false} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="photo" {...this.props} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="image" {...this.props} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="picture" {...this.props} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={`picture doing ${things}`} {...this.props} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={`photo doing ${things}`} {...this.props} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={`image doing ${things}`} {...this.props} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={`picture doing ${picture}`} {...this.props} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={`photo doing ${photo}`} {...this.props} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={`image doing ${image}`} {...this.props} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<Image alt="Photo of a friend" />',
+      settings: componentsSettings,
+      errors: [{ message: errorMessage }],
+    },
+
+    // ---- Array option tests ----
+    {
+      code: '<img alt="Word1" />;',
+      options: arrayOpts,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="Word2" />;',
+      options: arrayOpts,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<Image alt="Word1" />;',
+      options: arrayOpts,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<Image alt="Word2" />;',
+      options: arrayOpts,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="イメージ" />',
+      options: [{ words: ['イメージ'] }],
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="イメージです" />',
+      options: [{ words: ['イメージ'] }],
+      errors: [{ message: errorMessage }],
+    },
+
+    // ---- rslint extras ----
+    {
+      code: '<img alt="    photo    " />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="画像 photo" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="photo image picture" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={("photo")} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={(("photo"))} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={`photo`} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img {...{alt: "photo"}} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img {...{alt: `photo of bar`}} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<div><img alt="photo of bar" /></div>',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'function L({xs}) { return xs.map(x => <img alt="photo" key={x} />); }',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'class C { render() { return <img alt="picture" />; } }',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'function f<T>(x: T) { return <img alt="image" />; }',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'function F() { return <div>{cond && <img alt="photo" />}</div>; }',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<>{cond && <img alt="photo" />}</>',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<Box as="img" alt="photo of cat" />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<MyImg alt="photo of cat" />',
+      settings: { 'jsx-a11y': { components: { MyImg: 'img' } } },
+      errors: [{ message: errorMessage }],
+    },
+    // TaggedTemplate with redundant content.
+    { code: '<img alt={tag`photo`} />', errors: [{ message: errorMessage }] },
+    {
+      code: '<img alt={tag`picture of cat`} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={tag`image doing ${x}`} />',
+      errors: [{ message: errorMessage }],
+    },
+    // Unicode whitespace classifications — split by JS \s, redundant token.
+    { code: '<img alt={"photo bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo﻿bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo　bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo bar"} />', errors: [{ message: errorMessage }] },
+    { code: '<img alt={"photo bar"} />', errors: [{ message: errorMessage }] },
+    // Real-world React patterns with redundancy.
+    {
+      code: 'const Logo = () => <img alt="Photo of brand" />;',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'const X = forwardRef((p, r) => <img ref={r} alt="photo of x" />);',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'const Y = memo(() => <img alt="photo of memo" />);',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'function H() { useEffect(() => {}); return <img alt="picture hook" />; }',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'const j = (() => <img alt="photo iife" />)();',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'const o = { render() { return <img alt="photo method" />; } };',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'function G({c}) { return c ? <img alt="photo true" /> : <img alt="picture false" />; }',
+      errors: [{ message: errorMessage }, { message: errorMessage }],
+    },
+    {
+      code: 'const T = <section><header><img alt="photo header" /></header></section>;',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<><img alt="photo" /><img alt="picture" /></>',
+      errors: [{ message: errorMessage }, { message: errorMessage }],
+    },
+    {
+      code: '<img alt="photo cat" aria-label="Cat" aria-describedby="d1" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img aria-labelledby="x" alt="photo of y" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img src="x" srcSet="x@2x" sizes="100vw" alt="photo of bar" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img onClick={f} onLoad={g} alt="photo handler" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img data-test="x" data-foo="y" alt="photo data" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img role="presentation" alt="photo role" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img {...a} {...b} alt="photo" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img {...{src: "x", alt: "photo"}} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="🐱 photo of cat" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="A NICE PHOTO TODAY" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="    photo" />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="photo    " />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt="lovely photo today" />',
+      errors: [{ message: errorMessage }],
+    },
+    // AssignmentExpression — LITERAL_TYPES inherits TYPES, synthesizes
+    // "x = photo" string → fires.
+    {
+      code: '<img alt={x = "photo"} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={x += "image"} />',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: '<img alt={x ||= "picture"} />',
+      errors: [{ message: errorMessage }],
+    },
+    // Parenthesized ObjectLiteral spread — ESTree folds parens, ObjectExpression matches.
+    {
+      code: '<img {...({alt: "photo"})} />',
+      errors: [{ message: errorMessage }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -393,3 +393,5 @@ WHATWG
 tabindex
 webauthn
 xoff
+Bild
+Foto


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/img-redundant-alt` rule from `eslint-plugin-jsx-a11y` to rslint.

The rule reports `<img>` elements (and configured wrapper components) whose `alt` value contains the words `image`, `picture`, or `photo` as a whitespace-delimited token — screen readers already announce `img` tags as images, so the descriptors are redundant. Matching is case-insensitive; non-ASCII alt values fall back to substring matching, supporting custom words via the `words` option.

Differential-validated byte-for-byte against `eslint-plugin-jsx-a11y@6.10.2` on a 165-case fixture covering Dimension-4 universal edge shapes, TS expression wrappers (`as` / `!` / `satisfies`), 12 Unicode whitespace classifications (NEL / ZWNBSP / IDEOGRAPHIC SPACE / U+2000–200A / U+1680 / U+2028 / U+2029 / U+202F / U+205F), `LITERAL_TYPES` inheritance dispatch (TaggedTemplateExpression, AssignmentExpression), spread-argument shape strictness (TS-wrapped object literals don't match upstream's `argument.type === 'ObjectExpression'`), `polymorphicPropName` + components-map, and real-world React patterns (FC / forwardRef / memo / class render / Array.map / hook / generic / ternary / fragment / multi-aria mix).

Fixed three pre-existing bugs in `internal/plugins/jsx_a11y/jsxa11yutil/` surfaced by the differential check:

- `literalPropValue` and `attributeInnerExpression` were transparently unwrapping TS wrappers, but `jsx-ast-utils` `LITERAL_TYPES` maps `TSAsExpression` / `TSNonNullExpression` / `TypeCastExpression` to `noop → null`. Now strip parens only.
- `FindAttributeByName` spread argument was unwrapping TS wrappers — upstream checks `argument.type === 'ObjectExpression'` strictly. Now strip parens only.
- `literalPropValue` was missing `KindTaggedTemplateExpression` (LITERAL_TYPES inherits from TYPES — forwards to inner template) and `KindBinaryExpression` with assignment operator (LITERAL_TYPES inherits — synthesizes `\${left} \${op} \${right}` string).

`alt-text` and `aria-unsupported-elements` regression tests pass; both rules become more aligned with ESLint as a side effect.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/img-redundant-alt.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).