### PR TITLE
fix: register jsx-a11y in plugin name and website registry

### DIFF
--- a/internal/plugins/jsx_a11y/plugin.go
+++ b/internal/plugins/jsx_a11y/plugin.go
@@ -1,1 +1,3 @@
 package jsx_a11y_plugin
+
+const PLUGIN_NAME = "eslint-plugin-jsx-a11y"

--- a/website/theme/plugin-registry.ts
+++ b/website/theme/plugin-registry.ts
@@ -94,6 +94,13 @@ export const PLUGIN_REGISTRY: PluginMeta[] = [
     presetName: 'unicornPlugin.configs.recommended',
     description: 'Unicorn rules',
   },
+  {
+    prefix: 'jsx-a11y',
+    group: 'eslint-plugin-jsx-a11y',
+    importName: 'jsxA11yPlugin',
+    presetName: 'jsxA11yPlugin.configs.recommended',
+    description: 'JSX a11y rules',
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Fix two missing wirings that prevented the jsx-a11y plugin from being recognized correctly by the website rule manifest pipeline:

- Add `PLUGIN_NAME = "eslint-plugin-jsx-a11y"` to `internal/plugins/jsx_a11y/plugin.go`. Without it, `scripts/gen-rule-manifest.js` fell back to the package directory name (`jsx_a11y`), so the manifest used a group/slug that did not match the user-facing prefix (`jsx-a11y`) or the test directory (`tests/eslint-plugin-jsx-a11y/`).
- Add a `jsx-a11y` entry to `website/theme/plugin-registry.ts`, pointing at the newly-exported `jsxA11yPlugin.configs.recommended` preset. This lets `RuleConfig`, `PresetTable`, and the rules overview preset filter pick up jsx-a11y like every other plugin.

After these changes, rule detail pages render the recommended preset row for jsx-a11y rules, and the rules overview preset filter shows `jsxA11yPlugin.configs.recommended` as a selectable option.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).