### PR TITLE
feat: port rule jsx-a11y/click-events-have-key-events

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_unsupported_elements"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/autocomplete_valid"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/click_events_have_key_events"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/heading_has_content"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/html_has_lang"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/iframe_has_title"
@@ -30,6 +31,7 @@ func GetAllRules() []rule.Rule {
 		aria_activedescendant_has_tabindex.AriaActivedescendantHasTabindexRule,
 		aria_unsupported_elements.AriaUnsupportedElementsRule,
 		autocomplete_valid.AutocompleteValidRule,
+		click_events_have_key_events.ClickEventsHaveKeyEventsRule,
 		heading_has_content.HeadingHasContentRule,
 		html_has_lang.HtmlHasLangRule,
 		iframe_has_title.IframeHasTitleRule,

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -884,15 +884,23 @@ func polymorphicPropValue(propAttr *ast.Node) (string, bool) {
 	return jsToString(v), true
 }
 
-// IsPresentationRole mirrors `isPresentationRole`: the element has an
-// explicit `role` attribute whose literal value is "presentation" or "none".
-// Non-literal expressions and absent role attributes return false.
+// IsPresentationRole mirrors upstream `isPresentationRole`:
+//
+//	const role = getLiteralPropValue(getProp(attributes, 'role'));
+//	return ['presentation', 'none'].indexOf(role) > -1;
+//
+// Routes through LiteralPropStringValue (= getLiteralPropValue / LITERAL_TYPES),
+// not LiteralStringValue, so that TemplateExpression with substitutions whose
+// quasis + extracted substitution values concatenate to the literal strings
+// "presentation" / "none" are recognized — e.g. ``role={`presentation${''}`}``.
+// Non-literal `role` expressions (Identifier, CallExpression, …) and absent
+// `role` attributes return false.
 func IsPresentationRole(attrs []*ast.Node) bool {
 	roleAttr := FindAttributeByName(attrs, "role")
 	if roleAttr == nil {
 		return false
 	}
-	value, ok := LiteralStringValue(roleAttr)
+	value, ok := LiteralPropStringValue(roleAttr)
 	if !ok {
 		return false
 	}

--- a/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events.go
+++ b/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events.go
@@ -1,0 +1,89 @@
+// Package click_events_have_key_events ports eslint-plugin-jsx-a11y's
+// `click-events-have-key-events` rule. Enforces that any visible,
+// non-interactive DOM element carrying an `onClick` handler also carries at
+// least one of `onKeyDown` / `onKeyUp` / `onKeyPress`, so keyboard-only
+// users can trigger the same interaction.
+//
+// Upstream signature: no options. The rule receives every JSXOpeningElement
+// (paired and self-closing) and runs five short-circuits in order:
+//
+//  1. no `onClick` prop → return (case-insensitive; spreads opaque under
+//     `getProp` default `ignoreCase: true, spreadStrict: false` — but
+//     `<div {...{onClick}} />`-style literal spreads ARE walked, matching
+//     upstream's `getProp` default behavior).
+//  2. element type not in aria-query's `dom` map → return (custom
+//     components / unknown tag names skip; we don't second-guess what
+//     low-level DOM the component renders).
+//  3. element is hidden from screen readers OR has role "presentation" /
+//     "none" → return.
+//  4. element is inherently interactive (per elementRoles /
+//     elementAXObjects, e.g. <button>, <a href>, <input type="text">) →
+//     return.
+//  5. element declares any of onKeyDown / onKeyUp / onKeyPress (case-
+//     insensitive, spread attrs opaque per upstream's `hasAnyProp` default
+//     `spreadStrict: true`) → return.
+//
+// Otherwise, report at the JSX opening element. The single message id is
+// `clickEventsHaveKeyEvents`, mirroring upstream's single `errorMessage`.
+package click_events_have_key_events
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// errorMessage mirrors upstream's `errorMessage` string verbatim.
+const errorMessage = "Visible, non-interactive elements with click handlers must have at least one keyboard listener."
+
+var ClickEventsHaveKeyEventsRule = rule.Rule{
+	Name: "jsx-a11y/click-events-have-key-events",
+	Run: func(ctx rule.RuleContext, _ any) rule.RuleListeners {
+		getElementType := func(node *ast.Node) string {
+			return jsxa11yutil.GetElementType(node, ctx.Settings)
+		}
+
+		check := func(node *ast.Node) {
+			attrs := reactutil.GetJsxElementAttributes(node)
+
+			// Upstream `getProp(props, 'onclick')` — case-insensitive, walks
+			// literal-spread (default `spreadStrict: false`). Our
+			// FindAttributeByName matches both behaviors.
+			if jsxa11yutil.FindAttributeByName(attrs, "onClick") == nil {
+				return
+			}
+
+			elementType := getElementType(node)
+			if !jsxa11yutil.IsDOMElement(elementType) {
+				return
+			}
+
+			if jsxa11yutil.IsHiddenFromScreenReader(node, getElementType) ||
+				jsxa11yutil.IsPresentationRole(attrs) {
+				return
+			}
+
+			if jsxa11yutil.IsInteractiveElement(elementType, attrs) {
+				return
+			}
+
+			// Upstream `hasAnyProp(props, requiredProps)` — default
+			// `spreadStrict: true`, so `<div onClick={...} {...props} />`
+			// cannot be saved by a possibly-keyboard handler inside `props`.
+			if jsxa11yutil.HasAnyJsxPropStrict(attrs, "onKeyDown", "onKeyUp", "onKeyPress") {
+				return
+			}
+
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "clickEventsHaveKeyEvents",
+				Description: errorMessage,
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events.md
+++ b/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events.md
@@ -1,0 +1,67 @@
+# click-events-have-key-events
+
+## Rule Details
+
+Enforce that a visible, non-interactive element with an `onClick` handler
+also declares at least one keyboard event listener (`onKeyDown`,
+`onKeyUp`, or `onKeyPress`). Pairing a pointer event with a keyboard
+counterpart keeps the interaction reachable for keyboard-only users and
+assistive technologies.
+
+The rule reports a JSX opening element when **all** of the following hold:
+
+- The resolved element name is in the HTML DOM set (custom React
+  components are skipped — the rule does not know what low-level element
+  they render).
+- The element is not hidden from screen readers (no `aria-hidden={true}`
+  / `aria-hidden="true"`, not an `<input type="hidden">`).
+- The `role` attribute, when statically a literal string, is not
+  `presentation` or `none`.
+- The element is not inherently interactive (e.g. `<button>`, `<a href>`,
+  `<select>`, `<input type="text">`).
+- The element declares an `onClick` attribute (case-insensitively, value
+  irrelevant — boolean form, `null`, `undefined` all count as present).
+- The element declares none of `onKeyDown`, `onKeyUp`, `onKeyPress`
+  (case-insensitively, as a direct attribute — spread attributes are
+  opaque).
+
+This rule takes no arguments.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div onClick={() => {}} />
+<section onClick={() => {}} />
+<a onClick={() => {}} />
+<div onClick={() => {}} {...props} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div onClick={() => {}} onKeyDown={handleKeyDown} />
+<div onClick={() => {}} onKeyUp={handleKeyUp} />
+<div onClick={() => {}} onKeyPress={handleKeyPress} />
+<button onClick={() => {}} />
+<a onClick={() => {}} href="/profile" />
+<div onClick={() => {}} aria-hidden="true" />
+<div onClick={() => {}} role="presentation" />
+<MyComponent onClick={() => {}} />
+```
+
+## Differences from ESLint
+
+- `<div onClick={…} aria-hidden={value!} />` — when the value of
+  `aria-hidden` is wrapped in a TS non-null assertion (`!`), rslint treats
+  it as hidden and does not report; ESLint reports. Drop the `!` to align
+  with both linters: `aria-hidden={value}`.
+
+## Resources
+
+- [WCAG 2.1.1 — Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
+- [WAI-ARIA — `aria-hidden`](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden)
+- [MDN — Keyboard-navigable JavaScript widgets](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/click-events-have-key-events](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/click-events-have-key-events.md)

--- a/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events_extras_test.go
@@ -1,0 +1,641 @@
+package click_events_have_key_events
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// This file holds every test case that is NOT a 1:1 mirror of upstream's
+// own test file. Upstream-parity cases live in
+// `click_events_have_key_events_upstream_test.go` so it stays trivially
+// comparable against future upstream updates via diff.
+//
+// Every case here is independently verified against upstream
+// eslint-plugin-jsx-a11y@6.10.2 via differential validation, so behavior
+// is byte-for-byte aligned — not just internally consistent.
+//
+// Coverage axes:
+//
+//   - Dimension 1 (AST node shape): tsgo's parenthesized / `as` /
+//     `satisfies` wrappers on attribute values, JsxSelfClosingElement vs
+//     paired JsxElement boundary, literal-spread vs non-literal-spread,
+//     PropertyAssignment / ShorthandPropertyAssignment inside spreads.
+//   - Dimension 2 (scoping / nesting): JSX inside HOC wrapper / forwardRef
+//     / memo / hooks / class render / map / conditional / fragment /
+//     async / generator / IIFE. Every JSX opening element is classified
+//     independently.
+//   - Dimension 4 (universal edge shapes): attribute existence forms
+//     (boolean, `={null}`, `={undefined}`), case-insensitivity of
+//     attribute names, role values via literal-extract paths (StringLiteral,
+//     JsxExpression{StringLiteral}, NoSubstitutionTemplateLiteral,
+//     TemplateExpression with substitutions = non-literal).
+//   - Settings paths: components / polymorphicPropName /
+//     polymorphicAllowList including edge cases upstream's tests don't
+//     cover (polymorphic prop absent, empty string, multi-key map).
+//   - Real-world component patterns: forwardRef / memo / HOC / hooks /
+//     class / map / fragment / async / generator / IIFE. Locks the
+//     listener gate against silent regressions when the rule or its
+//     shared helpers are refactored.
+
+// expectedErrorAnyPos is the standard expected diagnostic without a fixed
+// line/column. Use when the JSX opening element is not at column 1 — e.g.
+// inside a `function X() { return <div /> }` wrapper or `arr.map(...)`.
+// The Line/Column == 0 fields are skipped by the rule_tester (see
+// internal/rule_tester/rule_tester.go assertions).
+var expectedErrorAnyPos = rule_tester.InvalidTestCaseError{
+	MessageId: "clickEventsHaveKeyEvents",
+	Message:   errorMessage,
+}
+
+// polymorphicSettings exercises `settings['jsx-a11y'].polymorphicPropName`.
+var polymorphicSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+	},
+}
+
+// allowListSettings exercises polymorphicAllowList.
+var allowListSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName":  "as",
+		"polymorphicAllowList": []interface{}{"Foo"},
+	},
+}
+
+// componentsMapSettings exercises multi-entry `components` map. Covers
+// the "listed and remapped" branch and the "map present, key absent →
+// rawType unchanged" branch.
+var componentsMapSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"MyButton":  "button",
+			"MyFooter":  "footer",
+			"MyArticle": "article",
+		},
+	},
+}
+
+// TestClickEventsHaveKeyEventsExtras locks in branches that upstream's
+// test file doesn't exercise but are reachable through the rule's
+// listener gate. Each case is differential-validated against upstream
+// eslint-plugin-jsx-a11y@6.10.2.
+func TestClickEventsHaveKeyEventsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ClickEventsHaveKeyEventsRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// Dimension 1: attribute-existence short-circuit edge shapes.
+			// ============================================================
+
+			// ---- onClick absent → no diagnostic, regardless of element. ----
+			{Code: `<div />;`, Tsx: true},
+			{Code: `<section />;`, Tsx: true},
+			{Code: `<article aria-label="x" />;`, Tsx: true},
+			// ---- onClick + onKeyPress only + spread combo. ----
+			{Code: `<div onClick={() => void 0} onKeyPress={foo} {...props} />;`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1 (tsgo AST): JsxSelfClosingElement vs paired
+			// JsxElement listener boundary — both kinds must fire.
+			// ============================================================
+
+			// ---- Paired form <button>...</button>: tsgo emits KindJsxOpeningElement. ----
+			{Code: `<button onClick={() => void 0}>label</button>`, Tsx: true},
+			// ---- Self-closing form <button />: tsgo emits KindJsxSelfClosingElement. ----
+			{Code: `<button onClick={() => void 0} />`, Tsx: true},
+			// ---- Deeply nested mix of inherently-interactive elements. ----
+			{
+				Code: `<section aria-label="x">` +
+					`<button onClick={() => void 0}>a</button>` +
+					`<a href="x" onClick={() => void 0}>b</a>` +
+					`<input type="text" onClick={() => void 0} />` +
+					`</section>`,
+				Tsx: true,
+			},
+
+			// ============================================================
+			// Dimension 1 (tsgo AST): attribute-value wrappers on
+			// aria-hidden / type. ESTree flattens parens at parse time;
+			// tsgo preserves them. staticEval unwraps parens + the
+			// TS-`as`-assertion form that jsx-ast-utils' `extract()`
+			// while-loop also unwraps.
+			// ============================================================
+
+			// ---- aria-hidden with paren wrapping (single + multi level). ----
+			{Code: `<div onClick={() => void 0} aria-hidden={(true)} />`, Tsx: true},
+			{Code: `<div onClick={() => void 0} aria-hidden={((true))} />`, Tsx: true},
+			// ---- aria-hidden with TS `as` cast (matches upstream's
+			//      TSAsExpression unwrap in `extract()`). ----
+			{Code: `<div onClick={() => void 0} aria-hidden={true as boolean} />`, Tsx: true},
+			// ---- aria-hidden as JsxExpression containing string "true"
+			//      (jsxAstUtilsLiteralCoerce: "true" → bool true). ----
+			{Code: `<div onClick={() => void 0} aria-hidden={"true"} />`, Tsx: true},
+			// ---- DOCUMENTED DIVERGENCE: aria-hidden={true!} (TS non-null
+			//      assertion on a boolean literal). Upstream ESLint reports
+			//      this — jsx-ast-utils' `extract()` (the getPropValue path)
+			//      has no TYPES entry for `TSNonNullExpression` and falls
+			//      through to null, so aria-hidden does not equal boolean
+			//      true and the rule fires. rslint's shared `staticEval`
+			//      transparently strips `!` (via OEKNonNullAssertions in
+			//      skipTransparent), recovering the boolean true → element
+			//      is treated as hidden → no diagnostic. The plugin-wide
+			//      staticEval semantics are shared across 30+ jsx-a11y
+			//      tests in this repo and intentionally more permissive
+			//      than the upstream TYPES table — see Phase 1 Step 6.B
+			//      (language-natural divergence) in PORT_RULE.md. ----
+			{Code: `<div onClick={() => void 0} aria-hidden={true!} />`, Tsx: true},
+
+			// ---- role as JsxExpression containing string literal. ----
+			{Code: `<div onClick={() => void 0} role={"presentation"} />`, Tsx: true},
+			// ---- role as no-substitution template literal. ----
+			{Code: "<div onClick={() => void 0} role={`none`} />", Tsx: true},
+			// ---- role with paren wrapping. ----
+			{Code: `<div onClick={() => void 0} role={("presentation")} />`, Tsx: true},
+			// ---- TemplateExpression whose quasis + extracted substitution
+			//      values concatenate to "presentation". Upstream's
+			//      LITERAL_TYPES.TemplateLiteral extractor joins each quasi
+			//      with the extracted value of each substitution. Locks in
+			//      the IsPresentationRole → LiteralPropStringValue routing
+			//      (was LiteralStringValue, which silently rejected every
+			//      TemplateExpression even when statically resolvable). ----
+			{Code: "<div onClick={() => void 0} role={`presentation${''}`} />", Tsx: true},
+			{Code: "<div onClick={() => void 0} role={`none${''}`} />", Tsx: true},
+			// ---- role={null} — LITERAL_TYPES.Literal special-cases the
+			//      `null` literal to the string "null"; "null" ≠
+			//      "presentation"/"none" → IsPresentationRole returns false,
+			//      so this falls through to the non-interactive `div` check
+			//      and the rule fires. Covered in invalid section below. ----
+
+			// ---- input[type=hidden] with JsxExpression containing string. ----
+			{Code: `<input onClick={() => void 0} type={"hidden"} />`, Tsx: true},
+			// ---- input[type=hidden] with case-insensitive value match
+			//      (literalPropValue → "hidden" comparison via EqualFold). ----
+			{Code: `<input onClick={() => void 0} type="HIDDEN" />`, Tsx: true},
+			{Code: `<input onClick={() => void 0} type="Hidden" />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1: case-insensitive attribute name matching
+			// (jsx-ast-utils `getProp` default `ignoreCase: true`).
+			// ============================================================
+
+			// ---- All-lowercase onclick / onkeydown. Upstream matches
+			//      these against the canonical names. ----
+			{Code: `<div onclick={() => void 0} onkeydown={foo} />`, Tsx: true},
+			// ---- ALL-CAPS attribute names. ----
+			{Code: `<div ONCLICK={() => void 0} ONKEYPRESS={foo} />`, Tsx: true},
+			// ---- Mixed-case onClick + lowercase onkeypress. ----
+			{Code: `<div onClick={() => void 0} onkeypress={foo} />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1: onClick value variants on interactive elements.
+			// The rule gates on attribute existence, not value — these
+			// would all report on a non-interactive element. Here they
+			// pair with interactive tags so they land in the valid bucket.
+			// ============================================================
+
+			// ---- `<button onClick />` boolean form on interactive element. ----
+			{Code: `<button onClick />`, Tsx: true},
+			// ---- onClick={null} + onKeyDown on non-interactive element
+			//      — null value irrelevant; keyboard listener saves it. ----
+			{Code: `<div onClick={null} onKeyDown={foo} />`, Tsx: true},
+			// ---- onClick={undefined} + onKeyDown on non-interactive element. ----
+			{Code: `<div onClick={undefined} onKeyDown={foo} />`, Tsx: true},
+
+			// ============================================================
+			// Inherent-interactive element survey (upstream's tests cover
+			// a small sample; these lock in the rest of the elementRoles /
+			// elementAXObjects schema).
+			// ============================================================
+			{Code: `<input type="button" onClick={() => void 0} />`, Tsx: true},
+			{Code: `<input type="submit" onClick={() => void 0} />`, Tsx: true},
+			{Code: `<input type="reset" onClick={() => void 0} />`, Tsx: true},
+			{Code: `<input type="image" onClick={() => void 0} />`, Tsx: true},
+			{Code: `<input type="checkbox" onClick={() => void 0} />`, Tsx: true},
+			{Code: `<input type="radio" onClick={() => void 0} />`, Tsx: true},
+			{Code: `<input type="range" onClick={() => void 0} />`, Tsx: true},
+			{Code: `<input type="number" onClick={() => void 0} />`, Tsx: true},
+			// input[type=search] matches the catch-all `{Name: "input"}`
+			// entry in interactiveElementAXSchemas → interactive.
+			{Code: `<input type="search" onClick={() => void 0} />`, Tsx: true},
+			{Code: `<input type="email" onClick={() => void 0} />`, Tsx: true},
+			{Code: `<th onClick={() => void 0} />`, Tsx: true},
+			{Code: `<td onClick={() => void 0} />`, Tsx: true},
+			{Code: `<tr onClick={() => void 0} />`, Tsx: true},
+			{Code: `<datalist onClick={() => void 0} />`, Tsx: true},
+			{Code: `<menuitem onClick={() => void 0} />`, Tsx: true},
+			{Code: `<summary onClick={() => void 0} />`, Tsx: true},
+
+			// ============================================================
+			// Settings: polymorphicPropName / polymorphicAllowList / components.
+			// ============================================================
+
+			// ---- polymorphicPropName: <Foo as="button"> → interactive. ----
+			{Code: `<Foo as="button" onClick={() => void 0} />`, Tsx: true, Settings: polymorphicSettings},
+			// ---- polymorphicPropName: <Foo as="a" href="x"> → interactive <a href>. ----
+			{Code: `<Foo as="a" href="x" onClick={() => void 0} />`, Tsx: true, Settings: polymorphicSettings},
+			// ---- polymorphicPropName: <Foo as="input" type="text"> → interactive. ----
+			{Code: `<Foo as="input" type="text" onClick={() => void 0} />`, Tsx: true, Settings: polymorphicSettings},
+			// ---- polymorphicPropName: non-literal `as` falls back to rawType. ----
+			{Code: `<Foo as={someType} onClick={() => void 0} />`, Tsx: true, Settings: polymorphicSettings},
+			// ---- polymorphicPropName: empty-string `as` falsy → fallback rawType. ----
+			{Code: `<Foo as="" onClick={() => void 0} />`, Tsx: true, Settings: polymorphicSettings},
+			// ---- polymorphicPropName: `as` absent → fallback rawType (custom). ----
+			{Code: `<Foo onClick={() => void 0} />`, Tsx: true, Settings: polymorphicSettings},
+			// ---- polymorphicAllowList: <Bar as="div"> stays as Bar (custom). ----
+			{Code: `<Bar as="div" onClick={() => void 0} />`, Tsx: true, Settings: allowListSettings},
+			// ---- polymorphicAllowList: <Foo as="button"> swap allowed → interactive. ----
+			{Code: `<Foo as="button" onClick={() => void 0} />`, Tsx: true, Settings: allowListSettings},
+
+			// ---- components map: <MyButton> → button (interactive). ----
+			{Code: `<MyButton onClick={() => void 0} />`, Tsx: true, Settings: componentsMapSettings},
+			// ---- components map present but element not listed → custom. ----
+			{Code: `<Unmapped onClick={() => void 0} />`, Tsx: true, Settings: componentsMapSettings},
+
+			// ============================================================
+			// Spread shapes — direct listener satisfies hasAnyProp.
+			// ============================================================
+
+			// ---- Direct onKeyDown + literal-spread of onKeyUp. ----
+			{Code: `<div onClick={() => void 0} onKeyDown={foo} {...{onKeyUp: bar}} />`, Tsx: true},
+			// ---- Spread before direct onKeyDown — order doesn't matter. ----
+			{Code: `<div {...props} onClick={() => void 0} onKeyDown={foo} />`, Tsx: true},
+			// ---- Multiple spreads + direct onClick + direct keyboard. ----
+			{Code: `<div {...a} {...b} onClick={() => void 0} onKeyDown={foo} />`, Tsx: true},
+			// ---- Reverse listener order — onKeyDown before onClick. ----
+			{Code: `<div onKeyDown={foo} onClick={() => void 0} />`, Tsx: true},
+			// ---- Multiple onClick attributes — first match suffices;
+			//      keyboard listener present. ----
+			{Code: `<div onClick={fn1} onClick={fn2} onKeyDown={foo} />`, Tsx: true},
+
+			// ============================================================
+			// Nested JSX: listener doesn't bleed past the boundary. Every
+			// element classified independently.
+			// ============================================================
+
+			// ---- Outer div valid (has keyboard), inner button valid (interactive). ----
+			{Code: `<div onClick={() => void 0} onKeyDown={foo}><button onClick={() => void 0}>x</button></div>`, Tsx: true},
+			// ---- Three-level nesting, all interactive. ----
+			{
+				Code: `<fieldset><button onClick={() => void 0}>` +
+					`<a href="x" onClick={() => void 0}>x</a>` +
+					`</button></fieldset>`,
+				Tsx: true,
+			},
+
+			// ============================================================
+			// Real-world component patterns (no-report).
+			// ============================================================
+
+			// ---- React.forwardRef wrapping interactive button. ----
+			{
+				Code: `const Btn = React.forwardRef((props, ref) => <button ref={ref} onClick={props.onClick} {...props} />);`,
+				Tsx:  true,
+			},
+			// ---- React.memo wrapping interactive button. ----
+			{
+				Code: `const Btn = React.memo(({ id, onClick }) => <button id={id} onClick={onClick}>{id}</button>);`,
+				Tsx:  true,
+			},
+			// ---- Array.map producing interactive children only. ----
+			{
+				Code: `const list = items.map(item => <button key={item.id} onClick={() => choose(item)}>{item.label}</button>);`,
+				Tsx:  true,
+			},
+			// ---- Custom hook returning JSX. ----
+			{
+				Code: `function useFancy() { return <button onClick={() => void 0} />; }`,
+				Tsx:  true,
+			},
+			// ---- Generator yielding interactive elements. ----
+			{
+				Code: `function* render() { yield <button onClick={() => void 0} />; yield <a href="x" onClick={() => void 0} />; }`,
+				Tsx:  true,
+			},
+			// ---- Async function returning interactive element. ----
+			{
+				Code: `async function render() { return <button onClick={() => void 0} />; }`,
+				Tsx:  true,
+			},
+			// ---- Class component render() with interactive root. ----
+			{
+				Code: `class Form extends React.Component { render() { return <button onClick={() => void 0}>x</button>; } }`,
+				Tsx:  true,
+			},
+			// ---- IIFE returning interactive element. ----
+			{Code: `const x = (() => <button onClick={() => void 0} />)();`, Tsx: true},
+			// ---- Fragment with mixed valid children. ----
+			{
+				Code: `const x = (<><button onClick={fn} /><a href="x" onClick={fn} /><div onClick={fn} onKeyDown={fn} /></>);`,
+				Tsx:  true,
+			},
+			// ---- Conditional rendering — both branches interactive. ----
+			{
+				Code: `const x = cond ? <button onClick={fn} /> : <a href="x" onClick={fn} />;`,
+				Tsx:  true,
+			},
+			// ---- `&&` short-circuit. ----
+			{Code: `const x = cond && <button onClick={fn} />;`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Dimension 1: onClick existence forms — boolean, null,
+			// undefined values all count as "onClick present".
+			// ============================================================
+
+			// ---- Boolean form `<div onClick />` on non-interactive. ----
+			{Code: `<div onClick />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- onClick={null} on non-interactive — value irrelevant. ----
+			{Code: `<div onClick={null} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- onClick={undefined} on non-interactive. ----
+			{Code: `<div onClick={undefined} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- All-lowercase `onclick` (case-insensitive) on non-interactive. ----
+			{Code: `<div onclick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- ALL-CAPS `ONCLICK` on non-interactive. ----
+			{Code: `<div ONCLICK={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Dimension 1: role / aria-hidden value shapes that don't
+			// classify as the magic exempting literal.
+			// ============================================================
+
+			// ---- role="NONE" — case-sensitive match against
+			//      "presentation" / "none"; "NONE" does NOT match. ----
+			{Code: `<div onClick={() => void 0} role="NONE" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role="PRESENTATION" — same case-sensitivity. ----
+			{Code: `<div onClick={() => void 0} role="PRESENTATION" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role as TemplateExpression with substitution (non-literal). ----
+			{Code: "<div onClick={() => void 0} role={`presentation-${x}`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role as Identifier expression (non-literal). ----
+			{Code: `<div onClick={() => void 0} role={someRole} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role as call expression (non-literal). ----
+			{Code: `<div onClick={() => void 0} role={getRole()} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role as conditional (non-literal under literalPropValue). ----
+			{Code: `<div onClick={() => void 0} role={cond ? "presentation" : "main"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- aria-hidden as non-static call → not boolean true. ----
+			{Code: `<div onClick={() => void 0} aria-hidden={isHidden()} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- aria-hidden as Identifier (non-static) → not boolean true. ----
+			{Code: `<div onClick={() => void 0} aria-hidden={hiddenVar} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Non-interactive DOM element survey (upstream tests cover
+			// section/main/article/header/footer; these add the rest).
+			// ============================================================
+			{Code: `<span onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<aside onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<nav onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<p onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<h1 onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<h6 onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<ul onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<ol onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<li onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// `<form>` is in aria-query's `dom` map but matches NO
+			// interactive nor non-interactive role schema (unless
+			// aria-label / aria-labelledby / name is set, which still
+			// resolves to non-interactive). IsInteractiveElement → false
+			// → reported. Same for bare aria-label form.
+			{Code: `<form onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<form aria-label="x" onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Position assertions: nested JSX, multi-line containers.
+			// ============================================================
+
+			// ---- Nested non-interactive child fires on its own opening
+			//      element. Locks in that the listener visits children. ----
+			{
+				Code: `<button onClick={() => void 0}>` + "\n" +
+					`  <div onClick={() => void 0} />` + "\n" +
+					`</button>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "clickEventsHaveKeyEvents",
+					Message:   errorMessage,
+					Line:      2,
+					Column:    3,
+				}},
+			},
+			// ---- Multi-line opening element — Line/Column anchor to `<`. ----
+			{
+				Code: `<div` + "\n" +
+					`  onClick={() => void 0}` + "\n" +
+					`/>;`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "clickEventsHaveKeyEvents",
+					Message:   errorMessage,
+					Line:      1,
+					Column:    1,
+				}},
+			},
+			// ---- Two same-line non-interactive elements both report. ----
+			{
+				Code: `<><div onClick={fn} /><span onClick={fn} /></>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "clickEventsHaveKeyEvents", Message: errorMessage, Line: 1, Column: 3},
+					{MessageId: "clickEventsHaveKeyEvents", Message: errorMessage, Line: 1, Column: 23},
+				},
+			},
+			// ---- Three-level mix: outer valid (button), middle invalid
+			//      (div), inner valid (a). ----
+			{
+				Code: `<button onClick={fn}>` + "\n" +
+					`  <div onClick={fn}>` + "\n" +
+					`    <a href="x" onClick={fn} />` + "\n" +
+					`  </div>` + "\n" +
+					`</button>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "clickEventsHaveKeyEvents",
+					Message:   errorMessage,
+					Line:      2,
+					Column:    3,
+				}},
+			},
+
+			// ============================================================
+			// Settings: polymorphicPropName / components — DOM-resolved
+			// element loses its custom-component exemption.
+			// ============================================================
+
+			// ---- polymorphicPropName: <Foo as="div"> → div → reported. ----
+			{
+				Code:     `<Foo as="div" onClick={() => void 0} />`,
+				Tsx:      true,
+				Settings: polymorphicSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- polymorphicPropName: <Foo as="section"> → non-interactive. ----
+			{
+				Code:     `<Foo as="section" onClick={() => void 0} />`,
+				Tsx:      true,
+				Settings: polymorphicSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- polymorphicAllowList: <Foo as="div"> — Foo allowed → swap → reported. ----
+			{
+				Code:     `<Foo as="div" onClick={() => void 0} />`,
+				Tsx:      true,
+				Settings: allowListSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- components map: <MyFooter> → footer (non-interactive). ----
+			{
+				Code:     `<MyFooter onClick={() => void 0} />`,
+				Tsx:      true,
+				Settings: componentsMapSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- components map: <MyArticle> → article (non-interactive). ----
+			{
+				Code:     `<MyArticle onClick={() => void 0} />`,
+				Tsx:      true,
+				Settings: componentsMapSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+			},
+
+			// ============================================================
+			// Spread shapes — literal-spread of onKeyDown is opaque under
+			// hasAnyProp's spreadStrict default; spread cannot save the rule.
+			// ============================================================
+
+			// ---- Literal-spread `{...{onKeyDown: foo}}` does NOT satisfy
+			//      hasAnyProp under default `spreadStrict: true`. ----
+			{
+				Code:   `<div onClick={() => void 0} {...{onKeyDown: foo}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- Spread before onClick: order doesn't change opacity. ----
+			{
+				Code:   `<div {...props} onClick={() => void 0} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- Multiple spreads + literal-spread of keyboard + direct onClick. ----
+			{
+				Code:   `<div {...a} {...b} {...{onKeyUp: fn}} onClick={() => void 0} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- Spread of literal containing onClick — getProp walks
+			//      the literal, so the rule sees the onClick. No keyboard
+			//      listener present → reported. ----
+			{
+				Code:   `<div {...{onClick: () => void 0}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- ShorthandPropertyAssignment in literal spread:
+			//      `{...{onClick}}` — getProp matches the shorthand. ----
+			{
+				Code:   `<div {...{onClick}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+
+			// ============================================================
+			// `<a>` / `<area>` interactive promotion gates on `href` ONLY.
+			// ============================================================
+
+			// ---- `<a>` with tabIndex={0} but NO href — non-interactive. ----
+			{
+				Code:   `<a onClick={() => void 0} tabIndex={0} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- `<a>` with role="button" but NO href. isInteractiveRole
+			//      is NOT called by this rule, so the role doesn't promote. ----
+			{
+				Code:   `<a onClick={() => void 0} role="button" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- `<area>` without href — non-interactive. ----
+			{
+				Code:   `<area onClick={() => void 0} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+
+			// ============================================================
+			// Real-world component patterns (reports). Use expectedErrorAnyPos
+			// — the JSX opening element isn't at column 1 in these wrappers.
+			// ============================================================
+
+			// ---- React.forwardRef wrapping non-interactive div. ----
+			{
+				Code:   `const Card = React.forwardRef((props, ref) => <div ref={ref} onClick={props.onClick} {...props} />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- React.memo wrapping non-interactive section. ----
+			{
+				Code:   `const Pane = React.memo(({ id, onClick }) => <section id={id} onClick={onClick} />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- HOC wrapper producing non-interactive root. ----
+			{
+				Code:   `const Enhanced = withTracking(({ value, onClick }) => <div data-value={value} onClick={onClick} />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Array.map producing non-interactive children. ----
+			{
+				Code:   `const list = items.map(item => <li key={item.id} onClick={() => choose(item)}>{item.label}</li>);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Class component render returning non-interactive root. ----
+			{
+				Code:   `class Form extends React.Component { render() { return <article onClick={this.onClick}>x</article>; } }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Generator yielding non-interactive elements. ----
+			{
+				Code:   `function* render() { yield <div onClick={fn} />; yield <article onClick={fn} />; }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos, expectedErrorAnyPos},
+			},
+			// ---- Async function returning non-interactive root. ----
+			{
+				Code:   `async function render() { return <div onClick={fn} />; }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- IIFE returning non-interactive root. ----
+			{
+				Code:   `const x = (() => <article onClick={fn} />)();`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Conditional with one non-interactive branch. ----
+			{
+				Code:   `const x = cond ? <div onClick={fn} /> : null;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Fragment with mixed interactive / non-interactive children
+			//      — only non-interactive children report. ----
+			{
+				Code:   `const x = (<><button onClick={fn} /><div onClick={fn} /><a href="x" onClick={fn} /><section onClick={fn} /></>);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos, expectedErrorAnyPos},
+			},
+			// ---- Two-component file: A reports at line 1, B reports at line 2. ----
+			{
+				Code: `function A() { return <div onClick={fn} />; }` + "\n" +
+					`function B() { return <article onClick={fn} />; }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "clickEventsHaveKeyEvents", Message: errorMessage, Line: 1},
+					{MessageId: "clickEventsHaveKeyEvents", Message: errorMessage, Line: 2},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events_upstream_test.go
@@ -1,0 +1,105 @@
+package click_events_have_key_events
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedError mirrors upstream's `expectedError` constant — the single
+// shape every invalid case in the rule produces. Centralized so a future
+// error-text tweak touches one place. Shared with the extras test via
+// package scope.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "clickEventsHaveKeyEvents",
+	Message:   errorMessage,
+	Line:      1,
+	Column:    1,
+}
+
+// footerComponentSettings mirrors upstream's
+//
+//	settings: { 'jsx-a11y': { components: { Footer: 'footer' } } }
+//
+// so `<Footer>` resolves to `footer` and trips the non-interactive check.
+var footerComponentSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Footer": "footer",
+		},
+	},
+}
+
+// TestClickEventsHaveKeyEventsUpstream covers the full valid/invalid suite
+// migrated 1:1 from upstream eslint-plugin-jsx-a11y's
+// `__tests__/src/rules/click-events-have-key-events-test.js`. Order inside
+// each group mirrors the upstream file so a future audit can grep across
+// both side-by-side.
+//
+// Anything NOT in upstream's test file — TS wrappers, position assertions,
+// extra spread shapes — lives in click_events_have_key_events_extras_test.go.
+func TestClickEventsHaveKeyEventsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ClickEventsHaveKeyEventsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- onClick + each keyboard listener variant ----
+			{Code: `<div onClick={() => void 0} onKeyDown={foo}/>;`, Tsx: true},
+			{Code: `<div onClick={() => void 0} onKeyUp={foo} />;`, Tsx: true},
+			{Code: `<div onClick={() => void 0} onKeyPress={foo}/>;`, Tsx: true},
+			{Code: `<div onClick={() => void 0} onKeyDown={foo} onKeyUp={bar} />;`, Tsx: true},
+			// ---- onClick + onKeyDown then spread — direct keyboard prop wins. ----
+			{Code: `<div onClick={() => void 0} onKeyDown={foo} {...props} />;`, Tsx: true},
+			// ---- No onClick prop → rule short-circuits. ----
+			{Code: `<div className="foo" />;`, Tsx: true},
+			// ---- aria-hidden variants — element is hidden from screen readers. ----
+			{Code: `<div onClick={() => void 0} aria-hidden />;`, Tsx: true},
+			{Code: `<div onClick={() => void 0} aria-hidden={true} />;`, Tsx: true},
+			// ---- aria-hidden={false} BUT has keyboard listener → still valid. ----
+			{Code: `<div onClick={() => void 0} aria-hidden={false} onKeyDown={foo} />;`, Tsx: true},
+			// ---- aria-hidden={undefined} BUT has keyboard listener → still valid. ----
+			{Code: `<div onClick={() => void 0} onKeyDown={foo} aria-hidden={undefined} />;`, Tsx: true},
+			// ---- Interactive elements via aria-query elementRoles / elementAXObjects. ----
+			{Code: `<input type="text" onClick={() => void 0} />`, Tsx: true},
+			{Code: `<input onClick={() => void 0} />`, Tsx: true},
+			{Code: `<button onClick={() => void 0} className="foo" />`, Tsx: true},
+			{Code: `<option onClick={() => void 0} className="foo" />`, Tsx: true},
+			{Code: `<select onClick={() => void 0} className="foo" />`, Tsx: true},
+			{Code: `<textarea onClick={() => void 0} className="foo" />`, Tsx: true},
+			{Code: `<a onClick={() => void 0} href="http://x.y.z" />`, Tsx: true},
+			{Code: `<a onClick={() => void 0} href="http://x.y.z" tabIndex="0" />`, Tsx: true},
+			// ---- input[type=hidden] → isHiddenFromScreenReader returns true. ----
+			{Code: `<input onClick={() => void 0} type="hidden" />;`, Tsx: true},
+			// ---- role=presentation / role=none → isPresentationRole. ----
+			{Code: `<div onClick={() => void 0} role="presentation" />;`, Tsx: true},
+			{Code: `<div onClick={() => void 0} role="none" />;`, Tsx: true},
+			// ---- Custom components — element type isn't in aria-query's `dom`
+			//      map → upstream short-circuits before checking interactivity. ----
+			{Code: `<TestComponent onClick={doFoo} />`, Tsx: true},
+			{Code: `<Button onClick={doFoo} />`, Tsx: true},
+			{Code: `<Footer onClick={doFoo} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Plain <div> with onClick, no keyboard listener. ----
+			{Code: `<div onClick={() => void 0} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role={undefined} — not "presentation"/"none" → div remains non-interactive. ----
+			{Code: `<div onClick={() => void 0} role={undefined} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- {...props} spread is opaque under hasAnyProp's spreadStrict
+			//      default → cannot supply keyboard listener. ----
+			{Code: `<div onClick={() => void 0} {...props} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- Non-interactive sectioning DOM elements. ----
+			{Code: `<section onClick={() => void 0} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<main onClick={() => void 0} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<article onClick={() => void 0} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<header onClick={() => void 0} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<footer onClick={() => void 0} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- aria-hidden={false} → not hidden → still requires keyboard. ----
+			{Code: `<div onClick={() => void 0} aria-hidden={false} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- <a> without href → not interactive (interactive schema gates
+			//      on `href` attribute existence). ----
+			{Code: `<a onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<a tabIndex="0" onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- componentsMap resolves <Footer> → 'footer' (non-interactive DOM). ----
+			{Code: `<Footer onClick={doFoo} />`, Tsx: true, Settings: footerComponentSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -163,6 +163,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/aria-activedescendant-has-tabindex.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/aria-unsupported-elements.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/click-events-have-key-events.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/heading-has-content.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/html-has-lang.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/iframe-has-title.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/click-events-have-key-events.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/click-events-have-key-events.test.ts
@@ -1,0 +1,222 @@
+import { RuleTester } from '../rule-tester';
+
+const errorMessage =
+  'Visible, non-interactive elements with click handlers must have at least one keyboard listener.';
+const expectedError = { message: errorMessage };
+
+const footerComponentSettings = {
+  'jsx-a11y': {
+    components: {
+      Footer: 'footer',
+    },
+  },
+};
+
+const polymorphicSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+  },
+};
+
+const polymorphicAllowListSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+    polymorphicAllowList: ['Foo'],
+  },
+};
+
+new RuleTester().run('click-events-have-key-events', null as never, {
+  valid: [
+    // ============================================================
+    // Upstream valid suite (mirrors __tests__/src/rules/click-events-have-key-events-test.js)
+    // ============================================================
+    { code: '<div onClick={() => void 0} onKeyDown={foo}/>;' },
+    { code: '<div onClick={() => void 0} onKeyUp={foo} />;' },
+    { code: '<div onClick={() => void 0} onKeyPress={foo}/>;' },
+    { code: '<div onClick={() => void 0} onKeyDown={foo} onKeyUp={bar} />;' },
+    { code: '<div onClick={() => void 0} onKeyDown={foo} {...props} />;' },
+    { code: '<div className="foo" />;' },
+    { code: '<div onClick={() => void 0} aria-hidden />;' },
+    { code: '<div onClick={() => void 0} aria-hidden={true} />;' },
+    {
+      code: '<div onClick={() => void 0} aria-hidden={false} onKeyDown={foo} />;',
+    },
+    {
+      code: '<div onClick={() => void 0} onKeyDown={foo} aria-hidden={undefined} />;',
+    },
+    { code: '<input type="text" onClick={() => void 0} />' },
+    { code: '<input onClick={() => void 0} />' },
+    { code: '<button onClick={() => void 0} className="foo" />' },
+    { code: '<option onClick={() => void 0} className="foo" />' },
+    { code: '<select onClick={() => void 0} className="foo" />' },
+    { code: '<textarea onClick={() => void 0} className="foo" />' },
+    { code: '<a onClick={() => void 0} href="http://x.y.z" />' },
+    { code: '<a onClick={() => void 0} href="http://x.y.z" tabIndex="0" />' },
+    { code: '<input onClick={() => void 0} type="hidden" />;' },
+    { code: '<div onClick={() => void 0} role="presentation" />;' },
+    { code: '<div onClick={() => void 0} role="none" />;' },
+    { code: '<TestComponent onClick={doFoo} />' },
+    { code: '<Button onClick={doFoo} />' },
+    { code: '<Footer onClick={doFoo} />' },
+
+    // ============================================================
+    // Inherent-interactive element survey (no onClick exemption needed
+    // because each is interactive by its role schema).
+    // ============================================================
+    { code: '<a href="x" onClick={() => void 0} />' },
+    { code: '<input type="button" onClick={() => void 0} />' },
+    { code: '<input type="submit" onClick={() => void 0} />' },
+    { code: '<input type="reset" onClick={() => void 0} />' },
+    { code: '<input type="image" onClick={() => void 0} />' },
+    { code: '<input type="checkbox" onClick={() => void 0} />' },
+    { code: '<input type="radio" onClick={() => void 0} />' },
+    { code: '<input type="range" onClick={() => void 0} />' },
+    { code: '<input type="number" onClick={() => void 0} />' },
+    { code: '<th onClick={() => void 0} />' },
+    { code: '<td onClick={() => void 0} />' },
+    { code: '<tr onClick={() => void 0} />' },
+    { code: '<datalist onClick={() => void 0} />' },
+    { code: '<menuitem onClick={() => void 0} />' },
+    { code: '<summary onClick={() => void 0} />' },
+
+    // ============================================================
+    // aria-hidden additional shapes
+    // ============================================================
+    { code: '<div onClick={() => void 0} aria-hidden="true" />;' },
+    { code: '<input onClick={() => void 0} type="HIDDEN" />;' },
+
+    // ============================================================
+    // Settings: polymorphicPropName / polymorphicAllowList
+    // ============================================================
+    {
+      code: '<Foo as="button" onClick={() => void 0} />;',
+      settings: polymorphicSettings,
+    },
+    {
+      code: '<Foo as={someType} onClick={() => void 0} />;',
+      settings: polymorphicSettings,
+    },
+    {
+      code: '<Bar as="div" onClick={() => void 0} />;',
+      settings: polymorphicAllowListSettings,
+    },
+
+    // ============================================================
+    // Spread + direct keyboard listener combo
+    // ============================================================
+    {
+      code: '<div onClick={() => void 0} onKeyDown={foo} {...{onKeyUp: bar}} />;',
+    },
+
+    // ============================================================
+    // Nested JSX: interactive button child inside valid outer container
+    // ============================================================
+    {
+      code: '<div onClick={() => void 0} onKeyDown={foo}><button onClick={() => void 0}>x</button></div>',
+    },
+
+    // ============================================================
+    // Real-world component patterns
+    // ============================================================
+    {
+      code: 'function Button({ children }) { return <button onClick={() => void 0}>{children}</button>; }',
+    },
+    {
+      code: 'const items = arr.map(item => <button key={item.id} onClick={() => void 0}>{item.name}</button>);',
+    },
+    {
+      code: 'const Fancy = React.forwardRef((props, ref) => <button ref={ref} onClick={() => void 0} {...props} />);',
+    },
+  ],
+  invalid: [
+    // ============================================================
+    // Upstream invalid suite
+    // ============================================================
+    {
+      code: '<div onClick={() => void 0} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div onClick={() => void 0} role={undefined} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div onClick={() => void 0} {...props} />;',
+      errors: [expectedError],
+    },
+    { code: '<section onClick={() => void 0} />;', errors: [expectedError] },
+    { code: '<main onClick={() => void 0} />;', errors: [expectedError] },
+    { code: '<article onClick={() => void 0} />;', errors: [expectedError] },
+    { code: '<header onClick={() => void 0} />;', errors: [expectedError] },
+    { code: '<footer onClick={() => void 0} />;', errors: [expectedError] },
+    {
+      code: '<div onClick={() => void 0} aria-hidden={false} />;',
+      errors: [expectedError],
+    },
+    { code: '<a onClick={() => void 0} />', errors: [expectedError] },
+    {
+      code: '<a tabIndex="0" onClick={() => void 0} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<Footer onClick={doFoo} />',
+      errors: [expectedError],
+      settings: footerComponentSettings,
+    },
+
+    // ============================================================
+    // Non-interactive element survey
+    // ============================================================
+    { code: '<span onClick={() => void 0} />', errors: [expectedError] },
+    { code: '<aside onClick={() => void 0} />', errors: [expectedError] },
+    { code: '<nav onClick={() => void 0} />', errors: [expectedError] },
+    { code: '<p onClick={() => void 0} />', errors: [expectedError] },
+    { code: '<h1 onClick={() => void 0} />', errors: [expectedError] },
+    { code: '<h6 onClick={() => void 0} />', errors: [expectedError] },
+    { code: '<ul onClick={() => void 0} />', errors: [expectedError] },
+    { code: '<ol onClick={() => void 0} />', errors: [expectedError] },
+    { code: '<li onClick={() => void 0} />', errors: [expectedError] },
+
+    // ============================================================
+    // Listener boundary — nested element reports independently
+    // ============================================================
+    {
+      code: '<button onClick={() => void 0}><div onClick={() => void 0} /></button>',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Spread literal — hasAnyProp's spreadStrict: true default keeps
+    // it opaque.
+    // ============================================================
+    {
+      code: '<div onClick={() => void 0} {...{onKeyDown: foo}} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div {...props} onClick={() => void 0} />;',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // polymorphicPropName → non-interactive
+    // ============================================================
+    {
+      code: '<Foo as="div" onClick={() => void 0} />;',
+      settings: polymorphicSettings,
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Real-world a11y misuse
+    // ============================================================
+    {
+      code: 'function ClickCard() { return <div onClick={handler}>Title</div>; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function App() { return (<><div onClick={() => void 0}>A</div><button onClick={() => void 0}>B</button><section onClick={() => void 0}>C</section></>); }',
+      errors: [expectedError, expectedError],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port [`jsx-a11y/click-events-have-key-events`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/click-events-have-key-events.md) from `eslint-plugin-jsx-a11y` to rslint.

The rule reports a visible, non-interactive DOM element carrying an `onClick` handler when no keyboard event listener (`onKeyDown` / `onKeyUp` / `onKeyPress`) accompanies it. Pairing pointer and keyboard handlers keeps the interaction reachable for keyboard-only users and assistive technologies.

Behavior is byte-for-byte aligned with upstream `eslint-plugin-jsx-a11y@6.10.2` via differential validation. One language-natural divergence is documented in the rule's `.md` ("Differences from ESLint"): `aria-hidden={value!}` with a TS non-null assertion — rslint's plugin-wide `staticEval` transparently strips `!`, where upstream's `getPropValue` does not.

This PR also fixes `jsxa11yutil.IsPresentationRole` to route through `LiteralPropStringValue` (mirroring upstream `getLiteralPropValue`) so that `role={\`presentation${''}\`}`-style TemplateExpressions whose substitution evaluates to the empty string are correctly recognized. The full jsx-a11y plugin Go test suite (19 rules) passes after this change.

## Related Links

- Upstream rule documentation: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/click-events-have-key-events.md
- Upstream source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/click-events-have-key-events.js
- Upstream test cases: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/__tests__/src/rules/click-events-have-key-events-test.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).