### PR TITLE
docs: switch port-rule docs to rslint.config.mjs

### DIFF
--- a/agents/port-rule/SKILL.md
+++ b/agents/port-rule/SKILL.md
@@ -174,7 +174,7 @@ Already-committed rules are not affected by later failures.
 - Commit message: `feat: port rule <rule-name>`
 - Do NOT include AI-related information in commit messages (no `Co-Authored-By: Claude` or similar)
 - Only stage files related to the current rule(s). `pnpm format:go` may reformat unrelated files — discard them with `git checkout -- <file>` before committing.
-- If the rule's plugin is already in `rslint.json` `plugins`, add the rule with `"warn"` severity. Otherwise, do NOT modify `rslint.json`.
+- If the rule's plugin is already in the repo-root `rslint.config.ts` `plugins`, add the rule with `'warn'` severity. Otherwise, do NOT modify `rslint.config.ts`.
 
 **PR title format**:
 

--- a/agents/port-rule/references/PORT_RULE.md
+++ b/agents/port-rule/references/PORT_RULE.md
@@ -501,15 +501,15 @@ rule_tester.InvalidTestCase{
 1. **Check Directory**: Verify if `packages/rslint-test-tools/tests/<plugin-name>` exists.
 
 2. **Check Configuration**:
-   - **Reference**: Use `packages/rslint-test-tools/tests/eslint-plugin-import` as the template.
+   - **Reference**: Use `packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y` as the template (ESM flat-config format).
    - **Required Files**:
-     - `rslint.json` (Configuration for the linter)
+     - `rslint.config.mjs` (Configuration for the linter — JSON `rslint.json` is legacy and the loader auto-migrates it to JS/TS; do NOT create new `rslint.json` files)
      - `tsconfig.files.json` (TS Config for file-based tests)
      - `tsconfig.virtual.json` (TS Config for virtual/code-based tests)
-   - **Plugin Configuration**: In `rslint.json`, set `plugins` field:
-     - **Core Rules**: `"plugins": []`
-     - **Plugin Rules**: `"plugins": ["eslint-plugin-import"]`
-   - **Warning**: When copying `rule-tester.ts`, remove any hardcoded rule prefixes (e.g., `ruleName = 'import/' + ruleName;`).
+   - **Plugin Configuration**: In `rslint.config.mjs`, set the `plugins` field (use the short plugin name, matching how rules are addressed in tests):
+     - **Core Rules**: `plugins: []`
+     - **Plugin Rules**: `plugins: ['<short-name>']` (e.g. `'jsx-a11y'`, `'jest'`, `'react'`, `'promise'`)
+   - **Warning**: When copying `rule-tester.ts`, remove any hardcoded rule prefixes (e.g., `ruleName = 'jsx-a11y/' + ruleName;`).
 
 ### Step 6: Add JS Tests
 
@@ -523,7 +523,7 @@ rule_tester.InvalidTestCase{
 
 - **Core ESLint Rules**: Import `RuleTester` from `../rule-tester` (in `tests/eslint/rule-tester.ts`, no prefix)
 - **typescript-eslint Rules**: Import `RuleTester` from `@typescript-eslint/rule-tester` (auto-prefixes with `@typescript-eslint/`)
-- **Other Plugin Rules**: Refer to `packages/rslint-test-tools/tests/eslint-plugin-import/rule-tester.ts`
+- **Other Plugin Rules**: Refer to `packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rule-tester.ts`
 
 **Options Format**: JS tests use array format: `options: [{ allow: ['warn'] }]`
 
@@ -707,8 +707,8 @@ Follow this **strict order** — each step depends on the previous one:
 This step is executed **after each rule's Phase 4 completes** (both in single-rule and batch mode).
 
 1. **Configure Project Settings (Conditional)**:
-   - If the rule's plugin is already in `rslint.json` `plugins`, add the rule with `"warn"` severity
-   - Otherwise, do NOT modify `rslint.json`
+   - If the rule's plugin is already in the repo-root `rslint.config.ts` `plugins`, add the rule with `'warn'` severity
+   - Otherwise, do NOT modify `rslint.config.ts`
 
 2. **Commit Changes**:
 
@@ -836,7 +836,7 @@ If JS tests fail with 0 diagnostics found:
 1. **Did you rebuild the binary?** Run `cd packages/rslint && pnpm run build:bin`
 2. **Is the rule registered?** Check `internal/config/config.go`
 3. **Are test files included?** Check `rstest.config.mts`
-4. **Is rslint.json configured?** Ensure the rule is enabled
+4. **Is the test-dir `rslint.config.mjs` configured?** Ensure the plugin is listed and the rule is enabled
 5. **Debug Mode**: Use `fmt.Fprintf(os.Stderr, "DEBUG: ...")` in Go code
 
 ### Line/Column Mismatch


### PR DESCRIPTION
## Summary

- The repo's config loader (`internal/config/config_init.go`) treats `rslint.json` as legacy and auto-migrates it to `rslint.config.{ts,mts,js,mjs}`, but the port-rule docs still instruct new test directories to create `rslint.json` and modify a non-existent root `rslint.json`.
- Update `agents/port-rule/references/PORT_RULE.md` Phase 3 Step 5 to point new plugin test directories at `rslint.config.mjs`, using `eslint-plugin-jsx-a11y` (the only test dir already on the new format, introduced with `alt-text`/`click-events-have-key-events`) as the template. Plugin name in `plugins:` uses the short form to match how rules are addressed in tests.
- Update Phase 5 commit guidance and the Troubleshooting checklist (in both `PORT_RULE.md` and `SKILL.md`) so the repo-root config is correctly referenced as `rslint.config.ts`.
- No code changes; existing test directories with `rslint.json` are left alone (separate migration PR).

## Test plan

- [x] `grep -rn 'rslint\.json' agents/port-rule/` — only the intentional "legacy" mention remains.
- [ ] Reviewer sanity check: open `agents/port-rule/references/PORT_RULE.md` Step 5 and confirm the `rslint.config.mjs` snippet matches `packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rslint.config.mjs`.