### PR TITLE
feat: add jsx-a11y recommended preset

### DIFF
--- a/packages/rslint/src/configs/index.ts
+++ b/packages/rslint/src/configs/index.ts
@@ -7,6 +7,7 @@ import { recommended as importRecommended } from './import.js';
 import { recommended as promiseRecommended } from './promise.js';
 import { recommended as jestRecommended } from './jest.js';
 import { recommended as unicornRecommended } from './unicorn.js';
+import { recommended as jsxA11yRecommended } from './jsx-a11y.js';
 
 interface PluginExport {
   configs: { recommended: RslintConfigEntry };
@@ -42,4 +43,8 @@ export const jestPlugin: PluginExport = {
 
 export const unicornPlugin: PluginExport = {
   configs: { recommended: unicornRecommended },
+};
+
+export const jsxA11yPlugin: PluginExport = {
+  configs: { recommended: jsxA11yRecommended },
 };

--- a/packages/rslint/src/configs/jsx-a11y.ts
+++ b/packages/rslint/src/configs/jsx-a11y.ts
@@ -1,0 +1,53 @@
+import type { RslintConfigEntry } from '../define-config.js';
+
+// Aligned with official eslint-plugin-jsx-a11y@6.x recommended.
+// Rules commented out with "not implemented" are in the official preset but not yet available.
+const recommended: RslintConfigEntry = {
+  files: ['**/*.jsx', '**/*.tsx'],
+  plugins: ['jsx-a11y'],
+  rules: {
+    'jsx-a11y/alt-text': 'error',
+    // 'jsx-a11y/anchor-ambiguous-text': 'off', // not implemented (off in upstream)
+    'jsx-a11y/anchor-has-content': 'error',
+    'jsx-a11y/anchor-is-valid': 'error',
+    // 'jsx-a11y/aria-activedescendant-has-tabindex': 'error', // not implemented
+    // 'jsx-a11y/aria-props': 'error', // not implemented
+    // 'jsx-a11y/aria-proptypes': 'error', // not implemented
+    // 'jsx-a11y/aria-role': 'error', // not implemented
+    'jsx-a11y/aria-unsupported-elements': 'error',
+    'jsx-a11y/autocomplete-valid': 'error',
+    // 'jsx-a11y/click-events-have-key-events': 'error', // not implemented
+    // 'jsx-a11y/control-has-associated-label': 'off', // not implemented (off in upstream)
+    'jsx-a11y/heading-has-content': 'error',
+    'jsx-a11y/html-has-lang': 'error',
+    'jsx-a11y/iframe-has-title': 'error',
+    'jsx-a11y/img-redundant-alt': 'error',
+    // 'jsx-a11y/interactive-supports-focus': 'error', // not implemented
+    // 'jsx-a11y/label-has-associated-control': 'error', // not implemented
+    // 'jsx-a11y/label-has-for': 'off', // not implemented (off in upstream)
+    'jsx-a11y/media-has-caption': 'error',
+    // 'jsx-a11y/mouse-events-have-key-events': 'error', // not implemented
+    'jsx-a11y/no-access-key': 'error',
+    'jsx-a11y/no-autofocus': 'error',
+    'jsx-a11y/no-distracting-elements': 'error',
+    // 'jsx-a11y/no-interactive-element-to-noninteractive-role': 'error', // not implemented
+    // 'jsx-a11y/no-noninteractive-element-interactions': 'error', // not implemented
+    // 'jsx-a11y/no-noninteractive-element-to-interactive-role': 'error', // not implemented
+    'jsx-a11y/no-noninteractive-tabindex': [
+      'error',
+      {
+        tags: [],
+        roles: ['tabpanel'],
+        allowExpressionValues: true,
+      },
+    ],
+    'jsx-a11y/no-redundant-roles': 'error',
+    // 'jsx-a11y/no-static-element-interactions': 'error', // not implemented
+    // 'jsx-a11y/role-has-required-aria-props': 'error', // not implemented
+    // 'jsx-a11y/role-supports-aria-props': 'error', // not implemented
+    'jsx-a11y/scope': 'error',
+    'jsx-a11y/tabindex-no-positive': 'error',
+  },
+};
+
+export { recommended };

--- a/packages/rslint/src/define-config.ts
+++ b/packages/rslint/src/define-config.ts
@@ -11,6 +11,7 @@ export type KnownPlugin =
   | '@typescript-eslint'
   | 'import'
   | 'jest'
+  | 'jsx-a11y'
   | 'promise'
   | 'react'
   | 'react-hooks'
@@ -103,6 +104,7 @@ export interface RslintConfigEntry {
    * - `'@typescript-eslint'` → `@typescript-eslint/eslint-plugin`
    * - `'import'`             → `eslint-plugin-import`
    * - `'jest'`               → `eslint-plugin-jest`
+   * - `'jsx-a11y'`           → `eslint-plugin-jsx-a11y`
    * - `'promise'`            → `eslint-plugin-promise`
    * - `'react'`              → `eslint-plugin-react`
    * - `'react-hooks'`        → `eslint-plugin-react-hooks`

--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -20,6 +20,7 @@ export {
   promisePlugin,
   jestPlugin,
   unicornPlugin,
+  jsxA11yPlugin,
 } from './configs/index.js';
 
 // Export the main RSLintService class for direct usage


### PR DESCRIPTION
## Summary

- Add `packages/rslint/src/configs/jsx-a11y.ts` mirroring `eslint-plugin-jsx-a11y@6.x` recommended; rules not yet ported are kept commented out as `// not implemented` placeholders.
- Export `jsxA11yPlugin` from `configs/index.ts` and `src/index.ts` so consumers can opt in alongside the other plugin presets.
- Register `'jsx-a11y'` in `KnownPlugin` and the JSDoc plugin map for type-safe config authoring.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).