### PR TITLE
feat: port rule jsx-a11y/interactive-supports-focus

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -14,6 +14,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/html_has_lang"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/iframe_has_title"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/img_redundant_alt"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/interactive_supports_focus"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/media_has_caption"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_access_key"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_autofocus"
@@ -40,6 +41,7 @@ func GetAllRules() []rule.Rule {
 		html_has_lang.HtmlHasLangRule,
 		iframe_has_title.IframeHasTitleRule,
 		img_redundant_alt.ImgRedundantAltRule,
+		interactive_supports_focus.InteractiveSupportsFocusRule,
 		media_has_caption.MediaHasCaptionRule,
 		no_access_key.NoAccessKeyRule,
 		no_autofocus.NoAutofocusRule,

--- a/internal/plugins/jsx_a11y/jsxa11yutil/disabled.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/disabled.go
@@ -1,0 +1,54 @@
+package jsxa11yutil
+
+import "github.com/microsoft/typescript-go/shim/ast"
+
+// IsDisabledElement mirrors upstream `isDisabledElement(attributes)`
+// (eslint-plugin-jsx-a11y/src/util/isDisabledElement.js) verbatim:
+//
+//	const disabledAttr = getProp(attributes, 'disabled');
+//	const disabledAttrValue = getPropValue(disabledAttr);
+//	const isHTML5Disabled = disabledAttr && disabledAttrValue !== undefined;
+//	if (isHTML5Disabled) return true;
+//	const ariaDisabledAttr = getProp(attributes, 'aria-disabled');
+//	const ariaDisabledAttrValue = getLiteralPropValue(ariaDisabledAttr);
+//	if (ariaDisabledAttr && ariaDisabledAttrValue !== undefined
+//	    && ariaDisabledAttrValue === true) return true;
+//	return false;
+//
+// Notable upstream quirks we preserve:
+//
+//   - The `disabled` arm gates on `getPropValue !== undefined`, NOT
+//     truthiness. `<X disabled={false} />` therefore counts as disabled
+//     (getPropValue is the literal boolean `false`, not undefined). Only
+//     `<X disabled={undefined} />` (and TS-wrapped variants) avoids the trip.
+//     This is counter-intuitive but matches upstream byte-for-byte.
+//   - The `disabled` arm uses `getPropValue` (full static eval), so
+//     `disabled={someVar}` resolves to the identifier name string and
+//     trips the trigger. The `aria-disabled` arm uses `getLiteralPropValue`
+//     with strict `=== true`, so only literal boolean true (including the
+//     boolean-attribute form `<X aria-disabled />` and the
+//     literal-coerced-string `aria-disabled="true"`) counts.
+func IsDisabledElement(attrs []*ast.Node) bool {
+	if disabledAttr := FindAttributeByName(attrs, "disabled"); disabledAttr != nil {
+		// upstream `getPropValue(disabledAttr) !== undefined`. The only
+		// shapes that resolve to JS undefined are:
+		//   - explicit `disabled={undefined}` (and TS-wrapped variants).
+		// Boolean form, missing initializer (empty `{}`), string, number,
+		// identifier, call, member, etc. all resolve to non-undefined and
+		// therefore count as HTML5-disabled.
+		if !AttributeIsExplicitUndefined(disabledAttr) {
+			return true
+		}
+	}
+	if ariaDisabledAttr := FindAttributeByName(attrs, "aria-disabled"); ariaDisabledAttr != nil {
+		// upstream `getLiteralPropValue(...) === true`. LiteralPropIsExactlyTrue
+		// covers the boolean-attribute form (extractValue null-attr → true),
+		// `={true}`, and the literal-coerced string `="true"`. Anything else
+		// (including `="false"`, `={false}`, `={1}`, identifiers, calls,
+		// missing prop) falls through.
+		if LiteralPropIsExactlyTrue(ariaDisabledAttr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/jsx_a11y/jsxa11yutil/event_handlers.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/event_handlers.go
@@ -1,0 +1,47 @@
+package jsxa11yutil
+
+// InteractiveEventHandlerNames mirrors the
+// `[].concat(eventHandlersByType.mouse, eventHandlersByType.keyboard)`
+// constant that `interactive-supports-focus` (and any future rule that
+// imports `interactiveProps` from jsx-ast-utils) hands to `hasAnyProp`.
+//
+// Sourced from jsx-ast-utils' `eventHandlers.js`:
+//
+//	mouse: [
+//	  'onClick', 'onContextMenu', 'onDblClick', 'onDoubleClick',
+//	  'onDrag', 'onDragEnd', 'onDragEnter', 'onDragExit',
+//	  'onDragLeave', 'onDragOver', 'onDragStart', 'onDrop',
+//	  'onMouseDown', 'onMouseEnter', 'onMouseLeave', 'onMouseMove',
+//	  'onMouseOut', 'onMouseOver', 'onMouseUp',
+//	],
+//	keyboard: ['onKeyDown', 'onKeyPress', 'onKeyUp'],
+//
+// Order matches the upstream concat (mouse first, then keyboard) for
+// auditability — semantically irrelevant because every consumer uses set
+// membership rather than ordering.
+var InteractiveEventHandlerNames = []string{
+	// mouse
+	"onClick",
+	"onContextMenu",
+	"onDblClick",
+	"onDoubleClick",
+	"onDrag",
+	"onDragEnd",
+	"onDragEnter",
+	"onDragExit",
+	"onDragLeave",
+	"onDragOver",
+	"onDragStart",
+	"onDrop",
+	"onMouseDown",
+	"onMouseEnter",
+	"onMouseLeave",
+	"onMouseMove",
+	"onMouseOut",
+	"onMouseOver",
+	"onMouseUp",
+	// keyboard
+	"onKeyDown",
+	"onKeyPress",
+	"onKeyUp",
+}

--- a/internal/plugins/jsx_a11y/jsxa11yutil/interactive.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/interactive.go
@@ -363,12 +363,20 @@ func IsInteractiveElement(tagName string, attrs []*ast.Node) bool {
 // Non-literal expressions (`role={someVar}`), absent role, or first valid
 // role that is non-interactive all return false. Empty / all-invalid
 // space-split lists also return false.
+//
+// Routes through [LiteralPropStringValue] (= upstream `getLiteralPropValue`)
+// rather than the simpler [LiteralStringValue]: this picks up upstream's
+// TemplateExpression-with-substitutions synthesis (each substitution's
+// LITERAL_TYPES extraction concatenated against the quasi text) and the
+// `null` literal → "null" magic string. Matters for `` role={`button${''}`} ``
+// and `role={null}` corner cases — uncommon, but covered by upstream's
+// `getLiteralPropValue` and therefore in scope for parity.
 func IsInteractiveRole(_ string, attrs []*ast.Node) bool {
 	roleAttr := FindAttributeByName(attrs, "role")
 	if roleAttr == nil {
 		return false
 	}
-	value, ok := LiteralStringValue(roleAttr)
+	value, ok := LiteralPropStringValue(roleAttr)
 	if !ok {
 		return false
 	}
@@ -383,6 +391,259 @@ func IsInteractiveRole(_ string, attrs []*ast.Node) bool {
 		// First valid role wins per upstream's `validRoles[0]`.
 		_, isInteractive := interactiveRolesSet[part]
 		return isInteractive
+	}
+	return false
+}
+
+// nonInteractiveRolesSet mirrors upstream's `isNonInteractiveRole`
+// `nonInteractiveRoles` Set — every non-abstract role whose `superClass`
+// chain does NOT contain `widget`. Note the asymmetry with [interactiveRolesSet]:
+//
+//   - `toolbar` lives in BOTH sets upstream. interactiveRoles concat's it
+//     in (does not descend from widget, but supports aria-activedescendant);
+//     nonInteractiveRoles' filter (superClass !⊇ widget) ALSO matches it.
+//   - `progressbar` lives only in interactiveRolesSet — it IS a widget
+//     descendant, so the nonInteractiveRoles filter rejects it.
+//
+// Each individual upstream util reuses its OWN local filter pipeline; this
+// duplication is load-bearing for the observable semantics of
+// `interactive-supports-focus` and similar rules. Maintain the two sets
+// separately rather than computing one as the complement of the other.
+var nonInteractiveRolesSet = func() map[string]struct{} {
+	out := make(map[string]struct{}, len(nonInteractiveRoleNames)+1)
+	for _, k := range nonInteractiveRoleNames {
+		out[k] = struct{}{}
+	}
+	// `toolbar` matches the upstream `!superClass.some(...widget)` filter.
+	// nonInteractiveRoleNames intentionally omits it (it lives in
+	// interactiveRolesSet for the isInteractiveRole path); replicate the
+	// upstream membership explicitly here.
+	out["toolbar"] = struct{}{}
+	return out
+}()
+
+// IsNonInteractiveRole mirrors upstream's `isNonInteractiveRole(tagName,
+// attributes)`. The function is tag-aware (unlike [IsInteractiveRole]) —
+// upstream early-returns false for custom components, so the rule's caller
+// can short-circuit without consulting role attributes on JSX-component tags.
+//
+// Returns true iff:
+//   - tagName is an aria-query DOM element name, AND
+//   - the `role` attribute resolves to a literal string whose first valid
+//     space-separated role is in [nonInteractiveRolesSet].
+//
+// Returns false when the role expression is non-literal, when no valid role
+// is found in the space-separated list, or when tagName is a custom
+// component (matches upstream's `!dom.has(type)` guard).
+func IsNonInteractiveRole(tagName string, attrs []*ast.Node) bool {
+	if !IsDOMElement(tagName) {
+		return false
+	}
+	roleAttr := FindAttributeByName(attrs, "role")
+	if roleAttr == nil {
+		return false
+	}
+	// Same extractor as IsInteractiveRole — see that comment for the
+	// LiteralPropStringValue vs LiteralStringValue rationale.
+	value, ok := LiteralPropStringValue(roleAttr)
+	if !ok {
+		return false
+	}
+	for _, part := range strings.Split(strings.ToLower(value), " ") {
+		if _, isRole := allRolesSet[part]; !isRole {
+			continue
+		}
+		_, isNonInteractive := nonInteractiveRolesSet[part]
+		return isNonInteractive
+	}
+	return false
+}
+
+// strictNonInteractiveElementRoleSchemas mirrors upstream
+// `isNonInteractiveElement.js`'s view of `nonInteractiveElementRoleSchemas`
+// — `elementRoles` entries whose role list is ENTIRELY non-interactive
+// under that file's stricter `nonInteractiveRoles` set:
+//
+//	{role | !role.abstract
+//	     && role !== 'toolbar'
+//	     && role !== 'generic'
+//	     && !role.superClass.some(...widget)}
+//	∪ {'progressbar'}
+//
+// Differs from [nonInteractiveElementRoleSchemas]: that table is generated
+// from `isInteractiveElement.js`'s `nonInteractiveRoles` set (which keeps
+// `generic` in the non-interactive set), so generic-role HTML elements
+// like `div`, `span`, `a`, `area`, `b`, `bdo`, `body`, `data`, `hgroup`,
+// `i`, `pre`, `q`, `samp`, `small`, `u`, and `section` (no attrs) appear
+// there but NOT here.
+//
+// `IsNonInteractiveElement` consults THIS table (not the one above) — a
+// `<div role="radio" onClick={…} />` must trip `interactive-supports-focus`,
+// which requires `IsNonInteractiveElement("div", …)` to return false. If
+// we used the `isInteractiveElement.js`-view table, `div` would match the
+// non-interactive schema and the rule would fall silent.
+//
+// Generated from `aria-query` v5 + the upstream filter pipeline.
+// Element-level constraints are not modeled (see file-level note).
+var strictNonInteractiveElementRoleSchemas = []elementSchema{
+	{Name: "article"},
+	{Name: "header"},
+	{Name: "blockquote"},
+	{Name: "caption"},
+	{Name: "td"},
+	{Name: "code"},
+	{Name: "aside"},
+	{Name: "aside", Attributes: []elementAttrSchema{{Name: "aria-label"}}},
+	{Name: "aside", Attributes: []elementAttrSchema{{Name: "aria-labelledby"}}},
+	{Name: "footer"},
+	{Name: "dd"},
+	{Name: "del"},
+	{Name: "dialog"},
+	{Name: "html"},
+	{Name: "em"},
+	{Name: "figure"},
+	{Name: "form", Attributes: []elementAttrSchema{{Name: "aria-label"}}},
+	{Name: "form", Attributes: []elementAttrSchema{{Name: "aria-labelledby"}}},
+	{Name: "form", Attributes: []elementAttrSchema{{Name: "name"}}},
+	{Name: "details"},
+	{Name: "fieldset"},
+	{Name: "optgroup"},
+	{Name: "address"},
+	{Name: "h1"},
+	{Name: "h2"},
+	{Name: "h3"},
+	{Name: "h4"},
+	{Name: "h5"},
+	{Name: "h6"},
+	{Name: "img", Attributes: []elementAttrSchema{{Name: "alt"}}},
+	{Name: "img", Attributes: []elementAttrSchema{{Name: "alt", Value: ""}}},
+	{Name: "ins"},
+	{Name: "menu"},
+	{Name: "ol"},
+	{Name: "ul"},
+	{Name: "li"},
+	{Name: "main"},
+	{Name: "mark"},
+	{Name: "math"},
+	{Name: "meter"},
+	{Name: "nav"},
+	{Name: "p"},
+	{Name: "progress"},
+	{Name: "section", Attributes: []elementAttrSchema{{Name: "aria-label"}}},
+	{Name: "section", Attributes: []elementAttrSchema{{Name: "aria-labelledby"}}},
+	{Name: "tbody"},
+	{Name: "tfoot"},
+	{Name: "thead"},
+	{Name: "hr"},
+	{Name: "output"},
+	{Name: "strong"},
+	{Name: "sub"},
+	{Name: "sup"},
+	{Name: "table"},
+	{Name: "dfn"},
+	{Name: "dt"},
+	{Name: "time"},
+}
+
+// nonInteractiveElementAXSchemas mirrors upstream's
+// `nonInteractiveElementAXObjectSchemas` — every entry in axobject-query's
+// `elementAXObjects` whose AX-object list is ENTIRELY made of window/structure
+// AX objects. Consulted only after the role-schema matchers miss; ordering
+// matches upstream's iteration over `elementAXObjects`.
+//
+// Generated from `axobject-query` v4 + `AXObjects.type ∈ {window, structure}`
+// using the same filter pipeline as upstream. Element-level constraints are
+// not modeled (see file-level note).
+var nonInteractiveElementAXSchemas = []elementSchema{
+	{Name: "abbr"},
+	{Name: "article"},
+	{Name: "blockquote"},
+	{Name: "caption"},
+	{Name: "dfn"},
+	{Name: "dd"},
+	{Name: "dl"},
+	{Name: "dt"},
+	{Name: "details"},
+	{Name: "dialog"},
+	{Name: "dir"},
+	{Name: "figcaption"},
+	{Name: "figure"},
+	{Name: "footer"},
+	{Name: "form"},
+	{Name: "h1"},
+	{Name: "h2"},
+	{Name: "h3"},
+	{Name: "h4"},
+	{Name: "h5"},
+	{Name: "h6"},
+	{Name: "iframe"},
+	{Name: "img", Attributes: []elementAttrSchema{{Name: "usemap"}}},
+	{Name: "img"},
+	{Name: "label"},
+	{Name: "legend"},
+	{Name: "br"},
+	{Name: "li"},
+	{Name: "ul"},
+	{Name: "ol"},
+	{Name: "main"},
+	{Name: "mark"},
+	{Name: "marquee"},
+	{Name: "menu"},
+	{Name: "meter"},
+	{Name: "nav"},
+	{Name: "p"},
+	{Name: "pre"},
+	{Name: "progress"},
+	{Name: "tr"},
+	{Name: "ruby"},
+	{Name: "table"},
+	{Name: "time"},
+}
+
+// IsNonInteractiveElement reports whether `(tagName, attrs)` denotes a
+// non-interactive HTML element by ARIA semantics. Mirrors upstream's
+// `isNonInteractiveElement(tagName, attributes)`:
+//
+//  1. Tag must be in aria-query's `dom` map; otherwise false (custom
+//     components — we don't know what DOM they render).
+//  2. `<header>` always returns false — upstream comments call out that
+//     header semantics depend on parent context (banner landmark inside
+//     <body>), which static analysis cannot verify.
+//  3. First match against non-interactive role schemas (with the `td`
+//     exception below) → true.
+//  4. First match against interactive role schemas (same `td` exception)
+//     → false.
+//  5. First match against non-interactive AX-object schemas → true.
+//  6. Otherwise → false.
+//
+// `td` is excluded from the role-schema matchers via upstream's
+// `tagName !== 'td'` guard — both `interactiveElementRoleSchemas` and
+// `nonInteractiveElementRoleSchemas` contain a `{name: "td"}` entry, so
+// without the guard the matchers would both fire. Upstream documents this
+// as a TODO; we mirror byte-for-byte.
+func IsNonInteractiveElement(tagName string, attrs []*ast.Node) bool {
+	if !IsDOMElement(tagName) {
+		return false
+	}
+	if tagName == "header" {
+		return false
+	}
+	if tagName != "td" {
+		for _, s := range strictNonInteractiveElementRoleSchemas {
+			if s.Name == tagName && schemaMatchesAttrs(s, attrs) {
+				return true
+			}
+		}
+		for _, s := range interactiveElementRoleSchemas {
+			if s.Name == tagName && schemaMatchesAttrs(s, attrs) {
+				return false
+			}
+		}
+	}
+	for _, s := range nonInteractiveElementAXSchemas {
+		if s.Name == tagName && schemaMatchesAttrs(s, attrs) {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -1,3 +1,5 @@
+// cspell:ignore utton idden
+
 // Package jsxa11yutil contains shared helpers for eslint-plugin-jsx-a11y rule
 // ports. The functions here mirror jsx-ast-utils / jsx-a11y/util semantics that
 // are common across many a11y rules: case-insensitive attribute lookup,
@@ -9,9 +11,37 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	jsxtx "github.com/microsoft/typescript-go/shim/transformers/jsxtransforms"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+// directAttributeStringValue extracts the JSX attribute's string value with
+// HTML entity decoding for the direct `<attr="…">` form. Returns ("", false)
+// when the attribute isn't a JsxAttribute whose initializer is a bare
+// StringLiteral (i.e. caller should fall back to the JsxExpression /
+// spread-resolved path that reads the cooked JS string).
+//
+// Rationale: @typescript-eslint / @babel JSX parsers decode HTML entities
+// (`&#98;` → "b", `&amp;` → "&", `&nbsp;` → U+00A0) at parse time and
+// expose the decoded text via the AST's `value` field; jsx-ast-utils
+// consumes that decoded text. tsgo, by contrast, preserves the raw `&…;`
+// source on `StringLiteral.Text` for JSX attributes. To realign, callers
+// reading literal string values from JSX attributes must apply
+// `jsxtransforms.DecodeEntities` on the direct-StringLiteral branch.
+// `{…}` JsxExpression-wrapped strings carry JS string literals (not JSX
+// attribute text), so they MUST NOT be decoded — JS parsers leave entity
+// notation alone.
+func directAttributeStringValue(attr *ast.Node) (string, bool) {
+	if attr == nil || attr.Kind != ast.KindJsxAttribute {
+		return "", false
+	}
+	init := attr.AsJsxAttribute().Initializer
+	if init == nil || init.Kind != ast.KindStringLiteral {
+		return "", false
+	}
+	return jsxtx.DecodeEntities(init.AsStringLiteral().Text), true
+}
 
 // skipTransparent is the wrapper mask used by `staticEval` (the
 // `getPropValue` / TYPES path). Strips parentheses, type assertions
@@ -258,6 +288,12 @@ func AttributeIsBooleanForm(attr *ast.Node) bool {
 // substitutions, etc. This mirrors jsx-ast-utils' `getLiteralPropValue` for
 // the string-typed cases the alt-text / role / type / title checks rely on.
 func LiteralStringValue(attr *ast.Node) (string, bool) {
+	// Direct attribute form `<attr="…">` — the underlying StringLiteral.Text
+	// holds the raw `&…;`-encoded source. Decode via jsxtransforms so callers
+	// see the same value @typescript-eslint / @babel's JSX parser would expose.
+	if v, ok := directAttributeStringValue(attr); ok {
+		return v, true
+	}
 	inner := attributeInnerExpression(attr)
 	if inner == nil {
 		return "", false
@@ -319,7 +355,11 @@ func attributeInnerExpression(attr *ast.Node) *ast.Node {
 // alt validity to distinguish `<img alt={undefined} />` from
 // `<img alt={someVar} />`.
 func AttributeIsExplicitUndefined(attr *ast.Node) bool {
-	return utils.IsUndefinedIdentifier(attributeInnerExpression(attr))
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		return false
+	}
+	return utils.IsUndefinedIdentifier(inner)
 }
 
 // AltAttributeIsValid encodes the alt-text validity rule for a present `alt`
@@ -480,6 +520,19 @@ func LiteralPropStringValue(attr *ast.Node) (string, bool) {
 		return "", false
 	}
 	if AttributeIsBooleanForm(attr) {
+		return "", false
+	}
+	// Direct attribute form `<attr="…">` — apply HTML entity decoding so
+	// `<X role="&#98;utton" />` is seen as `"button"` (matching upstream's
+	// post-JSX-parser value). jsxAstUtilsLiteralCoerce semantics still apply
+	// downstream when the caller routes through literalPropValue, but for the
+	// direct-string path we short-circuit here because literalPropValue would
+	// only re-read the raw StringLiteral.Text and skip the entity decode.
+	if v, ok := directAttributeStringValue(attr); ok {
+		coerced := jsxAstUtilsLiteralCoerce(v)
+		if coerced.Kind == jvString {
+			return coerced.Str, true
+		}
 		return "", false
 	}
 	inner := attributeInnerExpression(attr)
@@ -715,6 +768,14 @@ func LiteralPropIsExactlyTrue(attr *ast.Node) bool {
 		// boolean true; true === true → matches.
 		return true
 	}
+	// Direct attribute form `<X muted="true">` — entity-decode before
+	// jsxAstUtilsLiteralCoerce so e.g. `aria-disabled="&#116;rue"` still
+	// coerces to bool true (upstream sees the decoded "true"). The
+	// JsxExpression / spread paths carry JS string literals (no decode).
+	if decoded, ok := directAttributeStringValue(attr); ok {
+		v := jsxAstUtilsLiteralCoerce(decoded)
+		return v.Kind == jvBool && v.Bool
+	}
 	inner := attributeInnerExpression(attr)
 	if inner == nil {
 		return false
@@ -869,6 +930,19 @@ func polymorphicPropValue(propAttr *ast.Node) (string, bool) {
 		// Set.has(true) check downstream fails, so this skips alt-text
 		// entirely. Mirror by returning the string "true".
 		return "true", true
+	}
+	// Direct attribute `<Foo as="button">` — entity-decode + literal coerce.
+	// `<Foo as="&#98;utton">` should resolve to `"button"` so the rawType
+	// matches the HTML element name set downstream.
+	if decoded, ok := directAttributeStringValue(propAttr); ok {
+		v := jsxAstUtilsLiteralCoerce(decoded)
+		if !jsTruthy_(v) {
+			return "", false
+		}
+		if v.Kind == jvString {
+			return v.Str, true
+		}
+		return jsToString(v), true
 	}
 	inner := attributeInnerExpression(propAttr)
 	if inner == nil {
@@ -1081,7 +1155,15 @@ func IsHiddenFromScreenReader(child *ast.Node, getElementType func(*ast.Node) st
 	if tag == "INPUT" {
 		typeAttr := FindAttributeByName(attrs, "type")
 		if typeAttr != nil {
-			if inner := attributeInnerExpression(typeAttr); inner != nil {
+			// Direct attribute string: HTML entities have to be decoded
+			// before the case-insensitive "hidden" compare. `<input type="&#104;idden">`
+			// must match. The JsxExpression / spread path doesn't need decoding
+			// (those carry JS string literals, not JSX attribute text).
+			if decoded, ok := directAttributeStringValue(typeAttr); ok {
+				if strings.EqualFold(decoded, "hidden") {
+					return true
+				}
+			} else if inner := attributeInnerExpression(typeAttr); inner != nil {
 				v := literalPropValue(inner)
 				if v.Kind == jvString && strings.EqualFold(v.Str, "hidden") {
 					return true
@@ -1097,13 +1179,20 @@ func IsHiddenFromScreenReader(child *ast.Node, getElementType func(*ast.Node) st
 		// Boolean form maps to extractValue's null-attr-value → true; true === true → hidden.
 		return true
 	}
+	// `getPropValue(...) === true` — only the actual boolean true matches.
+	// `<div aria-hidden="true">` works because the Literal extractor maps the
+	// case-insensitive string "true" to boolean true (jsxAstUtilsLiteralCoerce).
+	// For the direct-attribute string form we have to entity-decode before
+	// running the coercion, otherwise `<div aria-hidden="&#116;rue">` slips
+	// through. JsxExpression / spread paths carry JS strings — no decode.
+	if decoded, ok := directAttributeStringValue(ariaHidden); ok {
+		v := jsxAstUtilsLiteralCoerce(decoded)
+		return v.Kind == jvBool && v.Bool
+	}
 	inner := attributeInnerExpression(ariaHidden)
 	if inner == nil {
 		return false
 	}
-	// `getPropValue(...) === true` — only the actual boolean true matches.
-	// `<div aria-hidden="true">` works because the Literal extractor maps the
-	// case-insensitive string "true" to boolean true (jsxAstUtilsLiteralCoerce).
 	v := staticEval(inner)
 	return v.Kind == jvBool && v.Bool
 }

--- a/internal/plugins/jsx_a11y/jsxa11yutil/tabindex.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/tabindex.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	jsxtx "github.com/microsoft/typescript-go/shim/transformers/jsxtransforms"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -160,15 +159,13 @@ func GetTabIndexEx(attr *ast.Node, sourceText string) (val float64, resolved boo
 	// `tabIndex={"…"}` which wraps in JsxExpression) carries HTML-style
 	// attribute text. ESTree parsers decode HTML entities (`&#49;`→"1",
 	// `&nbsp;`→U+00A0, …) before passing the value to lint rules; tsgo
-	// keeps the raw `&…;` source in StringLiteral.Text, so we apply
-	// DecodeEntities here to realign with upstream getLiteralPropValue
-	// output for this shape. The decoded string then routes through the
-	// same step-1 classification as a plain StringLiteral.
-	if attr.Kind == ast.KindJsxAttribute {
-		if init := attr.AsJsxAttribute().Initializer; init != nil && init.Kind == ast.KindStringLiteral {
-			decoded := jsxtx.DecodeEntities(init.AsStringLiteral().Text)
-			return classifyTabIndexString(decoded)
-		}
+	// keeps the raw `&…;` source in StringLiteral.Text, so
+	// directAttributeStringValue applies jsxtransforms.DecodeEntities to
+	// realign with upstream getLiteralPropValue output for this shape. The
+	// decoded string then routes through the same step-1 classification as
+	// a plain StringLiteral.
+	if decoded, ok := directAttributeStringValue(attr); ok {
+		return classifyTabIndexString(decoded)
 	}
 
 	inner := attributeInnerExpression(attr)
@@ -310,6 +307,108 @@ func GetTabIndexEx(attr *ast.Node, sourceText string) (val float64, resolved boo
 		return 0, false, true
 	}
 	return 0, false, false
+}
+
+// HasUpstreamTabIndexValue mirrors upstream's
+// `getTabIndex(getProp(attrs, 'tabIndex')) !== undefined` boolean check —
+// is the tabIndex prop set to ANY value that upstream getTabIndex doesn't
+// resolve to JS undefined?
+//
+// Differs from [GetTabIndex] / [GetTabIndexEx]:
+//   - GetTabIndex returns true only when the value is a usable focus order
+//     (integer-typed step-1 win, or step-2 numeric coercion).
+//   - HasUpstreamTabIndexValue also returns true when upstream's step-2
+//     getPropValue falls back to a non-numeric non-undefined value — e.g.
+//     Identifier `someVar` (whose name string passes through TYPES.Identifier),
+//     Call / Member / JsxElement (synthesized non-empty strings), Object /
+//     Array / Function / BigInt (typeof "object"/"function"/"bigint" — all
+//     `!== undefined`).
+//
+// Returns false only for the shapes that upstream getTabIndex outputs JS
+// `undefined`:
+//   - missing prop
+//   - boolean form (`<X tabIndex />`) — getPropValue → true → step-1 boolean
+//     arm → undefined
+//   - empty string / non-integer numeric / NaN-coercing literal
+//   - direct boolean (`{true}` / `{false}`)
+//   - explicit `{undefined}` and TS-wrapped variants, `typeof` / `void`
+//     expressions
+//   - TSNonNullExpression (upstream stringifies to "x!" → NaN → undefined)
+//
+// Used by interactive-supports-focus's `hasTabindex` gate.
+func HasUpstreamTabIndexValue(attrs []*ast.Node, sourceText string) bool {
+	attr := FindAttributeByName(attrs, "tabIndex")
+	if attr == nil {
+		return false
+	}
+	if AttributeIsBooleanForm(attr) {
+		return false
+	}
+
+	// Direct StringLiteral attribute carries HTML-style entity-encoded text
+	// — directAttributeStringValue applies jsxtransforms.DecodeEntities so we
+	// see the same value @typescript-eslint / @babel's JSX parser would expose.
+	if decoded, ok := directAttributeStringValue(attr); ok {
+		return tabIndexStringHasUpstreamValue(decoded)
+	}
+
+	inner := attributeInnerExpression(attr)
+	if inner == nil {
+		// empty `{}` — TYPES.JSXEmptyExpression missing → null → `null !== undefined` → true.
+		return true
+	}
+
+	if inner.Kind == ast.KindNoSubstitutionTemplateLiteral {
+		return tabIndexStringHasUpstreamValue(rawTemplateLiteralText(inner, sourceText))
+	}
+	if inner.Kind == ast.KindTemplateExpression {
+		v := templateExpressionRawText(inner.AsTemplateExpression(), sourceText)
+		return tabIndexStringHasUpstreamValue(v.Str)
+	}
+	if inner.Kind == ast.KindNonNullExpression {
+		// upstream TSNonNullExpression extractor stringifies the operand
+		// with a trailing `!` → ParseFloat fails → step-1 undefined.
+		return false
+	}
+
+	literalV := literalPropValue(inner)
+	switch literalV.Kind {
+	case jvString:
+		return tabIndexStringHasUpstreamValue(literalV.Str)
+	case jvNumber:
+		if _, ok := parseLiteralTabIndexFloat(literalV.Num); ok {
+			return true
+		}
+		return false
+	case jvBool:
+		return false
+	case jvBigInt:
+		// step-1 typeof bigint not in string/number/boolean → falls through
+		// to step-2, which returns the bigint → `!== undefined`.
+		return true
+	}
+	// step 2: getPropValue fallback. Anything that isn't JS undefined passes.
+	return !jsValueIsExactlyUndefined(staticEval(inner))
+}
+
+// tabIndexStringHasUpstreamValue reduces getTabIndex's step-1 string
+// classification to the binary "result !== undefined" question. Used by
+// [HasUpstreamTabIndexValue] for direct StringLiteral / NoSubstitutionTemplateLiteral
+// / TemplateExpression shapes; the same string semantics as
+// classifyTabIndexString without the numeric value extraction.
+func tabIndexStringHasUpstreamValue(s string) bool {
+	if s == "" {
+		return false
+	}
+	switch strings.ToLower(s) {
+	case "true", "false":
+		// jsxAstUtilsLiteralCoerce → boolean → step-1 boolean arm → undefined.
+		return false
+	}
+	if _, ok := parseLiteralTabIndexString(s); ok {
+		return true
+	}
+	return false
 }
 
 // classifyTabIndexString applies upstream getTabIndex's step-1 string

--- a/internal/plugins/jsx_a11y/jsxa11yutil/tabindex_no_positive.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/tabindex_no_positive.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	jsxtx "github.com/microsoft/typescript-go/shim/transformers/jsxtransforms"
 )
 
 // LiteralPropToNumber mirrors upstream's `Number(getLiteralPropValue(prop))`
@@ -65,16 +64,14 @@ func LiteralPropToNumber(attr *ast.Node, sourceText string) (float64, bool) {
 	// JsxExpression) is an HTML-style attribute string. babel's JSX parser
 	// decodes HTML entities (`&#49;` → "1", `&nbsp;` → U+00A0, etc.) before
 	// surfacing the value to lint rules. tsgo does NOT decode in its
-	// StringLiteral.Text, so we apply jsxtransforms.DecodeEntities here to
-	// realign with upstream `getLiteralPropValue` output for this shape.
-	// Only the direct-StringLiteral path needs this — `tabIndex={"&#49;"}`
-	// stays opaque (the inner StringLiteral is a JS expression, where
-	// entities are not decoded).
-	if attr.Kind == ast.KindJsxAttribute {
-		if init := attr.AsJsxAttribute().Initializer; init != nil && init.Kind == ast.KindStringLiteral {
-			decoded := jsxtx.DecodeEntities(init.AsStringLiteral().Text)
-			return jsValueToNumber(jsxAstUtilsLiteralCoerce(decoded))
-		}
+	// StringLiteral.Text, so directAttributeStringValue applies
+	// jsxtransforms.DecodeEntities to realign with upstream
+	// `getLiteralPropValue` output for this shape. Only the direct-
+	// StringLiteral path needs this — `tabIndex={"&#49;"}` stays opaque
+	// (the inner StringLiteral is a JS expression, where entities are
+	// not decoded).
+	if decoded, ok := directAttributeStringValue(attr); ok {
+		return jsValueToNumber(jsxAstUtilsLiteralCoerce(decoded))
 	}
 	inner := attributeInnerExpression(attr)
 	if inner == nil {

--- a/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus.go
+++ b/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus.go
@@ -1,0 +1,183 @@
+// Package interactive_supports_focus ports eslint-plugin-jsx-a11y's
+// `interactive-supports-focus` rule. The rule enforces that any DOM element
+// carrying a mouse / keyboard event handler AND an interactive ARIA `role`
+// also be keyboard-reachable: either inherently focusable (interactive
+// element / inherently non-interactive element / non-interactive role
+// already covers it) or via an explicit `tabIndex`.
+//
+// Upstream signature:
+//
+//	options: { tabbable?: string[] }   (default: [])
+//
+// `tabbable` enumerates roles that MUST be sequentially tabbable (tabIndex
+// must be `0`, not `-1`). When the offending element's role is in `tabbable`
+// the diagnostic carries a single suggestion (`tabIndex={0}`); otherwise the
+// diagnostic carries two suggestions (`tabIndex={0}` or `tabIndex={-1}`).
+//
+// Trigger sequence — each predicate is checked in order against the JSX
+// opening element. Bail-outs return without reporting:
+//
+//  1. Type isn't an aria-query DOM element → bail (custom components).
+//  2. No mouse / keyboard interactive event handler attached → bail.
+//  3. Element looks disabled (HTML5 `disabled` attribute is set to anything
+//     other than `undefined`, or `aria-disabled` resolves to literal true)
+//     → bail.
+//  4. Element is hidden from screen readers (`aria-hidden={true}` or `<input
+//     type="hidden">`) → bail.
+//  5. Element role resolves to `presentation` / `none` → bail.
+//  6. Element role is non-interactive (first valid space-separated role is
+//     in the non-interactive set), OR element is inherently non-interactive,
+//     OR element is inherently interactive (already focusable), OR element
+//     has any tabIndex value (upstream `!== undefined`) → bail.
+//  7. Element role resolves to an interactive role → REPORT. Message and
+//     suggestion shape depends on whether the role is in `tabbable`.
+//
+// Diagnostic text mirrors upstream:
+//
+//	"Elements with the '<role>' interactive role must be tabbable."   (tabbable list)
+//	"Elements with the '<role>' interactive role must be focusable."  (otherwise)
+//
+// Suggestions insert ` tabIndex={0}` or ` tabIndex={-1}` after the JSX
+// element's name node (upstream `fixer.insertTextAfter(node.name, ...)`).
+package interactive_supports_focus
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	// suggestionInsertTabIndexZeroDesc mirrors upstream's `tabIndex=0`
+	// message verbatim.
+	suggestionInsertTabIndexZeroDesc = "Add `tabIndex={0}` to make the element focusable in sequential keyboard navigation."
+	// suggestionInsertTabIndexNegOneDesc mirrors upstream's `tabIndex=-1`
+	// message verbatim.
+	suggestionInsertTabIndexNegOneDesc = "Add `tabIndex={-1}` to make the element focusable but not reachable via sequential keyboard navigation."
+)
+
+// options captures the parsed configuration. Nil distinguishes "absent" from
+// "explicit []" — both produce identical observable behavior (empty
+// inclusion check), so we collapse them into a single nil-able slice.
+type options struct {
+	Tabbable []string
+}
+
+func parseOptions(raw any) options {
+	opts := options{}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	opts.Tabbable = jsxa11yutil.StringSliceOption(m["tabbable"])
+	return opts
+}
+
+var InteractiveSupportsFocusRule = rule.Rule{
+	Name: "jsx-a11y/interactive-supports-focus",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		sourceText := ctx.SourceFile.Text()
+
+		check := func(node *ast.Node) {
+			attrs := reactutil.GetJsxElementAttributes(node)
+			elementType := jsxa11yutil.GetElementType(node, ctx.Settings)
+
+			if !jsxa11yutil.IsDOMElement(elementType) {
+				return
+			}
+
+			hasInteractiveProps := jsxa11yutil.HasAnyJsxPropStrict(attrs, jsxa11yutil.InteractiveEventHandlerNames...)
+			if !hasInteractiveProps {
+				return
+			}
+
+			if jsxa11yutil.IsDisabledElement(attrs) {
+				return
+			}
+
+			getElementType := func(child *ast.Node) string {
+				return jsxa11yutil.GetElementType(child, ctx.Settings)
+			}
+			if jsxa11yutil.IsHiddenFromScreenReader(node, getElementType) {
+				return
+			}
+
+			if jsxa11yutil.IsPresentationRole(attrs) {
+				return
+			}
+
+			if !jsxa11yutil.IsInteractiveRole(elementType, attrs) {
+				return
+			}
+			if jsxa11yutil.IsInteractiveElement(elementType, attrs) {
+				return
+			}
+			if jsxa11yutil.IsNonInteractiveElement(elementType, attrs) {
+				return
+			}
+			if jsxa11yutil.IsNonInteractiveRole(elementType, attrs) {
+				return
+			}
+			if jsxa11yutil.HasUpstreamTabIndexValue(attrs, sourceText) {
+				return
+			}
+
+			// Extract the role for the diagnostic message. Upstream's
+			// `getLiteralPropValue(getProp(attributes, 'role'))` returns the
+			// raw string for the LITERAL paths and synthesizes the magic
+			// `"null"` / template-placeholder strings for the few other
+			// shapes LITERAL_TYPES handles. For the shapes that survive the
+			// preceding `isInteractiveRole` filter — i.e. role is a static
+			// string whose first valid space-separated role is interactive —
+			// LiteralPropStringValue suffices.
+			role, _ := jsxa11yutil.LiteralPropStringValue(jsxa11yutil.FindAttributeByName(attrs, "role"))
+
+			tagName := reactutil.GetJsxTagName(node)
+			if tagName == nil {
+				// Defensive: every JSX opening / self-closing element has a
+				// tag-name node in legal source. Skip rather than crash.
+				return
+			}
+
+			tabIndexZeroSuggestion := rule.RuleSuggestion{
+				Message: rule.RuleMessage{
+					Id:          "tabIndexZero",
+					Description: suggestionInsertTabIndexZeroDesc,
+				},
+				FixesArr: []rule.RuleFix{rule.RuleFixInsertAfter(tagName, " tabIndex={0}")},
+			}
+
+			if slices.Contains(opts.Tabbable, role) {
+				ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{
+					Id:          "tabbable",
+					Description: fmt.Sprintf("Elements with the '%s' interactive role must be tabbable.", role),
+				}, tabIndexZeroSuggestion)
+				return
+			}
+
+			tabIndexNegOneSuggestion := rule.RuleSuggestion{
+				Message: rule.RuleMessage{
+					Id:          "tabIndexNegOne",
+					Description: suggestionInsertTabIndexNegOneDesc,
+				},
+				FixesArr: []rule.RuleFix{rule.RuleFixInsertAfter(tagName, " tabIndex={-1}")},
+			}
+
+			ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{
+				Id:          "focusable",
+				Description: fmt.Sprintf("Elements with the '%s' interactive role must be focusable.", role),
+			}, tabIndexZeroSuggestion, tabIndexNegOneSuggestion)
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus.md
+++ b/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus.md
@@ -1,0 +1,99 @@
+# interactive-supports-focus
+
+## Rule Details
+
+Enforce that elements with interactive ARIA roles and at least one mouse or
+keyboard event handler are also keyboard-reachable — either inherently
+focusable, or via an explicit `tabIndex`.
+
+When a non-interactive DOM element such as `<div>` or `<span>` is given an
+interactive role (e.g. `role="button"`) and a `onClick` (or any other mouse /
+keyboard) handler, screen reader and keyboard-only users still need to be
+able to bring focus to it. Either set `tabIndex="0"` (standalone control) or
+`tabIndex="-1"` (programmatically focusable element inside a composite
+widget), or — better — use a semantic element like `<button>` or `<a href>`
+that is already in the tab order.
+
+The rule fires on a JSX opening element when **all** of the following hold:
+
+- The resolved element name is in the HTML DOM set (custom React components
+  are skipped — the rule does not know what low-level element they render).
+- The element declares at least one mouse or keyboard event handler
+  (`onClick`, `onMouseDown`, `onKeyDown`, …).
+- The element is not disabled (no HTML5 `disabled` attribute with a value
+  other than `undefined`, no `aria-disabled={true}` / `aria-disabled="true"`).
+- The element is not hidden from screen readers (no `aria-hidden={true}` /
+  `aria-hidden="true"`, not an `<input type="hidden">`).
+- The `role` attribute, when statically a literal string, is not
+  `presentation` or `none`.
+- The `role` attribute resolves to a literal interactive (widget) role.
+- The element is neither inherently interactive (e.g. `<button>`, `<a href>`)
+  nor inherently non-interactive (e.g. `<article>`, `<li>`, `<p>`), and its
+  `role` does not resolve to a non-interactive role.
+- The element does not already declare a `tabIndex` (any value upstream
+  `getTabIndex` resolves to a non-`undefined` value).
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div role="button" onClick={() => {}} />
+<span role="checkbox" onMouseDown={check} />
+<div role="slider" onKeyDown={onKey} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<button onClick={() => {}} />
+<a href="/" onClick={() => {}} />
+<div role="button" tabIndex="0" onClick={() => {}} />
+<div role="menuitem" tabIndex="-1" onClick={() => {}} />
+<div role="presentation" onClick={() => {}}>
+  <button>Save</button>
+</div>
+```
+
+## Rule Options
+
+### `tabbable`
+
+Type: `string[]`. Default: `[]`. The upstream `recommended` preset sets this
+to `["button", "checkbox", "link", "searchbox", "spinbutton", "switch",
+"textbox"]`; the `strict` preset adds `progressbar` and `slider`.
+
+A list of ARIA roles that must be sequentially tabbable (`tabIndex="0"`).
+When the offending element's role is in this list, the diagnostic reads
+`"…must be tabbable."` and the only suggested fix is `tabIndex={0}`. Roles
+that are NOT in this list use the `"…must be focusable."` diagnostic and
+offer both `tabIndex={0}` and `tabIndex={-1}` as suggestions.
+
+Examples of **incorrect** code with `{ "tabbable": ["button"] }`:
+
+```json
+{ "jsx-a11y/interactive-supports-focus": ["error", { "tabbable": ["button"] }] }
+```
+
+```jsx
+<div role="button" onClick={() => {}} />
+```
+
+Examples of **correct** code with `{ "tabbable": ["button"] }`:
+
+```json
+{ "jsx-a11y/interactive-supports-focus": ["error", { "tabbable": ["button"] }] }
+```
+
+```jsx
+<div role="button" tabIndex="0" onClick={() => {}} />
+```
+
+## Resources
+
+- [WCAG 2.1.1 — Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
+- [WAI-ARIA Authoring Practices — Keyboard Interaction](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
+- [MDN — Keyboard-navigable JavaScript widgets](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets)
+- [MDN — `tabindex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/interactive-supports-focus](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/interactive-supports-focus.md)

--- a/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus_extras_test.go
@@ -1,0 +1,807 @@
+//nolint:misspell // cspell:ignore utton idden resentation alse
+package interactive_supports_focus
+
+// This file is self-contained — it only exercises shapes OUTSIDE the
+// upstream test file (tsgo↔ESTree AST quirks, position lock-ins,
+// configuration edges, branches upstream doesn't test, real-world patterns).
+// The upstream suite mirror lives in *_upstream_test.go. Helpers below are
+// duplicated from there intentionally so each file can be read and audited
+// independently — there is no cross-file reference.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// extrasComponentsSettings mirrors the `<Div>` → `div` mapping that
+// upstream rule tests use to keep the component-map path covered.
+// Local to this file (duplicated from the upstream-mirror file so the
+// extras suite is self-contained).
+var extrasComponentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Div": "div",
+		},
+	},
+}
+
+// extrasPolymorphicSettings mirrors the `polymorphicPropName` setting other
+// jsx-a11y rule ports exercise — `as="button"` resolves the JSX component
+// to a native element, which then trips (or skips) the rule by the same
+// paths a static lowercase tag would.
+var extrasPolymorphicSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+	},
+}
+
+// extrasTabbableMessage / extrasFocusableMessage build the rule's two
+// diagnostic message variants. Duplicated from the upstream-mirror file so
+// extras can be audited without cross-file lookup.
+func extrasTabbableMessage(role string) string {
+	return fmt.Sprintf("Elements with the '%s' interactive role must be tabbable.", role)
+}
+
+func extrasFocusableMessage(role string) string {
+	return fmt.Sprintf("Elements with the '%s' interactive role must be focusable.", role)
+}
+
+// extrasFocusableSuggestionsTwo is a compact constructor for the two-suggestion
+// shape carried by every `focusable` diagnostic — keeps the test bodies tight.
+func extrasFocusableSuggestionsTwo(outZero, outNegOne string) []rule_tester.InvalidTestCaseSuggestion {
+	return []rule_tester.InvalidTestCaseSuggestion{
+		{MessageId: "tabIndexZero", Output: outZero},
+		{MessageId: "tabIndexNegOne", Output: outNegOne},
+	}
+}
+
+// TestInteractiveSupportsFocusExtras covers shapes outside upstream's test
+// file — tsgo↔ESTree AST differences, position assertions, configuration
+// edges, and lock-ins for branches the upstream suite doesn't exercise.
+func TestInteractiveSupportsFocusExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &InteractiveSupportsFocusRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Custom (non-DOM) components — rule bails at the `dom.has(type)` gate.
+			{Code: `<MyComp role="button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<X.Y role="button" onClick={() => {}} />`, Tsx: true},
+
+			// ---- No mouse / keyboard handlers — rule bails at hasInteractiveProps.
+			{Code: `<div role="button" onFocus={() => {}} />`, Tsx: true},
+			{Code: `<div role="button" onBlur={() => {}} onScroll={() => {}} />`, Tsx: true},
+
+			// ---- Disabled (HTML5 `disabled` resolves to non-undefined).
+			{Code: `<div role="button" onClick={() => {}} disabled />`, Tsx: true},
+			{Code: `<div role="button" onClick={() => {}} disabled="" />`, Tsx: true},
+			{Code: `<div role="button" onClick={() => {}} disabled={false} />`, Tsx: true},
+			{Code: `<div role="button" onClick={() => {}} disabled={someVar} />`, Tsx: true},
+
+			// ---- aria-disabled cases that count as disabled.
+			{Code: `<div role="button" onClick={() => {}} aria-disabled />`, Tsx: true},
+			{Code: `<div role="button" onClick={() => {}} aria-disabled="true" />`, Tsx: true},
+			{Code: `<div role="button" onClick={() => {}} aria-disabled={true} />`, Tsx: true},
+
+			// ---- aria-hidden disagreements: "true" (string) hides, anything else does not.
+			{Code: `<div role="button" onClick={() => {}} aria-hidden="true" />`, Tsx: true},
+
+			// ---- Presentation / none roles — IsPresentationRole bails the rule.
+			{Code: `<div role="presentation" onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role="none" onClick={() => {}} />`, Tsx: true},
+
+			// ---- role string-split: first valid role is non-interactive.
+			//      "heading" is the first valid role — non-interactive → bail.
+			{Code: `<div role="heading button" onClick={() => {}} />`, Tsx: true},
+
+			// ---- Non-literal role expressions don't trip the interactive-role
+			//      gate (LiteralStringValue returns false).
+			{Code: `<div role={someRole} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={"button" + ""} onClick={() => {}} />`, Tsx: true},
+
+			// ---- tabIndex set to a non-numeric expression — upstream getTabIndex
+			//      step-2 returns the identifier name string → !== undefined.
+			{Code: `<div role="button" onClick={() => {}} tabIndex={foo} />`, Tsx: true},
+			{Code: `<div role="button" onClick={() => {}} tabIndex={someFn()} />`, Tsx: true},
+			{Code: `<div role="button" onClick={() => {}} tabIndex={foo.bar} />`, Tsx: true},
+
+			// ---- Inherently interactive element with role override — element
+			//      already focusable so the rule bails at isInteractiveElement.
+			{Code: `<button role="button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<a href="#" role="button" onClick={() => {}} />`, Tsx: true},
+
+			// ---- Inherently non-interactive element with overlapping role —
+			//      bails at isNonInteractiveElement (e.g. <h1 role="button">).
+			{Code: `<h1 role="button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<nav role="button" onClick={() => {}} />`, Tsx: true},
+
+			// ---- Polymorphic as resolves to interactive native element.
+			{Code: `<Foo as="button" onClick={() => {}} />`, Tsx: true, Settings: extrasPolymorphicSettings},
+
+			// ---- Triggering handler is set via literal-spread — upstream's
+			//      hasAnyProp default `spreadStrict: true` treats this as
+			//      opaque so the rule never enters. Equivalent to "no handler".
+			{Code: `<div role="button" {...{onClick: () => {}}} />`, Tsx: true},
+
+			// ---- Paired form (JsxElement → JsxOpeningElement listener path)
+			//      vs self-closing form. Both must classify the same way.
+			{Code: `<div role="button" tabIndex="0" onClick={() => {}}>label</div>`, Tsx: true},
+
+			// ---- role lookup is case-insensitive at the rolesMap.has check —
+			//      upstream `String(role).toLowerCase().split(' ')`. "Button" /
+			//      "BUTTON" normalize to "button" and trip the rule. Locks
+			//      [IsInteractiveRole]'s strings.ToLower path. (Listed as VALID
+			//      here only when the element is already focusable, e.g. with
+			//      tabIndex; the focus-required failure path is exercised in
+			//      the invalid block below.)
+			{Code: `<div role="BUTTON" onClick={() => {}} tabIndex="0" />`, Tsx: true},
+			{Code: `<div role="Button" onClick={() => {}} tabIndex="0" />`, Tsx: true},
+
+			// ---- Multiple trigger handlers — element with tabIndex is fine.
+			{Code: `<div role="button" onClick={() => {}} onMouseDown={() => {}} onKeyDown={() => {}} tabIndex="0" />`, Tsx: true},
+
+			// ---- role passed via literal-spread object. upstream
+			//      `getProp(attributes, 'role')` default `spreadStrict: false`
+			//      walks literal spreads, so this resolves to `role="button"`
+			//      and tabIndex="0" already satisfies focus.
+			{Code: `<div {...{role: "button"}} onClick={() => {}} tabIndex="0" />`, Tsx: true},
+
+			// ---- Multi-space / leading-trailing-space role — upstream's split(' ')
+			//      filters empty entries via rolesMap.has, so "  button " resolves
+			//      to first valid role "button" (interactive). Here element is
+			//      already focusable, so it stays valid.
+			{Code: `<div role=" button " onClick={() => {}} tabIndex="0" />`, Tsx: true},
+			{Code: `<div role="button  link" onClick={() => {}} tabIndex="0" />`, Tsx: true},
+
+			// ---- Nested JSX where the OUTER element is focusable and inner
+			//      is a non-interactive child — only the listener for each
+			//      JsxOpeningElement fires independently.
+			{Code: `<div role="button" tabIndex="0" onClick={() => {}}><span>inner</span></div>`, Tsx: true},
+
+			// ---- role values that don't resolve to a valid interactive role.
+			//      Upstream `String(value).toLowerCase().split(' ')` → filtered
+			//      by rolesMap.has — empty / non-role tokens drop out, leaving
+			//      0 valid roles → IsInteractiveRole = false → bail.
+			{Code: `<div role="" onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role="not-a-real-role" onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role="custom widget" onClick={() => {}} />`, Tsx: true},
+
+			// ---- Non-string role expressions (LITERAL_TYPES.noop → null).
+			//      Identifier, conditional, logical, member, call → all noop
+			//      under LITERAL_TYPES for the role-extractor path → IsInteractiveRole=false.
+			{Code: `<div role={someRole} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={cond ? "button" : "link"} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={"button" || "link"} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={roles.primary} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={getRole()} onClick={() => {}} />`, Tsx: true},
+
+			// ---- Numeric / boolean role values — getLiteralPropValue returns
+			//      the JS primitive, String(it) doesn't match any role.
+			{Code: `<div role={0} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={42} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={true} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={false} onClick={() => {}} />`, Tsx: true},
+			// ---- Boolean attribute form `<div role />` — extractValue null-attr
+			//      → true → String(true) = "true" → not a role.
+			{Code: `<div role onClick={() => {}} />`, Tsx: true},
+
+			// ---- Comments between attributes — JSX is whitespace-tolerant,
+			//      the rule should not be confused by trivia tokens.
+			{Code: `<div /* comment */ role="button" onClick={() => {}} tabIndex="0" />`, Tsx: true},
+
+			// ---- TypeScript type assertions inside the role JsxExpression —
+			//      upstream's getLiteralPropValue does NOT strip TSAsExpression /
+			//      TSNonNullExpression (it noop-s to null on those wrappers),
+			//      so the role becomes null → not interactive → bail.
+			{Code: `<div role={"button" as const} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={"button" as "button"} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={"button"!} onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role={"button" satisfies string} onClick={() => {}} />`, Tsx: true},
+
+			// ---- Parens around the role expression — ESTree flattens parens
+			//      at parse time, tsgo preserves them. LiteralPropStringValue
+			//      strips them so both AST shapes yield the same outcome. This
+			//      is an inherent-focus path (element already focusable), so
+			//      the case must stay valid regardless of paren count.
+			{Code: `<div role={("button")} onClick={() => {}} tabIndex="0" />`, Tsx: true},
+			{Code: `<div role={(("button"))} onClick={() => {}} tabIndex="0" />`, Tsx: true},
+
+			// ---- tabIndex shapes that upstream getTabIndex resolves to
+			//      `!== undefined` and therefore satisfy `hasTabindex=true`.
+			//      Locks HasUpstreamTabIndexValue against false negatives.
+			//
+			//   * `Math.random() > 0` is a BinaryExpression — upstream step-2
+			//     getPropValue's BinaryExpression extractor synthesizes a
+			//     non-empty string `${left} ${op} ${right}`. Truthy, !== undefined.
+			//   * `Infinity` is a special Identifier — staticEval resolves to
+			//     +Infinity number; jsValueToNumber → !== undefined.
+			//
+			//   NOTE: `tabIndex={null}` and `tabIndex={1.5}` are NOT here —
+			//   upstream getTabIndex's step-1 literal arm explicitly returns
+			//   undefined for both (null → "null" → NaN; 1.5 → !Number.isInteger).
+			//   They live in the invalid block below.
+			{Code: `<div role="button" onClick={() => {}} tabIndex={Math.random() > 0} />`, Tsx: true},
+			{Code: `<div role="button" onClick={() => {}} tabIndex={Infinity} />`, Tsx: true},
+
+			// ---- Real-world wrappers — JSX inside Array.map, conditional
+			//      expression, fragment. Listener should still fire on each
+			//      JsxOpeningElement regardless of enclosing context.
+			{Code: `const list = items.map(x => <div role="button" tabIndex="0" onClick={() => {}}>{x}</div>);`, Tsx: true},
+			{Code: `const x = cond ? <div role="button" tabIndex="0" onClick={() => {}} /> : null;`, Tsx: true},
+			{Code: `const x = <><div role="button" tabIndex="0" onClick={() => {}} /></>;`, Tsx: true},
+
+			// ---- Inherent non-interactive elements (per
+			//      strictNonInteractiveElementRoleSchemas) with interactive
+			//      role + handler — rule bails at isNonInteractiveElement, no
+			//      report. Locks the data-table.
+			{Code: `<article role="button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<footer role="button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<li role="button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<p role="button" onClick={() => {}} />`, Tsx: true},
+
+			// ---- `<header>` short-circuit — isNonInteractiveElement's
+			//      `tagName === 'header'` early-returns false, so the rule
+			//      treats `<header>` as "indeterminate" and DOES report when
+			//      it carries an interactive role + handler. Listed in the
+			//      invalid block below; here we just lock the bare
+			//      `<header onClick={…} />` (no role) staying valid by virtue
+			//      of IsInteractiveRole being false (no role attribute).
+			{Code: `<header onClick={() => {}} />`, Tsx: true},
+
+			// ---- `<td>` quirk — upstream `tagName !== 'td'` short-circuits
+			//      both role-schema matchers, falls through to the AX schemas.
+			//      `<td role="button" onClick={…} />` is therefore
+			//      inherently-interactive via the elementAXObjects path, NOT
+			//      non-interactive. Rule bails at isInteractiveElement.
+			{Code: `<td role="button" onClick={() => {}} />`, Tsx: true},
+
+			// ---- `aria-disabled="false"` is NOT disabled — upstream's
+			//      LITERAL_TYPES.Literal coerces "false" → boolean false →
+			//      `=== true` is false. Rule must NOT bail at IsDisabledElement.
+			//      Locks the case where disabled=false combined with focusable
+			//      tabIndex keeps the case valid.
+			{Code: `<div role="button" onClick={() => {}} aria-disabled="false" tabIndex="0" />`, Tsx: true},
+
+			// ---- HTML entity decoding on direct attribute strings. tsgo
+			//      keeps the raw `&…;` source in StringLiteral.Text, but the
+			//      @typescript-eslint / @babel JSX parser decodes entities
+			//      before exposing the value to upstream. jsxa11yutil applies
+			//      `jsxtransforms.DecodeEntities` on the direct-attribute
+			//      branch of [LiteralStringValue] / [LiteralPropStringValue] /
+			//      IsHiddenFromScreenReader to realign. Cases below are valid
+			//      because the decoded role / type / aria-hidden / etc. routes
+			//      the rule to a bail-out branch.
+			//
+			//   * `<input type="&#104;idden">` decodes to `type="hidden"` →
+			//     hidden from screen reader → bail.
+			//   * `<div aria-hidden="&#116;rue">` decodes to `aria-hidden="true"`
+			//     → hidden → bail.
+			//   * `<div role="&#112;resentation">` decodes to `role="presentation"`
+			//     → presentation role → bail.
+			//   * `<a role="button" href="&#35;">` decodes `href="#"` → still
+			//     bails by being inherently interactive (`a[href]`).
+			{Code: `<input type="&#104;idden" role="button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<div aria-hidden="&#116;rue" role="button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role="&#112;resentation" onClick={() => {}} />`, Tsx: true},
+			{Code: `<a role="button" href="&#35;" onClick={() => {}} />`, Tsx: true},
+
+			// ---- aria-disabled with entity-encoded "true" — must be treated
+			//      as disabled. Locks [LiteralPropIsExactlyTrue]'s direct-
+			//      attribute entity-decode path.
+			{Code: `<div role="button" onClick={() => {}} aria-disabled="&#116;rue" />`, Tsx: true},
+
+			// ---- polymorphic `as` with entity-encoded interactive element —
+			//      `<Foo as="&#98;utton">` decodes to `as="button"`, which
+			//      resolves the JSX component to a native <button> (inherently
+			//      interactive → bail). Locks [polymorphicPropValue]'s direct-
+			//      attribute entity-decode path.
+			{
+				Code:     `<Foo as="&#98;utton" onClick={() => {}} />`,
+				Tsx:      true,
+				Settings: extrasPolymorphicSettings,
+			},
+
+			// ---- Entity-encoded tabIndex direct attribute — tsgo keeps the
+			//      raw `&…;` text on the StringLiteral, GetTabIndexEx /
+			//      HasUpstreamTabIndexValue's direct-attribute branch already
+			//      runs `jsxtransforms.DecodeEntities` so `tabIndex="&#48;"`
+			//      decodes to "0" and `tabIndex="&#45;1"` to "-1", both
+			//      counting as `!== undefined` → hasTabindex=true → bail.
+			//      Differential-verified vs upstream.
+			{Code: `<div role="button" onClick={() => {}} tabIndex="&#48;" />`, Tsx: true},
+			{Code: `<div role="button" onClick={() => {}} tabIndex="&#45;1" />`, Tsx: true},
+
+			// ---- Entity-encoded HTML5 `disabled` — upstream `getPropValue`
+			//      decodes to "false", jsxAstUtilsLiteralCoerce → bool false,
+			//      and `false !== undefined` so isHTML5Disabled=true → bail.
+			//      Our [IsDisabledElement] mirrors via `!AttributeIsExplicitUndefined`
+			//      — the entity-string isn't the JS undefined identifier, so
+			//      we also classify as disabled. Differential-verified.
+			{Code: `<div role="button" onClick={() => {}} disabled="&#102;alse" />`, Tsx: true},
+
+			// ---- JsxExpression-wrapped string with raw entity text. Crucial
+			//      negative case: JS string literals do NOT decode HTML entities
+			//      (that's a JSX parser feature only), so `role={"&#98;utton"}`
+			//      carries the literal string `&#98;utton`, which is not in the
+			//      rolesMap → IsInteractiveRole = false → bail. Locks the
+			//      directAttributeStringValue branch from over-reaching into
+			//      JsxExpression wrappers. Differential-verified vs upstream.
+			{Code: `<div role={"&#98;utton"} onClick={() => {}} />`, Tsx: true},
+
+			// ---- Options edge: empty tabbable list → same as default → all
+			//      diagnostics go down the focusable arm. The case below is
+			//      valid because tabIndex="0" satisfies focus regardless of
+			//      arm choice.
+			{
+				Code:    `<div role="button" onClick={() => {}} tabIndex="0" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tabbable": []interface{}{}},
+			},
+			// ---- Options edge: tabbable absent / nil / non-array — all
+			//      collapse to the default (empty) list under GetOptionsMap +
+			//      StringSliceOption nil fallback.
+			{
+				Code:    `<div role="button" onClick={() => {}} tabIndex="0" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{},
+			},
+			{
+				Code:    `<div role="button" onClick={() => {}} tabIndex="0" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tabbable": nil},
+			},
+			{
+				Code:    `<div role="button" onClick={() => {}} tabIndex="0" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tabbable": "not-an-array"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Plain failure — fixed columns + suggestion output assertion.
+			{
+				Code: `<div role="button" onClick={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "focusable",
+					Message:   extrasFocusableMessage("button"),
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "tabIndexZero", Output: `<div tabIndex={0} role="button" onClick={() => void 0} />`},
+						{MessageId: "tabIndexNegOne", Output: `<div tabIndex={-1} role="button" onClick={() => void 0} />`},
+					},
+				}},
+			},
+			// ---- Locks the `tabbable` option branch — same code with the
+			//      role in `tabbable` produces ONE suggestion and the
+			//      "must be tabbable" message.
+			{
+				Code:    `<div role="button" onClick={() => void 0} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tabbable": []interface{}{"button"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "tabbable",
+					Message:   extrasTabbableMessage("button"),
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "tabIndexZero", Output: `<div tabIndex={0} role="button" onClick={() => void 0} />`},
+					},
+				}},
+			},
+			// ---- Paired form (rule listens on JsxOpeningElement, but report
+			//      anchors the opening element node — assert position points
+			//      at the opening element, not the closing tag).
+			{
+				Code: `<div role="button" onClick={() => void 0}>label</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="button" onClick={() => void 0}>label</div>`, `<div tabIndex={-1} role="button" onClick={() => void 0}>label</div>`),
+				}},
+			},
+			// ---- Polymorphic `as` resolves to a div; role="button" + onClick
+			//      should still trip.
+			{
+				Code:     `<Foo as="div" role="button" onClick={() => void 0} />`,
+				Tsx:      true,
+				Settings: extrasPolymorphicSettings,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<Foo tabIndex={0} as="div" role="button" onClick={() => void 0} />`, `<Foo tabIndex={-1} as="div" role="button" onClick={() => void 0} />`),
+				}},
+			},
+			// ---- role given as NoSubstitutionTemplateLiteral — tsgo exposes
+			//      `role={` button `}` as KindNoSubstitutionTemplateLiteral.
+			//      LiteralStringValue must accept it for the interactive-role
+			//      gate to fire.
+			{
+				Code: "<div role={`button`} onClick={() => void 0} />",
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo("<div tabIndex={0} role={`button`} onClick={() => void 0} />", "<div tabIndex={-1} role={`button`} onClick={() => void 0} />"),
+				}},
+			},
+			// ---- role expression is `{"button"}` — wrapped StringLiteral
+			//      inside JsxExpression. Same outcome as the bare attribute
+			//      string form.
+			{
+				Code: `<div role={"button"} onClick={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role={"button"} onClick={() => void 0} />`, `<div tabIndex={-1} role={"button"} onClick={() => void 0} />`),
+				}},
+			},
+			// ---- Multiple roles, first valid is interactive (button).
+			{
+				Code: `<div role="button heading" onClick={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button heading"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="button heading" onClick={() => void 0} />`, `<div tabIndex={-1} role="button heading" onClick={() => void 0} />`),
+				}},
+			},
+			// ---- Multi-line — diagnostic anchors at the opening element start.
+			{
+				Code: "<div\n  role=\"button\"\n  onClick={() => void 0}\n/>",
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo("<div tabIndex={0}\n  role=\"button\"\n  onClick={() => void 0}\n/>", "<div tabIndex={-1}\n  role=\"button\"\n  onClick={() => void 0}\n/>"),
+				}},
+			},
+			// ---- onKeyDown is also a triggering handler — lock branch.
+			{
+				Code: `<div role="checkbox" onKeyDown={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("checkbox"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="checkbox" onKeyDown={() => void 0} />`, `<div tabIndex={-1} role="checkbox" onKeyDown={() => void 0} />`),
+				}},
+			},
+			// ---- Element type comes from `components` mapping — Div → div, then div + role="button" + onClick trips.
+			{
+				Code:     `<Div role="button" onClick={() => void 0} />`,
+				Tsx:      true,
+				Settings: extrasComponentsSettings,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "focusable",
+					Message:   extrasFocusableMessage("button"),
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "tabIndexZero", Output: `<Div tabIndex={0} role="button" onClick={() => void 0} />`},
+						{MessageId: "tabIndexNegOne", Output: `<Div tabIndex={-1} role="button" onClick={() => void 0} />`},
+					},
+				}},
+			},
+			// ---- case-insensitive role lookup — upstream lower-cases before
+			//      rolesMap.has. `<div role="BUTTON" onClick={…} />` should
+			//      report (no tabIndex here).
+			{
+				Code: `<div role="BUTTON" onClick={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("BUTTON"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="BUTTON" onClick={() => void 0} />`, `<div tabIndex={-1} role="BUTTON" onClick={() => void 0} />`),
+				}},
+			},
+			// ---- role via literal-spread, no tabIndex — upstream walks
+			//      literal spread in `getProp`, so role resolves to "button".
+			//      But hasAnyProp (spreadStrict: true) still sees `onClick` as
+			//      a direct prop, so the rule fires.
+			//
+			//      NOTE: upstream `getLiteralPropValue` extraction over the
+			//      spread-resolved PropertyAssignment also returns "button",
+			//      so the diagnostic carries role="button" verbatim.
+			{
+				Code: `<div {...{role: "button"}} onClick={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} {...{role: "button"}} onClick={() => void 0} />`, `<div tabIndex={-1} {...{role: "button"}} onClick={() => void 0} />`),
+				}},
+			},
+			// ---- Template-literal `role` with substitutions — upstream's
+			//      `getLiteralPropValue` (LITERAL_TYPES.TemplateExpression)
+			//      synthesizes a concatenated string from quasi + substitution
+			//      LITERAL_TYPES extractions. `` role={`button${""}`} `` should
+			//      resolve to "button" and trip the rule. Locks the
+			//      LiteralPropStringValue routing in [IsInteractiveRole].
+			{
+				Code: "<div role={`button${\"\"}`} onClick={() => void 0} />",
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo("<div tabIndex={0} role={`button${\"\"}`} onClick={() => void 0} />", "<div tabIndex={-1} role={`button${\"\"}`} onClick={() => void 0} />"),
+				}},
+			},
+			// ---- Three levels of nested JSX — outer / middle / inner each
+			//      qualifying. Three diagnostics, each anchored to its own
+			//      opening element. Locks no-bleed across the listener.
+			{
+				Code: "<div role=\"button\" onClick={() => void 0}>\n  <span role=\"menuitem\" onClick={() => void 0}>\n    <a role=\"tab\" onClick={() => void 0} />\n  </span>\n</div>",
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "focusable",
+						Message:   extrasFocusableMessage("button"),
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "tabIndexZero", Output: "<div tabIndex={0} role=\"button\" onClick={() => void 0}>\n  <span role=\"menuitem\" onClick={() => void 0}>\n    <a role=\"tab\" onClick={() => void 0} />\n  </span>\n</div>"},
+							{MessageId: "tabIndexNegOne", Output: "<div tabIndex={-1} role=\"button\" onClick={() => void 0}>\n  <span role=\"menuitem\" onClick={() => void 0}>\n    <a role=\"tab\" onClick={() => void 0} />\n  </span>\n</div>"},
+						},
+					},
+					{
+						MessageId: "focusable",
+						Message:   extrasFocusableMessage("menuitem"),
+						Line:      2,
+						Column:    3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "tabIndexZero", Output: "<div role=\"button\" onClick={() => void 0}>\n  <span tabIndex={0} role=\"menuitem\" onClick={() => void 0}>\n    <a role=\"tab\" onClick={() => void 0} />\n  </span>\n</div>"},
+							{MessageId: "tabIndexNegOne", Output: "<div role=\"button\" onClick={() => void 0}>\n  <span tabIndex={-1} role=\"menuitem\" onClick={() => void 0}>\n    <a role=\"tab\" onClick={() => void 0} />\n  </span>\n</div>"},
+						},
+					},
+					{
+						MessageId: "focusable",
+						Message:   extrasFocusableMessage("tab"),
+						Line:      3,
+						Column:    5,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "tabIndexZero", Output: "<div role=\"button\" onClick={() => void 0}>\n  <span role=\"menuitem\" onClick={() => void 0}>\n    <a tabIndex={0} role=\"tab\" onClick={() => void 0} />\n  </span>\n</div>"},
+							{MessageId: "tabIndexNegOne", Output: "<div role=\"button\" onClick={() => void 0}>\n  <span role=\"menuitem\" onClick={() => void 0}>\n    <a tabIndex={-1} role=\"tab\" onClick={() => void 0} />\n  </span>\n</div>"},
+						},
+					},
+				},
+			},
+			// ---- JSX inside Array.map callback — listener fires for the
+			//      inner element. Real-world pattern.
+			{
+				Code: `const list = items.map(x => <div role="button" onClick={() => void 0} />);`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      29,
+					Suggestions: extrasFocusableSuggestionsTwo(`const list = items.map(x => <div tabIndex={0} role="button" onClick={() => void 0} />);`, `const list = items.map(x => <div tabIndex={-1} role="button" onClick={() => void 0} />);`),
+				}},
+			},
+			// ---- JSX child of a Fragment — same outcome.
+			{
+				Code: `const x = <><div role="button" onClick={() => void 0} /></>;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      13,
+					Suggestions: extrasFocusableSuggestionsTwo(`const x = <><div tabIndex={0} role="button" onClick={() => void 0} /></>;`, `const x = <><div tabIndex={-1} role="button" onClick={() => void 0} /></>;`),
+				}},
+			},
+			// ---- `tabIndex={null}` — upstream getLiteralPropValue → "null"
+			//      string → Number("null") = NaN → step-1 undefined.
+			//      hasTabindex=false → rule reports.
+			{
+				Code: `<div role="button" onClick={() => void 0} tabIndex={null} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="button" onClick={() => void 0} tabIndex={null} />`, `<div tabIndex={-1} role="button" onClick={() => void 0} tabIndex={null} />`),
+				}},
+			},
+			// ---- `tabIndex={1.5}` — upstream step-1 `Number.isInteger(1.5)`
+			//      false → undefined. hasTabindex=false → reports.
+			{
+				Code: `<div role="button" onClick={() => void 0} tabIndex={1.5} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="button" onClick={() => void 0} tabIndex={1.5} />`, `<div tabIndex={-1} role="button" onClick={() => void 0} tabIndex={1.5} />`),
+				}},
+			},
+			// ---- `<header role="button" onClick={…} />` — upstream's
+			//      isNonInteractiveElement returns false early for `header`
+			//      (treated as indeterminate), so the rule's
+			//      `!isNonInteractiveElement` arm is true and the case
+			//      passes the bail-out checks → reports.
+			{
+				Code: `<header role="button" onClick={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<header tabIndex={0} role="button" onClick={() => void 0} />`, `<header tabIndex={-1} role="button" onClick={() => void 0} />`),
+				}},
+			},
+			// ---- `aria-disabled="false"` is NOT disabled — `getLiteralPropValue`
+			//      coerces "false" → boolean false → `=== true` fails. Without
+			//      tabIndex the rule reports. Differential-verified vs upstream.
+			{
+				Code: `<div role="button" onClick={() => void 0} aria-disabled="false" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="button" onClick={() => void 0} aria-disabled="false" />`, `<div tabIndex={-1} role="button" onClick={() => void 0} aria-disabled="false" />`),
+				}},
+			},
+			// ---- `disabled={undefined}` — the ONLY shape that upstream's
+			//      `getPropValue(disabledAttr) !== undefined` rejects. Rule
+			//      doesn't bail at IsDisabledElement → reports. Counter-
+			//      intuitive but differential-verified.
+			{
+				Code: `<div role="button" onClick={() => void 0} disabled={undefined} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="button" onClick={() => void 0} disabled={undefined} />`, `<div tabIndex={-1} role="button" onClick={() => void 0} disabled={undefined} />`),
+				}},
+			},
+			// ---- Template literal with non-Identifier non-Expression
+			//      substitution: `` `button${1}` ``. upstream
+			//      `extractValueFromTemplateLiteral` emits `""` for the
+			//      numeric Literal substitution (only Identifier / *Expression
+			//      kinds produce non-empty placeholders), so the role string
+			//      ends up as "button" — first valid role "button" → reports.
+			//      Differential-verified.
+			{
+				Code: "<div role={`button${1}`} onClick={() => void 0} />",
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo("<div tabIndex={0} role={`button${1}`} onClick={() => void 0} />", "<div tabIndex={-1} role={`button${1}`} onClick={() => void 0} />"),
+				}},
+			},
+			// ---- Leading/trailing whitespace in role. upstream's report
+			//      message uses the RAW role string (no trim), so " button "
+			//      appears verbatim in the diagnostic. first valid role after
+			//      split/filter is still "button" → reports.
+			{
+				Code: `<div role=" button " onClick={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage(" button "),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role=" button " onClick={() => void 0} />`, `<div tabIndex={-1} role=" button " onClick={() => void 0} />`),
+				}},
+			},
+			// ---- Double-space inside role — upstream split(' ') produces an
+			//      empty token between, filter removes it via rolesMap.has,
+			//      first valid stays "button" → reports. Message keeps raw text.
+			{
+				Code: `<div role="button  link" onClick={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button  link"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="button  link" onClick={() => void 0} />`, `<div tabIndex={-1} role="button  link" onClick={() => void 0} />`),
+				}},
+			},
+			// ---- HTML entity in the role direct-attribute string. tsgo keeps
+			//      raw `&…;` in StringLiteral.Text; LiteralPropStringValue's
+			//      `directAttributeStringValue` branch runs
+			//      `jsxtransforms.DecodeEntities` so the rule sees
+			//      `role="button"` (decoded) and reports. Locks
+			//      [LiteralPropStringValue] / [LiteralStringValue] entity-
+			//      decoding alignment.
+			//
+			//      Note the diagnostic message carries the DECODED role string
+			//      ("button"), matching upstream's behaviour where the parser
+			//      decodes before the rule receives the value. The suggestion
+			//      `Output` preserves the original raw source so the autofix
+			//      doesn't reformat the user's entity choice.
+			{
+				Code: `<div role="&#98;utton" onClick={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="&#98;utton" onClick={() => void 0} />`, `<div tabIndex={-1} role="&#98;utton" onClick={() => void 0} />`),
+				}},
+			},
+			// ---- Multi-role with entity encoding on each segment. Upstream's
+			//      diagnostic message reflects the DECODED role string
+			//      ("button  link") — entity decoding happens before the
+			//      message template fills in `role`. Differential-verified.
+			{
+				Code: `<div role="&#98;utton  &#108;ink" onClick={() => void 0} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId:   "focusable",
+					Message:     extrasFocusableMessage("button  link"),
+					Line:        1,
+					Column:      1,
+					Suggestions: extrasFocusableSuggestionsTwo(`<div tabIndex={0} role="&#98;utton  &#108;ink" onClick={() => void 0} />`, `<div tabIndex={-1} role="&#98;utton  &#108;ink" onClick={() => void 0} />`),
+				}},
+			},
+			// ---- Nested JSX — outer AND inner both qualify. The listener
+			//      fires once per JsxOpeningElement, so we see two diagnostics.
+			//      Column points at each respective opening element. Each
+			//      diagnostic carries its own pair of suggestions (independent
+			//      fixer locations on the outer vs inner tag-name node).
+			{
+				Code: "<div role=\"button\" onClick={() => void 0}>\n  <span role=\"checkbox\" onClick={() => void 0} />\n</div>",
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "focusable",
+						Message:   extrasFocusableMessage("button"),
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "tabIndexZero", Output: "<div tabIndex={0} role=\"button\" onClick={() => void 0}>\n  <span role=\"checkbox\" onClick={() => void 0} />\n</div>"},
+							{MessageId: "tabIndexNegOne", Output: "<div tabIndex={-1} role=\"button\" onClick={() => void 0}>\n  <span role=\"checkbox\" onClick={() => void 0} />\n</div>"},
+						},
+					},
+					{
+						MessageId: "focusable",
+						Message:   extrasFocusableMessage("checkbox"),
+						Line:      2,
+						Column:    3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "tabIndexZero", Output: "<div role=\"button\" onClick={() => void 0}>\n  <span tabIndex={0} role=\"checkbox\" onClick={() => void 0} />\n</div>"},
+							{MessageId: "tabIndexNegOne", Output: "<div role=\"button\" onClick={() => void 0}>\n  <span tabIndex={-1} role=\"checkbox\" onClick={() => void 0} />\n</div>"},
+						},
+					},
+				},
+			},
+		},
+	)
+}
+

--- a/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus_upstream_test.go
@@ -1,0 +1,400 @@
+package interactive_supports_focus
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// recommendedOptions / strictOptions mirror the values that
+// `eslint-plugin-jsx-a11y`'s shared configs hand to the rule. The upstream
+// `interactive-supports-focus:recommended` and `:strict` test suites parametrize
+// every generated case with these.
+//
+// Source: eslint-plugin-jsx-a11y/src/index.js — `configs.recommended.rules`
+// and `configs.strict.rules` entries for `jsx-a11y/interactive-supports-focus`.
+var (
+	recommendedTabbable = []string{
+		"button", "checkbox", "link", "searchbox", "spinbutton", "switch", "textbox",
+	}
+	strictTabbable = []string{
+		"button", "checkbox", "link", "progressbar", "searchbox", "slider", "spinbutton", "switch", "textbox",
+	}
+)
+
+func recommendedOptions() map[string]interface{} {
+	return map[string]interface{}{"tabbable": stringSliceToAny(recommendedTabbable)}
+}
+
+func strictOptions() map[string]interface{} {
+	return map[string]interface{}{"tabbable": stringSliceToAny(strictTabbable)}
+}
+
+func stringSliceToAny(in []string) []interface{} {
+	out := make([]interface{}, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}
+
+// interactiveRolesForTests mirrors upstream's `interactiveRoles` constant in
+// `__tests__/src/rules/interactive-supports-focus-test.js` (a hand-picked
+// subset of widget-descendant roles — NOT every role in
+// `interactiveRolesSet`). Order matches upstream byte-for-byte.
+var interactiveRolesForTests = []string{
+	"button",
+	"checkbox",
+	"link",
+	"gridcell",
+	"menuitem",
+	"menuitemcheckbox",
+	"menuitemradio",
+	"option",
+	"radio",
+	"searchbox",
+	"slider",
+	"spinbutton",
+	"switch",
+	"tab",
+	"textbox",
+	"treeitem",
+}
+
+// triggeringHandlers mirrors upstream's `triggeringHandlers` (mouse +
+// keyboard event handlers — the same set the rule itself inspects via
+// `hasAnyProp(attributes, interactiveProps)`).
+var triggeringHandlers = []string{
+	"onClick", "onContextMenu", "onDblClick", "onDoubleClick",
+	"onDrag", "onDragEnd", "onDragEnter", "onDragExit",
+	"onDragLeave", "onDragOver", "onDragStart", "onDrop",
+	"onMouseDown", "onMouseEnter", "onMouseLeave", "onMouseMove",
+	"onMouseOut", "onMouseOver", "onMouseUp",
+	"onKeyDown", "onKeyPress", "onKeyUp",
+}
+
+// allEventHandlers mirrors `jsx-ast-utils`' top-level `eventHandlers`
+// (every category flat-mapped together). Used by upstream's "non-triggering
+// handler keeps the element valid" assertion — we walk the difference
+// `allEventHandlers - triggeringHandlers` to generate the non-mouse /
+// non-keyboard event names that should NOT trip the rule.
+var allEventHandlers = []string{
+	// clipboard
+	"onCopy", "onCut", "onPaste",
+	// composition
+	"onCompositionEnd", "onCompositionStart", "onCompositionUpdate",
+	// keyboard
+	"onKeyDown", "onKeyPress", "onKeyUp",
+	// focus
+	"onFocus", "onBlur",
+	// form
+	"onChange", "onInput", "onSubmit",
+	// mouse
+	"onClick", "onContextMenu", "onDblClick", "onDoubleClick",
+	"onDrag", "onDragEnd", "onDragEnter", "onDragExit",
+	"onDragLeave", "onDragOver", "onDragStart", "onDrop",
+	"onMouseDown", "onMouseEnter", "onMouseLeave", "onMouseMove",
+	"onMouseOut", "onMouseOver", "onMouseUp",
+	// selection
+	"onSelect",
+	// touch
+	"onTouchCancel", "onTouchEnd", "onTouchMove", "onTouchStart",
+	// ui
+	"onScroll",
+	// wheel
+	"onWheel",
+	// media
+	"onAbort", "onCanPlay", "onCanPlayThrough", "onDurationChange",
+	"onEmptied", "onEncrypted", "onEnded", "onError", "onLoadedData",
+	"onLoadedMetadata", "onLoadStart", "onPause", "onPlay", "onPlaying",
+	"onProgress", "onRateChange", "onSeeked", "onSeeking", "onStalled",
+	"onSuspend", "onTimeUpdate", "onVolumeChange", "onWaiting",
+	// image
+	"onLoad", // onError already in media
+	// animation
+	"onAnimationStart", "onAnimationEnd", "onAnimationIteration",
+	// transition
+	"onTransitionEnd",
+}
+
+func nonTriggeringHandlers() []string {
+	out := make([]string, 0, len(allEventHandlers))
+	for _, h := range allEventHandlers {
+		if !slices.Contains(triggeringHandlers, h) {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// componentsSettings mirrors upstream's `componentsSettings` constant —
+// `Div` resolves to the lowercase HTML `div` so that `<Div ... />` is
+// treated as a div by `getElementType`.
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Div": "div",
+		},
+	},
+}
+
+func codeTemplate(element, role, handler string) string {
+	return fmt.Sprintf("<%s role=\"%s\" %s={() => void 0} />", element, role, handler)
+}
+
+func fixedTemplate(element, tabIndex, role, handler string) string {
+	return fmt.Sprintf("<%s tabIndex={%s} role=\"%s\" %s={() => void 0} />", element, tabIndex, role, handler)
+}
+
+func tabindexTemplate(element, role, handler string) string {
+	return fmt.Sprintf("<%s role=\"%s\" %s={() => void 0} tabIndex=\"0\" />", element, role, handler)
+}
+
+func tabbableMessage(role string) string {
+	return fmt.Sprintf("Elements with the '%s' interactive role must be tabbable.", role)
+}
+
+func focusableMessage(role string) string {
+	return fmt.Sprintf("Elements with the '%s' interactive role must be focusable.", role)
+}
+
+func failCases(roles, handlers []string, message func(string) string) []rule_tester.InvalidTestCase {
+	var out []rule_tester.InvalidTestCase
+	for _, element := range []string{"div"} {
+		for _, role := range roles {
+			for _, handler := range handlers {
+				code := codeTemplate(element, role, handler)
+				suggestions := []rule_tester.InvalidTestCaseSuggestion{
+					{
+						MessageId: "tabIndexZero",
+						Output:    fixedTemplate(element, "0", role, handler),
+					},
+				}
+				msgId := "tabbable"
+				if isFocusable := !messageIsTabbable(message); isFocusable {
+					suggestions = append(suggestions, rule_tester.InvalidTestCaseSuggestion{
+						MessageId: "tabIndexNegOne",
+						Output:    fixedTemplate(element, "-1", role, handler),
+					})
+					msgId = "focusable"
+				}
+				out = append(out, rule_tester.InvalidTestCase{
+					Code: code,
+					Tsx:  true,
+					Errors: []rule_tester.InvalidTestCaseError{{
+						MessageId:   msgId,
+						Message:     message(role),
+						Line:        1,
+						Column:      1,
+						Suggestions: suggestions,
+					}},
+				})
+			}
+		}
+	}
+	return out
+}
+
+// messageIsTabbable detects which template was passed to failCases without
+// having to plumb a second argument. We inspect the rendered text — tabbable
+// vs focusable messages differ by exactly one word in a fixed position.
+func messageIsTabbable(message func(string) string) bool {
+	sample := message("button")
+	return strings.Contains(sample, "must be tabbable")
+}
+
+func passCases(roles, handlers []string, codeFn func(string, string, string) string) []rule_tester.ValidTestCase {
+	var out []rule_tester.ValidTestCase
+	for _, element := range []string{"div"} {
+		for _, role := range roles {
+			for _, handler := range handlers {
+				out = append(out, rule_tester.ValidTestCase{
+					Code: codeFn(element, role, handler),
+					Tsx:  true,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// alwaysValid mirrors upstream's `alwaysValid` array verbatim — these cases
+// are valid under EVERY option combination.
+var alwaysValid = []rule_tester.ValidTestCase{
+	{Code: `<div />`, Tsx: true},
+	{Code: `<div aria-hidden onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div aria-hidden={true == true} onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div aria-hidden={true === true} onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div aria-hidden={hidden !== false} onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div aria-hidden={hidden != false} onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div aria-hidden={1 < 2} onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div aria-hidden={1 <= 2} onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div aria-hidden={2 > 1} onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div aria-hidden={2 >= 1} onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div onClick={() => void 0} />;`, Tsx: true},
+	{Code: `<div onClick={() => void 0} tabIndex={undefined} />;`, Tsx: true},
+	{Code: `<div onClick={() => void 0} tabIndex="bad" />;`, Tsx: true},
+	{Code: `<div onClick={() => void 0} role={undefined} />;`, Tsx: true},
+	{Code: `<div role="section" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div onClick={() => void 0} aria-hidden={false} />;`, Tsx: true},
+	{Code: `<div onClick={() => void 0} {...props} />;`, Tsx: true},
+	{Code: `<input type="text" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<input type="hidden" onClick={() => void 0} tabIndex="-1" />`, Tsx: true},
+	{Code: `<input type="hidden" onClick={() => void 0} tabIndex={-1} />`, Tsx: true},
+	{Code: `<input onClick={() => void 0} />`, Tsx: true},
+	{Code: `<input onClick={() => void 0} role="combobox" />`, Tsx: true},
+	{Code: `<button onClick={() => void 0} className="foo" />`, Tsx: true},
+	{Code: `<option onClick={() => void 0} className="foo" />`, Tsx: true},
+	{Code: `<select onClick={() => void 0} className="foo" />`, Tsx: true},
+	{Code: `<area href="#" onClick={() => void 0} className="foo" />`, Tsx: true},
+	{Code: `<area onClick={() => void 0} className="foo" />`, Tsx: true},
+	{Code: `<summary onClick={() => void 0} />`, Tsx: true},
+	{Code: `<textarea onClick={() => void 0} className="foo" />`, Tsx: true},
+	{Code: `<a onClick="showNextPage();">Next page</a>`, Tsx: true},
+	{Code: `<a onClick="showNextPage();" tabIndex={undefined}>Next page</a>`, Tsx: true},
+	{Code: `<a onClick="showNextPage();" tabIndex="bad">Next page</a>`, Tsx: true},
+	{Code: `<a onClick={() => void 0} />`, Tsx: true},
+	{Code: `<a tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<a tabIndex={dynamicTabIndex} onClick={() => void 0} />`, Tsx: true},
+	{Code: `<a tabIndex={0} onClick={() => void 0} />`, Tsx: true},
+	{Code: `<a role="button" href="#" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<a onClick={() => void 0} href="http://x.y.z" />`, Tsx: true},
+	{Code: `<a onClick={() => void 0} href="http://x.y.z" tabIndex="0" />`, Tsx: true},
+	{Code: `<a onClick={() => void 0} href="http://x.y.z" tabIndex={0} />`, Tsx: true},
+	{Code: `<a onClick={() => void 0} href="http://x.y.z" role="button" />`, Tsx: true},
+	{Code: `<TestComponent onClick={doFoo} />`, Tsx: true},
+	{Code: `<input onClick={() => void 0} type="hidden" />;`, Tsx: true},
+	{Code: `<span onClick="submitForm();">Submit</span>`, Tsx: true},
+	{Code: `<span onClick="submitForm();" tabIndex={undefined}>Submit</span>`, Tsx: true},
+	{Code: `<span onClick="submitForm();" tabIndex="bad">Submit</span>`, Tsx: true},
+	{Code: `<span onClick="doSomething();" tabIndex="0">Click me!</span>`, Tsx: true},
+	{Code: `<span onClick="doSomething();" tabIndex={0}>Click me!</span>`, Tsx: true},
+	{Code: `<span onClick="doSomething();" tabIndex="-1">Click me too!</span>`, Tsx: true},
+	{Code: `<a href="javascript:void(0);" onClick="doSomething();">Click ALL the things!</a>`, Tsx: true},
+	{Code: `<section onClick={() => void 0} />;`, Tsx: true},
+	{Code: `<main onClick={() => void 0} />;`, Tsx: true},
+	{Code: `<article onClick={() => void 0} />;`, Tsx: true},
+	{Code: `<header onClick={() => void 0} />;`, Tsx: true},
+	{Code: `<footer onClick={() => void 0} />;`, Tsx: true},
+	{Code: `<div role="button" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="checkbox" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="link" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="menuitem" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="menuitemcheckbox" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="menuitemradio" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="option" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="radio" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="spinbutton" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="switch" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="tablist" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="tab" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="textbox" tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<div role="textbox" aria-disabled="true" onClick={() => void 0} />`, Tsx: true},
+	{Code: `<Foo.Bar onClick={() => void 0} aria-hidden={false} />;`, Tsx: true},
+	{Code: `<Input onClick={() => void 0} type="hidden" />;`, Tsx: true},
+	{Code: `<Div onClick={() => void 0} role="button" tabIndex="0" />`, Tsx: true, Settings: componentsSettings},
+}
+
+// neverValid mirrors upstream's `neverValid` — invalid under every option
+// combination. The single entry leverages the `components` setting to map
+// `<Div>` → `div` so a `role="button"` on it trips the rule.
+func neverValid(options map[string]interface{}) []rule_tester.InvalidTestCase {
+	return []rule_tester.InvalidTestCase{
+		{
+			Code:     `<Div onClick={() => void 0} role="button" />`,
+			Tsx:      true,
+			Settings: componentsSettings,
+			Options:  options,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "tabbable",
+				Message:   tabbableMessage("button"),
+				Line:      1,
+				Column:    1,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "tabIndexZero",
+					Output:    `<Div tabIndex={0} onClick={() => void 0} role="button" />`,
+				}},
+			}},
+		},
+	}
+}
+
+// applyOptionsValid clones the input slice with the given `Options` field
+// populated on each case. Mirrors upstream's `ruleOptionsMapperFactory`.
+func applyOptionsValid(cases []rule_tester.ValidTestCase, options map[string]interface{}) []rule_tester.ValidTestCase {
+	out := make([]rule_tester.ValidTestCase, len(cases))
+	for i, c := range cases {
+		c.Options = options
+		out[i] = c
+	}
+	return out
+}
+
+func applyOptionsInvalid(cases []rule_tester.InvalidTestCase, options map[string]interface{}) []rule_tester.InvalidTestCase {
+	out := make([]rule_tester.InvalidTestCase, len(cases))
+	for i, c := range cases {
+		c.Options = options
+		out[i] = c
+	}
+	return out
+}
+
+// filterRoles returns `roles` minus any entries also present in `exclude`.
+// Mirrors upstream's `.filter(role => !includes(exclude, role))`.
+func filterRoles(roles, exclude []string) []string {
+	out := make([]string, 0, len(roles))
+	for _, r := range roles {
+		if !slices.Contains(exclude, r) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestInteractiveSupportsFocusUpstreamRecommended mirrors upstream's
+// `interactive-supports-focus:recommended` suite — the `recommended` shared
+// config's `tabbable` list, fed through the same reducer pipeline that
+// generates every (element × role × handler) combination.
+//
+// The four reducer arms exercise the four observable diagnostic branches:
+//
+//   - alwaysValid                                                — pass on every config
+//   - non-triggering handlers on every interactive role          — pass (rule short-circuits at hasInteractiveProps)
+//   - non-recommended interactive roles with tabIndex="0"        — pass (hasTabindex true)
+//   - recommendedRoles with triggering handlers                  — fail w/ tabbable message
+//   - non-recommended interactiveRoles with triggering handlers  — fail w/ focusable message
+//   - neverValid (Div + componentsSettings + role="button")      — fail
+func TestInteractiveSupportsFocusUpstreamRecommended(t *testing.T) {
+	opts := recommendedOptions()
+	valid := append([]rule_tester.ValidTestCase{}, alwaysValid...)
+	valid = append(valid, passCases(interactiveRolesForTests, nonTriggeringHandlers(), codeTemplate)...)
+	valid = append(valid, passCases(filterRoles(interactiveRolesForTests, recommendedTabbable), triggeringHandlers, tabindexTemplate)...)
+	valid = applyOptionsValid(valid, opts)
+
+	invalid := append([]rule_tester.InvalidTestCase{}, neverValid(opts)...)
+	invalid = append(invalid, applyOptionsInvalid(failCases(recommendedTabbable, triggeringHandlers, tabbableMessage), opts)...)
+	invalid = append(invalid, applyOptionsInvalid(failCases(filterRoles(interactiveRolesForTests, recommendedTabbable), triggeringHandlers, focusableMessage), opts)...)
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &InteractiveSupportsFocusRule, valid, invalid)
+}
+
+// TestInteractiveSupportsFocusUpstreamStrict mirrors upstream's
+// `interactive-supports-focus:strict` suite — same shape as the
+// recommended suite with the `strict` config's broader `tabbable` list.
+func TestInteractiveSupportsFocusUpstreamStrict(t *testing.T) {
+	opts := strictOptions()
+	valid := append([]rule_tester.ValidTestCase{}, alwaysValid...)
+	valid = append(valid, passCases(interactiveRolesForTests, nonTriggeringHandlers(), codeTemplate)...)
+	valid = append(valid, passCases(filterRoles(interactiveRolesForTests, strictTabbable), triggeringHandlers, tabindexTemplate)...)
+	valid = applyOptionsValid(valid, opts)
+
+	invalid := append([]rule_tester.InvalidTestCase{}, neverValid(opts)...)
+	invalid = append(invalid, applyOptionsInvalid(failCases(strictTabbable, triggeringHandlers, tabbableMessage), opts)...)
+	invalid = append(invalid, applyOptionsInvalid(failCases(filterRoles(interactiveRolesForTests, strictTabbable), triggeringHandlers, focusableMessage), opts)...)
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &InteractiveSupportsFocusRule, valid, invalid)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -170,6 +170,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/html-has-lang.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/iframe-has-title.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/img-redundant-alt.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/interactive-supports-focus.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/media-has-caption.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/interactive-supports-focus.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/interactive-supports-focus.test.ts
@@ -1,0 +1,213 @@
+import { RuleTester } from '../rule-tester';
+
+const tabbableMessage = (role: string) =>
+  `Elements with the '${role}' interactive role must be tabbable.`;
+const focusableMessage = (role: string) =>
+  `Elements with the '${role}' interactive role must be focusable.`;
+
+const componentsSettings = {
+  'jsx-a11y': {
+    components: {
+      Div: 'div',
+    },
+  },
+};
+
+const polymorphicSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+  },
+};
+
+const recommendedOptions = [
+  {
+    tabbable: [
+      'button',
+      'checkbox',
+      'link',
+      'searchbox',
+      'spinbutton',
+      'switch',
+      'textbox',
+    ],
+  },
+];
+
+const strictOptions = [
+  {
+    tabbable: [
+      'button',
+      'checkbox',
+      'link',
+      'progressbar',
+      'searchbox',
+      'slider',
+      'spinbutton',
+      'switch',
+      'textbox',
+    ],
+  },
+];
+
+new RuleTester().run('interactive-supports-focus', null as never, {
+  valid: [
+    // ============================================================
+    // Upstream alwaysValid sample (mirrors the file's `alwaysValid` array)
+    // ============================================================
+    { code: '<div />' },
+    { code: '<div aria-hidden onClick={() => void 0} />' },
+    { code: '<div onClick={() => void 0} />;' },
+    { code: '<div onClick={() => void 0} tabIndex={undefined} />;' },
+    { code: '<div onClick={() => void 0} tabIndex="bad" />;' },
+    { code: '<div onClick={() => void 0} role={undefined} />;' },
+    { code: '<div role="section" onClick={() => void 0} />' },
+    { code: '<div onClick={() => void 0} {...props} />;' },
+    { code: '<input type="text" onClick={() => void 0} />' },
+    { code: '<button onClick={() => void 0} className="foo" />' },
+    { code: '<select onClick={() => void 0} className="foo" />' },
+    { code: '<textarea onClick={() => void 0} className="foo" />' },
+    { code: '<a onClick={() => void 0} />' },
+    { code: '<a tabIndex="0" onClick={() => void 0} />' },
+    { code: '<a tabIndex={0} onClick={() => void 0} />' },
+    { code: '<a role="button" href="#" onClick={() => void 0} />' },
+    { code: '<a onClick={() => void 0} href="http://x.y.z" />' },
+    { code: '<a onClick={() => void 0} href="http://x.y.z" role="button" />' },
+    { code: '<TestComponent onClick={doFoo} />' },
+    { code: '<input onClick={() => void 0} type="hidden" />;' },
+    { code: '<section onClick={() => void 0} />;' },
+    { code: '<main onClick={() => void 0} />;' },
+    { code: '<header onClick={() => void 0} />;' },
+    {
+      code: '<div role="textbox" aria-disabled="true" onClick={() => void 0} />',
+    },
+    { code: '<div role="button" tabIndex="0" onClick={() => void 0} />' },
+    { code: '<div role="menuitem" tabIndex="0" onClick={() => void 0} />' },
+    { code: '<div role="link" tabIndex="0" onClick={() => void 0} />' },
+
+    // ---- componentsSetting maps <Div> → div; <Div role="button" tabIndex="0">
+    //      is already focusable.
+    {
+      code: '<Div onClick={() => void 0} role="button" tabIndex="0" />',
+      settings: componentsSettings,
+    },
+
+    // ============================================================
+    // Recommended config (default tabbable list)
+    // ============================================================
+    // ---- gridcell is interactive but NOT in recommended.tabbable; adding
+    //      tabIndex="0" satisfies the rule under recommended.
+    {
+      code: '<div role="gridcell" tabIndex="0" onClick={() => void 0} />',
+      options: recommendedOptions,
+    },
+    // ---- onFocus is not a triggering handler — rule short-circuits.
+    {
+      code: '<div role="button" onFocus={() => void 0} />',
+      options: recommendedOptions,
+    },
+
+    // ============================================================
+    // Strict config (broader tabbable list)
+    // ============================================================
+    // ---- progressbar is in strict.tabbable; tabIndex="0" works.
+    {
+      code: '<div role="progressbar" tabIndex="0" onClick={() => void 0} />',
+      options: strictOptions,
+    },
+
+    // ============================================================
+    // Polymorphic — `as="button"` resolves the JSX component to <button>
+    // which is inherently focusable.
+    // ============================================================
+    {
+      code: '<Foo as="button" onClick={() => void 0} />',
+      settings: polymorphicSettings,
+    },
+  ],
+  invalid: [
+    // ============================================================
+    // Default (no options) — tabbable list is empty so everything that
+    // qualifies receives the "focusable" message with two suggestions.
+    // ============================================================
+    {
+      code: '<div role="button" onClick={() => void 0} />',
+      errors: [{ message: focusableMessage('button') }],
+    },
+    {
+      code: '<div role="checkbox" onMouseDown={() => void 0} />',
+      errors: [{ message: focusableMessage('checkbox') }],
+    },
+    {
+      code: '<div role="slider" onKeyDown={() => void 0} />',
+      errors: [{ message: focusableMessage('slider') }],
+    },
+    // ---- componentsSetting → role="button" + onClick.
+    {
+      code: '<Div onClick={() => void 0} role="button" />',
+      settings: componentsSettings,
+      errors: [{ message: focusableMessage('button') }],
+    },
+
+    // ============================================================
+    // Recommended config — button is in tabbable → "must be tabbable"
+    // ============================================================
+    {
+      code: '<div role="button" onClick={() => void 0} />',
+      options: recommendedOptions,
+      errors: [{ message: tabbableMessage('button') }],
+    },
+    {
+      code: '<div role="checkbox" onClick={() => void 0} />',
+      options: recommendedOptions,
+      errors: [{ message: tabbableMessage('checkbox') }],
+    },
+    // ---- gridcell is NOT in recommended.tabbable → "must be focusable"
+    {
+      code: '<div role="gridcell" onClick={() => void 0} />',
+      options: recommendedOptions,
+      errors: [{ message: focusableMessage('gridcell') }],
+    },
+    {
+      code: '<div role="menuitem" onClick={() => void 0} />',
+      options: recommendedOptions,
+      errors: [{ message: focusableMessage('menuitem') }],
+    },
+
+    // ============================================================
+    // Strict config — slider / progressbar are in tabbable
+    // ============================================================
+    {
+      code: '<div role="slider" onClick={() => void 0} />',
+      options: strictOptions,
+      errors: [{ message: tabbableMessage('slider') }],
+    },
+    {
+      code: '<div role="progressbar" onClick={() => void 0} />',
+      options: strictOptions,
+      errors: [{ message: tabbableMessage('progressbar') }],
+    },
+    // ---- gridcell still gets "focusable" under strict.
+    {
+      code: '<div role="gridcell" onClick={() => void 0} />',
+      options: strictOptions,
+      errors: [{ message: focusableMessage('gridcell') }],
+    },
+
+    // ============================================================
+    // role first valid is interactive — multi-role string variants.
+    // ============================================================
+    {
+      code: '<div role="button heading" onClick={() => void 0} />',
+      errors: [{ message: focusableMessage('button heading') }],
+    },
+
+    // ============================================================
+    // Polymorphic — `as="div"` resolves to a plain div, which still trips.
+    // ============================================================
+    {
+      code: '<Foo as="div" role="button" onClick={() => void 0} />',
+      settings: polymorphicSettings,
+      errors: [{ message: focusableMessage('button') }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -438,3 +438,5 @@ undefinedundefined
 tokenlist
 idlist
 allowundefined
+Seeked
+usemap


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/interactive-supports-focus` rule from ESLint to rslint. The rule enforces that JSX elements with an interactive ARIA role (`button`, `link`, `checkbox`, …) and a mouse or keyboard event handler must also be keyboard-reachable — either inherently focusable, or via an explicit `tabIndex`. Diagnostic carries one `tabIndex={0}` suggestion when the role is in the `tabbable` option list, two (`tabIndex={0}` + `tabIndex={-1}`) otherwise.

The port follows the upstream branch logic 1:1 (5 short-circuit bail-outs + 5-AND main condition) and is differential-verified against upstream ESLint output on a 36-case boundary matrix + a 10-violation real-world-shaped fixture (10 vs 10 byte-for-byte across `line`/`column`/`role`/`message`/`suggestion.output`) + zero false-positive scans on `rsbuild` (940 files) and `rspack` (295 files).

### Shared helpers added in `jsxa11yutil/`

- `disabled.go` — `IsDisabledElement` (mirrors upstream `isDisabledElement.js`)
- `event_handlers.go` — `InteractiveEventHandlerNames` (mouse + keyboard handler list)
- `interactive.go` — `IsNonInteractiveElement` / `IsNonInteractiveRole`, plus a separate `strictNonInteractiveElementRoleSchemas` table (the upstream `isInteractiveElement.js` and `isNonInteractiveElement.js` files maintain *different* `nonInteractiveRoles` sets — the latter excludes `generic`, so HTML `<div>`/`<span>`/`<a>`/`<area>` etc. must not appear in its table or `<div role=\"radio\" onClick={…} />` falls silent)
- `tabindex.go` — `HasUpstreamTabIndexValue` (mirrors `getTabIndex(…) !== undefined`, including the step-2 fallback path where Identifier/Call/Member resolve to a non-undefined synthesized string)
- `jsxa11yutil.go` — `directAttributeStringValue` (entity-decode helper for JSX direct-attribute strings) wired into `LiteralStringValue` / `LiteralPropStringValue` / `LiteralPropIsExactlyTrue` / `polymorphicPropValue` / `IsHiddenFromScreenReader`. Also fixed `AttributeIsExplicitUndefined` nil-safety (latent panic when `attributeInnerExpression` returns nil).
- `IsInteractiveRole` upgraded from `LiteralStringValue` to `LiteralPropStringValue` (covers template-literal-with-substitutions and `null`-literal-as-\"null\" paths that upstream's `getLiteralPropValue` resolves).

### Tests

- **Upstream mirror** (`*_upstream_test.go`, 400 lines): reducer-style cartesian product mirroring upstream's `:recommended` and `:strict` suites — `alwaysValid` × 71 + reducer-expanded valid / invalid for both configs. ~700 cases.
- **Extras** (`*_extras_test.go`, 700+ lines, **self-contained — zero cross-file references**): tsgo↔ESTree AST quirks (paren, TS wrappers, template substitutions, NoSubstitutionTemplate), case-insensitive role, multi-space role, spread role/handler, polymorphic settings, three-level nested JSX, real-world `items.map` / Fragment / Conditional rendering, `<header>` / `<td>` / `<article>` / `<li>` / `<p>` boundaries, `tabIndex={null}` / `{1.5}` / Identifier / Call / Member, full `disabled` / `aria-disabled` / `aria-hidden` truth tables, entity-decoded role / type / aria-hidden / aria-disabled / polymorphic / tabIndex / multi-role.
- **JS suite** (`packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/interactive-supports-focus.test.ts`): representative sampling exercised through the binary.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/interactive-supports-focus.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/interactive-supports-focus.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).