### PR TITLE
feat: port rule jsx-a11y/control-has-associated-label

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_unsupported_elements"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/autocomplete_valid"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/click_events_have_key_events"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/control_has_associated_label"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/heading_has_content"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/html_has_lang"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/iframe_has_title"
@@ -37,6 +38,7 @@ func GetAllRules() []rule.Rule {
 		aria_unsupported_elements.AriaUnsupportedElementsRule,
 		autocomplete_valid.AutocompleteValidRule,
 		click_events_have_key_events.ClickEventsHaveKeyEventsRule,
+		control_has_associated_label.ControlHasAssociatedLabelRule,
 		heading_has_content.HeadingHasContentRule,
 		html_has_lang.HtmlHasLangRule,
 		iframe_has_title.IframeHasTitleRule,

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -44,25 +44,36 @@ func directAttributeStringValue(attr *ast.Node) (string, bool) {
 }
 
 // skipTransparent is the wrapper mask used by `staticEval` (the
-// `getPropValue` / TYPES path). Strips parentheses, type assertions
-// (`as` / `<T>x` / `TypeCastExpression`), and non-null assertions (`!`),
-// because upstream's jsx-ast-utils does the equivalent:
+// `getPropValue` / TYPES path). Strips parentheses and type assertions
+// (`as` / `<T>x` / `TypeCastExpression`), mirroring upstream
+// jsx-ast-utils:
 //
-//   - parens are flattened by ESTree's parser; tsgo preserves them, so
+//   - Parens are flattened by ESTree's parser; tsgo preserves them, so
 //     stripping is needed for parity.
-//   - `TSAsExpression` is unwrapped via the while-loop in
-//     `extractValueFromExpression`.
-//   - `TSNonNullExpression` has its own TYPES extractor that recurses
-//     into `.expression`, equivalent to stripping.
+//   - `TSAsExpression` is unwrapped via the `while (type ===
+//     'TSAsExpression')` loop in `extractValueFromExpression`.
 //
-// `OEKSatisfies` is INTENTIONALLY EXCLUDED. Upstream's `TYPES` table has
-// no entry for `TSSatisfiesExpression`, so it falls to the
+// `OEKNonNullAssertions` is INTENTIONALLY EXCLUDED. Upstream has a
+// dedicated `TSNonNullExpression` entry in `TYPES` that recurses into
+// `.expression` and APPENDS the `!` token to the stringified inner
+// result — so `{x!}` resolves to the string `"x!"`, `{true!}` to
+// `"true!"`, `{0!}` to `"0!"` (never the bare inner literal). The
+// presence of `!` makes upstream's `=== true` / `=== null` /
+// `Number(...) is integer` comparisons fail for these inputs while
+// truthiness / non-empty-after-trim checks still pass. Stripping `!`
+// here would silently convert `aria-hidden={true!}` to bool true (and
+// `tabIndex={0!}` to 0), diverging from upstream. The corresponding
+// `case ast.KindNonNullExpression` in `staticEval` produces the
+// stringified-with-`!` value upstream emits.
+//
+// `OEKSatisfies` is also INTENTIONALLY EXCLUDED. Upstream's `TYPES`
+// table has no entry for `TSSatisfiesExpression`, so it falls to the
 // `TYPES[type] === undefined → return null` branch. Keeping satisfies
 // opaque here makes it land on `staticEval`'s default `jsNull` arm,
 // matching upstream's null exactly. Used only by `staticEval`; the
 // `getLiteralPropValue` (`literalPropValue`) and `getProp` paths strip
 // parens only — see those callers.
-const skipTransparent = ast.OEKParentheses | ast.OEKTypeAssertions | ast.OEKNonNullAssertions
+const skipTransparent = ast.OEKParentheses | ast.OEKTypeAssertions
 
 // StringSliceOption coerces a JSON-decoded option value into `[]string`,
 // silently dropping any non-string entries. It is the standard helper for
@@ -621,9 +632,13 @@ func LiteralPropJSNumber(attr *ast.Node) (float64, bool) {
 //     no entry for `JSXEmptyExpression` and falls through to its
 //     `TYPES[type] === undefined → return null` path, which is `== null`.
 //   - the prop's value statically resolves to `null` or `undefined`. This
-//     covers `prop={null}`, `prop={undefined}`, and the TS-wrapped variants
-//     `prop={null as any}` / `prop={undefined!}` (skipTransparent unwraps
-//     parens + assertion wrappers per jsx-ast-utils' extract loop).
+//     covers `prop={null}`, `prop={undefined}`, and the `as`-wrapped
+//     variant `prop={null as any}` (skipTransparent unwraps parens +
+//     TSAsExpression per jsx-ast-utils' extract while-loop). Note that
+//     the `!`-wrapped variant `prop={undefined!}` is NOT nullish — upstream's
+//     `TSNonNullExpression` extractor stringifies it to `"undefined!"`
+//     (a non-empty string, `!= null`), and staticEval mirrors that. See
+//     the `case ast.KindNonNullExpression` arm.
 //   - staticEval cannot resolve the expression at all (`jvUnknown`). This
 //     mirrors jsx-ast-utils returning `null` for unrecognized expression
 //     types via the same fallback path. Producing this state is rare in
@@ -706,7 +721,7 @@ func PropValueIsTruthy(attr *ast.Node) bool {
 //   - boolean-attribute form (`<iframe title />` → upstream returns boolean
 //     true → typeof "boolean")
 //   - empty `{}` JsxExpression (upstream's "type not in TYPES" → null)
-//   - explicitly empty string (`title=""`, `title={""}`, `title={``}`)
+//   - explicitly empty string (`title=""`, `title={""}`, `title={“}`)
 //   - non-string truthy shapes: Object / Array / New / RegExp / function
 //     (Arrow / Function / Class) / Number / BigInt / Boolean / null /
 //     undefined / typeof / void / delete / SequenceExpression
@@ -966,7 +981,7 @@ func polymorphicPropValue(propAttr *ast.Node) (string, bool) {
 // Routes through LiteralPropStringValue (= getLiteralPropValue / LITERAL_TYPES),
 // not LiteralStringValue, so that TemplateExpression with substitutions whose
 // quasis + extracted substitution values concatenate to the literal strings
-// "presentation" / "none" are recognized — e.g. ``role={`presentation${''}`}``.
+// "presentation" / "none" are recognized — e.g. “role={`presentation${”}`}“.
 // Non-literal `role` expressions (Identifier, CallExpression, …) and absent
 // `role` attributes return false.
 func IsPresentationRole(attrs []*ast.Node) bool {

--- a/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/static_eval.go
@@ -42,7 +42,7 @@ import (
 // jsx-ast-utils' `getPropValue` output. Returning the actual value (instead of
 // just a truthy / falsy bit) is required because alt-text and similar a11y
 // rules distinguish three states: truthy, falsy, AND empty-string, and the
-// `=== ''` branch alone takes precedence over truthiness.
+// `=== ”` branch alone takes precedence over truthiness.
 //
 // Discriminated by Kind. Only the field corresponding to Kind is meaningful.
 //
@@ -88,7 +88,7 @@ var (
 // staticEval mirrors jsx-ast-utils' `getValue` (the engine behind getPropValue).
 // Walks the expression tree and computes the static JS value, applying real
 // JS semantics for `&&` / `||` / `??` / ternary / arithmetic so that callers
-// can distinguish "altValue === ''" from "altValue is truthy" precisely.
+// can distinguish "altValue === ”" from "altValue is truthy" precisely.
 //
 // Parentheses and TS assertion wrappers are unwrapped on every recursion.
 //
@@ -172,6 +172,38 @@ func staticEval(node *ast.Node) jsValue {
 		// Upstream's ThisExpression extractor returns the magic string "this"
 		// — non-empty truthy.
 		return jsValue{Kind: jvString, Str: "this"}
+	case ast.KindNonNullExpression:
+		// Upstream jsx-ast-utils keeps a dedicated `TSNonNullExpression`
+		// entry in TYPES that recurses into the inner expression and
+		// APPENDS `!` to the stringified result. Examples (verbatim
+		// upstream output of `getPropValue`):
+		//
+		//   {x!}        → "x!"
+		//   {true!}     → "true!"          (Number-coerces to NaN)
+		//   {0!}        → "0!"             (Number-coerces to NaN)
+		//   {"foo"!}    → "foo!"
+		//   {x.y!}      → "x.y!"
+		//   {(x as T)!} → "x!"             (TSAsExpression flattened first)
+		//   {(x!)!}     → "(x!)!"          (parenthesized inner gets "(…)!" wrap)
+		//
+		// The result is ALWAYS a non-empty string — never the bare
+		// inner boolean / null / number — so `=== true`, `=== null`,
+		// and integer-only comparisons fail for these inputs while
+		// truthy / non-empty-after-trim checks still pass. We mirror
+		// by converting the inner staticEval result to a string and
+		// appending "!". The parenthesized wrapping variant
+		// (`(x!)!` → "(x!)!")
+		// is not currently distinguished here because `staticEval`
+		// strips parens at the outermost level via `skipTransparent`;
+		// for the inputs the a11y rules actually inspect, the
+		// non-parenthesized form is sufficient.
+		inner := node.AsNonNullExpression().Expression
+		if inner == nil {
+			// Defensive: malformed source. A bare `!` with no operand
+			// shouldn't reach here; treat as the literal `!` string.
+			return jsValue{Kind: jvString, Str: "!"}
+		}
+		return jsValue{Kind: jvString, Str: jsToString(staticEval(inner)) + "!"}
 	case ast.KindBinaryExpression:
 		return staticEvalBinary(node.AsBinaryExpression())
 	case ast.KindConditionalExpression:
@@ -562,7 +594,7 @@ func staticEvalUnary(un *ast.PrefixUnaryExpression) jsValue {
 // NOT recursively extract substitution values. Anything whose ESTree type
 // name is `Literal` / `JSXElement` / `JSXFragment` / `TemplateLiteral` /
 // `Super` / `SpreadElement` / `MetaProperty` / `TSTypeAssertion` etc.
-// contributes the empty string. So `\`${"en"}\`` → `""` (falsy), NOT `"en"`.
+// contributes the empty string. So `\`${"en"}\“ → `""` (falsy), NOT `"en"`.
 //
 // We previously used `${name}` / `${Expression}` (with a `$` prefix) and
 // always returned a truthy non-empty string for non-Identifier substitutions.
@@ -745,7 +777,7 @@ func jsToString(v jsValue) string {
 }
 
 // jsValueIsExactlyEmptyString reports whether the value is statically known
-// to be the empty string. Used for the `altValue === ''` branch of the
+// to be the empty string. Used for the `altValue === ”` branch of the
 // alt-text validity check.
 func jsValueIsExactlyEmptyString(v jsValue) bool {
 	return v.Kind == jvString && v.Str == ""
@@ -952,7 +984,7 @@ func assignmentOperatorText(k ast.Kind) string {
 // Why this matters: alt-text and other a11y rules read attribute values
 // through this extractor. A literal `<img alt="false" />` evaluates to the
 // boolean `false`, not the string "false" — making it falsy and failing the
-// `(altValue && !isNullValued) || altValue === ''` check. Skipping this
+// `(altValue && !isNullValued) || altValue === ”` check. Skipping this
 // normalization would silently accept `alt="false"`.
 func jsxAstUtilsLiteralCoerce(text string) jsValue {
 	switch strings.ToLower(text) {

--- a/internal/plugins/jsx_a11y/rules/alt_text/alt_text_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/alt_text/alt_text_extras_test.go
@@ -331,6 +331,12 @@ func TestAltTextExtras(t *testing.T) {
 		{Code: `<img alt={altText as string} />`, Tsx: true},
 		// Double TS wrapping `(altText as any)!`.
 		{Code: `<img alt={(altText as any)!} />`, Tsx: true},
+		// `(undefined as any)!` — upstream `TSNonNullExpression` extractor
+		// stringifies inner + appends "!" → "undefined!" (non-empty truthy
+		// string, ≠ ''). AltAttributeIsValid → valid alt → no report.
+		// Locks in alignment after the OEKNonNullAssertions strip was
+		// removed from `skipTransparent` (see jsxa11yutil.go).
+		{Code: `<img alt={(undefined as any)!} />`, Tsx: true},
 		// String literal under `as` — extracts to "foo" → truthy → valid.
 		{Code: `<img alt={"foo" as string} />`, Tsx: true},
 		// Empty string under `as` — extracts to "" → valid via `=== ''`.
@@ -796,14 +802,6 @@ func TestAltTextExtras(t *testing.T) {
 		// undefined identifier; alt is still missing semantically.
 		{
 			Code: `<img alt={undefined as any} />`,
-			Tsx:  true,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},
-			},
-		},
-		// `(undefined as any)!` — double-wrapped, still undefined.
-		{
-			Code: `<img alt={(undefined as any)!} />`,
 			Tsx:  true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "altValue", Message: altValueMessage("img"), Line: 1, Column: 1},

--- a/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events.md
+++ b/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events.md
@@ -49,13 +49,6 @@ Examples of **correct** code for this rule:
 <MyComponent onClick={() => {}} />
 ```
 
-## Differences from ESLint
-
-- `<div onClick={…} aria-hidden={value!} />` — when the value of
-  `aria-hidden` is wrapped in a TS non-null assertion (`!`), rslint treats
-  it as hidden and does not report; ESLint reports. Drop the `!` to align
-  with both linters: `aria-hidden={value}`.
-
 ## Resources
 
 - [WCAG 2.1.1 — Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)

--- a/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events_extras_test.go
@@ -131,20 +131,6 @@ func TestClickEventsHaveKeyEventsExtras(t *testing.T) {
 			// ---- aria-hidden as JsxExpression containing string "true"
 			//      (jsxAstUtilsLiteralCoerce: "true" → bool true). ----
 			{Code: `<div onClick={() => void 0} aria-hidden={"true"} />`, Tsx: true},
-			// ---- DOCUMENTED DIVERGENCE: aria-hidden={true!} (TS non-null
-			//      assertion on a boolean literal). Upstream ESLint reports
-			//      this — jsx-ast-utils' `extract()` (the getPropValue path)
-			//      has no TYPES entry for `TSNonNullExpression` and falls
-			//      through to null, so aria-hidden does not equal boolean
-			//      true and the rule fires. rslint's shared `staticEval`
-			//      transparently strips `!` (via OEKNonNullAssertions in
-			//      skipTransparent), recovering the boolean true → element
-			//      is treated as hidden → no diagnostic. The plugin-wide
-			//      staticEval semantics are shared across 30+ jsx-a11y
-			//      tests in this repo and intentionally more permissive
-			//      than the upstream TYPES table — see Phase 1 Step 6.B
-			//      (language-natural divergence) in PORT_RULE.md. ----
-			{Code: `<div onClick={() => void 0} aria-hidden={true!} />`, Tsx: true},
 
 			// ---- role as JsxExpression containing string literal. ----
 			{Code: `<div onClick={() => void 0} role={"presentation"} />`, Tsx: true},
@@ -376,6 +362,15 @@ func TestClickEventsHaveKeyEventsExtras(t *testing.T) {
 			{Code: `<div onClick={() => void 0} aria-hidden={isHidden()} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 			// ---- aria-hidden as Identifier (non-static) → not boolean true. ----
 			{Code: `<div onClick={() => void 0} aria-hidden={hiddenVar} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- aria-hidden={true!} (TS non-null assertion on a boolean
+			//      literal). Upstream's `TSNonNullExpression` extractor
+			//      stringifies the inner value and appends "!" → "true!"
+			//      (a non-empty string, NOT bool true). aria-hidden !== true
+			//      → element NOT hidden → rule fires. Aligned with upstream
+			//      after the OEKNonNullAssertions strip was removed from
+			//      `skipTransparent`; see the `case ast.KindNonNullExpression`
+			//      arm in static_eval.go. ----
+			{Code: `<div onClick={() => void 0} aria-hidden={true!} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 
 			// ============================================================
 			// Non-interactive DOM element survey (upstream tests cover

--- a/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label.go
+++ b/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label.go
@@ -1,0 +1,451 @@
+// Package control_has_associated_label ports eslint-plugin-jsx-a11y's
+// `control-has-associated-label` rule. Enforces that an interactive control
+// (DOM element, control component, or DOM element with an interactive role)
+// has a discernible text label — either through visible text content, a
+// labelling attribute (`alt` / `aria-label` / `aria-labelledby` / user-
+// configured `labelAttributes`), or descendant content within a configured
+// recursion depth.
+//
+// Upstream listener gate (`JSXElement`), checked in order:
+//
+//  1. `newIgnoreElements` (= user `ignoreElements` ∪ `['link']`) contains the
+//     resolved tag → skip. The `link` exemption is hard-coded upstream and
+//     cannot be disabled via config.
+//  2. `getLiteralPropValue` of the `role` attribute is in `ignoreRoles` → skip.
+//  3. Element is hidden from screen readers (`<input type="hidden">`,
+//     `aria-hidden={true}`, `aria-hidden="true"`) → skip.
+//  4. Trigger condition: `isInteractiveElement || (isDOMElement &&
+//     isInteractiveRole) || controlComponents.indexOf(tag) > -1`.
+//     - When false: no label requirement (rule does not apply).
+//     - When true: run `mayHaveAccessibleLabel(root, min(options.depth ?? 2,
+//     25), labelAttributes, getElementType, controlComponents)`.
+//  5. If no label is found, report on the opening element.
+//
+// The message id is `controlHasAssociatedLabel`; the message text is taken
+// verbatim from upstream's `errorMessage`.
+package control_has_associated_label
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// errorMessage mirrors upstream's `errorMessage` constant verbatim.
+const errorMessage = "A control must be associated with a text label."
+
+// defaultDepth mirrors upstream's `options.depth === undefined ? 2 : options.depth`.
+const defaultDepth = 2
+
+// maxDepthCap mirrors upstream's `Math.min(..., 25)` ceiling on the recursion
+// budget — protects against pathological JSX trees regardless of user config.
+const maxDepthCap = 25
+
+type options struct {
+	labelAttributes   []string
+	controlComponents []string
+	ignoreElements    []string
+	ignoreRoles       []string
+	depth             int
+}
+
+func parseOptions(raw any) options {
+	opts := options{depth: defaultDepth}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	opts.labelAttributes = jsxa11yutil.StringSliceOption(m["labelAttributes"])
+	opts.controlComponents = jsxa11yutil.StringSliceOption(m["controlComponents"])
+	opts.ignoreElements = jsxa11yutil.StringSliceOption(m["ignoreElements"])
+	opts.ignoreRoles = jsxa11yutil.StringSliceOption(m["ignoreRoles"])
+	// depth: number, default 2. JSON decodes numbers as float64.
+	// Upstream truthiness: `options.depth === undefined ? 2 : options.depth`,
+	// then `Math.min(depth, 25)`. We treat the absence of the key (`v == nil`)
+	// as "undefined" and apply the default.
+	if v, ok := m["depth"]; ok && v != nil {
+		if f, ok := v.(float64); ok {
+			opts.depth = int(f)
+		}
+	}
+	if opts.depth > maxDepthCap {
+		opts.depth = maxDepthCap
+	}
+	return opts
+}
+
+var ControlHasAssociatedLabelRule = rule.Rule{
+	Name: "jsx-a11y/control-has-associated-label",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		// Upstream `newIgnoreElements = new Set([].concat(ignoreElements,
+		// ignoreList))` where `ignoreList = ['link']`. The `link` entry is
+		// applied unconditionally — there is no way to opt out via config.
+		newIgnoreElements := append([]string{}, opts.ignoreElements...)
+		newIgnoreElements = append(newIgnoreElements, "link")
+
+		getElementType := func(node *ast.Node) string {
+			return jsxa11yutil.GetElementType(node, ctx.Settings)
+		}
+
+		check := func(elementNode *ast.Node) {
+			opening, openingAttrs := openingElementOf(elementNode)
+			if opening == nil {
+				return
+			}
+			tag := getElementType(opening)
+
+			// Step 1: newIgnoreElements (user ignoreElements ∪ ['link']).
+			// Exact match — matches upstream's `Set.has(tag)`.
+			if slices.Contains(newIgnoreElements, tag) {
+				return
+			}
+
+			// Step 2: `getLiteralPropValue(getProp(attributes, 'role'))` in
+			// `ignoreRoles`. Routes through `LiteralPropStringValue` (=
+			// upstream's `getLiteralPropValue` for string-typed results) so
+			// non-literal role expressions (Identifier, Call, Conditional)
+			// fall through to ok=false and never satisfy `ignoreRoles`.
+			roleAttr := jsxa11yutil.FindAttributeByName(openingAttrs, "role")
+			if roleAttr != nil {
+				if roleValue, ok := jsxa11yutil.LiteralPropStringValue(roleAttr); ok {
+					if slices.Contains(opts.ignoreRoles, roleValue) {
+						return
+					}
+				}
+			}
+
+			// Step 3: hidden from screen reader — same helper used across
+			// the plugin (e.g. click-events-have-key-events). Treats
+			// `<input type="hidden">` and `aria-hidden={true}` /
+			// `aria-hidden="true"` as hidden.
+			if jsxa11yutil.IsHiddenFromScreenReader(opening, getElementType) {
+				return
+			}
+
+			// Step 4: trigger condition.
+			// Upstream: `isInteractiveElement || (isDOMElement &&
+			// isInteractiveRole) || controlComponents.indexOf(tag) > -1`.
+			// `controlComponents.indexOf` is EXACT match (case-sensitive)
+			// and does NOT use minimatch — the minimatch comparison only
+			// appears inside `mayHaveAccessibleLabel`'s React-component
+			// fallback. Preserve this asymmetry.
+			nodeIsInteractiveElement := jsxa11yutil.IsInteractiveElement(tag, openingAttrs)
+			nodeIsDOMElement := jsxa11yutil.IsDOMElement(tag)
+			nodeIsInteractiveRole := jsxa11yutil.IsInteractiveRole(tag, openingAttrs)
+			nodeIsControlComponent := slices.Contains(opts.controlComponents, tag)
+			shouldCheck := nodeIsInteractiveElement ||
+				(nodeIsDOMElement && nodeIsInteractiveRole) ||
+				nodeIsControlComponent
+			if !shouldCheck {
+				return
+			}
+
+			if mayHaveAccessibleLabel(elementNode, 0, opts.depth, opts.labelAttributes, opts.controlComponents, getElementType) {
+				return
+			}
+
+			ctx.ReportNode(opening, rule.RuleMessage{
+				Id:          "controlHasAssociatedLabel",
+				Description: errorMessage,
+			})
+		}
+
+		// Listen on both paired (JsxElement) and self-closing
+		// (JsxSelfClosingElement) — tsgo splits these into separate kinds
+		// while ESTree (and therefore upstream) sees them as JSXElement with
+		// `selfClosing` flag. Both forms must be classified independently.
+		return rule.RuleListeners{
+			ast.KindJsxElement:            check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}
+
+// openingElementOf returns the focal "opening element" used for label-prop
+// inspection and reporting, plus that element's attribute list. For a paired
+// JsxElement, this is `node.openingElement`; for a JsxSelfClosingElement, the
+// node itself plays both roles.
+func openingElementOf(node *ast.Node) (*ast.Node, []*ast.Node) {
+	if node == nil {
+		return nil, nil
+	}
+	switch node.Kind {
+	case ast.KindJsxElement:
+		opening := node.AsJsxElement().OpeningElement
+		if opening == nil {
+			return nil, nil
+		}
+		return opening, reactutil.GetJsxElementAttributes(opening)
+	case ast.KindJsxSelfClosingElement:
+		return node, reactutil.GetJsxElementAttributes(node)
+	}
+	return nil, nil
+}
+
+// mayHaveAccessibleLabel mirrors upstream's
+//
+//	mayHaveAccessibleLabel(root, maxDepth, additionalLabellingProps,
+//	                      getElementType, controlComponents)
+//
+// — a DFS that returns true if any of the following conditions hold within
+// `maxDepth` levels of descent:
+//
+//   - The node is a JSX text / string literal whose trimmed value is non-empty.
+//   - The node is a JsxExpression (`{expr}`) — assumed to render a label.
+//   - The node has an opening element that declares a labelling prop with a
+//     non-empty trimmed value (`alt`, `aria-label`, `aria-labelledby`, plus
+//     any `labelAttributes` configured by the user). Spread attributes are
+//     opaque and count as labelling.
+//   - The node is a JSX element with no children whose tag name starts with
+//     uppercase (= React component) AND is not in the `controlComponents`
+//     minimatch list. This codifies "an opaque React component might render
+//     a label".
+//
+// On every recursion the function fires before any of the above checks. The
+// caller passes `depth=0` for the root.
+func mayHaveAccessibleLabel(node *ast.Node, depth, maxDepth int, labelAttributes, controlComponents []string, getElementType func(*ast.Node) string) bool {
+	if node == nil {
+		return false
+	}
+	// Bail when maxDepth is exceeded. Upstream uses `depth > maxDepth`, so a
+	// node at exactly `maxDepth` still gets inspected.
+	if depth > maxDepth {
+		return false
+	}
+
+	switch node.Kind {
+	// JSXText — upstream's `node.type === 'JSXText' && !!tryTrim(node.value)`.
+	// tsgo splits text into two kinds; both carry the raw text on `.Text`.
+	case ast.KindJsxText, ast.KindJsxTextAllWhiteSpaces:
+		if strings.TrimSpace(node.AsJsxText().Text) != "" {
+			return true
+		}
+		return false
+	// Literal text — upstream's `node.type === 'Literal' && !!tryTrim(node.value)`.
+	// tsgo splits the ESTree `Literal` across several `Kind*Literal` kinds.
+	// Only string-shaped literals can carry a textual label; other literal
+	// kinds (NumericLiteral, etc.) are conceivable as JSX children only in
+	// edge cases and fall to the no-recursion default.
+	case ast.KindStringLiteral:
+		if strings.TrimSpace(node.AsStringLiteral().Text) != "" {
+			return true
+		}
+		return false
+	case ast.KindNoSubstitutionTemplateLiteral:
+		if strings.TrimSpace(node.AsNoSubstitutionTemplateLiteral().Text) != "" {
+			return true
+		}
+		return false
+	// JSXExpressionContainer — upstream returns true unconditionally, even
+	// for `{undefined}`. We mirror; the only sound static analysis would
+	// require full constant folding which jsx-ast-utils does not perform.
+	case ast.KindJsxExpression:
+		return true
+	}
+
+	// Labelling-prop check on the opening element. Upstream's `node.openingElement
+	// && hasLabellingProp(...)` only applies to nodes that have an opening
+	// element (JSXElement / JSXFragment-with-opening — but ESTree fragments
+	// don't carry one). In tsgo, only JsxElement / JsxSelfClosingElement
+	// expose an opening element.
+	opening, openingAttrs := openingElementOf(node)
+	if opening != nil && hasLabellingProp(openingAttrs, labelAttributes) {
+		return true
+	}
+
+	// Empty-children React-component fallback. Upstream:
+	//
+	//   if (node.type === 'JSXElement' && node.children.length === 0 && node.openingElement) {
+	//     const name = getElementType(node.openingElement);
+	//     const isReactComponent = name.length > 0 && name[0] === name[0].toUpperCase();
+	//     if (isReactComponent && !controlComponents.some((c) => minimatch(name, c))) {
+	//       return true;
+	//     }
+	//   }
+	//
+	// Self-closing forms (`<Foo />`) match this branch upstream because
+	// ESTree models them as JSXElement with `selfClosing: true` and empty
+	// `children`. In tsgo, both KindJsxElement-with-empty-children and
+	// KindJsxSelfClosingElement satisfy "JSXElement with no children".
+	//
+	// NOTE: `controlComponents` here is matched via `minimatch` — glob
+	// patterns are supported. This is intentionally asymmetric with the
+	// top-level trigger which uses exact `indexOf`. Mirror both.
+	if opening != nil && childrenIsEmpty(node) {
+		name := getElementType(opening)
+		if isReactComponentName(name) && !anyMinimatch(name, controlComponents) {
+			return true
+		}
+	}
+
+	// Recurse into children. `reactutil.GetJsxChildren` covers both
+	// JsxElement and JsxFragment (upstream treats fragments transparently
+	// here — the switch in `checkElement` has no case for them, but the
+	// `node.children` loop still walks them).
+	for _, child := range reactutil.GetJsxChildren(node) {
+		if mayHaveAccessibleLabel(child, depth+1, maxDepth, labelAttributes, controlComponents, getElementType) {
+			return true
+		}
+	}
+	return false
+}
+
+// childrenIsEmpty reports whether the JSX-element-like node has zero
+// children. Self-closing elements always satisfy this; paired elements
+// inspect their Children list.
+func childrenIsEmpty(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindJsxElement:
+		j := node.AsJsxElement()
+		return j.Children == nil || len(j.Children.Nodes) == 0
+	case ast.KindJsxSelfClosingElement:
+		return true
+	}
+	return false
+}
+
+// isReactComponentName mirrors upstream's
+//
+//	name.length > 0 && name[0] === name[0].toUpperCase()
+//
+// The JS check is true for every first character EXCEPT lowercase letters
+// (`'a'.toUpperCase()` is `'A'`, which is not strict-equal to `'a'`). For
+// ASCII this is exactly `c < 'a' || c > 'z'` — uppercase letters, digits,
+// `$`, `_`, and other symbols all satisfy `c === c.toUpperCase()` and thus
+// classify as "React component" upstream. Aligning with upstream rather
+// than the stricter "uppercase letter only" check matters for tags like
+// `<_Custom />` / `<$Foo />` (rare but legal as React component-like
+// expressions) — upstream applies the fallback to them too.
+//
+// Non-ASCII first characters fall under the same byte-level rule. JSX tag
+// names are ASCII identifiers in practice, so the byte-level check is
+// faithful to upstream's intent within that domain.
+func isReactComponentName(name string) bool {
+	if name == "" {
+		return false
+	}
+	c := name[0]
+	return c < 'a' || c > 'z'
+}
+
+// anyMinimatch returns true iff at least one pattern in `patterns` matches
+// `name` per minimatch (via `reactutil.MatchGlob` — same glob engine used
+// by `react/jsx-handler-names` and other ports). Mirrors upstream's
+// `controlComponents.some((c) => minimatch(name, c))`.
+func anyMinimatch(name string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if reactutil.MatchGlob(name, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasLabellingProp mirrors upstream's `hasLabellingProp(openingElement,
+// additionalLabellingProps)`:
+//
+//	const labellingProps = ['alt', 'aria-label', 'aria-labelledby',
+//	                       ...additionalLabellingProps];
+//	return openingElement.attributes.some((attribute) => {
+//	  if (attribute.type !== 'JSXAttribute') return true;  // spread → opaque
+//	  if (labellingProps.includes(propName(attribute))
+//	      && !!tryTrim(getPropValue(attribute))) return true;
+//	  return false;
+//	});
+//
+// Key semantics preserved:
+//
+//   - Spread attributes (`{...props}` and literal-resolvable variants like
+//     `{...{title: 'x'}}`) ALWAYS count as labelling, regardless of
+//     content. Upstream's first conditional short-circuits the entire
+//     `some()` to true when any attribute isn't a JSXAttribute.
+//   - The prop-name match is CASE-SENSITIVE — `includes()` uses `===`. So
+//     `<X ALT="x" />` does not match `alt`. Upstream's `propName(attribute)`
+//     returns the attribute's name verbatim (no casing).
+//   - The value check is `tryTrim(getPropValue(attribute))` truthy — for
+//     string values this is "non-empty after trim"; for non-string values
+//     (boolean true from the boolean attribute form, numeric, synthesized
+//     non-empty strings from Identifier / Call / Member) it's the raw
+//     truthy check.
+func hasLabellingProp(openingAttrs []*ast.Node, additionalLabellingProps []string) bool {
+	for _, attr := range openingAttrs {
+		// Spread (JsxSpreadAttribute) — upstream's "type !== 'JSXAttribute'"
+		// arm returns true unconditionally. Even literal-resolvable spreads
+		// (`{...{title: 'x'}}`) count, because upstream's `hasLabellingProp`
+		// short-circuits before inspecting the spread's contents.
+		if attr.Kind == ast.KindJsxSpreadAttribute {
+			return true
+		}
+		if attr.Kind != ast.KindJsxAttribute {
+			continue
+		}
+		name := reactutil.GetJsxPropName(attr)
+		if !isLabellingPropName(name, additionalLabellingProps) {
+			continue
+		}
+		if labellingValueIsPresent(attr) {
+			return true
+		}
+	}
+	return false
+}
+
+// isLabellingPropName performs the case-sensitive `===` check against the
+// labelling-prop names. The base set is the upstream-fixed
+// `['alt', 'aria-label', 'aria-labelledby']`; `additional` carries the
+// user-configured `labelAttributes`.
+func isLabellingPropName(name string, additional []string) bool {
+	if name == "alt" || name == "aria-label" || name == "aria-labelledby" {
+		return true
+	}
+	for _, n := range additional {
+		if name == n {
+			return true
+		}
+	}
+	return false
+}
+
+// labellingValueIsPresent mirrors upstream's `!!tryTrim(getPropValue(attr))`.
+//
+// `tryTrim` only trims strings — non-string values pass through unchanged,
+// so the final `!!` applies the JS truthiness rule. We split the
+// implementation into two paths:
+//
+//  1. Boolean-attribute form (`<X aria-label />`) — upstream's `extractValue`
+//     null-attribute-value path returns boolean `true`; `tryTrim(true)` is
+//     `true`; `!!true` → true.
+//  2. JsxExpression / direct-string-literal value — attempt to extract as a
+//     string via `PropStaticStringValue`. When that succeeds the value
+//     IS a string, and we apply the trim. When it fails (the value is a
+//     non-string: boolean false/true, number, null, undefined, etc.), fall
+//     back to `PropValueIsTruthy` which encodes upstream's full `getPropValue`
+//     truthiness.
+//
+// Examples covered:
+//   - `aria-label="Save"`     → "Save"  → trim → "Save"  → truthy → true
+//   - `aria-label=""`         → ""      → trim → ""       → falsy  → false
+//   - `aria-label="  "`       → "  "    → trim → ""       → falsy  → false
+//   - `aria-label={"x"}`      → "x"     → truthy → true
+//   - `aria-label={"  "}`     → "  "    → trim → ""       → falsy  → false
+//   - `aria-label`            → boolean true (boolean form)          → true
+//   - `aria-label={someVar}`  → Identifier → staticEval → "someVar"  → true
+//   - `aria-label={true}`     → boolean true                         → true
+//   - `aria-label={false}`    → boolean false → falsy                → false
+//   - `aria-label={null}`     → null → falsy                         → false
+//   - `aria-label={undefined}`→ undefined → falsy                    → false
+func labellingValueIsPresent(attr *ast.Node) bool {
+	if jsxa11yutil.AttributeIsBooleanForm(attr) {
+		return true
+	}
+	if s, ok := jsxa11yutil.PropStaticStringValue(attr); ok {
+		return strings.TrimSpace(s) != ""
+	}
+	return jsxa11yutil.PropValueIsTruthy(attr)
+}

--- a/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label.md
+++ b/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label.md
@@ -1,0 +1,164 @@
+# control-has-associated-label
+
+## Rule Details
+
+Enforce that a control (an interactive element) has a text label.
+
+There are several ways to supply a control with a text label:
+
+- Provide text content inside the element.
+- Set `aria-label` on the element.
+- Set `aria-labelledby` and point it at an element with an accessible label.
+- For an `img` inside the control, set its `alt` attribute.
+
+The rule is permissive about runtime-resolvable labels: when the label
+comes from an expression (`{maybeLabel}`) the rule assumes it will
+provide a label.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<button />
+<button><span /></button>
+<button><span title="This is not a real label" /></button>
+<a href="#" />
+<area href="#" />
+<menuitem />
+<option />
+<th />
+<div role="button" />
+<div role="checkbox" />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<button>Save</button>
+<button><span>Save</span></button>
+<button><img alt="Save" /></button>
+<button aria-label="Save" />
+<button aria-labelledby="js_1" />
+<button>{maybeLabel}</button>
+<a href="#">Save</a>
+<th>Save</th>
+<div role="button">Save</div>
+<div role="checkbox" aria-label="Save" />
+<div role="link" aria-labelledby="js_1" />
+```
+
+## Rule Options
+
+This rule takes one optional object argument:
+
+```json
+{
+  "labelAttributes": ["label"],
+  "controlComponents": ["CustomControl"],
+  "ignoreElements": [
+    "audio",
+    "canvas",
+    "embed",
+    "input",
+    "textarea",
+    "tr",
+    "video"
+  ],
+  "ignoreRoles": [
+    "grid",
+    "listbox",
+    "menu",
+    "menubar",
+    "radiogroup",
+    "row",
+    "tablist",
+    "toolbar",
+    "tree",
+    "treegrid"
+  ],
+  "depth": 3
+}
+```
+
+- `labelAttributes` — extra attribute names to treat as labels in
+  addition to `alt`, `aria-label`, and `aria-labelledby`. Useful when a
+  custom component renders a label from a specific prop (e.g. `label`).
+- `controlComponents` — custom React component names to treat as
+  interactive controls. The top-level trigger uses exact matching; the
+  recursive children-walk's React-component fallback uses minimatch
+  glob patterns (mirrors upstream).
+- `ignoreElements` — elements that should not be considered interactive
+  controls (e.g. `input`, `textarea`, where labels are commonly supplied
+  by a wrapping `<label>`).
+- `ignoreRoles` — ARIA roles that should not be considered interactive
+  controls.
+- `depth` (default `2`, max `25`) — how deep within the JSX subtree the
+  rule should look for an accessible label.
+
+The `link` tag is **always** ignored — the upstream rule hard-codes this
+exemption and it cannot be disabled.
+
+Examples of **incorrect** code for this rule with
+`{ "controlComponents": ["CustomControl"] }`:
+
+```json
+{
+  "jsx-a11y/control-has-associated-label": [
+    "error",
+    { "controlComponents": ["CustomControl"] }
+  ]
+}
+```
+
+```jsx
+<CustomControl />
+<CustomControl><span /></CustomControl>
+```
+
+Examples of **correct** code for this rule with
+`{ "depth": 3, "controlComponents": ["CustomControl"] }`:
+
+```json
+{
+  "jsx-a11y/control-has-associated-label": [
+    "error",
+    { "depth": 3, "controlComponents": ["CustomControl"] }
+  ]
+}
+```
+
+```jsx
+<CustomControl><span><span>Save</span></span></CustomControl>
+<CustomControl aria-label="Save" />
+```
+
+Examples of **correct** code for this rule with
+`{ "labelAttributes": ["label"] }`:
+
+```json
+{
+  "jsx-a11y/control-has-associated-label": [
+    "error",
+    { "labelAttributes": ["label"] }
+  ]
+}
+```
+
+```jsx
+<button><span label="Save" /></button>
+```
+
+## Accessibility guidelines
+
+- [WCAG 1.3.1 — Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
+- [WCAG 3.3.2 — Labels or Instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions)
+- [WCAG 4.1.2 — Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+
+### Resources
+
+- [MDN — `aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
+- [MDN — `aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
+- [WAI-ARIA 1.2 — Accessible Name and Description Computation](https://www.w3.org/TR/wai-aria-1.2/#namecalculation)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/control-has-associated-label](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/control-has-associated-label.md)

--- a/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label_extras_test.go
@@ -1,0 +1,904 @@
+package control_has_associated_label
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedErrorAnyPos is the standard expected diagnostic without a fixed
+// line/column. Use when the JSX opening element is not at column 1 — e.g.
+// inside a `function X() { return <button /> }` wrapper or `arr.map(...)`.
+var expectedErrorAnyPos = rule_tester.InvalidTestCaseError{
+	MessageId: "controlHasAssociatedLabel",
+	Message:   errorMessage,
+}
+
+// polymorphicSettings exercises `settings['jsx-a11y'].polymorphicPropName`.
+var polymorphicSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+	},
+}
+
+// componentsMapSettings demotes named components to specific tags via the
+// settings.components map. `MyButton` becomes `button` (interactive),
+// `MyDiv` becomes `div` (non-interactive — won't trigger).
+var componentsMapSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"MyButton": "button",
+			"MyDiv":    "div",
+		},
+	},
+}
+
+// TestControlHasAssociatedLabelExtras locks in branches that upstream's
+// test file does not exercise but are reachable through the rule's listener
+// gate. Coverage axes:
+//
+//   - Dimension 1 (tsgo AST shape): parenthesized / `as` / `satisfies` /
+//     non-null wrappers on attribute values; self-closing vs paired forms
+//     on every branch (root, recursion, React-component fallback).
+//   - Dimension 1 (literal shapes): JsxExpression-with-StringLiteral
+//     vs direct StringLiteral; NoSubstitutionTemplateLiteral; TemplateExpression
+//     with substitutions (non-literal under literalPropValue).
+//   - Dimension 2 (nesting / containers): JSX inside React.forwardRef /
+//     React.memo / HOC / hooks / class render / map / fragment / generator /
+//     async / IIFE. Each opening element classified independently.
+//   - Dimension 4 (universal edge shapes):
+//   - Spread attribute opacity (`{...x}` / `{...{...}}` count as
+//     labelling under upstream's `attribute.type !== 'JSXAttribute'`
+//     short-circuit).
+//   - controlComponents glob matching INSIDE mayHaveAccessibleLabel
+//     (different from the top-level exact match).
+//   - settings.components demoting custom → DOM removes the React-component
+//     fallback and re-enables interactive checks.
+//   - depth cap at 25 — supplying depth=100 behaves identically to
+//     depth=25.
+//   - Listener gate branches:
+//   - hard-coded `link` ignore (cannot be disabled via ignoreElements
+//     absent or set to []).
+//   - ignoreRoles via literal vs non-literal role expression.
+//   - aria-hidden via TS-wrapper / JsxExpression / case-insensitive
+//     string "true".
+//   - empty `<X />` root + uppercase tag + not in controlComponents →
+//     fallback applies at root depth 0.
+func TestControlHasAssociatedLabelExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ControlHasAssociatedLabelRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// Listener gate: hard-coded `link` ignore. Always exempt
+			// regardless of ignoreElements / options.
+			// ============================================================
+			{Code: `<link />`, Tsx: true},
+			{Code: `<link />`, Tsx: true, Options: map[string]interface{}{
+				"ignoreElements": []interface{}{}, // explicit empty
+			}},
+
+			// ============================================================
+			// Listener gate: ignoreRoles literal-only match. A non-literal
+			// `role={someVar}` does NOT match ignoreRoles (literalPropValue
+			// returns null for Identifier) — so this falls through to the
+			// trigger / label check.
+			// ============================================================
+			// Literal role match → skip.
+			{Code: `<div role="grid" />`, Tsx: true, Options: map[string]interface{}{
+				"ignoreRoles": []interface{}{"grid"},
+			}},
+			// JsxExpression-wrapped StringLiteral role → still extractable
+			// via literalPropValue → match → skip.
+			{Code: `<div role={"grid"} />`, Tsx: true, Options: map[string]interface{}{
+				"ignoreRoles": []interface{}{"grid"},
+			}},
+			// NoSubstitutionTemplateLiteral role → extractable → match.
+			{Code: "<div role={`grid`} />", Tsx: true, Options: map[string]interface{}{
+				"ignoreRoles": []interface{}{"grid"},
+			}},
+
+			// ============================================================
+			// Listener gate: isHiddenFromScreenReader paths.
+			// ============================================================
+			// aria-hidden boolean form — boolean attribute → true.
+			{Code: `<button aria-hidden />`, Tsx: true},
+			// aria-hidden={true} — direct boolean.
+			{Code: `<button aria-hidden={true} />`, Tsx: true},
+			// aria-hidden="true" — string coerced to bool true.
+			{Code: `<button aria-hidden="true" />`, Tsx: true},
+			// aria-hidden with paren wrapping (single + multi level).
+			{Code: `<button aria-hidden={(true)} />`, Tsx: true},
+			{Code: `<button aria-hidden={((true))} />`, Tsx: true},
+			// aria-hidden with TS `as` cast — staticEval strips TSAsExpression.
+			{Code: `<button aria-hidden={true as boolean} />`, Tsx: true},
+			// <input type="hidden"> case-insensitive.
+			{Code: `<input type="hidden" />`, Tsx: true,
+				Options: map[string]interface{}{
+					// drop input from ignoreElements so we exercise the
+					// IsHiddenFromScreenReader branch, not the early ignore.
+					"ignoreElements": []interface{}{},
+				}},
+			{Code: `<input type="HIDDEN" />`, Tsx: true,
+				Options: map[string]interface{}{"ignoreElements": []interface{}{}}},
+			{Code: `<input type="Hidden" />`, Tsx: true,
+				Options: map[string]interface{}{"ignoreElements": []interface{}{}}},
+
+			// ============================================================
+			// hasLabellingProp: spread attributes are opaque and count
+			// as labelling. Even literal-resolvable spreads.
+			// ============================================================
+			{Code: `<button {...props} />`, Tsx: true},
+			{Code: `<button {...{title: 'x'}} />`, Tsx: true},
+
+			// ============================================================
+			// hasLabellingProp: trim semantics — whitespace-only values are
+			// treated as missing labels (upstream `tryTrim`). Each case
+			// pairs with a non-empty sibling that DOES count, to lock both
+			// arms of the conditional.
+			// ============================================================
+			// Non-empty label string.
+			{Code: `<button aria-label="Save" />`, Tsx: true},
+			// Boolean form on aria-label — counts as label (upstream null-attr
+			// → true → tryTrim non-string passes through truthy).
+			{Code: `<button aria-label />`, Tsx: true},
+			// JsxExpression with non-whitespace string.
+			{Code: `<button aria-label={"Save"} />`, Tsx: true},
+			// ---- aria-label={x!} (TS non-null assertion). Upstream's
+			//      `TSNonNullExpression` extractor stringifies and appends
+			//      "!" → "x!" (non-empty, !!tryTrim non-empty) → counts
+			//      as labelled. rslint's staticEval emits the same
+			//      stringified form via the dedicated KindNonNullExpression
+			//      arm → also counts as labelled → no report. ALIGNED. ----
+			{Code: `<button aria-label={x!} />`, Tsx: true},
+			// Same on aria-labelledby and alt (shared labellingValueIsPresent
+			// path; same staticEval emission).
+			{Code: `<button aria-labelledby={ref!} />`, Tsx: true},
+			{Code: `<button><img alt={src!} /></button>`, Tsx: true},
+
+			// ============================================================
+			// labelAttributes: user-configured extra label attribute names.
+			// ============================================================
+			{Code: `<button label="Save" />`, Tsx: true,
+				Options: map[string]interface{}{"labelAttributes": []interface{}{"label"}}},
+
+			// ============================================================
+			// JsxExpression child — assumed to render label regardless of
+			// expression content (even {undefined} / {null}).
+			// ============================================================
+			{Code: `<button>{maybeLabel}</button>`, Tsx: true},
+			{Code: `<button>{undefined}</button>`, Tsx: true},
+			{Code: `<button>{null}</button>`, Tsx: true},
+			{Code: `<button>{0}</button>`, Tsx: true},
+
+			// ============================================================
+			// Recursion: JsxFragment as a transparent child container.
+			// Upstream's checkElement walks `node.children` regardless of
+			// node type — fragments don't have a switch arm but the
+			// children loop still picks up their kids.
+			// ============================================================
+			{Code: `<button><>Save</></button>`, Tsx: true},
+
+			// ============================================================
+			// React-component fallback inside recursion: an uppercase-named
+			// self-closing component (not in controlComponents) is assumed
+			// to render a label.
+			// ============================================================
+			{Code: `<button><MyLabel /></button>`, Tsx: true},
+			{Code: `<button><MyLabel></MyLabel></button>`, Tsx: true},
+
+			// ============================================================
+			// React-component fallback: minimatch in controlComponents.
+			// `MyControl*` glob matches `MyControlA` → fallback NOT
+			// triggered → falls through; but since this case has a label,
+			// it stays valid. Pairs with the invalid version below.
+			// ============================================================
+			{Code: `<button><MyControlA aria-label="Save" /></button>`, Tsx: true,
+				Options: map[string]interface{}{"controlComponents": []interface{}{"MyControl*"}}},
+
+			// ============================================================
+			// settings.polymorphicPropName: <Foo as="button">Save</Foo>
+			// becomes button → interactive → check label → "Save" present.
+			// ============================================================
+			{Code: `<Foo as="button">Save</Foo>`, Tsx: true, Settings: polymorphicSettings},
+
+			// ============================================================
+			// settings.components: <MyButton aria-label="Save" /> demotes
+			// to button (interactive) → label found.
+			// ============================================================
+			{Code: `<MyButton aria-label="Save" />`, Tsx: true, Settings: componentsMapSettings},
+
+			// ============================================================
+			// depth cap: depth=100 is clamped to 25, but a 3-level
+			// label is still found. (Pure regression: don't accidentally
+			// invert the cap.)
+			// ============================================================
+			{Code: `<button><span><span>Save</span></span></button>`, Tsx: true,
+				Options: map[string]interface{}{"depth": float64(100)}},
+
+			// ============================================================
+			// Real-world component patterns.
+			// ============================================================
+			// React.forwardRef wrapping interactive button with label.
+			{Code: `const Btn = React.forwardRef((props, ref) => <button ref={ref} aria-label="Save" />);`, Tsx: true},
+			// Array.map producing labelled interactive children.
+			{Code: `const list = items.map(item => <button key={item.id} aria-label={item.label} />);`, Tsx: true},
+			// Class component render() with labelled root.
+			{Code: `class Form extends React.Component { render() { return <button>Save</button>; } }`, Tsx: true},
+
+			// ============================================================
+			// Complex nesting: outer non-control wrapping interactive
+			// child with label → only inner is classified; outer doesn't
+			// require a label.
+			// ============================================================
+			{Code: `<div><button>Save</button></div>`, Tsx: true},
+			{Code: `<section><a href="#" aria-label="Home" /></section>`, Tsx: true},
+
+			// ============================================================
+			// Nested interactive elements — both interactive, each
+			// independently labelled.
+			// ============================================================
+			{Code: `<button aria-label="outer"><a href="#" aria-label="inner" /></button>`, Tsx: true},
+
+			// ============================================================
+			// Multi-level fragments + label deep within (counts fragments
+			// in the depth budget).
+			// ============================================================
+			// Fragment + div + span + text: depth needs to reach JsxText.
+			// button(0) -> fragment(1) -> JsxText(2) at depth 2 still works
+			// at default depth 2.
+			{Code: `<button><>Save</></button>`, Tsx: true},
+			// button(0) -> fragment(1) -> fragment(2) -> JsxText(3) at depth=3.
+			{Code: `<button><><>Save</></></button>`, Tsx: true,
+				Options: map[string]interface{}{"depth": float64(3)}},
+
+			// ============================================================
+			// React-component fallback at root (no children) — uppercase-
+			// named element NOT in controlComponents, but it IS triggered
+			// via controlComponents EXACT-match at top level. Pair sanity
+			// case: the rule must NOT trigger for an uppercase-named tag
+			// that is NOT in controlComponents at all (no DOM/role match
+			// either) — no diagnostic.
+			// ============================================================
+			{Code: `<UnrelatedComponent />`, Tsx: true}, // no trigger anywhere
+			{Code: `<UnrelatedComponent>Anything</UnrelatedComponent>`, Tsx: true},
+
+			// ============================================================
+			// Nested labelling via spread on the inner control element —
+			// hasLabellingProp's spread short-circuit kicks in.
+			// ============================================================
+			{Code: `<button><span {...props} /></button>`, Tsx: true},
+
+			// ============================================================
+			// Deep-tree React component fallback at the leaf: the deepest
+			// child is an uppercase-named component (not in controlComponents)
+			// → fallback returns true → outer label requirement satisfied.
+			// ============================================================
+			{Code: `<button><div><Label /></div></button>`, Tsx: true},
+
+			// ============================================================
+			// controlComponents exact-match at top + minimatch in recursion
+			// — `<CustomButton><CustomIcon /></CustomButton>` with
+			// controlComponents=['CustomButton', 'CustomIcon']:
+			//   - Top: CustomButton ∈ list → trigger.
+			//   - depth 1: CustomIcon name in list (exact or glob) → fallback NOT
+			//     triggered → empty recurse → false → REPORT.
+			// Sanity: add aria-label to inner makes it valid.
+			// ============================================================
+			{Code: `<CustomButton><CustomIcon aria-label="Open" /></CustomButton>`, Tsx: true,
+				Options: map[string]interface{}{
+					"controlComponents": []interface{}{"CustomButton", "CustomIcon"},
+				}},
+
+			// ============================================================
+			// Trigger combinations × ignoreRoles / settings interactions.
+			// ============================================================
+			// DOM-interactive + ignoreRoles match → ignoreRoles checked BEFORE
+			// trigger → skip regardless of interactivity.
+			{Code: `<button role="grid" />`, Tsx: true,
+				Options: map[string]interface{}{"ignoreRoles": []interface{}{"grid"}}},
+			// DOM-interactive + role outside ignoreRoles → trigger fires →
+			// label required → here Save text satisfies.
+			{Code: `<button role="grid">Save</button>`, Tsx: true},
+			// Custom component in controlComponents + ignoreRoles match → skip.
+			{Code: `<Widget role="grid" />`, Tsx: true,
+				Options: map[string]interface{}{
+					"controlComponents": []interface{}{"Widget"},
+					"ignoreRoles":       []interface{}{"grid"},
+				}},
+			// Custom component + ignoreElements match → skip (ignoreElements
+			// applies to the resolved tag name, even custom ones).
+			{Code: `<Widget aria-label="x" />`, Tsx: true,
+				Options: map[string]interface{}{
+					"controlComponents": []interface{}{"Widget"},
+					"ignoreElements":    []interface{}{"Widget"},
+				}},
+			// ignoreElements containing `link` (redundant — `link` is
+			// always ignored anyway) — no-op, both `link` and `audio` skip.
+			{Code: `<link />`, Tsx: true,
+				Options: map[string]interface{}{"ignoreElements": []interface{}{"link", "audio"}}},
+			{Code: `<audio />`, Tsx: true,
+				Options: map[string]interface{}{"ignoreElements": []interface{}{"link", "audio"}}},
+
+			// ============================================================
+			// Role values: case-sensitivity in ignoreRoles AND
+			// case-insensitivity in isInteractiveRole.
+			// ============================================================
+			// ignoreRoles is case-SENSITIVE (`includes` uses ===). role="GRID"
+			// does NOT match ignoreRoles=['grid']. But isInteractiveRole
+			// lowercases internally so "GRID" still resolves to interactive.
+			// Combined: rule fires (not ignored, is interactive role on div) →
+			// must label → "Save" satisfies → valid.
+			{Code: `<div role="GRID">Save</div>`, Tsx: true,
+				Options: map[string]interface{}{"ignoreRoles": []interface{}{"grid"}}},
+			// Multi-role `role="button switch"` — first valid role wins.
+			// "button" is interactive → trigger → label required.
+			{Code: `<div role="button switch">Save</div>`, Tsx: true},
+			// Multi-role with non-interactive first → no trigger via role
+			// (still depends on element).
+			{Code: `<div role="alert button" />`, Tsx: true},
+
+			// ============================================================
+			// `depth` extremes — 0, max=25, above max (clamped).
+			// ============================================================
+			// depth=0: only root inspected. Root has labelling prop → valid.
+			{Code: `<button aria-label="Save" />`, Tsx: true,
+				Options: map[string]interface{}{"depth": float64(0)}},
+			// depth=0: root has no labelling prop, no children fall within
+			// budget → invalid (tested in the invalid array below).
+			// depth=25 (max): deep enough for 25-level nested text.
+			{Code: `<button><span><span><span><span><span><span><span><span><span><span>Save</span></span></span></span></span></span></span></span></span></span></button>`, Tsx: true,
+				Options: map[string]interface{}{"depth": float64(25)}},
+			// depth=999: clamped to 25, still enough for the 11-level case
+			// above (way under 25).
+			{Code: `<button><span>Save</span></button>`, Tsx: true,
+				Options: map[string]interface{}{"depth": float64(999)}},
+
+			// ============================================================
+			// labelAttributes edge cases.
+			// ============================================================
+			// labelAttributes with hyphenated prop name.
+			{Code: `<button data-label="Save" />`, Tsx: true,
+				Options: map[string]interface{}{"labelAttributes": []interface{}{"data-label"}}},
+			// labelAttributes with duplicate entries — defensive.
+			{Code: `<button title="Save" />`, Tsx: true,
+				Options: map[string]interface{}{"labelAttributes": []interface{}{"title", "title"}}},
+			// labelAttributes containing a builtin name (alt) — redundant
+			// but harmless.
+			{Code: `<button><img alt="Save" /></button>`, Tsx: true,
+				Options: map[string]interface{}{"labelAttributes": []interface{}{"alt"}}},
+
+			// ============================================================
+			// Mixed children patterns (real-world JSX shapes).
+			// ============================================================
+			// Text + element child — text alone satisfies at depth 1.
+			{Code: `<button>Save<span /></button>`, Tsx: true},
+			// Element + text — same.
+			{Code: `<button><span />Save</button>`, Tsx: true},
+			// Expression + text — JsxExpression unconditional true.
+			{Code: `<button>{prefix} Save</button>`, Tsx: true},
+			// Non-ASCII text content.
+			{Code: `<button>→</button>`, Tsx: true},
+			{Code: `<button>保存</button>`, Tsx: true},
+			// Newlines + indentation in text — TrimSpace handles.
+			{
+				Code: `<button>` + "\n" +
+					`  Save` + "\n" +
+					`</button>`,
+				Tsx: true,
+			},
+			// Comment-only JsxExpression — tsgo emits KindJsxExpression
+			// with no inner Expression. Our switch returns true
+			// unconditionally for KindJsxExpression, matching upstream's
+			// `case 'JSXExpressionContainer': return true`.
+			{Code: `<button>{/* coming soon */}</button>`, Tsx: true},
+
+			// ============================================================
+			// Custom event handlers don't substitute for a label.
+			// Already covered in invalid via `<button />` etc. but lock
+			// in `<button onClick={fn} />` and friends here as INVALID.
+			// (Covered below in invalid section.)
+			// ============================================================
+
+			// ============================================================
+			// `controlComponents` with universal glob `["*"]` in recursion.
+			// Top-level still uses exact match — `["*"]` doesn't exact-match
+			// any tag → no top-level trigger from controlComponents. But
+			// the rule still triggers via interactive-element / role on a
+			// labelled inner: outer `<button>` triggers, inner `<Label />`
+			// is uppercase + matches `*` glob → fallback OFF → recurse →
+			// empty → no label → REPORT (covered in invalid below). The
+			// VALID counterpart adds explicit label at the outer level.
+			// ============================================================
+			{Code: `<button aria-label="Save"><Anything /></button>`, Tsx: true,
+				Options: map[string]interface{}{"controlComponents": []interface{}{"*"}}},
+
+			// ============================================================
+			// Settings: polymorphicAllowList narrows the polymorphic prop.
+			// `<Bar as="button">` with allowList=['Foo'] → Bar NOT remapped
+			// → stays custom → no trigger → valid.
+			// ============================================================
+			{Code: `<Bar as="button" />`, Tsx: true,
+				Settings: map[string]interface{}{
+					"jsx-a11y": map[string]interface{}{
+						"polymorphicPropName":  "as",
+						"polymorphicAllowList": []interface{}{"Foo"},
+					},
+				}},
+			// Same settings + `<Foo as="button">` → Foo IS in allowList →
+			// remapped to `button` → interactive → label required → "Save"
+			// satisfies.
+			{Code: `<Foo as="button">Save</Foo>`, Tsx: true,
+				Settings: map[string]interface{}{
+					"jsx-a11y": map[string]interface{}{
+						"polymorphicPropName":  "as",
+						"polymorphicAllowList": []interface{}{"Foo"},
+					},
+				}},
+
+			// ============================================================
+			// JSX tag name shapes — member expression, namespaced.
+			// ============================================================
+			// Member expression `<Foo.Bar />` — resolves to "Foo.Bar"
+			// (uppercase first) → not DOM → no trigger.
+			{Code: `<Foo.Bar />`, Tsx: true},
+			// Member expression as controlComponent (must match the full
+			// dotted form exactly at top level).
+			{Code: `<Foo.Bar aria-label="x" />`, Tsx: true,
+				Options: map[string]interface{}{"controlComponents": []interface{}{"Foo.Bar"}}},
+			// Namespaced `<svg:path />` — resolves to "svg:path" (lowercase
+			// prefix) → not in dom map → no trigger.
+			{Code: `<svg:path />`, Tsx: true},
+
+			// ============================================================
+			// Real-world component patterns (extended).
+			// ============================================================
+			// React.lazy + Suspense (Suspense is a custom component → no
+			// trigger; inner button has label).
+			{Code: `<Suspense fallback={<Spinner />}><button>Save</button></Suspense>`, Tsx: true},
+			// Render-prop pattern — children-as-function. The function
+			// body's JSX is in a JsxExpression; the OUTER component is
+			// custom (no trigger). Inner button is interactive but labelled.
+			{Code: `<DataLoader>{(data) => <button>Save</button>}</DataLoader>`, Tsx: true},
+			// Spread props onto a custom component — the spread is opaque
+			// at the custom-component level (no trigger anyway).
+			{Code: `<MyButton {...props} />`, Tsx: true},
+			// Conditional rendering with both branches labelled.
+			{Code: `<>{cond ? <button>A</button> : <button>B</button>}</>`, Tsx: true},
+			// Logical `&&` short-circuit with labelled button.
+			{Code: `<>{loading && <button aria-label="Loading" />}</>`, Tsx: true},
+			// Portal-style wrapper (custom component) with labelled child.
+			{Code: `<Portal><button aria-label="Close">×</button></Portal>`, Tsx: true},
+			// TypeScript generic on a JSX component (not a control).
+			{Code: `<Select<string> options={opts} aria-label="x" />`, Tsx: true,
+				Options: map[string]interface{}{"controlComponents": []interface{}{"Select"}}},
+
+			// ============================================================
+			// Settings.components: cascading remaps + override.
+			// ============================================================
+			// MyButton → button (interactive, needs label) — labelled here.
+			{Code: `<MyButton>Save</MyButton>`, Tsx: true,
+				Settings: map[string]interface{}{
+					"jsx-a11y": map[string]interface{}{
+						"components": map[string]interface{}{"MyButton": "button"},
+					},
+				}},
+			// MyDiv → div (no trigger).
+			{Code: `<MyDiv />`, Tsx: true,
+				Settings: map[string]interface{}{
+					"jsx-a11y": map[string]interface{}{
+						"components": map[string]interface{}{"MyDiv": "div"},
+					},
+				}},
+
+			// ============================================================
+			// Settings.components + ignoreElements interaction. Component
+			// resolves to "input", which is in default-recommended
+			// ignoreElements → skipped. Locks in the resolution order:
+			// componentsMap FIRST, then ignore checks against the
+			// resolved name.
+			// ============================================================
+			{Code: `<MyInput />`, Tsx: true,
+				Settings: map[string]interface{}{
+					"jsx-a11y": map[string]interface{}{
+						"components": map[string]interface{}{"MyInput": "input"},
+					},
+				},
+				Options: map[string]interface{}{
+					"ignoreElements": []interface{}{"input"},
+				}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Listener gate: `link` is hard-coded ignored but `a` is not.
+			// `<a href="#" />` triggers via interactive elementRoles.
+			// ============================================================
+			{Code: `<a href="#" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// `aria-hidden={true!}` (TS non-null assertion on boolean
+			// literal). Upstream `TSNonNullExpression` extractor stringifies
+			// the inner value and appends "!" → "true!" (a string, NOT
+			// bool true). `aria-hidden === true` fails → element NOT
+			// hidden → trigger check fires → no label → REPORT. rslint
+			// emits the same stringified form via the dedicated
+			// `case ast.KindNonNullExpression` arm in static_eval.go →
+			// aligned with upstream.
+			// ============================================================
+			{Code: `<button aria-hidden={true!} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Listener gate: non-literal role does NOT match ignoreRoles
+			// — `<div role={someRole} />` with ignoreRoles=['grid'] does
+			// not skip; falls through to the trigger check. But here,
+			// without a literal role, isInteractiveRole returns false →
+			// trigger is false → no diagnostic. So the case is VALID, not
+			// invalid. We test the invalid sibling: literal role NOT in
+			// ignoreRoles → trigger fires → no label.
+			// ============================================================
+			{Code: `<div role="button" />`, Tsx: true,
+				Options: map[string]interface{}{"ignoreRoles": []interface{}{"grid"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// hasLabellingProp trim: whitespace-only aria-label fails.
+			// ============================================================
+			{Code: `<button aria-label="   " />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<button aria-label="" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// JsxExpression with empty string.
+			{Code: `<button aria-label={""} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// JsxExpression with whitespace-only string.
+			{Code: `<button aria-label={"   "} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// aria-label={false} → falsy.
+			{Code: `<button aria-label={false} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// aria-label={null} → falsy.
+			{Code: `<button aria-label={null} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// aria-label={undefined} → falsy.
+			{Code: `<button aria-label={undefined} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// React-component fallback: name matched in controlComponents
+			// via minimatch DOES NOT save the parent. With
+			// controlComponents=['MyControl*'] and `<button><MyControlA /></button>`,
+			// the inner MyControlA matches the glob → fallback NOT
+			// triggered → empty recurse → button reports.
+			// ============================================================
+			{Code: `<button><MyControlA /></button>`, Tsx: true,
+				Options: map[string]interface{}{"controlComponents": []interface{}{"MyControl*"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// React-component fallback at root: `<CustomControl />` with
+			// controlComponents=['CustomControl'] — the rule fires
+			// because controlComponents triggers at top level, then
+			// mayHaveAccessibleLabel checks the root which has empty
+			// children — name='CustomControl' IS in controlComponents
+			// minimatch list → fallback NOT triggered → empty recurse →
+			// false → REPORT.
+			// ============================================================
+			{Code: `<CustomControl />`, Tsx: true,
+				Options: map[string]interface{}{"controlComponents": []interface{}{"CustomControl"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// settings.components: <MyButton /> demotes to `button`. Now
+			// `button` is interactive → trigger. Empty children, name is
+			// now 'button' (lowercase, after componentsMap) → not React
+			// component → fallback off → REPORT.
+			// ============================================================
+			{Code: `<MyButton />`, Tsx: true, Settings: componentsMapSettings,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos}},
+
+			// ============================================================
+			// settings.polymorphicPropName: <Foo as="button" /> becomes
+			// button → interactive → no children, no label → REPORT.
+			// ============================================================
+			{Code: `<Foo as="button" />`, Tsx: true, Settings: polymorphicSettings,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos}},
+
+			// ============================================================
+			// Depth cap: depth=100 clamps to 25, but depth=2 (default)
+			// can't reach a 4-level-nested label.
+			// ============================================================
+			{Code: `<button><span><span><span>Save</span></span></span></button>`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Multi-line opening element — Line/Column anchor to `<`.
+			// ============================================================
+			{
+				Code: `<button` + "\n" +
+					`/>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "controlHasAssociatedLabel",
+					Message:   errorMessage,
+					Line:      1,
+					Column:    1,
+				}},
+			},
+
+			// ============================================================
+			// Nested non-interactive parent with interactive child: only
+			// the inner control reports.
+			// ============================================================
+			{
+				Code: `<div>` + "\n" +
+					`  <button />` + "\n" +
+					`</div>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "controlHasAssociatedLabel",
+					Message:   errorMessage,
+					Line:      2,
+					Column:    3,
+				}},
+			},
+
+			// ============================================================
+			// Two same-line non-interactive controls both report.
+			// ============================================================
+			{
+				Code: `<><button /><a href="x" /></>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "controlHasAssociatedLabel", Message: errorMessage, Line: 1, Column: 3},
+					{MessageId: "controlHasAssociatedLabel", Message: errorMessage, Line: 1, Column: 13},
+				},
+			},
+
+			// ============================================================
+			// Real-world component patterns (reports).
+			// ============================================================
+			// React.forwardRef wrapping interactive button with no label.
+			{Code: `const Btn = React.forwardRef((props, ref) => <button ref={ref} />);`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos}},
+			// Array.map producing unlabelled interactive children.
+			{Code: `const list = items.map(item => <button key={item.id} />);`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos}},
+			// Generator yielding unlabelled controls — each reports.
+			{Code: `function* render() { yield <button />; yield <button />; }`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos, expectedErrorAnyPos}},
+
+			// ============================================================
+			// Complex nesting: a non-control parent wrapping an unlabelled
+			// interactive child. Only the inner control reports — outer
+			// `div` is not interactive and doesn't trigger.
+			// ============================================================
+			{Code: `<div><button /></div>`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos}},
+
+			// ============================================================
+			// Nested controls — each independently classified. Outer
+			// button has no label; inner has none either; BOTH report.
+			// Position assertions lock the two-fire pattern.
+			// ============================================================
+			{
+				Code: `<button><a href="#" /></button>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "controlHasAssociatedLabel", Message: errorMessage, Line: 1, Column: 1},
+					{MessageId: "controlHasAssociatedLabel", Message: errorMessage, Line: 1, Column: 9},
+				},
+			},
+
+			// ============================================================
+			// Fragment-only label deep beyond depth budget.
+			// button(0) → fragment(1) → fragment(2) → fragment(3) → JsxText(4)
+			// At default depth=2, depth(3)>2 → recursion bails before
+			// reaching the text. REPORT.
+			// ============================================================
+			{Code: `<button><><><>Save</></></></button>`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// controlComponents EXACT match at root vs glob inside:
+			// `<CustomA />` with controlComponents=['CustomA*'] does NOT
+			// trigger at root (top-level uses indexOf — exact only). So
+			// no diagnostic fires here even though the glob would match
+			// in a recursive context. Sanity: this case must be VALID
+			// (asymmetry is upstream-faithful). Pair with the actual
+			// invalid `<CustomA />` with exact-match controlComponents=['CustomA'].
+			// ============================================================
+			// Exact match at top → trigger → no label → REPORT.
+			{Code: `<CustomA />`, Tsx: true,
+				Options: map[string]interface{}{
+					"controlComponents": []interface{}{"CustomA"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// React-component fallback at root: `<CustomA />` is in
+			// controlComponents → triggers → fallback at depth 0 checks
+			// anyMinimatch and finds CustomA in the list → fallback off
+			// → empty recurse → false → REPORT.
+			// (Already partially covered above; this locks in glob-only
+			// match for the controlComponents list — 'C*' covers 'CustomA'.)
+			// ============================================================
+			{Code: `<CustomA />`, Tsx: true,
+				Options: map[string]interface{}{
+					"controlComponents": []interface{}{"CustomA", "C*"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Common real-world failure: icon button without label.
+			// ============================================================
+			// Bare button wrapping an SVG — svg lowercase, not in DomElements
+			// strictly used by IsInteractiveElement, but it IS in dom map so
+			// IsDOMElement(svg)=true; isReactComponent('svg')=false → fallback
+			// off → no label.
+			{Code: `<button><svg /></button>`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// Icon class on void child — i element, no children.
+			{Code: `<button><i className="icon-save" /></button>`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// Span with className but no text.
+			{Code: `<button><span className="material-icons" /></button>`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// onClick / event handlers don't substitute for a text label.
+			// ============================================================
+			{Code: `<button onClick={fn} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<a href="#" onClick={fn} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="button" onClick={fn} onKeyDown={fn} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// depth=0: only root inspected, descendants invisible. A
+			// labelled grandchild does NOT save the button.
+			// ============================================================
+			{Code: `<button><span>Save</span></button>`, Tsx: true,
+				Options: map[string]interface{}{"depth": float64(0)},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// depth=25 (max) — text at depth 26 not reached.
+			// ============================================================
+			{Code: `<button><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span><span>Save</span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></button>`, Tsx: true,
+				Options: map[string]interface{}{"depth": float64(25)},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Trigger fires regardless of `role` value when element itself
+			// is interactive. `<button role="img" />`, `<button role="presentation" />`,
+			// `<button role={unknown} />` — all still need a label.
+			// ============================================================
+			{Code: `<button role="img" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<button role="presentation" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<button role={unknown} />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Multi-role: first valid role wins for isInteractiveRole.
+			// "presentation" is non-interactive; on a `div` with this as the
+			// FIRST role, no role-trigger; div not interactive → no trigger →
+			// valid actually. So this case must use BUTTON (interactive
+			// element) to get a trigger. Or use role="button presentation"
+			// on div: first valid = "button" (interactive) → trigger.
+			// ============================================================
+			{Code: `<div role="button presentation" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Cross-listener report: nested controls in a real component.
+			// Each opening element classified independently.
+			// ============================================================
+			{
+				Code: `function Toolbar() {` + "\n" +
+					`  return (` + "\n" +
+					`    <div>` + "\n" +
+					`      <button />` + "\n" +
+					`      <a href="#" />` + "\n" +
+					`      <button aria-label="Save" />` + "\n" +
+					`    </div>` + "\n" +
+					`  );` + "\n" +
+					`}`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "controlHasAssociatedLabel", Message: errorMessage, Line: 4, Column: 7},
+					{MessageId: "controlHasAssociatedLabel", Message: errorMessage, Line: 5, Column: 7},
+				},
+			},
+
+			// ============================================================
+			// Render-prop pattern producing an unlabelled control.
+			// ============================================================
+			{Code: `<DataLoader>{(data) => <button />}</DataLoader>`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos}},
+
+			// ============================================================
+			// `controlComponents=["*"]` glob: inner Anything matches → fallback off.
+			// Outer `<button>` still triggers via element-level interactivity;
+			// recursion hits Anything at depth 1 (children empty + matches
+			// `*`) → fallback off → empty recurse at deeper level → false →
+			// no label found → outer button REPORTS.
+			// ============================================================
+			{Code: `<button><Anything /></button>`, Tsx: true,
+				Options: map[string]interface{}{"controlComponents": []interface{}{"*"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// `controlComponents` glob with brace expansion (minimatch
+			// supports `{a,b}` style).
+			// ============================================================
+			{Code: `<button><CustomA /></button>`, Tsx: true,
+				Options: map[string]interface{}{"controlComponents": []interface{}{"Custom{A,B,C}"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Settings.components remaps the element to a non-ignored DOM
+			// tag that IS interactive — rule fires.
+			// ============================================================
+			{Code: `<Submit />`, Tsx: true,
+				Settings: map[string]interface{}{
+					"jsx-a11y": map[string]interface{}{
+						"components": map[string]interface{}{"Submit": "button"},
+					},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos}},
+
+			// ============================================================
+			// Settings.polymorphicAllowList NOT covering the component →
+			// stays custom → no trigger → valid. But for the variant where
+			// allowList covers it AND `as` resolves to interactive →
+			// trigger fires.
+			// ============================================================
+			{Code: `<Foo as="th" />`, Tsx: true,
+				Settings: map[string]interface{}{
+					"jsx-a11y": map[string]interface{}{
+						"polymorphicPropName":  "as",
+						"polymorphicAllowList": []interface{}{"Foo"},
+					},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos}},
+
+			// ============================================================
+			// Multi-line position assertions.
+			// ============================================================
+			// Self-closing on its own line — column on `<`.
+			{
+				Code: `(` + "\n" +
+					`  <button` + "\n" +
+					`    onClick={fn}` + "\n" +
+					`  />` + "\n" +
+					`)`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "controlHasAssociatedLabel",
+					Message:   errorMessage,
+					Line:      2,
+					Column:    3,
+				}},
+			},
+			// Opening tag with attribute spanning multiple lines, then
+			// children, then closing — report column on `<` of opening.
+			{
+				Code: `<button` + "\n" +
+					`  className="primary"` + "\n" +
+					`  onClick={fn}` + "\n" +
+					`>` + "\n" +
+					`</button>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "controlHasAssociatedLabel",
+					Message:   errorMessage,
+					Line:      1,
+					Column:    1,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label_upstream_test.go
@@ -1,0 +1,445 @@
+package control_has_associated_label
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedError mirrors upstream's
+//
+//	const expectedError = {
+//	  message: 'A control must be associated with a text label.',
+//	  type: 'JSXOpeningElement',
+//	};
+//
+// Shared with the no-config and extras tests via package scope so a future
+// message tweak touches one place.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "controlHasAssociatedLabel",
+	Message:   errorMessage,
+}
+
+// recommendedOptions mirrors `configs.recommended.rules[ruleName][1]` /
+// `configs.strict.rules[ruleName][1]` from eslint-plugin-jsx-a11y's
+// `src/index.js`. The two configs ship identical option dictionaries for
+// this rule — both presets disable the rule by default and supply these
+// option defaults to apply when the user enables it.
+//
+// Notes:
+//   - `depth` is NOT in either preset; tests that need a deeper traversal
+//     supply it themselves under `Options` and it is preserved by upstream's
+//     `ruleOptionsMapperFactory` (concat + Object.fromEntries union — the
+//     test-supplied keys are listed first, but only the preset's keys
+//     overwrite on conflict and neither preset includes `depth`).
+//   - `includeRoles: ['alert', 'dialog']` (also shipped in the preset) is
+//     NOT in the rule's option schema and is silently ignored by upstream
+//     (`generateObjSchema` does not set `additionalProperties: false`).
+//     We omit it for parity with the schema, since passing an extra key
+//     would be a no-op anyway.
+var recommendedOptions = map[string]interface{}{
+	"ignoreElements": []interface{}{
+		"audio", "canvas", "embed", "input", "textarea", "tr", "video",
+	},
+	"ignoreRoles": []interface{}{
+		"grid", "listbox", "menu", "menubar", "radiogroup",
+		"row", "tablist", "toolbar", "tree", "treegrid",
+	},
+}
+
+// withRecommended returns a fresh options map that merges the per-test
+// overrides onto recommendedOptions. Mirrors upstream's
+// `ruleOptionsMapperFactory(recommendedOptions)` semantics:
+//   - test-supplied keys are listed FIRST in upstream's `concat`, so on
+//     conflict the recommended-preset value wins. This rule's preset
+//     ships only `ignoreElements` and `ignoreRoles`, so conflicts in
+//     practice only matter when a test tries to override one of those.
+//   - For non-conflicting keys (e.g. `depth`, `controlComponents`,
+//     `labelAttributes`), the test value is preserved verbatim.
+func withRecommended(overrides map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(recommendedOptions)+len(overrides))
+	for k, v := range overrides {
+		out[k] = v
+	}
+	for k, v := range recommendedOptions {
+		out[k] = v
+	}
+	return out
+}
+
+// customControlSettings mirrors upstream's
+//
+//	settings: { 'jsx-a11y': { components: { CustomControl: 'button' } } }
+//
+// — used by `<CustomControl>Save</CustomControl>` and
+// `<CustomControl></CustomControl>` cases.
+var customControlSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"CustomControl": "button",
+		},
+	},
+}
+
+// TestControlHasAssociatedLabelUpstreamRecommended mirrors upstream's
+// `:recommended` AND `:strict` test runs combined. The two configs ship
+// identical options for this rule, so a single Go test exercises both
+// alwaysValid (expect no diagnostic) and neverValid (expect a diagnostic)
+// arrays with recommendedOptions merged in.
+//
+// Anything outside upstream's test file lives in
+// `control_has_associated_label_extras_test.go`. Upstream's `:no-config`
+// run lives in `TestControlHasAssociatedLabelUpstreamNoConfig` below.
+func TestControlHasAssociatedLabelUpstreamRecommended(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ControlHasAssociatedLabelRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Custom Control Components ----
+			{Code: `<CustomControl><span><span>Save</span></span></CustomControl>`, Tsx: true,
+				Options: withRecommended(map[string]interface{}{
+					"depth":             float64(3),
+					"controlComponents": []interface{}{"CustomControl"},
+				})},
+			{Code: `<CustomControl><span><span label="Save"></span></span></CustomControl>`, Tsx: true,
+				Options: withRecommended(map[string]interface{}{
+					"depth":             float64(3),
+					"controlComponents": []interface{}{"CustomControl"},
+					"labelAttributes":   []interface{}{"label"},
+				})},
+			{Code: `<CustomControl>Save</CustomControl>`, Tsx: true,
+				Options:  withRecommended(nil),
+				Settings: customControlSettings},
+			// ---- Interactive Elements ----
+			{Code: `<button>Save</button>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<button><span>Save</span></button>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<button><span><span>Save</span></span></button>`, Tsx: true,
+				Options: withRecommended(map[string]interface{}{"depth": float64(3)})},
+			{Code: `<button><span><span><span><span><span><span><span><span>Save</span></span></span></span></span></span></span></span></button>`, Tsx: true,
+				Options: withRecommended(map[string]interface{}{"depth": float64(9)})},
+			{Code: `<button><img alt="Save" /></button>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<button aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<button><span aria-label="Save" /></button>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<button aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<button><span aria-labelledby="js_1" /></button>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<button>{sureWhyNot}</button>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<button><span><span label="Save"></span></span></button>`, Tsx: true,
+				Options: withRecommended(map[string]interface{}{
+					"depth":           float64(3),
+					"labelAttributes": []interface{}{"label"},
+				})},
+			{Code: `<a href="#">Save</a>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<area href="#">Save</area>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<link>Save</link>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<menuitem>Save</menuitem>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<option>Save</option>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<th>Save</th>`, Tsx: true, Options: withRecommended(nil)},
+			// ---- Interactive Roles ----
+			{Code: `<div role="button">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="checkbox">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="columnheader">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="combobox">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="gridcell">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="link">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menuitem">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menuitemcheckbox">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menuitemradio">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="option">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="progressbar">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="radio">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="rowheader">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="searchbox">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="slider">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="spinbutton">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="switch">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="tab">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="textbox">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="treeitem">Save</div>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="button" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="checkbox" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="columnheader" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="combobox" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="gridcell" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="link" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menuitem" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menuitemcheckbox" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menuitemradio" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="option" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="progressbar" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="radio" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="rowheader" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="searchbox" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="slider" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="spinbutton" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="switch" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="tab" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="textbox" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="treeitem" aria-label="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="button" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="checkbox" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="columnheader" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="combobox" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="gridcell" aria-labelledby="Save" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="link" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menuitem" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menuitemcheckbox" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menuitemradio" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="option" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="progressbar" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="radio" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="rowheader" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="searchbox" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="slider" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="spinbutton" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="switch" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="tab" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="textbox" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="treeitem" aria-labelledby="js_1" />`, Tsx: true, Options: withRecommended(nil)},
+			// ---- Non-interactive Elements ----
+			{Code: `<abbr />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<article />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<blockquote />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<br />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<caption />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<dd />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<details />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<dfn />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<dialog />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<dir />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<dl />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<dt />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<fieldset />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<figcaption />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<figure />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<footer />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<form />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<frame />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<h1 />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<h2 />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<h3 />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<h4 />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<h5 />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<h6 />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<hr />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<iframe />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<img />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<label />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<legend />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<li />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<link />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<main />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<mark />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<marquee />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<menu />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<meter />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<nav />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<ol />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<p />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<pre />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<progress />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<ruby />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<section />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<table />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<tbody />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<tfoot />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<thead />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<time />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<ul />`, Tsx: true, Options: withRecommended(nil)},
+			// ---- Non-interactive Roles ----
+			{Code: `<div role="alert" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="alertdialog" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="application" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="article" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="banner" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="cell" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="complementary" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="contentinfo" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="definition" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="dialog" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="directory" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="document" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="feed" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="figure" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="form" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="group" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="heading" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="img" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="list" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="listitem" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="log" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="main" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="marquee" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="math" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="navigation" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="none" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="note" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="presentation" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="region" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="rowgroup" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="search" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="separator" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="status" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="table" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="tabpanel" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="term" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="timer" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="tooltip" />`, Tsx: true, Options: withRecommended(nil)},
+			// ---- Via config: inputs / marginal interactive elements (skipped
+			//      under recommended's ignoreElements) ----
+			{Code: `<input />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="button" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="checkbox" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="color" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="date" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="datetime" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="email" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="file" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="hidden" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="hidden" name="bot-field"/>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="hidden" name="form-name" value="Contact Form"/>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="image" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="month" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="number" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="password" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="radio" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="range" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="reset" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="search" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="submit" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="tel" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="text" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<label>Foo <input type="text" /></label>`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input name={field.name} id="foo" type="text" value={field.value} disabled={isDisabled} onChange={changeText(field.onChange, field.name)} onBlur={field.onBlur} />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="time" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="url" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<input type="week" />`, Tsx: true, Options: withRecommended(nil)},
+			// Marginal interactive elements
+			{Code: `<audio />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<canvas />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<embed />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<textarea />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<tr />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<video />`, Tsx: true, Options: withRecommended(nil)},
+			// Interactive roles to ignore
+			{Code: `<div role="grid" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="listbox" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menu" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="menubar" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="radiogroup" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="row" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="tablist" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="toolbar" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="tree" />`, Tsx: true, Options: withRecommended(nil)},
+			{Code: `<div role="treegrid" />`, Tsx: true, Options: withRecommended(nil)},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: `<button />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<button><span /></button>`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<button><img /></button>`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<button><span title="This is not a real label" /></button>`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<button><span><span><span>Save</span></span></span></button>`, Tsx: true,
+				Options: withRecommended(map[string]interface{}{"depth": float64(3)}),
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<CustomControl><span><span></span></span></CustomControl>`, Tsx: true,
+				Options: withRecommended(map[string]interface{}{
+					"depth":             float64(3),
+					"controlComponents": []interface{}{"CustomControl"},
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<CustomControl></CustomControl>`, Tsx: true,
+				Options:  withRecommended(nil),
+				Settings: customControlSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<a href="#" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<area href="#" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<menuitem />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<option />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<th />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<td />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// Interactive Roles
+			{Code: `<div role="button" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="checkbox" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="columnheader" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="combobox" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="link" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="gridcell" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="menuitem" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="menuitemcheckbox" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="menuitemradio" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="option" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="progressbar" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="radio" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="rowheader" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="scrollbar" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="searchbox" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="slider" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="spinbutton" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="switch" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="tab" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<div role="textbox" />`, Tsx: true, Options: withRecommended(nil),
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		},
+	)
+}
+
+// TestControlHasAssociatedLabelUpstreamNoConfig mirrors upstream's
+// `:no-config` run:
+//
+//	ruleTester.run(`${ruleName}:no-config`, rule, {
+//	  valid: [
+//	    { code: '<input type="hidden" />' },
+//	    { code: '<input type="text" aria-hidden="true" />' },
+//	  ],
+//	  invalid: [
+//	    { code: '<input type="text" />', errors: [expectedError] },
+//	  ],
+//	});
+//
+// Important contrast with the :recommended/:strict suite: without options,
+// the `input` element is NOT in `newIgnoreElements` (only the hard-coded
+// `link` is). The hidden-from-screen-reader short-circuit therefore decides
+// whether the rule reports. `<input type="hidden">` is caught by the input
+// branch of IsHiddenFromScreenReader; `<input type="text" aria-hidden="true">`
+// is caught by the `aria-hidden === true` branch. A plain
+// `<input type="text" />` reaches the interactive-element check (input is
+// in the interactive AX schema) and reports because it has no label.
+func TestControlHasAssociatedLabelUpstreamNoConfig(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ControlHasAssociatedLabelRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `<input type="hidden" />`, Tsx: true},
+			{Code: `<input type="text" aria-hidden="true" />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: `<input type="text" />`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		},
+	)
+}

--- a/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus_extras_test.go
@@ -103,7 +103,6 @@ func TestNoAutofocusExtras(t *testing.T) {
 		{Code: `<div autoFocus={"False"} />`, Tsx: true},
 		{Code: `<div autoFocus={("false")} />`, Tsx: true},
 		{Code: `<div autoFocus={"false" as string} />`, Tsx: true},
-		{Code: `<div autoFocus={"false"!} />`, Tsx: true},
 		{Code: `<div autoFocus={false as boolean} />`, Tsx: true},
 		// NoSubstitutionTemplateLiteral does NOT route through
 		// jsxAstUtilsLiteralCoerce, so `` `false` `` extracts to string
@@ -441,6 +440,14 @@ func TestNoAutofocusExtras(t *testing.T) {
 		{Code: `<div autoFocus={true as boolean} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 		{Code: `<div autoFocus={(true)} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 		{Code: `<div autoFocus={(true)!} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `<div autoFocus={"false"!} />` — upstream's `TSNonNullExpression`
+		// extractor stringifies the inner string literal and appends "!"
+		// → "false!" (a NEW string, NOT coerced via the case-insensitive
+		// "true"/"false" Literal rule). `"false!" !== false` →
+		// autoFocus enabled → reports. rslint emits the same stringified
+		// form via the dedicated `case ast.KindNonNullExpression` arm
+		// in static_eval.go.
+		{Code: `<div autoFocus={"false"!} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
 
 		// ============================================================
 		// Group 10: `satisfies` is OPAQUE — wrapped value falls through

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -166,6 +166,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/aria-unsupported-elements.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/autocomplete-valid.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/click-events-have-key-events.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/control-has-associated-label.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/heading-has-content.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/html-has-lang.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/iframe-has-title.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/control-has-associated-label.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/control-has-associated-label.test.ts
@@ -1,0 +1,344 @@
+import { RuleTester } from '../rule-tester';
+
+const errorMessage = 'A control must be associated with a text label.';
+const expectedError = { message: errorMessage };
+
+// Mirrors `configs.recommended` / `configs.strict` from
+// eslint-plugin-jsx-a11y. Both presets ship identical options for this
+// rule; depth is absent so per-test overrides win.
+const recommendedOptions = {
+  ignoreElements: [
+    'audio',
+    'canvas',
+    'embed',
+    'input',
+    'textarea',
+    'tr',
+    'video',
+  ],
+  ignoreRoles: [
+    'grid',
+    'listbox',
+    'menu',
+    'menubar',
+    'radiogroup',
+    'row',
+    'tablist',
+    'toolbar',
+    'tree',
+    'treegrid',
+  ],
+};
+
+const customControlSettings = {
+  'jsx-a11y': {
+    components: {
+      CustomControl: 'button',
+    },
+  },
+};
+
+const polymorphicSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+  },
+};
+
+new RuleTester().run('control-has-associated-label', null as never, {
+  valid: [
+    // ============================================================
+    // Upstream :recommended / :strict valid suite (mirrors
+    // __tests__/src/rules/control-has-associated-label-test.js, with
+    // recommendedOptions merged in via ruleOptionsMapperFactory).
+    // ============================================================
+    {
+      code: '<CustomControl><span><span>Save</span></span></CustomControl>',
+      options: [
+        {
+          depth: 3,
+          controlComponents: ['CustomControl'],
+          ...recommendedOptions,
+        },
+      ],
+    },
+    {
+      code: '<CustomControl>Save</CustomControl>',
+      options: [recommendedOptions],
+      settings: customControlSettings,
+    },
+    { code: '<button>Save</button>', options: [recommendedOptions] },
+    {
+      code: '<button><span>Save</span></button>',
+      options: [recommendedOptions],
+    },
+    {
+      code: '<button aria-label="Save" />',
+      options: [recommendedOptions],
+    },
+    {
+      code: '<button aria-labelledby="js_1" />',
+      options: [recommendedOptions],
+    },
+    {
+      code: '<button>{sureWhyNot}</button>',
+      options: [recommendedOptions],
+    },
+    { code: '<a href="#">Save</a>', options: [recommendedOptions] },
+    { code: '<link>Save</link>', options: [recommendedOptions] },
+    { code: '<th>Save</th>', options: [recommendedOptions] },
+    {
+      code: '<div role="button">Save</div>',
+      options: [recommendedOptions],
+    },
+    {
+      code: '<div role="button" aria-label="Save" />',
+      options: [recommendedOptions],
+    },
+    // Non-interactive elements / roles
+    { code: '<div role="alert" />', options: [recommendedOptions] },
+    { code: '<article />', options: [recommendedOptions] },
+    { code: '<p />', options: [recommendedOptions] },
+    // Inputs / marginal interactive elements — skipped via ignoreElements.
+    { code: '<input />', options: [recommendedOptions] },
+    { code: '<input type="text" />', options: [recommendedOptions] },
+    { code: '<textarea />', options: [recommendedOptions] },
+    { code: '<tr />', options: [recommendedOptions] },
+    // Interactive roles in ignoreRoles.
+    { code: '<div role="grid" />', options: [recommendedOptions] },
+    { code: '<div role="tablist" />', options: [recommendedOptions] },
+
+    // ============================================================
+    // :no-config — hidden elements skip regardless of options.
+    // ============================================================
+    { code: '<input type="hidden" />' },
+    { code: '<input type="text" aria-hidden="true" />' },
+
+    // ============================================================
+    // Listener gate edge cases.
+    // ============================================================
+    // Hard-coded `link` ignore — not removable via empty ignoreElements.
+    { code: '<link />', options: [{ ignoreElements: [] }] },
+    // aria-hidden on a control short-circuits.
+    { code: '<button aria-hidden />' },
+    { code: '<button aria-hidden={true} />' },
+    { code: '<button aria-hidden="true" />' },
+    // Spread attribute opacity — counts as labelling.
+    { code: '<button {...props} />' },
+    // JsxExpression child — assumed label.
+    { code: '<button>{maybeLabel}</button>' },
+    // React-component fallback inside recursion.
+    { code: '<button><MyLabel /></button>' },
+    // settings.components: <MyButton aria-label="Save" /> demotes to button.
+    {
+      code: '<MyButton aria-label="Save" />',
+      settings: {
+        'jsx-a11y': { components: { MyButton: 'button' } },
+      },
+    },
+    // settings.polymorphicPropName: <Foo as="button">Save</Foo>.
+    {
+      code: '<Foo as="button">Save</Foo>',
+      settings: polymorphicSettings,
+    },
+
+    // ============================================================
+    // Real-world JSX patterns
+    // ============================================================
+    // Multi-line button with label.
+    {
+      code: ['<button', '  className="primary"', '>Save</button>'].join('\n'),
+    },
+    // Newline-indented text child.
+    { code: '<button>\n  Save\n</button>' },
+    // Non-ASCII text.
+    { code: '<button>保存</button>' },
+    // Render-prop pattern with labelled inner control.
+    { code: '<DataLoader>{(data) => <button>Save</button>}</DataLoader>' },
+    // Suspense + labelled child.
+    {
+      code: '<Suspense fallback={<Spinner />}><button>Save</button></Suspense>',
+    },
+    // Array.map with labelled controls.
+    { code: 'items.map((item) => <button key={item.id}>{item.name}</button>)' },
+    // Logical && rendering.
+    { code: '{loading && <button aria-label="Loading" />}' },
+    // Conditional with both branches labelled.
+    { code: '{cond ? <button>A</button> : <button>B</button>}' },
+    // TS generic on a component (treated as custom — no trigger).
+    { code: '<Select<string> options={opts} />' },
+    // Member-expression JSX tag (custom — no trigger).
+    { code: '<Foo.Bar />' },
+    // Namespaced lowercase JSX tag (not in DOM map — no trigger).
+    { code: '<svg:path />' },
+
+    // ============================================================
+    // labelAttributes — hyphenated prop name.
+    // ============================================================
+    {
+      code: '<button data-label="Save" />',
+      options: [{ labelAttributes: ['data-label'] }],
+    },
+    // labelAttributes — duplicate entry, defensive.
+    {
+      code: '<button title="Save" />',
+      options: [{ labelAttributes: ['title', 'title'] }],
+    },
+
+    // ============================================================
+    // ignoreRoles vs case-sensitivity / multi-role
+    // ============================================================
+    // role="GRID" not in ignoreRoles=['grid'] (case-sensitive) but
+    // isInteractiveRole lowercases — combined: role-trigger fires →
+    // label required → "Save" satisfies.
+    {
+      code: '<div role="GRID">Save</div>',
+      options: [{ ignoreRoles: ['grid'] }],
+    },
+    // Multi-role: first valid role wins for isInteractiveRole.
+    { code: '<div role="button switch">Save</div>' },
+
+    // ============================================================
+    // depth extremes
+    // ============================================================
+    // depth=0 with label directly on root.
+    { code: '<button aria-label="Save" />', options: [{ depth: 0 }] },
+    // depth=999 clamped to 25 — still resolves a shallow label.
+    { code: '<button><span>Save</span></button>', options: [{ depth: 999 }] },
+  ],
+  invalid: [
+    // ============================================================
+    // Upstream :recommended / :strict invalid suite.
+    // ============================================================
+    {
+      code: '<button />',
+      options: [recommendedOptions],
+      errors: [expectedError],
+    },
+    {
+      code: '<button><span /></button>',
+      options: [recommendedOptions],
+      errors: [expectedError],
+    },
+    {
+      code: '<button><img /></button>',
+      options: [recommendedOptions],
+      errors: [expectedError],
+    },
+    {
+      code: '<CustomControl><span><span></span></span></CustomControl>',
+      options: [
+        {
+          depth: 3,
+          controlComponents: ['CustomControl'],
+          ...recommendedOptions,
+        },
+      ],
+      errors: [expectedError],
+    },
+    {
+      code: '<CustomControl></CustomControl>',
+      options: [recommendedOptions],
+      settings: customControlSettings,
+      errors: [expectedError],
+    },
+    {
+      code: '<a href="#" />',
+      options: [recommendedOptions],
+      errors: [expectedError],
+    },
+    {
+      code: '<area href="#" />',
+      options: [recommendedOptions],
+      errors: [expectedError],
+    },
+    {
+      code: '<menuitem />',
+      options: [recommendedOptions],
+      errors: [expectedError],
+    },
+    {
+      code: '<option />',
+      options: [recommendedOptions],
+      errors: [expectedError],
+    },
+    { code: '<th />', options: [recommendedOptions], errors: [expectedError] },
+    { code: '<td />', options: [recommendedOptions], errors: [expectedError] },
+    {
+      code: '<div role="button" />',
+      options: [recommendedOptions],
+      errors: [expectedError],
+    },
+    {
+      code: '<div role="link" />',
+      options: [recommendedOptions],
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // :no-config — <input type="text" /> reports because input is
+    // interactive when ignoreElements is empty.
+    // ============================================================
+    { code: '<input type="text" />', errors: [expectedError] },
+
+    // ============================================================
+    // Listener gate: aria-label trim semantics.
+    // ============================================================
+    { code: '<button aria-label="" />', errors: [expectedError] },
+    { code: '<button aria-label="   " />', errors: [expectedError] },
+    { code: '<button aria-label={null} />', errors: [expectedError] },
+    { code: '<button aria-label={false} />', errors: [expectedError] },
+
+    // ============================================================
+    // Real-world failure modes
+    // ============================================================
+    // Icon-only button (SVG).
+    { code: '<button><svg /></button>', errors: [expectedError] },
+    // Icon class on void child.
+    {
+      code: '<button><i className="icon-save" /></button>',
+      errors: [expectedError],
+    },
+    // onClick without label — common mistake.
+    { code: '<button onClick={fn} />', errors: [expectedError] },
+    { code: '<a href="#" onClick={fn} />', errors: [expectedError] },
+    // depth=0 cannot see labelled descendant.
+    {
+      code: '<button><span>Save</span></button>',
+      options: [{ depth: 0 }],
+      errors: [expectedError],
+    },
+    // Element interactive regardless of role.
+    { code: '<button role="presentation" />', errors: [expectedError] },
+    { code: '<button role="img" />', errors: [expectedError] },
+    // Multi-role: first valid role "button" → trigger.
+    { code: '<div role="button presentation" />', errors: [expectedError] },
+    // Settings.components remap exposes interactivity.
+    {
+      code: '<Submit />',
+      settings: { 'jsx-a11y': { components: { Submit: 'button' } } },
+      errors: [expectedError],
+    },
+    // polymorphicAllowList lets `<Foo as="th" />` become th.
+    {
+      code: '<Foo as="th" />',
+      settings: {
+        'jsx-a11y': {
+          polymorphicPropName: 'as',
+          polymorphicAllowList: ['Foo'],
+        },
+      },
+      errors: [expectedError],
+    },
+    // Multi-line position assertion.
+    {
+      code: ['(', '  <button', '    onClick={fn}', '  />', ')'].join('\n'),
+      errors: [expectedError],
+    },
+    // controlComponents glob — minimatch in recursion.
+    {
+      code: '<button><CustomIcon /></button>',
+      options: [{ controlComponents: ['Custom*'] }],
+      errors: [expectedError],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts
@@ -70,7 +70,6 @@ new RuleTester().run('no-autofocus', null as never, {
     { code: '<div autoFocus={"False"} />' },
     { code: '<div autoFocus={("false")} />' },
     { code: '<div autoFocus={"false" as string} />' },
-    { code: '<div autoFocus={"false"!} />' },
     { code: '<div autoFocus={false as boolean} />' },
     { code: '<div autoFocus={`false`} />' },
 
@@ -235,6 +234,10 @@ new RuleTester().run('no-autofocus', null as never, {
     { code: '<div autoFocus={true as boolean} />', errors: [expectedError] },
     { code: '<div autoFocus={(true)} />', errors: [expectedError] },
     { code: '<div autoFocus={(true)!} />', errors: [expectedError] },
+    // TSNonNullExpression on string literal: upstream stringifies to "false!"
+    // (NOT coerced via case-insensitive "true"/"false" Literal rule).
+    // "false!" !== false → autoFocus enabled → reports.
+    { code: '<div autoFocus={"false"!} />', errors: [expectedError] },
 
     // ---- `satisfies` is opaque — even `false satisfies boolean` reports ----
     {


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/control-has-associated-label` rule with full 1:1 alignment on inputs / outputs / options. The rule enforces that an interactive control (a DOM element, an element with an interactive role, or a configured control component) has a discernible text label — via visible text, a labelling attribute (`alt` / `aria-label` / `aria-labelledby` / user-configured `labelAttributes`), or descendant content within a configured recursion depth.

While porting, fixed a long-standing divergence in the shared `staticEval` helper: `skipTransparent` was stripping TS non-null assertions (`!`), but upstream `jsx-ast-utils` keeps a dedicated `TSNonNullExpression` extractor that returns a stringified form (e.g. `"x!"`, `"true!"`). Removed `OEKNonNullAssertions` from `skipTransparent` and added a `case ast.KindNonNullExpression` arm in `staticEval` that emits the upstream-faithful stringified form. This propagates upstream-alignment to 4 rules (the new one, `click-events-have-key-events`, `alt-text`, `no-autofocus`) and removes two previously-documented "Differences from ESLint" sections that turn out to be no longer divergent.

### Tests

- **Upstream suite** (`UpstreamRecommended` + `UpstreamNoConfig`): 246 cases mirrored 1:1 from upstream `eslint-plugin-jsx-a11y` test file
- **Extras** (Dimension 1-4 + listener gate branches + real-world patterns): 123 cases covering position assertions, trigger-combination matrix, role case-sensitivity, multi-role, depth extremes (0 / 25 / clamped), `labelAttributes` edge shapes, mixed children, AST member-expression tags, `React.forwardRef` / `map` / generator / `Suspense` / render-prop / TS generics, `controlComponents` glob, `settings.components` + `polymorphicPropName`
- **JS rstest suite**: 50 cases covering the same axes through the rslint binary E2E path
- **Differential validation** against `eslint-plugin-jsx-a11y@HEAD` on real rsbuild (945 files) and rspack (361 files) — both clean (their interactive elements all have labels); a 15-bad / 10-good fixture verifies every diagnostic shape with correct line+column positions

### Affected by the staticEval alignment fix

- `click-events-have-key-events`: `aria-hidden={true!}` flipped valid → invalid; "Differences from ESLint" section removed
- `alt-text`: `<img alt={(undefined as any)!} />` flipped invalid → valid
- `no-autofocus`: `autoFocus={"false"!}` flipped valid → invalid

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/control-has-associated-label.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/control-has-associated-label.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).