### PR TITLE
feat: port rule jsx-a11y/no-autofocus

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/html_has_lang"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/img_redundant_alt"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_access_key"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_autofocus"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_distracting_elements"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -25,6 +26,7 @@ func GetAllRules() []rule.Rule {
 		html_has_lang.HtmlHasLangRule,
 		img_redundant_alt.ImgRedundantAltRule,
 		no_access_key.NoAccessKeyRule,
+		no_autofocus.NoAutofocusRule,
 		no_distracting_elements.NoDistractingElementsRule,
 	}
 }

--- a/internal/plugins/jsx_a11y/jsxa11yutil/dom.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/dom.go
@@ -1,0 +1,44 @@
+package jsxa11yutil
+
+// DomElements mirrors aria-query's `dom.keys()` ordered list — the set of
+// HTML element names that aria-query's `dom` map contains. Used by rules
+// (no-autofocus, …) that need to distinguish DOM elements from custom
+// components without depending on aria-query at runtime.
+//
+// Source: https://github.com/A11yance/aria-query/blob/main/src/domMap.ts
+var DomElements = []string{
+	"a", "abbr", "acronym", "address", "applet", "area", "article", "aside",
+	"audio", "b", "base", "bdi", "bdo", "big", "blink", "blockquote", "body",
+	"br", "button", "canvas", "caption", "center", "cite", "code", "col",
+	"colgroup", "content", "data", "datalist", "dd", "del", "details", "dfn",
+	"dialog", "dir", "div", "dl", "dt", "em", "embed", "fieldset", "figcaption",
+	"figure", "font", "footer", "form", "frame", "frameset", "h1", "h2", "h3",
+	"h4", "h5", "h6", "head", "header", "hgroup", "hr", "html", "i", "iframe",
+	"img", "input", "ins", "kbd", "keygen", "label", "legend", "li", "link",
+	"main", "map", "mark", "marquee", "menu", "menuitem", "meta", "meter",
+	"nav", "noembed", "noscript", "object", "ol", "optgroup", "option",
+	"output", "p", "param", "picture", "pre", "progress", "q", "rp", "rt",
+	"rtc", "ruby", "s", "samp", "script", "section", "select", "small",
+	"source", "spacer", "span", "strike", "strong", "style", "sub", "summary",
+	"sup", "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "time",
+	"title", "tr", "track", "tt", "u", "ul", "var", "video", "wbr", "xmp",
+}
+
+var domSet = func() map[string]struct{} {
+	set := make(map[string]struct{}, len(DomElements))
+	for _, el := range DomElements {
+		set[el] = struct{}{}
+	}
+	return set
+}()
+
+// IsDOMElement reports whether `name` is an HTML element name in
+// aria-query's `dom` map. Mirrors upstream `dom.get(type)` truthy check used
+// by `no-autofocus`'s `ignoreNonDOM` option to skip custom components.
+// Comparison is exact (case-sensitive) — upstream's `dom.get(type)` is a
+// Map.get with no normalization, and `getElementType(node)` already returns
+// the resolved element name verbatim.
+func IsDOMElement(name string) bool {
+	_, ok := domSet[name]
+	return ok
+}

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -383,6 +383,44 @@ func PropStaticStringValue(attr *ast.Node) (string, bool) {
 	return "", false
 }
 
+// PropStaticBoolValue mirrors `getPropValue(prop)` for callers that need to
+// compare against a JS boolean. Returns (value, true) when the prop's static
+// value is a JS boolean — including string literals "true" / "false" that
+// jsxAstUtilsLiteralCoerce normalizes to booleans, and the boolean attribute
+// form (`<div autoFocus />` → upstream's null-attribute-value path → true).
+// Returns (false, false) for every other shape (undefined, null, numbers,
+// non-coerced strings, identifiers, calls, etc.).
+//
+// Use this for upstream call sites that pass `getPropValue(...) === false`
+// or `=== true` — e.g. `no-autofocus`'s `getPropValue(attribute) !== false`
+// gate, where upstream applies real JS `===` semantics against the coerced
+// static value.
+//
+// Differs from PropValueIsTruthy: that one returns the JS-truthiness of the
+// extracted value (so `null`, `0`, `""` all return false). This one
+// distinguishes "exactly the boolean false" from "a different falsy value"
+// — required when the upstream check uses `===` rather than `!`.
+func PropStaticBoolValue(attr *ast.Node) (bool, bool) {
+	if attr == nil {
+		return false, false
+	}
+	if AttributeIsBooleanForm(attr) {
+		// `<div autoFocus />` — extractValue's null-attr-value path returns
+		// JS boolean true. Mirrors upstream `getPropValue(<div autoFocus />)
+		// === true`.
+		return true, true
+	}
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		return false, false
+	}
+	v := staticEval(inner)
+	if v.Kind == jvBool {
+		return v.Bool, true
+	}
+	return false, false
+}
+
 // LiteralPropStringValue mirrors `getLiteralPropValue(prop)` filtered to the
 // string-typed result. Returns ("", false) when the prop's literal-typed
 // value isn't a string under jsx-ast-utils' LITERAL_TYPES rules:

--- a/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus.go
+++ b/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus.go
@@ -1,0 +1,113 @@
+// Package no_autofocus ports eslint-plugin-jsx-a11y's `no-autofocus` rule.
+// The rule discourages the `autoFocus` prop on JSX elements: programmatically
+// shifting focus on render disrupts both sighted users (unexpected viewport
+// jumps) and assistive-technology users (screen-reader / keyboard navigation
+// gets reset out from under them).
+//
+// Upstream signature:
+//
+//	options: { ignoreNonDOM?: boolean (default false) }
+//
+// Trigger: a JsxAttribute whose name is exactly `autoFocus` (case-sensitive
+// per upstream `propName`) and whose extracted value is anything other than
+// the JS boolean `false` or the literal string `"false"`. The boolean-attribute
+// form (`<div autoFocus />`) extracts to JS `true` and trips the rule.
+//
+// `ignoreNonDOM`: when true, the rule resolves the parent element's name via
+// `getElementType` (honoring `polymorphicPropName` and the `components` map
+// from `settings['jsx-a11y']`) and only fires when the resolved name is in
+// aria-query's `dom` map — i.e. an HTML element. Custom components are
+// silently skipped.
+//
+// All AST plumbing (case-sensitive prop name lookup, value coercion,
+// boolean-form handling, element-type resolution) lives in `jsxa11yutil`;
+// this rule just wires the gates.
+package no_autofocus
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// errorMessage mirrors upstream's `errorMessage` string verbatim.
+const errorMessage = "The autoFocus prop should not be enabled, as it can reduce usability and accessibility for users."
+
+// options holds the rule's parsed configuration. Mirrors the upstream
+// `generateObjSchema({ ignoreNonDOM: { type: 'boolean', default: false } })`
+// shape.
+type options struct {
+	IgnoreNonDOM bool
+}
+
+func parseOptions(raw any) options {
+	opts := options{}
+	optsMap := utils.GetOptionsMap(raw)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["ignoreNonDOM"].(bool); ok {
+		opts.IgnoreNonDOM = v
+	}
+	return opts
+}
+
+var NoAutofocusRule = rule.Rule{
+	Name: "jsx-a11y/no-autofocus",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		return rule.RuleListeners{
+			ast.KindJsxAttribute: func(attr *ast.Node) {
+				// Upstream's `propName(attribute) === 'autoFocus'` is a strict
+				// case-sensitive equality. Lowercase variants like `autofocus`
+				// are NOT matched (they're the HTML-DOM attribute, not React's
+				// camelCased prop) — locked by the upstream valid case
+				// `<div autofocus />`.
+				if reactutil.GetJsxPropName(attr) != "autoFocus" {
+					return
+				}
+				if opts.IgnoreNonDOM {
+					// Resolve via the parent JsxOpeningElement /
+					// JsxSelfClosingElement so polymorphicPropName and the
+					// `components` map are honored. Skip when the parent isn't
+					// an element-like node (defensive — JsxAttribute always has
+					// a JsxAttributes parent, which always has an opening /
+					// self-closing element parent in legal source).
+					parent := reactutil.GetJsxParentElement(attr)
+					if parent == nil {
+						return
+					}
+					elementType := jsxa11yutil.GetElementType(parent, ctx.Settings)
+					if !jsxa11yutil.IsDOMElement(elementType) {
+						return
+					}
+				}
+				// Mirrors upstream's
+				//   getPropValue(attribute) !== false &&
+				//   getPropValue(attribute) !== 'false'
+				// `=== false` covers boolean false and the
+				// jsxAstUtilsLiteralCoerce'd string literals "true"/"false"
+				// (case-insensitive) which extract to a JS boolean.
+				// `=== 'false'` is upstream-defensive: the only path that
+				// produces the literal string "false" is a
+				// NoSubstitutionTemplateLiteral (`` `false` ``), which routes
+				// through ESTree's TemplateLiteral extractor and skips the
+				// boolean coercion. Both checks must match exactly per JS `===`
+				// semantics; a non-coerced falsy value (null, undefined, 0, "")
+				// still trips the rule.
+				if boolVal, ok := jsxa11yutil.PropStaticBoolValue(attr); ok && !boolVal {
+					return
+				}
+				if strVal, ok := jsxa11yutil.PropStaticStringValue(attr); ok && strVal == "false" {
+					return
+				}
+				ctx.ReportNode(attr, rule.RuleMessage{
+					Id:          "noAutoFocus",
+					Description: errorMessage,
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus.md
+++ b/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus.md
@@ -1,0 +1,74 @@
+# no-autofocus
+
+Enforce that the `autoFocus` prop is not used on JSX elements.
+Programmatically moving focus on render is disorienting for sighted users
+(the viewport jumps to an unexpected location) and disruptive for
+assistive-technology users (screen-reader and keyboard navigation are
+reset).
+
+## Rule Details
+
+The rule fires on a JSX attribute named `autoFocus` (case-sensitive — the
+lowercase HTML attribute `autofocus` is **not** matched) whose value is
+anything other than the JS boolean `false` or the literal string `"false"`.
+The boolean attribute form (`<div autoFocus />`) is treated as `true` and is
+reported.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div autoFocus />
+<div autoFocus={true} />
+<div autoFocus={undefined} />
+<div autoFocus="true" />
+<input autoFocus />
+<Foo autoFocus />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div />
+<div autofocus />
+<input autofocus="true" />
+<Foo bar />
+<div autoFocus={false} />
+<div autoFocus="false" />
+```
+
+## Rule Options
+
+### `ignoreNonDOM`
+
+Type: `boolean`. Default: `false`.
+
+When `true`, custom components (anything not in the HTML DOM element set)
+are skipped. The element name is resolved through
+`settings['jsx-a11y'].polymorphicPropName` and
+`settings['jsx-a11y'].components` before the DOM-set lookup, so a custom
+component remapped to a DOM tag is still checked.
+
+Examples of **correct** code with `{ "ignoreNonDOM": true }`:
+
+```json
+{ "jsx-a11y/no-autofocus": ["error", { "ignoreNonDOM": true }] }
+```
+
+```jsx
+<Foo autoFocus />
+<div><div autofocus /></div>
+```
+
+Examples of **incorrect** code with `{ "ignoreNonDOM": true }`:
+
+```json
+{ "jsx-a11y/no-autofocus": ["error", { "ignoreNonDOM": true }] }
+```
+
+```jsx
+<input autoFocus />
+```
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/no-autofocus](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-autofocus.md)

--- a/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus_extras_test.go
@@ -1,0 +1,823 @@
+package no_autofocus
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// polymorphicSettings mirrors upstream's `polymorphicPropName: 'as'` config.
+// `<Box as="input" autoFocus />` should resolve to `input` and be reported
+// even with ignoreNonDOM:true.
+var polymorphicSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+	},
+}
+
+// polymorphicWithComponentsSettings combines polymorphicPropName + components
+// — locks in the resolution order in jsxa11yutil.GetElementType (polymorphic
+// runs first, then components-map remap on the unresolved rawType).
+var polymorphicWithComponentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+		"components": map[string]interface{}{
+			"Box": "div",
+		},
+	},
+}
+
+// componentsToCustomSettings maps a custom component name to ANOTHER custom
+// component name (not in the dom set). Used to verify ignoreNonDOM still
+// skips when components remap stays outside the dom set.
+var componentsToCustomSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Foo": "Bar",
+		},
+	},
+}
+
+// emptyJsxA11ySettings has the `jsx-a11y` key but no inner config — exercises
+// the GetElementType / IsDOMElement defensive paths when the settings tree
+// exists but is empty.
+var emptyJsxA11ySettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{},
+}
+
+// polymorphicAllowListSettings combines polymorphicPropName +
+// polymorphicAllowList — the allow-list restricts which raw tag names the
+// `as` swap applies to. Locks in that GetElementType honors the allow-list
+// for ignoreNonDOM resolution.
+var polymorphicAllowListSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+		"polymorphicAllowList": []interface{}{"Box"},
+	},
+}
+
+// TestNoAutofocusExtras is the catch-all for everything beyond upstream's
+// 18-case suite (which lives in no_autofocus_upstream_test.go). Cases here
+// fall in three groups, kept in one suite so a regression bisects easily:
+//
+//  1. **Dimension 4 universal edge shapes** — TS wrappers, namespaced names,
+//     paired vs self-closing element kinds, satisfies opaqueness, template
+//     substitution placeholders, listener boundary across nested elements.
+//  2. **Upstream getPropValue branches lacking dedicated upstream coverage**
+//     — boolean form, numeric / null / bigint / call / member / template
+//     literals, the "true"/"false" string coercion direction, exact position
+//     assertions per JSX surface.
+//  3. **ignoreNonDOM × polymorphicPropName × components × polymorphicAllowList
+//     resolution matrix**, plus the bare/array-wrapped/malformed options
+//     shapes that exercise GetOptionsMap.
+//  4. **Real-world React / TS patterns** — TS generics, hyphenated tags,
+//     hooks / forwardRef / memo / HOC wrappers, fragments + portals,
+//     conditional rendering, multi-component files, generator/async/IIFE
+//     bodies. These don't lock new semantics; they certify the listener
+//     fires reliably across the AST shapes a real codebase produces.
+func TestNoAutofocusExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoAutofocusRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// Group 1: Case-sensitivity locks
+		// ============================================================
+		// upstream `propName(attribute) === 'autoFocus'` is strict; lowercase
+		// HTML attribute / random casings must NOT match.
+		{Code: `<div autofocus />`, Tsx: true},
+		{Code: `<div AUTOFOCUS />`, Tsx: true},
+		{Code: `<div AutoFocus />`, Tsx: true},
+		{Code: `<div autoFocuS />`, Tsx: true},
+		// Namespaced attribute name `xml:autoFocus` becomes the composite
+		// "xml:autoFocus" via reactutil.GetJsxPropName, which is not equal to
+		// the bare "autoFocus" — listener does NOT match.
+		{Code: `<div xml:autoFocus />`, Tsx: true},
+
+		// ============================================================
+		// Group 2: "false" literal forms — all coerce to boolean false
+		// ============================================================
+		// Locks in jsxAstUtilsLiteralCoerce's case-insensitive coverage and
+		// the TS-wrapper unwrapping inside staticEval.
+		{Code: `<div autoFocus="False" />`, Tsx: true},
+		{Code: `<div autoFocus="FALSE" />`, Tsx: true},
+		{Code: `<div autoFocus={"false"} />`, Tsx: true},
+		{Code: `<div autoFocus={"False"} />`, Tsx: true},
+		{Code: `<div autoFocus={("false")} />`, Tsx: true},
+		{Code: `<div autoFocus={"false" as string} />`, Tsx: true},
+		{Code: `<div autoFocus={"false"!} />`, Tsx: true},
+		{Code: `<div autoFocus={false as boolean} />`, Tsx: true},
+		// NoSubstitutionTemplateLiteral does NOT route through
+		// jsxAstUtilsLiteralCoerce, so `` `false` `` extracts to string
+		// "false", which matches the upstream `=== 'false'` defensive check.
+		{Code: "<div autoFocus={`false`} />", Tsx: true},
+
+		// ============================================================
+		// Group 3: Boolean / Conditional resolving to false
+		// ============================================================
+		{Code: `<div autoFocus={true && false} />`, Tsx: true},
+		{Code: `<div autoFocus={true ? false : true} />`, Tsx: true},
+		{Code: `<div autoFocus={false || false} />`, Tsx: true},
+
+		// ============================================================
+		// Group 4: ignoreNonDOM matrix — skips
+		// ============================================================
+		// ignoreNonDOM: true skips custom components and namespaced /
+		// member-expression tag names that aren't in the dom set.
+		{Code: `<Foo autoFocus />`, Tsx: true, Options: ignoreNonDOMOption},
+		{Code: `<UX.Layout autoFocus />`, Tsx: true, Options: ignoreNonDOMOption},
+		// `svg:circle` is a JsxNamespacedName — the composite "svg:circle" is
+		// not an exact key in aria-query's dom map, so ignoreNonDOM skips.
+		{Code: `<svg:circle autoFocus />`, Tsx: true, Options: ignoreNonDOMOption},
+		// ignoreNonDOM:true — components map promotes `Button` → `button`
+		// (in dom set), so ignoreNonDOM does not skip; explicit `false`
+		// short-circuits the report.
+		{Code: `<Button autoFocus={false} />`, Tsx: true, Options: ignoreNonDOMOption, Settings: componentsSettings},
+		// ignoreNonDOM:true with polymorphicPropName: `<Box as="div" />`
+		// resolves to `div` (in dom set), ignoreNonDOM doesn't skip, but
+		// `false` short-circuits.
+		{Code: `<Box as="div" autoFocus={false} />`, Tsx: true, Options: ignoreNonDOMOption, Settings: polymorphicSettings},
+		// `<Box as="ComponentName" autoFocus />` resolves to `ComponentName`
+		// — not in the dom set → ignoreNonDOM skips.
+		{Code: `<Box as="ComponentName" autoFocus />`, Tsx: true, Options: ignoreNonDOMOption, Settings: polymorphicSettings},
+
+		// ============================================================
+		// Group 5: Default-options shapes — JSON path coverage
+		// ============================================================
+		// Bare `{}` (single-option CLI shape) and array-wrapped `[{}]`
+		// (multi-element / rule_tester shape) — exercise both arms of
+		// utils.GetOptionsMap. Default ignoreNonDOM=false → custom Foo
+		// would normally fire, but explicit `false` value short-circuits.
+		{Code: `<Foo autoFocus={false} />`, Tsx: true, Options: map[string]interface{}{}},
+		{Code: `<Foo autoFocus={false} />`, Tsx: true, Options: []interface{}{map[string]interface{}{}}},
+
+		// ============================================================
+		// Group 6: Spread attributes are NOT JsxAttribute → listener never fires
+		// ============================================================
+		// upstream's listener is `JSXAttribute` only; SpreadAttribute is its
+		// own AST kind. Even `{...{autoFocus: true}}` cannot trigger this
+		// rule because no JsxAttribute named autoFocus exists in the tree.
+		{Code: `<div {...{autoFocus: true}} />`, Tsx: true},
+		{Code: `<div {...props} />`, Tsx: true},
+		{Code: `<div {...{autoFocus: true}} {...props} />`, Tsx: true},
+
+		// ============================================================
+		// Group 7: Real-world patterns with explicit false (no-report)
+		// ============================================================
+		{
+			Code: `function Modal({ open }) { return <dialog open={open}><input autoFocus={false} placeholder="search" /></dialog>; }`,
+			Tsx:  true,
+		},
+		// useRef + manual focus pattern (recommended a11y replacement) — no
+		// autoFocus prop, so nothing to report.
+		{
+			Code: `function Search() { const ref = useRef(null); useEffect(() => ref.current?.focus(), []); return <input ref={ref} />; }`,
+			Tsx:  true,
+		},
+		// HOC wrapping — no autoFocus on the inner component.
+		{
+			Code: `const Enhanced = withTracking(({ value }) => <input value={value} />);`,
+			Tsx:  true,
+		},
+		// React.forwardRef with autoFocus={false} — explicit false suppresses.
+		{
+			Code: `const FocusInput = React.forwardRef((props, ref) => <input ref={ref} autoFocus={false} {...props} />);`,
+			Tsx:  true,
+		},
+		// React.memo + arrow component — autoFocus={false} suppresses.
+		{
+			Code: `const Item = React.memo(({ id }) => <li id={id} autoFocus={false}>{id}</li>);`,
+			Tsx:  true,
+		},
+		// ignoreNonDOM × Suspense / Portal — these are framework components,
+		// not in dom set; the listener must not crash on the surrounding tree.
+		{
+			Code:    `<Suspense fallback={<div autoFocus={false} />}><div>x</div></Suspense>`,
+			Tsx:     true,
+			Options: ignoreNonDOMOption,
+		},
+
+		// ============================================================
+		// Group 8: TypeScript generic JSX components
+		// ============================================================
+		// `<List<string> autoFocus={false}>` — the type-arg is a TS-only
+		// extension; tsgo parses it as a JsxOpeningElement with type args.
+		// The autoFocus attribute is still reachable as a plain JsxAttribute.
+		{Code: `<List<string> autoFocus={false} />`, Tsx: true},
+		{
+			Code:    `<List<{a: number}> autoFocus />`,
+			Tsx:     true,
+			Options: ignoreNonDOMOption,
+		},
+
+		// ============================================================
+		// Group 9: Long-chain member-expression tags
+		// ============================================================
+		// `<Foo.Bar.Baz autoFocus={false} />` — element name resolves to the
+		// dotted string. With ignoreNonDOM:true, the resolved string isn't in
+		// the dom set → skip; without, the explicit false suppresses.
+		{Code: `<Foo.Bar.Baz autoFocus={false} />`, Tsx: true},
+		{
+			Code:    `<Foo.Bar.Baz autoFocus />`,
+			Tsx:     true,
+			Options: ignoreNonDOMOption,
+		},
+
+		// ============================================================
+		// Group 10: Hyphenated DOM tags (web components)
+		// ============================================================
+		// `<my-element>` is a custom element; jsx-ast-utils sees it as a
+		// lowercase string. `dom.get('my-element')` is undefined, so with
+		// ignoreNonDOM:true → not in dom set → skipped.
+		{
+			Code:    `<my-element autoFocus />`,
+			Tsx:     true,
+			Options: ignoreNonDOMOption,
+		},
+
+		// ============================================================
+		// Group 11: components / settings edge shapes
+		// ============================================================
+		// components map promoting custom → custom (still custom): `Foo` →
+		// `Bar`, neither in dom set → ignoreNonDOM still skips.
+		{
+			Code:     `<Foo autoFocus />`,
+			Tsx:      true,
+			Options:  ignoreNonDOMOption,
+			Settings: componentsToCustomSettings,
+		},
+		// Empty `jsx-a11y` settings: settings present but inner is empty →
+		// IsDOMElement falls back to raw element name; `Foo` not in dom set
+		// → ignoreNonDOM skips.
+		{
+			Code:     `<Foo autoFocus />`,
+			Tsx:      true,
+			Options:  ignoreNonDOMOption,
+			Settings: emptyJsxA11ySettings,
+		},
+
+		// ============================================================
+		// Group 12: polymorphicAllowList restricts the `as` swap
+		// ============================================================
+		// `<Box as="input" />` IS in the allow-list, so rawType becomes
+		// "input"; explicit false suppresses.
+		{
+			Code:     `<Box as="input" autoFocus={false} />`,
+			Tsx:      true,
+			Options:  ignoreNonDOMOption,
+			Settings: polymorphicAllowListSettings,
+		},
+		// `<Other as="input" />` is NOT in the allow-list, so the `as` swap
+		// is skipped → rawType stays "Other" → not in dom set → ignoreNonDOM
+		// skips even though autoFocus is truthy.
+		{
+			Code:     `<Other as="input" autoFocus />`,
+			Tsx:      true,
+			Options:  ignoreNonDOMOption,
+			Settings: polymorphicAllowListSettings,
+		},
+
+		// ============================================================
+		// Group 13: Comments around the prop don't break extraction
+		// ============================================================
+		{Code: `<div /* before */ autoFocus={false} /* after */ />`, Tsx: true},
+		{Code: `<div autoFocus={/* false */ false} />`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// Group 1: Position assertions — JsxAttribute node range
+		// ============================================================
+		// `<div autoFocus />` — the JsxAttribute spans columns 6..14
+		// (1-based, end-exclusive), covering exactly `autoFocus`.
+		{
+			Code: `<div autoFocus />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAutoFocus",
+				Message:   errorMessage,
+				Line:      1, Column: 6, EndLine: 1, EndColumn: 15,
+			}},
+		},
+		// Position with explicit value — JsxAttribute spans `autoFocus={true}`
+		// (16 chars wide), columns 6..22 (1-based, end-exclusive).
+		{
+			Code: `<div autoFocus={true} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAutoFocus",
+				Message:   errorMessage,
+				Line:      1, Column: 6, EndLine: 1, EndColumn: 22,
+			}},
+		},
+		// Multi-line attribute — position spans the entire attribute.
+		{
+			Code: "<div\n  autoFocus={\n    true\n  } />",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAutoFocus",
+				Message:   errorMessage,
+				Line:      2, Column: 3, EndLine: 4, EndColumn: 4,
+			}},
+		},
+		// Paired (non-self-closing) element — listener still fires on the
+		// JsxAttribute inside the JsxOpeningElement.
+		{
+			Code: `<div autoFocus>child</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAutoFocus",
+				Message:   errorMessage,
+				Line:      1, Column: 6, EndLine: 1, EndColumn: 15,
+			}},
+		},
+		// String "true" → coerce to true → reports; the JsxAttribute spans
+		// `autoFocus="true"` (16 chars wide), columns 6..22.
+		{
+			Code: `<div autoFocus="true" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAutoFocus",
+				Message:   errorMessage,
+				Line:      1, Column: 6, EndLine: 1, EndColumn: 22,
+			}},
+		},
+
+		// ============================================================
+		// Group 2: Listener boundary — nested elements report independently
+		// ============================================================
+		// Outer `<a autoFocus>` AND inner `<span autoFocus />` each emit a
+		// diagnostic. Locks in that the listener doesn't dedupe and doesn't
+		// bleed across the nesting boundary.
+		{
+			Code: `<a autoFocus><span autoFocus /></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noAutoFocus", Message: errorMessage, Line: 1, Column: 4, EndLine: 1, EndColumn: 13},
+				{MessageId: "noAutoFocus", Message: errorMessage, Line: 1, Column: 20, EndLine: 1, EndColumn: 29},
+			},
+		},
+		// Multiple autoFocus attributes on one element each report.
+		// JsxAttribute listener fires once per matching attribute; tsgo
+		// preserves duplicates (legal source though typically a typo).
+		{
+			Code: `<div autoFocus autoFocus />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noAutoFocus", Message: errorMessage, Line: 1, Column: 6, EndLine: 1, EndColumn: 15},
+				{MessageId: "noAutoFocus", Message: errorMessage, Line: 1, Column: 16, EndLine: 1, EndColumn: 25},
+			},
+		},
+
+		// ============================================================
+		// Group 3: Element kind survey (ignoreNonDOM unset)
+		// ============================================================
+		// Rule fires regardless of element type when ignoreNonDOM is unset.
+		{Code: `<a autoFocus />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input autoFocus />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Component autoFocus />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<UX.Layout autoFocus />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<svg:circle autoFocus />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 4: Truthy literal coercions
+		// ============================================================
+		// jsxAstUtilsLiteralCoerce handles "true" / "TRUE" / "True" → boolean
+		// true → !== false → reports.
+		{Code: `<div autoFocus="True" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus="TRUE" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={"true"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 5: Non-coerced falsy values still report
+		// ============================================================
+		// upstream's check is `!== false` (strict) — null / 0 / "" / NaN are
+		// all falsy in JS but distinct from boolean false → still report.
+		{Code: `<div autoFocus={null} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={""} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Empty string attribute: extracts to "" via the StringLiteral path
+		// (no coerce — not "true"/"false"). "" !== false → reports.
+		{Code: `<div autoFocus="" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `void 0` evaluates to undefined under upstream's UnaryExpression
+		// extractor → undefined !== false → reports.
+		{Code: `<div autoFocus={void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 6: Numeric / BigInt / Identifier expressions are truthy
+		// ============================================================
+		{Code: `<div autoFocus={1} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={42} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={1n} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Identifier extracts to the name string under jsx-ast-utils — non-empty
+		// truthy, but more importantly !== false / 'false'.
+		{Code: `<div autoFocus={someVar} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 7: Conditional / logical resolving to NOT-false
+		// ============================================================
+		// `true && true` → true → reports. `false || true` → true → reports.
+		{Code: `<div autoFocus={true && true} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={false || true} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={"x" && true} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 8: Call / Member / TaggedTemplate — upstream truthy synthesis
+		// ============================================================
+		// Upstream synthesizes a non-empty truthy string for these via the
+		// call / member / tagged-template extractors, all !== false.
+		{Code: `<div autoFocus={fn()} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={obj.x} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={obj?.x} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: "<div autoFocus={tag`x`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// TemplateExpression with substitution → upstream renders a string of
+		// the form "${...}" → non-empty, !== false / 'false'.
+		{Code: "<div autoFocus={`${x}`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Even `` `true` `` (NoSubstitutionTemplateLiteral) extracts to the
+		// raw string "true" — does not coerce to boolean → !== false → reports.
+		{Code: "<div autoFocus={`true`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 9: TS wrappers around a truthy expression
+		// ============================================================
+		// skipTransparent unwraps parens / TS assertion wrappers inside
+		// staticEval. Locks in that wrapped truthy values still trip the rule.
+		{Code: `<div autoFocus={true as boolean} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={(true)} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={(true)!} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 10: `satisfies` is OPAQUE — wrapped value falls through
+		// ============================================================
+		// jsx-ast-utils' TYPES table has no entry for SatisfiesExpression →
+		// console.error → null. staticEval mirrors by deliberately excluding
+		// OEKSatisfies from skipTransparent, so the SatisfiesExpression node
+		// hits the default arm → jsNull. PropStaticBoolValue → (false, false)
+		// and PropStaticStringValue → ("", false), so neither short-circuit
+		// matches → reports. Even `<div autoFocus={false satisfies boolean} />`
+		// reports because satisfies hides the boolean false from extraction.
+		{Code: `<div autoFocus={false satisfies boolean} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div autoFocus={"false" satisfies string} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 11: TemplateExpression with `${false}` substitution
+		// ============================================================
+		// staticEvalTemplate renders the literal `${false}` placeholder, so the
+		// full string is "${Expression}" (or similar) — non-empty truthy and
+		// not equal to "false". Even an inner `false` substitution does not
+		// short-circuit the report.
+		{Code: "<div autoFocus={`${false}`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: "<div autoFocus={`prefix${false}suffix`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 12: Deep nesting × ignoreNonDOM
+		// ============================================================
+		// The listener visits every JsxAttribute regardless of ancestor
+		// boundary; ignoreNonDOM is decided per attribute, not per subtree.
+		// Outer `<Custom autoFocus />` is skipped (not in dom set), but inner
+		// `<input autoFocus />` is in dom set → reports. Locks in that the
+		// rule isn't accidentally inheriting an ancestor's "isCustom" verdict.
+		{
+			Code:    `<Outer><Mid><input autoFocus /></Mid></Outer>`,
+			Tsx:     true,
+			Options: ignoreNonDOMOption,
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Both outer and inner are DOM under ignoreNonDOM:true → both report.
+		{
+			Code:    `<div autoFocus><span autoFocus /></div>`,
+			Tsx:     true,
+			Options: ignoreNonDOMOption,
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError, expectedError},
+		},
+		// Mixed: DOM + custom interleaved under ignoreNonDOM:true → only the
+		// DOM ones report. `<Custom autoFocus>` is skipped, `<input autoFocus />`
+		// reports.
+		{
+			Code:    `<Custom autoFocus><input autoFocus /></Custom>`,
+			Tsx:     true,
+			Options: ignoreNonDOMOption,
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 13: ignoreNonDOM × DOM element → still reports
+		// ============================================================
+		// `input` is in the dom set → ignoreNonDOM skip does NOT apply.
+		{Code: `<input autoFocus />`, Tsx: true, Options: ignoreNonDOMOption, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button autoFocus />`, Tsx: true, Options: ignoreNonDOMOption, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 14: ignoreNonDOM × polymorphicPropName resolving to DOM
+		// ============================================================
+		// `<Box as="input" autoFocus />` resolves to `input` (in dom set)
+		// → ignoreNonDOM does NOT skip → reports.
+		{Code: `<Box as="input" autoFocus />`, Tsx: true, Options: ignoreNonDOMOption, Settings: polymorphicSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `<Box as="div" autoFocus />` — same shape, different tag.
+		{Code: `<Box as="div" autoFocus />`, Tsx: true, Options: ignoreNonDOMOption, Settings: polymorphicSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// polymorphic + components map: `<Box as="input" autoFocus />` →
+		// polymorphic runs first → rawType = "input" (in dom set) → reports.
+		// The components map's `Box → div` is not consulted because the
+		// polymorphic prop short-circuits the rawType.
+		{Code: `<Box as="input" autoFocus />`, Tsx: true, Options: ignoreNonDOMOption, Settings: polymorphicWithComponentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// ignoreNonDOM × polymorphicAllowList: `<Box as="input" autoFocus />`
+		// — `Box` IS in allow-list → swap applies → rawType = "input" → reports.
+		{
+			Code:     `<Box as="input" autoFocus />`,
+			Tsx:      true,
+			Options:  ignoreNonDOMOption,
+			Settings: polymorphicAllowListSettings,
+			Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 15: Options coverage matrix — JSON path
+		// ============================================================
+		// Bare object (single-option CLI shape) — exercises GetOptionsMap's
+		// `opts.(map[string]interface{})` arm.
+		{
+			Code:    `<Foo autoFocus />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreNonDOM": false},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Array-wrapped (multi-element / rule_tester shape) — exercises the
+		// `arr.([]interface{})` arm.
+		{
+			Code:    `<Foo autoFocus />`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"ignoreNonDOM": false}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Malformed option (wrong type) is silently ignored → defaults to
+		// ignoreNonDOM=false → custom component still reports.
+		{
+			Code:    `<Foo autoFocus />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreNonDOM": "yes"},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 16: Real-world component patterns
+		// ============================================================
+		{
+			Code:   `function LoginField() { return <input type="text" autoFocus />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const x = items.map(item => <li autoFocus key={item.id} />)`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Class component render with multiple offending children — each
+		// reports independently.
+		{
+			Code: "class MyForm { render() { return <form><input autoFocus name=\"a\" /><input autoFocus name=\"b\" /></form>; } }",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError, expectedError},
+		},
+		// Fragment + conditional rendering.
+		{
+			Code:   `const x = <>{cond && <input autoFocus />}</>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 17: Form patterns — search / login / signup
+		// ============================================================
+		{
+			Code:   `function SearchBar() { return <input type="search" autoFocus placeholder="Search…" />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `function LoginForm() { return <form><input autoFocus name="user" /><input type="password" name="pass" /></form>; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code: `function Signup() { return (<form><label>Email<input type="email" autoFocus /></label><label>Pass<input type="password" autoFocus /></label></form>); }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedError, expectedError,
+			},
+		},
+
+		// ============================================================
+		// Group 18: Modal / Dialog with offending autoFocus
+		// ============================================================
+		{
+			Code:   `function Modal() { return <dialog open><input autoFocus name="title" /><button>OK</button></dialog>; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 19: HOC / forwardRef / memo wrappers carrying autoFocus
+		// ============================================================
+		{
+			Code:   `const Enhanced = withTracking(({ value }) => <input value={value} autoFocus />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const FocusInput = React.forwardRef((props, ref) => <input ref={ref} autoFocus {...props} />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const Item = React.memo(({ id }) => <li id={id} autoFocus>{id}</li>);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 20: TypeScript generic JSX components
+		// ============================================================
+		// `<List<string> autoFocus />` — the listener must still see the
+		// JsxAttribute despite the type args.
+		{
+			Code:   `<List<string> autoFocus />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<Cell<{a: number}> autoFocus={true} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 21: Long-chain member-expression tags (without ignoreNonDOM)
+		// ============================================================
+		{
+			Code:   `<Foo.Bar.Baz autoFocus />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<this.Foo autoFocus />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 22: Hyphenated DOM tags without ignoreNonDOM
+		// ============================================================
+		// Listener still fires; only the truthy gate matters.
+		{
+			Code:   `<my-element autoFocus />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 23: Comments around / inside the prop don't suppress
+		// ============================================================
+		{
+			Code: `<div /* a */ autoFocus /* b */ />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAutoFocus",
+				Message:   errorMessage,
+				Line:      1, Column: 14, EndLine: 1, EndColumn: 23,
+			}},
+		},
+		{
+			Code:   `<div autoFocus={/* truthy */ true} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 24: Complex value expressions: arrays / objects / new
+		// ============================================================
+		// All extract to truthy values per upstream's TYPES table; reports.
+		{
+			Code:   `<div autoFocus={[1, 2, 3]} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div autoFocus={{nested: true}} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div autoFocus={new Boolean(false)} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 25: Nullish coalescing / optional chain values
+		// ============================================================
+		{
+			Code:   `<div autoFocus={cfg?.autoFocus} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<div autoFocus={cfg ?? true} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 26: Conditional rendering forms
+		// ============================================================
+		// && short-circuit
+		{
+			Code:   `function Foo({cond}) { return cond && <input autoFocus />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Ternary with offending branch
+		{
+			Code:   `function Foo({cond}) { return cond ? <input autoFocus /> : <div />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Both branches offending
+		{
+			Code: `function Foo({a, b}) { return a ? <input autoFocus /> : <textarea autoFocus />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedError, expectedError,
+			},
+		},
+
+		// ============================================================
+		// Group 27: Switch-case rendering
+		// ============================================================
+		{
+			Code: `function Foo({type}) { switch(type) { case 'input': return <input autoFocus />; default: return null; } }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 28: Lists rendered via .map / .filter / .flatMap
+		// ============================================================
+		// Boolean attribute form inside arrow body — extracts to true → reports.
+		{
+			Code:   `const items = arr.map((x, i) => <li key={i} autoFocus>{x}</li>);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code: `const items = arr.filter(Boolean).flatMap(x => [<li autoFocus key={x.a}>{x.a}</li>, <li key={x.b}>{x.b}</li>]);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 29: Multiple components in one file
+		// ============================================================
+		{
+			Code: "function A() { return <input autoFocus />; }\nfunction B() { return <input autoFocus />; }",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedError, expectedError,
+			},
+		},
+
+		// ============================================================
+		// Group 30: Class component with state-driven JSX
+		// ============================================================
+		{
+			Code: `class Form extends React.Component { state = {ready: true}; render() { return this.state.ready ? <input autoFocus /> : <div />; } }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 31: Generator / async / IIFE bodies
+		// ============================================================
+		{
+			Code: `function* render() { yield <input autoFocus />; yield <textarea autoFocus />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedError, expectedError,
+			},
+		},
+		{
+			Code:   `async function render() { return <input autoFocus />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const x = (() => <input autoFocus />)();`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 32: Object destructuring + JSX returning element
+		// ============================================================
+		{
+			Code: `function Form({ initial: { autoFocus = true } }) { return <input autoFocus={autoFocus} />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus_upstream_test.go
@@ -1,0 +1,103 @@
+package no_autofocus
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedError mirrors upstream's expected error shape — every invalid case
+// emits the same single message. Centralized so a future text tweak lives in
+// one place. Shared with no_autofocus_extras_test.go.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "noAutoFocus",
+	Message:   errorMessage,
+}
+
+// ignoreNonDOMOption mirrors upstream's `[{ ignoreNonDOM: true }]` schema —
+// passed via the JSON path (not a typed struct) so the GetOptionsMap
+// integration is exercised end-to-end. Shared with extras tests.
+var ignoreNonDOMOption = []interface{}{
+	map[string]interface{}{
+		"ignoreNonDOM": true,
+	},
+}
+
+// componentsSettings mirrors upstream's
+//
+//	settings: { 'jsx-a11y': { components: { Button: 'button' } } }
+//
+// Used to verify GetElementType honors the components map for
+// `ignoreNonDOM` resolution.
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Button": "button",
+		},
+	},
+}
+
+// TestNoAutofocusUpstream covers the full valid/invalid suite migrated 1:1
+// from upstream eslint-plugin-jsx-a11y's
+// `__tests__/src/rules/no-autofocus-test.js`. Order and grouping mirror the
+// upstream file so a future audit can grep across both side-by-side.
+//
+// rslint-specific lock-ins (TS wrappers, spread literals, listener boundary
+// repeats, position assertions, the upstream getPropValue branches that
+// upstream never tests directly) live in no_autofocus_extras_test.go.
+func TestNoAutofocusUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoAutofocusRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid ----
+		{Code: `<div />;`, Tsx: true},
+		// Lowercase `autofocus` is the HTML DOM attribute, not the React prop;
+		// the rule only matches the camelCased `autoFocus`.
+		{Code: `<div autofocus />;`, Tsx: true},
+		{Code: `<input autofocus="true" />;`, Tsx: true},
+		// Component without the autoFocus prop — nothing to inspect.
+		{Code: `<Foo bar />`, Tsx: true},
+		// Explicit boolean false → !== false fails → no report.
+		{Code: `<div autoFocus={false} />`, Tsx: true},
+		// String "false" coerces to boolean false via jsxAstUtilsLiteralCoerce
+		// → !== false fails → no report.
+		{Code: `<div autoFocus="false" />`, Tsx: true},
+		// ignoreNonDOM: true — `Foo` is not in the dom set, so the rule skips
+		// even though autoFocus is truthy.
+		{Code: `<Foo autoFocus />`, Tsx: true, Options: ignoreNonDOMOption},
+		// ignoreNonDOM: true on a nested div with the lowercase HTML attribute
+		// — the inner div has `autofocus` (lowercase, not matched) so even
+		// without ignoreNonDOM there is nothing to report; with it, the same
+		// holds.
+		{Code: `<div><div autofocus /></div>`, Tsx: true, Options: ignoreNonDOMOption},
+		// components map promotes `Button` → `button`, but no autoFocus is
+		// declared so nothing to report.
+		{Code: `<Button />`, Tsx: true, Settings: componentsSettings},
+		// Same shape, with ignoreNonDOM: true (still no autoFocus).
+		{Code: `<Button />`, Tsx: true, Options: ignoreNonDOMOption, Settings: componentsSettings},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid ----
+		// Boolean attribute form → extractValue null-attr-value → JS true.
+		{Code: `<div autoFocus />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Explicit boolean true.
+		{Code: `<div autoFocus={true} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `undefined` !== false AND !== "false" → reports. Locks in upstream's
+		// "anything other than literal false" semantic — even an explicit
+		// undefined trips the rule.
+		{Code: `<div autoFocus={undefined} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// String "true" → coerces to boolean true via jsxAstUtilsLiteralCoerce
+		// → !== false → reports.
+		{Code: `<div autoFocus="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Same boolean-form on a different intrinsic element — listener fires
+		// regardless of element kind when ignoreNonDOM is unset.
+		{Code: `<input autoFocus />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Custom component — without ignoreNonDOM, the rule fires on all
+		// elements equally.
+		{Code: `<Foo autoFocus />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// components map promotes `Button` → `button`, then the rule reports.
+		{Code: `<Button autoFocus />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}, Settings: componentsSettings},
+		// Same shape with ignoreNonDOM: true — the resolved name is `button`
+		// (in the dom set), so the skip does NOT apply and the rule still
+		// reports. Locks in the components-map → ignoreNonDOM interaction.
+		{Code: `<Button autoFocus />`, Tsx: true, Options: ignoreNonDOMOption, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -166,6 +166,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/html-has-lang.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/img-redundant-alt.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts',
 
     // typescript-eslint

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts
@@ -1,0 +1,439 @@
+import { RuleTester } from '../rule-tester';
+
+const errorMessage =
+  'The autoFocus prop should not be enabled, as it can reduce usability and accessibility for users.';
+const expectedError = { message: errorMessage };
+
+const ignoreNonDOMSchema = [{ ignoreNonDOM: true }];
+
+const componentsSettings = {
+  'jsx-a11y': {
+    components: {
+      Button: 'button',
+    },
+  },
+};
+
+const polymorphicSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+  },
+};
+
+const polymorphicAllowListSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+    polymorphicAllowList: ['Box'],
+  },
+};
+
+const componentsToCustomSettings = {
+  'jsx-a11y': {
+    components: { Foo: 'Bar' },
+  },
+};
+
+const emptyJsxA11ySettings = {
+  'jsx-a11y': {},
+};
+
+new RuleTester().run('no-autofocus', null as never, {
+  valid: [
+    // ---- Upstream valid ----
+    { code: '<div />;' },
+    // Lowercase `autofocus` is the HTML DOM attribute, not React's prop.
+    { code: '<div autofocus />;' },
+    { code: '<input autofocus="true" />;' },
+    { code: '<Foo bar />' },
+    { code: '<div autoFocus={false} />' },
+    { code: '<div autoFocus="false" />' },
+    // ignoreNonDOM: true skips custom components.
+    { code: '<Foo autoFocus />', options: ignoreNonDOMSchema },
+    { code: '<div><div autofocus /></div>', options: ignoreNonDOMSchema },
+    { code: '<Button />', settings: componentsSettings },
+    {
+      code: '<Button />',
+      options: ignoreNonDOMSchema,
+      settings: componentsSettings,
+    },
+
+    // ---- rslint extras: case-sensitivity ----
+    { code: '<div AUTOFOCUS />' },
+    { code: '<div AutoFocus />' },
+    { code: '<div autoFocuS />' },
+    { code: '<div xml:autoFocus />' },
+
+    // ---- "false" literal forms — all coerce to boolean false ----
+    { code: '<div autoFocus="False" />' },
+    { code: '<div autoFocus="FALSE" />' },
+    { code: '<div autoFocus={"false"} />' },
+    { code: '<div autoFocus={"False"} />' },
+    { code: '<div autoFocus={("false")} />' },
+    { code: '<div autoFocus={"false" as string} />' },
+    { code: '<div autoFocus={"false"!} />' },
+    { code: '<div autoFocus={false as boolean} />' },
+    { code: '<div autoFocus={`false`} />' },
+
+    // ---- Logical / conditional resolving to false ----
+    { code: '<div autoFocus={true && false} />' },
+    { code: '<div autoFocus={true ? false : true} />' },
+    { code: '<div autoFocus={false || false} />' },
+
+    // ---- ignoreNonDOM: true skips non-DOM tags ----
+    { code: '<UX.Layout autoFocus />', options: ignoreNonDOMSchema },
+    { code: '<svg:circle autoFocus />', options: ignoreNonDOMSchema },
+
+    // ---- ignoreNonDOM × components map: false short-circuits ----
+    {
+      code: '<Button autoFocus={false} />',
+      options: ignoreNonDOMSchema,
+      settings: componentsSettings,
+    },
+
+    // ---- ignoreNonDOM × polymorphicPropName ----
+    {
+      code: '<Box as="div" autoFocus={false} />',
+      options: ignoreNonDOMSchema,
+      settings: polymorphicSettings,
+    },
+    {
+      code: '<Box as="ComponentName" autoFocus />',
+      options: ignoreNonDOMSchema,
+      settings: polymorphicSettings,
+    },
+
+    // ---- Default options: bare {} and array-wrapped [{}] ----
+    { code: '<Foo autoFocus={false} />', options: [{}] },
+
+    // ---- Spread attributes are NOT JsxAttribute → listener never fires ----
+    { code: '<div {...{autoFocus: true}} />' },
+    { code: '<div {...props} />' },
+    { code: '<div {...{autoFocus: true}} {...props} />' },
+
+    // ---- Real-world valid: explicit false suppresses across patterns ----
+    {
+      code: 'function Modal({ open }) { return <dialog open={open}><input autoFocus={false} placeholder="search" /></dialog>; }',
+    },
+    {
+      code: 'function Search() { const ref = useRef(null); useEffect(() => ref.current?.focus(), []); return <input ref={ref} />; }',
+    },
+    {
+      code: 'const Enhanced = withTracking(({ value }) => <input value={value} />);',
+    },
+    {
+      code: 'const FocusInput = React.forwardRef((props, ref) => <input ref={ref} autoFocus={false} {...props} />);',
+    },
+    {
+      code: 'const Item = React.memo(({ id }) => <li id={id} autoFocus={false}>{id}</li>);',
+    },
+
+    // ---- TypeScript generic JSX components ----
+    { code: '<List<string> autoFocus={false} />' },
+    { code: '<List<{a: number}> autoFocus />', options: ignoreNonDOMSchema },
+
+    // ---- Long-chain member-expression tags ----
+    { code: '<Foo.Bar.Baz autoFocus={false} />' },
+    { code: '<Foo.Bar.Baz autoFocus />', options: ignoreNonDOMSchema },
+
+    // ---- Hyphenated DOM tags (web components) ----
+    { code: '<my-element autoFocus />', options: ignoreNonDOMSchema },
+
+    // ---- components map: custom → custom (still custom) ----
+    {
+      code: '<Foo autoFocus />',
+      options: ignoreNonDOMSchema,
+      settings: componentsToCustomSettings,
+    },
+
+    // ---- empty `jsx-a11y` settings ----
+    {
+      code: '<Foo autoFocus />',
+      options: ignoreNonDOMSchema,
+      settings: emptyJsxA11ySettings,
+    },
+
+    // ---- polymorphicAllowList restricts the `as` swap ----
+    {
+      code: '<Box as="input" autoFocus={false} />',
+      options: ignoreNonDOMSchema,
+      settings: polymorphicAllowListSettings,
+    },
+    {
+      code: '<Other as="input" autoFocus />',
+      options: ignoreNonDOMSchema,
+      settings: polymorphicAllowListSettings,
+    },
+
+    // ---- Comments around the prop don't break extraction ----
+    { code: '<div /* before */ autoFocus={false} /* after */ />' },
+    { code: '<div autoFocus={/* false */ false} />' },
+  ],
+  invalid: [
+    // ---- Upstream invalid ----
+    { code: '<div autoFocus />', errors: [expectedError] },
+    { code: '<div autoFocus={true} />', errors: [expectedError] },
+    { code: '<div autoFocus={undefined} />', errors: [expectedError] },
+    { code: '<div autoFocus="true" />', errors: [expectedError] },
+    { code: '<input autoFocus />', errors: [expectedError] },
+    { code: '<Foo autoFocus />', errors: [expectedError] },
+    {
+      code: '<Button autoFocus />',
+      errors: [expectedError],
+      settings: componentsSettings,
+    },
+    {
+      code: '<Button autoFocus />',
+      errors: [expectedError],
+      options: ignoreNonDOMSchema,
+      settings: componentsSettings,
+    },
+
+    // ---- rslint extras: paired element + nested listener boundary ----
+    { code: '<div autoFocus>child</div>', errors: [expectedError] },
+    {
+      code: '<a autoFocus><span autoFocus /></a>',
+      errors: [expectedError, expectedError],
+    },
+
+    // ---- Element kind survey ----
+    { code: '<a autoFocus />', errors: [expectedError] },
+    { code: '<Component autoFocus />', errors: [expectedError] },
+    { code: '<UX.Layout autoFocus />', errors: [expectedError] },
+    { code: '<svg:circle autoFocus />', errors: [expectedError] },
+
+    // ---- Truthy literal coercions ----
+    { code: '<div autoFocus="True" />', errors: [expectedError] },
+    { code: '<div autoFocus="TRUE" />', errors: [expectedError] },
+    { code: '<div autoFocus={"true"} />', errors: [expectedError] },
+
+    // ---- Non-coerced falsy values still report ----
+    { code: '<div autoFocus={null} />', errors: [expectedError] },
+    { code: '<div autoFocus={0} />', errors: [expectedError] },
+    { code: '<div autoFocus={""} />', errors: [expectedError] },
+    { code: '<div autoFocus="" />', errors: [expectedError] },
+    { code: '<div autoFocus={void 0} />', errors: [expectedError] },
+
+    // ---- Numeric / BigInt / Identifier expressions ----
+    { code: '<div autoFocus={1} />', errors: [expectedError] },
+    { code: '<div autoFocus={1n} />', errors: [expectedError] },
+    { code: '<div autoFocus={someVar} />', errors: [expectedError] },
+
+    // ---- Conditional / logical resolving to truthy ----
+    { code: '<div autoFocus={true && true} />', errors: [expectedError] },
+    { code: '<div autoFocus={false || true} />', errors: [expectedError] },
+    { code: '<div autoFocus={"x" && true} />', errors: [expectedError] },
+
+    // ---- Call / Member / Template ----
+    { code: '<div autoFocus={fn()} />', errors: [expectedError] },
+    { code: '<div autoFocus={obj.x} />', errors: [expectedError] },
+    { code: '<div autoFocus={obj?.x} />', errors: [expectedError] },
+    { code: '<div autoFocus={tag`x`} />', errors: [expectedError] },
+    { code: '<div autoFocus={`${x}`} />', errors: [expectedError] },
+    { code: '<div autoFocus={`true`} />', errors: [expectedError] },
+
+    // ---- TS wrappers around truthy ----
+    { code: '<div autoFocus={true as boolean} />', errors: [expectedError] },
+    { code: '<div autoFocus={(true)} />', errors: [expectedError] },
+    { code: '<div autoFocus={(true)!} />', errors: [expectedError] },
+
+    // ---- `satisfies` is opaque — even `false satisfies boolean` reports ----
+    {
+      code: '<div autoFocus={false satisfies boolean} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<div autoFocus={"false" satisfies string} />',
+      errors: [expectedError],
+    },
+
+    // ---- TemplateExpression with `${false}` substitution → truthy string ----
+    { code: '<div autoFocus={`${false}`} />', errors: [expectedError] },
+    {
+      code: '<div autoFocus={`prefix${false}suffix`} />',
+      errors: [expectedError],
+    },
+
+    // ---- Deep nesting × ignoreNonDOM ----
+    {
+      code: '<Outer><Mid><input autoFocus /></Mid></Outer>',
+      options: ignoreNonDOMSchema,
+      errors: [expectedError],
+    },
+    {
+      code: '<Custom autoFocus><input autoFocus /></Custom>',
+      options: ignoreNonDOMSchema,
+      errors: [expectedError],
+    },
+    {
+      code: '<div autoFocus><span autoFocus /></div>',
+      options: ignoreNonDOMSchema,
+      errors: [expectedError, expectedError],
+    },
+
+    // ---- ignoreNonDOM: true × DOM element ----
+    {
+      code: '<input autoFocus />',
+      options: ignoreNonDOMSchema,
+      errors: [expectedError],
+    },
+    {
+      code: '<button autoFocus />',
+      options: ignoreNonDOMSchema,
+      errors: [expectedError],
+    },
+
+    // ---- ignoreNonDOM: true × polymorphicPropName resolving to DOM ----
+    {
+      code: '<Box as="input" autoFocus />',
+      options: ignoreNonDOMSchema,
+      settings: polymorphicSettings,
+      errors: [expectedError],
+    },
+    {
+      code: '<Box as="div" autoFocus />',
+      options: ignoreNonDOMSchema,
+      settings: polymorphicSettings,
+      errors: [expectedError],
+    },
+
+    // ---- Multiple autoFocus attributes on one element ----
+    {
+      code: '<div autoFocus autoFocus />',
+      errors: [expectedError, expectedError],
+    },
+
+    // ---- Real-world component patterns ----
+    {
+      code: 'function LoginField() { return <input type="text" autoFocus />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'const x = items.map(item => <li autoFocus key={item.id} />)',
+      errors: [expectedError],
+    },
+    {
+      code: 'const x = <>{cond && <input autoFocus />}</>',
+      errors: [expectedError],
+    },
+
+    // ---- Form patterns: search / login / signup ----
+    {
+      code: 'function SearchBar() { return <input type="search" autoFocus placeholder="Search…" />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function LoginForm() { return <form><input autoFocus name="user" /><input type="password" name="pass" /></form>; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function Signup() { return (<form><label>Email<input type="email" autoFocus /></label><label>Pass<input type="password" autoFocus /></label></form>); }',
+      errors: [expectedError, expectedError],
+    },
+
+    // ---- Modal / Dialog with offending autoFocus ----
+    {
+      code: 'function Modal() { return <dialog open><input autoFocus name="title" /><button>OK</button></dialog>; }',
+      errors: [expectedError],
+    },
+
+    // ---- HOC / forwardRef / memo wrappers carrying autoFocus ----
+    {
+      code: 'const Enhanced = withTracking(({ value }) => <input value={value} autoFocus />);',
+      errors: [expectedError],
+    },
+    {
+      code: 'const FocusInput = React.forwardRef((props, ref) => <input ref={ref} autoFocus {...props} />);',
+      errors: [expectedError],
+    },
+    {
+      code: 'const Item = React.memo(({ id }) => <li id={id} autoFocus>{id}</li>);',
+      errors: [expectedError],
+    },
+
+    // ---- TypeScript generic JSX ----
+    { code: '<List<string> autoFocus />', errors: [expectedError] },
+    { code: '<Cell<{a: number}> autoFocus={true} />', errors: [expectedError] },
+
+    // ---- Long-chain member-expression tags (without ignoreNonDOM) ----
+    { code: '<Foo.Bar.Baz autoFocus />', errors: [expectedError] },
+    { code: '<this.Foo autoFocus />', errors: [expectedError] },
+
+    // ---- Hyphenated DOM tags without ignoreNonDOM ----
+    { code: '<my-element autoFocus />', errors: [expectedError] },
+
+    // ---- Comments around / inside the prop don't suppress ----
+    { code: '<div /* a */ autoFocus /* b */ />', errors: [expectedError] },
+    {
+      code: '<div autoFocus={/* truthy */ true} />',
+      errors: [expectedError],
+    },
+
+    // ---- Complex value expressions ----
+    { code: '<div autoFocus={[1, 2, 3]} />', errors: [expectedError] },
+    { code: '<div autoFocus={{nested: true}} />', errors: [expectedError] },
+    {
+      code: '<div autoFocus={new Boolean(false)} />',
+      errors: [expectedError],
+    },
+
+    // ---- Optional chain / nullish ----
+    { code: '<div autoFocus={cfg?.autoFocus} />', errors: [expectedError] },
+    { code: '<div autoFocus={cfg ?? true} />', errors: [expectedError] },
+
+    // ---- ignoreNonDOM × polymorphicAllowList ----
+    {
+      code: '<Box as="input" autoFocus />',
+      options: ignoreNonDOMSchema,
+      settings: polymorphicAllowListSettings,
+      errors: [expectedError],
+    },
+
+    // ---- Conditional rendering forms ----
+    {
+      code: 'function Foo({cond}) { return cond && <input autoFocus />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function Foo({cond}) { return cond ? <input autoFocus /> : <div />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function Foo({a, b}) { return a ? <input autoFocus /> : <textarea autoFocus />; }',
+      errors: [expectedError, expectedError],
+    },
+
+    // ---- Switch / list / multi-component / generator / async / IIFE ----
+    {
+      code: "function Foo({type}) { switch(type) { case 'input': return <input autoFocus />; default: return null; } }",
+      errors: [expectedError],
+    },
+    {
+      code: 'const items = arr.map((x, i) => <li key={i} autoFocus>{x}</li>);',
+      errors: [expectedError],
+    },
+    {
+      code: 'function A() { return <input autoFocus />; }\nfunction B() { return <input autoFocus />; }',
+      errors: [expectedError, expectedError],
+    },
+    {
+      code: 'class Form extends React.Component { state = {ready: true}; render() { return this.state.ready ? <input autoFocus /> : <div />; } }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function* render() { yield <input autoFocus />; yield <textarea autoFocus />; }',
+      errors: [expectedError, expectedError],
+    },
+    {
+      code: 'async function render() { return <input autoFocus />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'const x = (() => <input autoFocus />)();',
+      errors: [expectedError],
+    },
+    {
+      code: 'function Form({ initial: { autoFocus = true } }) { return <input autoFocus={autoFocus} />; }',
+      errors: [expectedError],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -11,6 +11,7 @@ arrayliteralexpression
 ascript
 assertee
 autofixers
+autofocus
 auvred
 bazz
 Bbar


### PR DESCRIPTION
## Summary

Port the [`jsx-a11y/no-autofocus`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-autofocus.md) rule from `eslint-plugin-jsx-a11y` to rslint.

The rule discourages the `autoFocus` prop on JSX elements: programmatically shifting focus on render disorients sighted users (unexpected viewport jumps) and disrupts assistive-technology users (screen-reader / keyboard navigation gets reset). It supports the `ignoreNonDOM` option to skip custom components, honoring \`settings['jsx-a11y'].polymorphicPropName\`, \`polymorphicAllowList\`, and \`components\`.

Two reusable helpers were extracted to \`jsxa11yutil\`:
- \`PropStaticBoolValue\` — mirrors \`getPropValue === bool\` semantics (boolean-form + jsxAstUtilsLiteralCoerce'd \`"true"\`/\`"false"\` strings).
- \`IsDOMElement\` + \`DomElements\` — aria-query \`dom\` map ported as a Go set.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-autofocus.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/no-autofocus.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).