### PR TITLE
test: skip VSCode 1.106.3 run in extension tests

### DIFF
--- a/packages/vscode-extension/__tests__/runTest.ts
+++ b/packages/vscode-extension/__tests__/runTest.ts
@@ -26,17 +26,17 @@ async function main() {
     failed = true;
   }
 
-  try {
-    await runTests({
-      extensionDevelopmentPath,
-      extensionTestsPath,
-      launchArgs: ['--disable-extensions', testWorkspace],
-      version: '1.106.3',
-    });
-  } catch (err) {
-    console.error('JSON config tests (1.106.3) failed:', err);
-    failed = true;
-  }
+  // try {
+  //   await runTests({
+  //     extensionDevelopmentPath,
+  //     extensionTestsPath,
+  //     launchArgs: ['--disable-extensions', testWorkspace],
+  //     version: '1.106.3',
+  //   });
+  // } catch (err) {
+  //   console.error('JSON config tests (1.106.3) failed:', err);
+  //   failed = true;
+  // }
 
   // --- JS config tests ---
   const testsSourceDir = path.resolve(extensionDevelopmentPath, '__tests__');


### PR DESCRIPTION
## Summary

- Comment out the second `runTests` call pinned to VSCode `1.106.3` in `packages/vscode-extension/__tests__/runTest.ts`. The JSON config suite now only runs once against `stable`.
- The duplicate run roughly doubled the windows-latest CI time for this segment (~2m23s for the `1.106.3` round, ~36s of which was downloading the second VSCode build) without adding coverage signal beyond what the `stable` run already provides.
- Easy to re-enable later by uncommenting the block if/when we want a pinned-version safety net again.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).