### PR TITLE
feat: port rule jsx-a11y/no-access-key

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_unsupported_elements"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/autocomplete_valid"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/img_redundant_alt"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_access_key"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -18,5 +19,6 @@ func GetAllRules() []rule.Rule {
 		aria_unsupported_elements.AriaUnsupportedElementsRule,
 		autocomplete_valid.AutocompleteValidRule,
 		img_redundant_alt.ImgRedundantAltRule,
+		no_access_key.NoAccessKeyRule,
 	}
 }

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -479,6 +479,46 @@ func PropValueIsNullish(attr *ast.Node) bool {
 	return v.Kind == jvNull || v.Kind == jvUndef || v.Kind == jvUnknown
 }
 
+// PropValueIsTruthy mirrors `!!getPropValue(prop)` — the truthy classification
+// of upstream's full TYPES extractor. Used by rules whose upstream form is
+// `if (prop && getPropValue(prop)) ...` (e.g. no-access-key).
+//
+// Differs from LiteralPropTruthy (which uses the LITERAL_TYPES path):
+//
+//   - Identifier (other than `undefined`) here returns the identifier name as
+//     a non-empty string → truthy. Under LiteralPropTruthy non-undefined
+//     identifiers map to null → falsy.
+//   - CallExpression / MemberExpression / Conditional / Logical / Binary
+//     resolve via staticEval (truthy synthesis or genuine evaluation) here;
+//     all noop → null (falsy) under LiteralPropTruthy.
+//   - String literals "true" / "false" coerce to booleans on both paths;
+//     `<div accessKey="false" />` is therefore falsy → not reported.
+//
+// Boolean attribute form (`<div accessKey />`) maps to upstream's
+// null-attribute-value path → boolean `true` → truthy, matching
+// jsx-ast-utils' getPropValue(`<div accessKey />`).
+//
+// Returns false when `attr` is nil — callers are expected to test for the
+// attribute's existence first; a nil attr has no value to coerce.
+func PropValueIsTruthy(attr *ast.Node) bool {
+	if attr == nil {
+		return false
+	}
+	if AttributeIsBooleanForm(attr) {
+		// `<div accessKey />` — extractValue's null-attr-value path returns
+		// boolean true; `!!true` == true.
+		return true
+	}
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		// Empty `{}` JsxExpression. tsgo synthesizes this only for malformed
+		// source; getPropValue would route through "type not in TYPES" → null
+		// → falsy.
+		return false
+	}
+	return jsTruthy_(staticEval(inner))
+}
+
 // LiteralPropTruthy mirrors `!!getLiteralPropValue(prop)`. Returns true when
 // the attribute's value is a JS-truthy *literal*. Crucial differences from
 // PropStaticStringValue / staticEval-based truthiness:

--- a/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
@@ -117,9 +117,17 @@ func staticEval(node *ast.Node) jsValue {
 		// normalization the rule would incorrectly accept `alt="false"`.
 		return jsxAstUtilsLiteralCoerce(node.AsStringLiteral().Text)
 	case ast.KindNoSubstitutionTemplateLiteral:
-		// NoSubTemplate is treated as a string literal by jsx-ast-utils, so
-		// the same "true" / "false" coercion applies.
-		return jsxAstUtilsLiteralCoerce(node.AsNoSubstitutionTemplateLiteral().Text)
+		// `` `text` `` parses as a TemplateLiteral with no expressions in
+		// ESTree, so jsx-ast-utils routes it through extractValueFromTemplateLiteral
+		// — which simply joins the quasi text and returns the raw string.
+		// Crucially, the "true" / "false" → boolean coercion in
+		// extractValueFromLiteral applies ONLY to ESTree's `Literal` (string)
+		// type, NOT to `TemplateLiteral`. So `` `false` `` evaluates to the
+		// non-empty string "false" (truthy), not boolean false. Confirmed via
+		// differential against eslint-plugin-jsx-a11y v6.10.2 with
+		// `<div accessKey={`false`} />`: ESLint reports, rslint pre-fix did
+		// not. Do NOT pipe through jsxAstUtilsLiteralCoerce here.
+		return jsValue{Kind: jvString, Str: node.AsNoSubstitutionTemplateLiteral().Text}
 	case ast.KindTrueKeyword:
 		return jsValue{Kind: jvBool, Bool: true}
 	case ast.KindFalseKeyword:
@@ -672,7 +680,10 @@ func literalPropValue(node *ast.Node) jsValue {
 	case ast.KindStringLiteral:
 		return jsxAstUtilsLiteralCoerce(node.AsStringLiteral().Text)
 	case ast.KindNoSubstitutionTemplateLiteral:
-		return jsxAstUtilsLiteralCoerce(node.AsNoSubstitutionTemplateLiteral().Text)
+		// See the staticEval comment for the same case: jsx-ast-utils treats
+		// `` `text` `` as a TemplateLiteral and does NOT apply the
+		// "true"/"false" → boolean coercion that the Literal extractor uses.
+		return jsValue{Kind: jvString, Str: node.AsNoSubstitutionTemplateLiteral().Text}
 	case ast.KindTrueKeyword:
 		return jsValue{Kind: jvBool, Bool: true}
 	case ast.KindFalseKeyword:

--- a/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key.go
+++ b/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key.go
@@ -1,0 +1,59 @@
+// Package no_access_key ports eslint-plugin-jsx-a11y's `no-access-key` rule.
+// The rule discourages the `accessKey` (or case-insensitive variants like
+// `accesskey`, `acCesSKeY`) prop on JSX elements: keyboard shortcuts assigned
+// via `accessKey` collide with the keyboard commands used by screen readers
+// and keyboard-only users, causing accessibility regressions.
+//
+// Upstream is intentionally minimal — there are no options, the rule reports
+// once per JsxOpeningElement whose `accesskey` prop has a truthy
+// jsx-ast-utils `getPropValue`. The case-insensitive name lookup, spread
+// expansion, and TS-wrapper unwrapping all live in `jsxa11yutil`; this rule
+// just wires the listener and the truthy gate.
+package no_access_key
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// errorMessage mirrors upstream's `errorMessage` string verbatim.
+const errorMessage = "No access key attribute allowed. Inconsistencies between keyboard shortcuts and keyboard commands used by screen readers and keyboard-only users create a11y complications."
+
+var NoAccessKeyRule = rule.Rule{
+	Name: "jsx-a11y/no-access-key",
+	Run: func(ctx rule.RuleContext, _ any) rule.RuleListeners {
+		check := func(node *ast.Node) {
+			attrs := reactutil.GetJsxElementAttributes(node)
+			accessKeyAttr := jsxa11yutil.FindAttributeByName(attrs, "accesskey")
+			if accessKeyAttr == nil {
+				return
+			}
+			// Mirrors upstream's `if (accessKey && accessKeyValue)` —
+			// `accessKey` is the prop node (truthy when present),
+			// `accessKeyValue` is `getPropValue(accessKey)` and we gate on
+			// its JS-truthiness. PropValueIsTruthy handles the full TYPES
+			// path: literal coercion of "true"/"false", identifier-name
+			// stringification (non-undefined identifiers are truthy),
+			// template-literal substitution (always truthy), conditional
+			// / logical / binary short-circuits, the boolean-attribute
+			// form (extractValue null-attr-value → true), and so on.
+			if !jsxa11yutil.PropValueIsTruthy(accessKeyAttr) {
+				return
+			}
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noAccessKey",
+				Description: errorMessage,
+			})
+		}
+		// tsgo splits ESTree's `JSXOpeningElement` into KindJsxOpeningElement
+		// (paired tags `<div>...</div>`) and KindJsxSelfClosingElement
+		// (`<div />`). Upstream's single `JSXOpeningElement` listener covers
+		// both; we mirror by registering on both kinds.
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key.md
+++ b/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key.md
@@ -1,0 +1,44 @@
+# no-access-key
+
+## Rule Details
+
+This rule disallows the `accessKey` prop on JSX elements. The attribute
+name is matched case-insensitively, so `accesskey`, `accessKey`, and
+`acCesSKeY` are all checked. Access-key shortcuts assigned through this
+prop frequently conflict with the keyboard commands used by screen
+readers and keyboard-only users, causing accessibility regressions.
+
+The rule reports an element whenever it carries an `accessKey` attribute
+whose value resolves to a truthy JavaScript value. An attribute whose
+value is `undefined`, `null`, `false`, `0`, or the empty string is left
+alone.
+
+This rule takes no arguments.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div accessKey="h" />
+<div accesskey="h" />
+<div accessKey="h" {...props} />
+<div acCesSKeY="y" />
+<div accessKey={"y"} />
+<div accessKey={`${y}`} />
+<div accessKey={accessKey} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div />
+<div {...props} />
+<div accessKey={undefined} />
+```
+
+## Resources
+
+- [WebAIM — Keyboard Accessibility: Accesskey](https://webaim.org/techniques/keyboard/accesskey#spec)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/no-access-key](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-access-key.md)

--- a/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key_extras_test.go
@@ -1,0 +1,438 @@
+package no_access_key
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoAccessKeyExtras covers rule behavior the upstream test suite leaves
+// unaudited — Dimension 4 universal edge shapes (TS wrappers, spread
+// literals, paired vs self-closing element kinds), upstream getPropValue
+// branches that have no dedicated upstream test (boolean attribute form,
+// numeric / null / false literals, "true"/"false" string coercion), exact
+// position assertions across the JSX surface, and the listener boundary
+// between nested elements.
+func TestNoAccessKeyExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoAccessKeyRule, []rule_tester.ValidTestCase{
+		// ---- Empty-ish / falsy literal values ----
+		// Locks in upstream getPropValue → empty string is falsy and the
+		// `accessKey && accessKeyValue` gate filters this out.
+		{Code: `<div accessKey="" />`, Tsx: true},
+		{Code: `<div accessKey={""} />`, Tsx: true},
+		// Locks in upstream Literal.js' "true"/"false" string coercion: the
+		// string `"false"` extracts to JS boolean `false`, hence falsy. This
+		// applies ONLY to ESTree `Literal` (string) — not to TemplateLiteral.
+		{Code: `<div accessKey="false" />`, Tsx: true},
+		{Code: `<div accessKey={"false"} />`, Tsx: true},
+		// Numeric / null / boolean falsy literals.
+		{Code: `<div accessKey={0} />`, Tsx: true},
+		{Code: `<div accessKey={null} />`, Tsx: true},
+		{Code: `<div accessKey={false} />`, Tsx: true},
+		// `void 0` evaluates to undefined under upstream's UnaryExpression
+		// extractor.
+		{Code: `<div accessKey={void 0} />`, Tsx: true},
+
+		// ---- Logical / conditional short-circuits resolving to falsy ----
+		// Locks in upstream's Logical / Conditional extractors with
+		// statically-known operands.
+		{Code: `<div accessKey={false && "h"} />`, Tsx: true},
+		{Code: `<div accessKey={"" || ""} />`, Tsx: true},
+		{Code: `<div accessKey={true ? "" : "h"} />`, Tsx: true},
+		{Code: `<div accessKey={false ? "h" : ""} />`, Tsx: true},
+
+		// ---- TS wrapper around a falsy literal — staticEval unwraps ----
+		{Code: `<div accessKey={undefined as any} />`, Tsx: true},
+		{Code: `<div accessKey={(undefined)} />`, Tsx: true},
+		{Code: `<div accessKey={"" as string} />`, Tsx: true},
+
+		// ---- Spread of an object literal whose accessKey is falsy ----
+		// Locks in FindAttributeByName's literal-spread walk + PropValueIsTruthy
+		// stripping of TS wrappers around the synthesized property value.
+		{Code: `<div {...{accessKey: undefined}} />`, Tsx: true},
+		{Code: `<div {...{accessKey: ""}} />`, Tsx: true},
+		{Code: `<div {...{accesskey: false}} />`, Tsx: true},
+
+		// ---- Spread of a non-literal — opaque to FindAttributeByName ----
+		// `{...this.props}` cannot be statically known to set accessKey, so
+		// the rule remains silent. Locks in the "spread non-literal is opaque"
+		// behavior so a future refactor can't start treating spreads as
+		// matches.
+		{Code: `<div {...this.props} />`, Tsx: true},
+
+		// ---- Element kind survey: rule is type-agnostic ----
+		// Make sure the falsy gate trips for every common element shape so a
+		// future "only check intrinsics" or "only check anchors" refactor
+		// would have to re-pass these.
+		{Code: `<a />`, Tsx: true},
+		{Code: `<input />`, Tsx: true},
+		{Code: `<Component />`, Tsx: true},
+		{Code: `<svg:path />`, Tsx: true},
+		{Code: `<UX.Layout>x</UX.Layout>`, Tsx: true},
+
+		// ---- Paired (non-self-closing) element with no accesskey ----
+		{Code: `<div>content</div>`, Tsx: true},
+
+		// ============================================================
+		// Differential-locked valid cases — every code shape below was
+		// run through eslint-plugin-jsx-a11y v6.10.2 and produced the
+		// same verdict (no diagnostic). Adding to lock against future
+		// drift in jsxa11yutil.staticEval / FindAttributeByName.
+		// ============================================================
+
+		// ---- Numeric edge cases that resolve to a falsy number ----
+		// `-0` is falsy under jsTruthy_ (Num != 0 check); upstream
+		// PrefixUnary returns Number(-0).
+		{Code: `<div accessKey={-0} />`, Tsx: true},
+		// BigInt 0n is the only BigInt value that is falsy.
+		{Code: `<div accessKey={0n} />`, Tsx: true},
+
+		// ---- String concatenation resolving to empty ----
+		{Code: `<div accessKey={"" + ""} />`, Tsx: true},
+
+		// ---- Logical / nullish-coalescing → falsy ----
+		// `null ?? ""` → "" (empty string, falsy). `undefined ?? null`
+		// → null (falsy). Locks in staticEvalBinary's `??` arm.
+		{Code: `<div accessKey={null ?? ""} />`, Tsx: true},
+		{Code: `<div accessKey={undefined ?? null} />`, Tsx: true},
+
+		// ---- `satisfies` is OPAQUE for jsx-ast-utils ----
+		// jsx-ast-utils' TYPES table has no entry for SatisfiesExpression
+		// → console.error → null (falsy). Our staticEval's
+		// `skipTransparent` deliberately excludes OEKSatisfies for the
+		// same reason; the SatisfiesExpression node falls to the default
+		// `jsNull` arm. Locks in that intentional asymmetry between TS
+		// assertion wrappers (transparent) and `satisfies` (opaque).
+		{Code: `<div accessKey={"h" satisfies string} />`, Tsx: true},
+
+		// ---- Multiple spreads with same prop — first-match wins ----
+		// jsx-ast-utils' getProp returns the FIRST matching property
+		// across attributes (in source order, walking literal spreads
+		// as it goes). When the first hit is falsy, the rule passes,
+		// regardless of later truthy declarations.
+		{Code: `<div {...{accessKey: ""}} {...{accessKey: "h"}} />`, Tsx: true},
+		{Code: `<div {...{accessKey: ""}} accessKey="h" />`, Tsx: true},
+		{Code: `<div accessKey="" {...{accessKey: "h"}} />`, Tsx: true},
+
+		// ---- Same key declared twice in one literal spread ----
+		// Object literal duplicate-key: at runtime the LATER value wins,
+		// but jsx-ast-utils uses Array.prototype.find on the parsed
+		// properties, so the FIRST occurrence wins. Locks in this
+		// AST-walk semantic.
+		{Code: `<div {...{accessKey: "", accessKey: "h"}} />`, Tsx: true},
+
+		// ---- TS-wrapped spread argument is opaque ----
+		// upstream's `attribute.argument.type === 'ObjectExpression'`
+		// check is strict; an `as any` / `!` wrapped object literal
+		// fails the type check and is treated as opaque. Mirrors
+		// FindAttributeByName's "strip parens only" policy.
+		{Code: `<div {...({accessKey: "h"} as any)} />`, Tsx: true},
+		{Code: `<div {...({accessKey: "h"})!} />`, Tsx: true},
+
+		// ---- Computed / non-Identifier property keys are skipped ----
+		// upstream getNodeName returns `key.name`; computed keys
+		// (`["accesskey"]`), numeric keys (`0:`), and string keys
+		// (`"accesskey":`) all have no `.name` (or it's undefined),
+		// so they fall out of the case-insensitive comparison.
+		{Code: `<div {...{["accessKey"]: "h"}} />`, Tsx: true},
+		{Code: `<div {...{["accesskey"]: "h"}} />`, Tsx: true},
+		{Code: `<div {...{0: "h"}} />`, Tsx: true},
+		{Code: `<div {...{"accesskey": "h"}} />`, Tsx: true},
+
+		// ---- Namespaced attribute name does NOT match "accesskey" ----
+		// `xml:accesskey` becomes the composite name "xml:accesskey"
+		// (per reactutil.GetJsxPropName), which is not equal-fold to
+		// "accesskey". The rule does not match.
+		{Code: `<div xml:accesskey="h" />`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Exact position on a self-closing element ----
+		// Two-row position assertion (Line/Column/EndLine/EndColumn) — we
+		// emit on the JsxSelfClosingElement node, which spans `<div … />`.
+		{
+			Code: `<div accessKey="h" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAccessKey",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 22,
+			}},
+		},
+		// Multi-line element — position must span the entire opening
+		// self-closing tag.
+		{
+			Code: "<div\n  accessKey=\"h\"\n  className=\"x\"\n/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAccessKey",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 4, EndColumn: 3,
+			}},
+		},
+
+		// ---- Paired element: report on the OPENING element only ----
+		// tsgo emits KindJsxOpeningElement for `<div ...>`; the listener
+		// fires once. Also locks in that the position covers only the
+		// opening tag (not the entire JsxElement). `<div accessKey="h">`
+		// is 19 chars wide → EndColumn 20 (exclusive).
+		{
+			Code: `<div accessKey="h">child</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAccessKey",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 20,
+			}},
+		},
+
+		// ---- Listener boundary: nested elements both report ----
+		// Outer `<a accessKey="h">` AND inner `<span accessKey="i">` each
+		// emit a diagnostic. Locks in that the listener doesn't dedupe and
+		// doesn't bleed across the nesting boundary.
+		{
+			Code: `<a accessKey="h"><span accessKey="i" /></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noAccessKey", Message: errorMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 18},
+				{MessageId: "noAccessKey", Message: errorMessage, Line: 1, Column: 18, EndLine: 1, EndColumn: 40},
+			},
+		},
+
+		// ---- Element kind survey: rule fires regardless of element type ----
+		{Code: `<a accessKey="h" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input accessKey="h" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Component accessKey="h" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<UX.Layout accessKey="h" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Boolean attribute form ----
+		// Upstream's getPropValue maps a missing attribute initializer
+		// (`<div accesskey />`) to JS boolean `true` via the
+		// null-attribute-value branch. The truthy gate trips. Locks in
+		// AttributeIsBooleanForm + PropValueIsTruthy's boolean-form path.
+		{Code: `<div accessKey />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- "true" / non-zero / non-empty literal coercions ----
+		// Locks in jsxAstUtilsLiteralCoerce for the boolean-truthy direction.
+		{Code: `<div accessKey="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={"true"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// NoSubstitutionTemplateLiteral does NOT go through the
+		// `"true"`/`"false"` → boolean coercion (it routes through ESTree's
+		// TemplateLiteral extractor in jsx-ast-utils, which only joins the
+		// quasi text). Both `` `true` `` and `` `false` `` therefore extract
+		// to non-empty strings → truthy. Locks in the staticEval branch
+		// after the 2026-05 alignment fix; differential-verified against
+		// eslint-plugin-jsx-a11y v6.10.2.
+		{Code: "<div accessKey={`true`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: "<div accessKey={`false`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Numeric / non-empty-string truthy literals.
+		{Code: `<div accessKey={1} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={"0"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- TS wrappers around a truthy expression ----
+		// Locks in skipTransparent unwrapping inside staticEval.
+		{Code: `<div accessKey={"h" as string} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={"h"!} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={("h")} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Conditional / logical resolving to truthy ----
+		// Locks in staticEval Conditional / Logical short-circuits.
+		{Code: `<div accessKey={true && "h"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={"" || "h"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={true ? "h" : ""} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- CallExpression / MemberExpression — upstream truthy synthesis ----
+		// Upstream synthesizes a non-empty string for these via the call /
+		// member extractors. Locks in jsTruthy via staticEval's jsTruthy
+		// fallback for these kinds.
+		{Code: `<div accessKey={fn()} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={obj.x} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={obj?.x} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Spread of an object literal whose accessKey is truthy ----
+		// Locks in the FindAttributeByName literal-spread walk for both
+		// PropertyAssignment and ShorthandPropertyAssignment forms; the
+		// shorthand resolves to an Identifier with the property's name (a
+		// non-empty string → truthy under PropValueIsTruthy).
+		{Code: `<div {...{accessKey: "h"}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div {...{accessKey: "h"}} className="x" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Mixed-case key inside a literal spread — case-insensitive lookup.
+		{Code: `<div {...{ACCESSKEY: "h"}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Shorthand-property-assignment form: `<div {...{accessKey}} />`.
+		// FindAttributeByName returns the ShorthandPropertyAssignment, whose
+		// initializer (per AttributeInitializer) is the bound Identifier with
+		// name "accessKey" — a non-undefined identifier → name string →
+		// truthy.
+		{Code: `<div {...{accessKey}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Differential-locked invalid cases — every code shape below was
+		// run through eslint-plugin-jsx-a11y v6.10.2 with the SAME
+		// verdict.
+		// ============================================================
+
+		// ---- Numeric edge cases that resolve to truthy ----
+		// `NaN` is an Identifier (not in JS_RESERVED), so jsx-ast-utils'
+		// Identifier extractor returns the raw name string "NaN" →
+		// truthy. Note: this is counter-intuitive (a NaN value would be
+		// falsy, but jsx-ast-utils sees the *identifier name*, not the
+		// runtime value). Locks in this surprising shape.
+		{Code: `<div accessKey={NaN} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `Infinity` IS in JS_RESERVED → upstream returns the actual
+		// +Infinity number; truthy.
+		{Code: `<div accessKey={Infinity} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// PrefixUnary `-1` evaluates to -1, truthy.
+		{Code: `<div accessKey={-1} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// BigInt non-zero values are truthy.
+		{Code: `<div accessKey={1n} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `NaN + 0` — Identifier "NaN" treated as the string "NaN", and
+		// `+` with one string operand stringifies the other → "NaN0"
+		// (truthy). Mirrors staticEvalBinary's `+` string-concat path.
+		{Code: `<div accessKey={NaN + 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- String concatenation resolving to truthy ----
+		{Code: `<div accessKey={"h" + "i"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Identifier on the right — staticEval treats it as the name
+		// string "x" (matching upstream's Identifier extractor for the
+		// non-reserved name path).
+		{Code: `<div accessKey={"" + x} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Composite container literals — always truthy ----
+		// Array / Object / RegExp / JSX-element / arrow / function-expression
+		// all extract to truthy values per jsx-ast-utils' TYPES table.
+		{Code: `<div accessKey={[]} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={[1, 2]} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={{}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={{x: 1}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={/foo/} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={<span />} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={() => {}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div accessKey={function() {}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Logical / nullish-coalescing → truthy ----
+		// `??` arm coverage: left non-null/undef → returns left.
+		{Code: `<div accessKey={x ?? "h"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Left null → returns right.
+		{Code: `<div accessKey={null ?? "h"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Composite `||` chain.
+		{Code: `<div accessKey={x || y || ""} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Tagged template literal — upstream truthy synthesis ----
+		// staticEval's KindTaggedTemplateExpression returns jsTruthy.
+		{Code: "<div accessKey={tag`x`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Real-world component patterns ----
+		// Locks in that the listener fires reliably inside common React
+		// shapes: function components, class render methods, JSX inside
+		// .map() callbacks, fragment + conditional, ternary-rendered
+		// element, hooks consumers.
+		{
+			Code: `function SubmitButton() { return <button accessKey="s" type="submit">Submit</button>; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code: `function HomeLink() { return <a href="/home" accessKey="h" target="_blank">Home</a>; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code: `function NameField() { return <input type="text" accessKey="n" placeholder="name" />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code: `function ToolbarBtn() { return <div role="button" tabIndex={0} accessKey="t" onClick={fn} />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Fragment + conditional rendering.
+		{
+			Code:   `const x = <>{cond && <div accessKey="h" />}</>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// .map() callback — JSX inside arrow body.
+		{
+			Code:   `const x = items.map(item => <li accessKey={item.key} key={item.id} />)`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Ternary-rendered element.
+		{
+			Code:   `const x = cond ? <div accessKey="h" /> : <div />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Class component render with multiple offending children — each
+		// reports independently.
+		{
+			Code: "class MyForm { render() { return <form><input accessKey=\"u\" name=\"username\" /><input accessKey=\"p\" name=\"password\" type=\"password\" /></form>; } }",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError, expectedError},
+		},
+		// Hooks pattern.
+		{
+			Code:   `function Stateful() { return <input value={v} onChange={onChange} accessKey="i" />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Spread + direct attribute mix — multiple orderings ----
+		// In all these orderings, `accessKey="h"` is reachable as the
+		// first matching property, so the rule reports.
+		{
+			Code:   `<div {...spread1} {...spread2} accessKey="h" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div accessKey="h" {...spread1} {...spread2} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div {...spread1} accessKey="h" {...spread2} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Multiple spread literals — first-match wins (truthy first) ----
+		// First match `{accessKey: "h"}` is truthy, second `""` is
+		// ignored. Mirror image of the corresponding valid case.
+		{
+			Code:   `<div {...{accessKey: "h"}} {...{accessKey: ""}} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Same-spread duplicate keys, first found is truthy.
+		{
+			Code:   `<div {...{accessKey: "h", accessKey: ""}} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Multi-property literal spread ----
+		// Sibling property in the same literal does not interfere with
+		// the accesskey match.
+		{
+			Code:   `<div {...{className: "x", accessKey: "h"}} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ---- Nested SpreadAssignment inside literal spread ----
+		// upstream's getProp filters `type === 'Property'`, so the
+		// inner SpreadAssignment is opaque, but the sibling
+		// `accessKey: "h"` property is still found.
+		{
+			Code:   `<div {...{...other, accessKey: "h"}} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div {...{accessKey: "h", ...other}} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key_upstream_test.go
@@ -1,0 +1,89 @@
+package no_access_key
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedError mirrors upstream's expected error shape — every invalid case
+// emits the same single message. Centralized so a future text tweak lives in
+// one place. Shared with no_access_key_extras_test.go.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "noAccessKey",
+	Message:   errorMessage,
+}
+
+// TestNoAccessKeyUpstream covers the full valid/invalid suite migrated 1:1
+// from upstream eslint-plugin-jsx-a11y's
+// `__tests__/src/rules/no-access-key-test.js`. Order and grouping mirror the
+// upstream file so a future audit can grep across both side-by-side.
+//
+// rslint-specific lock-ins (TS wrappers, spread literal, listener boundary
+// repeats, position assertions, the upstream getPropValue-branch
+// classifications that upstream never tests directly) live in
+// no_access_key_extras_test.go.
+func TestNoAccessKeyUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoAccessKeyRule, []rule_tester.ValidTestCase{
+		{Code: `<div />;`, Tsx: true},
+		{Code: `<div {...props} />`, Tsx: true},
+		{Code: `<div accessKey={undefined} />`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:   `<div accesskey="h" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div accessKey="h" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div accessKey="h" {...props} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div acCesSKeY="y" />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div accessKey={"y"} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<div accessKey={`${y}`} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<div accessKey={`${undefined}y${undefined}`} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<div accessKey={`This is ${bad}`} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div accessKey={accessKey} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<div accessKey={`${undefined}`} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<div accessKey={`${undefined}${undefined}`} />",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -163,6 +163,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/aria-unsupported-elements.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/img-redundant-alt.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts',
 
     // typescript-eslint
     './tests/typescript-eslint/rules/adjacent-overload-signatures.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts
@@ -1,0 +1,256 @@
+import { RuleTester } from '../rule-tester';
+
+const errorMessage =
+  'No access key attribute allowed. Inconsistencies between keyboard shortcuts and keyboard commands used by screen readers and keyboard-only users create a11y complications.';
+const expectedError = { message: errorMessage };
+
+new RuleTester().run('no-access-key', null as never, {
+  valid: [
+    // ---- Upstream valid ----
+    { code: '<div />;' },
+    { code: '<div {...props} />' },
+    { code: '<div accessKey={undefined} />' },
+
+    // ---- rslint extras: falsy literal values ----
+    { code: '<div accessKey="" />' },
+    { code: '<div accessKey={""} />' },
+    { code: '<div accessKey="false" />' },
+    { code: '<div accessKey={"false"} />' },
+    { code: '<div accessKey={0} />' },
+    { code: '<div accessKey={null} />' },
+    { code: '<div accessKey={false} />' },
+    { code: '<div accessKey={void 0} />' },
+
+    // ---- Logical / conditional short-circuits to falsy ----
+    { code: '<div accessKey={false && "h"} />' },
+    { code: '<div accessKey={"" || ""} />' },
+    { code: '<div accessKey={true ? "" : "h"} />' },
+    { code: '<div accessKey={false ? "h" : ""} />' },
+
+    // ---- TS wrappers around falsy literal — staticEval unwraps ----
+    { code: '<div accessKey={undefined as any} />' },
+    { code: '<div accessKey={(undefined)} />' },
+    { code: '<div accessKey={"" as string} />' },
+
+    // ---- Spread literal of falsy values ----
+    { code: '<div {...{accessKey: undefined}} />' },
+    { code: '<div {...{accessKey: ""}} />' },
+    { code: '<div {...{accesskey: false}} />' },
+
+    // ---- Spread of non-literal — opaque ----
+    { code: '<div {...this.props} />' },
+
+    // ---- Element kind survey: falsy / no-attr forms ----
+    { code: '<a />' },
+    { code: '<input />' },
+    { code: '<Component />' },
+    { code: '<UX.Layout>x</UX.Layout>' },
+    { code: '<div>content</div>' },
+
+    // ---- Differential-locked valid (vs eslint-plugin-jsx-a11y v6.10.2) ----
+    // Numeric / BigInt falsy.
+    { code: '<div accessKey={-0} />' },
+    { code: '<div accessKey={0n} />' },
+    // String concat to empty.
+    { code: '<div accessKey={"" + ""} />' },
+    // Nullish coalescing → falsy right.
+    { code: '<div accessKey={null ?? ""} />' },
+    { code: '<div accessKey={undefined ?? null} />' },
+    // `satisfies` is opaque (TYPES table miss → null → falsy). Mirrors
+    // the staticEval skipTransparent's deliberate exclusion of
+    // OEKSatisfies.
+    { code: '<div accessKey={"h" satisfies string} />' },
+    // Multiple spreads / duplicate keys — first-match wins, when it's
+    // falsy the rule skips.
+    { code: '<div {...{accessKey: ""}} {...{accessKey: "h"}} />' },
+    { code: '<div {...{accessKey: ""}} accessKey="h" />' },
+    { code: '<div accessKey="" {...{accessKey: "h"}} />' },
+    { code: '<div {...{accessKey: "", accessKey: "h"}} />' },
+    // TS-wrapped spread argument is opaque (upstream's strict
+    // `argument.type === "ObjectExpression"` check).
+    { code: '<div {...({accessKey: "h"} as any)} />' },
+    { code: '<div {...({accessKey: "h"})!} />' },
+    // Computed / non-Identifier property keys — getProp skips.
+    { code: '<div {...{["accessKey"]: "h"}} />' },
+    { code: '<div {...{["accesskey"]: "h"}} />' },
+    { code: '<div {...{0: "h"}} />' },
+    { code: '<div {...{"accesskey": "h"}} />' },
+    // Namespaced attribute name does NOT match "accesskey".
+    { code: '<div xml:accesskey="h" />' },
+  ],
+  invalid: [
+    // ---- Upstream invalid ----
+    { code: '<div accesskey="h" />', errors: [expectedError] },
+    { code: '<div accessKey="h" />', errors: [expectedError] },
+    { code: '<div accessKey="h" {...props} />', errors: [expectedError] },
+    { code: '<div acCesSKeY="y" />', errors: [expectedError] },
+    { code: '<div accessKey={"y"} />', errors: [expectedError] },
+    { code: '<div accessKey={`${y}`} />', errors: [expectedError] },
+    {
+      code: '<div accessKey={`${undefined}y${undefined}`} />',
+      errors: [expectedError],
+    },
+    { code: '<div accessKey={`This is ${bad}`} />', errors: [expectedError] },
+    { code: '<div accessKey={accessKey} />', errors: [expectedError] },
+    { code: '<div accessKey={`${undefined}`} />', errors: [expectedError] },
+    {
+      code: '<div accessKey={`${undefined}${undefined}`} />',
+      errors: [expectedError],
+    },
+
+    // ---- Paired element: report on the OPENING element only ----
+    { code: '<div accessKey="h">child</div>', errors: [expectedError] },
+
+    // ---- Listener boundary: outer + inner each report ----
+    {
+      code: '<a accessKey="h"><span accessKey="i" /></a>',
+      errors: [expectedError, expectedError],
+    },
+
+    // ---- Element kind survey ----
+    { code: '<a accessKey="h" />', errors: [expectedError] },
+    { code: '<input accessKey="h" />', errors: [expectedError] },
+    { code: '<Component accessKey="h" />', errors: [expectedError] },
+    { code: '<UX.Layout accessKey="h" />', errors: [expectedError] },
+
+    // ---- Boolean attribute form ----
+    { code: '<div accessKey />', errors: [expectedError] },
+
+    // ---- "true" / non-zero literal coercions to truthy ----
+    { code: '<div accessKey="true" />', errors: [expectedError] },
+    { code: '<div accessKey={"true"} />', errors: [expectedError] },
+    // `` `true` `` / `` `false` `` are TemplateLiteral, NOT Literal — no
+    // boolean coercion; both extract to truthy strings.
+    { code: '<div accessKey={`true`} />', errors: [expectedError] },
+    { code: '<div accessKey={`false`} />', errors: [expectedError] },
+    { code: '<div accessKey={1} />', errors: [expectedError] },
+    { code: '<div accessKey={"0"} />', errors: [expectedError] },
+
+    // ---- TS wrappers around truthy ----
+    { code: '<div accessKey={"h" as string} />', errors: [expectedError] },
+    { code: '<div accessKey={"h"!} />', errors: [expectedError] },
+    { code: '<div accessKey={("h")} />', errors: [expectedError] },
+
+    // ---- Conditional / logical resolving to truthy ----
+    { code: '<div accessKey={true && "h"} />', errors: [expectedError] },
+    { code: '<div accessKey={"" || "h"} />', errors: [expectedError] },
+    { code: '<div accessKey={true ? "h" : ""} />', errors: [expectedError] },
+
+    // ---- Call / member — upstream truthy synthesis ----
+    { code: '<div accessKey={fn()} />', errors: [expectedError] },
+    { code: '<div accessKey={obj.x} />', errors: [expectedError] },
+    { code: '<div accessKey={obj?.x} />', errors: [expectedError] },
+
+    // ---- Spread literal: truthy values ----
+    { code: '<div {...{accessKey: "h"}} />', errors: [expectedError] },
+    { code: '<div {...{ACCESSKEY: "h"}} />', errors: [expectedError] },
+    { code: '<div {...{accessKey}} />', errors: [expectedError] },
+
+    // ---- Differential-locked invalid (vs eslint-plugin-jsx-a11y v6.10.2) ----
+    // Numeric / BigInt truthy edges.
+    // `NaN` is an Identifier, not in JS_RESERVED — extracted as the
+    // string "NaN" (truthy). Counter-intuitive but upstream-correct.
+    { code: '<div accessKey={NaN} />', errors: [expectedError] },
+    // `Infinity` IS in JS_RESERVED → +Infinity (truthy).
+    { code: '<div accessKey={Infinity} />', errors: [expectedError] },
+    { code: '<div accessKey={-1} />', errors: [expectedError] },
+    { code: '<div accessKey={1n} />', errors: [expectedError] },
+    // String concat: Identifier "NaN" treated as "NaN" string,
+    // `+ 0` stringifies → "NaN0" truthy.
+    { code: '<div accessKey={NaN + 0} />', errors: [expectedError] },
+    // String concat truthy.
+    { code: '<div accessKey={"h" + "i"} />', errors: [expectedError] },
+    { code: '<div accessKey={"" + x} />', errors: [expectedError] },
+    // Composite container literals — always truthy under jsx-ast-utils' TYPES.
+    { code: '<div accessKey={[]} />', errors: [expectedError] },
+    { code: '<div accessKey={[1, 2]} />', errors: [expectedError] },
+    { code: '<div accessKey={{}} />', errors: [expectedError] },
+    { code: '<div accessKey={{x: 1}} />', errors: [expectedError] },
+    { code: '<div accessKey={/foo/} />', errors: [expectedError] },
+    { code: '<div accessKey={<span />} />', errors: [expectedError] },
+    { code: '<div accessKey={() => {}} />', errors: [expectedError] },
+    { code: '<div accessKey={function() {}} />', errors: [expectedError] },
+    // Nullish coalescing → truthy.
+    { code: '<div accessKey={x ?? "h"} />', errors: [expectedError] },
+    { code: '<div accessKey={null ?? "h"} />', errors: [expectedError] },
+    { code: '<div accessKey={x || y || ""} />', errors: [expectedError] },
+    // Tagged template — upstream truthy synthesis.
+    { code: '<div accessKey={tag`x`} />', errors: [expectedError] },
+
+    // Real-world component patterns.
+    {
+      code: 'function SubmitButton() { return <button accessKey="s" type="submit">Submit</button>; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function HomeLink() { return <a href="/home" accessKey="h" target="_blank">Home</a>; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function NameField() { return <input type="text" accessKey="n" placeholder="name" />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function ToolbarBtn() { return <div role="button" tabIndex={0} accessKey="t" onClick={fn} />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'const x = <>{cond && <div accessKey="h" />}</>',
+      errors: [expectedError],
+    },
+    {
+      code: 'const x = items.map(item => <li accessKey={item.key} key={item.id} />)',
+      errors: [expectedError],
+    },
+    {
+      code: 'const x = cond ? <div accessKey="h" /> : <div />',
+      errors: [expectedError],
+    },
+    {
+      code: 'class MyForm { render() { return <form><input accessKey="u" name="username" /><input accessKey="p" name="password" type="password" /></form>; } }',
+      errors: [expectedError, expectedError],
+    },
+    {
+      code: 'function Stateful() { return <input value={v} onChange={onChange} accessKey="i" />; }',
+      errors: [expectedError],
+    },
+
+    // Spread + direct attribute mix (multiple orderings).
+    {
+      code: '<div {...spread1} {...spread2} accessKey="h" />',
+      errors: [expectedError],
+    },
+    {
+      code: '<div accessKey="h" {...spread1} {...spread2} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<div {...spread1} accessKey="h" {...spread2} />',
+      errors: [expectedError],
+    },
+    // First-match wins (truthy first).
+    {
+      code: '<div {...{accessKey: "h"}} {...{accessKey: ""}} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<div {...{accessKey: "h", accessKey: ""}} />',
+      errors: [expectedError],
+    },
+    // Sibling property doesn't interfere.
+    {
+      code: '<div {...{className: "x", accessKey: "h"}} />',
+      errors: [expectedError],
+    },
+    // Nested SpreadAssignment — inner spread opaque, sibling property
+    // still found.
+    {
+      code: '<div {...{...other, accessKey: "h"}} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<div {...{accessKey: "h", ...other}} />',
+      errors: [expectedError],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,5 +1,6 @@
 # Custom Dictionary Words
 aavascript
+accesskey
 apos
 accum
 afoob


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/no-access-key` rule from `eslint-plugin-jsx-a11y` v6.10.2 to rslint. The rule disallows the `accessKey` prop on JSX elements (matched case-insensitively); access-key shortcuts conflict with the keyboard commands used by screen readers and keyboard-only users.

Behavior is verified to be 1:1 aligned with upstream via three rounds of differential validation against `eslint-plugin-jsx-a11y` v6.10.2 — 80+ cases across upstream's own suite, real-world component patterns, and corner cases (TS wrappers, nested spreads, multi-byte column encoding, …). The diagnostic `line:column-endLine:endColumn + ruleName + message` four-tuple matches the reference output exactly.

While porting, a pre-existing alignment bug in `jsxa11yutil.staticEval` / `literalPropValue` was found and fixed: `KindNoSubstitutionTemplateLiteral` was incorrectly routed through `jsxAstUtilsLiteralCoerce` (the boolean-coercion path that only applies to ESTree's `Literal` type). After the fix, `` `false` `` evaluates to the truthy string \"false\", matching upstream. Plugin-wide tests confirm no regressions in `alt-text`, `autocomplete-valid`, or `img-redundant-alt` (the rules that consume the same engine).

A new shared helper `jsxa11yutil.PropValueIsTruthy` was added — the `getPropValue` truthy-path counterpart to the existing `LiteralPropTruthy`, available for future a11y rules whose upstream form is `if (prop && getPropValue(prop)) ...`.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-access-key.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/no-access-key.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).