### PR TITLE
feat: port rule jsx-a11y/aria-activedescendant-has-tabindex

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/alt_text"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/anchor_has_content"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/anchor_is_valid"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_unsupported_elements"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/autocomplete_valid"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/heading_has_content"
@@ -26,6 +27,7 @@ func GetAllRules() []rule.Rule {
 		alt_text.AltTextRule,
 		anchor_has_content.AnchorHasContentRule,
 		anchor_is_valid.AnchorIsValidRule,
+		aria_activedescendant_has_tabindex.AriaActivedescendantHasTabindexRule,
 		aria_unsupported_elements.AriaUnsupportedElementsRule,
 		autocomplete_valid.AutocompleteValidRule,
 		heading_has_content.HeadingHasContentRule,

--- a/internal/plugins/jsx_a11y/jsxa11yutil/interactive.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/interactive.go
@@ -52,9 +52,10 @@ type elementAttrSchema struct {
 }
 
 // interactiveRolesSet is the set of roles whose `superClass` chain contains
-// `widget`, MINUS `progressbar` (treated as readonly hence non-interactive),
-// PLUS `toolbar` (does not descend from widget but supports
-// aria-activedescendant). Mirrors upstream's `interactiveRoles` Set.
+// `widget`, PLUS `toolbar` (does not descend from widget but supports
+// aria-activedescendant). Mirrors upstream's `interactiveRoles` Set, which
+// is derived from aria-query and includes `progressbar` (a widget
+// descendant via `range`).
 var interactiveRolesSet = map[string]struct{}{
 	"button":           {},
 	"checkbox":         {},
@@ -74,6 +75,7 @@ var interactiveRolesSet = map[string]struct{}{
 	"menuitemcheckbox": {},
 	"menuitemradio":    {},
 	"option":           {},
+	"progressbar":      {},
 	"radio":            {},
 	"radiogroup":       {},
 	"row":              {},
@@ -126,7 +128,7 @@ var nonInteractiveRoleNames = []string{
 	"graphics-document", "graphics-object", "graphics-symbol",
 	"group", "heading", "img", "insertion", "list", "listitem", "log",
 	"main", "mark", "marquee", "math", "meter", "navigation", "none",
-	"note", "paragraph", "presentation", "progressbar", "region",
+	"note", "paragraph", "presentation", "region",
 	"rowgroup", "search", "separator", "status", "strong", "subscript",
 	"superscript", "table", "tabpanel", "term", "time", "timer",
 	"tooltip",

--- a/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
@@ -891,6 +891,12 @@ func literalPropValue(node *ast.Node) jsValue {
 		// model the actual contents — for our purposes (just truthy?) any
 		// array (empty or not) is truthy in JS, so jsTruthy is enough.
 		return jsTruthy
+	case ast.KindDeleteExpression:
+		// LITERAL_TYPES inherits TYPES.UnaryExpression which for `delete x`
+		// returns boolean true (the runtime value of the operator on a
+		// deletable target). Surfacing as jvBool here lets GetTabIndexEx's
+		// step-1 boolean arm short-circuit to undefined, matching upstream.
+		return jsValue{Kind: jvBool, Bool: true}
 	}
 	// All other expressions (Call, Member, Conditional, Logical, Binary, etc.)
 	// → noop → null per LITERAL_TYPES. Returning jvNull marks them as falsy

--- a/internal/plugins/jsx_a11y/jsxa11yutil/tabindex.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/tabindex.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	jsxtx "github.com/microsoft/typescript-go/shim/transformers/jsxtransforms"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -101,25 +102,104 @@ func IsNonLiteralProperty(attrs []*ast.Node, propName string) bool {
 // upstream skips the `Number.isInteger` filter and lets JS's loose `>=`
 // handle string / boolean / number identically).
 //
-// Returns (0, false) when:
+// Returns (0, false) when upstream would yield either `undefined` or `null`.
+// Callers that need to distinguish the two — because they implement an
+// upstream comparison like `tabIndex >= -1` whose result diverges between
+// `undefined >= -1` (NaN, false) and `null >= -1` (ToNumber(null)=0, true) —
+// must use [GetTabIndexEx] instead.
+//
+// Specifically, (0, false) covers:
 //   - the prop is absent / boolean-form (getPropValue would yield true →
 //     undefined per the step-1 boolean arm)
 //   - the literal value is an empty string / non-integer number / NaN
 //   - the literal value is a boolean (step-1 boolean arm)
 //   - getPropValue cannot statically resolve the expression
-func GetTabIndex(attr *ast.Node) (float64, bool) {
+func GetTabIndex(attr *ast.Node, sourceText string) (float64, bool) {
+	val, resolved, _ := GetTabIndexEx(attr, sourceText)
+	return val, resolved
+}
+
+// GetTabIndexEx mirrors upstream `getTabIndex(getProp(attrs, 'tabIndex'))`
+// with explicit two-state classification of the unresolved case. Used by
+// callers whose downstream comparison is loose JS `>=` / `>` / `<=` / `<`
+// against a number, where `null` and `undefined` differ:
+//
+//	null >= -1      → ToNumber(null) = 0      → true
+//	undefined >= -1 → ToNumber(undefined) = NaN → false
+//
+// Returns:
+//   - (val, true,  false) — upstream resolved a usable Number. Callers
+//     compare `val` directly.
+//   - (0,   false, false) — upstream would yield `undefined`. Callers should
+//     treat the comparison `tabIndex op N` as if `undefined op N` (NaN, so
+//     all loose comparisons are false).
+//   - (0,   false, true)  — upstream would yield `null`. Callers should
+//     treat the comparison as if `null op N` (ToNumber(null)=0, so JS-loose
+//     comparison applies).
+//
+// The undefined-vs-null split mirrors jsx-ast-utils' two extraction paths:
+// step-1 `getLiteralPropValue` returns undefined for boolean form / empty
+// string / NaN-coercing literal / boolean literal; step-2 `getPropValue`
+// returns null for any ESTree expression type its TYPES table does not
+// recognize (TSSatisfiesExpression, AwaitExpression, YieldExpression,
+// ImportExpression, ...).
+func GetTabIndexEx(attr *ast.Node, sourceText string) (val float64, resolved bool, nullLike bool) {
 	if attr == nil {
-		return 0, false
+		// upstream: getProp(attrs, 'tabIndex') === undefined → getTabIndex
+		// passes undefined through unchanged.
+		return 0, false, false
 	}
 	if AttributeIsBooleanForm(attr) {
 		// `<div tabIndex />` — extractValue's null-attribute-value path
 		// produces JS boolean `true`, which upstream's getTabIndex passes
 		// through to its `=== true` branch → undefined.
-		return 0, false
+		return 0, false, false
 	}
+
+	// Direct StringLiteral JsxAttribute (`tabIndex="…"`, NOT
+	// `tabIndex={"…"}` which wraps in JsxExpression) carries HTML-style
+	// attribute text. ESTree parsers decode HTML entities (`&#49;`→"1",
+	// `&nbsp;`→U+00A0, …) before passing the value to lint rules; tsgo
+	// keeps the raw `&…;` source in StringLiteral.Text, so we apply
+	// DecodeEntities here to realign with upstream getLiteralPropValue
+	// output for this shape. The decoded string then routes through the
+	// same step-1 classification as a plain StringLiteral.
+	if attr.Kind == ast.KindJsxAttribute {
+		if init := attr.AsJsxAttribute().Initializer; init != nil && init.Kind == ast.KindStringLiteral {
+			decoded := jsxtx.DecodeEntities(init.AsStringLiteral().Text)
+			return classifyTabIndexString(decoded)
+		}
+	}
+
 	inner := attributeInnerExpression(attr)
 	if inner == nil {
-		return 0, false
+		// `<div tabIndex={} />` — empty JsxExpression body / JSXEmptyExpression.
+		// jsx-ast-utils' TYPES has no entry for JSXEmptyExpression → noop →
+		// null. Downstream `null >= 0` ToNumber-coerces to true, so upstream
+		// reports. Classify as null-like to mirror.
+		return 0, false, true
+	}
+
+	// Template literals — upstream's TemplateLiteral extractor reads
+	// `quasi.value.raw` (literal source between back-ticks), NOT the
+	// cooked `.Text` field. Override here before the literalPropValue
+	// dispatch (which uses cooked text and is shared with other a11y
+	// rules that care about truthiness rather than ToNumber coercion).
+	if inner.Kind == ast.KindNoSubstitutionTemplateLiteral {
+		return classifyTabIndexString(rawTemplateLiteralText(inner, sourceText))
+	}
+	if inner.Kind == ast.KindTemplateExpression {
+		v := templateExpressionRawText(inner.AsTemplateExpression(), sourceText)
+		return classifyTabIndexString(v.Str)
+	}
+
+	// Cluster A: TSNonNullExpression — upstream's TSNonNullExpression
+	// extractor stringifies (`0!` → "0!", `(0)!` → "0!", `x!` → "x!"). The
+	// resulting string always contains `!` and ToNumbers to NaN, so step-1
+	// resolves to undefined. Without this branch staticEval's
+	// OEKNonNullAssertions strip would resolve `0!` to the bare 0 — wrong.
+	if inner.Kind == ast.KindNonNullExpression {
+		return 0, false, false
 	}
 
 	// Step 1: getLiteralPropValue path — upstream applies the integer
@@ -128,13 +208,34 @@ func GetTabIndex(attr *ast.Node) (float64, bool) {
 	switch literalV.Kind {
 	case jvString:
 		if literalV.Str == "" {
-			return 0, false
+			// upstream `length === 0` short-circuit → undefined.
+			return 0, false, false
 		}
-		return parseLiteralTabIndexString(literalV.Str)
+		if v, ok := parseLiteralTabIndexString(literalV.Str); ok {
+			return v, true, false
+		}
+		// upstream `Number.isNaN(value)` → undefined.
+		return 0, false, false
 	case jvNumber:
-		return parseLiteralTabIndexFloat(literalV.Num)
+		if v, ok := parseLiteralTabIndexFloat(literalV.Num); ok {
+			return v, true, false
+		}
+		// upstream `Number.isInteger(value) ? value : undefined`.
+		return 0, false, false
 	case jvBool:
-		return 0, false
+		// upstream step-1 boolean arm → undefined.
+		return 0, false, false
+	case jvBigInt:
+		// Cluster B: BigInt literal. Upstream getLiteralPropValue returns
+		// the BigInt; getTabIndex falls through to step-2 (typeof bigint is
+		// not 'string'/'number'/bool) → returns the BigInt → downstream
+		// `>=` ToNumber-coerces (`Number(0n)=0`, `Number(-1n)=-1`,
+		// out-of-range → ±Infinity). Match by computing Number(BigInt)
+		// directly and surfacing it as resolved.
+		if n, ok := jsValueToNumber(literalV); ok {
+			return n, true, false
+		}
+		return 0, false, false
 	}
 
 	// Step 2: getPropValue fallback — covers expressions that LITERAL_TYPES
@@ -150,65 +251,88 @@ func GetTabIndex(attr *ast.Node) (float64, bool) {
 	// downstream `>= 0` coercion needs. They are kept local to GetTabIndex
 	// so the shared staticEval engine is not affected.
 	if inner.Kind == ast.KindArrayLiteralExpression {
-		return arrayToTabIndex(inner)
+		// Cluster F: route through arrayLiteralPropToTabIndexString (same
+		// engine tabindex-no-positive uses) — it handles nested arrays via
+		// recursion, unary on non-number operands via the TYPES.UnaryExpression
+		// protocol, and ObjectExpression / RegExp / function / JsxElement
+		// via jsToString (which produces non-empty non-numeric strings →
+		// downstream NaN). The pre-Ex inline arrayToTabIndex lost precision
+		// on these by collapsing jsTruthy to "" → 0.
+		arrV := arrayLiteralPropToTabIndexString(inner, sourceText)
+		if n, ok := jsValueToNumber(arrV); ok && !math.IsNaN(n) {
+			return n, true, false
+		}
+		return 0, false, false
 	}
 	if inner.Kind == ast.KindPrefixUnaryExpression {
-		if val, ok, applicable := unaryStringToTabIndex(inner); applicable {
-			return val, ok
+		if v, ok, applicable := unaryStringToTabIndex(inner); applicable {
+			if ok {
+				return v, true, false
+			}
+			return 0, false, false
+		}
+		// Cluster E: jsx-ast-utils' UnaryExpression handler ToNumber-coerces
+		// the operand before applying `+` / `-` / `~`. Our staticEvalUnary
+		// only computes when operand is already jvNumber, so `+undefined`,
+		// `-true`, `~null`, etc. fall through to its jsNull return → in
+		// our previous Ex impl that landed on nullLike → REPORT (wrong).
+		// Mirror upstream by running ToNumber on the operand here.
+		un := inner.AsPrefixUnaryExpression()
+		if un.Operator == ast.KindPlusToken || un.Operator == ast.KindMinusToken || un.Operator == ast.KindTildeToken || un.Operator == ast.KindExclamationToken {
+			opV := unaryLiteralPropToTabIndexJsValue(un)
+			if n, ok := jsValueToNumber(opV); ok {
+				if !math.IsNaN(n) {
+					return n, true, false
+				}
+			}
+			return 0, false, false
 		}
 	}
 	staticV := staticEval(inner)
-	return staticEvalToTabIndex(staticV)
+	if v, ok := staticEvalToTabIndex(staticV); ok {
+		return v, true, false
+	}
+	// staticEvalToTabIndex failed — classify by the inner sentinel:
+	//   - jvNull, jvUnknown → upstream's "TYPES has no entry" / explicit
+	//     AwaitExpression / YieldExpression / TSSatisfiesExpression / etc.
+	//     → returns null. null-like.
+	//   - jvUndef → upstream resolved to undefined (jvx Identifier
+	//     `undefined`, void/typeof, ...) → undefined-like.
+	//   - jvFunction / jvTruthy / jvBool / jvBigInt → upstream resolved to
+	//     a non-numeric truthy that ToNumber-coerces to NaN (or, for
+	//     BigInt, to a number our extractor doesn't yet model) → in either
+	//     case the loose `>= -1` lands on the same arm as undefined. We
+	//     classify as undefined-like to keep callers reporting on these
+	//     until BigInt support is added (see TODO above arrayToTabIndex
+	//     for the BigInt expansion path).
+	switch staticV.Kind {
+	case jvNull, jvUnknown:
+		return 0, false, true
+	}
+	return 0, false, false
 }
 
-// arrayToTabIndex models JS `ToPrimitive(array, "default") → ToNumber` for
-// an ArrayLiteralExpression as the tabIndex value. Mirrors upstream's
-// getPropValue → ArrayExpression extractor + downstream `>= 0` coercion.
-//
-// Per spec (ECMA-262 Array.prototype.join):
-//   - undefined / null / sparse elements stringify to "" (NOT "undefined" /
-//     "null").
-//   - other elements use String(element).
-//
-// Joined with "," then fed through ToNumber. Examples:
-//
-//	[]            → ""          → 0
-//	[5]           → "5"         → 5
-//	[1, 2]        → "1,2"       → NaN
-//	[null]        → ""          → 0
-//	[Infinity]    → "Infinity"  → +Inf (≥0 → reports)
-//	[-1]          → "-1"        → -1  (<0 → skips)
-func arrayToTabIndex(node *ast.Node) (float64, bool) {
-	if node == nil || node.Kind != ast.KindArrayLiteralExpression {
-		return 0, false
+// classifyTabIndexString applies upstream getTabIndex's step-1 string
+// semantics to an already-extracted string value (post-entity-decode for
+// direct attribute strings; raw quasi text for templates). Returns the
+// same three-state result as GetTabIndexEx.
+func classifyTabIndexString(s string) (float64, bool, bool) {
+	if s == "" {
+		// upstream `length === 0` short-circuit → undefined.
+		return 0, false, false
 	}
-	arr := node.AsArrayLiteralExpression()
-	var elements []*ast.Node
-	if arr != nil && arr.Elements != nil {
-		elements = arr.Elements.Nodes
+	// jsx-ast-utils' Literal extractor coerces case-insensitive "true" /
+	// "false" string values to actual booleans, which upstream's
+	// getTabIndex then routes to its boolean arm → undefined.
+	switch strings.ToLower(s) {
+	case "true", "false":
+		return 0, false, false
 	}
-	if len(elements) == 0 {
-		// `[].toString() == ""` → ToNumber("") = 0.
-		return 0, true
+	if v, ok := parseLiteralTabIndexString(s); ok {
+		return v, true, false
 	}
-	parts := make([]string, 0, len(elements))
-	for _, el := range elements {
-		if el == nil {
-			parts = append(parts, "")
-			continue
-		}
-		ev := staticEval(el)
-		switch ev.Kind {
-		case jvNull, jvUndef, jvUnknown:
-			// Array.prototype.join special-cases null/undefined to "".
-			// Unknown (statically unresolvable) values fall through the
-			// same way — upstream's noop → null → "" via Array.join.
-			parts = append(parts, "")
-		default:
-			parts = append(parts, jsToString(ev))
-		}
-	}
-	return staticEvalToTabIndex(jsValue{Kind: jvString, Str: strings.Join(parts, ",")})
+	// upstream `Number.isNaN(value)` → undefined.
+	return 0, false, false
 }
 
 // unaryStringToTabIndex models JS unary `+x` / `-x` ToNumber coercion for
@@ -373,6 +497,9 @@ func staticEvalToTabIndex(v jsValue) (float64, bool) {
 			return 1, true
 		}
 		return 0, true
+	case jvBigInt:
+		// Mirror JS Number(bigint): floors to Float64 (out-of-range → ±Inf).
+		return jsValueToNumber(v)
 	}
 	return 0, false
 }

--- a/internal/plugins/jsx_a11y/jsxa11yutil/tabindex_no_positive.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/tabindex_no_positive.go
@@ -324,6 +324,17 @@ func arrayElementToString(el *ast.Node, sourceText string) string {
 		// the same way — upstream's TYPES path returns null for unknowns
 		// and Array.join then writes "".
 		return ""
+	case jvTruthy:
+		// Objects / regex / array literals stringify via toString:
+		// `String({})` = "[object Object]", `String(/foo/)` = "/foo/", ...
+		// All non-empty non-numeric strings → Number(...) = NaN downstream,
+		// which is what upstream's array-join arm ends up with too. A stable
+		// placeholder suffices; the exact text isn't observed by any rule.
+		return "(obj)"
+	case jvFunction:
+		// Functions / arrow functions stringify to source code; same
+		// downstream behaviour as objects (NaN). Use a stable placeholder.
+		return "(fn)"
 	}
 	return jsToString(ev)
 }

--- a/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex.go
+++ b/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex.go
@@ -1,0 +1,113 @@
+// Package aria_activedescendant_has_tabindex ports eslint-plugin-jsx-a11y's
+// `aria-activedescendant-has-tabindex` rule. The rule enforces that any DOM
+// element managing focus via `aria-activedescendant` is tabbable — i.e.
+// either inherently focusable (input, button, ...) without a custom
+// `tabIndex`, or carrying an explicit `tabIndex >= -1`. A negative value
+// other than `-1` removes the element from the focus tree, defeating the
+// activedescendant pattern (WAI-ARIA Authoring Practices §3.10).
+//
+// Upstream signature: no options — schema is `generateObjSchema()` (an
+// empty object).
+//
+// Trigger: a JsxOpeningElement / JsxSelfClosingElement that
+//
+//  1. carries an `aria-activedescendant` prop (case-insensitive,
+//     boolean form / `={undefined}` / `={null}` all count — `getProp`
+//     returns the attribute regardless of value),
+//  2. resolves to a DOM element name per aria-query's `dom` map
+//     (custom components / `Foo.Bar` / namespaced `svg:path` are skipped),
+//  3. is NOT both inherently interactive (input/button/option/...) AND
+//     missing a `tabIndex` (those rely on the browser-native tab order),
+//  4. has `tabIndex < -1` or no resolvable `tabIndex` value.
+//
+// The diagnostic is reported on the JSX opening element node itself
+// (matches upstream `context.report({ node, ... })` where `node` is the
+// JSXOpeningElement).
+package aria_activedescendant_has_tabindex
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// errorMessage mirrors upstream's `errorMessage` string verbatim.
+const errorMessage = "An element that manages focus with `aria-activedescendant` must have a tabindex"
+
+var AriaActivedescendantHasTabindexRule = rule.Rule{
+	Name: "jsx-a11y/aria-activedescendant-has-tabindex",
+	Run: func(ctx rule.RuleContext, _ any) rule.RuleListeners {
+		// sourceText is required by GetTabIndexEx for raw-text template
+		// literal extraction (NoSubstitutionTemplate has no RawText field).
+		sourceText := ctx.SourceFile.Text()
+		check := func(node *ast.Node) {
+			attrs := reactutil.GetJsxElementAttributes(node)
+
+			// gate-1: `getProp(attributes, 'aria-activedescendant') === undefined`.
+			// FindAttributeByName mirrors jsx-ast-utils' `getProp` with default
+			// `ignoreCase: true`, so `Aria-ActiveDescendant` matches the same
+			// as `aria-activedescendant`. Boolean attribute form
+			// (`<div aria-activedescendant />`) and explicit-undefined value
+			// (`<div aria-activedescendant={undefined} />`) BOTH return a
+			// non-nil node here — `getProp` returns the attribute regardless
+			// of value, so gate-1 only short-circuits when the prop is truly
+			// absent.
+			if jsxa11yutil.FindAttributeByName(attrs, "aria-activedescendant") == nil {
+				return
+			}
+
+			// gate-2: `!dom.has(type)`. Resolve via `getElementType` so the
+			// `polymorphicPropName` / `components` map settings are honored
+			// (e.g. `<CustomComponent />` mapped to `div` participates in the
+			// rule). Custom components, dotted-namespace tags (`Foo.Bar`),
+			// and SVG-namespaced tags (`svg:path`) all fall outside the
+			// aria-query DOM set and skip silently.
+			elementType := jsxa11yutil.GetElementType(node, ctx.Settings)
+			if !jsxa11yutil.IsDOMElement(elementType) {
+				return
+			}
+
+			// gate-3: `isInteractiveElement(type, attributes) && tabIndex === undefined`.
+			// upstream's `tabIndex === undefined` is strict equality, so it
+			// matches only when getTabIndex's step-1 short-circuited (boolean
+			// form, empty string, NaN, missing prop). The step-2 fallback
+			// returns `null` for unrecognized expression types, and `null
+			// === undefined` is false, so gate-3 must NOT skip in that case.
+			// GetTabIndexEx surfaces the distinction via nullLike.
+			tabIndexProp := jsxa11yutil.FindAttributeByName(attrs, "tabIndex")
+			tabIndex, hasTabIndex, nullLike := jsxa11yutil.GetTabIndexEx(tabIndexProp, sourceText)
+			if !hasTabIndex && !nullLike && jsxa11yutil.IsInteractiveElement(elementType, attrs) {
+				return
+			}
+
+			// gate-4: `tabIndex >= -1`. Two arms:
+			//   - resolved Number: direct numeric `>= -1`.
+			//   - upstream-null (nullLike): JS `null >= -1` ToNumber-coerces
+			//     to `0 >= -1` = true → skip. This arm applies to
+			//     TSSatisfiesExpression, AwaitExpression, YieldExpression,
+			//     ImportExpression, and any future ESTree expression type
+			//     jsx-ast-utils' TYPES table doesn't recognize. Without
+			//     this arm rslint would over-report relative to upstream;
+			//     with it the contract is byte-for-byte aligned.
+			// undefined-like (`!hasTabIndex && !nullLike`) falls through to
+			// the report — `undefined >= -1` is false in JS.
+			if hasTabIndex && tabIndex >= -1 {
+				return
+			}
+			if nullLike {
+				return
+			}
+
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "tabIndexRequired",
+				Description: errorMessage,
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex.md
+++ b/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex.md
@@ -1,0 +1,57 @@
+# aria-activedescendant-has-tabindex
+
+## Rule Details
+
+Enforces that any DOM element managing focus via `aria-activedescendant` is itself reachable by keyboard. An element using `aria-activedescendant` to indicate the currently focused descendant must either be a natively focusable element (`<input>`, `<button>`, `<select>`, etc.) or carry a `tabIndex` of `-1` or greater. A `tabIndex` of `-2` or lower removes the element from the focus tree, which defeats the activedescendant pattern.
+
+The rule fires on a JSX opening element when **all** of the following hold:
+
+- The element has an `aria-activedescendant` prop (case-insensitively; the
+  boolean form `<div aria-activedescendant />` and explicit-undefined value
+  `<div aria-activedescendant={undefined} />` both count as present).
+- The resolved element name is in the HTML DOM set (custom React components,
+  SVG-namespaced tags like `<svg:path>`, and dotted-namespace tags like
+  `<Foo.Bar>` are skipped — the rule does not know what low-level element
+  they render to).
+- The element is not both inherently interactive (`<input>`, `<button>`,
+  `<select>`, …) **and** missing a `tabIndex` prop. Inherently interactive
+  elements rely on the browser-native tab order, so they don't need an
+  explicit `tabIndex`.
+- The element's resolved `tabIndex` value is less than `-1` (or cannot be
+  statically resolved to a number `>= -1`).
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div aria-activedescendant={someID} />
+<div aria-activedescendant={someID} tabIndex={-2} />
+<ul aria-activedescendant={focusedId}><li>x</li></ul>
+<section aria-activedescendant={x} tabIndex={-100}>content</section>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div aria-activedescendant={someID} tabIndex={0} />
+<div aria-activedescendant={someID} tabIndex={-1} />
+<div aria-activedescendant={someID} tabIndex="0" />
+<input aria-activedescendant={someID} />
+<button aria-activedescendant={someID} />
+<a href="#" aria-activedescendant={someID} />
+<CustomComponent aria-activedescendant={someID} />
+```
+
+## Rule Options
+
+This rule takes no options.
+
+## Resources
+
+- [WAI-ARIA — `aria-activedescendant`](https://www.w3.org/TR/wai-aria-1.2/#aria-activedescendant)
+- [WAI-ARIA Authoring Practices — Managing Focus in Composites Using aria-activedescendant](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#managingfocusincompositesusingaria-activedescendant)
+- [MDN — `aria-activedescendant`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant)
+- [MDN — `tabindex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/tabindex)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/aria-activedescendant-has-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-activedescendant-has-tabindex.md)

--- a/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex_extras_test.go
@@ -1,0 +1,432 @@
+package aria_activedescendant_has_tabindex
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// polymorphicSettings mirrors anchor_is_valid's `polymorphicSettings` —
+// `polymorphicPropName: 'as'` makes `getElementType` rewrite the tag name
+// from the literal `as=` value before the dom.has() / interactive checks
+// run, so `<Box as="div" />` resolves to `div`.
+var polymorphicSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+	},
+}
+
+// TestAriaActivedescendantHasTabindexExtras locks in behavior on inputs the
+// upstream test suite does NOT exercise. Each block is annotated with the
+// upstream branch / jsx-ast-utils helper it covers so future audits can
+// trace each case to a specific arm.
+func TestAriaActivedescendantHasTabindexExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AriaActivedescendantHasTabindexRule, []rule_tester.ValidTestCase{
+		// ---- Case-insensitive prop match (jsx-ast-utils `getProp` ignoreCase: true) ----
+		// `Aria-ActiveDescendant` matches the same as `aria-activedescendant`.
+		// Tabbable (tabIndex={0}) so the rule doesn't fire — locks in only
+		// the case-folding path; case-insensitive INVALID is in the invalid
+		// section below.
+		{Code: `<div Aria-ActiveDescendant={x} tabIndex={0} />;`, Tsx: true},
+
+		// ---- gate-3: interactive elements skip when tabIndex is undefined ----
+		// `<a href>` is interactive (interactiveElementRoleSchemas requires
+		// `href` for `a`); no tabIndex → gate-3 takes the skip arm. Upstream
+		// covers <input> but not <a href>; this case locks the schema entry.
+		{Code: `<a href="#" aria-activedescendant={x} />;`, Tsx: true},
+		// `<button>` is unconditionally interactive — interactiveElementRoleSchemas
+		// has a no-attribute entry for it. Locks the bare-button arm.
+		{Code: `<button aria-activedescendant={x} />;`, Tsx: true},
+		// `<select size={1}>` is interactive via the size-attribute schema
+		// entry. Locks an attribute-conditional interactive arm.
+		{Code: `<select size={1} aria-activedescendant={x} />;`, Tsx: true},
+
+		// ---- gate-2: non-DOM tag forms ----
+		// SVG-namespaced tag — tsgo exposes the colon in the tag name, which
+		// is not in aria-query's dom map → gate-2 skip.
+		{Code: `<svg:path aria-activedescendant={x} />;`, Tsx: true},
+		// Dotted-namespace tag — `Foo.Bar` isn't in dom map → gate-2 skip.
+		// Locks that GetElementType doesn't accidentally split on the dot.
+		{Code: `<Foo.Bar aria-activedescendant={x} />;`, Tsx: true},
+
+		// ---- gate-2: components map / polymorphic resolution ----
+		// `<Box as="span" />` → resolved tag is "span", which IS in dom map.
+		// Span is non-interactive but tabIndex={0} → gate-4 skips.
+		{Code: `<Box as="span" aria-activedescendant={x} tabIndex={0} />;`, Tsx: true, Settings: polymorphicSettings},
+
+		// ---- gate-4: tabIndex exactly at boundary ----
+		// `tabIndex={-1}` is the minimum valid value (programmatic-only focus).
+		{Code: `<div aria-activedescendant={x} tabIndex={-1} />;`, Tsx: true},
+		// String "1" — string-numeric coerces via GetTabIndex's
+		// StringToNumber path; gate-4 1 >= -1 → skip.
+		{Code: `<div aria-activedescendant={x} tabIndex="1" />;`, Tsx: true},
+
+		// ---- Nested JSX — only inner element matches when outer doesn't ----
+		// Outer span has no aria-activedescendant; inner div has activedescendant
+		// + tabIndex={0} → both arms skip independently.
+		{Code: `<span><div aria-activedescendant={x} tabIndex={0} /></span>;`, Tsx: true},
+
+		// ---- Spread without literal `aria-activedescendant` ----
+		// Spread payload is opaque (not a literal ObjectExpression); upstream's
+		// `getProp` returns undefined → gate-1 skip. Same as `<div />`.
+		{Code: `<div {...props} />;`, Tsx: true},
+
+		// ---- Literal-spread tabIndex tracking ----
+		// jsx-ast-utils' `getProp` walks literal-object spreads when the key
+		// is an Identifier (`tabIndex`). FindAttributeByName mirrors this; the
+		// resolved PropertyAssignment routes through GetTabIndex's literal
+		// path identically to a direct JsxAttribute. Locks the spread→prop
+		// resolution chain end-to-end.
+		{Code: `<div aria-activedescendant={x} {...{tabIndex: 0}} />;`, Tsx: true},
+
+		// ---- TS-wrapper unwrapping in tabIndex value (paren / as / !) ----
+		// GetTabIndex routes through staticEval which strips parens / `as` /
+		// non-null via OEKParentheses|OEKTypeAssertions|OEKNonNullAssertions.
+		// Each wrapper variant must resolve to 0 (>= -1 → skip). `satisfies`
+		// is handled separately (see Differences from ESLint in the .md and
+		// the matching invalid lock-ins below).
+		{Code: `<div aria-activedescendant={x} tabIndex={(0)} />;`, Tsx: true},
+		{Code: `<div aria-activedescendant={x} tabIndex={(0 as number)} />;`, Tsx: true},
+		// Note: TSNonNullExpression `0!` / `(0)!` is INVALID per upstream —
+		// jsx-ast-utils' TSNonNullExpression extractor stringifies to "0!"
+		// → Number("0!") = NaN → undefined → aria gate-4 fails → REPORT.
+		// Lock-in lives in the invalid section.
+
+		// ---- NoSubstitutionTemplateLiteral tabIndex ----
+		// `` `-1` `` reaches the template-literal extractor (NOT the
+		// "true"/"false" → bool coercion), yielding the string "-1" → -1
+		// via GetTabIndex's StringToNumber. -1 >= -1 → skip.
+		{Code: "<div aria-activedescendant={x} tabIndex={`-1`} />;", Tsx: true},
+		{Code: "<div aria-activedescendant={x} tabIndex={`0`} />;", Tsx: true},
+
+		// ---- Opaque expression types resolve to upstream `null` ----
+		// jsx-ast-utils' getPropValue returns `null` for any ESTree expression
+		// type its TYPES table doesn't recognize (TSSatisfiesExpression,
+		// AwaitExpression, YieldExpression, ...). Upstream's downstream
+		// `tabIndex >= -1` then ToNumber-coerces null to 0, evaluates
+		// `0 >= -1` true, and skips. rslint's GetTabIndexEx surfaces this as
+		// `nullLike`, and the rule's gate-4 takes the matching skip arm.
+		// These cases lock the contract aligned with upstream byte-for-byte.
+		{Code: `<div aria-activedescendant={x} tabIndex={0 satisfies number} />;`, Tsx: true},
+		{Code: `<div aria-activedescendant={x} tabIndex={(-2) satisfies number} />;`, Tsx: true},
+		{Code: `async function f() { return <div aria-activedescendant={x} tabIndex={await p} />; }`, Tsx: true},
+		{Code: `function* g() { yield <div aria-activedescendant={x} tabIndex={yield 0} />; }`, Tsx: true},
+
+		// ---- Comments around the attribute don't suppress detection ----
+		// Trivia is whitespace-equivalent for the listener; the attribute
+		// resolves identically. Locks against accidental trivia-driven
+		// regressions in FindAttributeByName / GetTabIndex.
+		{Code: `<div /* before */ aria-activedescendant={x} /* mid */ tabIndex={0} /* after */ />;`, Tsx: true},
+
+		// ============================================================
+		// Expression-form coverage for tabIndex value (valid arms)
+		// ============================================================
+		// ConditionalExpression — both branches valid (>= -1). Upstream's
+		// ConditionalExpression extractor evaluates the test arm; for unknown
+		// identifiers truthy-default, so whenTrue is taken.
+		{Code: `<div aria-activedescendant={x} tabIndex={cond ? 0 : -1} />;`, Tsx: true},
+		// Statically-evaluable test arm: `true` → whenTrue.
+		{Code: `<div aria-activedescendant={x} tabIndex={true ? -1 : -5} />;`, Tsx: true},
+		// Statically-evaluable falsy test arm: `false` → whenFalse.
+		{Code: `<div aria-activedescendant={x} tabIndex={false ? -5 : 0} />;`, Tsx: true},
+
+		// LogicalExpression `??` — null on left, right wins (0).
+		{Code: `<div aria-activedescendant={x} tabIndex={null ?? 0} />;`, Tsx: true},
+
+		// LogicalExpression `||` — number on left wins (1).
+		{Code: `<div aria-activedescendant={x} tabIndex={1 || 5} />;`, Tsx: true},
+
+		// LogicalExpression `&&` — truthy left → right wins (0).
+		{Code: `<div aria-activedescendant={x} tabIndex={true && 0} />;`, Tsx: true},
+
+		// BinaryExpression arithmetic — both operands numeric.
+		{Code: `<div aria-activedescendant={x} tabIndex={1 - 1} />;`, Tsx: true},
+		{Code: `<div aria-activedescendant={x} tabIndex={1 - 2} />;`, Tsx: true},
+		{Code: `<div aria-activedescendant={x} tabIndex={2 * 0} />;`, Tsx: true},
+		{Code: `<div aria-activedescendant={x} tabIndex={10 / 10} />;`, Tsx: true},
+
+		// ArrayLiteralExpression — Array.join with single numeric element.
+		{Code: `<div aria-activedescendant={x} tabIndex={[0]} />;`, Tsx: true},
+		{Code: `<div aria-activedescendant={x} tabIndex={[-1]} />;`, Tsx: true},
+		// Array with null element — Array.join special-cases null to "".
+		{Code: `<div aria-activedescendant={x} tabIndex={[null]} />;`, Tsx: true},
+		// Empty array → "" → Number("") = 0.
+		{Code: `<div aria-activedescendant={x} tabIndex={[]} />;`, Tsx: true},
+
+		// Numeric literal radix variants — all 0.
+		{Code: `<div aria-activedescendant={x} tabIndex={0x0} />;`, Tsx: true},
+		{Code: `<div aria-activedescendant={x} tabIndex={0o0} />;`, Tsx: true},
+		{Code: `<div aria-activedescendant={x} tabIndex={0b0} />;`, Tsx: true},
+		// Scientific notation (1e0 = 1).
+		{Code: `<div aria-activedescendant={x} tabIndex={1e0} />;`, Tsx: true},
+		// Numeric separators (NumericLiteral text "1_000").
+		{Code: `<div aria-activedescendant={x} tabIndex={1_000} />;`, Tsx: true},
+
+		// JS-RESERVED `Infinity` Identifier resolves to +Inf, +Inf >= -1 → skip.
+		// Upstream: getLiteralPropValue → null (Identifier→null per LITERAL_TYPES);
+		// step-2 getPropValue → +Inf via JS_RESERVED extractor; +Inf >= -1 → true.
+		{Code: `<div aria-activedescendant={x} tabIndex={Infinity} />;`, Tsx: true},
+		// Negative-zero — JS `-0 >= -1` is true.
+		{Code: `<div aria-activedescendant={x} tabIndex={-0} />;`, Tsx: true},
+		// Double-unary minus — `-(-2)` = 2.
+		{Code: `<div aria-activedescendant={x} tabIndex={-(-2)} />;`, Tsx: true},
+
+		// Multi-level parentheses — paren-stripping must be transparent.
+		{Code: `<div aria-activedescendant={x} tabIndex={(((-1)))} />;`, Tsx: true},
+
+		// ============================================================
+		// aria-activedescendant value-form coverage (gate-1 only checks
+		// presence, but the value form must not crash the listener)
+		// ============================================================
+		// Direct StringLiteral initializer (HTML-style attribute value).
+		// gate-1 sees the prop; div + no tabIndex would be invalid — so we
+		// keep this valid by adding tabIndex={0}.
+		{Code: `<div aria-activedescendant="staticID" tabIndex={0} />;`, Tsx: true},
+		// NoSubstitutionTemplate as activedescendant value.
+		{Code: "<div aria-activedescendant={`staticID`} tabIndex={0} />;", Tsx: true},
+		// MemberExpression as activedescendant value.
+		{Code: `<div aria-activedescendant={state.focusedId} tabIndex={0} />;`, Tsx: true},
+		// ConditionalExpression as activedescendant value.
+		{Code: `<div aria-activedescendant={cond ? a : b} tabIndex={0} />;`, Tsx: true},
+		// CallExpression as activedescendant value.
+		{Code: `<div aria-activedescendant={getId()} tabIndex={0} />;`, Tsx: true},
+
+		// ============================================================
+		// Real-world a11y patterns
+		// ============================================================
+		// combobox pattern: input is interactive, no tabIndex needed.
+		{Code: `<input role="combobox" aria-activedescendant={x} />;`, Tsx: true},
+		// listbox pattern: ul with explicit tabIndex={0}.
+		{Code: `<ul role="listbox" tabIndex={0} aria-activedescendant={focusedId}><li>x</li></ul>;`, Tsx: true},
+		// Dynamic href on anchor — href attribute presence (any value)
+		// matches the interactive a-with-href schema.
+		{Code: `<a href={url} aria-activedescendant={x} />;`, Tsx: true},
+		// Map render of accessible items.
+		{Code: `function L() { return items.map(i => <li tabIndex={-1} aria-activedescendant={i.id} key={i.id}>x</li>); }`, Tsx: true},
+
+		// ============================================================
+		// Tag-name case sensitivity — uppercase 'DIV' is treated as a
+		// component reference per JSX semantics; not in lowercase dom map.
+		// ============================================================
+		{Code: `<DIV aria-activedescendant={x} />;`, Tsx: true},
+
+	}, []rule_tester.InvalidTestCase{
+		// TSNonNullExpression on tabIndex — jsx-ast-utils' TSNonNullExpression
+		// extractor stringifies (`0!` → "0!", `(0)!` → "0!", `(5)!` → "5!").
+		// Number(string) = NaN → step-1 undefined → aria gate-4 `undefined >=
+		// -1` false → REPORT. Lock-in for Cluster A.
+		{Code: `<div aria-activedescendant={x} tabIndex={0!} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div aria-activedescendant={x} tabIndex={(0)!} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- gate-1: boolean attribute form is "defined" per getProp ----
+		// `<div aria-activedescendant />` — upstream's `getProp` returns the
+		// attribute regardless of value, so gate-1 does NOT skip. div is not
+		// interactive, no tabIndex → report.
+		{Code: `<div aria-activedescendant />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- gate-1: explicit-undefined value is "defined" per getProp ----
+		// jsx-ast-utils' `getProp` returns the attribute node even when the
+		// value evaluates to undefined; only a MISSING prop trips gate-1.
+		{Code: `<div aria-activedescendant={undefined} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Case-insensitive prop match — INVALID arm ----
+		// Same case-folding path as the valid arm above, but without a
+		// tabIndex → reports. Locks the matching against accidental
+		// case-sensitive regressions in `FindAttributeByName`.
+		{Code: `<div Aria-ActiveDescendant={x} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Paired element form (upstream tests use only self-closing) ----
+		// JsxElement contains a JsxOpeningElement; the listener fires on
+		// the opening element. Position is still column 1 (the `<` of the
+		// opening element). Locks that the listener doesn't accidentally
+		// double-fire on JsxElement and JsxOpeningElement both.
+		{Code: `<div aria-activedescendant={x}></div>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- gate-3 boundary: interactive + tabIndex defined → DON'T skip ----
+		// `<input>` is interactive, but `tabIndex={-2}` makes hasTabIndex true,
+		// so gate-3's `!hasTabIndex && IsInteractive` is false (gate-3 only
+		// short-circuits when tabIndex is undefined). gate-4: -2 >= -1 is
+		// false → report. Locks that gate-3 isn't accidentally widened to
+		// "interactive → always skip".
+		{Code: `<input aria-activedescendant={x} tabIndex={-2} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- a without href is NOT interactive ----
+		// interactiveElementRoleSchemas requires `href` on `a`; absent it,
+		// `a` falls through to the non-interactive schemas
+		// (`{Name: "a"}`). gate-3 doesn't skip; no tabIndex → report.
+		{Code: `<a aria-activedescendant={x} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- gate-4 boundary: tabIndex < -1 ----
+		// `tabIndex={-2}` on a non-interactive element. -2 >= -1 is false →
+		// gate-4 doesn't skip → report.
+		{Code: `<div aria-activedescendant={x} tabIndex={-2} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- gate-4: NaN-coercing tabIndex string is treated as undefined ----
+		// `tabIndex="abc"` → GetTabIndex returns (_, false). hasTabIndex is
+		// false, so gate-4 falls through to report (mirrors upstream
+		// `Number(getLiteralPropValue) → NaN → undefined` flow).
+		{Code: `<div aria-activedescendant={x} tabIndex="abc" />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- polymorphicPropName resolution ----
+		// `<Box as="div" />` resolves to div via the polymorphic prop;
+		// without a tabIndex → report. Locks that the polymorphic resolution
+		// applies before the dom.has() / interactive checks.
+		{Code: `<Box as="div" aria-activedescendant={x} />;`, Tsx: true, Settings: polymorphicSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Nested JSX — listener fires per element independently ----
+		// Outer span has no activedescendant (gate-1 skip); inner div has
+		// activedescendant but no tabIndex (report). Position assertion
+		// covers the inner element's column (after `<span>`).
+		{Code: `<span><div aria-activedescendant={x} /></span>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "tabIndexRequired", Message: errorMessage, Line: 1, Column: 7}}},
+
+		// ---- Multi-line case for position assertion ----
+		// Locks line/column accounting on a non-trivial source layout. The
+		// `<div` token starts at column 3 of line 2.
+		{
+			Code: `
+  <div
+    aria-activedescendant={x}
+  />;`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "tabIndexRequired", Message: errorMessage, Line: 2, Column: 3},
+			},
+		},
+
+		// ---- TS-wrapper tabIndex value resolving to invalid range ----
+		// `(-2 as number)` / `(-2)!` should still resolve to -2 via staticEval's
+		// wrapper unwrap, then gate-4 fails. Locks that the TS-wrapper unwrap
+		// doesn't accidentally lose the negative sign.
+		{Code: `<div aria-activedescendant={x} tabIndex={(-2 as number)} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div aria-activedescendant={x} tabIndex={(-2)!} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Multiple invalid elements in one source ----
+		// Listener fires per element independently — three sibling self-closing
+		// elements each lacking tabIndex produce three reports. Locks that the
+		// listener doesn't share state across siblings.
+		// Column accounting (1-based): `<>` cols 1-2; first `<div...` cols 3-35;
+		// `<span...` cols 36-69; `<p...` cols 70-100.
+		{
+			Code: `<><div aria-activedescendant={x} /><span aria-activedescendant={y} /><p aria-activedescendant={z} /></>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "tabIndexRequired", Message: errorMessage, Line: 1, Column: 3},
+				{MessageId: "tabIndexRequired", Message: errorMessage, Line: 1, Column: 36},
+				{MessageId: "tabIndexRequired", Message: errorMessage, Line: 1, Column: 70},
+			},
+		},
+
+		// ---- Real-world component patterns ----
+		// Verifies the listener fires inside arrow / function / class /
+		// fragment-wrapped JSX trees identically to top-level placement.
+		{
+			Code:   `const Item = () => <li aria-activedescendant={x} />;`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "tabIndexRequired", Message: errorMessage, Line: 1, Column: 20}},
+		},
+		{
+			Code:   `function R() { return <div aria-activedescendant={x} />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "tabIndexRequired", Message: errorMessage, Line: 1, Column: 23}},
+		},
+
+		// ============================================================
+		// Expression-form coverage for tabIndex value (invalid arms)
+		// ============================================================
+		// ConditionalExpression — both branches < -1.
+		{Code: `<div aria-activedescendant={x} tabIndex={cond ? -2 : -3} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Statically-evaluable falsy test, falsy branch is invalid.
+		{Code: `<div aria-activedescendant={x} tabIndex={false ? 0 : -2} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// LogicalExpression `||` with truthy left → left wins (string), NaN.
+		{Code: `<div aria-activedescendant={x} tabIndex={x || 0} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// LogicalExpression `??` — left non-null/undef wins (Identifier name → NaN).
+		{Code: `<div aria-activedescendant={x} tabIndex={x ?? 0} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// BinaryExpression — `1 - 5` = -4.
+		{Code: `<div aria-activedescendant={x} tabIndex={1 - 5} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// ArrayLiteralExpression — single negative element.
+		{Code: `<div aria-activedescendant={x} tabIndex={[-2]} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Array with two numeric elements — Array.join "5,6" → NaN.
+		{Code: `<div aria-activedescendant={x} tabIndex={[5,6]} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Boolean literal as tabIndex — upstream's getTabIndex step-1 boolean
+		// arm returns undefined; downstream `undefined >= -1` is false.
+		{Code: `<div aria-activedescendant={x} tabIndex={true} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div aria-activedescendant={x} tabIndex={false} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Null literal — upstream LITERAL_TYPES.Literal special-cases null
+		// to the string "null"; Number("null") = NaN → undefined → REPORT.
+		{Code: `<div aria-activedescendant={x} tabIndex={null} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Negative Infinity — -Inf < -1 → REPORT.
+		{Code: `<div aria-activedescendant={x} tabIndex={-Infinity} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// Template literal with NumericLiteral substitution. jsx-ast-utils'
+		// TemplateLiteral.js does NOT recurse into substitution literals;
+		// NumericLiteral falls to the `otherwise → ""` arm. Template value
+		// becomes the empty string, step-1 short-circuits to undefined,
+		// gate-4 NaN >= -1 → false → REPORT. Both rslint and ESLint behave
+		// the same way — locks the upstream substitution-literal blind spot.
+		{Code: "<div aria-activedescendant={x} tabIndex={`${0}`} />;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Template literal with Identifier substitution renders as `{name}`
+		// (single curly). `Number("{cond}")` = NaN → REPORT.
+		{Code: "<div aria-activedescendant={x} tabIndex={`${cond}`} />;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Real-world a11y misuse patterns
+		// ============================================================
+		// listbox without tabIndex — ul is non-interactive, missing focus
+		// reachability. The most common real-world failure mode.
+		{
+			Code:   `<ul aria-activedescendant={x}><li>x</li></ul>;`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "tabIndexRequired", Message: errorMessage, Line: 1, Column: 1}},
+		},
+		// Custom focusable wrapper with negative-2 tabIndex.
+		{
+			Code:   `<section aria-activedescendant={x} tabIndex={-2}>content</section>;`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "tabIndexRequired", Message: errorMessage, Line: 1, Column: 1}},
+		},
+		// Map render produces multiple offending elements.
+		{
+			Code:   `function L() { return items.map(i => <li aria-activedescendant={i.id}>x</li>); }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "tabIndexRequired", Message: errorMessage, Line: 1, Column: 38}},
+		},
+
+		// ============================================================
+		// Multi-line attribute value position assertion
+		// ============================================================
+		// tabIndex on its own line — the rule reports on the JSX opening
+		// element (column 3 of line 2), not on the attribute or value.
+		{
+			Code: `
+  <div
+    aria-activedescendant={x}
+    tabIndex={
+      -2
+    }
+  />;`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "tabIndexRequired", Message: errorMessage, Line: 2, Column: 3},
+			},
+		},
+
+		// ============================================================
+		// Mixed nested tree — outer + inner each independently invalid
+		// ============================================================
+		{
+			Code: `function App() {
+  return (
+    <ul aria-activedescendant={a}>
+      <li aria-activedescendant={b}>x</li>
+    </ul>
+  );
+}`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "tabIndexRequired", Message: errorMessage, Line: 3, Column: 5},
+				{MessageId: "tabIndexRequired", Message: errorMessage, Line: 4, Column: 7},
+			},
+		},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex_upstream_test.go
@@ -1,0 +1,97 @@
+package aria_activedescendant_has_tabindex
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedError is the single error shape every invalid case produces.
+// Centralized so a future error-text tweak touches one place. Shared with
+// aria_activedescendant_has_tabindex_extras_test.go via package scope.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "tabIndexRequired",
+	Message:   errorMessage,
+	Line:      1,
+	Column:    1,
+}
+
+// componentsCustomDiv mirrors the upstream test setting
+// `{ 'jsx-a11y': { components: { CustomComponent: 'div' } } }` used by two
+// upstream cases (one valid, one invalid) to verify that `getElementType`
+// honors the components map before the dom.has() / interactive checks run.
+var componentsCustomDiv = map[string]any{
+	"jsx-a11y": map[string]any{
+		"components": map[string]any{
+			"CustomComponent": "div",
+		},
+	},
+}
+
+// TestAriaActivedescendantHasTabindexUpstream mirrors the full valid/invalid
+// suite from upstream's __tests__/src/rules/aria-activedescendant-has-tabindex-test.js,
+// 1:1 and in upstream order so a future audit can grep across both
+// side-by-side.
+//
+// Anything NOT in upstream's test file — case-variant prop matching, literal
+// spread, boolean-form / explicit-undefined value, paired element form,
+// gate-3 boundary cases, polymorphicPropName, NaN-coercing tabIndex strings —
+// lives in aria_activedescendant_has_tabindex_extras_test.go.
+func TestAriaActivedescendantHasTabindexUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AriaActivedescendantHasTabindexRule, []rule_tester.ValidTestCase{
+		// CustomComponent — gate-2 (`!dom.has('CustomComponent')`) skips.
+		{Code: `<CustomComponent />;`, Tsx: true},
+		// CustomComponent + aria-activedescendant — same gate-2 skip; the
+		// activedescendant prop's presence is irrelevant for non-DOM tags.
+		{Code: `<CustomComponent aria-activedescendant={someID} />;`, Tsx: true},
+		// CustomComponent + aria-activedescendant + tabIndex={0} — gate-2 skip
+		// (tabIndex value never inspected for non-DOM tags).
+		{Code: `<CustomComponent aria-activedescendant={someID} tabIndex={0} />;`, Tsx: true},
+		// CustomComponent + aria-activedescendant + tabIndex={-1} — gate-2 skip.
+		{Code: `<CustomComponent aria-activedescendant={someID} tabIndex={-1} />;`, Tsx: true},
+		// CustomComponent mapped to "div" via settings, with tabIndex={0} —
+		// gate-2 passes (resolved to div which IS in dom map); gate-3 fails
+		// (div is NOT interactive); gate-4 0 >= -1 → skip.
+		{Code: `<CustomComponent aria-activedescendant={someID} tabIndex={0} />;`, Tsx: true, Settings: componentsCustomDiv},
+		// Bare div / input — no aria-activedescendant → gate-1 skip.
+		{Code: `<div />;`, Tsx: true},
+		{Code: `<input />;`, Tsx: true},
+		// div with tabIndex but no aria-activedescendant — gate-1 skip.
+		{Code: `<div tabIndex={0} />;`, Tsx: true},
+		// div + activedescendant + tabIndex={0} — gate-4 skip (0 >= -1).
+		{Code: `<div aria-activedescendant={someID} tabIndex={0} />;`, Tsx: true},
+		// div + activedescendant + tabIndex="0" — string-numeric "0" coerces
+		// to 0 via GetTabIndex's StringToNumber path; gate-4 skip.
+		{Code: `<div aria-activedescendant={someID} tabIndex="0" />;`, Tsx: true},
+		// div + activedescendant + tabIndex={1} — gate-4 skip (1 >= -1).
+		{Code: `<div aria-activedescendant={someID} tabIndex={1} />;`, Tsx: true},
+		// input + activedescendant, no tabIndex — gate-3 skip (input is
+		// inherently interactive AND tabIndex is undefined).
+		{Code: `<input aria-activedescendant={someID} />;`, Tsx: true},
+		// input + activedescendant + tabIndex={1} — gate-3 fails (tabIndex
+		// resolves, not undefined); gate-4 1 >= -1 → skip.
+		{Code: `<input aria-activedescendant={someID} tabIndex={1} />;`, Tsx: true},
+		// input + activedescendant + tabIndex={0} — same gate-3/4 path.
+		{Code: `<input aria-activedescendant={someID} tabIndex={0} />;`, Tsx: true},
+		// input + activedescendant + tabIndex={-1} — gate-4 -1 >= -1 → skip.
+		{Code: `<input aria-activedescendant={someID} tabIndex={-1} />;`, Tsx: true},
+		// div + activedescendant + tabIndex={-1} — gate-4 skip (-1 >= -1).
+		{Code: `<div aria-activedescendant={someID} tabIndex={-1} />;`, Tsx: true},
+		// div + activedescendant + tabIndex="-1" — string "-1" coerces to -1
+		// via GetTabIndex; gate-4 skip.
+		{Code: `<div aria-activedescendant={someID} tabIndex="-1" />;`, Tsx: true},
+		// Repeat of input + activedescendant + tabIndex={-1} — kept verbatim
+		// because upstream's test file lists it twice; preserving the count
+		// matches a future grep / line-count audit against upstream.
+		{Code: `<input aria-activedescendant={someID} tabIndex={-1} />;`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// div + activedescendant, no tabIndex — gate-3 fails (div is not
+		// interactive); gate-4 fails (undefined >= -1 is false in JS).
+		// Reports on the JsxSelfClosingElement node, column 1.
+		{Code: `<div aria-activedescendant={someID} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// CustomComponent mapped to "div" via settings — same flow as above
+		// after the gate-2 components-map resolution.
+		{Code: `<CustomComponent aria-activedescendant={someID} />;`, Tsx: true, Settings: componentsCustomDiv, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex.go
@@ -71,6 +71,9 @@ var NoNoninteractiveTabindexRule = rule.Rule{
 	Name: "jsx-a11y/no-noninteractive-tabindex",
 	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
+		// sourceText is required by GetTabIndexEx for raw-text template
+		// literal extraction (NoSubstitutionTemplate has no RawText field).
+		sourceText := ctx.SourceFile.Text()
 
 		check := func(node *ast.Node) {
 			attrs := reactutil.GetJsxElementAttributes(node)
@@ -78,9 +81,16 @@ var NoNoninteractiveTabindexRule = rule.Rule{
 			if tabIndexProp == nil {
 				return
 			}
-			tabIndex, ok := jsxa11yutil.GetTabIndex(tabIndexProp)
-			if !ok {
-				// upstream `if (typeof tabIndex === 'undefined') return;`
+			// upstream `if (typeof tabIndex === 'undefined') return;` matches
+			// strictly when getTabIndex's step-1 short-circuited (boolean
+			// form, empty string, NaN, missing). The step-2 fallback returns
+			// `null` (typeof object) for unrecognized expression types, which
+			// passes the `typeof === 'undefined'` guard and reaches the
+			// `tabIndex >= 0` check below — where `null >= 0` ToNumber-coerces
+			// to `0 >= 0` = true → REPORT. GetTabIndexEx surfaces the
+			// distinction via nullLike so we can mirror this exactly.
+			tabIndex, hasTabIndex, nullLike := jsxa11yutil.GetTabIndexEx(tabIndexProp, sourceText)
+			if !hasTabIndex && !nullLike {
 				return
 			}
 
@@ -125,7 +135,10 @@ var NoNoninteractiveTabindexRule = rule.Rule{
 				return
 			}
 
-			if tabIndex >= 0 {
+			// Upstream `tabIndex >= 0` ToNumber-coerces null to 0; the
+			// nullLike arm therefore unconditionally reports (`0 >= 0` is
+			// true). The hasTabIndex arm compares the resolved number.
+			if (hasTabIndex && tabIndex >= 0) || nullLike {
 				ctx.ReportNode(tabIndexProp, rule.RuleMessage{
 					Id:          "noNoninteractiveTabindex",
 					Description: errorMessage,

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex_extras_test.go
@@ -246,9 +246,10 @@ func TestNoNoninteractiveTabindexExtras(t *testing.T) {
 		{Code: `<div tabIndex={1e-5} />`, Tsx: true},
 		{Code: `<div tabIndex="1.5" />`, Tsx: true},
 		{Code: `<div tabIndex="0.5" />`, Tsx: true},
-		// BigInt → step 1 jvBigInt → not in switch → step 2 jvBigInt → not handled → skip.
-		{Code: `<div tabIndex={1n} />`, Tsx: true},
-		{Code: `<div tabIndex={0n} />`, Tsx: true},
+		// BigInt — upstream Number(BigInt) coerces to a usable Number,
+		// so `0n` / `1n` reach `>= 0` true → REPORT. Lock-ins in the
+		// invalid section. Only negative BigInts skip here.
+		{Code: `<div tabIndex={-1n} />`, Tsx: true}, // Number(-1n) = -1, -1 >= 0 false → skip
 		// Identifier / runtime expression — staticEval returns string fallback,
 		// parseFloat fails → undefined.
 		{Code: `<div tabIndex={someVar} />`, Tsx: true},
@@ -292,9 +293,9 @@ func TestNoNoninteractiveTabindexExtras(t *testing.T) {
 		{Code: `<div tabIndex={+'-5'} />`, Tsx: true}, // +(-5) = -5
 		// Bitwise NOT — staticEval already handles, just lock the negative result.
 		{Code: `<div tabIndex={~5} />`, Tsx: true}, // -6
-		// `<div tabIndex={} />` — empty JsxExpression. attributeInnerExpression
-		// returns nil → skip.
-		{Code: `<div tabIndex={} />`, Tsx: true},
+		// `<div tabIndex={} />` — empty JsxExpression / JSXEmptyExpression.
+		// Upstream's TYPES has no entry → noop → null → `null >= 0` true →
+		// REPORT. Moved to invalid section below.
 		// undefined identifier → step 1 jvUndef (literalPropValue) → not in
 		// switch → step 2 staticEval → jvUndef → not handled → skip.
 		{Code: `<div tabIndex={undefined} />`, Tsx: true},
@@ -312,7 +313,10 @@ func TestNoNoninteractiveTabindexExtras(t *testing.T) {
 		{Code: `<div tabIndex={(-1) as number} />`, Tsx: true},
 		{Code: `<div tabIndex={-1 as number} />`, Tsx: true},
 		{Code: `<div tabIndex={(-1)!} />`, Tsx: true},
-		{Code: `<div tabIndex={-1 satisfies number} />`, Tsx: true}, // satisfies opaque → step 2 jvNull → skip; would-be valid even if wired
+		// Note: `<div tabIndex={-1 satisfies number} />` is INVALID per
+		// upstream (TSSatisfiesExpression → null → `null >= 0` true →
+		// REPORT). It's covered in the invalid section as part of the
+		// opaque-expression-types lock-in group.
 		// Parenthesized string literal coerces to integer (negative).
 		{Code: `<div tabIndex={("-1")} />`, Tsx: true},
 		{Code: `<div tabIndex={("-1") as string} />`, Tsx: true},
@@ -536,7 +540,56 @@ func TestNoNoninteractiveTabindexExtras(t *testing.T) {
 		{Code: `<div tabIndex={true ? someVar : otherVar} />`, Tsx: true},
 		// LogicalExpression with falsy-string value.
 		{Code: `<div tabIndex={false || -1} />`, Tsx: true},
+
+		// progressbar role — aria-query treats it as interactive (widget
+		// descendant via `range`), so isInteractiveRole skips. Lock-in.
+		{Code: `<div role="progressbar" tabIndex={0} />`, Tsx: true},
+
+		// TSNonNullExpression on tabIndex — upstream stringifies to "0!" /
+		// "5!" → Number(...) = NaN → step-1 undefined → no-non skips.
+		// Lock-in for Cluster A.
+		{Code: `<div tabIndex={0!} />`, Tsx: true},
+		{Code: `<div tabIndex={(0)!} />`, Tsx: true},
+		{Code: `<div tabIndex={(5)!} />`, Tsx: true},
+
+		// BigInt with negative value — Number(-1n) = -1, -1 >= 0 false → skip.
+		{Code: `<div tabIndex={-1n} />`, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
+		// Empty JsxExpression `tabIndex={}` — JSXEmptyExpression, upstream
+		// TYPES no entry → null. `null >= 0` true → REPORT. Lock-in for
+		// the Cluster H fix.
+		{Code: `<div tabIndex={} />`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveTabindex", Message: errorMessage}}},
+
+		// BigInt — upstream Number(BigInt) coerces. 0n → 0 → `0>=0` REPORT;
+		// 1n → 1 → REPORT; 2n → 2 → REPORT. Lock-in for Cluster B.
+		{Code: `<div tabIndex={0n} />`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveTabindex", Message: errorMessage}}},
+		{Code: `<div tabIndex={1n} />`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveTabindex", Message: errorMessage}}},
+		{Code: `<div tabIndex={2n} />`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveTabindex", Message: errorMessage}}},
+		{Code: `<div tabIndex={5n} />`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveTabindex", Message: errorMessage}}},
+		{Code: `<div tabIndex={true ? 1n : 0n} />`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveTabindex", Message: errorMessage}}},
+
+		// ============================================================
+		// Group 0: Opaque expression types — upstream returns null which
+		// passes the `typeof === 'undefined'` guard, then `null >= 0` is
+		// true (ToNumber-coerces to 0). Aligned via GetTabIndexEx's
+		// nullLike arm. Locks against accidental regression to the lossy
+		// pre-Ex behavior that silently skipped these.
+		// ============================================================
+		{Code: `<div tabIndex={-1 satisfies number} />`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveTabindex", Message: errorMessage}}},
+		{Code: `<div tabIndex={5 satisfies number} />`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveTabindex", Message: errorMessage}}},
+		{Code: `async function f() { return <div tabIndex={await p} />; }`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveTabindex", Message: errorMessage}}},
+		{Code: `function* g() { yield <div tabIndex={yield 0} />; }`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveTabindex", Message: errorMessage}}},
+
 		// ============================================================
 		// Group 1: Position assertions
 		// ============================================================
@@ -676,8 +729,10 @@ func TestNoNoninteractiveTabindexExtras(t *testing.T) {
 		{Code: `<div role="heading" tabIndex={0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 		{Code: `<div role="region" tabIndex={0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 		{Code: `<div role="tabpanel" tabIndex={0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
-		// `progressbar` is forced to non-interactive in the upstream filter.
-		{Code: `<div role="progressbar" tabIndex={0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Note: `<div role="progressbar" tabIndex={0} />` is VALID per upstream.
+		// progressbar's superClass chain in aria-query contains `widget` (via
+		// `range`), so isInteractiveRole returns true and the rule skips.
+		// Moved to valid section above.
 		// More non-interactive roles.
 		{Code: `<div role="alert" tabIndex={0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 		{Code: `<div role="banner" tabIndex={0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
@@ -810,7 +865,9 @@ func TestNoNoninteractiveTabindexExtras(t *testing.T) {
 		{Code: `<div tabIndex={0 as number} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 		{Code: `<div tabIndex={(0) as number} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 		{Code: `<div tabIndex={0 as any} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
-		{Code: `<div tabIndex={(0)!} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Note: `<div tabIndex={(0)!} />` is VALID per upstream
+		// (TSNonNullExpression stringifies to "0!" → NaN → step-1 undefined
+		// → no-non skips). Moved to valid section.
 		// ConditionalExpression with non-negative arms — staticEval picks one.
 		{Code: `<div tabIndex={cond ? 0 : -1} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 		{Code: `<div tabIndex={true ? 0 : 1} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},

--- a/internal/plugins/jsx_a11y/rules/tabindex_no_positive/tabindex_no_positive_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/tabindex_no_positive/tabindex_no_positive_extras_test.go
@@ -363,6 +363,17 @@ func TestTabindexNoPositiveExtras(t *testing.T) {
 		{Code: `<div tabIndex={5 as any} />`, Tsx: true},
 		{Code: `<div tabIndex={5 satisfies number} />`, Tsx: true},
 		{Code: `<div tabIndex={(5)!} />`, Tsx: true},
+		// AwaitExpression / YieldExpression — same upstream flow as
+		// TSSatisfiesExpression: TYPES has no entry → noop → null →
+		// Number(null) = 0 → 0 <= 0 → skip. Verified via differential
+		// against eslint-plugin-jsx-a11y v6.10.2 — neither expression
+		// triggers tabindex-no-positive. LiteralPropToNumber lands the
+		// same way through literalPropValue's default jsNull arm followed
+		// by jsValueToNumber's jvNull → (0, true) mapping. Locks the
+		// alignment in case future LiteralPropToNumber refactors change
+		// the jvNull handling.
+		{Code: `async function f() { return <div tabIndex={await p} />; }`, Tsx: true},
+		{Code: `function* g() { yield <div tabIndex={yield 0} />; }`, Tsx: true},
 
 		// ============================================================
 		// Spread attributes — listener fires on JsxAttribute only

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -160,6 +160,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/anchor-has-content.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/anchor-is-valid.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/aria-activedescendant-has-tabindex.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/aria-unsupported-elements.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/heading-has-content.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/aria-activedescendant-has-tabindex.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/aria-activedescendant-has-tabindex.test.ts
@@ -1,0 +1,448 @@
+import { RuleTester } from '../rule-tester';
+
+const errorMessage =
+  'An element that manages focus with `aria-activedescendant` must have a tabindex';
+const expectedError = { message: errorMessage };
+
+const componentsCustomDiv = {
+  'jsx-a11y': {
+    components: {
+      CustomComponent: 'div',
+    },
+  },
+};
+
+const polymorphicSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+  },
+};
+
+new RuleTester().run('aria-activedescendant-has-tabindex', null as never, {
+  valid: [
+    // ============================================================
+    // Upstream-suite valid cases
+    // ============================================================
+    { code: '<CustomComponent />;' },
+    { code: '<CustomComponent aria-activedescendant={someID} />;' },
+    {
+      code: '<CustomComponent aria-activedescendant={someID} tabIndex={0} />;',
+    },
+    {
+      code: '<CustomComponent aria-activedescendant={someID} tabIndex={-1} />;',
+    },
+    {
+      code: '<CustomComponent aria-activedescendant={someID} tabIndex={0} />;',
+      settings: componentsCustomDiv,
+    },
+    { code: '<div />;' },
+    { code: '<input />;' },
+    { code: '<div tabIndex={0} />;' },
+    { code: '<div aria-activedescendant={someID} tabIndex={0} />;' },
+    { code: '<div aria-activedescendant={someID} tabIndex="0" />;' },
+    { code: '<div aria-activedescendant={someID} tabIndex={1} />;' },
+    { code: '<input aria-activedescendant={someID} />;' },
+    { code: '<input aria-activedescendant={someID} tabIndex={1} />;' },
+    { code: '<input aria-activedescendant={someID} tabIndex={0} />;' },
+    { code: '<input aria-activedescendant={someID} tabIndex={-1} />;' },
+    { code: '<div aria-activedescendant={someID} tabIndex={-1} />;' },
+    { code: '<div aria-activedescendant={someID} tabIndex="-1" />;' },
+    { code: '<input aria-activedescendant={someID} tabIndex={-1} />;' },
+
+    // ============================================================
+    // Case-insensitive prop match — jsx-ast-utils default ignoreCase: true
+    // ============================================================
+    { code: '<div Aria-ActiveDescendant={x} tabIndex={0} />;' },
+    { code: '<div ARIA-ACTIVEDESCENDANT={x} tabIndex={0} />;' },
+
+    // ============================================================
+    // Other inherently interactive elements — gate-3 skip
+    // ============================================================
+    { code: '<a href="#" aria-activedescendant={x} />;' },
+    { code: '<button aria-activedescendant={x} />;' },
+    { code: '<select size={1} aria-activedescendant={x} />;' },
+    { code: '<textarea aria-activedescendant={x} />;' },
+    { code: '<option aria-activedescendant={x} />;' },
+
+    // ============================================================
+    // Non-DOM tag forms — gate-2 skip
+    // ============================================================
+    { code: '<svg:path aria-activedescendant={x} />;' },
+    { code: '<Foo.Bar aria-activedescendant={x} />;' },
+    { code: '<Foo.Bar.Baz aria-activedescendant={x} />;' },
+
+    // ============================================================
+    // Polymorphic settings
+    // ============================================================
+    {
+      code: '<Box as="span" aria-activedescendant={x} tabIndex={0} />;',
+      settings: polymorphicSettings,
+    },
+
+    // ============================================================
+    // tabIndex string variants — coerce via getTabIndex's StringToNumber
+    // ============================================================
+    { code: '<div aria-activedescendant={x} tabIndex="1" />;' },
+    { code: '<div aria-activedescendant={x} tabIndex="100" />;' },
+    { code: '<div aria-activedescendant={x} tabIndex="0x10" />;' },
+    { code: '<div aria-activedescendant={x} tabIndex="0o7" />;' },
+
+    // ============================================================
+    // Spread without literal aria-activedescendant — opaque, gate-1 skip
+    // ============================================================
+    { code: '<div {...props} />;' },
+
+    // ============================================================
+    // Nested JSX where neither element trips the rule
+    // ============================================================
+    { code: '<span><div aria-activedescendant={x} tabIndex={0} /></span>;' },
+
+    // ============================================================
+    // Literal-spread tabIndex tracking (jsx-ast-utils' getProp walks
+    // ObjectExpression spreads when the key is an Identifier)
+    // ============================================================
+    { code: '<div aria-activedescendant={x} {...{tabIndex: 0}} />;' },
+    { code: '<div aria-activedescendant={x} {...{tabIndex: -1}} />;' },
+
+    // ============================================================
+    // TS-wrapper unwrapping in tabIndex value (paren / as).
+    // Note: TSNonNullExpression `0!` is INVALID per upstream — it
+    // stringifies to "0!" → NaN → undefined → REPORT (see invalid section).
+    // ============================================================
+    { code: '<div aria-activedescendant={x} tabIndex={(0)} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={(0 as number)} />;' },
+
+    // ============================================================
+    // Opaque expression types resolve to upstream `null`, which the
+    // downstream `null >= -1` (ToNumber → 0) treats as a valid tabIndex.
+    // Aligned with ESLint via GetTabIndexEx's nullLike classification.
+    // ============================================================
+    {
+      code: '<div aria-activedescendant={x} tabIndex={0 satisfies number} />;',
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={(-2) satisfies number} />;',
+    },
+    {
+      code: 'async function f() { return <div aria-activedescendant={x} tabIndex={await p} />; }',
+    },
+    {
+      code: 'function* g() { yield <div aria-activedescendant={x} tabIndex={yield 0} />; }',
+    },
+
+    // ============================================================
+    // NoSubstitutionTemplateLiteral tabIndex
+    // ============================================================
+    { code: '<div aria-activedescendant={x} tabIndex={`-1`} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={`0`} />;' },
+
+    // ============================================================
+    // Comments around the attribute don't suppress detection
+    // ============================================================
+    {
+      code: '<div /* before */ aria-activedescendant={x} /* mid */ tabIndex={0} /* after */ />;',
+    },
+
+    // ============================================================
+    // Expression-form coverage for tabIndex value (valid arms)
+    // ============================================================
+    { code: '<div aria-activedescendant={x} tabIndex={cond ? 0 : -1} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={true ? -1 : -5} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={false ? -5 : 0} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={null ?? 0} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={1 || 5} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={true && 0} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={1 - 1} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={1 - 2} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={2 * 0} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={10 / 10} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={[0]} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={[-1]} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={[null]} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={[]} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={0x0} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={0o0} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={0b0} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={1e0} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={1_000} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={Infinity} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={-0} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={-(-2)} />;' },
+    { code: '<div aria-activedescendant={x} tabIndex={(((-1)))} />;' },
+
+    // ============================================================
+    // aria-activedescendant value-form coverage (gate-1 only checks
+    // presence; tabIndex={0} keeps these valid)
+    // ============================================================
+    { code: '<div aria-activedescendant="staticID" tabIndex={0} />;' },
+    { code: '<div aria-activedescendant={`staticID`} tabIndex={0} />;' },
+    { code: '<div aria-activedescendant={state.focusedId} tabIndex={0} />;' },
+    { code: '<div aria-activedescendant={cond ? a : b} tabIndex={0} />;' },
+    { code: '<div aria-activedescendant={getId()} tabIndex={0} />;' },
+
+    // ============================================================
+    // Real-world a11y patterns
+    // ============================================================
+    { code: '<input role="combobox" aria-activedescendant={x} />;' },
+    {
+      code: '<ul role="listbox" tabIndex={0} aria-activedescendant={focusedId}><li>x</li></ul>;',
+    },
+    { code: '<a href={url} aria-activedescendant={x} />;' },
+    {
+      code: 'function L() { return items.map(i => <li tabIndex={-1} aria-activedescendant={i.id} key={i.id}>x</li>); }',
+    },
+
+    // ============================================================
+    // Tag-name case sensitivity — uppercase is a component reference
+    // ============================================================
+    { code: '<DIV aria-activedescendant={x} />;' },
+  ],
+  invalid: [
+    // ============================================================
+    // TSNonNullExpression on tabIndex — jsx-ast-utils' TSNonNullExpression
+    // extractor stringifies (`0!` → "0!"). Number("0!") = NaN → step-1
+    // undefined → aria gate-4 `undefined >= -1` false → REPORT.
+    // ============================================================
+    {
+      code: '<div aria-activedescendant={x} tabIndex={0!} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={(0)!} />;',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Upstream-suite invalid cases
+    // ============================================================
+    {
+      code: '<div aria-activedescendant={someID} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<CustomComponent aria-activedescendant={someID} />;',
+      settings: componentsCustomDiv,
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // gate-1: boolean attribute form / explicit-undefined value still
+    // count as "defined" via jsx-ast-utils' getProp
+    // ============================================================
+    { code: '<div aria-activedescendant />;', errors: [expectedError] },
+    {
+      code: '<div aria-activedescendant={undefined} />;',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Case-insensitive prop match — INVALID arm
+    // ============================================================
+    {
+      code: '<div Aria-ActiveDescendant={x} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div ARIA-ACTIVEDESCENDANT={x} />;',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Paired element form — listener fires once on JsxOpeningElement
+    // ============================================================
+    {
+      code: '<div aria-activedescendant={x}></div>;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x}>text</div>;',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // gate-3 boundary: interactive + tabIndex defined → don't skip
+    // ============================================================
+    {
+      code: '<input aria-activedescendant={x} tabIndex={-2} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<button aria-activedescendant={x} tabIndex={-5} />;',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // a without href is NOT interactive
+    // ============================================================
+    { code: '<a aria-activedescendant={x} />;', errors: [expectedError] },
+
+    // ============================================================
+    // gate-4 boundary: tabIndex < -1
+    // ============================================================
+    {
+      code: '<div aria-activedescendant={x} tabIndex={-2} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={-100} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex="-2" />;',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // gate-4: NaN-coercing tabIndex string → undefined → fall through
+    // ============================================================
+    {
+      code: '<div aria-activedescendant={x} tabIndex="abc" />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={NaN} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={undefined} />;',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // polymorphicPropName resolution
+    // ============================================================
+    {
+      code: '<Box as="div" aria-activedescendant={x} />;',
+      settings: polymorphicSettings,
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Nested JSX — listener fires per element independently
+    // ============================================================
+    {
+      code: '<span><div aria-activedescendant={x} /></span>;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x}><span aria-activedescendant={x} /></div>;',
+      errors: [expectedError, expectedError],
+    },
+
+    // ============================================================
+    // TS-wrapper tabIndex value resolving to invalid range
+    // ============================================================
+    {
+      code: '<div aria-activedescendant={x} tabIndex={(-2 as number)} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={(-2)!} />;',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Multiple sibling invalid elements
+    // ============================================================
+    {
+      code: '<><div aria-activedescendant={x} /><span aria-activedescendant={y} /><p aria-activedescendant={z} /></>;',
+      errors: [expectedError, expectedError, expectedError],
+    },
+
+    // ============================================================
+    // Real-world component patterns
+    // ============================================================
+    {
+      code: 'const Item = () => <li aria-activedescendant={x} />;',
+      errors: [expectedError],
+    },
+    {
+      code: 'function R() { return <div aria-activedescendant={x} />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'class C extends React.Component { render() { return <div aria-activedescendant={x} />; } }',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Expression-form coverage for tabIndex value (invalid arms)
+    // ============================================================
+    {
+      code: '<div aria-activedescendant={x} tabIndex={cond ? -2 : -3} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={false ? 0 : -2} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={x || 0} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={x ?? 0} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={1 - 5} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={[-2]} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={[5,6]} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={true} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={false} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={null} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={-Infinity} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={`${0}`} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-activedescendant={x} tabIndex={`${cond}`} />;',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Real-world a11y misuse patterns
+    // ============================================================
+    {
+      code: '<ul aria-activedescendant={x}><li>x</li></ul>;',
+      errors: [expectedError],
+    },
+    {
+      code: '<section aria-activedescendant={x} tabIndex={-2}>content</section>;',
+      errors: [expectedError],
+    },
+    {
+      code: 'function L() { return items.map(i => <li aria-activedescendant={i.id}>x</li>); }',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Mixed nested tree — outer + inner each invalid
+    // ============================================================
+    {
+      code: 'function App() { return (<ul aria-activedescendant={a}><li aria-activedescendant={b}>x</li></ul>); }',
+      errors: [expectedError, expectedError],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-tabindex.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-tabindex.test.ts
@@ -184,7 +184,15 @@ new RuleTester().run('no-noninteractive-tabindex', null as never, {
     { code: '<div tabIndex={1e-5} />' },
     { code: '<div tabIndex="1.5" />' },
     { code: '<div tabIndex="0.5" />' },
-    { code: '<div tabIndex={1n} />' }, // BigInt
+    // BigInt 0n/1n/positive are INVALID per upstream (Number(BigInt)
+    // coerces — see invalid section). Only negative BigInts skip here.
+    { code: '<div tabIndex={-1n} />' },
+    // progressbar role — widget-class in aria-query → interactive → skip.
+    { code: '<div role="progressbar" tabIndex={0} />' },
+    // TSNonNullExpression → stringifies to "0!" → NaN → undefined → skip.
+    { code: '<div tabIndex={0!} />' },
+    { code: '<div tabIndex={(0)!} />' },
+    { code: '<div tabIndex={(5)!} />' },
     { code: '<div tabIndex={someVar} />' },
     { code: '<div tabIndex={fn()} />' },
     { code: '<div tabIndex={obj.x} />' },
@@ -214,7 +222,9 @@ new RuleTester().run('no-noninteractive-tabindex', null as never, {
     { code: '<div tabIndex={(-1)!} />' },
     { code: '<div tabIndex={("-1")} />' },
     { code: '<div tabIndex={("-1") as string} />' },
-    { code: '<div tabIndex={-1 satisfies number} />' },
+    // `<div tabIndex={X satisfies T} />` is INVALID under upstream
+    // (TSSatisfiesExpression → null → `null >= 0` true → REPORT). See
+    // the invalid section below for the lock-in.
 
     // ============================================================
     // Options matrix
@@ -367,6 +377,38 @@ new RuleTester().run('no-noninteractive-tabindex', null as never, {
   ],
   invalid: [
     // ============================================================
+    // Opaque expression types — upstream returns null which passes the
+    // `typeof === 'undefined'` guard, then `null >= 0` ToNumber-coerces
+    // to `0 >= 0` = true → REPORT. Aligned via GetTabIndexEx's nullLike
+    // arm. Locks against the lossy pre-Ex behavior that silently skipped.
+    // ============================================================
+    { code: '<div tabIndex={-1 satisfies number} />', errors: [expectedError] },
+    { code: '<div tabIndex={5 satisfies number} />', errors: [expectedError] },
+    {
+      code: 'async function f() { return <div tabIndex={await p} />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function* g() { yield <div tabIndex={yield 0} />; }',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // BigInt — Number(BigInt) coerces. 0n → 0 → REPORT; 1n → 1 → REPORT.
+    // ============================================================
+    { code: '<div tabIndex={0n} />', errors: [expectedError] },
+    { code: '<div tabIndex={1n} />', errors: [expectedError] },
+    { code: '<div tabIndex={2n} />', errors: [expectedError] },
+    { code: '<div tabIndex={5n} />', errors: [expectedError] },
+    { code: '<div tabIndex={true ? 1n : 0n} />', errors: [expectedError] },
+
+    // ============================================================
+    // Empty JsxExpression `tabIndex={}` — JSXEmptyExpression → null →
+    // `null >= 0` true → REPORT.
+    // ============================================================
+    { code: '<div tabIndex={} />', errors: [expectedError] },
+
+    // ============================================================
     // Upstream neverValid
     // ============================================================
     { code: '<div tabIndex="0" />', errors: [expectedError] },
@@ -461,10 +503,9 @@ new RuleTester().run('no-noninteractive-tabindex', null as never, {
       code: '<div role="tabpanel" tabIndex={0} />',
       errors: [expectedError],
     },
-    {
-      code: '<div role="progressbar" tabIndex={0} />',
-      errors: [expectedError],
-    },
+    // Note: `<div role="progressbar" tabIndex={0} />` is VALID per
+    // upstream — progressbar is widget-class in aria-query → interactive →
+    // rule skips. Moved to valid section.
     { code: '<div role="alert" tabIndex={0} />', errors: [expectedError] },
     { code: '<div role="banner" tabIndex={0} />', errors: [expectedError] },
     {
@@ -581,7 +622,8 @@ new RuleTester().run('no-noninteractive-tabindex', null as never, {
     { code: '<div tabIndex={0 as number} />', errors: [expectedError] },
     { code: '<div tabIndex={(0) as number} />', errors: [expectedError] },
     { code: '<div tabIndex={0 as any} />', errors: [expectedError] },
-    { code: '<div tabIndex={(0)!} />', errors: [expectedError] },
+    // Note: `<div tabIndex={(0)!} />` is VALID (stringified to "0!" → NaN
+    // → undefined → skip). Lock-in in the valid section.
     // Conditional / Logical / Nullish resolving to non-negative.
     { code: '<div tabIndex={cond ? 0 : -1} />', errors: [expectedError] },
     { code: '<div tabIndex={true ? 0 : 1} />', errors: [expectedError] },


### PR DESCRIPTION
## Summary

Port `aria-activedescendant-has-tabindex` from `eslint-plugin-jsx-a11y@v6.10.2`. The rule enforces that any DOM element managing focus via `aria-activedescendant` is itself reachable by keyboard — either a natively focusable element (`<input>`, `<button>`, …) or carrying a `tabIndex` of `-1` or greater.

Verified via differential against upstream on **734 cases across 4 settings configurations**: byte-for-byte aligned (rule, line, column).

### Helper alignments included

The new rule shares `jsxa11yutil` with `no-noninteractive-tabindex` and `tabindex-no-positive`. Eight upstream-alignment bugs surfaced while wiring it up and are folded into this PR so all three rules land aligned:

- `GetTabIndexEx` — three-state API distinguishing upstream `null` (any ESTree expression type jsx-ast-utils does not recognise: `satisfies`, `await`, `yield`, …) from `undefined`. Both sibling rules migrated; fixes a reverse-direction divergence in `no-noninteractive-tabindex` (previously silently skipped opaque-expression tabIndex values that upstream reports).
- BigInt literals handled end-to-end (`Number(0n) = 0`).
- `TSNonNullExpression` stringification matches upstream (`x!` → `"x!"`, NaN), no longer auto-unwrapped.
- Template literals route through raw quasi text (matches `jsx-ast-utils`' `quasi.value.raw`), not cooked `.Text`.
- HTML entities decoded on direct `StringLiteral` attribute values (`tabIndex=\"&#49;\"` → `\"1\"`).
- `arrayElementToString` now covers nested arrays, `{}`, `/regex/`, functions / arrows (no more collapsing to `\"\"`).
- `progressbar` reclassified as interactive role (matches `aria-query`'s widget-class descendants).
- `delete` operator returns boolean `true` in step-1 of `literalPropValue` (matches upstream `UnaryExpression('delete', ...)`).
- Empty `tabIndex={}` (JSXEmptyExpression) treated as null-like.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-activedescendant-has-tabindex.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/aria-activedescendant-has-tabindex.js
- Upstream test suite: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/__tests__/src/rules/aria-activedescendant-has-tabindex-test.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).