### PR TITLE
docs: align anchor-has-content rule heading casing

### DIFF
--- a/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content.md
+++ b/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content.md
@@ -35,7 +35,7 @@ Examples of **correct** code for this rule:
 <a aria-label="Some content" />
 ```
 
-## Rule options
+## Rule Options
 
 The rule accepts an options object with the following properties:
 


### PR DESCRIPTION
## Summary

Align the `## Rule Options` heading casing in `anchor-has-content.md` with the rest of the same plugin (`anchor-is-valid.md`, `img-redundant-alt.md`, and the newly ported `heading-has-content.md`). Trivial doc-only change — one character.

## Related Links

- Same-plugin docs that already use capital `O`: `internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.md`, `internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.md`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).