### PR TITLE
feat: port rule jsx-a11y/no-distracting-elements

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/html_has_lang"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/img_redundant_alt"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_access_key"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_distracting_elements"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -24,5 +25,6 @@ func GetAllRules() []rule.Rule {
 		html_has_lang.HtmlHasLangRule,
 		img_redundant_alt.ImgRedundantAltRule,
 		no_access_key.NoAccessKeyRule,
+		no_distracting_elements.NoDistractingElementsRule,
 	}
 }

--- a/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements.go
+++ b/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements.go
@@ -1,0 +1,103 @@
+// Package no_distracting_elements ports eslint-plugin-jsx-a11y's
+// `no-distracting-elements` rule. The rule flags JSX elements whose resolved
+// type matches one of a configurable list of "distracting" tag names —
+// `<marquee>` and `<blink>` by default. Both elements are deprecated and
+// commonly cited for triggering motion sickness / reading difficulty.
+//
+// Upstream is a one-listener rule: read the (settings-resolved) element type
+// for every JsxOpeningElement, look it up in `options.elements ||
+// DEFAULT_ELEMENTS` via Array.prototype.find, and report when found. The
+// element-type resolution (polymorphic prop, components map) lives in
+// `jsxa11yutil.GetElementType`; this rule wires the listener and the find.
+package no_distracting_elements
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// errorMessage mirrors upstream's `errorMessage(element)` template literal
+// verbatim. The element name is interpolated into the diagnostic so a
+// reviewer can grep for the exact tag.
+func errorMessage(element string) string {
+	return fmt.Sprintf("Do not use <%s> elements as they can create visual accessibility issues and are deprecated.", element)
+}
+
+// defaultElements mirrors upstream's `DEFAULT_ELEMENTS` constant. Order is
+// preserved because upstream uses Array.prototype.find — when a configured
+// list contains duplicates (legal but degenerate), the FIRST occurrence
+// wins.
+var defaultElements = []string{"marquee", "blink"}
+
+type options struct {
+	elements []string
+}
+
+func parseOptions(raw any) options {
+	opts := options{elements: defaultElements}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	// Upstream: `const elementOptions = options.elements || DEFAULT_ELEMENTS`.
+	// `||` only falls through when the LHS is JS-falsy (undefined / null /
+	// "" / 0 / NaN). An EXPLICITLY empty array is JS-truthy so it replaces
+	// the default and effectively disables the rule for everyone — mirror
+	// that. StringSliceOption returns nil for an absent / non-array value
+	// (we keep the default) and a non-nil possibly-empty []string for any
+	// present array (we use as-is).
+	if rawElements, ok := m["elements"]; ok {
+		if elements := jsxa11yutil.StringSliceOption(rawElements); elements != nil {
+			opts.elements = elements
+		}
+	}
+	return opts
+}
+
+var NoDistractingElementsRule = rule.Rule{
+	Name: "jsx-a11y/no-distracting-elements",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		// Empty element list — rule is effectively disabled for this run.
+		// Skip listener registration to avoid `GetElementType` + an empty
+		// loop on every JsxOpeningElement in the file. Triggered by:
+		//   - explicit `{ elements: [] }` (the user-facing way to disable)
+		//   - rslint extension: `[123, true]` (StringSliceOption filters
+		//     all non-string entries, leaving an empty slice)
+		// Observable behavior matches upstream's `find` over an empty
+		// array (always undefined → never reports).
+		if len(opts.elements) == 0 {
+			return rule.RuleListeners{}
+		}
+
+		check := func(node *ast.Node) {
+			elementType := jsxa11yutil.GetElementType(node, ctx.Settings)
+			// Upstream uses Array.prototype.find — first matching element
+			// wins. We mirror by short-circuiting on the first hit. Strict
+			// equality (`===`) is preserved by Go's `==` on string values.
+			for _, e := range opts.elements {
+				if elementType == e {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "distractingElement",
+						Description: errorMessage(e),
+					})
+					return
+				}
+			}
+		}
+
+		// tsgo splits ESTree's `JSXOpeningElement` into KindJsxOpeningElement
+		// (paired tags `<marquee>...</marquee>`) and KindJsxSelfClosingElement
+		// (`<marquee />`). Upstream's single `JSXOpeningElement` listener
+		// fires on both forms; we mirror by registering on both kinds.
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements.md
+++ b/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements.md
@@ -1,0 +1,103 @@
+# no-distracting-elements
+
+## Rule Details
+
+Enforces that no distracting elements are used. Elements that can be visually
+distracting can cause accessibility issues for visually impaired users — they
+are also typically deprecated in the HTML specification. By default, this
+rule reports `<marquee>` and `<blink>`.
+
+The check is case-sensitive: only the lowercase intrinsic tags `marquee` and
+`blink` are flagged. React components named `Marquee` or `Blink` are
+considered safe unless mapped via the `jsx-a11y` `components` setting.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<marquee />
+<blink />
+<marquee>scrolling text</marquee>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div />
+<Marquee />
+<div marquee />
+```
+
+## Rule Options
+
+```json
+{
+  "jsx-a11y/no-distracting-elements": [
+    "error",
+    {
+      "elements": ["marquee", "blink"]
+    }
+  ]
+}
+```
+
+### `elements`
+
+Type: `string[]`. Default: `["marquee", "blink"]`.
+
+The list of intrinsic tag names to flag. Provide a subset to disable the
+check for specific tags, or `[]` to disable the rule entirely.
+
+Examples of **incorrect** code with `{ "elements": ["blink"] }`:
+
+```json
+{ "jsx-a11y/no-distracting-elements": ["error", { "elements": ["blink"] }] }
+```
+
+```jsx
+<blink />
+```
+
+Examples of **correct** code with `{ "elements": ["blink"] }`:
+
+```json
+{ "jsx-a11y/no-distracting-elements": ["error", { "elements": ["blink"] }] }
+```
+
+```jsx
+<marquee />
+```
+
+## Settings
+
+The rule reads `settings['jsx-a11y']` to resolve the effective element type
+for a JSX tag. Resolution is two-step: the polymorphic prop runs first,
+then the components map looks up the (possibly already-replaced) name.
+
+- `polymorphicPropName` — name of a polymorphic prop (e.g. `"as"`) that
+  remaps the element type. With `polymorphicPropName: "as"`,
+  `<Box as="marquee" />` is flagged as `<marquee />`. Reverse direction is
+  supported too — `<marquee as="div" />` resolves to `"div"` and is **not**
+  flagged.
+- `polymorphicAllowList` — `string[]` restricting which raw component names
+  may be remapped via the polymorphic prop. When omitted, every component
+  may be remapped.
+- `components` — a `{ ComponentName: "html-element" }` map. With
+  `{ "Blink": "blink" }`, `<Blink />` is flagged as `<blink />`. The map can
+  also remap an intrinsic tag away from the flagged set — e.g.
+  `{ "marquee": "div" }` causes `<marquee />` to be treated as `<div />` and
+  the rule will not report it. When combined with `polymorphicPropName`,
+  the lookup runs against the post-polymorphic name — e.g.
+  `<Foo as="Bar" />` with `{ "components": { "Bar": "marquee" } }` is
+  flagged as `<marquee />`.
+
+These mirror the upstream `eslint-plugin-jsx-a11y` settings exactly.
+
+## Resources
+
+- [WCAG 2.2.2 — Pause, Stop, Hide](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide)
+- [Deque University — `<marquee>`](https://dequeuniversity.com/rules/axe/3.2/marquee)
+- [Deque University — `<blink>`](https://dequeuniversity.com/rules/axe/3.2/blink)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/no-distracting-elements](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-distracting-elements.md)

--- a/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements_extras_test.go
@@ -1,0 +1,787 @@
+package no_distracting_elements
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoDistractingElementsExtras covers behavior the upstream test suite
+// leaves unaudited — Dimension 1-4 universal edge shapes, options coverage
+// (default vs explicit empty array vs custom list), settings coverage
+// (components map / polymorphic prop / polymorphicAllowList), exact position
+// assertions across the JSX surface, and the listener boundary between
+// nested elements.
+func TestNoDistractingElementsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDistractingElementsRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// Dimension 1: AST node type / tag-shape variants
+		// ============================================================
+
+		// PropertyAccess tag — full type is "UI.Marquee", not "marquee".
+		{Code: `<UI.Marquee />`, Tsx: true},
+		// Namespaced tag — full type is "svg:marquee", not "marquee". Locks in
+		// that namespaced names match the COMPOSITE form, not just the local
+		// name.
+		{Code: `<svg:marquee />`, Tsx: true},
+		// Case-sensitive comparison: uppercase / mixed-case never match.
+		{Code: `<MARQUEE />`, Tsx: true},
+		{Code: `<Marquee />`, Tsx: true},
+		{Code: `<MarQuee />`, Tsx: true},
+		{Code: `<BLINK />`, Tsx: true},
+		{Code: `<Blink />`, Tsx: true},
+
+		// ---- Element kind survey: rule is a no-op for every non-listed tag ----
+		{Code: `<a />`, Tsx: true},
+		{Code: `<input />`, Tsx: true},
+		{Code: `<Component />`, Tsx: true},
+
+		// ---- Multi-segment PropertyAccess — full type is "A.B.C", not any
+		// segment in isolation. Locks in that the joined dotted form is
+		// what's compared.
+		{Code: `<A.B.C />`, Tsx: true},
+		// `<this.Foo />` — type is "this.Foo".
+		{Code: `<this.Foo />`, Tsx: true},
+		// PropertyAccess where the FINAL segment is lowercased "marquee" —
+		// upstream's getElementType returns "UI.marquee" (the dotted whole),
+		// which does not strict-equal "marquee". Differentially verified
+		// against eslint-plugin-jsx-a11y v6.10.2 — no report.
+		{Code: `<UI.marquee />`, Tsx: true},
+
+		// ============================================================
+		// Options: explicitly empty `elements` array disables every check
+		// ============================================================
+		// Upstream's `options.elements || DEFAULT_ELEMENTS` only falls back
+		// when the LHS is JS-falsy. An empty array is JS-truthy, so it
+		// replaces the default and the rule becomes a no-op.
+		{
+			Code:    `<marquee />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{}},
+		},
+		{
+			Code:    `<blink />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{}},
+		},
+
+		// ============================================================
+		// Options: custom `elements` list — types not in the list pass
+		// ============================================================
+		{
+			Code:    `<marquee />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{"blink"}},
+		},
+		{
+			Code:    `<blink />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{"marquee"}},
+		},
+
+		// ============================================================
+		// Settings: components map without a matching entry leaves rawType
+		// alone; `<Blink />` doesn't match the default elements list.
+		// ============================================================
+		{
+			Code: `<Blink />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"OtherTag": "marquee"},
+				},
+			},
+		},
+
+		// ============================================================
+		// Settings: polymorphic prop with allow-list NOT containing the tag —
+		// rawType remains the React component name, no match.
+		// ============================================================
+		{
+			Code: `<Foo as="marquee" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName":  "as",
+					"polymorphicAllowList": []interface{}{"Bar"},
+				},
+			},
+		},
+
+		// ============================================================
+		// Empty options object — equivalent to the default case
+		// ============================================================
+		{
+			Code:    `<div />`,
+			Tsx:     true,
+			Options: map[string]interface{}{},
+		},
+
+		// ============================================================
+		// `options.elements` is NOT a list — fallback to defaults; `<div />`
+		// still passes.
+		// ============================================================
+		{
+			Code:    `<div />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": "marquee"}, // wrong type, ignored
+		},
+
+		// `options.elements` is null — StringSliceOption returns nil →
+		// fallback to default. `<div />` is still valid.
+		{
+			Code:    `<div />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": nil},
+		},
+
+		// rslint extension: an `elements` array containing only non-string
+		// entries — StringSliceOption filters them all out, leaving an empty
+		// `[]string`, which silences the rule. ESLint's JSON schema rejects
+		// this at config-load time so it never reaches rule logic upstream;
+		// rslint accepts the input and we lock the silenced behavior.
+		{
+			Code:    `<marquee />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{123, true}},
+		},
+
+		// ============================================================
+		// Components map: map-to-non-distracting / non-string value
+		// ============================================================
+		// `<Foo />` aliased to a non-distracting tag — no report.
+		{
+			Code: `<Foo />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"Foo": "div"},
+				},
+			},
+		},
+		// **Reverse aliasing**: a literal `<marquee />` mapped to "div" —
+		// upstream's getElementType replaces "marquee" with "div" before the
+		// lookup, so the rule does NOT report. Locks in that components-map
+		// supports per-codebase opt-out, not just opt-in. Differentially
+		// verified against eslint-plugin-jsx-a11y v6.10.2.
+		{
+			Code: `<marquee />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"marquee": "div"},
+				},
+			},
+		},
+		// Components map with a non-string value — upstream silently
+		// preserves the original rawType (the type assertion fails).
+		// `<Foo />` stays "Foo", not "marquee".
+		{
+			Code: `<Foo />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"Foo": 123},
+				},
+			},
+		},
+
+		// ============================================================
+		// Polymorphic prop edge cases (verified differentially)
+		// ============================================================
+		// `polymorphicPropName` set, but the `as` prop is missing on the
+		// element — getElementType keeps rawType. `<Foo />` stays "Foo".
+		{
+			Code: `<Foo />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+		// `as={x}` (Identifier) — literalPropValue maps Identifier → null,
+		// polymorphic doesn't replace, rawType stays "Foo".
+		{
+			Code: `<Foo as={x} />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+		// `as=""` — empty string is JS-falsy, polymorphic doesn't replace.
+		{
+			Code: `<Foo as="" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+		// `as={cond ? "marquee" : "blink"}` — Conditional is noop in
+		// LITERAL_TYPES → null → polymorphic doesn't replace.
+		{
+			Code: `<Foo as={cond ? "marquee" : "blink"} />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+		// Empty `polymorphicAllowList` — zero entries means no rawType
+		// passes the allow check → polymorphic doesn't replace anything.
+		{
+			Code: `<Foo as="marquee" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName":  "as",
+					"polymorphicAllowList": []interface{}{},
+				},
+			},
+		},
+
+		// Polymorphic REVERSE exemption: an intrinsic distracting tag
+		// remapped to a non-distracting one via the `as` prop is silenced.
+		// Mirrors the components-map reverse alias (`marquee: 'div'`) but
+		// at the polymorphic layer — `<marquee as="div" />` resolves to
+		// "div", which is not in the elements list. Differentially
+		// verified against eslint-plugin-jsx-a11y v6.10.2.
+		{
+			Code: `<marquee as="div" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+		{
+			Code: `<blink as="span" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+
+		// Polymorphic replaces rawType with a non-distracting intermediate
+		// component name AND no components-map entry rebinds it back —
+		// rule does not report. Locks in that the polymorphic step alone
+		// is sufficient to silence; we don't need a components-map entry
+		// for the replaced name to "exist".
+		{
+			Code: `<Foo as="Bar" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+
+		// ============================================================
+		// Defensive type handling: settings shapes that ARE truthy but
+		// don't match expected types. All differentially verified against
+		// eslint-plugin-jsx-a11y v6.10.2 — same observable behavior (no
+		// report) on all the inputs that upstream doesn't crash on.
+		// ============================================================
+		// `settings['jsx-a11y']` is a string (not a map) — type assertion
+		// in getJsxA11ySettings fails → no polymorphic / components.
+		{
+			Code:     `<Foo />`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"jsx-a11y": "invalid"},
+		},
+		// `settings['jsx-a11y']` is null — same path.
+		{
+			Code:     `<Foo />`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"jsx-a11y": nil},
+		},
+		// `components` is a string instead of a map — the inner type
+		// assertion fails → components block is a no-op, rawType stays.
+		{
+			Code: `<Foo />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"components": "invalid"},
+			},
+		},
+		// `polymorphicPropName` is a number — upstream THROWS TypeError
+		// here (`getProp(attrs, 123)` calls `123.toUpperCase()`). rslint
+		// can't reproduce the throw under Go's static typing — the
+		// `.(string)` assertion fails, polymorphicPropName becomes "",
+		// the polymorphic block is skipped silently. This is a Go-natural
+		// robustness divergence (no report rather than crashing the lint
+		// run), not a rule-semantics divergence.
+		{
+			Code: `<Foo as="marquee" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": 123},
+			},
+		},
+		// `polymorphicAllowList` containing only non-strings — every entry
+		// fails the `.(string)` assertion, the for-loop never finds rawType
+		// in the allow list, polymorphic doesn't replace.
+		{
+			Code: `<Foo as="marquee" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName":  "as",
+					"polymorphicAllowList": []interface{}{123},
+				},
+			},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// Dimension 1: paired element form — listener fires on the opening
+		// tag. Position covers only the opening tag (`<marquee>`), not the
+		// entire JsxElement. `<marquee>` is 9 characters → EndColumn 10.
+		// ============================================================
+		{
+			Code: `<marquee>scrolling</marquee>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "distractingElement",
+				Message:   "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 10,
+			}},
+		},
+
+		// Empty body: still reports.
+		{
+			Code:   `<marquee></marquee>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// Position assertions on a self-closing element. `<marquee />` is
+		// 11 characters → EndColumn 12 (exclusive).
+		// ============================================================
+		{
+			Code: `<marquee />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "distractingElement",
+				Message:   "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 12,
+			}},
+		},
+
+		// Multi-line element — position must span the entire opening
+		// self-closing tag.
+		{
+			Code: "<marquee\n  lang=\"en\"\n/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "distractingElement",
+				Message:   "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+				Line:      1, Column: 1, EndLine: 3, EndColumn: 3,
+			}},
+		},
+
+		// ============================================================
+		// Dimension 2: same-kind nesting — both outer and inner report,
+		// listener doesn't dedupe.
+		// ============================================================
+		{
+			Code: `<marquee><marquee /></marquee>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "distractingElement", Message: "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+					Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				{MessageId: "distractingElement", Message: "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+					Line: 1, Column: 10, EndLine: 1, EndColumn: 21},
+			},
+		},
+
+		// ============================================================
+		// Boolean / numeric / spread attribute forms — none affect the
+		// type comparison, but exercise the listener for shape coverage.
+		// ============================================================
+		{
+			Code:   `<marquee draggable />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		{
+			Code:   `<marquee className="x" id={n} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// Options: custom `elements` list — `<custom />` reports when
+		// "custom" is in the list.
+		// ============================================================
+		{
+			Code:    `<custom />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{"custom"}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "distractingElement",
+				Message:   "Do not use <custom> elements as they can create visual accessibility issues and are deprecated.",
+			}},
+		},
+		// Custom list with only one of the defaults — only that one fires.
+		{
+			Code:    `<blink />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{"blink"}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedBlinkError},
+		},
+
+		// ============================================================
+		// Options array shape — the rule_tester accepts both bare-map
+		// and array-wrapped option shapes; cover the array form to lock
+		// the JSON path through GetOptionsMap.
+		// ============================================================
+		{
+			Code:    `<marquee />`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"elements": []interface{}{"marquee"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// Settings: components map with multiple aliases.
+		// ============================================================
+		{
+			Code: `<CustomMarquee />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"CustomMarquee": "marquee"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// Settings: polymorphic prop without an allow-list — every truthy
+		// `as` value replaces rawType, so `<Foo as="marquee" />` reports.
+		// ============================================================
+		{
+			Code: `<Foo as="marquee" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		// Polymorphic with an allow-list that DOES include the rawType.
+		{
+			Code: `<Foo as="blink" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName":  "as",
+					"polymorphicAllowList": []interface{}{"Foo"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedBlinkError},
+		},
+
+		// ============================================================
+		// Listener boundary: marquee inside non-distracting wrapper, and
+		// blink inside marquee — each fires independently.
+		// ============================================================
+		{
+			Code: `<div><marquee /></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "distractingElement",
+				Message:   "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+				Line:      1, Column: 6, EndLine: 1, EndColumn: 17,
+			}},
+		},
+		{
+			Code: `<marquee><blink /></marquee>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "distractingElement", Message: "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+					Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				{MessageId: "distractingElement", Message: "Do not use <blink> elements as they can create visual accessibility issues and are deprecated.",
+					Line: 1, Column: 10, EndLine: 1, EndColumn: 19},
+			},
+		},
+
+		// ============================================================
+		// Real-world component patterns — locks in that the listener fires
+		// inside common React shapes.
+		// ============================================================
+		{
+			Code:   `function Banner() { return <marquee>News</marquee>; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		{
+			Code:   `const x = items.map(item => <blink key={item.id}>{item.text}</blink>)`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedBlinkError},
+		},
+		{
+			Code:   `const x = cond ? <marquee /> : <div />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		{
+			Code: `class C { render() { return <div><marquee /><blink /></div>; } }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedMarqueeError,
+				expectedBlinkError,
+			},
+		},
+
+		// ============================================================
+		// Deep nesting (3 levels): each opening tag fires independently.
+		// Position assertions lock in tsgo column counting on adjacent
+		// JSX elements: outer `<marquee>` cols 1-9, middle 10-18, inner
+		// `<marquee />` cols 19-29.
+		// ============================================================
+		{
+			Code: `<marquee><marquee><marquee /></marquee></marquee>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "distractingElement", Message: "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+					Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				{MessageId: "distractingElement", Message: "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+					Line: 1, Column: 10, EndLine: 1, EndColumn: 19},
+				{MessageId: "distractingElement", Message: "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+					Line: 1, Column: 19, EndLine: 1, EndColumn: 30},
+			},
+		},
+
+		// ============================================================
+		// JsxFragment surrounding a distracting element. The Fragment
+		// itself is NOT a JsxOpeningElement / JsxSelfClosingElement and
+		// is silently skipped, but the inner marquee still fires.
+		// ============================================================
+		{
+			Code:   `<><marquee /></>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// JSX inside an expression container (children, attribute value,
+		// logical short-circuit, optional chain) — listener fires
+		// regardless of where the JSX appears.
+		// ============================================================
+		{
+			Code:   `<div>{<marquee />}</div>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		{
+			Code:   `<div>{cond && <marquee />}</div>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		{
+			Code:   `<div content={<marquee />} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		{
+			Code:   `<Provider value={data}>{<marquee />}</Provider>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// Components map: map-to-distracting and map-to-self
+		// ============================================================
+		// `<Foo />` aliased to "marquee" — reports.
+		{
+			Code: `<Foo />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"Foo": "marquee"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		// `<marquee />` aliased to "marquee" (self-map) — still reports.
+		{
+			Code: `<marquee />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"marquee": "marquee"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// Polymorphic + components combination: polymorphic replaces FIRST,
+		// then components looks up the (already-replaced) rawType. So
+		// `<Foo as="marquee" />` with `components: { Foo: 'div' }` still
+		// reports — polymorphic turns rawType into "marquee", and there's
+		// no "marquee" key in components, so the lookup is a no-op.
+		// Differentially verified against eslint-plugin-jsx-a11y v6.10.2.
+		// ============================================================
+		{
+			Code: `<Foo as="marquee" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"Foo": "div"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		// Same shape, components mapping `Foo: 'blink'` — also reports
+		// `marquee` (NOT blink), because polymorphic already changed
+		// rawType to "marquee" before components ran.
+		{
+			Code: `<Foo as="marquee" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"Foo": "blink"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// Polymorphic + components CHAIN: rawType "Foo" → polymorphic
+		// replaces with "Bar" → components map rebinds "Bar" to "marquee".
+		// Locks in that the components step looks up the POST-polymorphic
+		// rawType, not the original tag name. Differentially verified
+		// against eslint-plugin-jsx-a11y v6.10.2.
+		{
+			Code: `<Foo as="Bar" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"Bar": "marquee"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// Polymorphic prop value forms — JsxExpression-wrapped string
+		// literal, no-substitution template literal — both extract through
+		// LITERAL_TYPES and replace rawType.
+		// ============================================================
+		{
+			Code: `<Foo as={"marquee"} />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		{
+			Code: "<Foo as={`marquee`} />",
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// Real-world patterns (extended): HOC, filter+map chain, array
+		// literal, function arg, object property, forwardRef pattern.
+		// ============================================================
+		// HOC wrapping returning a distracting element.
+		{
+			Code:   `const Banner = withTheme(() => <marquee />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		// Iterator-chain: `.filter().map(...)` returning JSX.
+		{
+			Code:   `const x = items.filter(x => x).map(x => <marquee key={x.id} />)`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		// Array literal with multiple distracting elements.
+		{
+			Code: `const items = [<marquee key="1" />, <blink key="2" />];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedMarqueeError,
+				expectedBlinkError,
+			},
+		},
+		// JSX as a function argument.
+		{
+			Code:   `wrap(<marquee />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		// JSX as an object-literal property value.
+		{
+			Code:   `const x = { content: <marquee /> };`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		// React.forwardRef + spread props — listener still fires on the
+		// inner JSX.
+		{
+			Code:   `const Marquee = React.forwardRef((props, ref) => <marquee ref={ref} {...props} />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// Defensive type handling (invalid side): mixed-type allowList —
+		// non-string entries are silently dropped, "Foo" is honored, so
+		// polymorphic replaces rawType and the rule reports.
+		// Differentially verified against eslint-plugin-jsx-a11y v6.10.2.
+		// ============================================================
+		{
+			Code: `<Foo as="marquee" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName":  "as",
+					"polymorphicAllowList": []interface{}{123, "Foo"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+
+		// ============================================================
+		// rslint-specific options coverage. ESLint's JSON schema
+		// (`enumArraySchema(DEFAULT_ELEMENTS)`) rejects any of these at
+		// config-load time, so they never reach the rule logic upstream.
+		// rslint does not perform JSON-schema validation, so these inputs
+		// reach the rule's `find` and we lock in the literal-comparison
+		// behavior.
+		// ============================================================
+		// Mixed-type array — non-strings are dropped by StringSliceOption,
+		// "marquee" still matches.
+		{
+			Code:    `<marquee />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{"marquee", 123}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		// (Note: "all non-strings → silenced" is a Valid case, see the
+		// valid block above for `[123, true]` coverage location.)
+		// Empty-string entry alongside marquee — empty never matches a
+		// real tag name, marquee still does.
+		{
+			Code:    `<marquee />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{"", "marquee"}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		// Duplicate entry — `find` short-circuits on the first hit, only
+		// one report emitted. (Schema rejects upstream as
+		// uniqueItems-violation.)
+		{
+			Code:    `<marquee />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"elements": []interface{}{"marquee", "marquee"}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements_upstream_test.go
@@ -1,0 +1,98 @@
+package no_distracting_elements
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedMarqueeError / expectedBlinkError mirror upstream's
+// `expectedError(element)` helper. Both messages are interpolated forms of
+// the same template, but it is more readable to spell them out.
+var expectedMarqueeError = rule_tester.InvalidTestCaseError{
+	MessageId: "distractingElement",
+	Message:   "Do not use <marquee> elements as they can create visual accessibility issues and are deprecated.",
+}
+
+var expectedBlinkError = rule_tester.InvalidTestCaseError{
+	MessageId: "distractingElement",
+	Message:   "Do not use <blink> elements as they can create visual accessibility issues and are deprecated.",
+}
+
+// blinkComponentSettings mirrors upstream's `componentsSettings` constant —
+// the components-map entry that aliases `<Blink />` to the intrinsic `blink`
+// tag, exercising the GetElementType components-map path.
+var blinkComponentSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Blink": "blink",
+		},
+	},
+}
+
+// TestNoDistractingElementsUpstream covers the full valid / invalid suite
+// migrated 1:1 from upstream eslint-plugin-jsx-a11y's
+// `__tests__/src/rules/no-distracting-elements-test.js`. Order and grouping
+// mirror the upstream file so a future audit can grep across both
+// side-by-side.
+//
+// rslint-specific lock-ins (Dimension 1-4 edge shapes, options coverage,
+// position assertions, polymorphic prop, listener boundary) live in
+// no_distracting_elements_extras_test.go.
+func TestNoDistractingElementsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDistractingElementsRule, []rule_tester.ValidTestCase{
+		{Code: `<div />;`, Tsx: true},
+		// React component name is case-sensitive — `<Marquee />` is a user
+		// component, NOT the intrinsic `marquee`. Locks in the strict-equality
+		// comparison.
+		{Code: `<Marquee />`, Tsx: true},
+		// `marquee` as an attribute on a `<div>` doesn't trigger — the rule
+		// inspects the tag name only.
+		{Code: `<div marquee />`, Tsx: true},
+		// Same for `Blink`: capital-B component name doesn't match without a
+		// components-map alias.
+		{Code: `<Blink />`, Tsx: true},
+		{Code: `<div blink />`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:   `<marquee />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		{
+			Code:   `<marquee {...props} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		{
+			Code:   `<marquee lang={undefined} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedMarqueeError},
+		},
+		{
+			Code:   `<blink />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedBlinkError},
+		},
+		{
+			Code:   `<blink {...props} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedBlinkError},
+		},
+		{
+			Code:   `<blink foo={undefined} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedBlinkError},
+		},
+		// `<Blink />` aliased to `blink` via the components-map setting —
+		// jsx-ast-utils' getElementType replaces "Blink" with "blink" before
+		// the lookup, so the rule reports.
+		{
+			Code:     `<Blink />`,
+			Tsx:      true,
+			Settings: blinkComponentSettings,
+			Errors:   []rule_tester.InvalidTestCaseError{expectedBlinkError},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -166,6 +166,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/html-has-lang.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/img-redundant-alt.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts',
 
     // typescript-eslint
     './tests/typescript-eslint/rules/adjacent-overload-signatures.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts
@@ -1,0 +1,401 @@
+import { RuleTester } from '../rule-tester';
+
+const expectedError = (element: string) => ({
+  message: `Do not use <${element}> elements as they can create visual accessibility issues and are deprecated.`,
+});
+
+const blinkComponentSettings = {
+  'jsx-a11y': {
+    components: {
+      Blink: 'blink',
+    },
+  },
+};
+
+new RuleTester().run('no-distracting-elements', null as never, {
+  valid: [
+    // ---- Upstream valid ----
+    { code: '<div />;' },
+    { code: '<Marquee />' },
+    { code: '<div marquee />' },
+    { code: '<Blink />' },
+    { code: '<div blink />' },
+
+    // ---- Case sensitivity: only lowercase intrinsic tags match ----
+    { code: '<MARQUEE />' },
+    { code: '<MarQuee />' },
+    { code: '<BLINK />' },
+
+    // ---- PropertyAccess / namespaced tags do NOT match ----
+    { code: '<UI.Marquee />' },
+    { code: '<svg:marquee />' },
+
+    // ---- Element kind survey: rule is a no-op for every non-listed tag ----
+    { code: '<a />' },
+    { code: '<input />' },
+    { code: '<Component />' },
+
+    // ---- Empty `elements` array disables every check ----
+    { code: '<marquee />', options: [{ elements: [] }] },
+    { code: '<blink />', options: [{ elements: [] }] },
+
+    // ---- Custom `elements` list — types not in the list pass ----
+    { code: '<marquee />', options: [{ elements: ['blink'] }] },
+    { code: '<blink />', options: [{ elements: ['marquee'] }] },
+
+    // ---- Components map without a matching entry ----
+    {
+      code: '<Blink />',
+      settings: { 'jsx-a11y': { components: { OtherTag: 'marquee' } } },
+    },
+
+    // ---- Polymorphic with allow-list NOT containing the tag ----
+    {
+      code: '<Foo as="marquee" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          polymorphicAllowList: ['Bar'],
+        },
+      },
+    },
+
+    // ---- Multi-segment PropertyAccess + this.Foo + lowercase final ----
+    { code: '<A.B.C />' },
+    { code: '<this.Foo />' },
+    { code: '<UI.marquee />' }, // type "UI.marquee" ≠ "marquee"
+
+    // ---- options: null elements falls back to default ----
+    { code: '<div />', options: [{ elements: null }] },
+    // rslint extension: array-of-non-strings silences the rule.
+    { code: '<marquee />', options: [{ elements: [123, true] }] },
+
+    // ---- Components map: map-to-non-distracting / non-string value ----
+    {
+      code: '<Foo />',
+      settings: { 'jsx-a11y': { components: { Foo: 'div' } } },
+    },
+    // Reverse aliasing: <marquee/> → "div" → no report.
+    {
+      code: '<marquee />',
+      settings: { 'jsx-a11y': { components: { marquee: 'div' } } },
+    },
+    {
+      code: '<Foo />',
+      settings: { 'jsx-a11y': { components: { Foo: 123 } } },
+    },
+
+    // ---- Polymorphic prop edge cases ----
+    {
+      code: '<Foo />', // no `as` prop
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+    },
+    {
+      code: '<Foo as={x} />', // dynamic Identifier
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+    },
+    {
+      code: '<Foo as="" />', // empty string falsy
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+    },
+    {
+      code: '<Foo as={cond ? "marquee" : "blink"} />', // Conditional opaque
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+    },
+    {
+      code: '<Foo as="marquee" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          polymorphicAllowList: [], // empty list → never replace
+        },
+      },
+    },
+
+    // ---- Polymorphic reverse exemption ----
+    {
+      code: '<marquee as="div" />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+    },
+    {
+      code: '<blink as="span" />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+    },
+    // Polymorphic alone replaces with non-distracting; no components chain.
+    {
+      code: '<Foo as="Bar" />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+    },
+
+    // ---- Defensive type handling for settings ----
+    // `settings['jsx-a11y']` is not a map.
+    {
+      code: '<Foo />',
+      settings: { 'jsx-a11y': 'invalid' as unknown as object },
+    },
+    // `settings['jsx-a11y']` is null.
+    { code: '<Foo />', settings: { 'jsx-a11y': null as unknown as object } },
+    // `components` is not a map.
+    {
+      code: '<Foo />',
+      settings: { 'jsx-a11y': { components: 'invalid' as unknown as object } },
+    },
+    // `polymorphicPropName` is a number — upstream throws TypeError on
+    // this; rslint silently skips the polymorphic block (Go-natural
+    // robustness divergence). Locking in our behavior.
+    {
+      code: '<Foo as="marquee" />',
+      settings: {
+        'jsx-a11y': { polymorphicPropName: 123 as unknown as string },
+      },
+    },
+    // allowList contains only non-strings.
+    {
+      code: '<Foo as="marquee" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          polymorphicAllowList: [123 as unknown as string],
+        },
+      },
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid ----
+    { code: '<marquee />', errors: [expectedError('marquee')] },
+    { code: '<marquee {...props} />', errors: [expectedError('marquee')] },
+    {
+      code: '<marquee lang={undefined} />',
+      errors: [expectedError('marquee')],
+    },
+    { code: '<blink />', errors: [expectedError('blink')] },
+    { code: '<blink {...props} />', errors: [expectedError('blink')] },
+    { code: '<blink foo={undefined} />', errors: [expectedError('blink')] },
+    {
+      code: '<Blink />',
+      settings: blinkComponentSettings,
+      errors: [expectedError('blink')],
+    },
+
+    // ---- Paired form: report on the OPENING element only ----
+    {
+      code: '<marquee>scrolling</marquee>',
+      errors: [expectedError('marquee')],
+    },
+    { code: '<marquee></marquee>', errors: [expectedError('marquee')] },
+
+    // ---- Same-kind nesting: outer + inner each report ----
+    {
+      code: '<marquee><marquee /></marquee>',
+      errors: [expectedError('marquee'), expectedError('marquee')],
+    },
+
+    // ---- Boolean / spread / various attribute forms ----
+    { code: '<marquee draggable />', errors: [expectedError('marquee')] },
+    {
+      code: '<marquee className="x" id={n} />',
+      errors: [expectedError('marquee')],
+    },
+
+    // ---- Custom `elements` list ----
+    {
+      code: '<custom />',
+      options: [{ elements: ['custom'] }],
+      errors: [expectedError('custom')],
+    },
+    {
+      code: '<blink />',
+      options: [{ elements: ['blink'] }],
+      errors: [expectedError('blink')],
+    },
+
+    // ---- Components map with a matching entry ----
+    {
+      code: '<CustomMarquee />',
+      settings: {
+        'jsx-a11y': { components: { CustomMarquee: 'marquee' } },
+      },
+      errors: [expectedError('marquee')],
+    },
+
+    // ---- Polymorphic prop without an allow-list — every truthy `as` value
+    //      replaces rawType ----
+    {
+      code: '<Foo as="marquee" />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+      errors: [expectedError('marquee')],
+    },
+    // Polymorphic with allow-list that DOES include the rawType.
+    {
+      code: '<Foo as="blink" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          polymorphicAllowList: ['Foo'],
+        },
+      },
+      errors: [expectedError('blink')],
+    },
+
+    // ---- Listener boundary: each violation reports independently ----
+    { code: '<div><marquee /></div>', errors: [expectedError('marquee')] },
+    {
+      code: '<marquee><blink /></marquee>',
+      errors: [expectedError('marquee'), expectedError('blink')],
+    },
+
+    // ---- Real-world component patterns ----
+    {
+      code: 'function Banner() { return <marquee>News</marquee>; }',
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: 'const x = items.map(item => <blink key={item.id}>{item.text}</blink>)',
+      errors: [expectedError('blink')],
+    },
+    {
+      code: 'const x = cond ? <marquee /> : <div />',
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: 'class C { render() { return <div><marquee /><blink /></div>; } }',
+      errors: [expectedError('marquee'), expectedError('blink')],
+    },
+
+    // ---- Deep nesting (3 levels) ----
+    {
+      code: '<marquee><marquee><marquee /></marquee></marquee>',
+      errors: [
+        expectedError('marquee'),
+        expectedError('marquee'),
+        expectedError('marquee'),
+      ],
+    },
+
+    // ---- JsxFragment wrapper ----
+    { code: '<><marquee /></>', errors: [expectedError('marquee')] },
+
+    // ---- JSX inside expression containers (children, attribute, &&) ----
+    { code: '<div>{<marquee />}</div>', errors: [expectedError('marquee')] },
+    {
+      code: '<div>{cond && <marquee />}</div>',
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: '<div content={<marquee />} />',
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: '<Provider value={data}>{<marquee />}</Provider>',
+      errors: [expectedError('marquee')],
+    },
+
+    // ---- Components map: map-to-distracting / map-to-self ----
+    {
+      code: '<Foo />',
+      settings: { 'jsx-a11y': { components: { Foo: 'marquee' } } },
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: '<marquee />',
+      settings: { 'jsx-a11y': { components: { marquee: 'marquee' } } },
+      errors: [expectedError('marquee')],
+    },
+
+    // ---- Polymorphic + components combination ----
+    // Polymorphic replaces FIRST → rawType becomes "marquee"; components
+    // has no "marquee" key, so it's a no-op. Reports marquee.
+    {
+      code: '<Foo as="marquee" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          components: { Foo: 'div' },
+        },
+      },
+      errors: [expectedError('marquee')],
+    },
+
+    // Polymorphic + components CHAIN: Foo → Bar (polymorphic) → marquee
+    // (components). Locks in that components looks up the post-polymorphic
+    // name.
+    {
+      code: '<Foo as="Bar" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          components: { Bar: 'marquee' },
+        },
+      },
+      errors: [expectedError('marquee')],
+    },
+
+    // ---- Polymorphic prop value forms ----
+    {
+      code: '<Foo as={"marquee"} />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: '<Foo as={`marquee`} />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+      errors: [expectedError('marquee')],
+    },
+
+    // ---- Real-world patterns (extended) ----
+    {
+      code: 'const Banner = withTheme(() => <marquee />);',
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: 'const x = items.filter(x => x).map(x => <marquee key={x.id} />)',
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: 'const items = [<marquee key="1" />, <blink key="2" />];',
+      errors: [expectedError('marquee'), expectedError('blink')],
+    },
+    {
+      code: 'wrap(<marquee />);',
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: 'const x = { content: <marquee /> };',
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: 'const Marquee = React.forwardRef((props, ref) => <marquee ref={ref} {...props} />);',
+      errors: [expectedError('marquee')],
+    },
+
+    // ---- Defensive type handling (invalid side) ----
+    // Mixed-type allowList — non-string entries dropped, "Foo" honored.
+    {
+      code: '<Foo as="marquee" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          polymorphicAllowList: [123 as unknown as string, 'Foo'],
+        },
+      },
+      errors: [expectedError('marquee')],
+    },
+
+    // ---- rslint-specific options (no schema validation) ----
+    {
+      code: '<marquee />',
+      options: [{ elements: ['marquee', 123] }],
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: '<marquee />',
+      options: [{ elements: ['', 'marquee'] }],
+      errors: [expectedError('marquee')],
+    },
+    {
+      code: '<marquee />',
+      options: [{ elements: ['marquee', 'marquee'] }],
+      errors: [expectedError('marquee')],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -402,3 +402,4 @@ subtag
 macrolanguage
 rozaj
 biske
+Deque


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/no-distracting-elements` rule from ESLint to rslint.

The rule flags JSX elements whose resolved type matches a configurable list of "distracting" tag names — `<marquee>` and `<blink>` by default. Element-type resolution honors the shared `jsx-a11y` `components` map, `polymorphicPropName`, and `polymorphicAllowList` settings via the existing `jsxa11yutil.GetElementType` helper.

Verification:

- 12 upstream test cases migrated 1:1 (`*_upstream_test.go`)
- 70+ extra Go cases (`*_extras_test.go`) covering Dimension 1-4 edge shapes, deep nesting, expression containers, real-world component patterns, defensive settings types, and rslint-specific options
- Differential validation against `eslint-plugin-jsx-a11y@6.10.2` — every observable diagnostic (message text, line, column, endLine, endColumn) matches byte-for-byte on the inputs upstream's schema accepts
- Smoke-tested on rsbuild and rspack: zero false positives across 49 real `.tsx` files; 18 synthetic probe reports (12 in rsbuild + 6 in rspack) all match expected line/column

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-distracting-elements.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/no-distracting-elements.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).