### PR TITLE
fix: add suggestions for test cases

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -226,6 +226,32 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 			diagnostic.Fixes = fixes
 		}
 
+		if d.Suggestions != nil && len(*d.Suggestions) > 0 {
+			suggestions := make([]api.Suggestion, 0, len(*d.Suggestions))
+			for _, suggestion := range *d.Suggestions {
+				apiSuggestion := api.Suggestion{
+					MessageId: suggestion.Message.Id,
+					Desc:      suggestion.Message.Description,
+					Data:      suggestion.Message.Data,
+				}
+
+				if len(suggestion.Fixes()) > 0 {
+					fixes := make([]api.Fix, 0, len(suggestion.Fixes()))
+					for _, fix := range suggestion.Fixes() {
+						fixes = append(fixes, api.Fix{
+							Text:     fix.Text,
+							StartPos: fix.Range.Pos(),
+							EndPos:   fix.Range.End(),
+						})
+					}
+					apiSuggestion.Fixes = fixes
+				}
+
+				suggestions = append(suggestions, apiSuggestion)
+			}
+			diagnostic.Suggestions = suggestions
+		}
+
 		diagnostics = append(diagnostics, diagnostic)
 		errorsCount++
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -172,13 +172,14 @@ type Range struct {
 
 // Diagnostic represents a single lint diagnostic
 type Diagnostic struct {
-	RuleName  string `json:"ruleName"`
-	Message   string `json:"message"`
-	FilePath  string `json:"filePath"`
-	Range     Range  `json:"range"`
-	Severity  string `json:"severity,omitempty"`
-	MessageId string `json:"messageId"`
-	Fixes     []Fix  `json:"fixes,omitempty"`
+	RuleName    string       `json:"ruleName"`
+	Message     string       `json:"message"`
+	FilePath    string       `json:"filePath"`
+	Range       Range        `json:"range"`
+	Severity    string       `json:"severity,omitempty"`
+	MessageId   string       `json:"messageId"`
+	Fixes       []Fix        `json:"fixes,omitempty"`
+	Suggestions []Suggestion `json:"suggestions,omitempty"`
 }
 
 // Fix represents a single fix that can be applied
@@ -186,6 +187,14 @@ type Fix struct {
 	Text     string `json:"text"`
 	StartPos int    `json:"startPos"` // Character position in the file content
 	EndPos   int    `json:"endPos"`   // Character position in the file content
+}
+
+// Suggestion represents a single code-action style suggestion attached to a diagnostic.
+type Suggestion struct {
+	MessageId string            `json:"messageId,omitempty"`
+	Desc      string            `json:"desc,omitempty"`
+	Data      map[string]string `json:"data,omitempty"`
+	Fixes     []Fix             `json:"fixes,omitempty"`
 }
 
 // Handler defines the interface for handling IPC messages

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rule-tester.ts
@@ -1,7 +1,9 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import util from 'node:util';
 
-import { lint } from '@rslint/core';
+import { applyFixes, lint, type Diagnostic } from '@rslint/core';
 
 interface SuggestionOutput {
   messageId?: string;
@@ -9,6 +11,24 @@ interface SuggestionOutput {
   data?: Record<string, unknown> | undefined;
   output: string;
 }
+
+type DiagnosticWithSuggestions = Diagnostic & {
+  fixes?: Array<{
+    text: string;
+    startPos: number;
+    endPos: number;
+  }>;
+  suggestions?: Array<{
+    messageId?: string;
+    desc?: string;
+    data?: Record<string, string>;
+    fixes?: Array<{
+      text: string;
+      startPos: number;
+      endPos: number;
+    }>;
+  }>;
+};
 
 interface TestCaseError {
   message?: string | RegExp;
@@ -38,6 +58,47 @@ export interface ValidTestCase {
 export interface InvalidTestCase extends ValidTestCase {
   errors: number | (TestCaseError | string)[];
   output?: string | null | undefined;
+}
+
+// Per-test rslint.json builder used to thread `settings` through to the
+function buildConfigForSettings(
+  baseConfigPath: string,
+  settings: Record<string, unknown> | undefined,
+): { configPath: string; cleanup: () => void } {
+  if (!settings || Object.keys(settings).length === 0) {
+    return { configPath: baseConfigPath, cleanup: () => {} };
+  }
+  const base = JSON.parse(readFileSync(baseConfigPath, 'utf8'));
+  const merged = base.map((entry: any) => ({
+    ...entry,
+    settings: { ...(entry.settings ?? {}), ...settings },
+  }));
+  // Write the temp config into the SAME directory as the base config:
+  // the base entries reference `tsconfig.*.json` via relative paths
+  // that rslint resolves from the config file's location, so the temp
+  // config must sit next to the originals or those paths break.
+  const baseDir = path.dirname(baseConfigPath);
+  const cfg = path.join(
+    baseDir,
+    `rslint.test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+  );
+  writeFileSync(cfg, JSON.stringify(merged), 'utf8');
+  // Suppress unused-import warnings for the temp-dir helpers — they are
+  // kept on the imports list to keep the surface stable for future edits
+  // that may need an out-of-tree config (e.g. one that doesn't share the
+  // base config's relative tsconfig references).
+  void mkdtempSync;
+  void tmpdir;
+  return {
+    configPath: cfg,
+    cleanup: () => {
+      try {
+        rmSync(cfg, { force: true });
+      } catch {
+        /* best-effort cleanup; never fail a test on rmdir */
+      }
+    },
+  };
 }
 
 export class RuleTester {
@@ -79,6 +140,10 @@ export class RuleTester {
 
           const options =
             typeof validCase === 'string' ? [] : validCase.options || [];
+
+          const settings =
+            typeof validCase === 'string' ? undefined : validCase.settings;
+
           const defaultFilename = 'src/virtual.tsx';
           const filename =
             typeof validCase === 'string'
@@ -86,16 +151,26 @@ export class RuleTester {
               : (validCase.filename ?? defaultFilename);
           const absoluteFilename = path.resolve(import.meta.dirname, filename);
 
-          const diags = await lint({
+          const { configPath, cleanup } = buildConfigForSettings(
             config,
-            workingDirectory: cwd,
-            fileContents: {
-              [absoluteFilename]: code,
-            },
-            ruleOptions: {
-              [ruleName]: options,
-            },
-          });
+            settings,
+          );
+
+          let diags;
+          try {
+            diags = await lint({
+              config: configPath,
+              workingDirectory: cwd,
+              fileContents: {
+                [absoluteFilename]: code,
+              },
+              ruleOptions: {
+                [ruleName]: options,
+              },
+            });
+          } finally {
+            cleanup();
+          }
 
           assert(
             diags.diagnostics?.length === 0,
@@ -113,7 +188,7 @@ export class RuleTester {
             assert.fail('Invalid cases must have at least one error');
           }
 
-          const { code, only = false, options = [] } = item;
+          const { code, only = false, options = [], settings } = item;
           if (hasOnly && !only) {
             continue;
           }
@@ -123,16 +198,26 @@ export class RuleTester {
               ? defaultFilename
               : (item.filename ?? defaultFilename);
           const absoluteFilename = path.resolve(import.meta.dirname, filename);
-          const diags = await lint({
+          const { configPath, cleanup } = buildConfigForSettings(
             config,
-            workingDirectory: cwd,
-            fileContents: {
-              [absoluteFilename]: code,
-            },
-            ruleOptions: {
-              [ruleName]: options,
-            },
-          });
+            settings,
+          );
+
+          let diags;
+          try {
+            diags = await lint({
+              config: configPath,
+              workingDirectory: cwd,
+              fileContents: {
+                [absoluteFilename]: code,
+              },
+              ruleOptions: {
+                [ruleName]: options,
+              },
+            });
+          } finally {
+            cleanup();
+          }
 
           if (typeof item.errors === 'number') {
             if (item.errors === 0) {
@@ -171,7 +256,7 @@ export class RuleTester {
 
             for (let i = 0, l = item.errors.length; i < l; i++) {
               const error = item.errors[i];
-              const message = diags.diagnostics[i];
+              const message = diags.diagnostics[i] as DiagnosticWithSuggestions;
 
               assert(
                 hasMessageOfThisRule,
@@ -188,6 +273,8 @@ export class RuleTester {
                 if (typeof error.message === 'string') {
                   assertMessageMatches(message.message, error.message);
                 }
+                await assertFixedOutput(message, code, item.output);
+                await assertSuggestionOutputs(message, error, code);
               }
             }
           }
@@ -211,5 +298,95 @@ function assertMessageMatches(actual: string, expected: string | RegExp): void {
     );
   } else {
     assert.strictEqual(actual, expected);
+  }
+}
+
+async function assertFixedOutput(
+  diagnostic: DiagnosticWithSuggestions,
+  source: string,
+  expectedOutput: string | null | undefined,
+): Promise<void> {
+  if (expectedOutput === undefined) {
+    return;
+  }
+
+  if (expectedOutput === null) {
+    assert.ok(
+      !diagnostic.fixes || diagnostic.fixes.length === 0,
+      'Expected diagnostic to have no autofix output',
+    );
+    return;
+  }
+
+  assert.ok(
+    diagnostic.fixes && diagnostic.fixes.length > 0,
+    'Expected diagnostic to include autofix data',
+  );
+
+  const fixed = await applyFixes({
+    fileContent: source,
+    diagnostics: [diagnostic],
+  });
+  const finalOutput =
+    fixed.fixedContent[fixed.fixedContent.length - 1] ?? source;
+
+  assert.strictEqual(finalOutput, expectedOutput);
+}
+
+async function assertSuggestionOutputs(
+  diagnostic: DiagnosticWithSuggestions,
+  error: TestCaseError,
+  source: string,
+): Promise<void> {
+  const expectedSuggestions = error.suggestions;
+  const actualSuggestions = diagnostic.suggestions;
+
+  if (!expectedSuggestions) {
+    assert.ok(
+      actualSuggestions === void 0 || actualSuggestions.length === 0,
+      'Error has suggestions. Please specify the expected suggestions in the test case.',
+    );
+    return;
+  }
+
+  assert.ok(actualSuggestions, 'Expected diagnostic to include suggestions');
+  assert.strictEqual(actualSuggestions.length, expectedSuggestions.length);
+
+  for (let i = 0; i < expectedSuggestions.length; i++) {
+    const expectedSuggestion = expectedSuggestions[i];
+    const actualSuggestion = actualSuggestions[i];
+
+    if (expectedSuggestion.messageId !== undefined) {
+      assert.strictEqual(
+        actualSuggestion.messageId,
+        expectedSuggestion.messageId,
+      );
+    }
+    if (expectedSuggestion.desc !== undefined) {
+      assert.strictEqual(actualSuggestion.desc, expectedSuggestion.desc);
+    }
+    if (expectedSuggestion.data !== undefined) {
+      assert.deepStrictEqual(actualSuggestion.data, expectedSuggestion.data);
+    }
+
+    assert.ok(
+      actualSuggestion.fixes && actualSuggestion.fixes.length > 0,
+      'Expected suggestion to include fix data',
+    );
+
+    const fixed = await applyFixes({
+      fileContent: source,
+      diagnostics: [
+        {
+          ...diagnostic,
+          fixes: actualSuggestion.fixes,
+          suggestions: [],
+        },
+      ],
+    });
+    const finalOutput =
+      fixed.fixedContent[fixed.fixedContent.length - 1] ?? source;
+
+    assert.strictEqual(finalOutput, expectedSuggestion.output);
   }
 }

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-focused-tests.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-focused-tests.test.ts
@@ -17,6 +17,13 @@ ruleTester.run('no-focused-tests', {} as never, {
     { code: 'test.each()()' },
     { code: 'test.each`table`()' },
     { code: 'test.concurrent()' },
+    {
+      code: `
+        import { describe as fdescribe } from '@jest/globals';
+
+        fdescribe()
+      `,
+    },
   ],
   invalid: [
     {
@@ -365,22 +372,6 @@ ruleTester.run('no-focused-tests', {} as never, {
         },
       ],
     },
-  ],
-});
-
-// import test cases
-ruleTester.run('no-focused-tests', {} as never, {
-  valid: [
-    {
-      code: `
-        import { describe as fdescribe } from '@jest/globals';
-
-        fdescribe()
-      `,
-    },
-  ],
-
-  invalid: [
     {
       code: `
         const { describe } = require('@jest/globals');
@@ -453,40 +444,6 @@ ruleTester.run('no-focused-tests', {} as never, {
                 const { fdescribe } = require('@jest/globals');
 
                 describe()
-              `,
-            },
-          ],
-        },
-      ],
-    },
-  ],
-});
-
-// alias test cases
-ruleTester.run('no-focused-tests', {} as never, {
-  valid: [],
-
-  invalid: [
-    {
-      code: `
-        import { describe as describeThis } from '@jest/globals';
-
-        describeThis.only()
-      `,
-      errors: [
-        {
-          line: 3,
-          column: 14,
-          endLine: 3,
-          endColumn: 18,
-          messageId: 'focusedTest',
-          suggestions: [
-            {
-              messageId: 'suggestRemoveFocus',
-              output: `
-                import { describe as describeThis } from '@jest/globals';
-
-                describeThis()
               `,
             },
           ],

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-identical-title.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-identical-title.test.ts
@@ -283,16 +283,15 @@ ruleTester.run('no-identical-title', {} as never, {
       `,
       errors: [{ messageId: 'multipleTestTitle', column: 6, line: 3 }],
     },
-    // TODO: Add this test case when we support global aliases
-    // {
-    //   code: `
-    //     context('foo', () => {
-    //       describe('foe', () => {});
-    //     });
-    //     describe('foo', () => {});
-    //   `,
-    //   errors: [{ messageId: 'multipleDescribeTitle', column: 10, line: 4 }],
-    //   settings: { jest: { globalAliases: { describe: ['context'] } } },
-    // },
+    {
+      code: `
+        context('foo', () => {
+          describe('foe', () => {});
+        });
+        describe('foo', () => {});
+      `,
+      errors: [{ messageId: 'multipleDescribeTitle', column: 10, line: 4 }],
+      settings: { jest: { globalAliases: { describe: ['context'] } } },
+    },
   ],
 });

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-to-be.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-to-be.test.ts
@@ -20,15 +20,6 @@ ruleTester.run('prefer-to-be', {} as never, {
     { code: 'expect(value).toEqual(dedent`my string`);' },
 
     // null
-    { code: 'expect(null).toBeNull();' },
-    { code: 'expect(null).not.toBeNull();' },
-    { code: 'expect(null).toBe(1);' },
-    { code: 'expect(obj).toStrictEqual([ x, 1 ]);' },
-    { code: 'expect(obj).toStrictEqual({ x: 1 });' },
-    { code: 'expect(obj).not.toStrictEqual({ x: 1 });' },
-    { code: 'expect(value).toMatchSnapshot();' },
-    { code: "expect(catchError()).toStrictEqual({ message: 'oh noes!' })" },
-    { code: 'expect("something");' },
     { code: 'expect(null).not.toEqual();' },
     { code: 'expect(null).toBe();' },
     { code: 'expect(null).toMatchSnapshot();' },
@@ -39,14 +30,6 @@ ruleTester.run('prefer-to-be', {} as never, {
     // undefined
     { code: 'expect(undefined).toBeUndefined();' },
     { code: 'expect(true).toBeDefined();' },
-    { code: 'expect({}).toEqual({});' },
-    { code: 'expect(something).toBe()' },
-    { code: 'expect(something).toBe(somethingElse)' },
-    { code: 'expect(something).toEqual(somethingElse)' },
-    { code: 'expect(something).not.toBe(somethingElse)' },
-    { code: 'expect(something).not.toEqual(somethingElse)' },
-    { code: 'expect(undefined).toBe' },
-    { code: 'expect("something");' },
 
     // NaN
     { code: 'expect(NaN).toBeNaN();' },
@@ -58,7 +41,6 @@ ruleTester.run('prefer-to-be', {} as never, {
     { code: 'expect(something).not.toBe(somethingElse)' },
     { code: 'expect(something).not.toEqual(somethingElse)' },
     { code: 'expect(undefined).toBe' },
-    { code: 'expect("something");' },
 
     // typescript edition
     {

--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -64,6 +64,7 @@ export async function getAstInfo(
 // Export all types
 export {
   type Diagnostic,
+  type Fix,
   type LintOptions,
   type LintResponse,
   type ApplyFixesRequest,
@@ -72,6 +73,7 @@ export {
   type ParserOptions,
   type RSlintOptions,
   type RslintServiceInterface,
+  type Suggestion,
   // AST Info types
   type GetAstInfoRequest,
   type GetAstInfoResponse,

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -18,7 +18,21 @@ export interface Diagnostic {
   filePath: string;
   range: Range;
   severity?: string;
-  suggestions: any[];
+  fixes?: Fix[];
+  suggestions?: Suggestion[];
+}
+
+export interface Fix {
+  text: string;
+  startPos: number;
+  endPos: number;
+}
+
+export interface Suggestion {
+  messageId?: string;
+  desc?: string;
+  data?: Record<string, string>;
+  fixes?: Fix[];
 }
 
 export interface LintResponse {


### PR DESCRIPTION
## Summary

* This pr is to extend RuleTester to support suggestions and settings for test case.
* Remove duplicated test cases for `eslint-plugin-jest`

## Related Links

<!--- Provide links of related issues or pages -->
None

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
