### PR TITLE
feat: port rule jsx-a11y/media-has-caption

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/heading_has_content"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/html_has_lang"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/img_redundant_alt"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/media_has_caption"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_access_key"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_autofocus"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_distracting_elements"
@@ -25,6 +26,7 @@ func GetAllRules() []rule.Rule {
 		heading_has_content.HeadingHasContentRule,
 		html_has_lang.HtmlHasLangRule,
 		img_redundant_alt.ImgRedundantAltRule,
+		media_has_caption.MediaHasCaptionRule,
 		no_access_key.NoAccessKeyRule,
 		no_autofocus.NoAutofocusRule,
 		no_distracting_elements.NoDistractingElementsRule,

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -557,6 +557,48 @@ func PropValueIsTruthy(attr *ast.Node) bool {
 	return jsTruthy_(staticEval(inner))
 }
 
+// LiteralPropIsExactlyTrue mirrors upstream's `getLiteralPropValue(prop) === true`
+// — strict boolean-true equality on the LITERAL_TYPES extraction. Differs from
+// LiteralPropTruthy: only the actual boolean `true` matches, not the magic
+// "null"/"undefined" strings or non-empty strings that LITERAL_TYPES happens
+// to synthesize. Used by media-has-caption's `muted={true}` exemption check,
+// where upstream gates on `mutedPropVal === true` and any other literal value
+// (including `false`, `"true"`-coerced-from-string when not strict, `null`,
+// numbers, identifiers) must NOT skip the rule.
+//
+// Behavior table (mirrors jsx-ast-utils' getLiteralPropValue then `=== true`):
+//
+//   - Boolean form `<X muted />`         → true (extractValue null-attr → true)
+//   - `<X muted={true}>`                 → true
+//   - `<X muted="true">`                 → true (jsxAstUtilsLiteralCoerce → bool)
+//   - `<X muted={false}>`                → false
+//   - `<X muted="false">`                → false (coerced to bool false)
+//   - `<X muted="anything">`             → false (string ≠ bool true)
+//   - `<X muted={null}>`                 → false ("null" string ≠ bool true)
+//   - `<X muted={undefined}>`            → false (jvUndef)
+//   - `<X muted={someVar}>`              → false (Identifier → null)
+//   - `<X muted={1}>`                    → false (number ≠ bool true)
+//   - `<X muted={cond ? true : false}>`  → false (Conditional noop → null)
+//
+// Returns false when `attr` is nil — callers should test for the attribute's
+// existence first; a nil attr has no literal value to compare.
+func LiteralPropIsExactlyTrue(attr *ast.Node) bool {
+	if attr == nil {
+		return false
+	}
+	if AttributeIsBooleanForm(attr) {
+		// `<X muted />` — extractValue's null-attribute-value path returns
+		// boolean true; true === true → matches.
+		return true
+	}
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		return false
+	}
+	v := literalPropValue(inner)
+	return v.Kind == jvBool && v.Bool
+}
+
 // LiteralPropTruthy mirrors `!!getLiteralPropValue(prop)`. Returns true when
 // the attribute's value is a JS-truthy *literal*. Crucial differences from
 // PropStaticStringValue / staticEval-based truthiness:

--- a/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption.go
+++ b/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption.go
@@ -1,0 +1,184 @@
+// Package media_has_caption ports eslint-plugin-jsx-a11y's
+// `media-has-caption` rule. The rule enforces that `<audio>` and `<video>`
+// elements include a `<track kind="captions">` child for accessibility,
+// unless the media element is muted (`muted={true}` or boolean form).
+//
+// Custom wrappers can be registered via the `audio`, `video`, and `track`
+// option arrays. Like the other jsx-a11y rules, the polymorphic prop /
+// components-map settings are honored via `jsxa11yutil.GetElementType`.
+package media_has_caption
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const errorMessage = "Media elements such as <audio> and <video> must have a <track> for captions."
+
+// mediaTypes mirrors upstream's `MEDIA_TYPES` constant — the always-on base
+// set for the `isMediaType` check, regardless of `options.audio` /
+// `options.video`.
+var mediaTypes = []string{"audio", "video"}
+
+type options struct {
+	// audio / video / track mirror upstream's `options.{audio,video,track}`.
+	// Each is an array of additional component names that should be treated
+	// as the corresponding native element. Compared AS-IS against the
+	// resolved nodeType (after `getElementType`'s polymorphic / components-map
+	// resolution).
+	audio []string
+	video []string
+	track []string
+}
+
+func parseOptions(raw any) options {
+	opts := options{}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	opts.audio = jsxa11yutil.StringSliceOption(m["audio"])
+	opts.video = jsxa11yutil.StringSliceOption(m["video"])
+	opts.track = jsxa11yutil.StringSliceOption(m["track"])
+	return opts
+}
+
+var MediaHasCaptionRule = rule.Rule{
+	Name: "jsx-a11y/media-has-caption",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		// Mirrors upstream's `isMediaType`:
+		//   MEDIA_TYPES.concat(flatMap(MEDIA_TYPES, m => options[m]))
+		//              .some(t => t === type)
+		// flatMap concatenates BOTH options.audio AND options.video into one
+		// pool, then strict-equality checks against the resolved type.
+		isMediaType := func(t string) bool {
+			if t == "" {
+				return false
+			}
+			if slices.Contains(mediaTypes, t) {
+				return true
+			}
+			return slices.Contains(opts.audio, t) || slices.Contains(opts.video, t)
+		}
+
+		// Mirrors upstream's `isTrackType`:
+		//   ['track'].concat(options.track || []).some(t => t === type)
+		isTrackType := func(t string) bool {
+			if t == "track" {
+				return true
+			}
+			return slices.Contains(opts.track, t)
+		}
+
+		check := func(node *ast.Node) {
+			elementType := jsxa11yutil.GetElementType(node, ctx.Settings)
+			if !isMediaType(elementType) {
+				return
+			}
+
+			attrs := reactutil.GetJsxElementAttributes(node)
+			mutedProp := jsxa11yutil.FindAttributeByName(attrs, "muted")
+			// Upstream's `mutedPropVal === true` is the strict literal check —
+			// only the actual boolean `true` (or coerced `"true"` string)
+			// silences the rule. `null`, `false`, identifiers, conditionals
+			// all fall through to the report path.
+			if jsxa11yutil.LiteralPropIsExactlyTrue(mutedProp) {
+				return
+			}
+
+			// Children only exist for the paired form. tsgo splits ESTree's
+			// `JSXElement` into KindJsxElement (paired, owns Children) and
+			// KindJsxSelfClosingElement (no children). Upstream's
+			// `node.children.filter(...)` returns [] for the self-closing
+			// shape since ESTree's JSXElement of a self-closing element has
+			// `children: []`.
+			var children []*ast.Node
+			if node.Kind == ast.KindJsxOpeningElement && node.Parent != nil &&
+				node.Parent.Kind == ast.KindJsxElement {
+				children = reactutil.GetJsxChildren(node.Parent)
+			}
+
+			// Filter for track-type element children. Upstream filters by
+			// `child.type === 'JSXElement'`, which in ESTree covers BOTH
+			// paired and self-closing JSX child elements (both share the
+			// JSXElement type). tsgo splits them, so we accept both
+			// KindJsxElement and KindJsxSelfClosingElement.
+			//
+			// JsxFragment children are skipped to match upstream — JSXFragment
+			// is a distinct ESTree type and fails the `=== 'JSXElement'` filter.
+			var trackChildren []*ast.Node
+			for _, child := range children {
+				var trackOpening *ast.Node
+				switch child.Kind {
+				case ast.KindJsxElement:
+					trackOpening = child.AsJsxElement().OpeningElement
+				case ast.KindJsxSelfClosingElement:
+					trackOpening = child
+				default:
+					continue
+				}
+				if trackOpening == nil {
+					continue
+				}
+				if isTrackType(jsxa11yutil.GetElementType(trackOpening, ctx.Settings)) {
+					trackChildren = append(trackChildren, trackOpening)
+				}
+			}
+
+			if len(trackChildren) == 0 {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "mediaHasCaption",
+					Description: errorMessage,
+				})
+				return
+			}
+
+			// Upstream's caption check:
+			//   const kindPropValue = getLiteralPropValue(kindProp) || '';
+			//   return kindPropValue.toLowerCase() === 'captions';
+			// `LiteralPropStringValue` returns ("", false) for non-string
+			// literal extractions (Identifier, missing prop, boolean form,
+			// "true"/"false" coerced to bool). The `|| ''` fallback then
+			// turns it into "" — which case-insensitive-fails the captions
+			// match. Net effect: only an actual literal string "captions"
+			// (case-insensitive) clears the rule.
+			hasCaption := false
+			for _, trackOpening := range trackChildren {
+				trackAttrs := reactutil.GetJsxElementAttributes(trackOpening)
+				kindProp := jsxa11yutil.FindAttributeByName(trackAttrs, "kind")
+				if kind, ok := jsxa11yutil.LiteralPropStringValue(kindProp); ok {
+					if strings.EqualFold(kind, "captions") {
+						hasCaption = true
+						break
+					}
+				}
+			}
+
+			if !hasCaption {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "mediaHasCaption",
+					Description: errorMessage,
+				})
+			}
+		}
+
+		// tsgo splits ESTree's `JSXOpeningElement` into KindJsxOpeningElement
+		// (paired tags `<audio>...</audio>`) and KindJsxSelfClosingElement
+		// (`<audio />`). Upstream's single `JSXElement` listener fires once
+		// per element regardless of form; we mirror by registering on both
+		// opening kinds. The JsxOpeningElement case walks up to its parent
+		// JsxElement to read children.
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption.md
+++ b/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption.md
@@ -1,0 +1,125 @@
+# media-has-caption
+
+## Rule Details
+
+Enforces that `<audio>` and `<video>` elements include a `<track>` child with
+`kind="captions"`. Captions are essential for deaf users to follow along, and
+should contain dialogue, sound effects, musical cues, and other relevant audio
+information. Captions are **not** required for media elements that carry the
+`muted` attribute set to `true`.
+
+The `kind` value comparison is case-insensitive — `kind="captions"`,
+`kind="Captions"`, and `kind="CAPTIONS"` all satisfy the rule. The `muted`
+exemption is the strict literal `true` (boolean form `<audio muted />`,
+`muted={true}`, and the `"true"` string that coerces to boolean true).
+`muted={false}`, `muted={null}`, identifiers, conditionals, and other
+non-literal expressions do **not** silence the rule.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<audio />
+<video />
+<audio><track /></audio>
+<video><track kind="subtitles" /></video>
+<audio>Foo</audio>
+<audio muted={false}></audio>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<audio><track kind="captions" /></audio>
+<video><track kind="captions" /></video>
+<audio><track kind="Captions" /><track kind="subtitles" /></audio>
+<audio muted></audio>
+<video muted={true}></video>
+```
+
+## Rule Options
+
+```json
+{
+  "jsx-a11y/media-has-caption": [
+    "error",
+    {
+      "audio": ["Audio"],
+      "video": ["Video"],
+      "track": ["Track"]
+    }
+  ]
+}
+```
+
+### `audio`
+
+Type: `string[]`. Default: `[]`.
+
+Additional component names that should be treated as `<audio>` for purposes
+of the caption requirement. The native `audio` tag is always checked.
+
+### `video`
+
+Type: `string[]`. Default: `[]`.
+
+Additional component names that should be treated as `<video>`. The native
+`video` tag is always checked.
+
+### `track`
+
+Type: `string[]`. Default: `[]`.
+
+Additional component names that should be treated as `<track>` when looking
+for caption children. The native `track` tag is always recognized.
+
+Examples of **correct** code with
+`{ "audio": ["Audio"], "video": ["Video"], "track": ["Track"] }`:
+
+```json
+{
+  "jsx-a11y/media-has-caption": [
+    "error",
+    { "audio": ["Audio"], "video": ["Video"], "track": ["Track"] }
+  ]
+}
+```
+
+```jsx
+<Audio><Track kind="captions" /></Audio>
+<Video><Track kind="captions" /></Video>
+<Audio muted></Audio>
+```
+
+## Settings
+
+The rule reads `settings['jsx-a11y']` to resolve the effective element type
+for a JSX tag. Resolution is two-step: the polymorphic prop runs first,
+then the components map looks up the (possibly already-replaced) name.
+
+- `polymorphicPropName` — name of a polymorphic prop (e.g. `"as"`) that
+  remaps the element type. With `polymorphicPropName: "as"`,
+  `<Box as="audio" muted={true}>` is recognized as `<audio muted={true}>`
+  and silenced. The reverse direction is supported too —
+  `<audio as="div" />` resolves to `"div"` and is not checked.
+- `polymorphicAllowList` — `string[]` restricting which raw component names
+  may be remapped via the polymorphic prop. When omitted, every component
+  may be remapped.
+- `components` — a `{ ComponentName: "html-element" }` map. With
+  `{ "Audio": "audio", "Track": "track" }`, `<Audio><Track kind="captions" /></Audio>`
+  is recognized as `<audio><track kind="captions" /></audio>` and accepted.
+
+These mirror the upstream `eslint-plugin-jsx-a11y` settings exactly.
+
+## Accessibility guidelines
+
+- [WCAG 1.2.2 — Captions (Prerecorded)](https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html)
+- [WCAG 1.2.3 — Audio Description or Media Alternative (Prerecorded)](https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded.html)
+
+### Resources
+
+- [axe-core, audio-caption](https://dequeuniversity.com/rules/axe/2.1/audio-caption)
+- [axe-core, video-caption](https://dequeuniversity.com/rules/axe/2.1/video-caption)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/media-has-caption](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/media-has-caption.md)

--- a/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption_extras_test.go
@@ -1,0 +1,787 @@
+package media_has_caption
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestMediaHasCaptionExtras covers behavior the upstream test suite leaves
+// unaudited — Dimension 1-4 universal edge shapes, options coverage (bare-map
+// vs array-wrapped JSON paths), settings coverage (components map /
+// polymorphic prop / polymorphicAllowList), exact position assertions across
+// the JSX surface, the listener boundary for nested media elements, and the
+// muted / kind literal-extraction edge cases that upstream's "valid"-only
+// tests don't pin down.
+func TestMediaHasCaptionExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &MediaHasCaptionRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// Dimension 1: AST tag-shape variants — non-matching forms
+		// ============================================================
+
+		// PropertyAccess tag: full type is "UI.audio", not "audio". Locks in
+		// that the dotted form is compared, not any segment in isolation.
+		{Code: `<UI.audio><track /></UI.audio>`, Tsx: true},
+		// Namespaced tag: "svg:audio" ≠ "audio".
+		{Code: `<svg:audio><track /></svg:audio>`, Tsx: true},
+		// Multi-segment property access.
+		{Code: `<A.B.C />`, Tsx: true},
+		{Code: `<this.Audio />`, Tsx: true},
+		// Case-sensitive comparison: uppercase / mixed-case never match
+		// without a components-map alias.
+		{Code: `<AUDIO />`, Tsx: true},
+		{Code: `<Audio />`, Tsx: true},
+		{Code: `<AuDiO />`, Tsx: true},
+		{Code: `<VIDEO />`, Tsx: true},
+		{Code: `<Video />`, Tsx: true},
+
+		// ---- Element-kind survey: rule is a no-op for every non-media tag ----
+		{Code: `<a />`, Tsx: true},
+		{Code: `<input />`, Tsx: true},
+		{Code: `<Component><track kind="captions" /></Component>`, Tsx: true},
+
+		// `<track>` outside a media element doesn't trigger anything — the
+		// rule only runs the caption check when the OUTER element is media.
+		{Code: `<div><track kind="subtitles" /></div>`, Tsx: true},
+		{Code: `<track />`, Tsx: true},
+
+		// ============================================================
+		// Muted exemption — literal-value-extraction edge shapes
+		// ============================================================
+
+		// Boolean form (no initializer at all).
+		{Code: `<audio muted />`, Tsx: true},
+		{Code: `<video muted />`, Tsx: true},
+
+		// Parenthesized boolean — parens unwrap on every layer.
+		{Code: `<audio muted={(true)}></audio>`, Tsx: true},
+		{Code: `<video muted={((true))}></video>`, Tsx: true},
+
+		// String-literal "true" — jsxAstUtilsLiteralCoerce turns it into bool
+		// true, so the strict `=== true` matches. (Mirrors upstream's
+		// `getLiteralPropValue("true")` returning boolean true.)
+		{Code: `<audio muted="true"></audio>`, Tsx: true},
+		{Code: `<video muted="true"></video>`, Tsx: true},
+		{Code: `<audio muted={"true"}></audio>`, Tsx: true},
+
+		// Spread attribute carrying muted as an object literal — FindAttribute
+		// walks literal spreads, then literalPropValue extracts the value.
+		{Code: `<audio {...{muted: true}}></audio>`, Tsx: true},
+
+		// PrefixUnary IS evaluated in LITERAL_TYPES (UnaryExpression isn't
+		// noop'd). `!false` → bool true → matches → skip. Mirrors
+		// jsx-ast-utils' `extractValueFromLiteralUnaryExpression`.
+		{Code: `<audio muted={!false} />`, Tsx: true},
+
+		// ============================================================
+		// Captions extraction — kind-prop value edge shapes (valid side)
+		// ============================================================
+
+		// JsxExpression-wrapped string literal.
+		{Code: `<audio><track kind={"captions"} /></audio>`, Tsx: true},
+		{Code: `<video><track kind={"captions"} /></video>`, Tsx: true},
+
+		// Parenthesized string literal.
+		{Code: `<audio><track kind={("captions")} /></audio>`, Tsx: true},
+
+		// Mixed-case kind values. EqualFold is case-insensitive — "CAPTIONS",
+		// "Captions", "cAPtIoNS" all match.
+		{Code: `<audio><track kind="CAPTIONS" /></audio>`, Tsx: true},
+		{Code: `<audio><track kind="cAPtIoNS" /></audio>`, Tsx: true},
+
+		// Multiple tracks, only one with captions — `some` short-circuits.
+		{Code: `<audio><track kind="subtitles" /><track kind="captions" /></audio>`, Tsx: true},
+		{Code: `<audio><track kind="subtitles" /><track kind="metadata" /><track kind="captions" /></audio>`, Tsx: true},
+
+		// Track interspersed with non-track content (text, expressions, other elements)
+		// — text and expressions are filtered out by `child.type === 'JSXElement'`.
+		{Code: `<audio>Hello <track kind="captions" /></audio>`, Tsx: true},
+		{Code: `<audio>{header}<track kind="captions" /></audio>`, Tsx: true},
+		{Code: `<audio><source src="a.mp3" /><track kind="captions" /></audio>`, Tsx: true},
+
+		// Self-closing track (the same shape as paired empty track).
+		{Code: `<video><track kind="captions" /></video>`, Tsx: true},
+		{Code: `<video><track kind="captions"></track></video>`, Tsx: true},
+
+		// ============================================================
+		// Options: bare-map AND array-wrapped JSON shapes both work
+		// ============================================================
+
+		// Bare-map shape (single-option CLI shape after config.go unwrap).
+		{
+			Code:    `<MyAudio><track kind="captions" /></MyAudio>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"audio": []interface{}{"MyAudio"}},
+		},
+		// Array-wrapped shape (multi-element / rule_tester JSON shape).
+		{
+			Code:    `<MyAudio><track kind="captions" /></MyAudio>`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"audio": []interface{}{"MyAudio"}}},
+		},
+
+		// Empty options object — equivalent to default; non-media tag still passes.
+		{Code: `<div />`, Tsx: true, Options: map[string]interface{}{}},
+
+		// nil-valued audio/video/track — falls back to defaults (no extra
+		// component names). Default audio/video/track still match.
+		{Code: `<audio muted />`, Tsx: true, Options: map[string]interface{}{"audio": nil, "video": nil, "track": nil}},
+		{Code: `<audio><track kind="captions" /></audio>`, Tsx: true, Options: map[string]interface{}{"track": nil}},
+
+		// rslint-extension: non-string entries silently dropped by
+		// StringSliceOption — `<MyAudio>` doesn't match the (empty post-filter)
+		// audio list, so it's NOT considered a media element and the rule
+		// short-circuits. (ESLint's JSON schema would reject this at config
+		// load, so upstream never sees it.)
+		{Code: `<MyAudio />`, Tsx: true, Options: map[string]interface{}{"audio": []interface{}{123, true}}},
+
+		// ============================================================
+		// Settings: components map without a matching entry — `<Audio>`
+		// stays as "Audio", which is not in the default media list.
+		// ============================================================
+		{
+			Code: `<Audio />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"OtherTag": "audio"},
+				},
+			},
+		},
+
+		// Polymorphic prop with allow-list NOT containing the tag.
+		{
+			Code: `<Foo as="audio" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName":  "as",
+					"polymorphicAllowList": []interface{}{"Bar"},
+				},
+			},
+		},
+
+		// Reverse aliasing via components map: `<audio>` → "div". Rule no-op.
+		{
+			Code: `<audio />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"audio": "div"},
+				},
+			},
+		},
+
+		// Polymorphic reverse exemption: `<audio as="div">` → "div" → no
+		// match → rule no-op.
+		{
+			Code: `<audio as="div" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+
+		// ============================================================
+		// Defensive type handling: settings shapes that ARE truthy but
+		// don't match expected types. All silenced (no report).
+		// ============================================================
+		{Code: `<MyAudio />`, Tsx: true, Settings: map[string]interface{}{"jsx-a11y": "invalid"}},
+		{Code: `<MyAudio />`, Tsx: true, Settings: map[string]interface{}{"jsx-a11y": nil}},
+
+		// ============================================================
+		// Spread literal edge cases — FindAttributeByName walks ObjectLiteral
+		// spreads to find named props. Locks in the parens / TS-wrapper
+		// asymmetry so a refactor of attributeInnerExpression can't silently
+		// flip these.
+		// ============================================================
+
+		// Spread with multi-prop literal: muted is found, order doesn't matter.
+		{Code: `<audio {...{muted: true, src: "a.mp3"}}></audio>`, Tsx: true},
+		{Code: `<audio {...{src: "a.mp3", muted: true}}></audio>`, Tsx: true},
+
+		// Parens-wrapped ObjectLiteral in spread — parens stripped per
+		// FindAttributeByName's `OEKParentheses` unwrap.
+		{Code: `<audio {...({muted: true})}></audio>`, Tsx: true},
+
+		// Shorthand spread property: `{...{muted}}` — muted ShorthandProperty
+		// resolves to the bound identifier "muted", which under literalPropValue
+		// is a non-undefined identifier → null. NOT exactly true → rule should
+		// NOT silence. (locked in invalid section below.)
+
+		// ============================================================
+		// Children whitespace / comment / format variants
+		// ============================================================
+
+		// Whitespace-only text between elements — JsxText is filtered out by
+		// the JSXElement-only filter; track child still found.
+		{Code: `<audio>  <track kind="captions" />  </audio>`, Tsx: true},
+		{Code: "<audio>\n  <track kind=\"captions\" />\n</audio>", Tsx: true},
+
+		// JsxText comment alongside the track.
+		{Code: `<audio>{/* localized */}<track kind="captions" /></audio>`, Tsx: true},
+
+		// ============================================================
+		// Multi-track arrangements — captions can be at any position
+		// ============================================================
+		{Code: `<audio><track kind="captions" /><track kind="subtitles" /><track kind="metadata" /><track kind="chapters" /></audio>`, Tsx: true},
+		{Code: `<audio><track kind="subtitles" /><track kind="metadata" /><track kind="chapters" /><track kind="captions" /></audio>`, Tsx: true},
+		{Code: `<audio><track kind="subtitles" /><track kind="captions" /><track kind="metadata" /></audio>`, Tsx: true},
+		// Multiple captions tracks — `some` short-circuits on first hit.
+		{Code: `<video><track kind="captions" /><track kind="captions" /></video>`, Tsx: true},
+
+		// ============================================================
+		// Polymorphic prop value forms — JsxExpression-wrapped string,
+		// template literal — both extract via LITERAL_TYPES and replace
+		// rawType.
+		// ============================================================
+		{
+			Code: `<Box as={"audio"} muted={true}></Box>`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+		{
+			Code: "<Box as={`audio`} muted={true}></Box>",
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+		},
+
+		// ============================================================
+		// Multi-line valid form — captions on its own line.
+		// ============================================================
+		{
+			Code: "<video\n  controls\n  src=\"video.mp4\"\n>\n  <track kind=\"captions\" src=\"caps.vtt\" />\n</video>",
+			Tsx:  true,
+		},
+
+		// ============================================================
+		// Empty option arrays for audio/video/track — explicit empty list,
+		// behaves the same as absent (no extension; default media still match).
+		// ============================================================
+		{Code: `<audio><track kind="captions" /></audio>`, Tsx: true,
+			Options: map[string]interface{}{"audio": []interface{}{}, "video": []interface{}{}, "track": []interface{}{}}},
+
+		// ============================================================
+		// Duplicate `muted` attributes — JSX strict mode disallows but tsgo
+		// accepts. FindAttributeByName returns the FIRST matching attribute,
+		// so `<audio muted={true} muted={false}>` → first is true → silence.
+		// (Differential-verified against eslint-plugin-jsx-a11y v6.10.2.)
+		// ============================================================
+		{Code: `<audio muted={true} muted={false}></audio>`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// Position assertions: paired form — listener fires on the OPENING
+		// element only. `<audio>` is 7 characters → EndColumn 8.
+		// ============================================================
+		{
+			Code: `<audio>scrolling</audio>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mediaHasCaption",
+				Message:   "Media elements such as <audio> and <video> must have a <track> for captions.",
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 8,
+			}},
+		},
+
+		// Empty body still reports.
+		{
+			Code:   `<audio></audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Position assertions: self-closing form — `<audio />` is 10
+		// characters → EndColumn 11.
+		// ============================================================
+		{
+			Code: `<audio />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mediaHasCaption",
+				Message:   "Media elements such as <audio> and <video> must have a <track> for captions.",
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 10,
+			}},
+		},
+
+		// Multi-line element — position must span the entire opening
+		// self-closing tag.
+		{
+			Code: "<video\n  width=\"320\"\n/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mediaHasCaption",
+				Message:   "Media elements such as <audio> and <video> must have a <track> for captions.",
+				Line:      1, Column: 1, EndLine: 3, EndColumn: 3,
+			}},
+		},
+
+		// ============================================================
+		// Dimension 2: same-kind / cross-kind media nesting — both the
+		// outer and inner element fire (each fails the caption check
+		// independently).
+		// ============================================================
+		{
+			Code: `<video><audio /></video>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "mediaHasCaption", Message: "Media elements such as <audio> and <video> must have a <track> for captions.",
+					Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+				{MessageId: "mediaHasCaption", Message: "Media elements such as <audio> and <video> must have a <track> for captions.",
+					Line: 1, Column: 8, EndLine: 1, EndColumn: 17},
+			},
+		},
+		{
+			Code: `<audio><video><track kind="captions" /></video></audio>`,
+			Tsx:  true,
+			// Outer audio fails (no track child of audio); inner video
+			// satisfies via captions track and is silent.
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Muted exemption — literal-value-extraction edge shapes (invalid)
+		// ============================================================
+
+		// String "true" coerces to bool true and SKIPS — but the
+		// non-string-literal forms below do NOT.
+		{Code: `<audio muted={undefined} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<audio muted={null} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<audio muted={someVar} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<audio muted={1} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<audio muted="anything" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Conditional / Logical / Unary all map to noop → null in
+		// LITERAL_TYPES; not exactly true → reports.
+		{Code: `<audio muted={cond ? true : false} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// PrefixUnary that evaluates to false (NOT true) — extracted via
+		// staticEvalUnary, so `!true` → bool false → not exactly true → reports.
+		{Code: `<audio muted={!true} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// TS as-assertion: literalPropValue rejects TSAsExpression → null →
+		// not exactly true → reports.
+		{Code: `<audio muted={true as any} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// No-substitution template `\`true\`` is treated as TemplateLiteral
+		// (not Literal), so jsxAstUtilsLiteralCoerce is NOT applied — value
+		// stays jvString "true" → not exactly bool true → reports.
+		{Code: "<audio muted={`true`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Captions extraction — kind-prop value edge shapes (invalid)
+		// ============================================================
+
+		// `kind` is dynamic identifier — literalPropValue → null → "" →
+		// fails the "captions" match.
+		{Code: `<audio><track kind={someVar} /></audio>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `kind` is conditional — noop → null.
+		{Code: `<audio><track kind={cond ? "captions" : "subtitles"} /></audio>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Empty string kind — `"" === "captions"` is false.
+		{Code: `<audio><track kind="" /></audio>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<audio><track kind={""} /></audio>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `kind="true"` — Literal coerces "true" → boolean true → not a
+		// string → LiteralPropStringValue returns ("", false) → fails the
+		// captions match. (Mirrors upstream's `(true || '').toLowerCase()`
+		// throwing TypeError; we silently treat as no caption.)
+		{Code: `<audio><track kind="true" /></audio>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// `kind` value carrying TS wrapper — literalPropValue rejects
+		// TSAsExpression → null → empty string → fails.
+		{Code: `<audio><track kind={"captions" as string} /></audio>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// Boolean form `<track kind />` — extractValue maps to bool true →
+		// LiteralPropStringValue returns ("", false) → fails the captions
+		// match.
+		{Code: `<audio><track kind /></audio>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// Multiple tracks, none with captions.
+		{
+			Code:   `<audio><track kind="subtitles" /><track kind="metadata" /></audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// JsxFragment child — JSXFragment is NOT 'JSXElement' upstream, so
+		// it's filtered out. Audio still has no track → reports.
+		{
+			Code:   `<audio><><track kind="captions" /></></audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// Track wrapped in a JsxExpression (e.g. `{cond && <track />}`) —
+		// the child is a JsxExpression, NOT a JsxElement / JsxSelfClosingElement,
+		// so it doesn't satisfy the filter. Audio has no track child → reports.
+		{
+			Code:   `<audio>{cond && <track kind="captions" />}</audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// Spread attributes don't carry muted → reports.
+		{
+			Code:   `<audio {...props}></audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Spread literal carrying muted=false → not exactly true → reports.
+		{
+			Code:   `<audio {...{muted: false}}></audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Options: array-wrapped shape with audio extension
+		// ============================================================
+		{
+			Code:    `<MyAudio />`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"audio": []interface{}{"MyAudio"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Track extension via options.track.
+		{
+			Code:    `<audio><MyTrack kind="subtitles" /></audio>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"track": []interface{}{"MyTrack"}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Mixed: extension to BOTH audio AND track, with subtitles only.
+		{
+			Code:    `<MyAudio><MyTrack kind="subtitles" /></MyAudio>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"audio": []interface{}{"MyAudio"}, "track": []interface{}{"MyTrack"}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Extension via options.video — captures `<MyVideo />`.
+		{
+			Code:    `<MyVideo />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"video": []interface{}{"MyVideo"}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// rslint extension: mixed-type array — non-string entries silently
+		// dropped, "MyAudio" still honored. Reports.
+		{
+			Code:    `<MyAudio />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"audio": []interface{}{"MyAudio", 123}},
+			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Settings: components map maps `<MyAudio>` to "audio"
+		// ============================================================
+		{
+			Code: `<MyAudio />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"MyAudio": "audio"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code: `<MyVideo />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"MyVideo": "video"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// `<audio>` aliased to "audio" (self-map) — still reports.
+		{
+			Code: `<audio />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"components": map[string]interface{}{"audio": "audio"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// Polymorphic without allow-list — every truthy `as` value replaces
+		// rawType, so `<Foo as="audio" />` reports.
+		{
+			Code: `<Foo as="audio" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{"polymorphicPropName": "as"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// Polymorphic + components combo: polymorphic replaces FIRST, then
+		// components looks up the (post-polymorphic) name. So `<Foo as="audio">`
+		// with `components: {Foo: "div"}` still reports — polymorphic turns
+		// rawType into "audio", and there's no "audio" key in components.
+		{
+			Code: `<Foo as="audio" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"Foo": "div"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// Polymorphic + components CHAIN: Foo → Bar (polymorphic) → audio
+		// (components). Locks in that components looks up the post-polymorphic
+		// name.
+		{
+			Code: `<Foo as="Bar" />`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"jsx-a11y": map[string]interface{}{
+					"polymorphicPropName": "as",
+					"components":          map[string]interface{}{"Bar": "audio"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Real-world component patterns — listener fires inside common
+		// React shapes (function component, map callback, conditional, etc.).
+		// ============================================================
+		{
+			Code:   `function Banner() { return <video />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const x = items.map(item => <video key={item.id} />)`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const x = cond ? <audio /> : <div />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code: `class C { render() { return <div><audio /><video /></div>; } }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedError,
+				expectedError,
+			},
+		},
+
+		// ============================================================
+		// Listener boundary: media inside non-media wrapper (each fires
+		// independently from any wrapping element).
+		// ============================================================
+		{
+			Code:   `<div><audio /></div>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<><audio /></>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Spread literal edge cases (invalid side)
+		// ============================================================
+		// Non-literal spread is opaque — muted is unreachable through
+		// `{...someObj}`. Mirrors jsx-ast-utils' getProp behavior.
+		{
+			Code:   `<audio {...someObj}></audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Shorthand spread property `{...{muted}}` — value is the bound
+		// identifier "muted", which under literalPropValue is a non-undefined
+		// identifier → null. Not exactly true → reports.
+		{
+			Code:   `<audio {...{muted}}></audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Children wrapping boundary — JsxExpression / array literal /
+		// comment-only / whitespace-only wrapping all FAIL the
+		// JSXElement-only filter, so the audio still has no track child.
+		// ============================================================
+
+		// Track in unconditional JsxExpression — `{<track ...>}`.
+		{
+			Code:   `<audio>{<track kind="captions" />}</audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Track in array literal in JsxExpression — `{[<track .../>]}`.
+		{
+			Code:   `<audio>{[<track kind="captions" key="x" />]}</audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Comment-only children — JsxExpression payload only contains a
+		// comment. No track, no caption.
+		{
+			Code:   `<audio>{/* TODO add captions */}</audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Whitespace-only children — JsxText whitespace is filtered out
+		// by the JSXElement-only filter; no track child found.
+		{
+			Code:   `<audio>     </audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   "<audio>\n\n\n</audio>",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Cross-form nesting: outer media without its own track child fires;
+		// inner media with valid captions stays silent. Lock that the outer
+		// listener does NOT walk into nested media's children for tracks.
+		// ============================================================
+		{
+			Code:   `<video><audio><track kind="captions" /></audio></video>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Multi-line invalid form — position spans the entire opening tag.
+		// `<video controls src="…">` opening tag spans lines 1-4; tsgo
+		// EndColumn is exclusive, so `>` on line 4 col 1 → EndColumn 2.
+		// ============================================================
+		{
+			Code: "<video\n  controls\n  src=\"video.mp4\"\n>\n</video>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "mediaHasCaption",
+				Message:   "Media elements such as <audio> and <video> must have a <track> for captions.",
+				Line:      1, Column: 1, EndLine: 4, EndColumn: 2,
+			}},
+		},
+
+		// ============================================================
+		// kind extraction edge: dynamic references all map to noop → null in
+		// LITERAL_TYPES → empty-string fallback → fail captions match.
+		// ============================================================
+		{
+			Code:   `<audio><track kind={Foo.Bar} /></audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<audio><track kind={getKind()} /></audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<audio><track kind={someKind || "subtitles"} /></audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Real-world component patterns (extended) — listener fires inside
+		// the React idioms users actually write.
+		// ============================================================
+		// React.memo wrap.
+		{
+			Code:   `const Audio = React.memo(() => <audio />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// React.forwardRef wrap with spread props.
+		{
+			Code:   `const Audio = React.forwardRef((props, ref) => <audio ref={ref} {...props} />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// React.Suspense fallback containing media.
+		{
+			Code:   `<React.Suspense fallback={<video />}>{children}</React.Suspense>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Switch-style rendering — both arms fire.
+		{
+			Code: `function R({type}) { switch(type) { case 'a': return <audio />; case 'v': return <video />; default: return null; } }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedError,
+				expectedError,
+			},
+		},
+		// Iterator chain: `.filter().map(...)` returning JSX.
+		{
+			Code:   `const x = items.filter(i => i.kind === "media").map(i => <video key={i.id} src={i.src} />)`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Array of JSX literals.
+		{
+			Code: `const items = [<audio key="1" />, <video key="2" />];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedError,
+				expectedError,
+			},
+		},
+		// JSX as function argument.
+		{
+			Code:   `wrap(<audio />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// JSX as object property value.
+		{
+			Code:   `const x = { content: <audio /> };`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Deep nesting (3 levels): each opening tag fires independently.
+		// Position assertions lock in tsgo column counting on adjacent JSX.
+		// `<video>` is 7 chars, so outer cols 1-8, middle 8-15, inner 15-24
+		// (`<video />` is 9 chars).
+		// ============================================================
+		{
+			Code: `<video><video><video /></video></video>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "mediaHasCaption", Message: "Media elements such as <audio> and <video> must have a <track> for captions.",
+					Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+				{MessageId: "mediaHasCaption", Message: "Media elements such as <audio> and <video> must have a <track> for captions.",
+					Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				{MessageId: "mediaHasCaption", Message: "Media elements such as <audio> and <video> must have a <track> for captions.",
+					Line: 1, Column: 15, EndLine: 1, EndColumn: 24},
+			},
+		},
+
+		// ============================================================
+		// Mixed JsxExpression children — even if a track is inside an
+		// expression, it still doesn't satisfy the filter, so the audio
+		// is reported.
+		// ============================================================
+		{
+			Code:   `<audio>{props.captions}{props.children}</audio>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption_upstream_test.go
@@ -1,0 +1,144 @@
+package media_has_caption
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedError mirrors upstream's `expectedError` constant — single message,
+// no positional / per-rule data; the message is hard-coded and reported on
+// the opening element.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "mediaHasCaption",
+	Message:   "Media elements such as <audio> and <video> must have a <track> for captions.",
+}
+
+// customSchema mirrors upstream's `customSchema` array — adds capital-A
+// `Audio`, capital-V `Video`, capital-T `Track` as additional component names
+// to the corresponding native element pools. Exercises the options-schema
+// path of `isMediaType` / `isTrackType`.
+var customSchema = map[string]interface{}{
+	"audio": []interface{}{"Audio"},
+	"video": []interface{}{"Video"},
+	"track": []interface{}{"Track"},
+}
+
+// componentsSettings mirrors upstream's `componentsSettings` constant — the
+// jsx-a11y settings shape that aliases capital-A `Audio` / `Video` / `Track`
+// React components onto their lowercase intrinsic equivalents AND enables
+// the `as`-prop polymorphic resolution. Exercises both
+// `GetElementType.components` and `GetElementType.polymorphicPropName` paths
+// in the same setting block.
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+		"components": map[string]interface{}{
+			"Audio": "audio",
+			"Video": "video",
+			"Track": "track",
+		},
+	},
+}
+
+// TestMediaHasCaptionUpstream covers the full valid / invalid suite migrated
+// 1:1 from upstream eslint-plugin-jsx-a11y's
+// `__tests__/src/rules/media-has-caption-test.js`. Order and grouping mirror
+// the upstream file so a future audit can grep across both side-by-side.
+//
+// rslint-specific lock-ins (Dimension 1-4 edge shapes, options coverage,
+// position assertions, polymorphic prop, listener boundary) live in
+// media_has_caption_extras_test.go.
+func TestMediaHasCaptionUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &MediaHasCaptionRule, []rule_tester.ValidTestCase{
+		// ---- Non-media elements never trigger ----
+		{Code: `<div />;`, Tsx: true},
+		{Code: `<MyDiv />;`, Tsx: true},
+
+		// ---- Native audio with captions (case-insensitive kind match) ----
+		{Code: `<audio><track kind="captions" /></audio>`, Tsx: true},
+		{Code: `<audio><track kind="Captions" /></audio>`, Tsx: true},
+		{Code: `<audio><track kind="Captions" /><track kind="subtitles" /></audio>`, Tsx: true},
+
+		// ---- Native video with captions ----
+		{Code: `<video><track kind="captions" /></video>`, Tsx: true},
+		{Code: `<video><track kind="Captions" /></video>`, Tsx: true},
+		{Code: `<video><track kind="Captions" /><track kind="subtitles" /></video>`, Tsx: true},
+
+		// ---- Muted exemption: explicit boolean and shorthand ----
+		{Code: `<audio muted={true}></audio>`, Tsx: true},
+		{Code: `<video muted={true}></video>`, Tsx: true},
+		{Code: `<video muted></video>`, Tsx: true},
+
+		// ---- Custom schema (`audio: ['Audio'], video: ['Video'], track: ['Track']`) ----
+		{Code: `<Audio><track kind="captions" /></Audio>`, Tsx: true, Options: customSchema},
+		{Code: `<audio><Track kind="captions" /></audio>`, Tsx: true, Options: customSchema},
+		{Code: `<Video><track kind="captions" /></Video>`, Tsx: true, Options: customSchema},
+		{Code: `<video><Track kind="captions" /></video>`, Tsx: true, Options: customSchema},
+		{Code: `<Audio><Track kind="captions" /></Audio>`, Tsx: true, Options: customSchema},
+		{Code: `<Video><Track kind="captions" /></Video>`, Tsx: true, Options: customSchema},
+		{Code: `<Video muted></Video>`, Tsx: true, Options: customSchema},
+		{Code: `<Video muted={true}></Video>`, Tsx: true, Options: customSchema},
+		{Code: `<Audio muted></Audio>`, Tsx: true, Options: customSchema},
+		{Code: `<Audio muted={true}></Audio>`, Tsx: true, Options: customSchema},
+
+		// ---- componentsSettings (polymorphic + components map) ----
+		{Code: `<Audio><track kind="captions" /></Audio>`, Tsx: true, Settings: componentsSettings},
+		{Code: `<audio><Track kind="captions" /></audio>`, Tsx: true, Settings: componentsSettings},
+		{Code: `<Video><track kind="captions" /></Video>`, Tsx: true, Settings: componentsSettings},
+		{Code: `<video><Track kind="captions" /></video>`, Tsx: true, Settings: componentsSettings},
+		{Code: `<Audio><Track kind="captions" /></Audio>`, Tsx: true, Settings: componentsSettings},
+		{Code: `<Video><Track kind="captions" /></Video>`, Tsx: true, Settings: componentsSettings},
+		{Code: `<Video muted></Video>`, Tsx: true, Settings: componentsSettings},
+		{Code: `<Video muted={true}></Video>`, Tsx: true, Settings: componentsSettings},
+		{Code: `<Audio muted></Audio>`, Tsx: true, Settings: componentsSettings},
+		{Code: `<Audio muted={true}></Audio>`, Tsx: true, Settings: componentsSettings},
+
+		// ---- Polymorphic-prop exemption: `<Box as="audio" muted={true}>` ----
+		// `as` resolves Box → audio, then muted={true} silences the rule.
+		{Code: `<Box as="audio" muted={true}></Box>`, Tsx: true, Settings: componentsSettings},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Native audio missing captions ----
+		{Code: `<audio><track /></audio>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<audio><track kind="subtitles" /></audio>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<audio />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Native video missing captions ----
+		{Code: `<video><track /></video>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<video><track kind="subtitles" /></video>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Muted explicitly set to false (NOT exempt) ----
+		{Code: `<Audio muted={false}></Audio>`, Tsx: true, Options: customSchema, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Video muted={false}></Video>`, Tsx: true, Options: customSchema, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Audio muted={false}></Audio>`, Tsx: true, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Video muted={false}></Video>`, Tsx: true, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Self-closing video with no captions ----
+		{Code: `<video />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Text content children don't satisfy the track requirement ----
+		{Code: `<audio>Foo</audio>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<video>Foo</video>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Custom-schema components without captions ----
+		{Code: `<Audio />`, Tsx: true, Options: customSchema, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Video />`, Tsx: true, Options: customSchema, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Audio />`, Tsx: true, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Video />`, Tsx: true, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Track child without `kind` ----
+		{Code: `<audio><Track /></audio>`, Tsx: true, Options: customSchema, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<video><Track /></video>`, Tsx: true, Options: customSchema, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Track child with kind != captions ----
+		{Code: `<Audio><Track kind="subtitles" /></Audio>`, Tsx: true, Options: customSchema, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Video><Track kind="subtitles" /></Video>`, Tsx: true, Options: customSchema, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Audio><Track kind="subtitles" /></Audio>`, Tsx: true, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<Video><Track kind="subtitles" /></Video>`, Tsx: true, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Polymorphic + components: `<Box as="audio">` resolves to audio,
+		//      Track has kind="subtitles" so no caption ----
+		{Code: `<Box as="audio"><Track kind="subtitles" /></Box>`, Tsx: true, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -165,6 +165,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/heading-has-content.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/html-has-lang.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/img-redundant-alt.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/media-has-caption.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/media-has-caption.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/media-has-caption.test.ts
@@ -1,0 +1,412 @@
+import { RuleTester } from '../rule-tester';
+
+const expectedError = {
+  message:
+    'Media elements such as <audio> and <video> must have a <track> for captions.',
+};
+
+const customSchema = {
+  audio: ['Audio'],
+  video: ['Video'],
+  track: ['Track'],
+};
+
+const componentsSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+    components: {
+      Audio: 'audio',
+      Video: 'video',
+      Track: 'track',
+    },
+  },
+};
+
+new RuleTester().run('media-has-caption', null as never, {
+  valid: [
+    // ---- Upstream valid ----
+    { code: '<div />;' },
+    { code: '<MyDiv />;' },
+    { code: '<audio><track kind="captions" /></audio>' },
+    { code: '<audio><track kind="Captions" /></audio>' },
+    {
+      code: '<audio><track kind="Captions" /><track kind="subtitles" /></audio>',
+    },
+    { code: '<video><track kind="captions" /></video>' },
+    { code: '<video><track kind="Captions" /></video>' },
+    {
+      code: '<video><track kind="Captions" /><track kind="subtitles" /></video>',
+    },
+    { code: '<audio muted={true}></audio>' },
+    { code: '<video muted={true}></video>' },
+    { code: '<video muted></video>' },
+
+    // ---- Custom schema (`audio: ['Audio'], video: ['Video'], track: ['Track']`) ----
+    {
+      code: '<Audio><track kind="captions" /></Audio>',
+      options: [customSchema],
+    },
+    {
+      code: '<audio><Track kind="captions" /></audio>',
+      options: [customSchema],
+    },
+    {
+      code: '<Video><track kind="captions" /></Video>',
+      options: [customSchema],
+    },
+    {
+      code: '<video><Track kind="captions" /></video>',
+      options: [customSchema],
+    },
+    {
+      code: '<Audio><Track kind="captions" /></Audio>',
+      options: [customSchema],
+    },
+    {
+      code: '<Video><Track kind="captions" /></Video>',
+      options: [customSchema],
+    },
+    { code: '<Video muted></Video>', options: [customSchema] },
+    { code: '<Video muted={true}></Video>', options: [customSchema] },
+    { code: '<Audio muted></Audio>', options: [customSchema] },
+    { code: '<Audio muted={true}></Audio>', options: [customSchema] },
+
+    // ---- componentsSettings ----
+    {
+      code: '<Audio><track kind="captions" /></Audio>',
+      settings: componentsSettings,
+    },
+    {
+      code: '<audio><Track kind="captions" /></audio>',
+      settings: componentsSettings,
+    },
+    {
+      code: '<Video><track kind="captions" /></Video>',
+      settings: componentsSettings,
+    },
+    {
+      code: '<video><Track kind="captions" /></video>',
+      settings: componentsSettings,
+    },
+    {
+      code: '<Audio><Track kind="captions" /></Audio>',
+      settings: componentsSettings,
+    },
+    {
+      code: '<Video><Track kind="captions" /></Video>',
+      settings: componentsSettings,
+    },
+    { code: '<Video muted></Video>', settings: componentsSettings },
+    { code: '<Video muted={true}></Video>', settings: componentsSettings },
+    { code: '<Audio muted></Audio>', settings: componentsSettings },
+    { code: '<Audio muted={true}></Audio>', settings: componentsSettings },
+    {
+      code: '<Box as="audio" muted={true}></Box>',
+      settings: componentsSettings,
+    },
+
+    // ---- Case sensitivity / property-access tags don't match ----
+    { code: '<AUDIO />' },
+    { code: '<Audio />' },
+    { code: '<UI.audio />' },
+    { code: '<svg:audio />' },
+
+    // ---- Element kind survey: rule no-op for non-media tags ----
+    { code: '<a />' },
+    { code: '<input />' },
+    { code: '<Component><track kind="captions" /></Component>' },
+    { code: '<div><track kind="subtitles" /></div>' },
+    { code: '<track />' },
+
+    // ---- Muted exemption variants ----
+    { code: '<audio muted />' },
+    { code: '<audio muted={(true)}></audio>' },
+    { code: '<audio muted="true"></audio>' },
+    { code: '<audio muted={"true"}></audio>' },
+    { code: '<audio {...{muted: true}}></audio>' },
+    { code: '<audio muted={!false} />' },
+
+    // ---- Captions extraction variants ----
+    { code: '<audio><track kind={"captions"} /></audio>' },
+    { code: '<audio><track kind={("captions")} /></audio>' },
+    { code: '<audio><track kind="CAPTIONS" /></audio>' },
+    { code: '<audio><track kind="cAPtIoNS" /></audio>' },
+    {
+      code: '<audio><track kind="subtitles" /><track kind="captions" /></audio>',
+    },
+    { code: '<audio>Hello <track kind="captions" /></audio>' },
+    { code: '<audio>{header}<track kind="captions" /></audio>' },
+    { code: '<audio><source src="a.mp3" /><track kind="captions" /></audio>' },
+    { code: '<video><track kind="captions"></track></video>' },
+
+    // ---- Settings: polymorphic / components reverse exemption ----
+    {
+      code: '<Audio />',
+      settings: {
+        'jsx-a11y': { components: { OtherTag: 'audio' } },
+      },
+    },
+    {
+      code: '<Foo as="audio" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          polymorphicAllowList: ['Bar'],
+        },
+      },
+    },
+    {
+      code: '<audio />',
+      settings: { 'jsx-a11y': { components: { audio: 'div' } } },
+    },
+    {
+      code: '<audio as="div" />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+    },
+
+    // ---- Defensive type handling ----
+    {
+      code: '<MyAudio />',
+      settings: { 'jsx-a11y': 'invalid' as unknown as object },
+    },
+    {
+      code: '<MyAudio />',
+      settings: { 'jsx-a11y': null as unknown as object },
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid ----
+    { code: '<audio><track /></audio>', errors: [expectedError] },
+    {
+      code: '<audio><track kind="subtitles" /></audio>',
+      errors: [expectedError],
+    },
+    { code: '<audio />', errors: [expectedError] },
+    { code: '<video><track /></video>', errors: [expectedError] },
+    {
+      code: '<video><track kind="subtitles" /></video>',
+      errors: [expectedError],
+    },
+    {
+      code: '<Audio muted={false}></Audio>',
+      options: [customSchema],
+      errors: [expectedError],
+    },
+    {
+      code: '<Video muted={false}></Video>',
+      options: [customSchema],
+      errors: [expectedError],
+    },
+    {
+      code: '<Audio muted={false}></Audio>',
+      settings: componentsSettings,
+      errors: [expectedError],
+    },
+    {
+      code: '<Video muted={false}></Video>',
+      settings: componentsSettings,
+      errors: [expectedError],
+    },
+    { code: '<video />', errors: [expectedError] },
+    { code: '<audio>Foo</audio>', errors: [expectedError] },
+    { code: '<video>Foo</video>', errors: [expectedError] },
+    { code: '<Audio />', options: [customSchema], errors: [expectedError] },
+    { code: '<Video />', options: [customSchema], errors: [expectedError] },
+    {
+      code: '<Audio />',
+      settings: componentsSettings,
+      errors: [expectedError],
+    },
+    {
+      code: '<Video />',
+      settings: componentsSettings,
+      errors: [expectedError],
+    },
+    {
+      code: '<audio><Track /></audio>',
+      options: [customSchema],
+      errors: [expectedError],
+    },
+    {
+      code: '<video><Track /></video>',
+      options: [customSchema],
+      errors: [expectedError],
+    },
+    {
+      code: '<Audio><Track kind="subtitles" /></Audio>',
+      options: [customSchema],
+      errors: [expectedError],
+    },
+    {
+      code: '<Video><Track kind="subtitles" /></Video>',
+      options: [customSchema],
+      errors: [expectedError],
+    },
+    {
+      code: '<Audio><Track kind="subtitles" /></Audio>',
+      settings: componentsSettings,
+      errors: [expectedError],
+    },
+    {
+      code: '<Video><Track kind="subtitles" /></Video>',
+      settings: componentsSettings,
+      errors: [expectedError],
+    },
+    {
+      code: '<Box as="audio"><Track kind="subtitles" /></Box>',
+      settings: componentsSettings,
+      errors: [expectedError],
+    },
+
+    // ---- Paired form: report on the OPENING element only ----
+    { code: '<audio>scrolling</audio>', errors: [expectedError] },
+    { code: '<audio></audio>', errors: [expectedError] },
+
+    // ---- Same-kind / cross-kind nesting: each fires independently ----
+    {
+      code: '<video><audio /></video>',
+      errors: [expectedError, expectedError],
+    },
+    {
+      code: '<audio><video><track kind="captions" /></video></audio>',
+      errors: [expectedError],
+    },
+
+    // ---- Muted edge shapes — only strict literal `true` silences ----
+    { code: '<audio muted={undefined} />', errors: [expectedError] },
+    { code: '<audio muted={null} />', errors: [expectedError] },
+    { code: '<audio muted={someVar} />', errors: [expectedError] },
+    { code: '<audio muted={1} />', errors: [expectedError] },
+    { code: '<audio muted="anything" />', errors: [expectedError] },
+    { code: '<audio muted={cond ? true : false} />', errors: [expectedError] },
+    { code: '<audio muted={!true} />', errors: [expectedError] },
+    { code: '<audio muted={true as any} />', errors: [expectedError] },
+    { code: '<audio muted={`true`} />', errors: [expectedError] },
+
+    // ---- Captions extraction edge shapes ----
+    {
+      code: '<audio><track kind={someVar} /></audio>',
+      errors: [expectedError],
+    },
+    {
+      code: '<audio><track kind={cond ? "captions" : "subtitles"} /></audio>',
+      errors: [expectedError],
+    },
+    { code: '<audio><track kind="" /></audio>', errors: [expectedError] },
+    { code: '<audio><track kind={""} /></audio>', errors: [expectedError] },
+    { code: '<audio><track kind="true" /></audio>', errors: [expectedError] },
+    {
+      code: '<audio><track kind={"captions" as string} /></audio>',
+      errors: [expectedError],
+    },
+    { code: '<audio><track kind /></audio>', errors: [expectedError] },
+    {
+      code: '<audio><track kind="subtitles" /><track kind="metadata" /></audio>',
+      errors: [expectedError],
+    },
+
+    // ---- Filter rejects JsxFragment / JsxExpression children ----
+    {
+      code: '<audio><><track kind="captions" /></></audio>',
+      errors: [expectedError],
+    },
+    {
+      code: '<audio>{cond && <track kind="captions" />}</audio>',
+      errors: [expectedError],
+    },
+
+    // ---- Spread attributes don't carry muted / muted=false ----
+    { code: '<audio {...props}></audio>', errors: [expectedError] },
+    { code: '<audio {...{muted: false}}></audio>', errors: [expectedError] },
+
+    // ---- Options extension via array-wrapped JSON shape ----
+    {
+      code: '<MyAudio />',
+      options: [{ audio: ['MyAudio'] }],
+      errors: [expectedError],
+    },
+    {
+      code: '<audio><MyTrack kind="subtitles" /></audio>',
+      options: [{ track: ['MyTrack'] }],
+      errors: [expectedError],
+    },
+    {
+      code: '<MyAudio><MyTrack kind="subtitles" /></MyAudio>',
+      options: [{ audio: ['MyAudio'], track: ['MyTrack'] }],
+      errors: [expectedError],
+    },
+    {
+      code: '<MyVideo />',
+      options: [{ video: ['MyVideo'] }],
+      errors: [expectedError],
+    },
+
+    // ---- Settings: components map ----
+    {
+      code: '<MyAudio />',
+      settings: { 'jsx-a11y': { components: { MyAudio: 'audio' } } },
+      errors: [expectedError],
+    },
+    {
+      code: '<MyVideo />',
+      settings: { 'jsx-a11y': { components: { MyVideo: 'video' } } },
+      errors: [expectedError],
+    },
+    {
+      code: '<audio />',
+      settings: { 'jsx-a11y': { components: { audio: 'audio' } } },
+      errors: [expectedError],
+    },
+
+    // ---- Polymorphic without allow-list ----
+    {
+      code: '<Foo as="audio" />',
+      settings: { 'jsx-a11y': { polymorphicPropName: 'as' } },
+      errors: [expectedError],
+    },
+
+    // ---- Polymorphic + components combo / chain ----
+    {
+      code: '<Foo as="audio" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          components: { Foo: 'div' },
+        },
+      },
+      errors: [expectedError],
+    },
+    {
+      code: '<Foo as="Bar" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          components: { Bar: 'audio' },
+        },
+      },
+      errors: [expectedError],
+    },
+
+    // ---- Real-world component patterns ----
+    {
+      code: 'function Banner() { return <video />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'const x = items.map(item => <video key={item.id} />)',
+      errors: [expectedError],
+    },
+    {
+      code: 'const x = cond ? <audio /> : <div />',
+      errors: [expectedError],
+    },
+    {
+      code: 'class C { render() { return <div><audio /><video /></div>; } }',
+      errors: [expectedError, expectedError],
+    },
+
+    // ---- Listener boundary: wrapped in non-media ----
+    { code: '<div><audio /></div>', errors: [expectedError] },
+    { code: '<><audio /></>', errors: [expectedError] },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/media-has-caption` rule from `eslint-plugin-jsx-a11y` to rslint. The rule enforces that `<audio>` and `<video>` elements include a `<track kind="captions">` child for accessibility, unless the media element carries `muted={true}`.

Differential validation against `eslint-plugin-jsx-a11y@6.10.2` covered 89 cases (default config + customSchema options + polymorphic/components settings + extended Go-AST edges) — line/column/message tuples match 100%.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/media-has-caption.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/media-has-caption.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).