### PR TITLE
feat: port rule jsx-a11y/mouse-events-have-key-events

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -17,6 +17,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/img_redundant_alt"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/interactive_supports_focus"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/media_has_caption"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_access_key"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_autofocus"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_distracting_elements"
@@ -45,6 +46,7 @@ func GetAllRules() []rule.Rule {
 		img_redundant_alt.ImgRedundantAltRule,
 		interactive_supports_focus.InteractiveSupportsFocusRule,
 		media_has_caption.MediaHasCaptionRule,
+		mouse_events_have_key_events.MouseEventsHaveKeyEventsRule,
 		no_access_key.NoAccessKeyRule,
 		no_autofocus.NoAutofocusRule,
 		no_distracting_elements.NoDistractingElementsRule,

--- a/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events.go
+++ b/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events.go
@@ -1,0 +1,184 @@
+// Package mouse_events_have_key_events ports eslint-plugin-jsx-a11y's
+// `mouse-events-have-key-events` rule. Enforces that any HTML DOM element
+// carrying a configured "hover-in" handler (default: onMouseOver) also
+// carries a non-null `onFocus`, and that any "hover-out" handler (default:
+// onMouseOut) is paired with `onBlur`. Keyboard-only users rely on
+// focus / blur events to get the same affordance the mouse handlers
+// expose.
+//
+// Upstream signature:
+//
+//	options: {
+//	  hoverInHandlers?:  string[]  // default ['onMouseOver']
+//	  hoverOutHandlers?: string[]  // default ['onMouseOut']
+//	}
+//
+// Per-element flow (upstream JSXOpeningElement listener):
+//
+//  1. Resolve `name` via `node.name.name` — NOTE: upstream reads the raw
+//     tag name directly, NOT the `getElementType(context)(node)` helper
+//     other jsx-a11y rules use. So `settings['jsx-a11y'].components` and
+//     `polymorphicPropName` do NOT apply here — `<Foo as="div" />` and
+//     `settings.components.Footer = 'footer'` are both treated as custom
+//     components. We mirror by passing the raw `GetJsxElementTypeString`
+//     output through `IsDOMElement`.
+//  2. `dom.get(name)` must be truthy → tag is in aria-query's HTML DOM
+//     map. Custom components (`<MyElement>`) and member-expression /
+//     namespaced tags (`<Foo.Bar>`, `<svg:path>`) are skipped — the rule
+//     doesn't know what low-level element they render.
+//  3. For each configured `hoverInHandlers` entry, find the FIRST one
+//     whose `getProp` exists AND whose `getPropValue` is `!= null` (loose:
+//     excludes literal `null` / `undefined`, but accepts the boolean
+//     attribute form `<div onMouseOver />` which extracts to JS `true`).
+//     If none found → no hover-in pairing required.
+//  4. If hover-in handler found → check `onFocus` presence + non-null
+//     value via the same `getProp` + `getPropValue != null` semantics.
+//     If missing → report on the hover-in attribute.
+//  5. Same flow for `hoverOutHandlers` + `onBlur`.
+//
+// A single element can produce both diagnostics independently when both
+// pairings are missing.
+package mouse_events_have_key_events
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// defaultHoverInHandlers / defaultHoverOutHandlers mirror upstream's
+// `DEFAULT_HOVER_IN_HANDLERS` / `DEFAULT_HOVER_OUT_HANDLERS`. Used when
+// the option key is absent or explicitly `undefined` per upstream's
+// `options[0]?.hoverInHandlers ?? DEFAULT_*` semantics. An EXPLICIT
+// empty array (`{ hoverInHandlers: [] }`) is a deliberate "check nothing"
+// signal and is NOT replaced with the default — upstream's `??` only
+// catches nullish values.
+var (
+	defaultHoverInHandlers  = []string{"onMouseOver"}
+	defaultHoverOutHandlers = []string{"onMouseOut"}
+)
+
+type options struct {
+	HoverInHandlers  []string
+	HoverOutHandlers []string
+}
+
+func parseOptions(raw any) options {
+	opts := options{
+		HoverInHandlers:  defaultHoverInHandlers,
+		HoverOutHandlers: defaultHoverOutHandlers,
+	}
+	optsMap := utils.GetOptionsMap(raw)
+	if optsMap == nil {
+		return opts
+	}
+	// Explicit empty array stays empty; a non-array / missing key falls
+	// back to the upstream defaults via `??`. StringSliceOption returns
+	// nil for non-`[]interface{}` inputs and a non-nil zero-length slice
+	// for `[]`, so the `nil` check below distinguishes the two cases.
+	if v, ok := optsMap["hoverInHandlers"]; ok {
+		parsed := jsxa11yutil.StringSliceOption(v)
+		if parsed != nil {
+			opts.HoverInHandlers = parsed
+		}
+	}
+	if v, ok := optsMap["hoverOutHandlers"]; ok {
+		parsed := jsxa11yutil.StringSliceOption(v)
+		if parsed != nil {
+			opts.HoverOutHandlers = parsed
+		}
+	}
+	return opts
+}
+
+// firstHoverHandlerWithValue mirrors upstream's
+//
+//	hoverInHandlers.find((handler) => {
+//	  const prop = getProp(attributes, handler);
+//	  const propValue = getPropValue(prop);
+//	  return propValue != null;
+//	});
+//
+// Returns the handler name and its attribute node (used for the report
+// position), or ("", nil) when no configured handler is present with a
+// non-null value.
+func firstHoverHandlerWithValue(attrs []*ast.Node, handlers []string) (string, *ast.Node) {
+	for _, handler := range handlers {
+		prop := jsxa11yutil.FindAttributeByName(attrs, handler)
+		if prop == nil {
+			continue
+		}
+		// `getPropValue(prop) != null` (loose inequality).
+		// PropValueIsNullish encodes the inverse: true when the
+		// extracted value is null / undefined / unresolvable.
+		if jsxa11yutil.PropValueIsNullish(prop) {
+			continue
+		}
+		return handler, prop
+	}
+	return "", nil
+}
+
+// pairAttributeIsMissing mirrors upstream's
+//
+//	const hasOn{Focus,Blur} = getProp(attributes, 'on{Focus,Blur}');
+//	const on{...}Value = getPropValue(hasOn{...});
+//	hasOn{...} === false || on{...}Value === null || on{...}Value === undefined
+//
+// `hasOn === false` is never reached in practice (jsx-ast-utils returns
+// `undefined` when missing), so the gate simplifies to "absent or value
+// is nullish".
+func pairAttributeIsMissing(attrs []*ast.Node, pairName string) bool {
+	prop := jsxa11yutil.FindAttributeByName(attrs, pairName)
+	if prop == nil {
+		return true
+	}
+	return jsxa11yutil.PropValueIsNullish(prop)
+}
+
+var MouseEventsHaveKeyEventsRule = rule.Rule{
+	Name: "jsx-a11y/mouse-events-have-key-events",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		check := func(node *ast.Node) {
+			// Upstream reads `node.name.name` — the raw JSX tag identifier
+			// — directly, without applying `getElementType(context)`. We
+			// mirror by passing the raw string to IsDOMElement, which
+			// short-circuits non-Identifier tags (member-expression,
+			// namespaced) since their stringified forms aren't in
+			// aria-query's `dom` map.
+			name := reactutil.GetJsxElementTypeString(node)
+			if !jsxa11yutil.IsDOMElement(name) {
+				return
+			}
+
+			attrs := reactutil.GetJsxElementAttributes(node)
+
+			if hoverIn, hoverInProp := firstHoverHandlerWithValue(attrs, opts.HoverInHandlers); hoverInProp != nil {
+				if pairAttributeIsMissing(attrs, "onFocus") {
+					ctx.ReportNode(hoverInProp, rule.RuleMessage{
+						Id:          "mouseOver",
+						Description: hoverIn + " must be accompanied by onFocus for accessibility.",
+					})
+				}
+			}
+
+			if hoverOut, hoverOutProp := firstHoverHandlerWithValue(attrs, opts.HoverOutHandlers); hoverOutProp != nil {
+				if pairAttributeIsMissing(attrs, "onBlur") {
+					ctx.ReportNode(hoverOutProp, rule.RuleMessage{
+						Id:          "mouseOut",
+						Description: hoverOut + " must be accompanied by onBlur for accessibility.",
+					})
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events.md
+++ b/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events.md
@@ -1,0 +1,100 @@
+# mouse-events-have-key-events
+
+## Rule Details
+
+Enforce that hover-style mouse event handlers on HTML DOM elements are
+accompanied by their keyboard-equivalent focus listeners. Coding for the
+keyboard is important for users with physical disabilities, assistive
+technology compatibility, and screen-reader navigation: a button or card
+that only responds to `onMouseOver` is invisible to anyone who cannot
+move a pointer.
+
+By default, the rule checks two pairings:
+
+- `onMouseOver` must be accompanied by `onFocus`
+- `onMouseOut` must be accompanied by `onBlur`
+
+For each configured hover-in handler whose value is not `null` /
+`undefined`, the rule looks for an `onFocus` attribute whose value is
+also not `null` / `undefined`. Same flow for hover-out handlers and
+`onBlur`. The report sits on the offending mouse-handler attribute.
+
+Custom React components (`<MyButton>`, `<Foo.Bar>`, `<svg:circle>`) are
+skipped — the rule does not know which low-level element they render.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div onMouseOver={() => void 0} />
+<div onMouseOut={() => void 0} />
+<div onMouseOver={() => void 0} onFocus={undefined} />
+<div onMouseOut={() => void 0} onBlur={undefined} />
+<div onMouseOver={() => void 0} {...otherProps} />
+<div onMouseOut={() => void 0} {...otherProps} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div onMouseOver={() => void 0} onFocus={() => void 0} />
+<div onMouseOut={() => void 0} onBlur={() => void 0} />
+<div onMouseOver={() => void 0} onFocus={() => void 0} {...otherProps} />
+<div onMouseOut={() => void 0} onBlur={() => void 0} {...otherProps} />
+<MyComponent onMouseOver={() => void 0} />
+```
+
+## Rule Options
+
+The rule accepts an options object with two array fields. Each field
+lists the attribute names that should trigger the corresponding pairing
+check. When provided, an explicit list **replaces** the defaults — the
+canonical `onMouseOver` / `onMouseOut` names are not auto-included, so
+add them yourself if you want both default behavior and additional
+checks.
+
+```json
+{
+  "jsx-a11y/mouse-events-have-key-events": [
+    "error",
+    {
+      "hoverInHandlers": [
+        "onMouseOver",
+        "onMouseEnter",
+        "onPointerOver",
+        "onPointerEnter"
+      ],
+      "hoverOutHandlers": [
+        "onMouseOut",
+        "onMouseLeave",
+        "onPointerOut",
+        "onPointerLeave"
+      ]
+    }
+  ]
+}
+```
+
+Examples of **incorrect** code with the options above:
+
+```jsx
+<div onPointerEnter={() => void 0} />
+<div onPointerLeave={() => void 0} />
+```
+
+Examples of **correct** code with the options above:
+
+```jsx
+<div onPointerEnter={() => void 0} onFocus={() => void 0} />
+<div onPointerLeave={() => void 0} onBlur={() => void 0} />
+```
+
+An explicit empty array (`{ "hoverInHandlers": [] }`) disables the
+corresponding pairing entirely.
+
+## Resources
+
+- [WCAG 2.1.1 — Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/mouse-events-have-key-events](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/mouse-events-have-key-events.md)

--- a/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events_extras_test.go
@@ -1,0 +1,931 @@
+package mouse_events_have_key_events
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// This file holds test cases NOT in upstream's own test file. Upstream-parity
+// cases live in mouse_events_have_key_events_upstream_test.go so it stays
+// trivially comparable against future upstream updates via diff.
+//
+// Coverage axes:
+//
+//   - Dimension 1 (AST node shape): tsgo's parenthesized / `as` /
+//     `satisfies` / `!` wrappers on hover-handler values; JsxSelfClosingElement
+//     vs paired JsxElement boundary; literal-spread vs non-literal-spread
+//     for both the hover handler and the pair attribute.
+//   - Dimension 2 (scoping / nesting): nested JSX where listener must
+//     classify each element independently — outer hover-paired, inner
+//     missing pair, and vice versa.
+//   - Dimension 4 (universal edge shapes): attribute existence forms
+//     (boolean, `={null}`, `={undefined}`), case-insensitive matching
+//     on both hover-handler names and the `onFocus` / `onBlur` pair,
+//     multi-line opening-element position anchoring, multi-attribute
+//     same-element reports.
+//   - Upstream branch lock-in: hoverInHandlers `.find(handler => …)`
+//     short-circuits on the FIRST handler with a non-null value — the
+//     subsequent handler is irrelevant to the report; settings-style
+//     misuse (`settings.components`) is intentionally not honored per
+//     upstream's `node.name.name` raw read.
+
+// extras-only error templates — reused across the file.
+var (
+	pointerEnterErrorAtCol6 = rule_tester.InvalidTestCaseError{
+		MessageId: "mouseOver",
+		Message:   "onPointerEnter must be accompanied by onFocus for accessibility.",
+		Line:      1,
+		Column:    6,
+	}
+	pointerLeaveErrorAtCol6 = rule_tester.InvalidTestCaseError{
+		MessageId: "mouseOut",
+		Message:   "onPointerLeave must be accompanied by onBlur for accessibility.",
+		Line:      1,
+		Column:    6,
+	}
+	// {mouseOver,mouseOut}ErrorAnyPos — the standard diagnostic without
+	// fixed Line/Column. Use when the JSX opening element is buried inside
+	// a wrapper (forwardRef / memo / HOC / map / class / IIFE / async /
+	// generator / conditional / fragment) where the column offset is
+	// brittle and the test's value is "fires at all", not "fires exactly
+	// at column N". The Line/Column == 0 fields are skipped by the
+	// rule_tester (see internal/rule_tester/rule_tester.go assertions).
+	mouseOverErrorAnyPos = rule_tester.InvalidTestCaseError{
+		MessageId: "mouseOver",
+		Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+	}
+	mouseOutErrorAnyPos = rule_tester.InvalidTestCaseError{
+		MessageId: "mouseOut",
+		Message:   "onMouseOut must be accompanied by onBlur for accessibility.",
+	}
+)
+
+// TestMouseEventsHaveKeyEventsExtras locks in branches that upstream's
+// test file doesn't exercise but are reachable through the rule's
+// listener gate.
+func TestMouseEventsHaveKeyEventsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &MouseEventsHaveKeyEventsRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// Dimension 1: hover-handler value forms that count as nullish
+			// (propValue == null) — rule short-circuits before checking
+			// the pair attribute.
+			// ============================================================
+
+			// ---- onMouseOver={null} — extracted value is null → not
+			//      counted as a hover-in handler → no pair check. ----
+			{Code: `<div onMouseOver={null} />`, Tsx: true},
+			// ---- onMouseOver={undefined} — extracted undefined → skipped. ----
+			{Code: `<div onMouseOver={undefined} />`, Tsx: true},
+			// ---- onMouseOut={null} / {undefined} — same on the hover-out side. ----
+			{Code: `<div onMouseOut={null} />`, Tsx: true},
+			{Code: `<div onMouseOut={undefined} />`, Tsx: true},
+
+			// ---- Parens + `as` are unwrapped by staticEval (skipTransparent
+			//      strips parens + TS assertions); `!` (NonNullExpression) is
+			//      NOT — upstream jsx-ast-utils' TSNonNullExpression extractor
+			//      returns the stringified `"<inner>!"` form which is non-null
+			//      non-undefined truthy, so `<X attr={null!} />` does NOT
+			//      classify as nullish. The `null!` / `undefined!` cases move
+			//      to invalid below. ----
+			{Code: `<div onMouseOver={(null)} />`, Tsx: true},
+			{Code: `<div onMouseOver={null as any} />`, Tsx: true},
+			// ---- Pair value `null!` — upstream jsx-ast-utils' TSNonNullExpression
+			//      extractor returns the stringified `"null!"` (non-null
+			//      non-undefined truthy), so the pair is counted as present
+			//      and no diagnostic fires. Differential-validated against
+			//      eslint-plugin-jsx-a11y@6.10.2 — this is the corner case
+			//      that #915's jsxa11yutil fix aligned to upstream. ----
+			{Code: `<div onMouseOver={fn} onFocus={null!} />`, Tsx: true},
+			// ---- Pair value `undefined!` — same shape: string `"undefined!"`
+			//      is truthy non-null → pair counted as present → valid. ----
+			{Code: `<div onMouseOver={fn} onFocus={undefined!} />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1: paired-form `<div ...></div>` — tsgo emits
+			// KindJsxOpeningElement; rule fires on the OpeningElement
+			// regardless of whether `</div>` follows.
+			// ============================================================
+
+			// ---- Paired form, properly paired handlers. ----
+			{Code: `<div onMouseOver={() => void 0} onFocus={() => void 0}>label</div>`, Tsx: true},
+			{Code: `<div onMouseOut={() => void 0} onBlur={() => void 0}>label</div>`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1: case-insensitive attribute matching (upstream's
+			// getProp default `ignoreCase: true`). Lock both sides.
+			// ============================================================
+
+			// ---- All-lowercase hover + pair — both match case-insensitively. ----
+			{Code: `<div onmouseover={() => {}} onfocus={() => {}} />`, Tsx: true},
+			{Code: `<div onmouseout={() => {}} onblur={() => {}} />`, Tsx: true},
+			// ---- ALL-CAPS hover + pair. ----
+			{Code: `<div ONMOUSEOVER={() => {}} ONFOCUS={() => {}} />`, Tsx: true},
+			// ---- Mixed case: hover in canonical case, pair in lowercase. ----
+			{Code: `<div onMouseOver={() => {}} onfocus={() => {}} />`, Tsx: true},
+			{Code: `<div onMouseOut={() => {}} onblur={() => {}} />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1: TS-wrapped non-null pair value — staticEval
+			// unwraps so the pair still resolves to a non-null value.
+			// ============================================================
+
+			// ---- onFocus={(fn)} — paren wrapper. ----
+			{Code: `<div onMouseOver={fn} onFocus={(fn)} />`, Tsx: true},
+			// ---- onFocus={fn as any} — TS as cast. ----
+			{Code: `<div onMouseOver={fn} onFocus={fn as any} />`, Tsx: true},
+			// ---- onFocus={fn!} — TS non-null assertion. ----
+			{Code: `<div onMouseOver={fn} onFocus={fn!} />`, Tsx: true},
+
+			// ============================================================
+			// Element-type classification: non-DOM tag shapes skip the rule
+			// before any pairing check. Member-expression and namespaced
+			// tag names stringify to a form NOT in aria-query's `dom` map.
+			// ============================================================
+
+			// ---- `<Foo.Bar onMouseOver={fn} />` — "Foo.Bar" not in dom map. ----
+			{Code: `<Foo.Bar onMouseOver={() => {}} />`, Tsx: true},
+			// ---- `<Foo.Bar.Baz onMouseOut={fn} />` — same, deeper chain. ----
+			{Code: `<Foo.Bar.Baz onMouseOut={() => {}} />`, Tsx: true},
+			// ---- `<this.Foo onMouseOver={fn} />` — "this.Foo" not in dom map. ----
+			{Code: `<this.Foo onMouseOver={() => {}} />`, Tsx: true},
+			// ---- Lowercase member-expression also escapes — even though
+			//      it would be a DOM-component classification, the dotted
+			//      string is not in aria-query's `dom`. ----
+			{Code: `<foo.bar onMouseOver={() => {}} />`, Tsx: true},
+			// ---- Namespaced tag — "svg:circle" not in aria-query's `dom`. ----
+			{Code: `<svg:circle onMouseOver={() => {}} />`, Tsx: true},
+
+			// ============================================================
+			// Upstream NEVER respects settings.components / polymorphicPropName
+			// for this rule (it reads `node.name.name` directly). Lock the
+			// raw-name behavior — `<Footer>` with components map should
+			// NOT trigger even when the map would resolve to `footer`.
+			// ============================================================
+
+			// ---- settings.components map ignored — rule reads raw name. ----
+			{
+				Code: `<Footer onMouseOver={() => {}} />`,
+				Tsx:  true,
+				Settings: map[string]interface{}{
+					"jsx-a11y": map[string]interface{}{
+						"components": map[string]interface{}{
+							"Footer": "footer",
+						},
+					},
+				},
+			},
+			// ---- settings.polymorphicPropName ignored too. ----
+			{
+				Code: `<Foo as="div" onMouseOver={() => {}} />`,
+				Tsx:  true,
+				Settings: map[string]interface{}{
+					"jsx-a11y": map[string]interface{}{
+						"polymorphicPropName": "as",
+					},
+				},
+			},
+
+			// ============================================================
+			// Nesting: pair-check applies independently to each element.
+			// ============================================================
+
+			// ---- Outer + inner BOTH have pairs. ----
+			{
+				Code: `<div onMouseOver={fn} onFocus={fn}>` +
+					`<span onMouseOver={fn} onFocus={fn} />` +
+					`</div>`,
+				Tsx: true,
+			},
+
+			// ============================================================
+			// Multiple hover-in handlers in custom options — find returns
+			// the FIRST one with a non-null value. Add an onFocus and the
+			// rule passes regardless of which one was found first.
+			// ============================================================
+			{
+				Code: `<div onMouseOver={fn} onMouseEnter={fn} onFocus={fn} />`,
+				Tsx:  true,
+				Options: []interface{}{map[string]interface{}{
+					"hoverInHandlers": []interface{}{"onMouseOver", "onMouseEnter"},
+				}},
+			},
+			// ---- First listed handler is null, second has a value — only
+			//      the second triggers the pair check, which onFocus satisfies. ----
+			{
+				Code: `<div onMouseOver={null} onMouseEnter={fn} onFocus={fn} />`,
+				Tsx:  true,
+				Options: []interface{}{map[string]interface{}{
+					"hoverInHandlers": []interface{}{"onMouseOver", "onMouseEnter"},
+				}},
+			},
+
+			// ============================================================
+			// Real-world component patterns — properly paired across
+			// HOC / forwardRef / map / hooks shapes.
+			// ============================================================
+
+			// ---- forwardRef with paired handlers. ----
+			{
+				Code: `const Btn = React.forwardRef((props, ref) => <div ref={ref} onMouseOver={props.onHover} onFocus={props.onFocus} />);`,
+				Tsx:  true,
+			},
+			// ---- map() over items, each item paired. ----
+			{
+				Code: `const list = items.map(item => <li key={item.id} onMouseOver={() => hover(item)} onFocus={() => focus(item)}>{item.label}</li>);`,
+				Tsx:  true,
+			},
+			// ---- async function returning paired element. ----
+			{
+				Code: `async function render() { return <div onMouseOver={fn} onFocus={fn} />; }`,
+				Tsx:  true,
+			},
+			// ---- Conditional rendering: both branches paired. ----
+			{
+				Code: `const x = cond ? <div onMouseOver={fn} onFocus={fn} /> : <span onMouseOut={fn} onBlur={fn} />;`,
+				Tsx:  true,
+			},
+
+			// ============================================================
+			// staticEval branches: `||`, `&&`, `??`, ternary on hover-handler
+			// value. Statically-nullish results short-circuit before pair
+			// check; statically-truthy results trigger pair check normally.
+			// ============================================================
+
+			// ---- `null || null` → null → nullish → no pair check needed. ----
+			{Code: `<div onMouseOver={null || null} />`, Tsx: true},
+			// ---- `null ?? undefined` → undefined → nullish → skip. ----
+			{Code: `<div onMouseOut={null ?? undefined} />`, Tsx: true},
+			// ---- `false ? f : null` → static-false → use whenFalse `null`
+			//      → nullish → skip. Locks ConditionalExpression branching. ----
+			{Code: `<div onMouseOver={false ? f : null} />`, Tsx: true},
+			// ---- `false && fn` → false (LHS falsy short-circuits) →
+			//      coerced-falsy not equal to null exactly, BUT staticEval
+			//      returns the boolean false, which is `false != null` →
+			//      counted as PRESENT. Pair must be present too. With
+			//      paired onFocus, valid. ----
+			{
+				Code: `<div onMouseOver={false && fn} onFocus={fn} />`,
+				Tsx:  true,
+			},
+
+			// ============================================================
+			// Boolean attribute form on the PAIR. `<div ... onFocus />`
+			// extracts to JS `true` (extractValue's null-attribute path) →
+			// pair is counted as present → no report.
+			// ============================================================
+
+			// ---- Boolean-form hover + boolean-form pair. ----
+			{Code: `<div onMouseOver onFocus />`, Tsx: true},
+			{Code: `<div onMouseOut onBlur />`, Tsx: true},
+			// ---- Mixed: explicit hover, boolean pair. ----
+			{Code: `<div onMouseOver={fn} onFocus />`, Tsx: true},
+			{Code: `<div onMouseOut={fn} onBlur />`, Tsx: true},
+
+			// ============================================================
+			// Non-aria-query DOM elements skip the rule entirely. SVG tags
+			// (`<svg>`, `<path>`, `<circle>`, …) are NOT in aria-query's
+			// `dom` map — even though they're real DOM elements at runtime,
+			// upstream's `dom.get('svg')` returns undefined → skip.
+			// ============================================================
+
+			{Code: `<svg onMouseOver={() => {}} />`, Tsx: true},
+			{Code: `<path onMouseOver={() => {}} />`, Tsx: true},
+			{Code: `<circle onMouseOver={() => {}} />`, Tsx: true},
+
+			// ============================================================
+			// Options shape: bare-map form (CLI / single-option config).
+			// PORT_RULE.md requires exercising the JSON path on both shapes.
+			// utils.GetOptionsMap accepts either array-wrapped or bare map;
+			// the linter unwraps single-element option arrays to bare map
+			// before calling Run, so the CLI shape is what real users hit.
+			// ============================================================
+
+			// ---- Bare-map options (CLI shape) with custom hoverIn. ----
+			{
+				Code:    `<div onMouseEnter={() => {}} onFocus={() => {}} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"hoverInHandlers": []interface{}{"onMouseEnter"}},
+			},
+			// ---- Bare-map options with custom hoverOut. ----
+			{
+				Code:    `<div onMouseLeave={() => {}} onBlur={() => {}} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"hoverOutHandlers": []interface{}{"onMouseLeave"}},
+			},
+			// ---- Bare-map empty object → no keys → fall back to defaults
+			//      → `<div onMouseOver={fn} onFocus={fn} />` is paired. ----
+			{
+				Code:    `<div onMouseOver={fn} onFocus={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{},
+			},
+			// ---- Array-wrapped empty object → same as bare empty map →
+			//      defaults apply. ----
+			{
+				Code:    `<div onMouseOver={fn} onFocus={fn} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{}},
+			},
+			// ---- Empty option array → falls back to all defaults. ----
+			{
+				Code:    `<div onMouseOver={fn} onFocus={fn} />`,
+				Tsx:     true,
+				Options: []interface{}{},
+			},
+			// ---- Malformed options: non-string entries are filtered by
+			//      StringSliceOption. Remaining ["onMouseOver"] becomes
+			//      the effective hoverIn list. ----
+			{
+				Code:    `<div onMouseOver={fn} onFocus={fn} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverInHandlers": []interface{}{1, true, "onMouseOver"}}},
+			},
+			// ---- Malformed hoverInHandlers — not an array → StringSliceOption
+			//      returns nil → defaults apply → `<div onMouseOver={fn}
+			//      onFocus={fn} />` paired. ----
+			{
+				Code:    `<div onMouseOver={fn} onFocus={fn} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverInHandlers": "onMouseOver"}},
+			},
+
+			// ============================================================
+			// ShorthandPropertyAssignment in literal spread — `getProp`
+			// walks literal spreads (default spreadStrict: false). The
+			// shorthand `{...{onFocus}}` matches just like
+			// `{...{onFocus: onFocus}}`.
+			// ============================================================
+
+			// ---- Pair via shorthand spread. ----
+			{Code: `<div onMouseOver={fn} {...{onFocus}} />`, Tsx: true},
+			// ---- Hover via shorthand spread, pair via direct attribute. ----
+			{Code: `<div {...{onMouseOver}} onFocus={fn} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Dimension 1: boolean attribute form — extractValue's null-attr
+			// path yields JS true → `true != null` → counted as present
+			// hover handler → pair check fires → missing → reports.
+			// ============================================================
+
+			// ---- `<div onMouseOver />` — boolean form, no onFocus. ----
+			{
+				Code:   `<div onMouseOver />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			// ---- `<div onMouseOut />` boolean form, no onBlur. ----
+			{
+				Code:   `<div onMouseOut />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOutErrorAtCol6},
+			},
+			// ---- Boolean hover + boolean pair: pair extractValue = true
+			//      → != null → pair COUNTED → no report. (Validates that
+			//      `<div onMouseOver onFocus />` is the boolean-pairing
+			//      escape hatch.) ----
+
+			// ============================================================
+			// Dimension 1: pair attribute set to a nullish value — counted
+			// as missing pair → reports. Mirrors upstream's `null ||
+			// undefined` arm.
+			// ============================================================
+
+			// ---- onFocus={null} — same effect as `onFocus={undefined}`. ----
+			{
+				Code:   `<div onMouseOver={fn} onFocus={null} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			// ---- onBlur={null}. ----
+			{
+				Code:   `<div onMouseOut={fn} onBlur={null} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOutErrorAtCol6},
+			},
+
+			// ============================================================
+			// Dimension 1: case-insensitive — uppercase / lowercase handler
+			// matches against the default `onMouseOver` / `onMouseOut`.
+			// ============================================================
+
+			// ---- All-lowercase handler, no pair. ----
+			{
+				Code:   `<div onmouseover={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			{
+				Code:   `<div onmouseout={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOutErrorAtCol6},
+			},
+			// ---- ALL-CAPS handler with no pair. ----
+			{
+				Code: `<div ONMOUSEOVER={() => {}} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+					Line:      1,
+					Column:    6,
+				}},
+			},
+
+			// ============================================================
+			// Both hover-in and hover-out missing on the same element with
+			// default options — both reports fire. Defaults only check
+			// onMouseOver / onMouseOut, so we exercise the canonical pair.
+			// ============================================================
+
+			{
+				Code: `<div onMouseOver={() => {}} onMouseOut={() => {}} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "mouseOver",
+						Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+						Line:      1,
+						Column:    6,
+					},
+					{
+						MessageId: "mouseOut",
+						Message:   "onMouseOut must be accompanied by onBlur for accessibility.",
+						Line:      1,
+						Column:    29,
+					},
+				},
+			},
+
+			// ============================================================
+			// Multi-line opening element — Line/Column anchor to the
+			// hover-handler attribute, NOT the element start.
+			// ============================================================
+
+			{
+				Code: `<div` + "\n" +
+					`  onMouseOver={() => void 0}` + "\n" +
+					`/>;`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+					Line:      2,
+					Column:    3,
+				}},
+			},
+
+			// ============================================================
+			// Nested JSX — listener visits inner element independently.
+			// Outer paired (valid), inner missing pair (invalid).
+			// ============================================================
+
+			{
+				Code: `<div onMouseOver={fn} onFocus={fn}>` + "\n" +
+					`  <span onMouseOver={fn} />` + "\n" +
+					`</div>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+					Line:      2,
+					Column:    9,
+				}},
+			},
+
+			// ============================================================
+			// Custom hoverIn list with multiple entries — `find` returns
+			// the FIRST handler whose value is non-null. The report carries
+			// the FIRST matched name. Locks the iteration-order guarantee.
+			// ============================================================
+
+			{
+				Code: `<div onMouseOver={fn} onMouseEnter={fn} />`,
+				Tsx:  true,
+				Options: []interface{}{map[string]interface{}{
+					"hoverInHandlers": []interface{}{"onMouseOver", "onMouseEnter"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+					Line:      1,
+					Column:    6,
+				}},
+			},
+			// ---- First handler is null → skipped; second handler has
+			//      value → reported under the SECOND name. ----
+			{
+				Code: `<div onMouseOver={null} onMouseEnter={fn} />`,
+				Tsx:  true,
+				Options: []interface{}{map[string]interface{}{
+					"hoverInHandlers": []interface{}{"onMouseOver", "onMouseEnter"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseEnter must be accompanied by onFocus for accessibility.",
+					Line:      1,
+					Column:    25,
+				}},
+			},
+
+			// ============================================================
+			// Pointer-event variant lock-in via custom options.
+			// ============================================================
+
+			{
+				Code: `<div onPointerEnter={() => void 0} />`,
+				Tsx:  true,
+				Options: []interface{}{map[string]interface{}{
+					"hoverInHandlers": []interface{}{"onPointerEnter"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{pointerEnterErrorAtCol6},
+			},
+			{
+				Code: `<div onPointerLeave={() => void 0} />`,
+				Tsx:  true,
+				Options: []interface{}{map[string]interface{}{
+					"hoverOutHandlers": []interface{}{"onPointerLeave"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{pointerLeaveErrorAtCol6},
+			},
+
+			// ============================================================
+			// Two-element same-line fragment — each fires independently.
+			// ============================================================
+
+			{
+				Code: `<><div onMouseOver={fn} /><span onMouseOut={fn} /></>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "mouseOver",
+						Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+						Line:      1,
+						Column:    8,
+					},
+					{
+						MessageId: "mouseOut",
+						Message:   "onMouseOut must be accompanied by onBlur for accessibility.",
+						Line:      1,
+						Column:    33,
+					},
+				},
+			},
+
+			// ============================================================
+			// Deep nesting (3+ levels): listener visits every JsxOpening /
+			// JsxSelfClosing element regardless of depth. Outer paired
+			// (no report), middle unpaired hover-in (reports), inner
+			// unpaired hover-out (reports). Locks the per-element
+			// classification independence.
+			// ============================================================
+
+			{
+				Code: `<section onMouseOver={fn} onFocus={fn}>` + "\n" +
+					`  <div onMouseOver={fn}>` + "\n" +
+					`    <span onMouseOut={fn}>label</span>` + "\n" +
+					`  </div>` + "\n" +
+					`</section>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "mouseOver",
+						Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+						Line:      2,
+						Column:    8,
+					},
+					{
+						MessageId: "mouseOut",
+						Message:   "onMouseOut must be accompanied by onBlur for accessibility.",
+						Line:      3,
+						Column:    11,
+					},
+				},
+			},
+			// ---- 4-level nesting, all DOM, mixed valid / invalid. ----
+			{
+				Code: `<main onMouseOver={fn} onFocus={fn}>` + "\n" +
+					`  <section onMouseOver={fn} onFocus={fn}>` + "\n" +
+					`    <article onMouseOver={fn}>` + "\n" +
+					`      <p onMouseOut={fn}>x</p>` + "\n" +
+					`    </article>` + "\n" +
+					`  </section>` + "\n" +
+					`</main>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "mouseOver",
+						Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+						Line:      3,
+						Column:    14,
+					},
+					{
+						MessageId: "mouseOut",
+						Message:   "onMouseOut must be accompanied by onBlur for accessibility.",
+						Line:      4,
+						Column:    10,
+					},
+				},
+			},
+
+			// ============================================================
+			// Real-world component patterns (reports). Position is brittle
+			// inside wrapper code, so mouseOverErrorAnyPos / mouseOutErrorAnyPos
+			// skip Line/Column — the assertion locks "fires at all",
+			// "carries the right MessageId", and "carries the right Message
+			// text", which is the contract for an a11y rule embedded inside
+			// arbitrary surrounding code.
+			// ============================================================
+
+			// ---- React.forwardRef wrapping a non-paired div. The
+			//      inner <div onMouseOver={...} /> must still be classified
+			//      as a DOM element with a missing onFocus. ----
+			{
+				Code:   `const Btn = React.forwardRef((props, ref) => <div ref={ref} onMouseOver={props.onHover} />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos},
+			},
+			// ---- React.memo wrapping a non-paired section. ----
+			{
+				Code:   `const Pane = React.memo(({ id, onHover }) => <section id={id} onMouseOver={onHover} />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos},
+			},
+			// ---- Custom HOC wrapping a non-paired div. ----
+			{
+				Code:   `const Enhanced = withTracking(({ value, onHover }) => <div data-value={value} onMouseOver={onHover} />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos},
+			},
+			// ---- Array.map producing children with missing onFocus. ----
+			{
+				Code:   `const list = items.map(item => <li key={item.id} onMouseOver={() => hover(item)}>{item.label}</li>);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos},
+			},
+			// ---- Class component render() returning non-paired root. ----
+			{
+				Code:   `class Card extends React.Component { render() { return <article onMouseOver={this.onHover}>x</article>; } }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos},
+			},
+			// ---- Generator yielding non-paired elements — both fire. ----
+			{
+				Code:   `function* render() { yield <div onMouseOver={fn} />; yield <span onMouseOut={fn} />; }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos, mouseOutErrorAnyPos},
+			},
+			// ---- Async function returning non-paired root. ----
+			{
+				Code:   `async function render() { return <div onMouseOver={fn} />; }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos},
+			},
+			// ---- IIFE returning non-paired root. ----
+			{
+				Code:   `const x = (() => <article onMouseOver={fn} />)();`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos},
+			},
+			// ---- Conditional with one non-paired branch. The valid branch
+			//      stays silent; only the missing-onFocus branch reports. ----
+			{
+				Code:   `const x = cond ? <div onMouseOver={fn} /> : null;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos},
+			},
+			// ---- `&&` short-circuit producing non-paired element. ----
+			{
+				Code:   `const x = cond && <div onMouseOver={fn} />;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos},
+			},
+			// ---- Fragment with mixed valid / invalid children — only
+			//      non-paired children report. <button> is DOM and still
+			//      requires pairing (this rule has no "interactive element"
+			//      exemption — different from click-events-have-key-events). ----
+			{
+				Code:   `const x = (<><button onMouseOver={fn} onFocus={fn} /><div onMouseOver={fn} /><a href="x" onMouseOut={fn} onBlur={fn} /><section onMouseOver={fn} /></>);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAnyPos, mouseOverErrorAnyPos},
+			},
+			// ---- Two-function file: A reports at line 1, B at line 2 —
+			//      Line is stable (each top-level function on its own line),
+			//      Column is not (depends on inner whitespace). ----
+			{
+				Code: `function A() { return <div onMouseOver={fn} />; }` + "\n" +
+					`function B() { return <section onMouseOut={fn} />; }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "mouseOver",
+						Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+						Line:      1,
+					},
+					{
+						MessageId: "mouseOut",
+						Message:   "onMouseOut must be accompanied by onBlur for accessibility.",
+						Line:      2,
+					},
+				},
+			},
+
+			// ============================================================
+			// staticEval branches: statically-truthy hover value → pair
+			// check fires; statically-nullish pair value → counted as
+			// missing.
+			// ============================================================
+
+			// ---- `fn || null` — LHS truthy → uses LHS fn → not nullish →
+			//      hover counted; pair (onFocus) missing → report. ----
+			{
+				Code:   `<div onMouseOver={fn || null} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			// ---- `someVar ?? fallback` — both Identifiers,
+			//      `someVar` resolves to a string ("someVar") → not nullish
+			//      → use LHS → counted; pair missing → report. ----
+			{
+				Code:   `<div onMouseOver={someVar ?? fallback} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			// ---- `true ? fn : null` — static-true → use whenTrue fn →
+			//      counted; pair missing → report. ----
+			{
+				Code:   `<div onMouseOver={true ? fn : null} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			// ---- Hover handler set, pair statically resolves to null
+			//      via ternary → pair counted as missing → report. ----
+			{
+				Code:   `<div onMouseOver={fn} onFocus={false ? f : null} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			// ---- Pair value `undefined as any` — `as` strips → undefined
+			//      → nullish → missing → report. ----
+			{
+				Code:   `<div onMouseOver={fn} onFocus={undefined as any} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			// ---- Hover value `undefined!` — upstream jsx-ast-utils returns
+			//      string `"undefined!"` (truthy, non-null) → counted as
+			//      present hover handler → pair check fires → onFocus
+			//      missing → report. Differential-validated against
+			//      eslint-plugin-jsx-a11y@6.10.2. ----
+			{
+				Code:   `<div onMouseOver={undefined!} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			// ---- Hover value `null!` — same shape: string `"null!"` is
+			//      truthy non-null → counted as present hover handler →
+			//      onFocus missing → report. ----
+			{
+				Code:   `<div onMouseOver={null!} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+
+			// ============================================================
+			// Bare-map options (CLI shape) — must produce the same
+			// diagnostics as the array-wrapped form.
+			// ============================================================
+
+			// ---- Bare-map custom hoverIn: missing onFocus → report. ----
+			{
+				Code:    `<div onMouseEnter={() => {}} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"hoverInHandlers": []interface{}{"onMouseEnter"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseEnter must be accompanied by onFocus for accessibility.",
+					Line:      1,
+					Column:    6,
+				}},
+			},
+			// ---- Bare-map custom hoverOut: missing onBlur → report. ----
+			{
+				Code:    `<div onMouseLeave={() => {}} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"hoverOutHandlers": []interface{}{"onMouseLeave"}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOut",
+					Message:   "onMouseLeave must be accompanied by onBlur for accessibility.",
+					Line:      1,
+					Column:    6,
+				}},
+			},
+
+			// ============================================================
+			// Literal-spread containing a nullish pair value → pair is
+			// counted as missing (PropValueIsNullish sees null/undefined
+			// via the PropertyAssignment.Initializer staticEval).
+			// ============================================================
+
+			// ---- Hover direct, pair via literal spread with null. ----
+			{
+				Code:   `<div onMouseOver={fn} {...{onFocus: null}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			// ---- Hover direct, pair via literal spread with undefined. ----
+			{
+				Code:   `<div onMouseOut={fn} {...{onBlur: undefined}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOutErrorAtCol6},
+			},
+			// ---- Hover via literal spread, pair absent. ----
+			{
+				Code: `<div {...{onMouseOver: () => {}}} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+					// Position not pinned — the report node is the inner
+					// PropertyAssignment inside the spread; tsgo column
+					// differs from upstream's synthesized JSXAttribute.
+				}},
+			},
+
+			// ============================================================
+			// Spread + direct attribute order — spread before / after /
+			// multiple — does not affect the rule's classification.
+			// ============================================================
+
+			// ---- Spread before hover, no pair → report. ----
+			{
+				Code:   `<div {...props} onMouseOver={fn} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+					Line:      1,
+					Column:    17,
+				}},
+			},
+			// ---- Multiple spreads + direct hover, no pair → report. ----
+			{
+				Code:   `<div {...a} {...b} onMouseOver={fn} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+					Line:      1,
+					Column:    20,
+				}},
+			},
+
+			// ============================================================
+			// Self-closing void elements with hover handlers — the rule
+			// still applies (any DOM tag, any pairing miss → report).
+			// ============================================================
+
+			// ---- `<br>` — self-closing-only void DOM element. ----
+			{
+				Code: `<br onMouseOver={fn} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+					Line:      1,
+					Column:    5,
+				}},
+			},
+			// ---- `<input>` — `<input>` IS in aria-query's dom map and
+			//      this rule does NOT exempt interactive elements (unlike
+			//      click-events-have-key-events). So even `<input type="text">`
+			//      with onMouseOver and no onFocus reports. ----
+			{
+				Code: `<input type="text" onMouseOver={fn} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+					Line:      1,
+					Column:    20,
+				}},
+			},
+			// ---- `<button>` — same: button gets no exemption from this
+			//      rule (in contrast to click-events-have-key-events,
+			//      where button is interactive → exempt). ----
+			{
+				Code: `<button onMouseOver={fn}>label</button>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+					Line:      1,
+					Column:    9,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events_upstream_test.go
@@ -1,0 +1,237 @@
+package mouse_events_have_key_events
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Upstream `mouseOverError` / `mouseOutError` / `pointerEnterError` /
+// `pointerLeaveError` shape the expected diagnostic. We mirror with
+// `Message` exact-string assertions so the rule's user-visible text is
+// pinned. Position assertions are added on top of upstream because the
+// upstream report writes `node: getProp(attributes, handler)` — i.e. the
+// JsxAttribute, which always starts at column 6 (after `<div ` /
+// `<{tag} `).
+var (
+	mouseOverErrorAtCol6 = rule_tester.InvalidTestCaseError{
+		MessageId: "mouseOver",
+		Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+		Line:      1,
+		Column:    6,
+	}
+	mouseOutErrorAtCol6 = rule_tester.InvalidTestCaseError{
+		MessageId: "mouseOut",
+		Message:   "onMouseOut must be accompanied by onBlur for accessibility.",
+		Line:      1,
+		Column:    6,
+	}
+)
+
+// TestMouseEventsHaveKeyEventsUpstream covers the full valid/invalid
+// suite migrated 1:1 from upstream eslint-plugin-jsx-a11y's
+// `__tests__/src/rules/mouse-events-have-key-events-test.js`. Order
+// inside each group mirrors the upstream file so a future audit can
+// grep across both side-by-side.
+//
+// Anything NOT in upstream's test file — TS wrappers, position
+// assertions on multi-element / multi-line code, extra spread shapes,
+// extra edge cases — lives in mouse_events_have_key_events_extras_test.go.
+func TestMouseEventsHaveKeyEventsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &MouseEventsHaveKeyEventsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Default config — onMouseOver + onFocus pair, onMouseOut + onBlur pair. ----
+			{Code: `<div onMouseOver={() => void 0} onFocus={() => void 0} />;`, Tsx: true},
+			{Code: `<div onMouseOver={() => void 0} onFocus={() => void 0} {...props} />;`, Tsx: true},
+			{Code: `<div onMouseOver={handleMouseOver} onFocus={handleFocus} />;`, Tsx: true},
+			{Code: `<div onMouseOver={handleMouseOver} onFocus={handleFocus} {...props} />;`, Tsx: true},
+
+			// ---- No mouse event handlers → no pairing required. ----
+			{Code: `<div />;`, Tsx: true},
+			{Code: `<div onBlur={() => {}} />`, Tsx: true},
+			{Code: `<div onFocus={() => {}} />`, Tsx: true},
+
+			// ---- onMouseOut + onBlur pair (mirror of the onMouseOver/onFocus group). ----
+			{Code: `<div onMouseOut={() => void 0} onBlur={() => void 0} />`, Tsx: true},
+			{Code: `<div onMouseOut={() => void 0} onBlur={() => void 0} {...props} />`, Tsx: true},
+			{Code: `<div onMouseOut={handleMouseOut} onBlur={handleOnBlur} />`, Tsx: true},
+			{Code: `<div onMouseOut={handleMouseOut} onBlur={handleOnBlur} {...props} />`, Tsx: true},
+
+			// ---- Custom (non-DOM) component — rule short-circuits on
+			//      `dom.get(name)` check; mouse events on custom components
+			//      are out of scope (we don't know the rendered low-level DOM). ----
+			{Code: `<MyElement />`, Tsx: true},
+			{Code: `<MyElement onMouseOver={() => {}} />`, Tsx: true},
+			{Code: `<MyElement onMouseOut={() => {}} />`, Tsx: true},
+			{Code: `<MyElement onBlur={() => {}} />`, Tsx: true},
+			{Code: `<MyElement onFocus={() => {}} />`, Tsx: true},
+			{Code: `<MyElement onMouseOver={() => {}} {...props} />`, Tsx: true},
+			{Code: `<MyElement onMouseOut={() => {}} {...props} />`, Tsx: true},
+			{Code: `<MyElement onBlur={() => {}} {...props} />`, Tsx: true},
+			{Code: `<MyElement onFocus={() => {}} {...props} />`, Tsx: true},
+
+			// ---- Passing in empty options doesn't check any event handlers. ----
+			{
+				Code:    `<div onMouseOver={() => {}} onMouseOut={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverInHandlers": []interface{}{}, "hoverOutHandlers": []interface{}{}}},
+			},
+
+			// ---- Passing in custom handlers — explicit lists override the
+			//      defaults. A handler listed here still requires its pair
+			//      (onFocus for hover-in, onBlur for hover-out). ----
+			{
+				Code:    `<div onMouseOver={() => {}} onFocus={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverInHandlers": []interface{}{"onMouseOver"}}},
+			},
+			{
+				Code:    `<div onMouseEnter={() => {}} onFocus={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverInHandlers": []interface{}{"onMouseEnter"}}},
+			},
+			{
+				Code:    `<div onMouseOut={() => {}} onBlur={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverOutHandlers": []interface{}{"onMouseOut"}}},
+			},
+			{
+				Code:    `<div onMouseLeave={() => {}} onBlur={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverOutHandlers": []interface{}{"onMouseLeave"}}},
+			},
+			{
+				Code:    `<div onMouseOver={() => {}} onMouseOut={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverInHandlers": []interface{}{"onPointerEnter"}, "hoverOutHandlers": []interface{}{"onPointerLeave"}}},
+			},
+
+			// ---- Custom options only check the handlers passed in — the
+			//      element's other mouse handlers are ignored for pairing. ----
+			{
+				Code:    `<div onMouseLeave={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverOutHandlers": []interface{}{"onPointerLeave"}}},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Plain <div> with onMouseOver and no onFocus → reports. ----
+			{
+				Code:   `<div onMouseOver={() => void 0} />;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			// ---- Plain <div> with onMouseOut and no onBlur → reports. ----
+			{
+				Code:   `<div onMouseOut={() => void 0} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOutErrorAtCol6},
+			},
+
+			// ---- onFocus={undefined} — `getPropValue` extracts `undefined`,
+			//      `!= null` is false → onFocus counted as absent → reports. ----
+			{
+				Code:   `<div onMouseOver={() => void 0} onFocus={undefined} />;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			{
+				Code:   `<div onMouseOut={() => void 0} onBlur={undefined} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOutErrorAtCol6},
+			},
+
+			// ---- {...props} spread is opaque under FindAttributeByName's
+			//      semantics — it cannot supply onFocus / onBlur. ----
+			{
+				Code:   `<div onMouseOver={() => void 0} {...props} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			{
+				Code:   `<div onMouseOut={() => void 0} {...props} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{mouseOutErrorAtCol6},
+			},
+
+			// ---- Custom options enabling both pairings: hover-in and hover-out
+			//      both fire. Each report sits on its own attribute. ----
+			{
+				Code:    `<div onMouseOver={() => {}} onMouseOut={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverInHandlers": []interface{}{"onMouseOver"}, "hoverOutHandlers": []interface{}{"onMouseOut"}}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "mouseOver",
+						Message:   "onMouseOver must be accompanied by onFocus for accessibility.",
+						Line:      1,
+						Column:    6,
+					},
+					{
+						MessageId: "mouseOut",
+						Message:   "onMouseOut must be accompanied by onBlur for accessibility.",
+						Line:      1,
+						Column:    29,
+					},
+				},
+			},
+			// ---- Custom pointer-event handlers — same flow, different names. ----
+			{
+				Code:    `<div onPointerEnter={() => {}} onPointerLeave={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverInHandlers": []interface{}{"onPointerEnter"}, "hoverOutHandlers": []interface{}{"onPointerLeave"}}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "mouseOver",
+						Message:   "onPointerEnter must be accompanied by onFocus for accessibility.",
+						Line:      1,
+						Column:    6,
+					},
+					{
+						MessageId: "mouseOut",
+						Message:   "onPointerLeave must be accompanied by onBlur for accessibility.",
+						Line:      1,
+						Column:    32,
+					},
+				},
+			},
+
+			// ---- Custom options activating only one side — only that side reports. ----
+			{
+				Code:    `<div onMouseOver={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverInHandlers": []interface{}{"onMouseOver"}}},
+				Errors:  []rule_tester.InvalidTestCaseError{mouseOverErrorAtCol6},
+			},
+			{
+				Code:    `<div onPointerEnter={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverInHandlers": []interface{}{"onPointerEnter"}}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOver",
+					Message:   "onPointerEnter must be accompanied by onFocus for accessibility.",
+					Line:      1,
+					Column:    6,
+				}},
+			},
+			{
+				Code:    `<div onMouseOut={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverOutHandlers": []interface{}{"onMouseOut"}}},
+				Errors:  []rule_tester.InvalidTestCaseError{mouseOutErrorAtCol6},
+			},
+			{
+				Code:    `<div onPointerLeave={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"hoverOutHandlers": []interface{}{"onPointerLeave"}}},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "mouseOut",
+					Message:   "onPointerLeave must be accompanied by onBlur for accessibility.",
+					Line:      1,
+					Column:    6,
+				}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -173,6 +173,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/img-redundant-alt.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/interactive-supports-focus.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/media-has-caption.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/mouse-events-have-key-events.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/mouse-events-have-key-events.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/mouse-events-have-key-events.test.ts
@@ -1,0 +1,212 @@
+import { RuleTester } from '../rule-tester';
+
+const mouseOverError = {
+  message: 'onMouseOver must be accompanied by onFocus for accessibility.',
+};
+const mouseOutError = {
+  message: 'onMouseOut must be accompanied by onBlur for accessibility.',
+};
+const pointerEnterError = {
+  message: 'onPointerEnter must be accompanied by onFocus for accessibility.',
+};
+const pointerLeaveError = {
+  message: 'onPointerLeave must be accompanied by onBlur for accessibility.',
+};
+
+new RuleTester().run('mouse-events-have-key-events', null as never, {
+  valid: [
+    // ============================================================
+    // Upstream valid suite (mirrors __tests__/src/rules/mouse-events-have-key-events-test.js)
+    // ============================================================
+    { code: '<div onMouseOver={() => void 0} onFocus={() => void 0} />;' },
+    {
+      code: '<div onMouseOver={() => void 0} onFocus={() => void 0} {...props} />;',
+    },
+    { code: '<div onMouseOver={handleMouseOver} onFocus={handleFocus} />;' },
+    {
+      code: '<div onMouseOver={handleMouseOver} onFocus={handleFocus} {...props} />;',
+    },
+    { code: '<div />;' },
+    { code: '<div onBlur={() => {}} />' },
+    { code: '<div onFocus={() => {}} />' },
+    { code: '<div onMouseOut={() => void 0} onBlur={() => void 0} />' },
+    {
+      code: '<div onMouseOut={() => void 0} onBlur={() => void 0} {...props} />',
+    },
+    { code: '<div onMouseOut={handleMouseOut} onBlur={handleOnBlur} />' },
+    {
+      code: '<div onMouseOut={handleMouseOut} onBlur={handleOnBlur} {...props} />',
+    },
+    { code: '<MyElement />' },
+    { code: '<MyElement onMouseOver={() => {}} />' },
+    { code: '<MyElement onMouseOut={() => {}} />' },
+    { code: '<MyElement onBlur={() => {}} />' },
+    { code: '<MyElement onFocus={() => {}} />' },
+    { code: '<MyElement onMouseOver={() => {}} {...props} />' },
+    { code: '<MyElement onMouseOut={() => {}} {...props} />' },
+    { code: '<MyElement onBlur={() => {}} {...props} />' },
+    { code: '<MyElement onFocus={() => {}} {...props} />' },
+
+    // ---- Empty options disable both pairings. ----
+    {
+      code: '<div onMouseOver={() => {}} onMouseOut={() => {}} />',
+      options: [{ hoverInHandlers: [], hoverOutHandlers: [] }],
+    },
+
+    // ---- Custom handlers — pair check still applies. ----
+    {
+      code: '<div onMouseOver={() => {}} onFocus={() => {}} />',
+      options: [{ hoverInHandlers: ['onMouseOver'] }],
+    },
+    {
+      code: '<div onMouseEnter={() => {}} onFocus={() => {}} />',
+      options: [{ hoverInHandlers: ['onMouseEnter'] }],
+    },
+    {
+      code: '<div onMouseOut={() => {}} onBlur={() => {}} />',
+      options: [{ hoverOutHandlers: ['onMouseOut'] }],
+    },
+    {
+      code: '<div onMouseLeave={() => {}} onBlur={() => {}} />',
+      options: [{ hoverOutHandlers: ['onMouseLeave'] }],
+    },
+    {
+      code: '<div onMouseOver={() => {}} onMouseOut={() => {}} />',
+      options: [
+        {
+          hoverInHandlers: ['onPointerEnter'],
+          hoverOutHandlers: ['onPointerLeave'],
+        },
+      ],
+    },
+    {
+      code: '<div onMouseLeave={() => {}} />',
+      options: [{ hoverOutHandlers: ['onPointerLeave'] }],
+    },
+
+    // ============================================================
+    // Extras: hover-handler value is statically nullish → not counted.
+    // ============================================================
+    { code: '<div onMouseOver={null} />' },
+    { code: '<div onMouseOver={undefined} />' },
+    { code: '<div onMouseOut={null} />' },
+    { code: '<div onMouseOut={undefined} />' },
+
+    // ============================================================
+    // Extras: case-insensitive matching on both sides
+    // ============================================================
+    { code: '<div onmouseover={() => {}} onfocus={() => {}} />' },
+    { code: '<div onmouseout={() => {}} onblur={() => {}} />' },
+
+    // ============================================================
+    // Extras: member-expression / namespaced tags don't classify as DOM.
+    // ============================================================
+    { code: '<Foo.Bar onMouseOver={() => {}} />' },
+    { code: '<svg:circle onMouseOver={() => {}} />' },
+  ],
+  invalid: [
+    // ============================================================
+    // Upstream invalid suite
+    // ============================================================
+    {
+      code: '<div onMouseOver={() => void 0} />;',
+      errors: [mouseOverError],
+    },
+    {
+      code: '<div onMouseOut={() => void 0} />',
+      errors: [mouseOutError],
+    },
+    {
+      code: '<div onMouseOver={() => void 0} onFocus={undefined} />;',
+      errors: [mouseOverError],
+    },
+    {
+      code: '<div onMouseOut={() => void 0} onBlur={undefined} />',
+      errors: [mouseOutError],
+    },
+    {
+      code: '<div onMouseOver={() => void 0} {...props} />',
+      errors: [mouseOverError],
+    },
+    {
+      code: '<div onMouseOut={() => void 0} {...props} />',
+      errors: [mouseOutError],
+    },
+    {
+      code: '<div onMouseOver={() => {}} onMouseOut={() => {}} />',
+      options: [
+        {
+          hoverInHandlers: ['onMouseOver'],
+          hoverOutHandlers: ['onMouseOut'],
+        },
+      ],
+      errors: [mouseOverError, mouseOutError],
+    },
+    {
+      code: '<div onPointerEnter={() => {}} onPointerLeave={() => {}} />',
+      options: [
+        {
+          hoverInHandlers: ['onPointerEnter'],
+          hoverOutHandlers: ['onPointerLeave'],
+        },
+      ],
+      errors: [pointerEnterError, pointerLeaveError],
+    },
+    {
+      code: '<div onMouseOver={() => {}} />',
+      options: [{ hoverInHandlers: ['onMouseOver'] }],
+      errors: [mouseOverError],
+    },
+    {
+      code: '<div onPointerEnter={() => {}} />',
+      options: [{ hoverInHandlers: ['onPointerEnter'] }],
+      errors: [pointerEnterError],
+    },
+    {
+      code: '<div onMouseOut={() => {}} />',
+      options: [{ hoverOutHandlers: ['onMouseOut'] }],
+      errors: [mouseOutError],
+    },
+    {
+      code: '<div onPointerLeave={() => {}} />',
+      options: [{ hoverOutHandlers: ['onPointerLeave'] }],
+      errors: [pointerLeaveError],
+    },
+
+    // ============================================================
+    // Extras: boolean attribute form
+    // ============================================================
+    {
+      code: '<div onMouseOver />',
+      errors: [mouseOverError],
+    },
+    {
+      code: '<div onMouseOut />',
+      errors: [mouseOutError],
+    },
+
+    // ============================================================
+    // Extras: case-insensitive on lowercase
+    // ============================================================
+    {
+      code: '<div onmouseover={() => {}} />',
+      errors: [mouseOverError],
+    },
+    {
+      code: '<div onmouseout={() => {}} />',
+      errors: [mouseOutError],
+    },
+
+    // ============================================================
+    // Extras: onFocus / onBlur explicitly null → counted as missing.
+    // ============================================================
+    {
+      code: '<div onMouseOver={fn} onFocus={null} />',
+      errors: [mouseOverError],
+    },
+    {
+      code: '<div onMouseOut={fn} onBlur={null} />',
+      errors: [mouseOutError],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -440,3 +440,7 @@ idlist
 allowundefined
 Seeked
 usemap
+onmouseover
+onmouseout
+onfocus
+onblur


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/mouse-events-have-key-events` rule from `eslint-plugin-jsx-a11y` to rslint.

Enforces that any HTML DOM element carrying a configured hover-in handler (default: `onMouseOver`) also carries a non-null `onFocus`, and that any hover-out handler (default: `onMouseOut`) is paired with `onBlur`. Keyboard-only users rely on focus / blur events to get the same affordance the mouse handlers expose.

Options match upstream:

- `hoverInHandlers?: string[]` (default `['onMouseOver']`)
- `hoverOutHandlers?: string[]` (default `['onMouseOut']`)

Tests split into upstream 1:1 mirror (`*_upstream_test.go`, 27 valid + 12 invalid) and rslint extras (`*_extras_test.go`, ~49 valid + ~44 invalid covering tsgo AST wrappers, `staticEval` short-circuits, literal / shorthand spread, case-insensitive matching, multi-level nesting, real-world component patterns, options shape matrix including bare-map CLI form, and intentional non-exemption of interactive elements that distinguishes this rule from `click-events-have-key-events`).

Differential validation against `eslint-plugin-jsx-a11y@6.10.2` on a 35-case fixture: **18/18 invalid cases match byte-for-byte** (line, column, end-line, end-column, message text), **0 false-positive, 0 false-negative**.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/mouse-events-have-key-events.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/mouse-events-have-key-events.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).