### PR TITLE
feat: port rule jsx-a11y/aria-proptypes

### DIFF
--- a/cspell.config.cjs
+++ b/cspell.config.cjs
@@ -20,6 +20,7 @@ module.exports = {
     'internal/linter/*_test.go',
     'internal/rules/valid_typeof/valid_typeof.md',
     'internal/plugins/jsx_a11y/rules/aria_props/aria_props.md',
+    'internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes.md',
     'internal/plugins/react/rules/no_typos/no_typos.md',
     'website/docs/en/rules/*/',
   ],

--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -6,6 +6,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/anchor_is_valid"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_props"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_proptypes"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_unsupported_elements"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/autocomplete_valid"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/click_events_have_key_events"
@@ -31,6 +32,7 @@ func GetAllRules() []rule.Rule {
 		anchor_is_valid.AnchorIsValidRule,
 		aria_activedescendant_has_tabindex.AriaActivedescendantHasTabindexRule,
 		aria_props.AriaPropsRule,
+		aria_proptypes.AriaProptypesRule,
 		aria_unsupported_elements.AriaUnsupportedElementsRule,
 		autocomplete_valid.AutocompleteValidRule,
 		click_events_have_key_events.ClickEventsHaveKeyEventsRule,

--- a/internal/plugins/jsx_a11y/jsxa11yutil/aria.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/aria.go
@@ -1,6 +1,270 @@
 package jsxa11yutil
 
-import "strings"
+import (
+	"math/big"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// AriaPropertyDefinition describes the type and permitted values of a single
+// ARIA state / property as defined by `aria-query`'s `ariaPropsMap`.
+//
+// Source: https://github.com/A11yance/aria-query/blob/main/src/ariaPropsMap.js
+type AriaPropertyDefinition struct {
+	// Type is one of: "boolean", "string", "integer", "number",
+	// "tristate", "token", "tokenlist", "id", "idlist". The list is
+	// closed — aria-query has no other type tags.
+	Type string
+	// Values is the list of permitted token values for "token" /
+	// "tokenlist" types. Elements are either strings or booleans —
+	// `aria-current`, `aria-haspopup`, and `aria-invalid` include the
+	// JavaScript booleans `true` / `false` as valid token values, so the
+	// list is heterogeneous. Empty for other types.
+	//
+	// Iteration order matches upstream's array order so the error-message
+	// `${permittedValues}` (which hits Array.prototype.toString and joins
+	// with a bare comma) renders byte-for-byte identical.
+	Values []any
+	// AllowUndefined mirrors upstream's `allowundefined` (lowercase!) field.
+	// Set only for `aria-expanded`, `aria-grabbed`, `aria-hidden`, and
+	// `aria-selected`, where ARIA explicitly permits the value `undefined`
+	// as a third state distinct from absence.
+	AllowUndefined bool
+}
+
+// AriaPropertyDefinitions mirrors `aria-query`'s `ariaPropsMap` entries
+// keyed by lowercase canonical name. Source of truth for type / values /
+// allow-undefined metadata used by jsx-a11y/aria-proptypes.
+//
+// AriaPropertyNames and AriaPropertySet remain the sources of truth for
+// iteration order (suggestion ranking in jsx-a11y/aria-props) and existence
+// checks; this map covers ONLY the value-validation metadata.
+//
+// Source: https://github.com/A11yance/aria-query/blob/main/src/ariaPropsMap.js
+var AriaPropertyDefinitions = map[string]AriaPropertyDefinition{
+	"aria-activedescendant":       {Type: "id"},
+	"aria-atomic":                 {Type: "boolean"},
+	"aria-autocomplete":           {Type: "token", Values: []any{"inline", "list", "both", "none"}},
+	"aria-braillelabel":           {Type: "string"},
+	"aria-brailleroledescription": {Type: "string"},
+	"aria-busy":                   {Type: "boolean"},
+	"aria-checked":                {Type: "tristate"},
+	"aria-colcount":               {Type: "integer"},
+	"aria-colindex":               {Type: "integer"},
+	"aria-colspan":                {Type: "integer"},
+	"aria-controls":               {Type: "idlist"},
+	"aria-current":                {Type: "token", Values: []any{"page", "step", "location", "date", "time", true, false}},
+	"aria-describedby":            {Type: "idlist"},
+	"aria-description":            {Type: "string"},
+	"aria-details":                {Type: "id"},
+	"aria-disabled":               {Type: "boolean"},
+	"aria-dropeffect":             {Type: "tokenlist", Values: []any{"copy", "execute", "link", "move", "none", "popup"}},
+	"aria-errormessage":           {Type: "id"},
+	"aria-expanded":               {Type: "boolean", AllowUndefined: true},
+	"aria-flowto":                 {Type: "idlist"},
+	"aria-grabbed":                {Type: "boolean", AllowUndefined: true},
+	"aria-haspopup":               {Type: "token", Values: []any{false, true, "menu", "listbox", "tree", "grid", "dialog"}},
+	"aria-hidden":                 {Type: "boolean", AllowUndefined: true},
+	"aria-invalid":                {Type: "token", Values: []any{"grammar", false, "spelling", true}},
+	"aria-keyshortcuts":           {Type: "string"},
+	"aria-label":                  {Type: "string"},
+	"aria-labelledby":             {Type: "idlist"},
+	"aria-level":                  {Type: "integer"},
+	"aria-live":                   {Type: "token", Values: []any{"assertive", "off", "polite"}},
+	"aria-modal":                  {Type: "boolean"},
+	"aria-multiline":              {Type: "boolean"},
+	"aria-multiselectable":        {Type: "boolean"},
+	"aria-orientation":            {Type: "token", Values: []any{"vertical", "undefined", "horizontal"}},
+	"aria-owns":                   {Type: "idlist"},
+	"aria-placeholder":            {Type: "string"},
+	"aria-posinset":               {Type: "integer"},
+	"aria-pressed":                {Type: "tristate"},
+	"aria-readonly":               {Type: "boolean"},
+	"aria-relevant":               {Type: "tokenlist", Values: []any{"additions", "all", "removals", "text"}},
+	"aria-required":               {Type: "boolean"},
+	"aria-roledescription":        {Type: "string"},
+	"aria-rowcount":               {Type: "integer"},
+	"aria-rowindex":               {Type: "integer"},
+	"aria-rowspan":                {Type: "integer"},
+	"aria-selected":               {Type: "boolean", AllowUndefined: true},
+	"aria-setsize":                {Type: "integer"},
+	"aria-sort":                   {Type: "token", Values: []any{"ascending", "descending", "none", "other"}},
+	"aria-valuemax":               {Type: "number"},
+	"aria-valuemin":               {Type: "number"},
+	"aria-valuenow":               {Type: "number"},
+	"aria-valuetext":              {Type: "string"},
+}
+
+// AriaLiteralValueKind discriminates the literal-typed value of a JSX
+// attribute, mirroring jsx-ast-utils' `getLiteralPropValue` output.
+//
+// Used by jsx-a11y/aria-proptypes to branch validity-check logic on the
+// runtime type of the literal value, including the boolean attribute form
+// (`<div aria-hidden />` → `AriaLiteralBool` with `true`) and the
+// upstream "not a literal expression" path (Identifier non-undefined /
+// CallExpression / MemberExpression / Conditional / Logical / Binary /
+// TSAsExpression / TSNonNullExpression / TSSatisfiesExpression — all noop
+// in LITERAL_TYPES → null → `AriaLiteralNoLit`).
+type AriaLiteralValueKind int
+
+const (
+	// AriaLiteralNoLit signals jsx-ast-utils' `getLiteralPropValue` returned
+	// `null` — the LITERAL_TYPES noop path. Triggers upstream's
+	// `if (value === null) return;` short-circuit.
+	AriaLiteralNoLit AriaLiteralValueKind = iota
+	// AriaLiteralUndef signals an explicit `undefined` identifier resolved
+	// at parse time. Step-1 (`getPropValue == null`) normally catches this
+	// before we get here, so the value is rare in practice — preserved for
+	// upstream's `allowUndefined && value === undefined` branch parity.
+	AriaLiteralUndef
+	// AriaLiteralBool covers `{true}` / `{false}` / `<p />` boolean form
+	// AND string-literal "true" / "false" (case-insensitive) which
+	// jsx-ast-utils' Literal extractor coerces to actual booleans.
+	AriaLiteralBool
+	// AriaLiteralNumber covers numeric literals (including unary +/-/~)
+	// and the JS NaN value for failed parses.
+	AriaLiteralNumber
+	// AriaLiteralBigInt covers BigInt literals (`123n`). jsx-ast-utils
+	// has no special handling beyond returning the BigInt itself; ARIA
+	// types don't recognize bigints so all kinds report invalid except
+	// where the validityCheck explicitly inspects typeof.
+	AriaLiteralBigInt
+	// AriaLiteralString covers StringLiteral / NoSubstitutionTemplateLiteral
+	// (verbatim, no boolean coerce) / TemplateExpression with substitutions
+	// (synthesized placeholder string) / null-literal (LITERAL_TYPES.Literal
+	// override returns the string "null") / assignment-expression
+	// synthesized string.
+	AriaLiteralString
+)
+
+// AriaLiteralValue is the literal-typed value of a JSX attribute, as seen by
+// jsx-ast-utils' `getLiteralPropValue`. Discriminated by Kind — only the
+// matching field is meaningful.
+type AriaLiteralValue struct {
+	Kind   AriaLiteralValueKind
+	Bool   bool
+	Num    float64
+	BigInt *big.Int
+	Str    string
+}
+
+// AriaLiteralValueAsJSNumber mirrors JS `Number(value)` semantics on an
+// AriaLiteralValue:
+//
+//   - jvNumber: value passes through; NaN → (0, false).
+//   - jvString: trim whitespace, empty → 0, hex (`0x` / `0X`), octal (`0o` /
+//     `0O`), and binary (`0b` / `0B`) unsigned-integer prefixes handled
+//     explicitly (Go's strconv.ParseFloat does not recognize them, JS
+//     Number does), decimal via strconv.ParseFloat otherwise. Failed
+//     parse → (0, false).
+//   - jvBool: false → 0, true → 1 (mirrors JS `Number(true) = 1`).
+//   - jvBigInt: float64 cast (out-of-range → ±Inf). Mirrors JS `Number(2n) = 2`.
+//   - jvUndef: `Number(undefined) = NaN` → (0, false).
+//   - Other kinds (NoLit) → (0, false).
+//
+// Returns (value, false) for any NaN-producing input — callers who need
+// to distinguish "valid 0" from "no number" can use the boolean second
+// return; callers who just need `isNaN(Number(value)) === false` can
+// negate the boolean directly.
+//
+// Implementation reuses jsValueToNumber from tabindex_no_positive.go — the
+// only difference is the input type (AriaLiteralValue vs the internal
+// jsValue), so this is a thin adapter rather than a parallel implementation.
+func AriaLiteralValueAsJSNumber(v AriaLiteralValue) (float64, bool) {
+	return jsValueToNumber(ariaLiteralValueToInternal(v))
+}
+
+// ariaLiteralValueToInternal bridges the public AriaLiteralValue surface
+// with the package-internal jsValue used by static_eval.go and
+// tabindex_no_positive.go. Single hop, no semantics added.
+func ariaLiteralValueToInternal(v AriaLiteralValue) jsValue {
+	switch v.Kind {
+	case AriaLiteralBool:
+		return jsValue{Kind: jvBool, Bool: v.Bool}
+	case AriaLiteralNumber:
+		return jsValue{Kind: jvNumber, Num: v.Num}
+	case AriaLiteralBigInt:
+		return jsValue{Kind: jvBigInt, Big: v.BigInt}
+	case AriaLiteralString:
+		return jsValue{Kind: jvString, Str: v.Str}
+	case AriaLiteralUndef:
+		return jsUndef
+	}
+	// AriaLiteralNoLit — upstream's noop → null path.
+	return jsNull
+}
+
+// LiteralPropAriaValue extracts the literal-typed value of a JSX attribute,
+// mirroring jsx-ast-utils' `getLiteralPropValue` output kinds. Used by
+// jsx-a11y/aria-proptypes to drive type-specific validity checks.
+//
+// Behavior table:
+//
+//	<p />                       → Bool{true}   (boolean attribute form)
+//	<p={}>                      → NoLit        (empty JsxExpression)
+//	<p="text">                  → String{text} (NOT "true"/"false" — those coerce to Bool)
+//	<p="true"> / <p="false">    → Bool         (jsxAstUtilsLiteralCoerce)
+//	<p={true}> / <p={false}>    → Bool
+//	<p={`text`}>                → String{text} (NoSubstitutionTemplate — NO boolean coerce)
+//	<p={`a${b}c`}>              → String       (synthesized placeholder via staticEvalTemplate)
+//	<p={N}>                     → Number{N}
+//	<p={Nn}>                    → BigInt{N}
+//	<p={null}>                  → String{"null"} (LITERAL_TYPES.Literal override)
+//	<p={undefined}>             → Undef
+//	<p={someVar}>               → NoLit        (LITERAL_TYPES.Identifier non-undefined → null)
+//	<p={foo.bar}>               → NoLit        (LITERAL_TYPES.MemberExpression noop → null)
+//	<p={fn()}>                  → NoLit        (LITERAL_TYPES.CallExpression noop → null)
+//	<p={cond ? a : b}>          → NoLit        (LITERAL_TYPES.ConditionalExpression noop → null)
+//	<p={a && b}> / <p={a || b}> → NoLit        (LITERAL_TYPES.LogicalExpression noop → null)
+//	<p={a + b}>                 → NoLit        (LITERAL_TYPES.BinaryExpression noop → null)
+//	<p={x as any}>              → NoLit        (LITERAL_TYPES has no TSAsExpression — noop)
+//	<p={x!}>                    → NoLit        (LITERAL_TYPES has no TSNonNullExpression — noop)
+//	<p={x satisfies T}>         → NoLit        (LITERAL_TYPES has no TSSatisfiesExpression — noop)
+//	<p={!x}>                    → Bool         (LITERAL_TYPES.UnaryExpression mirrors TYPES for `!`)
+//	<p={-N}> / <p={+N}> / <p={~N}> → Number    (UnaryExpression numeric ops)
+//	<p={<el />}>                → NoLit        (LITERAL_TYPES has no JSX — default noop)
+//	<p={[a, b]}>                → NoLit        (we model arrays as truthy via jvTruthy; not a literal value)
+//
+// Parentheses are transparently unwrapped on every layer; TS-wrapper kinds
+// (`as`, `!`, `satisfies`, `<T>`) are intentionally NOT stripped — upstream's
+// LITERAL_TYPES rejects them, so we mirror.
+func LiteralPropAriaValue(attr *ast.Node) AriaLiteralValue {
+	if attr == nil {
+		return AriaLiteralValue{Kind: AriaLiteralNoLit}
+	}
+	if AttributeIsBooleanForm(attr) {
+		// `<div aria-hidden />` — upstream's extractValue maps the null
+		// initializer to JS boolean true. The boolean form is the ONLY
+		// path that produces a non-null `getPropValue` AND a non-null
+		// `getLiteralPropValue` without an inner expression.
+		return AriaLiteralValue{Kind: AriaLiteralBool, Bool: true}
+	}
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		// `<div aria-hidden={} />` — empty JsxExpression. tsgo synthesizes
+		// this only for malformed source; upstream falls through to noop
+		// → null. Mirror as NoLit.
+		return AriaLiteralValue{Kind: AriaLiteralNoLit}
+	}
+	v := literalPropValue(inner)
+	switch v.Kind {
+	case jvBool:
+		return AriaLiteralValue{Kind: AriaLiteralBool, Bool: v.Bool}
+	case jvNumber:
+		return AriaLiteralValue{Kind: AriaLiteralNumber, Num: v.Num}
+	case jvBigInt:
+		return AriaLiteralValue{Kind: AriaLiteralBigInt, BigInt: v.Big}
+	case jvString:
+		return AriaLiteralValue{Kind: AriaLiteralString, Str: v.Str}
+	case jvUndef:
+		return AriaLiteralValue{Kind: AriaLiteralUndef}
+	}
+	// jvNull, jvUnknown, jvTruthy, jvFunction — all the upstream "noop →
+	// null" / runtime-only paths. None are accepted as literal ARIA
+	// values, so they fold into AriaLiteralNoLit which step-3 short-circuits.
+	return AriaLiteralValue{Kind: AriaLiteralNoLit}
+}
 
 // AriaPropertyNames is the list of every ARIA state / property defined by
 // `aria-query`'s `ariaPropsMap`. The order mirrors `aria.keys()`, so callers

--- a/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes.go
+++ b/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes.go
@@ -1,0 +1,275 @@
+// Package aria_proptypes ports eslint-plugin-jsx-a11y's `aria-proptypes`
+// rule. The rule flags any recognized ARIA state / property whose literal
+// value disagrees with the type declared in `aria-query`'s `ariaPropsMap`
+// (e.g. `aria-hidden="yes"` — `aria-hidden` is a boolean, "yes" is not).
+//
+// Upstream signature: no options — schema is `generateObjSchema()` (an
+// empty object).
+//
+// Trigger order (mirrors upstream's JSXAttribute listener exactly):
+//
+//  1. Attribute name normalized to lowercase. If it doesn't start with
+//     `aria-` or isn't in aria-query's map, skip.
+//  2. `getPropValue(attribute) == null` — skip. Catches absent values,
+//     explicit `{null}` / `{undefined}` (and TS-wrapped variants), and
+//     any expression whose static value resolves to null/undefined.
+//  3. `getLiteralPropValue(attribute)` — fetch the literal-typed value.
+//  4. If the literal value is the upstream-null sentinel (Identifier
+//     non-undefined / Call / Member / Conditional / Logical / Binary /
+//     TS-wrapper kinds — all noop in LITERAL_TYPES → null), skip. The
+//     rule only inspects values it can resolve statically.
+//  5. Run the type-specific validity check. For `boolean`, the value
+//     must be a JS boolean; for `string` / `id`, a JS string; for
+//     `integer` / `number`, a non-boolean coercible to a non-NaN
+//     number; for `tristate`, a boolean OR the literal string "mixed";
+//     for `token`, the value (lowercased if string) must be in the
+//     permitted-values list; for `tokenlist`, the value must be a
+//     space-separated list where every space-delimited token (lowercased)
+//     is in the permitted-values list; for `idlist`, the value must be
+//     a JS string (split-and-recurse always succeeds since each
+//     space-delimited slice is still a string).
+//  6. If the check fails AND the property doesn't permit `undefined` via
+//     `allowUndefined`, emit a type-specific diagnostic.
+//
+// The diagnostic is reported on the JsxAttribute node (matches upstream's
+// `context.report({ node: attribute, ... })`).
+package aria_proptypes
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// errorMessage mirrors upstream's `errorMessage(name, type, permittedValues)`
+// byte-for-byte. The `${permittedValues}` interpolation in the JS template
+// literal hits Array.prototype.toString, which joins with a bare comma (no
+// space). Booleans stringify as "true" / "false". We preserve order.
+//
+// "a integer" / "a number" / "a boolean" / "a string" are upstream's literal
+// strings — note the (grammatically incorrect) "a integer" / "a undefined".
+// Reproduced verbatim so a future audit can diff against upstream exactly.
+func errorMessage(name, propType string, permittedValues []any) string {
+	switch propType {
+	case "tristate":
+		return "The value for " + name + ` must be a boolean or the string "mixed".`
+	case "token":
+		return "The value for " + name + " must be a single token from the following: " + joinPermittedValues(permittedValues) + "."
+	case "tokenlist":
+		return "The value for " + name + " must be a list of one or more tokens from the following: " + joinPermittedValues(permittedValues) + "."
+	case "idlist":
+		return "The value for " + name + " must be a list of strings that represent DOM element IDs (idlist)"
+	case "id":
+		return "The value for " + name + " must be a string that represents a DOM element ID"
+	}
+	// boolean / string / integer / number / default — upstream's switch
+	// fall-through collapses into the same template.
+	return "The value for " + name + " must be a " + propType + "."
+}
+
+// joinPermittedValues mirrors `Array.prototype.toString` on the
+// permitted-values array: bare-comma join, booleans stringified as
+// "true" / "false" — matching upstream's `${permittedValues}` template
+// interpolation.
+func joinPermittedValues(values []any) string {
+	parts := make([]string, len(values))
+	for i, v := range values {
+		switch x := v.(type) {
+		case string:
+			parts[i] = x
+		case bool:
+			if x {
+				parts[i] = "true"
+			} else {
+				parts[i] = "false"
+			}
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+// validityCheck mirrors upstream's `validityCheck(value, expectedType,
+// permittedValues)`. Returns true when the literal value satisfies the
+// ARIA type contract.
+//
+// Implementation notes:
+//
+//   - `boolean`: typeof === 'boolean'. Maps to AriaLiteralBool.
+//   - `string` / `id`: typeof === 'string'. Maps to AriaLiteralString.
+//     Note `id` adds no validation beyond "is string" — the actual DOM
+//     ID check is a runtime concern.
+//   - `tristate`: typeof === 'boolean' || value === 'mixed' (case-sensitive
+//     against the bare string "mixed"). aria-checked / aria-pressed.
+//   - `integer` / `number`: typeof !== 'boolean' && !isNaN(Number(value)).
+//     The boolean exclusion is intentional — JS coerces `true`/`false` to
+//     `1`/`0` which would otherwise satisfy `!isNaN(Number(...))` and
+//     trivially pass for any boolean-typed value. Number coercion itself
+//     is delegated to `jsxa11yutil.AriaLiteralValueAsJSNumber`, the same
+//     engine that powers tabindex / tabindex-no-positive — single source
+//     of truth for ECMA-262 StringToNumber semantics (trim, hex / oct /
+//     bin prefixes, empty → 0, BigInt → float64 cast).
+//   - `token`: permittedValues.indexOf(typeof === 'string' ? value.toLowerCase()
+//     : value) > -1. Strings are lowercased; booleans / others match by
+//     strict equality. aria-current / aria-haspopup / aria-invalid have
+//     heterogeneous lists with booleans intermixed.
+//   - `tokenlist`: typeof === 'string' && value.split(' ').every(tok →
+//     permittedValues.indexOf(tok.toLowerCase()) > -1). Empty strings or
+//     unknown tokens fail. aria-dropeffect / aria-relevant.
+//   - `idlist`: typeof === 'string' && value.split(' ').every(tok → typeof
+//     tok === 'string'). The inner check is trivially true for a string
+//     split — collapsed to "value is a string". aria-controls / aria-describedby
+//     / aria-flowto / aria-labelledby / aria-owns.
+func validityCheck(value jsxa11yutil.AriaLiteralValue, expectedType string, permittedValues []any) bool {
+	switch expectedType {
+	case "boolean":
+		return value.Kind == jsxa11yutil.AriaLiteralBool
+	case "string", "id":
+		return value.Kind == jsxa11yutil.AriaLiteralString
+	case "tristate":
+		if value.Kind == jsxa11yutil.AriaLiteralBool {
+			return true
+		}
+		return value.Kind == jsxa11yutil.AriaLiteralString && value.Str == "mixed"
+	case "integer", "number":
+		if value.Kind == jsxa11yutil.AriaLiteralBool {
+			return false
+		}
+		// Reuse jsxa11yutil's JS Number() implementation — same engine
+		// used by tabindex / tabindex-no-positive for string/number/bigint
+		// coercion. The boolean returned encodes `!isNaN(Number(value))`
+		// so we don't need a separate NaN check.
+		_, ok := jsxa11yutil.AriaLiteralValueAsJSNumber(value)
+		return ok
+	case "token":
+		return tokenMatch(value, permittedValues)
+	case "tokenlist":
+		if value.Kind != jsxa11yutil.AriaLiteralString {
+			return false
+		}
+		for _, tok := range strings.Split(value.Str, " ") {
+			lower := strings.ToLower(tok)
+			if !permittedValuesContainsString(permittedValues, lower) {
+				return false
+			}
+		}
+		return true
+	case "idlist":
+		// `value.split(' ').every(token => typeof token === 'string')` — since
+		// String.split always yields strings, this collapses to "value is a
+		// string". Mirrors upstream's recursive `validityCheck(token, 'id', [])`
+		// which itself only checks typeof === 'string'.
+		return value.Kind == jsxa11yutil.AriaLiteralString
+	}
+	// Unrecognized type tag — upstream returns false. Defensive parity;
+	// AriaPropertyDefinitions has no other tags.
+	return false
+}
+
+// tokenMatch mirrors upstream's `permittedValues.indexOf(typeof value ===
+// 'string' ? value.toLowerCase() : value) > -1`. Strings are lowercased
+// before lookup; non-strings (booleans) match the permitted list by
+// strict equality.
+//
+// The lookup uses JS `===` semantics: string-vs-bool returns false even
+// when textually similar (e.g. value=`true` (string) does NOT match the
+// boolean `true` in the permitted list — but jsx-ast-utils' Literal
+// extractor coerces case-insensitive "true"/"false" strings to actual
+// booleans first, so the typical `aria-haspopup="true"` flow still
+// matches the boolean entry).
+func tokenMatch(value jsxa11yutil.AriaLiteralValue, permittedValues []any) bool {
+	switch value.Kind {
+	case jsxa11yutil.AriaLiteralString:
+		lower := strings.ToLower(value.Str)
+		return permittedValuesContainsString(permittedValues, lower)
+	case jsxa11yutil.AriaLiteralBool:
+		for _, v := range permittedValues {
+			if b, ok := v.(bool); ok && b == value.Bool {
+				return true
+			}
+		}
+		return false
+	}
+	// Numbers / BigInts / undef / no-lit — never appear in any ARIA
+	// permitted-values list. Upstream's indexOf returns -1 for these.
+	return false
+}
+
+// permittedValuesContainsString reports whether the (already-lowercased)
+// candidate string is present in the heterogeneous permitted-values list.
+// Booleans in the list are silently skipped — they only match jvBool
+// candidates via tokenMatch's separate arm.
+func permittedValuesContainsString(values []any, candidate string) bool {
+	for _, v := range values {
+		if s, ok := v.(string); ok && s == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+var AriaProptypesRule = rule.Rule{
+	Name: "jsx-a11y/aria-proptypes",
+	Run: func(ctx rule.RuleContext, _ any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindJsxAttribute: func(attr *ast.Node) {
+				rawName := reactutil.GetJsxPropName(attr)
+				// Upstream normalizes to lowercase BEFORE the prefix check
+				// and the aria-query lookup. `ARIA-HIDDEN`, `Aria-Hidden`
+				// all resolve to `aria-hidden` for purposes of this rule.
+				// This differs from jsx-a11y/aria-props which uses a
+				// CASE-SENSITIVE prefix check — same plugin, different gate.
+				normalized := strings.ToLower(rawName)
+				if !strings.HasPrefix(normalized, "aria-") {
+					return
+				}
+				def, ok := jsxa11yutil.AriaPropertyDefinitions[normalized]
+				if !ok {
+					return
+				}
+
+				// step-1: `getPropValue(attribute) == null` — loose equality
+				// with null catches both null and undefined static values.
+				// PropValueIsNullish mirrors the full semantic, including
+				// the boolean attribute form (returns false → don't gate),
+				// explicit `{null}` / `{undefined}` (returns true → gate),
+				// and unrecognized expressions (returns true → gate).
+				if jsxa11yutil.PropValueIsNullish(attr) {
+					return
+				}
+
+				// step-3 setup: fetch the literal-typed value.
+				value := jsxa11yutil.LiteralPropAriaValue(attr)
+
+				// step-3: `if (value === null) return;` — gates the
+				// LITERAL_TYPES noop path (Identifier non-undefined / Call /
+				// Member / Conditional / Logical / Binary / TS-wrappers / JSX).
+				// Upstream skips because it cannot statically verify the
+				// runtime value.
+				if value.Kind == jsxa11yutil.AriaLiteralNoLit {
+					return
+				}
+
+				// step-4 & 5: validity check OR allowUndefined exemption.
+				if validityCheck(value, def.Type, def.Values) {
+					return
+				}
+				if def.AllowUndefined && value.Kind == jsxa11yutil.AriaLiteralUndef {
+					// Upstream preserves this branch even though step-1
+					// usually short-circuits on explicit `{undefined}` via
+					// the `getPropValue == null` check. Mirrored for
+					// byte-for-byte parity in case future jsx-ast-utils
+					// changes break that assumption.
+					return
+				}
+
+				ctx.ReportNode(attr, rule.RuleMessage{
+					Id:          "invalidAriaPropType",
+					Description: errorMessage(rawName, def.Type, def.Values),
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes.md
+++ b/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes.md
@@ -1,0 +1,93 @@
+# aria-proptypes
+
+Enforce that the literal value of every recognized `aria-*` state / property
+matches the type declared in [aria-query](https://github.com/A11yance/aria-query)'s
+`ariaPropsMap`. For example, `aria-hidden` is a boolean (`true` / `false` /
+`"true"` / `"false"`) — `aria-hidden="yes"` reports.
+
+## Rule Details
+
+The rule fires on a JSX attribute whose name (after lowercasing) starts with
+`aria-` and is one of the canonical ARIA states or properties. The value is
+extracted via jsx-ast-utils' `getLiteralPropValue` semantics, so only static
+literal values are inspected — expressions like `<div aria-hidden={someVar} />`,
+`<div aria-label={fn()} />`, `<div aria-checked={cond ? "true" : "false"} />`
+are not classified by this rule (the value isn't statically a literal).
+
+Values whose static result is `null` or `undefined` are also skipped — those
+are treated as "no value" rather than an invalid value.
+
+Type-specific rules:
+
+- **boolean**: must be `true` / `false` or one of the strings `"true"` /
+  `"false"` (case-insensitive).
+- **string** / **id**: must be a string. Empty string is valid.
+- **integer** / **number**: must coerce to a non-NaN number under JS
+  `Number(value)` semantics, and must not be a boolean.
+- **tristate**: boolean, OR the literal string `"mixed"`.
+- **token**: must be one of the permitted values (case-insensitive when
+  string; strict-equal when boolean). Permitted lists are heterogeneous —
+  `aria-haspopup` accepts both booleans and strings.
+- **tokenlist**: must be a space-separated string where every token is in
+  the permitted list (case-insensitive).
+- **idlist**: must be a string.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div aria-hidden="yes" />
+<div aria-label />
+<div aria-checked={1234} />
+<div aria-level="yes" />
+<div aria-sort="descnding" />
+<div aria-sort="ascending descending" />
+<div aria-relevant="additions removalss" />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div aria-hidden={true} />
+<div aria-hidden="false" />
+<div aria-hidden />
+<div aria-label="Close" />
+<div aria-checked="mixed" />
+<div aria-level={123} />
+<div aria-level="3" />
+<div aria-sort="ascending" />
+<div aria-sort="ASCENDING" />
+<div aria-relevant="additions removals text" />
+<div aria-invalid={true} />
+<div aria-invalid="grammar" />
+```
+
+Non-literal values are not flagged — the rule trusts the developer when
+the value isn't statically determinable:
+
+```jsx
+<div aria-hidden={someVar} />
+<div aria-level={getLevel()} />
+<div aria-sort={cond ? "ascending" : "descending"} />
+```
+
+`null` and `undefined` are silently ignored:
+
+```jsx
+<div aria-hidden={null} />
+<div aria-hidden={undefined} />
+```
+
+## Rule Options
+
+This rule takes no options.
+
+## Resources
+
+- [WAI-ARIA 1.2 — States and Properties](https://www.w3.org/TR/wai-aria-1.2/#state_prop_def)
+- [WCAG 2.2 — 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [MDN — ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes)
+- [aria-query — `ariaPropsMap`](https://github.com/A11yance/aria-query/blob/HEAD/src/ariaPropsMap.js)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/aria-proptypes](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-proptypes.md)

--- a/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes_extras_test.go
@@ -1,0 +1,452 @@
+// cspell:ignore foobar
+
+package aria_proptypes
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestAriaProptypesExtras covers tsgo-specific edge cases that upstream's
+// JS test file doesn't exercise but which are likely sources of silent
+// drift between rslint and ESLint:
+//
+//   - Case-insensitive attribute names (ARIA-HIDDEN, Aria-Hidden)
+//   - Parenthesized values (tsgo preserves Parens; ESTree flattens)
+//   - TS type-assertion wrappers (`as`, `!`, `satisfies`) — LITERAL_TYPES
+//     has no entry → noop → null → step-3 skip (VALID)
+//   - aria-haspopup heterogeneous list — boolean tokens alongside strings
+//   - aria-current heterogeneous list — strings + boolean tokens
+//   - aria-orientation's quirky string "undefined" as a valid token value
+//   - aria-pressed (tristate, distinct from aria-checked)
+//   - Token validity-check case sensitivity edge cases
+//   - Multi-attribute elements / mixed valid+invalid attrs
+//   - Nested JSX with invalid attrs at multiple depths
+//   - Bigint literals
+func TestAriaProptypesExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AriaProptypesRule,
+		[]rule_tester.ValidTestCase{
+			// Case-insensitive attribute names — upstream's `name.toLowerCase()`
+			// applies before the prefix and aria-query lookups.
+			{Code: `<div ARIA-HIDDEN="true" />`, Tsx: true},
+			{Code: `<div Aria-Hidden="true" />`, Tsx: true},
+			{Code: `<div ARIA-LEVEL={3} />`, Tsx: true},
+
+			// Parenthesized values — tsgo preserves ParenthesizedExpression,
+			// our SkipParentheses unwrap mirrors ESTree's parse-time flatten.
+			{Code: `<div aria-hidden={(true)} />`, Tsx: true},
+			{Code: `<div aria-hidden={((true))} />`, Tsx: true},
+			{Code: `<div aria-level={(123)} />`, Tsx: true},
+
+			// TS type-assertion wrappers — LITERAL_TYPES has no entry for
+			// TSAsExpression / TSNonNullExpression / TSSatisfiesExpression /
+			// TSTypeAssertion; all fall through to noop → null → step-3 skip.
+			{Code: `<div aria-hidden={true as boolean} />`, Tsx: true},
+			{Code: `<div aria-hidden={x!} />`, Tsx: true},
+			{Code: `<div aria-hidden={x satisfies boolean} />`, Tsx: true},
+			{Code: `<div aria-label={"x" as const} />`, Tsx: true},
+
+			// aria-haspopup (token: [false, true, 'menu', 'listbox', 'tree', 'grid', 'dialog']).
+			// Heterogeneous list — booleans AND strings both valid.
+			{Code: `<div aria-haspopup={true} />`, Tsx: true},
+			{Code: `<div aria-haspopup={false} />`, Tsx: true},
+			{Code: `<div aria-haspopup="true" />`, Tsx: true},
+			{Code: `<div aria-haspopup="false" />`, Tsx: true},
+			{Code: `<div aria-haspopup="menu" />`, Tsx: true},
+			{Code: `<div aria-haspopup="MENU" />`, Tsx: true},
+			{Code: `<div aria-haspopup="listbox" />`, Tsx: true},
+			{Code: `<div aria-haspopup="tree" />`, Tsx: true},
+			{Code: `<div aria-haspopup="grid" />`, Tsx: true},
+			{Code: `<div aria-haspopup="dialog" />`, Tsx: true},
+
+			// aria-current (token: ['page','step','location','date','time', true, false]).
+			{Code: `<div aria-current="page" />`, Tsx: true},
+			{Code: `<div aria-current="STEP" />`, Tsx: true},
+			{Code: `<div aria-current={true} />`, Tsx: true},
+			{Code: `<div aria-current={false} />`, Tsx: true},
+			{Code: `<div aria-current="true" />`, Tsx: true},
+			{Code: `<div aria-current="false" />`, Tsx: true},
+
+			// aria-orientation (token: ['vertical', 'undefined', 'horizontal']).
+			// "undefined" is intentionally a STRING in upstream's list; it
+			// matches the string literal, NOT the JS `undefined` keyword.
+			{Code: `<div aria-orientation="vertical" />`, Tsx: true},
+			{Code: `<div aria-orientation="HORIZONTAL" />`, Tsx: true},
+			{Code: `<div aria-orientation="undefined" />`, Tsx: true},
+
+			// aria-pressed (tristate, distinct rule entry from aria-checked).
+			{Code: `<div aria-pressed={true} />`, Tsx: true},
+			{Code: `<div aria-pressed={false} />`, Tsx: true},
+			{Code: `<div aria-pressed="mixed" />`, Tsx: true},
+
+			// aria-expanded / aria-grabbed / aria-selected — allowUndefined.
+			// Identifier `undefined` triggers step-1 (PropValueIsNullish),
+			// so the rule short-circuits before the allowUndefined branch.
+			// Verifying these are valid lets a future refactor surface
+			// regression if step-1 ever stops gating undefined.
+			{Code: `<div aria-expanded={undefined} />`, Tsx: true},
+			{Code: `<div aria-grabbed={undefined} />`, Tsx: true},
+			{Code: `<div aria-selected={undefined} />`, Tsx: true},
+
+			// aria-live (token: ['assertive', 'off', 'polite']).
+			{Code: `<div aria-live="polite" />`, Tsx: true},
+			{Code: `<div aria-live="POLITE" />`, Tsx: true},
+			{Code: `<div aria-live="off" />`, Tsx: true},
+
+			// aria-autocomplete (token: ['inline','list','both','none']).
+			{Code: `<div aria-autocomplete="inline" />`, Tsx: true},
+			{Code: `<div aria-autocomplete="LIST" />`, Tsx: true},
+
+			// aria-dropeffect (tokenlist: ['copy','execute','link','move','none','popup']).
+			{Code: `<div aria-dropeffect="copy" />`, Tsx: true},
+			{Code: `<div aria-dropeffect="copy execute" />`, Tsx: true},
+			{Code: `<div aria-dropeffect="copy execute link move" />`, Tsx: true},
+
+			// Integer / number — numeric string with whitespace (JS Number()
+			// trims). Upstream test doesn't include this; lock our parity
+			// in via the JS Number coercion rules.
+			{Code: `<div aria-level=" 3 " />`, Tsx: true},
+			{Code: `<div aria-valuemax="3.14" />`, Tsx: true},
+			{Code: `<div aria-valuemax={3.14} />`, Tsx: true},
+
+			// Integer / number — empty string coerces to 0. JS:
+			// `isNaN(Number("")) === false` is true → valid.
+			{Code: `<div aria-level="" />`, Tsx: true},
+			{Code: `<div aria-valuemax="" />`, Tsx: true},
+
+			// Multi-attribute element — only the offending attribute reports;
+			// peers stay clean.
+			{Code: `<div aria-label="ok" aria-hidden={true} aria-level={3} />`, Tsx: true},
+
+			// Boolean form is valid for boolean-typed attributes.
+			{Code: `<div aria-busy />`, Tsx: true},
+			{Code: `<div aria-disabled />`, Tsx: true},
+			{Code: `<div aria-required />`, Tsx: true},
+
+			// Aria-* attribute NOT in aria-query map — gate-1 skip even if
+			// the value would have been invalid for some hypothetical type.
+			{Code: `<div aria-tabindex="not-a-number" />`, Tsx: true},
+			{Code: `<div aria-onclick={fn} />`, Tsx: true},
+			// data-* prefix is not aria-*.
+			{Code: `<div data-aria-hidden="yes" />`, Tsx: true},
+
+			// JSXSpreadAttribute is not visited — invalid keys inside are
+			// silently ignored, matching upstream's JSXAttribute listener.
+			{Code: `<div {...{'aria-hidden': 'yes'}} />`, Tsx: true},
+
+			// React patterns — verify the listener fires correctly through
+			// nested elements / fragments / library wrappers.
+			{Code: `<>{cond && <div aria-hidden>x</div>}</>`, Tsx: true},
+			{Code: `function L({xs}) { return xs.map(x => <div aria-hidden key={x} />); }`, Tsx: true},
+			{Code: `class C { render() { return <div aria-label="x" />; } }`, Tsx: true},
+
+			// Custom tag — rule fires on the attribute regardless of tag.
+			{Code: `<Custom aria-hidden={true} />`, Tsx: true},
+			{Code: `<Foo.Bar aria-level={3} />`, Tsx: true},
+			{Code: `<my-element aria-hidden />`, Tsx: true},
+
+			// Identifier value that would be falsy at runtime — still
+			// LITERAL_TYPES noop → null → step-3 skip. The rule never
+			// inspects runtime values.
+			{Code: `<div aria-hidden={someExpression} />`, Tsx: true},
+
+			// CallExpression / NewExpression / TaggedTemplateExpression —
+			// LITERAL_TYPES noop except TaggedTemplate which extracts the
+			// inner quasi. Verify our wiring matches.
+			{Code: `<div aria-hidden={fn()} />`, Tsx: true},
+			{Code: `<div aria-hidden={new C()} />`, Tsx: true},
+			// TaggedTemplate with NoSubstitutionTemplate text "true" —
+			// literalPropValue routes to jsxAstUtilsLiteralCoerce → bool true → VALID for boolean.
+			{Code: "<div aria-hidden={tag`true`} />", Tsx: true},
+
+			// ConditionalExpression — LITERAL_TYPES noop → null → step-3
+			// skip regardless of branch values.
+			{Code: `<div aria-checked={cond ? true : "mixed"} />`, Tsx: true},
+			{Code: `<div aria-level={cond ? 1 : 2} />`, Tsx: true},
+
+			// LogicalExpression — LITERAL_TYPES noop → null → step-3 skip.
+			{Code: `<div aria-hidden={a && b} />`, Tsx: true},
+			{Code: `<div aria-hidden={a || b} />`, Tsx: true},
+			{Code: `<div aria-hidden={a ?? b} />`, Tsx: true},
+
+			// JSXNamespacedName — `<svg aria:hidden="true" />`. propName
+			// returns "aria:hidden" (colon-separated). Lowercase → still
+			// "aria:hidden", doesn't start with "aria-" → gate-1 skip.
+			{Code: `<svg aria:hidden="true" />`, Tsx: true},
+			{Code: `<svg aria:hidden="yes" />`, Tsx: true},
+
+			// BigInt literal as a value — typeof === "bigint" doesn't match
+			// any ARIA type check; integer/number's `Number(bigint)` would
+			// throw in JS so jsx-ast-utils' LITERAL_TYPES yields the BigInt
+			// itself. validityCheck returns false for every type → would be
+			// invalid... BUT step-1 may gate first. Verify behavior is
+			// stable rather than crashing.
+			//
+			// In upstream behavior, `<div aria-hidden={123n} />`:
+			//   - getPropValue returns BigInt — not null → step-1 doesn't gate.
+			//   - getLiteralPropValue returns BigInt — non-null → step-3 doesn't skip.
+			//   - validityCheck: typeof "bigint" → not boolean → INVALID.
+			// We classify this in extras as invalid below.
+
+			// React library wrappers — verify the listener fires through
+			// forwardRef / memo / useMemo / Suspense regardless of the
+			// surrounding expression scaffolding.
+			{
+				Code: `const Btn = React.forwardRef<HTMLButtonElement, {}>((props, ref) => <button ref={ref} aria-pressed="true" />);`,
+				Tsx:  true,
+			},
+			{
+				Code: `const M = React.memo(function M() { return <div aria-label="x" />; });`,
+				Tsx:  true,
+			},
+			{
+				Code: `function F() { const v = React.useMemo(() => <div aria-hidden>x</div>, []); return v; }`,
+				Tsx:  true,
+			},
+			{
+				Code: `<Suspense fallback={<div aria-busy="true">loading</div>}><Page aria-label="x" /></Suspense>`,
+				Tsx:  true,
+			},
+
+			// Tagged template — `tag\`true\`` routes through
+			// literalPropValue's TaggedTemplateExpression arm, which
+			// extracts the inner quasi via jsxAstUtilsLiteralCoerce, so a
+			// "true"/"false" template coerces to boolean. For aria-hidden
+			// (boolean), `tag\`true\`` should pass.
+			{Code: "<div aria-hidden={tag`true`} />", Tsx: true},
+			{Code: "<div aria-hidden={tag`false`} />", Tsx: true},
+
+			// Numeric literal forms — hex / oct / bin / exponent. JS Number()
+			// recognizes all; integer / number validity passes.
+			{Code: `<div aria-level={0x10} />`, Tsx: true},
+			{Code: `<div aria-level={0o10} />`, Tsx: true},
+			{Code: `<div aria-level={0b10} />`, Tsx: true},
+			{Code: `<div aria-valuemax={1e3} />`, Tsx: true},
+
+			// Numeric strings with hex / exponent prefix (Number("0x10") = 16).
+			{Code: `<div aria-level="0x10" />`, Tsx: true},
+			{Code: `<div aria-level="1e3" />`, Tsx: true},
+
+			// idlist allows ANY string — including arbitrary characters,
+			// because the inner check is just "is string".
+			{Code: `<div aria-labelledby="!@#$%^&*()" />`, Tsx: true},
+			{Code: `<div aria-controls="a-b c.d" />`, Tsx: true},
+
+			// PrefixUnary on numeric values for integer/number.
+			{Code: `<div aria-level={-0} />`, Tsx: true},
+			{Code: `<div aria-valuemin={-1.5} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Case-insensitive lookup — message uses the ORIGINAL (cased)
+			// attribute name as written in source, not the normalized form.
+			{
+				Code: `<div ARIA-HIDDEN="yes" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: "The value for ARIA-HIDDEN must be a boolean."}},
+			},
+			{
+				Code: `<div Aria-Hidden={1234} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: "The value for Aria-Hidden must be a boolean."}},
+			},
+
+			// Parenthesized invalid value still reports.
+			{
+				Code: `<div aria-hidden={(1234)} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-hidden")}},
+			},
+			{
+				Code: `<div aria-hidden={((1234))} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-hidden")}},
+			},
+
+			// aria-haspopup invalid token.
+			{
+				Code: `<div aria-haspopup="dropdown" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-haspopup")}},
+			},
+			{
+				Code: `<div aria-haspopup={123} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-haspopup")}},
+			},
+
+			// aria-current cross-class — strings and booleans valid; numbers / other strings not.
+			{
+				Code: `<div aria-current="foo" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-current")}},
+			},
+
+			// aria-orientation — non-listed string.
+			{
+				Code: `<div aria-orientation="diagonal" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-orientation")}},
+			},
+
+			// aria-pressed invalid (similar to aria-checked).
+			{
+				Code: `<div aria-pressed="partial" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-pressed")}},
+			},
+			{
+				Code: `<div aria-pressed={1234} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-pressed")}},
+			},
+
+			// aria-live invalid token.
+			{
+				Code: `<div aria-live="loud" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-live")}},
+			},
+
+			// aria-dropeffect — tokenlist, one unknown token in a multi-token list.
+			{
+				Code: `<div aria-dropeffect="copy fake" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-dropeffect")}},
+			},
+
+			// aria-colcount / aria-rowcount / aria-setsize / aria-posinset — integer.
+			{
+				Code: `<div aria-colcount="abc" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-colcount")}},
+			},
+			{
+				Code: `<div aria-setsize={true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-setsize")}},
+			},
+
+			// aria-valuenow / aria-valuemin — number.
+			{
+				Code: `<div aria-valuenow="abc" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-valuenow")}},
+			},
+			{
+				Code: `<div aria-valuemin={false} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-valuemin")}},
+			},
+
+			// aria-details / aria-errormessage — id (string).
+			{
+				Code: `<div aria-details={1234} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-details")}},
+			},
+			{
+				Code: `<div aria-errormessage={true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-errormessage")}},
+			},
+
+			// aria-controls / aria-describedby — idlist (string).
+			{
+				Code: `<div aria-controls={1234} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-controls")}},
+			},
+			{
+				Code: `<div aria-describedby={true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-describedby")}},
+			},
+
+			// Position assertions — confirm the diagnostic lands on the
+			// JsxAttribute node, not the entire element.
+			{
+				Code: `<div aria-hidden="yes" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidAriaPropType",
+					Message:   upstreamErrorMessage("aria-hidden"),
+					Line:      1, Column: 6,
+				}},
+			},
+			{
+				Code: `<div aria-label  =  "x"   aria-checked={1234} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidAriaPropType",
+					Message:   upstreamErrorMessage("aria-checked"),
+					Line:      1, Column: 27,
+				}},
+			},
+			// Multi-line — invalid attribute on line 2.
+			{
+				Code: "<div\n  aria-hidden=\"yes\"\n/>",
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidAriaPropType",
+					Message:   upstreamErrorMessage("aria-hidden"),
+					Line:      2, Column: 3,
+				}},
+			},
+
+			// Nested JSX — invalid attrs at multiple depths each report.
+			{
+				Code: `<main><section><h2 aria-hidden="yes"><span aria-label={1} /></h2></section></main>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-hidden")},
+					{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-label")},
+				},
+			},
+
+			// Mixed valid + invalid attrs on a single element — only the
+			// offending attribute reports.
+			{
+				Code: `<div aria-label="ok" aria-hidden="yes" aria-level={3} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-hidden")},
+				},
+			},
+
+			// BigInt literal — `typeof 123n === "bigint"` matches no
+			// ARIA type. integer / number / boolean / string / id / tristate
+			// all reject; token / idlist / tokenlist need string. Report.
+			{
+				Code: `<div aria-hidden={123n} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-hidden")}},
+			},
+			{
+				Code: `<div aria-label={123n} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-label")}},
+			},
+
+			// Library wrappers should not insulate the rule — invalid
+			// values inside forwardRef / memo / useMemo / Suspense still
+			// report.
+			{
+				Code: `const Btn = React.forwardRef<HTMLButtonElement, {}>((props, ref) => <button ref={ref} aria-pressed={1234} />);`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-pressed")},
+				},
+			},
+			{
+				Code: `<Suspense fallback={<div aria-busy="yes">loading</div>}><Page aria-label={1} /></Suspense>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-busy")},
+					{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-label")},
+				},
+			},
+
+			// Inside map callback — listener still fires per JSXAttribute.
+			{
+				Code: `function L({xs}) { return xs.map(x => <div aria-hidden="yes" key={x} />); }`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-hidden")},
+				},
+			},
+
+			// idlist with non-string value — boolean / number.
+			{
+				Code: `<div aria-labelledby={true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-labelledby")}},
+			},
+			{
+				Code: `<div aria-labelledby={1234} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-labelledby")}},
+			},
+
+			// id type with non-string value.
+			{
+				Code: `<div aria-activedescendant={true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-activedescendant")}},
+			},
+		})
+}

--- a/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes_upstream_test.go
@@ -1,0 +1,424 @@
+// cspell:ignore abcaria descnding foobar removalss
+
+package aria_proptypes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// upstreamErrorMessage mirrors the test file's local `errorMessage(name)`
+// helper byte-for-byte. It looks up the ARIA property's type / values in
+// aria-query's map, then formats the same template the rule itself uses.
+// Defined at package scope so aria_proptypes_extras_test.go can reuse.
+//
+// `${permittedValues}` in upstream's template literal hits
+// `Array.prototype.toString`, which joins with a bare comma (no space).
+// Booleans stringify as "true" / "false". Mirror byte-for-byte.
+func upstreamErrorMessage(name string) string {
+	def := jsxa11yutil.AriaPropertyDefinitions[strings.ToLower(name)]
+	return errorMessage(name, def.Type, def.Values)
+}
+
+// TestValidityCheckDefault locks in upstream's tape unit test:
+//
+//	test('validityCheck', (t) => {
+//	  t.equal(
+//	    validityCheck(null, null),
+//	    false,
+//	    'is false for an unknown expected type',
+//	  );
+//	  t.end();
+//	});
+//
+// Upstream runs this OUTSIDE the RuleTester suite as a direct assertion on
+// the exported `validityCheck` function. We mirror by feeding the helper a
+// NoLit value with a bogus type tag — both arms land on validityCheck's
+// `default: return false`.
+func TestValidityCheckDefault(t *testing.T) {
+	if got := validityCheck(jsxa11yutil.AriaLiteralValue{Kind: jsxa11yutil.AriaLiteralNoLit}, "unknownType", nil); got != false {
+		t.Fatalf("expected false for unknown type, got %v", got)
+	}
+	// Empty-string type — corresponds to upstream's literal `null` passed
+	// as the second arg; same default-arm hit.
+	if got := validityCheck(jsxa11yutil.AriaLiteralValue{Kind: jsxa11yutil.AriaLiteralNoLit}, "", nil); got != false {
+		t.Fatalf("expected false for empty type, got %v", got)
+	}
+}
+
+// TestAriaProptypesUpstream mirrors the full valid/invalid suite from
+// upstream's `__tests__/src/rules/aria-proptypes-test.js`, 1:1 and in
+// upstream order so a future audit can grep across both side-by-side.
+//
+// Anything NOT in upstream's test file — case-insensitive attribute names,
+// parenthesized / TS-wrapped values, BigInt literals, aria-haspopup
+// boolean tokens, aria-current cross-class values, aria-orientation's
+// "undefined" string token, real-user patterns — lives in
+// aria_proptypes_extras_test.go.
+func TestAriaProptypesUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AriaProptypesRule,
+		[]rule_tester.ValidTestCase{
+			// Non-aria-* and unrecognized aria-* attrs — gate-1 skip.
+			{Code: `<div aria-foo="true" />`, Tsx: true},
+			{Code: `<div abcaria-foo="true" />`, Tsx: true},
+
+			// aria-hidden (boolean, allowUndefined). Boolean literals,
+			// string-coerced "true"/"false", boolean attribute form,
+			// PrefixUnary booleans, Identifier / Member (non-literal →
+			// step-3 skip), null / undefined (step-1 skip), JSX
+			// (non-literal → step-3 skip).
+			{Code: `<div aria-hidden={true} />`, Tsx: true},
+			{Code: `<div aria-hidden="true" />`, Tsx: true},
+			{Code: `<div aria-hidden={"false"} />`, Tsx: true},
+			{Code: `<div aria-hidden={!false} />`, Tsx: true},
+			{Code: `<div aria-hidden />`, Tsx: true},
+			{Code: `<div aria-hidden={false} />`, Tsx: true},
+			{Code: `<div aria-hidden={!true} />`, Tsx: true},
+			{Code: `<div aria-hidden={!"yes"} />`, Tsx: true},
+			{Code: `<div aria-hidden={foo} />`, Tsx: true},
+			{Code: `<div aria-hidden={foo.bar} />`, Tsx: true},
+			{Code: `<div aria-hidden={null} />`, Tsx: true},
+			{Code: `<div aria-hidden={undefined} />`, Tsx: true},
+			{Code: `<div aria-hidden={<div />} />`, Tsx: true},
+
+			// aria-label (string). String literals, NoSubstitutionTemplate,
+			// Identifier / Member (skip), null / undefined (skip).
+			{Code: `<div aria-label="Close" />`, Tsx: true},
+			{Code: "<div aria-label={`Close`} />", Tsx: true},
+			{Code: `<div aria-label={foo} />`, Tsx: true},
+			{Code: `<div aria-label={foo.bar} />`, Tsx: true},
+			{Code: `<div aria-label={null} />`, Tsx: true},
+			{Code: `<div aria-label={undefined} />`, Tsx: true},
+
+			// aria-invalid (token: ['grammar', false, 'spelling', true]) via
+			// ConditionalExpression — getLiteralPropValue returns null for
+			// Conditional → step-3 skip.
+			{Code: `<input aria-invalid={error ? "true" : "false"} />`, Tsx: true},
+			{Code: `<input aria-invalid={undefined ? "true" : "false"} />`, Tsx: true},
+
+			// aria-checked (tristate). Boolean, "true"/"false" coerced,
+			// PrefixUnary, "mixed" (string + template), null / undefined.
+			{Code: `<div aria-checked={true} />`, Tsx: true},
+			{Code: `<div aria-checked="true" />`, Tsx: true},
+			{Code: `<div aria-checked={"false"} />`, Tsx: true},
+			{Code: `<div aria-checked={!false} />`, Tsx: true},
+			{Code: `<div aria-checked />`, Tsx: true},
+			{Code: `<div aria-checked={false} />`, Tsx: true},
+			{Code: `<div aria-checked={!true} />`, Tsx: true},
+			{Code: `<div aria-checked={!"yes"} />`, Tsx: true},
+			{Code: `<div aria-checked={foo} />`, Tsx: true},
+			{Code: `<div aria-checked={foo.bar} />`, Tsx: true},
+			{Code: `<div aria-checked="mixed" />`, Tsx: true},
+			{Code: "<div aria-checked={`mixed`} />", Tsx: true},
+			{Code: `<div aria-checked={null} />`, Tsx: true},
+			{Code: `<div aria-checked={undefined} />`, Tsx: true},
+
+			// aria-level (integer). Numeric / unary numeric / string
+			// numerics / template numerics / Identifier (skip) / null /
+			// undefined.
+			{Code: `<div aria-level={123} />`, Tsx: true},
+			{Code: `<div aria-level={-123} />`, Tsx: true},
+			{Code: `<div aria-level={+123} />`, Tsx: true},
+			{Code: `<div aria-level={~123} />`, Tsx: true},
+			{Code: `<div aria-level={"123"} />`, Tsx: true},
+			{Code: "<div aria-level={`123`} />", Tsx: true},
+			{Code: `<div aria-level="123" />`, Tsx: true},
+			{Code: `<div aria-level={foo} />`, Tsx: true},
+			{Code: `<div aria-level={foo.bar} />`, Tsx: true},
+			{Code: `<div aria-level={null} />`, Tsx: true},
+			{Code: `<div aria-level={undefined} />`, Tsx: true},
+
+			// aria-valuemax (number) — same shape as aria-level.
+			{Code: `<div aria-valuemax={123} />`, Tsx: true},
+			{Code: `<div aria-valuemax={-123} />`, Tsx: true},
+			{Code: `<div aria-valuemax={+123} />`, Tsx: true},
+			{Code: `<div aria-valuemax={~123} />`, Tsx: true},
+			{Code: `<div aria-valuemax={"123"} />`, Tsx: true},
+			{Code: "<div aria-valuemax={`123`} />", Tsx: true},
+			{Code: `<div aria-valuemax="123" />`, Tsx: true},
+			{Code: `<div aria-valuemax={foo} />`, Tsx: true},
+			{Code: `<div aria-valuemax={foo.bar} />`, Tsx: true},
+			{Code: `<div aria-valuemax={null} />`, Tsx: true},
+			{Code: `<div aria-valuemax={undefined} />`, Tsx: true},
+
+			// aria-sort (token: ['ascending','descending','none','other']).
+			// Case-insensitive token, template form (no boolean coerce),
+			// Identifier (skip).
+			{Code: `<div aria-sort="ascending" />`, Tsx: true},
+			{Code: `<div aria-sort="ASCENDING" />`, Tsx: true},
+			{Code: `<div aria-sort={"ascending"} />`, Tsx: true},
+			{Code: "<div aria-sort={`ascending`} />", Tsx: true},
+			{Code: `<div aria-sort="descending" />`, Tsx: true},
+			{Code: `<div aria-sort={"descending"} />`, Tsx: true},
+			{Code: "<div aria-sort={`descending`} />", Tsx: true},
+			{Code: `<div aria-sort="none" />`, Tsx: true},
+			{Code: `<div aria-sort={"none"} />`, Tsx: true},
+			{Code: "<div aria-sort={`none`} />", Tsx: true},
+			{Code: `<div aria-sort="other" />`, Tsx: true},
+			{Code: `<div aria-sort={"other"} />`, Tsx: true},
+			{Code: "<div aria-sort={`other`} />", Tsx: true},
+			{Code: `<div aria-sort={foo} />`, Tsx: true},
+			{Code: `<div aria-sort={foo.bar} />`, Tsx: true},
+
+			// aria-invalid (token: ['grammar', false, 'spelling', true]).
+			// Heterogeneous list — booleans AND strings both valid.
+			{Code: `<div aria-invalid={true} />`, Tsx: true},
+			{Code: `<div aria-invalid="true" />`, Tsx: true},
+			{Code: `<div aria-invalid={false} />`, Tsx: true},
+			{Code: `<div aria-invalid="false" />`, Tsx: true},
+			{Code: `<div aria-invalid="grammar" />`, Tsx: true},
+			{Code: `<div aria-invalid="spelling" />`, Tsx: true},
+			{Code: `<div aria-invalid={null} />`, Tsx: true},
+			{Code: `<div aria-invalid={undefined} />`, Tsx: true},
+
+			// aria-relevant (tokenlist: ['additions','all','removals','text']).
+			// Single token / multi-token / repeated / out-of-order / template
+			// / Identifier / null / undefined.
+			{Code: `<div aria-relevant="additions" />`, Tsx: true},
+			{Code: `<div aria-relevant={"additions"} />`, Tsx: true},
+			{Code: "<div aria-relevant={`additions`} />", Tsx: true},
+			{Code: `<div aria-relevant="additions removals" />`, Tsx: true},
+			{Code: `<div aria-relevant="additions additions" />`, Tsx: true},
+			{Code: `<div aria-relevant={"additions removals"} />`, Tsx: true},
+			{Code: "<div aria-relevant={`additions removals`} />", Tsx: true},
+			{Code: `<div aria-relevant="additions removals text" />`, Tsx: true},
+			{Code: `<div aria-relevant={"additions removals text"} />`, Tsx: true},
+			{Code: "<div aria-relevant={`additions removals text`} />", Tsx: true},
+			{Code: `<div aria-relevant="additions removals text all" />`, Tsx: true},
+			{Code: `<div aria-relevant={"additions removals text all"} />`, Tsx: true},
+			{Code: "<div aria-relevant={`removals additions text all`} />", Tsx: true},
+			{Code: `<div aria-relevant={foo} />`, Tsx: true},
+			{Code: `<div aria-relevant={foo.bar} />`, Tsx: true},
+			{Code: `<div aria-relevant={null} />`, Tsx: true},
+			{Code: `<div aria-relevant={undefined} />`, Tsx: true},
+
+			// aria-activedescendant (id). ANY string is valid — upstream's
+			// validityCheck for "id" only inspects typeof. Token-looking
+			// strings included by upstream to assert the absence of token
+			// validation for the id type.
+			{Code: `<div aria-activedescendant="ascending" />`, Tsx: true},
+			{Code: `<div aria-activedescendant="ASCENDING" />`, Tsx: true},
+			{Code: `<div aria-activedescendant={"ascending"} />`, Tsx: true},
+			{Code: "<div aria-activedescendant={`ascending`} />", Tsx: true},
+			{Code: `<div aria-activedescendant="descending" />`, Tsx: true},
+			{Code: `<div aria-activedescendant={"descending"} />`, Tsx: true},
+			{Code: "<div aria-activedescendant={`descending`} />", Tsx: true},
+			{Code: `<div aria-activedescendant="none" />`, Tsx: true},
+			{Code: `<div aria-activedescendant={"none"} />`, Tsx: true},
+			{Code: "<div aria-activedescendant={`none`} />", Tsx: true},
+			{Code: `<div aria-activedescendant="other" />`, Tsx: true},
+			{Code: `<div aria-activedescendant={"other"} />`, Tsx: true},
+			{Code: "<div aria-activedescendant={`other`} />", Tsx: true},
+			{Code: `<div aria-activedescendant={foo} />`, Tsx: true},
+			{Code: `<div aria-activedescendant={foo.bar} />`, Tsx: true},
+			{Code: `<div aria-activedescendant={null} />`, Tsx: true},
+			{Code: `<div aria-activedescendant={undefined} />`, Tsx: true},
+
+			// aria-labelledby (idlist). ANY string is valid — `idlist`'s
+			// inner `validityCheck(token, 'id', [])` reduces to "is string"
+			// since split always returns string tokens.
+			{Code: `<div aria-labelledby="additions" />`, Tsx: true},
+			{Code: `<div aria-labelledby={"additions"} />`, Tsx: true},
+			{Code: "<div aria-labelledby={`additions`} />", Tsx: true},
+			{Code: `<div aria-labelledby="additions removals" />`, Tsx: true},
+			{Code: `<div aria-labelledby="additions additions" />`, Tsx: true},
+			{Code: `<div aria-labelledby={"additions removals"} />`, Tsx: true},
+			{Code: "<div aria-labelledby={`additions removals`} />", Tsx: true},
+			{Code: `<div aria-labelledby="additions removals text" />`, Tsx: true},
+			{Code: `<div aria-labelledby={"additions removals text"} />`, Tsx: true},
+			{Code: "<div aria-labelledby={`additions removals text`} />", Tsx: true},
+			{Code: `<div aria-labelledby="additions removals text all" />`, Tsx: true},
+			{Code: `<div aria-labelledby={"additions removals text all"} />`, Tsx: true},
+			{Code: "<div aria-labelledby={`removals additions text all`} />", Tsx: true},
+			{Code: `<div aria-labelledby={foo} />`, Tsx: true},
+			{Code: `<div aria-labelledby={foo.bar} />`, Tsx: true},
+			{Code: `<div aria-labelledby={null} />`, Tsx: true},
+			{Code: `<div aria-labelledby={undefined} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// aria-hidden (boolean) — non-coerced string, number, template
+			// with substitution (placeholder string).
+			{
+				Code: `<div aria-hidden="yes" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-hidden")}},
+			},
+			{
+				Code: `<div aria-hidden="no" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-hidden")}},
+			},
+			{
+				Code: `<div aria-hidden={1234} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-hidden")}},
+			},
+			{
+				Code: "<div aria-hidden={`${abc}`} />", Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-hidden")}},
+			},
+
+			// aria-label (string) — boolean form, boolean literals, number,
+			// PrefixUnary boolean.
+			{
+				Code: `<div aria-label />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-label")}},
+			},
+			{
+				Code: `<div aria-label={true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-label")}},
+			},
+			{
+				Code: `<div aria-label={false} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-label")}},
+			},
+			{
+				Code: `<div aria-label={1234} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-label")}},
+			},
+			{
+				Code: `<div aria-label={!true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-label")}},
+			},
+
+			// aria-checked (tristate) — non-mixed string, number, template
+			// with substitution.
+			{
+				Code: `<div aria-checked="yes" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-checked")}},
+			},
+			{
+				Code: `<div aria-checked="no" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-checked")}},
+			},
+			{
+				Code: `<div aria-checked={1234} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-checked")}},
+			},
+			{
+				Code: "<div aria-checked={`${abc}`} />", Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-checked")}},
+			},
+
+			// aria-level (integer) — non-numeric strings, boolean, boolean-form,
+			// coerced "false" boolean, PrefixUnary boolean.
+			{
+				Code: `<div aria-level="yes" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-level")}},
+			},
+			{
+				Code: `<div aria-level="no" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-level")}},
+			},
+			{
+				Code: "<div aria-level={`abc`} />", Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-level")}},
+			},
+			{
+				Code: `<div aria-level={true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-level")}},
+			},
+			{
+				Code: `<div aria-level />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-level")}},
+			},
+			{
+				Code: `<div aria-level={"false"} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-level")}},
+			},
+			{
+				Code: `<div aria-level={!"false"} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-level")}},
+			},
+
+			// aria-valuemax (number) — same shape as aria-level.
+			{
+				Code: `<div aria-valuemax="yes" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-valuemax")}},
+			},
+			{
+				Code: `<div aria-valuemax="no" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-valuemax")}},
+			},
+			{
+				Code: "<div aria-valuemax={`abc`} />", Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-valuemax")}},
+			},
+			{
+				Code: `<div aria-valuemax={true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-valuemax")}},
+			},
+			{
+				Code: `<div aria-valuemax />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-valuemax")}},
+			},
+			{
+				Code: `<div aria-valuemax={"false"} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-valuemax")}},
+			},
+			{
+				Code: `<div aria-valuemax={!"false"} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-valuemax")}},
+			},
+
+			// aria-sort (token) — empty string, typo, boolean form, boolean
+			// literal, coerced "false" boolean, multi-token string.
+			{
+				Code: `<div aria-sort="" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-sort")}},
+			},
+			{
+				Code: `<div aria-sort="descnding" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-sort")}},
+			},
+			{
+				Code: `<div aria-sort />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-sort")}},
+			},
+			{
+				Code: `<div aria-sort={true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-sort")}},
+			},
+			{
+				Code: `<div aria-sort={"false"} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-sort")}},
+			},
+			{
+				Code: `<div aria-sort="ascending descending" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-sort")}},
+			},
+
+			// aria-relevant (tokenlist) — empty string, unknown token, boolean
+			// form, boolean literal, coerced "false" boolean, typo, trailing
+			// space (split yields empty trailing token).
+			{
+				Code: `<div aria-relevant="" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-relevant")}},
+			},
+			{
+				Code: `<div aria-relevant="foobar" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-relevant")}},
+			},
+			{
+				Code: `<div aria-relevant />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-relevant")}},
+			},
+			{
+				Code: `<div aria-relevant={true} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-relevant")}},
+			},
+			{
+				Code: `<div aria-relevant={"false"} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-relevant")}},
+			},
+			{
+				Code: `<div aria-relevant="additions removalss" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-relevant")}},
+			},
+			{
+				Code: `<div aria-relevant="additions removalss " />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidAriaPropType", Message: upstreamErrorMessage("aria-relevant")}},
+			},
+		})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -162,6 +162,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/anchor-is-valid.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/aria-activedescendant-has-tabindex.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/aria-props.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/aria-proptypes.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/aria-unsupported-elements.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/click-events-have-key-events.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/aria-proptypes.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/aria-proptypes.test.ts
@@ -1,0 +1,466 @@
+import { RuleTester } from '../rule-tester';
+
+// Mirrors aria-query's `ariaPropsMap` — keyed by lowercase canonical name.
+// Used to drive procedural error-message generation, matching upstream's
+// `__tests__/src/rules/aria-proptypes-test.js` local `errorMessage(name)`
+// helper which looks up `aria.get(name.toLowerCase())`.
+const ariaPropertyDefinitions: Record<
+  string,
+  { type: string; values?: (string | boolean)[] }
+> = {
+  'aria-activedescendant': { type: 'id' },
+  'aria-atomic': { type: 'boolean' },
+  'aria-autocomplete': {
+    type: 'token',
+    values: ['inline', 'list', 'both', 'none'],
+  },
+  'aria-busy': { type: 'boolean' },
+  'aria-checked': { type: 'tristate' },
+  'aria-colcount': { type: 'integer' },
+  'aria-controls': { type: 'idlist' },
+  'aria-current': {
+    type: 'token',
+    values: ['page', 'step', 'location', 'date', 'time', true, false],
+  },
+  'aria-describedby': { type: 'idlist' },
+  'aria-details': { type: 'id' },
+  'aria-disabled': { type: 'boolean' },
+  'aria-dropeffect': {
+    type: 'tokenlist',
+    values: ['copy', 'execute', 'link', 'move', 'none', 'popup'],
+  },
+  'aria-errormessage': { type: 'id' },
+  'aria-expanded': { type: 'boolean' },
+  'aria-grabbed': { type: 'boolean' },
+  'aria-haspopup': {
+    type: 'token',
+    values: [false, true, 'menu', 'listbox', 'tree', 'grid', 'dialog'],
+  },
+  'aria-hidden': { type: 'boolean' },
+  'aria-invalid': {
+    type: 'token',
+    values: ['grammar', false, 'spelling', true],
+  },
+  'aria-label': { type: 'string' },
+  'aria-labelledby': { type: 'idlist' },
+  'aria-level': { type: 'integer' },
+  'aria-live': { type: 'token', values: ['assertive', 'off', 'polite'] },
+  'aria-orientation': {
+    type: 'token',
+    values: ['vertical', 'undefined', 'horizontal'],
+  },
+  'aria-posinset': { type: 'integer' },
+  'aria-pressed': { type: 'tristate' },
+  'aria-relevant': {
+    type: 'tokenlist',
+    values: ['additions', 'all', 'removals', 'text'],
+  },
+  'aria-rowcount': { type: 'integer' },
+  'aria-selected': { type: 'boolean' },
+  'aria-setsize': { type: 'integer' },
+  'aria-sort': {
+    type: 'token',
+    values: ['ascending', 'descending', 'none', 'other'],
+  },
+  'aria-valuemax': { type: 'number' },
+  'aria-valuemin': { type: 'number' },
+  'aria-valuenow': { type: 'number' },
+};
+
+// Mirrors the rule's `errorMessage(name, type, permittedValues)`.
+// `${permittedValues}` interpolation hits `Array.prototype.toString` and
+// joins with a bare comma (no space). Booleans stringify as "true"/"false".
+const errorMessage = (name: string): string => {
+  const def = ariaPropertyDefinitions[name.toLowerCase()];
+  const { type, values: permittedValues = [] } = def;
+  switch (type) {
+    case 'tristate':
+      return `The value for ${name} must be a boolean or the string "mixed".`;
+    case 'token':
+      return `The value for ${name} must be a single token from the following: ${permittedValues.join(',')}.`;
+    case 'tokenlist':
+      return `The value for ${name} must be a list of one or more tokens from the following: ${permittedValues.join(',')}.`;
+    case 'idlist':
+      return `The value for ${name} must be a list of strings that represent DOM element IDs (idlist)`;
+    case 'id':
+      return `The value for ${name} must be a string that represents a DOM element ID`;
+    default:
+      return `The value for ${name} must be a ${type}.`;
+  }
+};
+
+new RuleTester().run('aria-proptypes', null as never, {
+  valid: [
+    // Upstream test file — order preserved.
+    { code: '<div aria-foo="true" />' },
+    { code: '<div abcaria-foo="true" />' },
+    { code: '<div aria-hidden={true} />' },
+    { code: '<div aria-hidden="true" />' },
+    { code: '<div aria-hidden={"false"} />' },
+    { code: '<div aria-hidden={!false} />' },
+    { code: '<div aria-hidden />' },
+    { code: '<div aria-hidden={false} />' },
+    { code: '<div aria-hidden={!true} />' },
+    { code: '<div aria-hidden={!"yes"} />' },
+    { code: '<div aria-hidden={foo} />' },
+    { code: '<div aria-hidden={foo.bar} />' },
+    { code: '<div aria-hidden={null} />' },
+    { code: '<div aria-hidden={undefined} />' },
+    { code: '<div aria-hidden={<div />} />' },
+    { code: '<div aria-label="Close" />' },
+    { code: '<div aria-label={`Close`} />' },
+    { code: '<div aria-label={foo} />' },
+    { code: '<div aria-label={foo.bar} />' },
+    { code: '<div aria-label={null} />' },
+    { code: '<div aria-label={undefined} />' },
+    { code: '<input aria-invalid={error ? "true" : "false"} />' },
+    { code: '<input aria-invalid={undefined ? "true" : "false"} />' },
+    { code: '<div aria-checked={true} />' },
+    { code: '<div aria-checked="true" />' },
+    { code: '<div aria-checked={"false"} />' },
+    { code: '<div aria-checked={!false} />' },
+    { code: '<div aria-checked />' },
+    { code: '<div aria-checked={false} />' },
+    { code: '<div aria-checked={!true} />' },
+    { code: '<div aria-checked={!"yes"} />' },
+    { code: '<div aria-checked={foo} />' },
+    { code: '<div aria-checked={foo.bar} />' },
+    { code: '<div aria-checked="mixed" />' },
+    { code: '<div aria-checked={`mixed`} />' },
+    { code: '<div aria-checked={null} />' },
+    { code: '<div aria-checked={undefined} />' },
+    { code: '<div aria-level={123} />' },
+    { code: '<div aria-level={-123} />' },
+    { code: '<div aria-level={+123} />' },
+    { code: '<div aria-level={~123} />' },
+    { code: '<div aria-level={"123"} />' },
+    { code: '<div aria-level={`123`} />' },
+    { code: '<div aria-level="123" />' },
+    { code: '<div aria-level={foo} />' },
+    { code: '<div aria-level={foo.bar} />' },
+    { code: '<div aria-level={null} />' },
+    { code: '<div aria-level={undefined} />' },
+    { code: '<div aria-valuemax={123} />' },
+    { code: '<div aria-valuemax={-123} />' },
+    { code: '<div aria-valuemax={+123} />' },
+    { code: '<div aria-valuemax={~123} />' },
+    { code: '<div aria-valuemax={"123"} />' },
+    { code: '<div aria-valuemax={`123`} />' },
+    { code: '<div aria-valuemax="123" />' },
+    { code: '<div aria-valuemax={foo} />' },
+    { code: '<div aria-valuemax={foo.bar} />' },
+    { code: '<div aria-valuemax={null} />' },
+    { code: '<div aria-valuemax={undefined} />' },
+    { code: '<div aria-sort="ascending" />' },
+    { code: '<div aria-sort="ASCENDING" />' },
+    { code: '<div aria-sort={"ascending"} />' },
+    { code: '<div aria-sort={`ascending`} />' },
+    { code: '<div aria-sort="descending" />' },
+    { code: '<div aria-sort={"descending"} />' },
+    { code: '<div aria-sort={`descending`} />' },
+    { code: '<div aria-sort="none" />' },
+    { code: '<div aria-sort={"none"} />' },
+    { code: '<div aria-sort={`none`} />' },
+    { code: '<div aria-sort="other" />' },
+    { code: '<div aria-sort={"other"} />' },
+    { code: '<div aria-sort={`other`} />' },
+    { code: '<div aria-sort={foo} />' },
+    { code: '<div aria-sort={foo.bar} />' },
+    { code: '<div aria-invalid={true} />' },
+    { code: '<div aria-invalid="true" />' },
+    { code: '<div aria-invalid={false} />' },
+    { code: '<div aria-invalid="false" />' },
+    { code: '<div aria-invalid="grammar" />' },
+    { code: '<div aria-invalid="spelling" />' },
+    { code: '<div aria-invalid={null} />' },
+    { code: '<div aria-invalid={undefined} />' },
+    { code: '<div aria-relevant="additions" />' },
+    { code: '<div aria-relevant={"additions"} />' },
+    { code: '<div aria-relevant={`additions`} />' },
+    { code: '<div aria-relevant="additions removals" />' },
+    { code: '<div aria-relevant="additions additions" />' },
+    { code: '<div aria-relevant={"additions removals"} />' },
+    { code: '<div aria-relevant={`additions removals`} />' },
+    { code: '<div aria-relevant="additions removals text" />' },
+    { code: '<div aria-relevant={"additions removals text"} />' },
+    { code: '<div aria-relevant={`additions removals text`} />' },
+    { code: '<div aria-relevant="additions removals text all" />' },
+    { code: '<div aria-relevant={"additions removals text all"} />' },
+    { code: '<div aria-relevant={`removals additions text all`} />' },
+    { code: '<div aria-relevant={foo} />' },
+    { code: '<div aria-relevant={foo.bar} />' },
+    { code: '<div aria-relevant={null} />' },
+    { code: '<div aria-relevant={undefined} />' },
+    { code: '<div aria-activedescendant="ascending" />' },
+    { code: '<div aria-activedescendant="ASCENDING" />' },
+    { code: '<div aria-activedescendant={"ascending"} />' },
+    { code: '<div aria-activedescendant={`ascending`} />' },
+    { code: '<div aria-activedescendant="descending" />' },
+    { code: '<div aria-activedescendant={"descending"} />' },
+    { code: '<div aria-activedescendant={`descending`} />' },
+    { code: '<div aria-activedescendant="none" />' },
+    { code: '<div aria-activedescendant={"none"} />' },
+    { code: '<div aria-activedescendant={`none`} />' },
+    { code: '<div aria-activedescendant="other" />' },
+    { code: '<div aria-activedescendant={"other"} />' },
+    { code: '<div aria-activedescendant={`other`} />' },
+    { code: '<div aria-activedescendant={foo} />' },
+    { code: '<div aria-activedescendant={foo.bar} />' },
+    { code: '<div aria-activedescendant={null} />' },
+    { code: '<div aria-activedescendant={undefined} />' },
+    { code: '<div aria-labelledby="additions" />' },
+    { code: '<div aria-labelledby={"additions"} />' },
+    { code: '<div aria-labelledby={`additions`} />' },
+    { code: '<div aria-labelledby="additions removals" />' },
+    { code: '<div aria-labelledby="additions additions" />' },
+    { code: '<div aria-labelledby={"additions removals"} />' },
+    { code: '<div aria-labelledby={`additions removals`} />' },
+    { code: '<div aria-labelledby="additions removals text" />' },
+    { code: '<div aria-labelledby={"additions removals text"} />' },
+    { code: '<div aria-labelledby={`additions removals text`} />' },
+    { code: '<div aria-labelledby="additions removals text all" />' },
+    { code: '<div aria-labelledby={"additions removals text all"} />' },
+    { code: '<div aria-labelledby={`removals additions text all`} />' },
+    { code: '<div aria-labelledby={foo} />' },
+    { code: '<div aria-labelledby={foo.bar} />' },
+    { code: '<div aria-labelledby={null} />' },
+    { code: '<div aria-labelledby={undefined} />' },
+
+    // Extra rslint lockdowns:
+    // Case-insensitive lookup — uppercase / mixed-case prefixes ARE
+    // accepted (unlike aria-props, which is case-sensitive).
+    { code: '<div ARIA-HIDDEN="true" />' },
+    { code: '<div Aria-Hidden="true" />' },
+    { code: '<div ARIA-LEVEL={3} />' },
+    // Parenthesized values — tsgo preserves Parens; ESTree flattens.
+    { code: '<div aria-hidden={(true)} />' },
+    { code: '<div aria-hidden={((true))} />' },
+    // TS type-assertion wrappers — LITERAL_TYPES has no entry → noop → skip.
+    { code: '<div aria-hidden={true as boolean} />' },
+    { code: '<div aria-hidden={x!} />' },
+    { code: '<div aria-hidden={x satisfies boolean} />' },
+    // aria-haspopup heterogeneous values.
+    { code: '<div aria-haspopup={true} />' },
+    { code: '<div aria-haspopup={false} />' },
+    { code: '<div aria-haspopup="menu" />' },
+    // aria-current heterogeneous values.
+    { code: '<div aria-current="page" />' },
+    { code: '<div aria-current={true} />' },
+    // aria-orientation includes string "undefined" as a token value.
+    { code: '<div aria-orientation="undefined" />' },
+    // JSXSpreadAttribute is not visited.
+    { code: "<div {...{'aria-hidden': 'yes'}} />" },
+    // data-* prefix is not aria-*.
+    { code: '<div data-aria-hidden="yes" />' },
+    // React patterns.
+    { code: '<>{cond && <div aria-hidden>x</div>}</>' },
+    { code: 'class C { render() { return <div aria-label="x" />; } }' },
+  ],
+  invalid: [
+    // Upstream test file — order preserved.
+    {
+      code: '<div aria-hidden="yes" />',
+      errors: [{ message: errorMessage('aria-hidden') }],
+    },
+    {
+      code: '<div aria-hidden="no" />',
+      errors: [{ message: errorMessage('aria-hidden') }],
+    },
+    {
+      code: '<div aria-hidden={1234} />',
+      errors: [{ message: errorMessage('aria-hidden') }],
+    },
+    {
+      code: '<div aria-hidden={`${abc}`} />',
+      errors: [{ message: errorMessage('aria-hidden') }],
+    },
+    {
+      code: '<div aria-label />',
+      errors: [{ message: errorMessage('aria-label') }],
+    },
+    {
+      code: '<div aria-label={true} />',
+      errors: [{ message: errorMessage('aria-label') }],
+    },
+    {
+      code: '<div aria-label={false} />',
+      errors: [{ message: errorMessage('aria-label') }],
+    },
+    {
+      code: '<div aria-label={1234} />',
+      errors: [{ message: errorMessage('aria-label') }],
+    },
+    {
+      code: '<div aria-label={!true} />',
+      errors: [{ message: errorMessage('aria-label') }],
+    },
+    {
+      code: '<div aria-checked="yes" />',
+      errors: [{ message: errorMessage('aria-checked') }],
+    },
+    {
+      code: '<div aria-checked="no" />',
+      errors: [{ message: errorMessage('aria-checked') }],
+    },
+    {
+      code: '<div aria-checked={1234} />',
+      errors: [{ message: errorMessage('aria-checked') }],
+    },
+    {
+      code: '<div aria-checked={`${abc}`} />',
+      errors: [{ message: errorMessage('aria-checked') }],
+    },
+    {
+      code: '<div aria-level="yes" />',
+      errors: [{ message: errorMessage('aria-level') }],
+    },
+    {
+      code: '<div aria-level="no" />',
+      errors: [{ message: errorMessage('aria-level') }],
+    },
+    {
+      code: '<div aria-level={`abc`} />',
+      errors: [{ message: errorMessage('aria-level') }],
+    },
+    {
+      code: '<div aria-level={true} />',
+      errors: [{ message: errorMessage('aria-level') }],
+    },
+    {
+      code: '<div aria-level />',
+      errors: [{ message: errorMessage('aria-level') }],
+    },
+    {
+      code: '<div aria-level={"false"} />',
+      errors: [{ message: errorMessage('aria-level') }],
+    },
+    {
+      code: '<div aria-level={!"false"} />',
+      errors: [{ message: errorMessage('aria-level') }],
+    },
+    {
+      code: '<div aria-valuemax="yes" />',
+      errors: [{ message: errorMessage('aria-valuemax') }],
+    },
+    {
+      code: '<div aria-valuemax="no" />',
+      errors: [{ message: errorMessage('aria-valuemax') }],
+    },
+    {
+      code: '<div aria-valuemax={`abc`} />',
+      errors: [{ message: errorMessage('aria-valuemax') }],
+    },
+    {
+      code: '<div aria-valuemax={true} />',
+      errors: [{ message: errorMessage('aria-valuemax') }],
+    },
+    {
+      code: '<div aria-valuemax />',
+      errors: [{ message: errorMessage('aria-valuemax') }],
+    },
+    {
+      code: '<div aria-valuemax={"false"} />',
+      errors: [{ message: errorMessage('aria-valuemax') }],
+    },
+    {
+      code: '<div aria-valuemax={!"false"} />',
+      errors: [{ message: errorMessage('aria-valuemax') }],
+    },
+    {
+      code: '<div aria-sort="" />',
+      errors: [{ message: errorMessage('aria-sort') }],
+    },
+    {
+      code: '<div aria-sort="descnding" />',
+      errors: [{ message: errorMessage('aria-sort') }],
+    },
+    {
+      code: '<div aria-sort />',
+      errors: [{ message: errorMessage('aria-sort') }],
+    },
+    {
+      code: '<div aria-sort={true} />',
+      errors: [{ message: errorMessage('aria-sort') }],
+    },
+    {
+      code: '<div aria-sort={"false"} />',
+      errors: [{ message: errorMessage('aria-sort') }],
+    },
+    {
+      code: '<div aria-sort="ascending descending" />',
+      errors: [{ message: errorMessage('aria-sort') }],
+    },
+    {
+      code: '<div aria-relevant="" />',
+      errors: [{ message: errorMessage('aria-relevant') }],
+    },
+    {
+      code: '<div aria-relevant="foobar" />',
+      errors: [{ message: errorMessage('aria-relevant') }],
+    },
+    {
+      code: '<div aria-relevant />',
+      errors: [{ message: errorMessage('aria-relevant') }],
+    },
+    {
+      code: '<div aria-relevant={true} />',
+      errors: [{ message: errorMessage('aria-relevant') }],
+    },
+    {
+      code: '<div aria-relevant={"false"} />',
+      errors: [{ message: errorMessage('aria-relevant') }],
+    },
+    {
+      code: '<div aria-relevant="additions removalss" />',
+      errors: [{ message: errorMessage('aria-relevant') }],
+    },
+    {
+      code: '<div aria-relevant="additions removalss " />',
+      errors: [{ message: errorMessage('aria-relevant') }],
+    },
+
+    // Extra rslint lockdowns.
+    // Case-insensitive: message reflects ORIGINAL (cased) name.
+    {
+      code: '<div ARIA-HIDDEN="yes" />',
+      errors: [{ message: 'The value for ARIA-HIDDEN must be a boolean.' }],
+    },
+    {
+      code: '<div Aria-Hidden={1234} />',
+      errors: [{ message: 'The value for Aria-Hidden must be a boolean.' }],
+    },
+    // Parenthesized invalid still reports.
+    {
+      code: '<div aria-hidden={(1234)} />',
+      errors: [{ message: errorMessage('aria-hidden') }],
+    },
+    // aria-haspopup unknown token.
+    {
+      code: '<div aria-haspopup="dropdown" />',
+      errors: [{ message: errorMessage('aria-haspopup') }],
+    },
+    // aria-orientation unknown token.
+    {
+      code: '<div aria-orientation="diagonal" />',
+      errors: [{ message: errorMessage('aria-orientation') }],
+    },
+    // aria-pressed invalid.
+    {
+      code: '<div aria-pressed="partial" />',
+      errors: [{ message: errorMessage('aria-pressed') }],
+    },
+    // Nested JSX with invalid attrs at multiple depths.
+    {
+      code: '<main><section><h2 aria-hidden="yes"><span aria-label={1} /></h2></section></main>',
+      errors: [
+        { message: errorMessage('aria-hidden') },
+        { message: errorMessage('aria-label') },
+      ],
+    },
+    // Mixed valid + invalid attrs on a single element.
+    {
+      code: '<div aria-label="ok" aria-hidden="yes" aria-level={3} />',
+      errors: [{ message: errorMessage('aria-hidden') }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -435,3 +435,6 @@ jsxtransforms
 jsxtx
 uppercased
 undefinedundefined
+tokenlist
+idlist
+allowundefined


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/aria-proptypes` rule from `eslint-plugin-jsx-a11y` (v6.10.2) to rslint.

The rule enforces that the literal value of every recognized `aria-*` state / property matches the type declared in `aria-query`'s `ariaPropsMap`. For example, `aria-hidden` must be a boolean — `aria-hidden="yes"` reports.

All 9 ARIA types are supported: `boolean`, `string`, `id`, `tristate`, `integer`, `number`, `token`, `tokenlist`, `idlist`. Heterogeneous permitted-values lists (booleans mixed with strings, e.g. `aria-current` / `aria-haspopup` / `aria-invalid`) and the `allowUndefined` flag on `aria-expanded` / `aria-grabbed` / `aria-hidden` / `aria-selected` are honored.

Test coverage:
- `aria_proptypes_upstream_test.go` — full 1:1 mirror of upstream v6.10.2 suite (133 valid + 40 invalid) plus the upstream `validityCheck(null, null)` tape unit assertion.
- `aria_proptypes_extras_test.go` — tsgo / rslint-specific edges (TS wrappers, parens, case-insensitive attribute names, heterogeneous token lists, library wrappers, multi-element nesting, BigInt, JSXNamespacedName, position assertions, etc.).
- `tests/eslint-plugin-jsx-a11y/rules/aria-proptypes.test.ts` — JS RuleTester suite mirroring upstream + extras.

Differential validation: built a 51-case canary covering every ARIA type, ran both rslint and upstream `eslint-plugin-jsx-a11y@6.10.2` against it — `diff` of sorted `line:column|message` outputs is empty (23 errors, 23 matches).

`aria-proptypes` is now enabled in `@rslint/core`'s `jsx-a11y` recommended preset.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-proptypes.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.2/src/rules/aria-proptypes.js
- aria-query `ariaPropsMap`: https://github.com/A11yance/aria-query/blob/main/src/ariaPropsMap.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).