### PR TITLE
feat: add --type-check-only flag to run only type checking

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -434,6 +434,7 @@ Options:
   --format FORMAT       Output format: default | jsonline | github
   --fix                 Automatically fix problems
   --type-check          Enable TypeScript type checking
+  --type-check-only     Run only TypeScript type checking (skip all lint rules)
   --no-color            Disable colored output
   --force-color         Force colored output
   --quiet               Report errors only
@@ -482,6 +483,142 @@ func applyFixPass(diagnosticsByFile map[string][]rule.RuleDiagnostic) int {
 	return fixed
 }
 
+// allowFileWarningKind categorizes why a CLI-specified file won't have lint
+// rules applied. These are Phase-1 (lint) concepts; Phase 2 (type-check) is
+// not affected by either case (it runs program-wide regardless of CLI scope
+// and rslint ignores).
+type allowFileWarningKind int
+
+const (
+	allowFileNotInProgram allowFileWarningKind = iota
+	allowFileIgnored
+)
+
+// allowFileWarning is the structured form of a "this CLI-specified file
+// won't be linted" diagnostic. Returned by collectAllowFileWarnings so the
+// emission policy (skip in --type-check-only, format with relative paths,
+// etc.) can be unit-tested without capturing stderr.
+type allowFileWarning struct {
+	Path string // absolute, normalized — matches what was put in allowFiles
+	Kind allowFileWarningKind
+}
+
+// formatAllowFileWarning renders an allowFileWarning for stderr emission,
+// resolving the absolute path against comparePathOptions. Returns "" for
+// unknown kinds so callers can safely ignore the empty case.
+func formatAllowFileWarning(w allowFileWarning, opts tspath.ComparePathsOptions) string {
+	rel := tspath.ConvertToRelativePath(w.Path, opts)
+	switch w.Kind {
+	case allowFileNotInProgram:
+		return fmt.Sprintf("warning: %s was not found in the project, skipping", rel)
+	case allowFileIgnored:
+		return fmt.Sprintf("warning: %s is ignored because of a matching ignore pattern", rel)
+	}
+	return ""
+}
+
+// collectAllowFileWarnings explains, for each CLI-specified file in
+// allowFiles, why it won't be visited by Phase 1 (lint). A file lands in
+// the result if it is outside every Program, or if it is in some Program
+// but the nearest config's `ignores` patterns exclude it. Returns nil for
+// empty allowFiles.
+//
+// This is a Phase-1 concern only. In --type-check-only mode the lint phase
+// is skipped, so callers MUST gate emission on `!typeCheckOnly` — otherwise
+// users see misleading messages like "is ignored because of a matching
+// ignore pattern" while Phase 2 happily reports type errors for that same
+// file. See website/docs/en/guide/type-checking.md ("type-check is not
+// constrained by `files`/`ignores`").
+func collectAllowFileWarnings(
+	allowFiles []string,
+	programs []*compiler.Program,
+	configMap map[string]rslintconfig.RslintConfig,
+	rslintConfig rslintconfig.RslintConfig,
+	currentDirectory string,
+) []allowFileWarning {
+	if len(allowFiles) == 0 {
+		return nil
+	}
+	programFiles := make(map[string]struct{})
+	for _, prog := range programs {
+		for _, sf := range prog.GetSourceFiles() {
+			programFiles[sf.FileName()] = struct{}{}
+		}
+	}
+
+	// Cache FindNearestConfig results by directory to avoid redundant lookups
+	// when many files are in the same directory (e.g., lint-staged).
+	type cachedConfig struct {
+		cfgDir string
+		cfg    rslintconfig.RslintConfig
+	}
+	dirConfigCache := make(map[string]*cachedConfig)
+
+	var out []allowFileWarning
+	for _, f := range allowFiles {
+		if _, inProgram := programFiles[f]; !inProgram {
+			out = append(out, allowFileWarning{Path: f, Kind: allowFileNotInProgram})
+			continue
+		}
+		// File is in a Program — check if config would assign rules
+		var merged *rslintconfig.MergedConfig
+		if configMap != nil {
+			dir := tspath.GetDirectoryPath(f)
+			cached, ok := dirConfigCache[dir]
+			if !ok {
+				cfgDir, cfg := rslintconfig.FindNearestConfig(f, configMap)
+				cached = &cachedConfig{cfgDir: cfgDir, cfg: cfg}
+				dirConfigCache[dir] = cached
+			}
+			if cached.cfg != nil {
+				merged = cached.cfg.GetConfigForFile(f, cached.cfgDir)
+			}
+		} else {
+			merged = rslintConfig.GetConfigForFile(f, currentDirectory)
+		}
+		if merged == nil {
+			out = append(out, allowFileWarning{Path: f, Kind: allowFileIgnored})
+		}
+	}
+	return out
+}
+
+// shouldShortCircuitOutput returns true when rslint should bail early
+// without printing diagnostics or a summary. The short-circuit exists so
+// that e.g. `rslint nonexistent-file.ts` returns 0 with no spurious output
+// when Phase 1 visited zero files.
+//
+// Any type-check mode (`--type-check` or `--type-check-only`) must NOT take
+// the short-circuit: Phase 2 runs program-wide and is not gated by the CLI
+// Scope/PerProgramFilter that drives lintedFileCount, so lintedFileCount==0
+// is a normal state in which Phase 2 may still have produced diagnostics.
+// Short-circuiting there would silently drop type errors that the user
+// explicitly asked for — see website/docs/en/guide/type-checking.md.
+func shouldShortCircuitOutput(typeCheckOnly, typeCheck, scopeRestricted bool, lintedFileCount int32) bool {
+	if typeCheckOnly || typeCheck {
+		return false
+	}
+	return scopeRestricted && lintedFileCount == 0
+}
+
+// validateTypeCheckOnlyFlags rejects --type-check-only combined with flags
+// whose semantics depend on the lint phase that this mode disables. Returns
+// (0, "") when the combination is valid (or --type-check-only isn't set);
+// otherwise returns (exitCode > 0, stderr message). Pulled out as a pure
+// function so the policy can be exercised in unit tests.
+func validateTypeCheckOnlyFlags(typeCheckOnly, fix bool, ruleFlags []string) (int, string) {
+	if !typeCheckOnly {
+		return 0, ""
+	}
+	if fix {
+		return 2, "error: --fix cannot be combined with --type-check-only (no lint rules run, nothing to fix)"
+	}
+	if len(ruleFlags) > 0 {
+		return 2, "error: --rule cannot be combined with --type-check-only (no lint rules run)"
+	}
+	return 0, ""
+}
+
 // resolveStartTime returns the start time for timing output.
 // If startTimeMs (epoch millis from the Node.js entry point) is positive,
 // it is used so the reported duration covers end-to-end execution.
@@ -501,8 +638,9 @@ func runCMD() int {
 		help        bool
 		config      string
 		configStdin bool
-		fix         bool
-		typeCheck   bool
+		fix           bool
+		typeCheck     bool
+		typeCheckOnly bool
 
 		traceOut       string
 		cpuprofOut     string
@@ -521,6 +659,7 @@ func runCMD() int {
 	flag.BoolVar(&init, "init", false, "initialize a default config in the current directory")
 	flag.BoolVar(&fix, "fix", false, "automatically fix problems")
 	flag.BoolVar(&typeCheck, "type-check", false, "enable TypeScript type checking")
+	flag.BoolVar(&typeCheckOnly, "type-check-only", false, "run only TypeScript type checking (skip all lint rules)")
 	flag.BoolVar(&help, "help", false, "show help")
 	flag.BoolVar(&help, "h", false, "show help")
 	flag.BoolVar(&noColor, "no-color", false, "disable colored output")
@@ -535,6 +674,16 @@ func runCMD() int {
 	flag.Var(&ruleFlags, "rule", "rule override, e.g. 'no-console: error' (repeatable)")
 
 	flag.Parse()
+
+	// --type-check-only implies --type-check and skips all lint rules.
+	// Reject incompatible flag combinations before doing any work.
+	if code, msg := validateTypeCheckOnlyFlags(typeCheckOnly, fix, []string(ruleFlags)); code != 0 {
+		fmt.Fprintln(os.Stderr, msg)
+		return code
+	}
+	if typeCheckOnly {
+		typeCheck = true
+	}
 
 	// Collect file/directory arguments for targeted linting (e.g. rslint file1.ts src/)
 	var allowFiles []string
@@ -969,12 +1118,20 @@ func runCMD() int {
 	// tsconfig Coverage").
 	skipTypeCheck := buildTypeCheckSkipMask(len(programs), fallbackProgramIndex)
 
+	// In --type-check-only mode, skip the lint phase entirely by passing
+	// nil for GetRulesForFile. RunLinter's Phase 1 is gated on this being
+	// non-nil; Phase 2 (type-check) runs independently.
+	var rulesForFile linter.RuleHandler
+	if !typeCheckOnly {
+		rulesForFile = getRulesForFile
+	}
+
 	lintResult, err := linter.RunLinter(linter.RunLinterOptions{
 		Programs:              programs,
 		SingleThreaded:        singleThreaded,
 		Scope:                 linter.FileScope{Files: allowFiles, Dirs: allowDirs},
 		PerProgramFilter:      toFileFilters(fileFilters),
-		GetRulesForFile:       getRulesForFile,
+		GetRulesForFile:       rulesForFile,
 		TypeInfoFiles:         typeInfoFiles,
 		TypeCheck:             typeCheck,
 		SkipTypeCheckPrograms: skipTypeCheck,
@@ -994,57 +1151,18 @@ func runCMD() int {
 	wg.Wait()
 
 	// Emit per-file warnings for CLI-specified files that won't be linted.
-	// Distinguish between "ignored by pattern" vs "no matching configuration"
-	// vs "not found in project", aligned with ESLint v10's warning behavior.
-	if len(allowFiles) > 0 {
-		programFiles := make(map[string]struct{})
-		for _, prog := range programs {
-			for _, sf := range prog.GetSourceFiles() {
-				programFiles[sf.FileName()] = struct{}{}
-			}
-		}
-		// Cache FindNearestConfig results by directory to avoid redundant lookups
-		// when many files are in the same directory (e.g., lint-staged).
-		type cachedConfig struct {
-			cfgDir string
-			cfg    rslintconfig.RslintConfig
-		}
-		dirConfigCache := make(map[string]*cachedConfig)
-
-		for _, f := range allowFiles {
-			_, inProgram := programFiles[f]
-
-			if !inProgram {
-				// File not in any Program — warn and skip
-				relPath := tspath.ConvertToRelativePath(f, comparePathOptions)
-				fmt.Fprintf(os.Stderr, "warning: %s was not found in the project, skipping\n", relPath)
-				continue
-			}
-
-			// File is in a Program — check if config would assign rules
-			var merged *rslintconfig.MergedConfig
-			if configMap != nil {
-				dir := tspath.GetDirectoryPath(f)
-				cached, ok := dirConfigCache[dir]
-				if !ok {
-					cfgDir, cfg := rslintconfig.FindNearestConfig(f, configMap)
-					cached = &cachedConfig{cfgDir: cfgDir, cfg: cfg}
-					dirConfigCache[dir] = cached
-				}
-				if cached.cfg != nil {
-					merged = cached.cfg.GetConfigForFile(f, cached.cfgDir)
-				}
-			} else {
-				merged = rslintConfig.GetConfigForFile(f, currentDirectory)
-			}
-
-			if merged == nil {
-				relPath := tspath.ConvertToRelativePath(f, comparePathOptions)
-				fmt.Fprintf(os.Stderr, "warning: %s is ignored because of a matching ignore pattern\n", relPath)
-			}
+	// Distinguishes "not found in project" vs "ignored by pattern", aligned
+	// with ESLint v10's warning behavior. Skipped in --type-check-only mode:
+	// these are lint-phase concepts and would mislead users about Phase 2
+	// (which runs program-wide regardless of CLI scope and rslint ignores).
+	if !typeCheckOnly {
+		warnings := collectAllowFileWarnings(allowFiles, programs, configMap, rslintConfig, currentDirectory)
+		for _, w := range warnings {
+			fmt.Fprintln(os.Stderr, formatAllowFileWarning(w, comparePathOptions))
 		}
 	}
-	if (len(allowFiles) > 0 || len(allowDirs) > 0) && lintedfileCount == 0 {
+	scopeRestricted := len(allowFiles) > 0 || len(allowDirs) > 0
+	if shouldShortCircuitOutput(typeCheckOnly, typeCheck, scopeRestricted, lintedfileCount) {
 		return 0
 	}
 
@@ -1164,21 +1282,54 @@ func runCMD() int {
 		// Build the errors summary part.
 		// When type-check is enabled and there are type errors, split the display.
 		var errorsSummary string
-		if typeCheck {
+		switch {
+		case typeCheckOnly:
+			// Lint phase was skipped; only type errors are possible.
+			errorsSummary = fmt.Sprintf("%s %s",
+				errorsColorFunc("%d", typeErrorsCount),
+				pluralize(typeErrorsCount, "type error", "type errors"),
+			)
+		case typeCheck:
 			errorsSummary = fmt.Sprintf("%s %s, %s %s",
 				errorsColorFunc("%d", lintErrorsCount),
 				pluralize(lintErrorsCount, "lint error", "lint errors"),
 				errorsColorFunc("%d", typeErrorsCount),
 				pluralize(typeErrorsCount, "type error", "type errors"),
 			)
-		} else {
+		default:
 			errorsSummary = fmt.Sprintf("%s %s",
 				errorsColorFunc("%d", errorsCount),
 				pluralize(errorsCount, "error", "errors"),
 			)
 		}
 
-		if fix && fixedCount > 0 {
+		if typeCheckOnly {
+			// type-check-only: omit lint-file/rule/warning columns since no
+			// lint ran. Report the type-checked file count derived from
+			// non-skipped programs' root files (tsconfig include/files);
+			// transitive .d.ts imports are excluded for user readability.
+			seen := make(map[string]struct{})
+			for i, prog := range programs {
+				if i < len(skipTypeCheck) && skipTypeCheck[i] {
+					continue
+				}
+				for _, fn := range prog.CommandLine().FileNames() {
+					seen[fn] = struct{}{}
+				}
+			}
+			typeCheckedFileCount := len(seen)
+			fmt.Fprintf(
+				os.Stdout,
+				"Found %s %s(type-checked %s %s in %s using %s threads)%s\n",
+				errorsSummary,
+				colors.DimText(""),
+				colors.BoldText("%d", typeCheckedFileCount),
+				pluralize(typeCheckedFileCount, "file", "files"),
+				colors.BoldText("%v", time.Since(timeBefore).Round(time.Millisecond)),
+				colors.BoldText("%d", threadsCount),
+				color.New().SprintFunc()(""),
+			)
+		} else if fix && fixedCount > 0 {
 			fixText := pluralize(fixedCount, "issue", "issues")
 			fmt.Fprintf(
 				os.Stdout,

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -672,3 +672,206 @@ func TestResolveStartTime_Negative(t *testing.T) {
 		t.Errorf("expected time.Now() when startTimeMs is negative, got %v", result)
 	}
 }
+
+// --- validateTypeCheckOnlyFlags ---
+//
+// These tests pin down the CLI compatibility policy for --type-check-only:
+// it implies --type-check, but is rejected with exit code 2 when combined
+// with --fix or --rule (both rely on the lint phase that this mode disables).
+
+func TestValidateTypeCheckOnlyFlags_OffIsNoop(t *testing.T) {
+	// typeCheckOnly=false → policy doesn't apply, every other combination ok.
+	cases := []struct {
+		fix       bool
+		ruleFlags []string
+	}{
+		{false, nil},
+		{true, nil},
+		{false, []string{"no-console: error"}},
+		{true, []string{"no-console: error"}},
+	}
+	for _, c := range cases {
+		code, msg := validateTypeCheckOnlyFlags(false, c.fix, c.ruleFlags)
+		if code != 0 || msg != "" {
+			t.Errorf("typeCheckOnly=false should never reject (fix=%v rules=%v), got (%d, %q)", c.fix, c.ruleFlags, code, msg)
+		}
+	}
+}
+
+func TestValidateTypeCheckOnlyFlags_AloneIsOK(t *testing.T) {
+	code, msg := validateTypeCheckOnlyFlags(true, false, nil)
+	if code != 0 || msg != "" {
+		t.Errorf("typeCheckOnly alone should be accepted, got (%d, %q)", code, msg)
+	}
+}
+
+func TestValidateTypeCheckOnlyFlags_RejectsFix(t *testing.T) {
+	code, msg := validateTypeCheckOnlyFlags(true, true, nil)
+	if code != 2 {
+		t.Errorf("expected exit code 2 for --type-check-only + --fix, got %d", code)
+	}
+	if !strings.Contains(msg, "--fix") || !strings.Contains(msg, "--type-check-only") {
+		t.Errorf("expected message to mention both flags, got %q", msg)
+	}
+}
+
+func TestValidateTypeCheckOnlyFlags_RejectsRule(t *testing.T) {
+	code, msg := validateTypeCheckOnlyFlags(true, false, []string{"no-console: error"})
+	if code != 2 {
+		t.Errorf("expected exit code 2 for --type-check-only + --rule, got %d", code)
+	}
+	if !strings.Contains(msg, "--rule") || !strings.Contains(msg, "--type-check-only") {
+		t.Errorf("expected message to mention both flags, got %q", msg)
+	}
+}
+
+// TestValidateTypeCheckOnlyFlags_FixTakesPriority documents the diagnostic
+// preference when both incompatible flags are present: the error message
+// names --fix (not --rule) because --fix is checked first. This isn't a
+// correctness property, just a stability guarantee for users with scripts
+// scraping stderr.
+func TestValidateTypeCheckOnlyFlags_FixTakesPriority(t *testing.T) {
+	code, msg := validateTypeCheckOnlyFlags(true, true, []string{"no-console: error"})
+	if code != 2 {
+		t.Errorf("expected exit code 2, got %d", code)
+	}
+	if !strings.Contains(msg, "--fix") {
+		t.Errorf("expected --fix to take priority in the error message, got %q", msg)
+	}
+}
+
+// --- shouldShortCircuitOutput ---
+//
+// Locks two regressions:
+//   1. `--type-check-only <dir>` returning exit 0 with no diagnostics
+//      because Phase 1's LintedFileCount was always 0, tripping a
+//      short-circuit meant for "user pointed at a nonexistent file"
+//      (lint mode).
+//   2. `--type-check <non-program-file.ts>` silently dropping Phase 2
+//      diagnostics: lintedFileCount==0 (scope filtered out everything in
+//      Phase 1) but Phase 2 ran program-wide and produced TS errors that
+//      the short-circuit would have swallowed.
+//
+// Either type-check mode must never take the short-circuit.
+
+func TestShouldShortCircuitOutput_NotInTypeCheckOnly(t *testing.T) {
+	// All combinations of scope/lintedFileCount must NOT short-circuit
+	// when type-check-only is on, because Phase 2 may have output.
+	cases := []struct {
+		scopeRestricted bool
+		lintedFileCount int32
+	}{
+		{false, 0},
+		{false, 5},
+		{true, 0},
+		{true, 5},
+	}
+	for _, c := range cases {
+		// typeCheckOnly=true with typeCheck=false is non-canonical (main()
+		// sets typeCheck=true when typeCheckOnly is on), but the guard must
+		// still hold on its own to avoid coupling.
+		if shouldShortCircuitOutput(true, false, c.scopeRestricted, c.lintedFileCount) {
+			t.Errorf("type-check-only mode must never short-circuit (scope=%v lintedFiles=%d)", c.scopeRestricted, c.lintedFileCount)
+		}
+	}
+}
+
+func TestShouldShortCircuitOutput_NotInTypeCheckMode(t *testing.T) {
+	// --type-check (without --type-check-only): Phase 2 runs program-wide
+	// regardless of Scope, so even lintedFileCount==0 + scopeRestricted is
+	// not enough to drop diagnostics. Locks review-111 Issue 1.
+	cases := []struct {
+		scopeRestricted bool
+		lintedFileCount int32
+	}{
+		{false, 0},
+		{false, 5},
+		{true, 0}, // <-- the previously-buggy case
+		{true, 5},
+	}
+	for _, c := range cases {
+		if shouldShortCircuitOutput(false, true, c.scopeRestricted, c.lintedFileCount) {
+			t.Errorf("--type-check mode must never short-circuit (scope=%v lintedFiles=%d)", c.scopeRestricted, c.lintedFileCount)
+		}
+	}
+}
+
+func TestShouldShortCircuitOutput_LintModeShortCircuitsWhenEmpty(t *testing.T) {
+	if !shouldShortCircuitOutput(false, false, true, 0) {
+		t.Error("lint mode with scope restriction and zero linted files should short-circuit")
+	}
+}
+
+func TestShouldShortCircuitOutput_LintModeKeepsRunningOtherwise(t *testing.T) {
+	cases := []struct {
+		name            string
+		scopeRestricted bool
+		lintedFileCount int32
+	}{
+		{"no scope, no files", false, 0},
+		{"no scope, files present", false, 5},
+		{"scope, files present", true, 5},
+	}
+	for _, c := range cases {
+		if shouldShortCircuitOutput(false, false, c.scopeRestricted, c.lintedFileCount) {
+			t.Errorf("%s: lint mode must not short-circuit", c.name)
+		}
+	}
+}
+
+// --- allowFileWarning ---
+//
+// collectAllowFileWarnings is the structured form of "this CLI file won't
+// be linted" diagnostics. formatAllowFileWarning is the message renderer.
+// We test them separately so the policy (when to emit) and the wording
+// (what the message looks like) are pinned independently.
+
+func TestFormatAllowFileWarning_NotInProgram(t *testing.T) {
+	opts := tspath.ComparePathsOptions{CurrentDirectory: "/work", UseCaseSensitiveFileNames: true}
+	msg := formatAllowFileWarning(allowFileWarning{Path: "/work/missing.ts", Kind: allowFileNotInProgram}, opts)
+	if !strings.Contains(msg, "missing.ts") {
+		t.Errorf("message should contain file name, got %q", msg)
+	}
+	if !strings.Contains(msg, "was not found in the project") {
+		t.Errorf("message should explain 'not in project', got %q", msg)
+	}
+	if !strings.Contains(msg, "skipping") {
+		t.Errorf("message should say 'skipping' (lint-side semantics), got %q", msg)
+	}
+	if strings.HasSuffix(msg, "\n") {
+		t.Errorf("message should NOT include trailing newline (caller adds it via Fprintln), got %q", msg)
+	}
+}
+
+func TestFormatAllowFileWarning_Ignored(t *testing.T) {
+	opts := tspath.ComparePathsOptions{CurrentDirectory: "/work", UseCaseSensitiveFileNames: true}
+	msg := formatAllowFileWarning(allowFileWarning{Path: "/work/src/x.ts", Kind: allowFileIgnored}, opts)
+	if !strings.Contains(msg, "src/x.ts") {
+		t.Errorf("message should contain relative path, got %q", msg)
+	}
+	if !strings.Contains(msg, "ignored because of a matching ignore pattern") {
+		t.Errorf("message should reference the ignore pattern, got %q", msg)
+	}
+}
+
+func TestFormatAllowFileWarning_UnknownKindIsEmpty(t *testing.T) {
+	// Defensive: future Kind enum additions shouldn't crash callers if
+	// formatter isn't updated. Empty string is the agreed sentinel.
+	msg := formatAllowFileWarning(allowFileWarning{Path: "/x.ts", Kind: allowFileWarningKind(99)}, tspath.ComparePathsOptions{})
+	if msg != "" {
+		t.Errorf("unknown kind should produce empty message, got %q", msg)
+	}
+}
+
+func TestCollectAllowFileWarnings_EmptyReturnsNil(t *testing.T) {
+	// No allowFiles → no work, no warnings. Important so callers can rely
+	// on a non-nil result implying actual user-specified files.
+	got := collectAllowFileWarnings(nil, nil, nil, nil, "/work")
+	if got != nil {
+		t.Errorf("empty allowFiles should produce nil, got %+v", got)
+	}
+	got = collectAllowFileWarnings([]string{}, nil, nil, nil, "/work")
+	if got != nil {
+		t.Errorf("empty allowFiles (non-nil slice) should still produce nil, got %+v", got)
+	}
+}

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -194,10 +194,16 @@ func buildFileOwnerMap(programs []*compiler.Program, configMap map[string]rslint
 //   - multi-config ownership: a file is linted by the program belonging to its
 //     nearest config (only active when len(configMap) > 1)
 //   - config `ignores`: files matching the user's ignore patterns are excluded
-//     from ALL diagnostics (lint rules, type-check, and the linted-file count)
+//     from lint rules and the linted-file count
 //
-// The returned slice is always len(programs). Entries are never nil — ignores
-// must apply to every program, including the gap-file fallback program.
+// These filters are consumed by RunLinter only in Phase 1 (lint). Phase 2
+// (type-check) does NOT consult them — type-check mirrors `tsgo --noEmit`
+// over the full tsconfig-determined program. See linter.go RunLinter doc
+// and website/docs/en/guide/type-checking.md for the contract.
+//
+// The returned slice is always len(programs). Entries are never nil — ignore
+// semantics must apply to every program in Phase 1, including the gap-file
+// fallback program.
 //
 // singleConfig / singleConfigDir are used when configMap is nil (single-config
 // mode). When configMap is non-nil, the per-file nearest config is looked up.

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -381,6 +381,10 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 // Phase 1 — lint rules: each program is processed via
 // runLintRulesInProgram, with files filtered through opts.ExcludePaths,
 // opts.Scope, opts.PerProgramFilter and the program's own owned-file set.
+// When opts.GetRulesForFile is nil, Phase 1 is skipped entirely — no work
+// group is created, no per-program goroutines are spawned, and no
+// owned-file sets are built. This is how callers run a pure type-check
+// pass (--type-check-only) without paying lint-side setup cost.
 //
 // Phase 2 — type-check (skipped when opts.TypeCheck is false): each
 // non-skipped program is handed to runTypeCheckAcrossPrograms, which
@@ -400,44 +404,45 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 	}
 
 	var executedRules sync.Map
-	trackedGetRules := opts.GetRulesForFile
-	if trackedGetRules != nil {
+	var lintedFileCount atomic.Int32
+
+	// Phase 1: lint rules per program (parallel). Skipped when no rule
+	// handler was supplied — see doc above.
+	if opts.GetRulesForFile != nil {
 		base := opts.GetRulesForFile
-		trackedGetRules = func(sf *ast.SourceFile) []ConfiguredRule {
+		trackedGetRules := func(sf *ast.SourceFile) []ConfiguredRule {
 			rules := base(sf)
 			for _, r := range rules {
 				executedRules.Store(r.Name, struct{}{})
 			}
 			return rules
 		}
-	}
 
-	// Phase 1: lint rules per program (parallel).
-	wg := core.NewWorkGroup(opts.SingleThreaded)
-	var lintedFileCount atomic.Int32
-	for i, program := range opts.Programs {
-		var perProgramFilter FileFilter
-		if i < len(opts.PerProgramFilter) {
-			perProgramFilter = opts.PerProgramFilter[i]
-		}
-		ownedFiles := buildOwnedFileSet(program)
-		filter := composeOwnedFilter(perProgramFilter, ownedFiles)
+		wg := core.NewWorkGroup(opts.SingleThreaded)
+		for i, program := range opts.Programs {
+			var perProgramFilter FileFilter
+			if i < len(opts.PerProgramFilter) {
+				perProgramFilter = opts.PerProgramFilter[i]
+			}
+			ownedFiles := buildOwnedFileSet(program)
+			filter := composeOwnedFilter(perProgramFilter, ownedFiles)
 
-		programOpts := runProgramOptions{
-			Program:         program,
-			Scope:           opts.Scope,
-			ExcludePaths:    opts.ExcludePaths,
-			FileFilter:      filter,
-			GetRulesForFile: trackedGetRules,
-			TypeInfoFiles:   opts.TypeInfoFiles,
-			OnDiagnostic:    opts.OnDiagnostic,
+			programOpts := runProgramOptions{
+				Program:         program,
+				Scope:           opts.Scope,
+				ExcludePaths:    opts.ExcludePaths,
+				FileFilter:      filter,
+				GetRulesForFile: trackedGetRules,
+				TypeInfoFiles:   opts.TypeInfoFiles,
+				OnDiagnostic:    opts.OnDiagnostic,
+			}
+			wg.Queue(func() {
+				n := runLintRulesInProgram(programOpts)
+				lintedFileCount.Add(n)
+			})
 		}
-		wg.Queue(func() {
-			n := runLintRulesInProgram(programOpts)
-			lintedFileCount.Add(n)
-		})
+		wg.RunAndWait()
 	}
-	wg.RunAndWait()
 
 	// Phase 2: program-level type-check (tsc-aligned).
 	if opts.TypeCheck {

--- a/internal/linter/linter_typecheck_typeonly_test.go
+++ b/internal/linter/linter_typecheck_typeonly_test.go
@@ -1,0 +1,264 @@
+package linter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// These tests exercise the "type-check only" code path: GetRulesForFile=nil
+// combined with TypeCheck=true. The contract is:
+//
+//   1. Phase 1 (lint rules) is skipped entirely — no rule diagnostics, no
+//      LintedFileCount, no ExecutedRules.
+//   2. Phase 2 (type-check) still produces tsc-aligned diagnostics.
+//   3. PerProgramFilter is a Phase-1-only concern; it does NOT suppress
+//      Phase 2 diagnostics. This locks the contract documented in
+//      website/docs/en/guide/type-checking.md (type-check mirrors
+//      `tsgo --noEmit`, ignoring rslint-side filters).
+//   4. SkipTypeCheckPrograms continues to gate Phase 2 per-program.
+
+// triggerOnIdentifierRule reports a warning on every identifier — used to
+// confirm rules really would have fired if Phase 1 had run.
+func triggerOnIdentifierRule() []ConfiguredRule {
+	return []ConfiguredRule{
+		{
+			Name:     "would-have-fired",
+			Severity: rule.SeverityError,
+			Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				return rule.RuleListeners{
+					ast.KindIdentifier: func(node *ast.Node) {
+						ctx.ReportNode(node, rule.RuleMessage{Id: "x", Description: "would have fired"})
+					},
+				}
+			},
+		},
+	}
+}
+
+// classifyDiagnostics splits a flat slice into (TypeScript(TS…) entries, lint entries).
+func classifyDiagnostics(diags []rule.RuleDiagnostic) (tsDiags, lintDiags []rule.RuleDiagnostic) {
+	for _, d := range diags {
+		if strings.HasPrefix(d.RuleName, "TypeScript(") {
+			tsDiags = append(tsDiags, d)
+		} else {
+			lintDiags = append(lintDiags, d)
+		}
+	}
+	return
+}
+
+func TestTypeCheckOnly_NoLintDiagnostics(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		// triggerOnIdentifierRule would fire many times on this file.
+		"a.ts": "const a = 1; const b = 2;",
+	})
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		ExcludePaths:    utils.ExcludePaths,
+		GetRulesForFile: nil, // <-- type-check-only path
+		TypeCheck:       true,
+		OnDiagnostic:    func(d rule.RuleDiagnostic) { diags = append(diags, d) },
+	})
+	if err != nil {
+		t.Fatalf("RunLinter returned error: %v", err)
+	}
+
+	_, lintDiags := classifyDiagnostics(diags)
+	if len(lintDiags) != 0 {
+		t.Fatalf("expected no lint diagnostics with GetRulesForFile=nil, got %d: %+v", len(lintDiags), lintDiags)
+	}
+}
+
+func TestTypeCheckOnly_StillReportsTSErrors(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const x: number = 'hello';", // TS2322 type mismatch
+	})
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		ExcludePaths:    utils.ExcludePaths,
+		GetRulesForFile: nil,
+		TypeCheck:       true,
+		OnDiagnostic:    func(d rule.RuleDiagnostic) { diags = append(diags, d) },
+	})
+	if err != nil {
+		t.Fatalf("RunLinter returned error: %v", err)
+	}
+
+	tsDiags, _ := classifyDiagnostics(diags)
+	if len(tsDiags) == 0 {
+		t.Fatal("expected TS diagnostics under type-check-only mode, got none")
+	}
+	foundTS2322 := false
+	for _, d := range tsDiags {
+		if strings.Contains(d.RuleName, "TS2322") {
+			foundTS2322 = true
+			break
+		}
+	}
+	if !foundTS2322 {
+		t.Errorf("expected TS2322 (type mismatch), got: %+v", tsDiags)
+	}
+}
+
+func TestTypeCheckOnly_LintedFileCountIsZero(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+		"b.ts": "const b = 2;",
+	})
+
+	result, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		ExcludePaths:    utils.ExcludePaths,
+		GetRulesForFile: nil,
+		TypeCheck:       true,
+		OnDiagnostic:    func(rule.RuleDiagnostic) {},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter returned error: %v", err)
+	}
+	if result.LintedFileCount != 0 {
+		t.Errorf("expected LintedFileCount=0 when Phase 1 is skipped, got %d", result.LintedFileCount)
+	}
+}
+
+func TestTypeCheckOnly_ExecutedRulesIsEmpty(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+	})
+
+	result, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		ExcludePaths:    utils.ExcludePaths,
+		GetRulesForFile: nil,
+		TypeCheck:       true,
+		OnDiagnostic:    func(rule.RuleDiagnostic) {},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter returned error: %v", err)
+	}
+	if len(result.ExecutedRules) != 0 {
+		t.Errorf("expected ExecutedRules to be empty when Phase 1 is skipped, got %v", result.ExecutedRules)
+	}
+}
+
+// TestTypeCheckOnly_BaselineLintWouldFire is a sanity check: with the same
+// program but a real GetRulesForFile, lint diagnostics WOULD fire — proving
+// the absence above is due to nil, not due to the file being un-lintable.
+func TestTypeCheckOnly_BaselineLintWouldFire(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1; const b = 2;",
+	})
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		ExcludePaths:    utils.ExcludePaths,
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule { return triggerOnIdentifierRule() },
+		TypeCheck:       false,
+		OnDiagnostic:    func(d rule.RuleDiagnostic) { diags = append(diags, d) },
+	})
+	if err != nil {
+		t.Fatalf("RunLinter returned error: %v", err)
+	}
+	_, lintDiags := classifyDiagnostics(diags)
+	if len(lintDiags) == 0 {
+		t.Fatal("baseline expectation broken: rule was supposed to fire when GetRulesForFile is non-nil")
+	}
+}
+
+// TestTypeCheckOnly_PerProgramFilterIgnoredByTypeCheck locks Claim B from
+// the design discussion: a PerProgramFilter that rejects ALL files still
+// does not suppress type-check diagnostics. This mirrors `tsgo --noEmit`
+// semantics — type-check scope is the tsconfig-determined program, not the
+// rslint-side ignore set.
+func TestTypeCheckOnly_PerProgramFilterIgnoredByTypeCheck(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const x: number = 'hello';",
+	})
+
+	rejectAll := func(string) bool { return false }
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:         []*compiler.Program{program},
+		SingleThreaded:   true,
+		ExcludePaths:     utils.ExcludePaths,
+		PerProgramFilter: []FileFilter{rejectAll},
+		GetRulesForFile:  nil,
+		TypeCheck:        true,
+		OnDiagnostic:     func(d rule.RuleDiagnostic) { diags = append(diags, d) },
+	})
+	if err != nil {
+		t.Fatalf("RunLinter returned error: %v", err)
+	}
+	tsDiags, _ := classifyDiagnostics(diags)
+	if len(tsDiags) == 0 {
+		t.Fatal("PerProgramFilter rejecting all files should NOT suppress type-check diagnostics, but got none")
+	}
+}
+
+// TestTypeCheckOnly_RespectsSkipMask verifies SkipTypeCheckPrograms still
+// gates Phase 2 even when Phase 1 is skipped (i.e. gap fallback programs
+// remain excluded from type-check, as committed in type-checking.md).
+func TestTypeCheckOnly_RespectsSkipMask(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const x: number = 'hello';",
+	})
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:              []*compiler.Program{program},
+		SingleThreaded:        true,
+		ExcludePaths:          utils.ExcludePaths,
+		GetRulesForFile:       nil,
+		TypeCheck:             true,
+		SkipTypeCheckPrograms: []bool{true}, // skip the only program
+		OnDiagnostic:          func(d rule.RuleDiagnostic) { diags = append(diags, d) },
+	})
+	if err != nil {
+		t.Fatalf("RunLinter returned error: %v", err)
+	}
+	tsDiags, _ := classifyDiagnostics(diags)
+	if len(tsDiags) != 0 {
+		t.Errorf("expected 0 TS diagnostics with SkipTypeCheckPrograms[0]=true, got %d: %+v", len(tsDiags), tsDiags)
+	}
+}
+
+// TestTypeCheckOnly_TypeCheckFalseProducesNothing closes the matrix: even
+// when GetRulesForFile is nil, if TypeCheck is also false there should be
+// no diagnostics at all (no work done in either phase).
+func TestTypeCheckOnly_TypeCheckFalseProducesNothing(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const x: number = 'hello';",
+	})
+
+	var diags []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:        []*compiler.Program{program},
+		SingleThreaded:  true,
+		ExcludePaths:    utils.ExcludePaths,
+		GetRulesForFile: nil,
+		TypeCheck:       false,
+		OnDiagnostic:    func(d rule.RuleDiagnostic) { diags = append(diags, d) },
+	})
+	if err != nil {
+		t.Fatalf("RunLinter returned error: %v", err)
+	}
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics when both phases are off, got %d: %+v", len(diags), diags)
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -25,6 +25,7 @@ export default defineConfig({
     './tests/cli/type-check/type-check.test.ts',
     './tests/cli/type-check/type-check-snapshot.test.ts',
     './tests/cli/type-check/ignores-suppression.test.ts',
+    './tests/cli/type-check/type-check-only.test.ts',
 
     // eslint
     './tests/eslint/rules/accessor-pairs.test.ts',

--- a/packages/rslint-test-tools/tests/cli/type-check/type-check-only.test.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/type-check-only.test.ts
@@ -1,0 +1,285 @@
+import { describe, test, expect } from '@rstest/core';
+import { runRslint, createTempDir, cleanupTempDir, TS_CONFIG } from './helpers';
+
+// End-to-end coverage for the `--type-check-only` mode (PR #905) and the
+// short-circuit / lint-only-warning fixes that landed alongside it (PR #905
+// review-111). The contracts under test:
+//
+//   1. Type-check-only skips the lint phase entirely (no rule diagnostics,
+//      no lint-file count) while still running Phase 2 type-check.
+//   2. `--fix` and `--rule` are rejected because the lint phase is gone.
+//   3. Lint-phase per-file warnings ("X was not found in the project" and
+//      "X is ignored because of a matching ignore pattern") are suppressed
+//      in --type-check-only — they describe a phase that didn't run, and
+//      Phase 2 itself ignores rslint's `ignores`/scope.
+//   4. `--type-check` (non-only) must NOT take the empty-scope short-circuit
+//      either: Phase 2 runs program-wide and may produce diagnostics even
+//      when Phase 1 visited zero files.
+//   5. In plain lint mode the existing "is ignored" warning still fires —
+//      lock-in so the suppression in (3) doesn't accidentally regress it.
+//
+// All assertions go through the actual CLI binary so behavior is verified
+// end-to-end (config loading, ignores resolution, program scoping, output).
+
+interface Diagnostic {
+  ruleName: string;
+  filePath: string;
+  severity?: string;
+}
+
+function makeConfigPlain(): string {
+  return `export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
+    plugins: ['@typescript-eslint'],
+    rules: { '@typescript-eslint/no-unsafe-member-access': 'error' },
+  }
+];
+`;
+}
+
+function makeConfigWithIgnores(ignores: string[]): string {
+  return `export default [
+  { ignores: ${JSON.stringify(ignores)} },
+  {
+    files: ['**/*.ts'],
+    languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
+    plugins: ['@typescript-eslint'],
+    rules: { '@typescript-eslint/no-unsafe-member-access': 'error' },
+  }
+];
+`;
+}
+
+function parseJsonline(stdout: string): Diagnostic[] {
+  return stdout
+    .trim()
+    .split('\n')
+    .filter((l) => l.trim().startsWith('{'))
+    .map((l) => JSON.parse(l) as Diagnostic);
+}
+
+describe('--type-check-only basic', () => {
+  test('reports type errors and skips lint diagnostics on the same file', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigPlain(),
+      // Triggers BOTH:
+      //   - @typescript-eslint/no-unsafe-member-access (lint, on `a.b`)
+      //   - TS2322 (type-check, on `const x: number = 'oops'`)
+      'a.ts': "const x: number = 'oops';\nlet a: any = 1;\na.b = 2;\n",
+    });
+    try {
+      const r = await runRslint(
+        ['--type-check-only', '--format', 'jsonline'],
+        tempDir,
+      );
+      const diags = parseJsonline(r.stdout);
+      const tsDiags = diags.filter((d) => d.ruleName.startsWith('TypeScript('));
+      const lintDiags = diags.filter(
+        (d) => !d.ruleName.startsWith('TypeScript('),
+      );
+      expect(tsDiags.length).toBeGreaterThan(0);
+      expect(tsDiags.some((d) => d.ruleName.includes('TS2322'))).toBe(true);
+      expect(lintDiags.length).toBe(0);
+      expect(r.exitCode).not.toBe(0);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('implies --type-check (no need to pass both)', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigPlain(),
+      'a.ts': "const x: number = 'oops';\n",
+    });
+    try {
+      // Without --type-check passed explicitly: should still type-check.
+      const r = await runRslint(
+        ['--type-check-only', '--format', 'jsonline'],
+        tempDir,
+      );
+      const diags = parseJsonline(r.stdout);
+      expect(diags.some((d) => d.ruleName.includes('TS2322'))).toBe(true);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('summary reports "type-checked N files" instead of "linted N files"', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigPlain(),
+      'a.ts': 'export const ok = 1;\n',
+    });
+    try {
+      const r = await runRslint(['--type-check-only'], tempDir);
+      expect(r.stdout).toContain('type-checked');
+      expect(r.stdout).toContain('type error');
+      // The summary line owns "linted N files"; --type-check-only uses a
+      // different summary so this phrasing should NOT appear.
+      expect(r.stdout).not.toContain('linted');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+});
+
+describe('--type-check-only flag compatibility', () => {
+  test('rejects --fix with exit code 2', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigPlain(),
+      'a.ts': 'export const ok = 1;\n',
+    });
+    try {
+      const r = await runRslint(['--type-check-only', '--fix'], tempDir);
+      expect(r.exitCode).toBe(2);
+      expect(r.stderr).toContain('--fix');
+      expect(r.stderr).toContain('--type-check-only');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('rejects --rule with exit code 2', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigPlain(),
+      'a.ts': 'export const ok = 1;\n',
+    });
+    try {
+      const r = await runRslint(
+        ['--type-check-only', '--rule', 'no-console: error'],
+        tempDir,
+      );
+      expect(r.exitCode).toBe(2);
+      expect(r.stderr).toContain('--rule');
+      expect(r.stderr).toContain('--type-check-only');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+});
+
+describe('--type-check-only suppresses lint-phase warnings', () => {
+  test('"was not found in the project" warning is suppressed', async () => {
+    // A CLI-specified file outside every program is a lint-phase concept
+    // (it would mean "Phase 1 has nothing to do"). Phase 2 is program-wide
+    // and unaffected, so the warning is noise in --type-check-only.
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigPlain(),
+      'existing.ts': 'export const ok = 1;\n',
+    });
+    try {
+      const r = await runRslint(
+        ['--type-check-only', 'nonexistent.ts'],
+        tempDir,
+      );
+      expect(r.stderr).not.toContain('not found in the project');
+      expect(r.stderr).not.toContain('nonexistent.ts');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('"is ignored because of a matching ignore pattern" warning is suppressed', async () => {
+    // The user asked for type-check; the lint-phase "ignored" notice would
+    // be misleading next to a type error on the same file (see (3) below).
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigWithIgnores(['ignored.ts']),
+      'ignored.ts': "const x: number = 'bad';\n", // TS2322 still surfaces
+    });
+    try {
+      const r = await runRslint(['--type-check-only', 'ignored.ts'], tempDir);
+      expect(r.stderr).not.toContain('matching ignore pattern');
+      expect(r.stderr).not.toContain('is ignored');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('type errors are still reported for files matched by rslint ignores', async () => {
+    // Documents the contract from type-checking.md L145-L152: rslint
+    // `ignores` is a lint-phase concept. Type-check is program-wide.
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigWithIgnores(['ignored.ts']),
+      'ignored.ts': "const x: number = 'bad';\n",
+    });
+    try {
+      const r = await runRslint(
+        ['--type-check-only', '--format', 'jsonline'],
+        tempDir,
+      );
+      const diags = parseJsonline(r.stdout);
+      const onIgnored = diags.filter((d) => d.filePath?.includes('ignored.ts'));
+      expect(onIgnored.some((d) => d.ruleName.includes('TS2322'))).toBe(true);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+});
+
+describe('--type-check (non-only) does not short-circuit on Phase 2 diagnostics', () => {
+  test('--type-check with a non-program file argument still reports program-wide type errors', async () => {
+    // Locks review-111 Issue 1: previously, `--type-check nonexistent.ts`
+    // would set scopeRestricted=true, lintedFileCount=0, and trip the
+    // short-circuit — silently dropping the TS2322 in src/bad.ts that
+    // Phase 2 had already collected.
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigPlain(),
+      'src/bad.ts': "const x: number = 'oops';\n", // TS2322
+    });
+    try {
+      const r = await runRslint(
+        ['--type-check', '--format', 'jsonline', 'nonexistent.ts'],
+        tempDir,
+      );
+      const diags = parseJsonline(r.stdout);
+      // The src/bad.ts type error must surface — short-circuiting on
+      // lintedFileCount==0 used to swallow it.
+      expect(
+        diags.some(
+          (d) =>
+            d.filePath?.includes('src/bad.ts') && d.ruleName.includes('TS2322'),
+        ),
+      ).toBe(true);
+      // And the lint-side "not found" warning still fires in --type-check
+      // (non-only) mode — only --type-check-only suppresses it.
+      expect(r.stderr).toContain('nonexistent.ts');
+      expect(r.stderr).toContain('not found in the project');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+});
+
+describe('lint mode baseline (lock-in)', () => {
+  test('"is ignored because of a matching ignore pattern" warning surfaces in plain lint mode', async () => {
+    // Counterpart to the --type-check-only suppression test above: in
+    // plain lint mode the warning MUST still appear, otherwise the
+    // suppression patch would have over-corrected.
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigWithIgnores(['ignored.ts']),
+      'ignored.ts': 'export const ok = 1;\n',
+      // A second non-ignored file so the run produces a clean summary.
+      'kept.ts': 'export const kept = 2;\n',
+    });
+    try {
+      const r = await runRslint(['ignored.ts'], tempDir);
+      expect(r.stderr).toContain('ignored.ts');
+      expect(r.stderr).toContain(
+        'is ignored because of a matching ignore pattern',
+      );
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+});

--- a/website/docs/en/guide/type-checking.md
+++ b/website/docs/en/guide/type-checking.md
@@ -1,82 +1,67 @@
 # Type Checking
 
-Rslint can perform TypeScript semantic type checking alongside lint diagnostics. This allows you to replace `tsc --noEmit` with a single `rslint --type-check` command.
+Rslint runs TypeScript semantic type-check alongside or instead of lint rules — a drop-in replacement for `tsc --noEmit` in CI.
 
-## Quick Start
+- `--type-check` — lint rules **and** type-check, in one pass.
+- `--type-check-only` — type-check only; lint phase is skipped entirely.
+
+## Quick start
+
+Point rslint at your tsconfig(s) via `languageOptions.parserOptions.project`:
+
+```js
+// rslint.config.mjs
+export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: { project: ['./tsconfig.json'] },
+    },
+  },
+];
+```
+
+Then:
 
 ```bash
-rslint --type-check .
+rslint --type-check .         # lint + type-check
+rslint --type-check-only .    # type-check only
 ```
 
-When `--type-check` is enabled, TypeScript semantic errors (e.g. type mismatches, missing properties, unresolved modules) are reported together with lint diagnostics in a single unified output.
+Without `parserOptions.project` no TypeScript program is built and type-check produces no diagnostics.
 
-## Replacing `tsc --noEmit`
+## What gets type-checked
 
-Traditionally, TypeScript projects run type checking and linting as two separate steps:
+`parserOptions.project` accepts one or more tsconfig paths:
 
-```bash
-tsc --noEmit        # type checking
-rslint .            # linting
+```js
+// Single tsconfig
+parserOptions: { project: ['./tsconfig.json'] }
+
+// Multiple tsconfigs (monorepo, separate test/build configs, …)
+parserOptions: {
+  project: ['./tsconfig.json', './packages/*/tsconfig.json'],
+}
 ```
 
-With `--type-check`, both can be done in one pass:
+Each entry produces one TypeScript program. Type-check runs over every program independently.
 
-```bash
-rslint --type-check .
-```
+**The type-check scope is each tsconfig's `include` / `files` minus `exclude` — nothing in your rslint config or on the CLI changes it.** Specifically, the following are **lint-phase concepts** that do **not** affect type-check scope:
 
-This provides several advantages:
+- rslint config's `files` patterns
+- rslint config's `ignores` patterns (root-level or per-entry)
+- `.gitignore`
+- CLI file / directory arguments — `rslint --type-check-only foo.ts` still type-checks every file in the program(s), not just `foo.ts`
 
-- **Single command** — no need to orchestrate two tools in scripts or CI pipelines.
-- **Shared TypeScript program** — type checking reuses the same TypeScript program built for type-aware lint rules, so it adds minimal overhead compared to running a separate `tsc` process.
-- **Unified output** — type errors and lint errors appear in the same output stream with a consistent format, making it easier to triage issues.
+If a file is included by tsconfig but matched by rslint `ignores`, lint rules do not run on it, but **type errors for it are still reported**. To exclude it from type-check as well, add it to the tsconfig's `exclude` or prepend `// @ts-nocheck` to the file.
 
-### CI Migration
+### Gap files
 
-#### GitHub Actions
-
-Before:
-
-```yaml
-steps:
-  - run: npx tsc --noEmit
-  - run: npx rslint .
-```
-
-After:
-
-```yaml
-steps:
-  - run: npx rslint --type-check .
-```
-
-To get inline annotations on pull request diffs, use `--format github`:
-
-```yaml
-steps:
-  - run: npx rslint --type-check --format github .
-```
-
-#### Other CI Environments
-
-```bash
-# Lint + type check in one command
-npx rslint --type-check .
-
-# With error threshold for warnings
-npx rslint --type-check --max-warnings 10 .
-
-# Errors only (cleaner CI logs)
-npx rslint --type-check --quiet .
-```
+Files that match your rslint config's `files` pattern but are **not** in any tsconfig (root-level scripts, ad-hoc config files, etc.) are called _gap files_. Syntactic lint rules still run on them, but type-check skips them — semantic type information requires tsconfig coverage. To enable type-check for a gap file, add it to an existing tsconfig's `include` or create a dedicated tsconfig that covers it.
 
 ## Output
 
-Type errors are reported with their original TypeScript error codes as the rule name, e.g. `TypeScript(TS2322)`. All type errors have severity `error` and cause a non-zero exit code.
-
-Type errors are included in all output formats (`default`, `jsonline`, `github`).
-
-### Default format
+Type errors carry `TypeScript(TS<code>)` as the rule name and severity `error`:
 
 ```
   TypeScript(TS2322)  — [error] Type 'string' is not assignable to type 'number'.
@@ -87,40 +72,102 @@ Type errors are included in all output formats (`default`, `jsonline`, `github`)
   ╰────────────────────────────────
 ```
 
-For errors with detailed explanations, TypeScript's message chain is displayed with indentation:
+Chained errors indent the TypeScript message chain:
 
 ```
   TypeScript(TS2322)  — [error] Type 'B' is not assignable to type 'A'.
     The types of 'x.y.z' are incompatible between these types.
       Type 'number' is not assignable to type 'string'.
-  ╭─┴──────────( src/types.ts:3:7 )─────
 ```
+
+Type errors appear in every output format (`default`, `jsonline`, `github`).
 
 ### Summary line
 
-When `--type-check` is enabled, the summary always splits lint errors and type errors:
+Three templates depending on mode:
 
 ```
-Found 3 lint errors, 2 type errors and 1 warning (linted 42 files in 120ms using 8 threads)
+# Plain lint
+Found 3 errors and 1 warning (linted 42 files with 5 rules in 120ms using 8 threads)
+
+# --type-check
+Found 3 lint errors, 2 type errors and 1 warning (linted 42 files with 5 rules in 120ms using 8 threads)
+
+# --type-check-only
+Found 2 type errors (type-checked 42 files in 80ms using 8 threads)
 ```
+
+### Exit codes
+
+| Code | When                                                                 |
+| :--: | -------------------------------------------------------------------- |
+|  0   | No errors. (Warnings still allowed unless `--max-warnings` rejects.) |
+|  1   | At least one error (lint or type), or a runtime failure.             |
+|  2   | Flag misuse — `--type-check-only` combined with `--fix` or `--rule`. |
 
 ## Alignment with `tsc --noEmit`
 
-`--type-check` is designed to produce the same diagnostics as `tsc --noEmit` (and `tsgo --noEmit`) for any given TypeScript program — same error code, same file, same line and column.
+For any given program, `--type-check` (and `--type-check-only`) produces the same diagnostics as `tsc --noEmit` / `tsgo --noEmit` — same error code, same file, same line and column.
 
-The one intentional difference: TypeScript diagnostics that have no source-file anchor (e.g. tsconfig validation messages such as `TS18003` "No inputs were found in config file" or `TS5108` "Option … has been removed") are not reported by `--type-check`, because rslint's output is rendered per file. Run `tsc --noEmit` directly when you need to surface those configuration-level errors.
+One intentional difference: TypeScript diagnostics without a source-file anchor (e.g. `TS18003` "No inputs were found in config file", `TS5108` removed-option warnings) are not reported, because rslint output is per file. Run `tsc --noEmit` directly to surface these configuration-level errors.
 
-## Files Without tsconfig Coverage
+## Replacing `tsc --noEmit` in CI
 
-Files that match your config's `files` patterns but are not included in any tsconfig (e.g. root-level scripts, config files) are still linted with syntax-level rules. However, `--type-check` will **not** report semantic type errors for these files, since reliable type information requires tsconfig coverage.
+```yaml
+# Before — two steps
+steps:
+  - run: npx tsc --noEmit
+  - run: npx rslint .
 
-To enable full type checking for these files, add them to your tsconfig's `include` or create a separate tsconfig that covers them.
+# After — one combined step
+steps:
+  - run: npx rslint --type-check .
+```
 
-## Interaction with Other Flags
+For inline annotations on PR diffs:
 
-| Flag             | Behavior with `--type-check`                                                     |
-| ---------------- | -------------------------------------------------------------------------------- |
-| `--fix`          | Applies lint auto-fixes as usual. Type errors have no auto-fix.                  |
-| `--quiet`        | Suppresses warnings. Type errors (severity `error`) are always shown.            |
-| `--format`       | Type errors are rendered in the chosen format (`default`, `jsonline`, `github`). |
-| `--max-warnings` | Only counts lint warnings, not type errors (which are always `error`).           |
+```yaml
+- run: npx rslint --type-check --format github .
+```
+
+If your CI keeps lint and type-check as separate jobs, use `--type-check-only` in the type-check job:
+
+```yaml
+jobs:
+  type-check:
+    steps:
+      - run: npx rslint --type-check-only .
+  lint:
+    steps:
+      - run: npx rslint .
+```
+
+## `--type-check-only`
+
+Skips every lint rule and runs only the type-check phase. Use this when CI splits "type-check" and "lint" into separate steps and you want the type-check step to pay zero lint-side cost.
+
+```bash
+rslint --type-check-only .
+```
+
+`--type-check-only` implies `--type-check`; passing both is redundant.
+
+### vs. `--type-check`
+
+| Flag                | Lint rules | Type diagnostics | Suppresses lint-phase warnings <sup>\*</sup> |
+| ------------------- | :--------: | :--------------: | :------------------------------------------: |
+| `--type-check`      |     ✓      |        ✓         |                      no                      |
+| `--type-check-only` |     ✗      |        ✓         |                     yes                      |
+
+<sup>\*</sup> The lint phase emits per-file stderr warnings like `<file> was not found in the project, skipping` and `<file> is ignored because of a matching ignore pattern`. In `--type-check-only` the lint phase doesn't run, so these are suppressed — they would otherwise mislead users into thinking the file wasn't type-checked, when in fact Phase 2 is independent of CLI scope and rslint ignores (see [What gets type-checked](#what-gets-type-checked)).
+
+## Flag matrix
+
+| Flag             | `--type-check`                                       | `--type-check-only`                          |
+| ---------------- | ---------------------------------------------------- | -------------------------------------------- |
+| `--fix`          | Applies lint fixes. Type errors have no auto-fix.    | **Rejected** (exit code 2).                  |
+| `--rule`         | Overrides lint rules normally.                       | **Rejected** (exit code 2).                  |
+| `--quiet`        | Suppresses warnings; type errors always shown.       | No-op — the lint phase produces nothing.     |
+| `--format`       | Type errors rendered in the chosen format.           | Same.                                        |
+| `--max-warnings` | Counts lint warnings only.                           | Always zero warnings (lint phase skipped).   |
+| File/dir args    | Restricts lint scope. Type-check stays program-wide. | Lint skipped. Type-check still program-wide. |


### PR DESCRIPTION
## Summary

Adds `--type-check-only`, which runs **only** TypeScript type checking and skips every lint rule. Designed as a direct CI-side replacement for `tsgo --noEmit` so a single rslint invocation can stand in for the standalone type-check step.

**Contract**

- Implies `--type-check`.
- Type-check scope is decided entirely by the tsconfig(s) referenced from `parserOptions.project`. rslint-side `files` / `ignores` / `.gitignore` do **not** affect it (matches the existing `--type-check` ↔ `tsgo --noEmit` alignment commitment in `website/docs/en/guide/type-checking.md`).
- Mutually exclusive with `--fix` and `--rule` (both depend on the lint phase that this mode disables) — rejected with exit code 2.
- Gap-fallback programs (files matched by config `files` but not in any tsconfig) remain excluded from type-check, same as `--type-check`.

**Output**

```text
$ rslint --type-check-only .

  TypeScript(TS2322)  — [error] Type 'string' is not assignable to type 'number'.
  ╭─┴──────────( bad.ts:1:7 )─────
  │ 1 │  const x: number = "wrong type";
  ╰────────────────────────────────

Found 1 type error (type-checked 1 file in 283ms using 10 threads)
```

**Implementation notes**

- `RunLinter` now skips Phase 1 entirely when `GetRulesForFile == nil` — no work group, no `buildOwnedFileSet`, no goroutines. Phase 2 (type-check) runs unchanged.
- Pulled the flag-compatibility policy into `validateTypeCheckOnlyFlags` so it's unit-testable.
- Pulled the existing "scope restricted but no files linted → exit 0" short-circuit into `shouldShortCircuitOutput` and guarded it so type-check-only mode never takes that path (where `LintedFileCount` is always 0 by design). This was caught during end-to-end smoke testing and would otherwise have silently swallowed all type diagnostics.
- Fixed a stale comment in `programs.go` that claimed config `ignores` were applied to type-check too — they aren't, and the contract docs say they shouldn't be.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).