### PR TITLE
feat: port rule jsx-a11y/no-noninteractive-element-interactions

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -22,6 +22,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_access_key"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_autofocus"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_distracting_elements"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_redundant_roles"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/scope"
@@ -52,6 +53,7 @@ func GetAllRules() []rule.Rule {
 		no_access_key.NoAccessKeyRule,
 		no_autofocus.NoAutofocusRule,
 		no_distracting_elements.NoDistractingElementsRule,
+		no_noninteractive_element_interactions.NoNoninteractiveElementInteractionsRule,
 		no_noninteractive_tabindex.NoNoninteractiveTabindexRule,
 		no_redundant_roles.NoRedundantRolesRule,
 		scope.ScopeRule,

--- a/internal/plugins/jsx_a11y/jsxa11yutil/content_editable.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/content_editable.go
@@ -1,0 +1,66 @@
+package jsxa11yutil
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+)
+
+// IsContentEditable mirrors upstream `isContentEditable(_, attributes)`
+// (eslint-plugin-jsx-a11y/src/util/isContentEditable.js) verbatim:
+//
+//	const prop = getProp(attributes, 'contentEditable');
+//	return prop?.value?.raw === '"true"';
+//
+// The upstream check is deliberately restrictive: it gates on the RAW
+// source text of the value (including surrounding quotes), so ONLY the bare
+// `contentEditable="true"` form matches. Specifically:
+//
+//   - `<X contentEditable />`           — no `.value` → no match
+//   - `<X contentEditable="true" />`    — raw `"true"` → MATCH
+//   - `<X contentEditable="false" />`   — raw `"false"` → no match
+//   - `<X contentEditable={true} />`    — raw is the JsxExpression text, not `"true"` → no match
+//   - `<X contentEditable={"true"} />`  — value is a JsxExpression, not a string-literal attribute init → no match
+//   - `<X contentEditable="&#116;rue" />` — raw `"&#116;rue"` (entity-encoded) → no match
+//
+// We mirror this by reading the JsxAttribute's StringLiteral initializer's
+// `.Text` directly — tsgo preserves the unprocessed (entity-encoded)
+// source text on StringLiteral.Text for JSX attributes, which is exactly
+// what upstream's `.raw` (minus the surrounding quotes) carries. Entity
+// decoding is intentionally NOT applied — upstream's raw comparison
+// rejects entity-encoded forms.
+//
+// getProp is case-insensitive by default, so `contentEditable`,
+// `contenteditable`, and `CONTENTEDITABLE` all match. JsxSpreadAttribute is
+// walked by FindAttributeByName for literal-object spreads — but a
+// PropertyAssignment / ShorthandPropertyAssignment inside a spread has no
+// `.value.raw` equivalent (the value is the bare initializer expression,
+// not a JSX-attribute string-literal wrapper), so spread matches fall
+// through to "no match" here.
+func IsContentEditable(attrs []*ast.Node) bool {
+	for _, attr := range attrs {
+		if attr.Kind != ast.KindJsxAttribute {
+			// JsxSpreadAttribute — upstream's `prop?.value?.raw` reads the
+			// JSXAttribute's literal value node, which spread synthesis does
+			// not produce. Skip rather than walk into spread.
+			continue
+		}
+		if !strings.EqualFold(reactutil.GetJsxPropName(attr), "contentEditable") {
+			continue
+		}
+		// upstream returns immediately on the FIRST matching getProp result;
+		// any subsequent contentEditable attrs are ignored. Mirror by
+		// returning here regardless of the value shape.
+		init := attr.AsJsxAttribute().Initializer
+		if init == nil || init.Kind != ast.KindStringLiteral {
+			return false
+		}
+		// StringLiteral.Text for JSX attributes preserves the raw source
+		// text (entity-encoded, no surrounding quotes). Upstream's
+		// `prop.value.raw === '"true"'` is equivalent to "the text between
+		// the quotes equals `true` byte-for-byte".
+		return init.AsStringLiteral().Text == "true"
+	}
+	return false
+}

--- a/internal/plugins/jsx_a11y/jsxa11yutil/event_handlers.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/event_handlers.go
@@ -62,4 +62,9 @@ var (
 // Order matches the upstream concat (mouse first, then keyboard) for
 // auditability — semantically irrelevant because every consumer uses set
 // membership rather than ordering.
-var InteractiveEventHandlerNames = append(append([]string{}, EventHandlersMouse...), EventHandlersKeyboard...)
+var InteractiveEventHandlerNames = func() []string {
+	out := make([]string, 0, len(EventHandlersMouse)+len(EventHandlersKeyboard))
+	out = append(out, EventHandlersMouse...)
+	out = append(out, EventHandlersKeyboard...)
+	return out
+}()

--- a/internal/plugins/jsx_a11y/jsxa11yutil/event_handlers.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/event_handlers.go
@@ -1,47 +1,65 @@
 package jsxa11yutil
 
+// Event handler name groups mirror jsx-ast-utils'
+// `eventHandlersByType` map. Each group corresponds to a single key in that
+// upstream map; rules that need a multi-group default (e.g. the
+// no-noninteractive-element-interactions / no-static-element-interactions
+// defaults of `focus + image + keyboard + mouse`) compose these slices
+// themselves rather than depending on a fixed shape.
+//
+// Source: https://github.com/jsx-eslint/jsx-ast-utils/blob/main/src/eventHandlers.js
+// Order within each group matches the upstream array — semantically
+// irrelevant (every consumer uses set membership) but kept for auditability.
+var (
+	// EventHandlersMouse mirrors `eventHandlersByType.mouse`.
+	EventHandlersMouse = []string{
+		"onClick",
+		"onContextMenu",
+		"onDblClick",
+		"onDoubleClick",
+		"onDrag",
+		"onDragEnd",
+		"onDragEnter",
+		"onDragExit",
+		"onDragLeave",
+		"onDragOver",
+		"onDragStart",
+		"onDrop",
+		"onMouseDown",
+		"onMouseEnter",
+		"onMouseLeave",
+		"onMouseMove",
+		"onMouseOut",
+		"onMouseOver",
+		"onMouseUp",
+	}
+
+	// EventHandlersKeyboard mirrors `eventHandlersByType.keyboard`.
+	EventHandlersKeyboard = []string{
+		"onKeyDown",
+		"onKeyPress",
+		"onKeyUp",
+	}
+
+	// EventHandlersFocus mirrors `eventHandlersByType.focus`.
+	EventHandlersFocus = []string{
+		"onFocus",
+		"onBlur",
+	}
+
+	// EventHandlersImage mirrors `eventHandlersByType.image`.
+	EventHandlersImage = []string{
+		"onLoad",
+		"onError",
+	}
+)
+
 // InteractiveEventHandlerNames mirrors the
 // `[].concat(eventHandlersByType.mouse, eventHandlersByType.keyboard)`
 // constant that `interactive-supports-focus` (and any future rule that
 // imports `interactiveProps` from jsx-ast-utils) hands to `hasAnyProp`.
 //
-// Sourced from jsx-ast-utils' `eventHandlers.js`:
-//
-//	mouse: [
-//	  'onClick', 'onContextMenu', 'onDblClick', 'onDoubleClick',
-//	  'onDrag', 'onDragEnd', 'onDragEnter', 'onDragExit',
-//	  'onDragLeave', 'onDragOver', 'onDragStart', 'onDrop',
-//	  'onMouseDown', 'onMouseEnter', 'onMouseLeave', 'onMouseMove',
-//	  'onMouseOut', 'onMouseOver', 'onMouseUp',
-//	],
-//	keyboard: ['onKeyDown', 'onKeyPress', 'onKeyUp'],
-//
 // Order matches the upstream concat (mouse first, then keyboard) for
 // auditability — semantically irrelevant because every consumer uses set
 // membership rather than ordering.
-var InteractiveEventHandlerNames = []string{
-	// mouse
-	"onClick",
-	"onContextMenu",
-	"onDblClick",
-	"onDoubleClick",
-	"onDrag",
-	"onDragEnd",
-	"onDragEnter",
-	"onDragExit",
-	"onDragLeave",
-	"onDragOver",
-	"onDragStart",
-	"onDrop",
-	"onMouseDown",
-	"onMouseEnter",
-	"onMouseLeave",
-	"onMouseMove",
-	"onMouseOut",
-	"onMouseOver",
-	"onMouseUp",
-	// keyboard
-	"onKeyDown",
-	"onKeyPress",
-	"onKeyUp",
-}
+var InteractiveEventHandlerNames = append(append([]string{}, EventHandlersMouse...), EventHandlersKeyboard...)

--- a/internal/plugins/jsx_a11y/jsxa11yutil/interactive.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/interactive.go
@@ -459,6 +459,61 @@ func IsNonInteractiveRole(tagName string, attrs []*ast.Node) bool {
 	return false
 }
 
+// abstractRolesSet mirrors upstream's `isAbstractRole.js` -
+// `new Set(roles.keys().filter((role) => roles.get(role).abstract))` -
+// every aria-query role whose definition carries `abstract: true`. These
+// roles are not assignable to HTML elements at runtime; some rules (e.g.
+// no-noninteractive-element-interactions) treat them as "no opinion"
+// short-circuits.
+//
+// Source: https://github.com/A11yance/aria-query/blob/main/src/etc/roles/abstract/
+var abstractRolesSet = map[string]struct{}{
+	"command":     {},
+	"composite":   {},
+	"input":       {},
+	"landmark":    {},
+	"range":       {},
+	"roletype":    {},
+	"section":     {},
+	"sectionhead": {},
+	"select":      {},
+	"structure":   {},
+	"widget":      {},
+	"window":      {},
+}
+
+// IsAbstractRole mirrors upstream `isAbstractRole(tagName, attributes)`:
+//
+//	if (!DOMElements.has(tagName)) return false;
+//	const role = getLiteralPropValue(getProp(attributes, 'role'));
+//	return abstractRoles.has(role);
+//
+// Notable upstream quirks we preserve:
+//
+//   - Custom components short-circuit to false (upstream `!DOMElements.has`).
+//   - The role lookup uses `getLiteralPropValue` (= [LiteralPropStringValue]),
+//     so non-literal `role` expressions (Identifier, CallExpression,
+//     ConditionalExpression, …) silently produce a `false` here.
+//   - Set membership is whole-string and case-sensitive — upstream does NOT
+//     lowercase or split on whitespace, unlike the interactive/non-interactive
+//     role predicates. `role=" widget "` (with surrounding whitespace) and
+//     `role="WIDGET"` therefore do NOT match. Mirror.
+func IsAbstractRole(tagName string, attrs []*ast.Node) bool {
+	if !IsDOMElement(tagName) {
+		return false
+	}
+	roleAttr := FindAttributeByName(attrs, "role")
+	if roleAttr == nil {
+		return false
+	}
+	value, ok := LiteralPropStringValue(roleAttr)
+	if !ok {
+		return false
+	}
+	_, isAbstract := abstractRolesSet[value]
+	return isAbstract
+}
+
 // strictNonInteractiveElementRoleSchemas mirrors upstream
 // `isNonInteractiveElement.js`'s view of `nonInteractiveElementRoleSchemas`
 // — `elementRoles` entries whose role list is ENTIRELY non-interactive

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -1163,10 +1163,31 @@ func HasAccessibleChild(node *ast.Node, getElementType func(*ast.Node) string) b
 //
 // `child` is the JsxOpeningElement / JsxSelfClosingElement to inspect;
 // `getElementType` is the per-context resolver (use a closure that calls
-// GetElementType with `ctx.Settings` already bound).
+// GetElementType with `ctx.Settings` already bound). This is a thin
+// convenience wrapper around [IsHiddenFromScreenReaderFromTagAttrs] —
+// callers that already have the element type and attribute list resolved
+// (e.g. rules that apply a filter/mask to attributes before classification
+// and need downstream helpers to observe the same filtered list) should
+// use the attrs variant directly.
 func IsHiddenFromScreenReader(child *ast.Node, getElementType func(*ast.Node) string) bool {
-	tag := strings.ToUpper(getElementType(child))
-	attrs := reactutil.GetJsxElementAttributes(child)
+	return IsHiddenFromScreenReaderFromTagAttrs(
+		getElementType(child),
+		reactutil.GetJsxElementAttributes(child),
+	)
+}
+
+// IsHiddenFromScreenReaderFromTagAttrs is the attrs-based variant of
+// [IsHiddenFromScreenReader]. Semantics are identical — see that function's
+// doc for the upstream mapping. Use this when the caller has already
+// computed the effective element type (via [GetElementType]) AND when the
+// caller's attribute list may have been filtered/masked relative to the
+// node's raw attributes (e.g. the per-element allow-list in
+// `no-noninteractive-element-interactions`'s `config[type]` filter).
+// Upstream's `isHiddenFromScreenReader(type, attributes)` takes both
+// arguments by value, so passing the filtered list mirrors upstream
+// byte-for-byte.
+func IsHiddenFromScreenReaderFromTagAttrs(elementType string, attrs []*ast.Node) bool {
+	tag := strings.ToUpper(elementType)
 	if tag == "INPUT" {
 		typeAttr := FindAttributeByName(attrs, "type")
 		if typeAttr != nil {

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.go
@@ -131,13 +131,9 @@ var NoNoninteractiveElementInteractionsRule = rule.Rule{
 			interactiveProps = *opts.Handlers
 		}
 
-		getElementType := func(node *ast.Node) string {
-			return jsxa11yutil.GetElementType(node, ctx.Settings)
-		}
-
 		check := func(node *ast.Node) {
 			rawAttrs := reactutil.GetJsxElementAttributes(node)
-			elementType := getElementType(node)
+			elementType := jsxa11yutil.GetElementType(node, ctx.Settings)
 
 			// Per-element allow-list filter. Upstream:
 			//   attributes.filter(attr =>

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.go
@@ -1,0 +1,238 @@
+// Package no_noninteractive_element_interactions ports
+// eslint-plugin-jsx-a11y's `no-noninteractive-element-interactions` rule.
+// The rule enforces that visible, non-interactive DOM elements do not carry
+// mouse / keyboard / focus / image event handlers — assigning handlers to a
+// non-interactive element (e.g. `<li onClick={…} />`, `<div role="article"
+// onClick={…} />`) is a strong signal of misuse of the platform a11y
+// semantics, since screen-reader / keyboard users get no productive
+// interaction once focus lands on the element.
+//
+// Upstream signature:
+//
+//	options: {
+//	  handlers?:        string[]            (default: focus + image + keyboard + mouse)
+//	  <element-name>?:  string[]            (per-element handler allow-list)
+//	}
+//
+// `handlers` (when present, even when explicitly `[]`) overrides the default
+// interactive-handler list. Any OTHER key is interpreted as a per-element
+// allow-list: a JsxAttribute whose name appears in `config[type]` is
+// filtered out of the trigger check, so e.g. recommended's
+// `iframe: ['onError', 'onLoad']` makes `<iframe onLoad={…} />` valid while
+// `<iframe onClick={…} />` still reports.
+//
+// Trigger sequence — each predicate is checked in order against the JSX
+// opening / self-closing element. Bail-outs return without reporting:
+//
+//  1. Element type not in aria-query's `dom` map → bail (custom
+//     components; we don't second-guess what low-level DOM they render).
+//  2. After per-element filter, no remaining `handlers` prop has a
+//     non-nullish value → bail (`getPropValue == null` upstream covers
+//     `prop={null}` / `prop={undefined}` / missing).
+//  3. `contentEditable="true"` (RAW source equality — see
+//     [jsxa11yutil.IsContentEditable]) → bail.
+//  4. Element is hidden from screen readers (`aria-hidden={true}` or
+//     `<input type="hidden">`) → bail.
+//  5. Element role resolves to `presentation` / `none` → bail.
+//  6. Element is inherently interactive, has an interactive role, is
+//     NEITHER inherently nor explicitly non-interactive, or has an
+//     ABSTRACT role → bail.
+//
+// Otherwise, report at the JSX opening element. The single message id is
+// `noNoninteractiveElementInteractions`, mirroring upstream's single
+// `errorMessage`.
+package no_noninteractive_element_interactions
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// errorMessage mirrors upstream's `errorMessage` string verbatim.
+const errorMessage = "Non-interactive elements should not be assigned mouse or keyboard event listeners."
+
+// options captures the parsed configuration.
+//
+// Handlers carries the override for the default interactive-handler list
+// (`config.handlers || defaultInteractiveProps`). A non-nil slice — INCLUDING
+// the explicit empty slice — wins; nil signals "absent" so we fall back to
+// the default. Mirrors JS `[] || x` truthiness (empty array is truthy → no
+// fallback).
+//
+// Elements maps tag-name → handler-allow-list. Matches upstream's
+// `hasOwn(config, type)` lookup: a JsxAttribute whose name is in
+// `Elements[type]` is filtered out before the interactive-prop check.
+type options struct {
+	Handlers *[]string
+	Elements map[string][]string
+}
+
+// defaultInteractiveProps mirrors upstream's
+// `[].concat(eventHandlersByType.focus, eventHandlersByType.image,
+//
+//	eventHandlersByType.keyboard, eventHandlersByType.mouse)` — used when
+//
+// `options.handlers` is absent. Order matches upstream concat for
+// auditability; semantically the slice acts as a set (lookup via .some()).
+var defaultInteractiveProps = func() []string {
+	out := make([]string, 0,
+		len(jsxa11yutil.EventHandlersFocus)+
+			len(jsxa11yutil.EventHandlersImage)+
+			len(jsxa11yutil.EventHandlersKeyboard)+
+			len(jsxa11yutil.EventHandlersMouse))
+	out = append(out, jsxa11yutil.EventHandlersFocus...)
+	out = append(out, jsxa11yutil.EventHandlersImage...)
+	out = append(out, jsxa11yutil.EventHandlersKeyboard...)
+	out = append(out, jsxa11yutil.EventHandlersMouse...)
+	return out
+}()
+
+func parseOptions(raw any) options {
+	opts := options{}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	if rawHandlers, ok := m["handlers"]; ok {
+		// Upstream `config.handlers || defaultInteractiveProps`. JS arrays
+		// (including empty) are truthy, so we treat any present `[]string`
+		// — even empty — as an override. StringSliceOption returns nil for
+		// non-array values, in which case we fall through to the default
+		// (mirrors JS's null/undefined being falsy).
+		if parsed := jsxa11yutil.StringSliceOption(rawHandlers); parsed != nil {
+			opts.Handlers = &parsed
+		}
+	}
+	for key, v := range m {
+		if key == "handlers" {
+			continue
+		}
+		if parsed := jsxa11yutil.StringSliceOption(v); parsed != nil {
+			if opts.Elements == nil {
+				opts.Elements = make(map[string][]string)
+			}
+			opts.Elements[key] = parsed
+		}
+	}
+	return opts
+}
+
+var NoNoninteractiveElementInteractionsRule = rule.Rule{
+	Name: "jsx-a11y/no-noninteractive-element-interactions",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		interactiveProps := defaultInteractiveProps
+		if opts.Handlers != nil {
+			interactiveProps = *opts.Handlers
+		}
+
+		getElementType := func(node *ast.Node) string {
+			return jsxa11yutil.GetElementType(node, ctx.Settings)
+		}
+
+		check := func(node *ast.Node) {
+			rawAttrs := reactutil.GetJsxElementAttributes(node)
+			elementType := getElementType(node)
+
+			// Per-element allow-list filter. Upstream:
+			//   attributes.filter(attr =>
+			//     attr.type !== 'JSXSpreadAttribute' &&
+			//     !includes(config[type], propName(attr)))
+			// — drop a non-spread attribute when its propName is in the
+			// element's allow-list. Spread attributes are always retained
+			// (the allow-list cannot prove what they carry), so a literal
+			// spread `{...{onLoad: foo}}` slips past the filter and trips
+			// the trigger downstream. Mirror exactly.
+			//
+			// Upstream's downstream calls — `isContentEditable(type, attrs)`,
+			// `isHiddenFromScreenReader(type, attrs)`,
+			// `isPresentationRole(type, attrs)`, `isInteractive*` /
+			// `isNonInteractive*` / `isAbstractRole(type, attrs)` — all
+			// consume the FILTERED `attributes` variable. We mirror that
+			// byte-for-byte by passing `attrs` to every downstream call
+			// (including [IsHiddenFromScreenReaderFromTagAttrs], the
+			// attrs-based variant added for exactly this case).
+			attrs := rawAttrs
+			if allow, ok := opts.Elements[elementType]; ok {
+				filtered := make([]*ast.Node, 0, len(rawAttrs))
+				for _, attr := range rawAttrs {
+					if attr.Kind != ast.KindJsxAttribute {
+						filtered = append(filtered, attr)
+						continue
+					}
+					if slices.Contains(allow, reactutil.GetJsxPropName(attr)) {
+						continue
+					}
+					filtered = append(filtered, attr)
+				}
+				attrs = filtered
+			}
+
+			// Upstream `interactiveProps.some(prop => hasProp(attrs, prop)
+			// && getPropValue(getProp(attrs, prop)) != null)`. `hasProp` /
+			// `getProp` default options walk LITERAL ObjectLiteral spreads,
+			// so `<div {...{onClick: foo}} />` counts here — matches
+			// [FindAttributeByName] semantics. `!= null` covers null and
+			// undefined (and the empty `{}` JsxExpression that
+			// `getPropValue` resolves to null for).
+			hasInteractiveProps := false
+			for _, prop := range interactiveProps {
+				attr := jsxa11yutil.FindAttributeByName(attrs, prop)
+				if attr == nil {
+					continue
+				}
+				if jsxa11yutil.PropValueIsNullish(attr) {
+					continue
+				}
+				hasInteractiveProps = true
+				break
+			}
+
+			if !jsxa11yutil.IsDOMElement(elementType) {
+				return
+			}
+			if !hasInteractiveProps {
+				return
+			}
+			if jsxa11yutil.IsContentEditable(attrs) {
+				return
+			}
+			if jsxa11yutil.IsHiddenFromScreenReaderFromTagAttrs(elementType, attrs) {
+				return
+			}
+			if jsxa11yutil.IsPresentationRole(attrs) {
+				return
+			}
+
+			// Upstream "no opinion" bail-out. Any ONE of these short-circuits
+			// the report:
+			//   - element is inherently interactive
+			//   - element has an interactive role
+			//   - element is NEITHER inherently nor explicitly non-interactive
+			//     (the "we don't know enough to call this non-interactive" arm)
+			//   - role is abstract
+			if jsxa11yutil.IsInteractiveElement(elementType, attrs) ||
+				jsxa11yutil.IsInteractiveRole(elementType, attrs) ||
+				(!jsxa11yutil.IsNonInteractiveElement(elementType, attrs) &&
+					!jsxa11yutil.IsNonInteractiveRole(elementType, attrs)) ||
+				jsxa11yutil.IsAbstractRole(elementType, attrs) {
+				return
+			}
+
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noNoninteractiveElementInteractions",
+				Description: errorMessage,
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.md
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.md
@@ -1,0 +1,144 @@
+# no-noninteractive-element-interactions
+
+## Rule Details
+
+Non-interactive HTML elements and non-interactive ARIA roles indicate
+_content_ and _containers_ in the user interface. A non-interactive element
+does not support event handlers (mouse and key handlers). Non-interactive
+elements include `<main>`, `<area>`, `<h1>` (and `<h2>` …), `<p>`, `<img>`,
+`<li>`, `<ul>` and `<ol>`. Non-interactive WAI-ARIA roles include `article`,
+`banner`, `complementary`, `img`, `listitem`, `main`, `region` and `tooltip`.
+
+When this rule fires, move the event handler to a semantically interactive
+element (`<button>`, `<a href>` …) or to an inner element with
+`role="presentation"`.
+
+The rule fires on a JSX opening element when **all** of the following hold:
+
+- The resolved element name is in the HTML DOM set (custom React components
+  are skipped — the rule does not know what low-level element they render).
+- After the per-element allow-list filter (see Rule Options below), the
+  element declares at least one of the configured `handlers` whose value
+  resolves to a non-nullish expression (`prop={null}` / `prop={undefined}`
+  do not count).
+- The element does not have `contentEditable="true"` (compared against the
+  raw attribute source, so `contentEditable={true}` and
+  `contentEditable={"true"}` do NOT exempt).
+- The element is not hidden from screen readers (no `aria-hidden={true}` /
+  `aria-hidden="true"`, not an `<input type="hidden">`).
+- The `role` attribute, when statically a literal string, is not
+  `presentation` or `none`.
+- The element is neither inherently interactive (e.g. `<button>`,
+  `<a href>`) nor carrying an interactive `role`.
+- The element IS inherently non-interactive (e.g. `<article>`, `<li>`,
+  `<p>`) OR has a non-interactive `role` (e.g. `role="article"`).
+- The `role` attribute, when statically a literal string, is not in the
+  ARIA abstract role set (`command`, `composite`, `input`, `landmark`,
+  `range`, `roletype`, `section`, `sectionhead`, `select`, `structure`,
+  `widget`, `window`).
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<li onClick={() => {}} />
+<div onClick={() => {}} role="listitem" />
+<article onClick={() => {}} />
+<h1 onClick={() => {}} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div onClick={() => {}} role="button" />
+<div onClick={() => {}} role="presentation" />
+<input type="text" onClick={() => {}} />
+<button onClick={() => {}} className="foo" />
+<div onClick={() => {}} role="button" aria-hidden />
+<Input onClick={() => {}} type="hidden" />
+```
+
+## Rule Options
+
+### `handlers`
+
+Type: `string[]`. Default: the union of `focus`, `image`, `keyboard`, and
+`mouse` event handlers — `onFocus`, `onBlur`, `onLoad`, `onError`,
+`onKeyDown`, `onKeyPress`, `onKeyUp`, `onClick`, `onContextMenu`,
+`onDblClick`, `onDoubleClick`, `onDrag`, `onDragEnd`, `onDragEnter`,
+`onDragExit`, `onDragLeave`, `onDragOver`, `onDragStart`, `onDrop`,
+`onMouseDown`, `onMouseEnter`, `onMouseLeave`, `onMouseMove`, `onMouseOut`,
+`onMouseOver`, `onMouseUp`.
+
+The upstream `recommended` preset overrides this with `["onClick",
+"onError", "onLoad", "onMouseDown", "onMouseUp", "onKeyPress", "onKeyDown",
+"onKeyUp"]`; the `strict` preset omits the override and uses the default.
+
+A list of handler prop names that the rule considers an "interactive
+listener". Adjust to expand or shrink the rule's coverage surface — an
+explicit empty array disables the rule entirely.
+
+Examples of **incorrect** code with `{ "handlers": ["onClick"] }`:
+
+```json
+{ "jsx-a11y/no-noninteractive-element-interactions": ["error", { "handlers": ["onClick"] }] }
+```
+
+```jsx
+<article onClick={() => {}} />
+```
+
+Examples of **correct** code with `{ "handlers": ["onClick"] }`:
+
+```json
+{ "jsx-a11y/no-noninteractive-element-interactions": ["error", { "handlers": ["onClick"] }] }
+```
+
+```jsx
+<article onMouseDown={() => {}} />
+```
+
+### Per-element allow-list
+
+Type: `string[]`, keyed by HTML element name. Default: not set. The
+upstream `recommended` and `strict` presets set `body`, `iframe`, and
+`img` to `["onError", "onLoad"]`.
+
+Any option key other than `handlers` is interpreted as an HTML element
+name → list of handler-prop names that are permitted on that element. The
+rule filters out matching non-spread attributes before the
+interactive-handler scan, so `<iframe onLoad={…} />` with `iframe:
+["onError", "onLoad"]` short-circuits, while `<iframe onClick={…} />`
+still reports.
+
+Examples of **correct** code with `{ "iframe": ["onError", "onLoad"] }`:
+
+```json
+{ "jsx-a11y/no-noninteractive-element-interactions": ["error", { "iframe": ["onError", "onLoad"] }] }
+```
+
+```jsx
+<iframe onLoad={() => {}} />
+<iframe onError={() => {}} />
+```
+
+Examples of **incorrect** code with `{ "iframe": ["onError", "onLoad"] }`:
+
+```json
+{ "jsx-a11y/no-noninteractive-element-interactions": ["error", { "iframe": ["onError", "onLoad"] }] }
+```
+
+```jsx
+<iframe onClick={() => {}} />
+```
+
+## Resources
+
+- [WCAG 4.1.2 — Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+- [WAI-ARIA — Usage Intro](https://www.w3.org/TR/wai-aria-1.1/#usage_intro)
+- [WAI-ARIA Authoring Practices Guide — Design Patterns and Widgets](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_ex)
+- [WAI-ARIA Authoring Practices — Keyboard Navigation Conventions](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav)
+- [MDN — ARIA Techniques: Using the `button` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Keyboard_and_focus)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/no-noninteractive-element-interactions](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-interactions.md)

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions_extras_test.go
@@ -1,0 +1,857 @@
+package no_noninteractive_element_interactions
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// This file holds every test case that is NOT a 1:1 mirror of upstream's
+// own test file. Upstream-parity cases live in
+// `no_noninteractive_element_interactions_upstream_test.go` so it stays
+// trivially comparable against future upstream updates via diff.
+//
+// Goals here, beyond upstream coverage:
+//
+//   - Lock every classifier arm under inputs upstream's own tests skip:
+//     attribute-value shapes (paren / TS `as` / TS `!` / member /
+//     identifier / call / conditional / template literal), attribute-name
+//     case-insensitivity, role / aria-hidden non-literal expressions,
+//     contentEditable raw-match nuances, literal-spread vs non-literal
+//     spread, multi-attribute first-match quirks.
+//   - Lock per-element allow-list semantics across the FULL downstream
+//     classifier chain (IsHiddenFromScreenReader, IsPresentationRole,
+//     IsContentEditable, IsAbstract/Non*/Interactive*Role/Element) — a
+//     bug here is invisible in upstream's tests because their preset
+//     never allow-lists state attributes.
+//   - Lock real-world component-wrapper patterns (forwardRef / memo /
+//     HOC / hooks / class render / map / fragment / async / generator /
+//     IIFE / conditional / `&&`) — each is an independent listener
+//     invocation that must classify on its own.
+//   - Lock settings paths upstream's tests don't exercise:
+//     polymorphicPropName with empty / non-literal `as`, polymorphicAllowList
+//     swap-and-no-swap, multi-entry components map.
+//   - Position assertions on multi-line / nested / fragment so a future
+//     refactor of listener registration can't silently shift columns.
+
+// expectedErrorAnyPos mirrors expectedError with Line/Column suppressed —
+// for nested / wrapped JSX where the opening element isn't at col 1.
+var expectedErrorAnyPos = rule_tester.InvalidTestCaseError{
+	MessageId: "noNoninteractiveElementInteractions",
+	Message:   errorMessage,
+}
+
+// polymorphicSettings exercises `settings['jsx-a11y'].polymorphicPropName`.
+var polymorphicSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+	},
+}
+
+// polymorphicAllowListSettings exercises `polymorphicAllowList` — only
+// the named rawTypes get the `as`-driven swap.
+var polymorphicAllowListSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName":  "as",
+		"polymorphicAllowList": []interface{}{"Foo"},
+	},
+}
+
+// componentsMapSettings exercises a multi-entry `components` map.
+var componentsMapSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"MyArticle": "article",
+			"MyButton":  "button",
+			"MyDiv":     "div",
+		},
+	},
+}
+
+// TestNoNoninteractiveElementInteractionsExtras locks in branches that
+// upstream's test file doesn't exercise but are reachable through the
+// rule's listener gate.
+func TestNoNoninteractiveElementInteractionsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+		&NoNoninteractiveElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// Dimension 1 — attribute VALUE: nullish shapes.
+			// PropValueIsNullish treats null / undefined / empty-{} as
+			// "absent", so even a non-interactive element with a nullish
+			// listener bails at the hasInteractiveProps gate.
+			// ============================================================
+
+			{Code: `<article onClick={null} />`, Tsx: true},
+			{Code: `<article onClick={undefined} />`, Tsx: true},
+			// ---- TS `as` cast unwrapped to null — extractValue while-loop
+			//      strips TSAsExpression. ----
+			{Code: `<article onClick={null as any} />`, Tsx: true},
+			// ---- Paren-wrapped null / undefined — parens stripped before
+			//      the nullish check. ----
+			{Code: `<article onClick={(null)} />`, Tsx: true},
+			{Code: `<article onClick={(undefined)} />`, Tsx: true},
+			// ---- Multiple nullish attributes of the same name — getProp
+			//      returns the FIRST match, so two nullish entries don't
+			//      synthesize a non-nullish listener. ----
+			{Code: `<article onClick={null} onClick={undefined} />`, Tsx: true},
+			// ---- First-match quirk: upstream `getProp` returns the FIRST
+			//      matching attribute; even though `onClick={fn}` follows,
+			//      the FIRST onClick is null → getPropValue == null → the
+			//      handler scan skips this name. Locks in the
+			//      FindAttributeByName first-match semantics — a future
+			//      refactor that walks "any non-null match" would silently
+			//      flip this case. ----
+			{Code: `<article onClick={null} onClick={fn} />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1 — non-default handlers (default = focus + image
+			// + keyboard + mouse). These groups are NOT in the default:
+			// clipboard, composition, form, selection, touch, ui, wheel,
+			// media-subset, animation, transition. Sampling a few exercises
+			// the default-handler-set boundary.
+			// ============================================================
+
+			{Code: `<article onCopy={fn} />`, Tsx: true},
+			{Code: `<article onCompositionStart={fn} />`, Tsx: true},
+			{Code: `<article onChange={fn} />`, Tsx: true},
+			{Code: `<article onSubmit={fn} />`, Tsx: true},
+			{Code: `<article onTouchStart={fn} />`, Tsx: true},
+			{Code: `<article onScroll={fn} />`, Tsx: true},
+			{Code: `<article onWheel={fn} />`, Tsx: true},
+			{Code: `<article onAnimationStart={fn} />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1 — contentEditable raw-match: VALID forms.
+			// IsContentEditable matches `prop.value.raw === '"true"'`,
+			// so only the bare `contentEditable="true"` string-literal
+			// form bails.
+			// ============================================================
+
+			{Code: `<article contentEditable="true" onClick={fn} />`, Tsx: true},
+			// ---- Case-insensitive attribute name (upstream `getProp`
+			//      default `ignoreCase: true`). ----
+			{Code: `<article contenteditable="true" onClick={fn} />`, Tsx: true},
+			{Code: `<article CONTENTEDITABLE="true" onClick={fn} />`, Tsx: true},
+			// ---- contentEditable on a div with non-interactive role —
+			//      same bail. ----
+			{Code: `<div role="article" contentEditable="true" onClick={fn} />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1 — aria-hidden VALUE shapes that resolve to JS
+			// boolean `true`. Locks the staticEval-based aria-hidden check.
+			// ============================================================
+
+			{Code: `<article aria-hidden onClick={fn} />`, Tsx: true},
+			{Code: `<article aria-hidden={true} onClick={fn} />`, Tsx: true},
+			{Code: `<article aria-hidden="true" onClick={fn} />`, Tsx: true},
+			// ---- Paren-wrapped boolean — parens stripped. ----
+			{Code: `<article aria-hidden={(true)} onClick={fn} />`, Tsx: true},
+			{Code: `<article aria-hidden={((true))} onClick={fn} />`, Tsx: true},
+			// ---- TS `as` cast — TSAsExpression unwrapped (extractValue
+			//      while-loop). ----
+			{Code: `<article aria-hidden={true as boolean} onClick={fn} />`, Tsx: true},
+			// ---- aria-hidden as JsxExpression containing the case-insensitive
+			//      string "true" — jsxAstUtilsLiteralCoerce maps to bool true. ----
+			{Code: `<article aria-hidden={"true"} onClick={fn} />`, Tsx: true},
+			// ---- Entity-encoded aria-hidden="&#116;rue" — direct-string
+			//      path entity-decodes BEFORE coercion (jsxAstUtilsLiteralCoerce). ----
+			{Code: `<article aria-hidden="&#116;rue" onClick={fn} />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1 — role VALUE shapes that resolve to literal
+			// "presentation" / "none". Locks LiteralPropStringValue across
+			// paren / NoSubstitutionTemplate / TemplateExpression-with-literal-
+			// substitution.
+			// ============================================================
+
+			{Code: `<article role="presentation" onClick={fn} />`, Tsx: true},
+			{Code: `<article role="none" onClick={fn} />`, Tsx: true},
+			{Code: `<article role={"presentation"} onClick={fn} />`, Tsx: true},
+			// ---- Paren around the literal — stripped. ----
+			{Code: `<article role={("presentation")} onClick={fn} />`, Tsx: true},
+			// ---- NoSubstitutionTemplate (`role={\`none\`}`). ----
+			{Code: "<article role={`none`} onClick={fn} />", Tsx: true},
+			// ---- TemplateExpression whose quasis + literal substitution
+			//      collapse to "presentation" — upstream LITERAL_TYPES
+			//      walks each substitution as a literal extract. ----
+			{Code: "<article role={`presentation${''}`} onClick={fn} />", Tsx: true},
+
+			// ============================================================
+			// Dimension 1 — IsAbstractRole arm. Locks the abstract-role
+			// bail-out path on INHERENTLY non-interactive elements; the
+			// `(!nonInt && !nonIntRole)` fallback returns false here
+			// because `<img>` / `<p>` ARE inherently non-interactive
+			// (matching the AX bare-schema). Upstream tests only the
+			// `<div role="X">` shape where the no-opinion arm also bails;
+			// these cases lock the IsAbstractRole branch on its own.
+			// ============================================================
+
+			{Code: `<img role="widget" onClick={fn} />`, Tsx: true},
+			{Code: `<p role="window" onClick={fn} />`, Tsx: true},
+			{Code: `<li role="composite" onClick={fn} />`, Tsx: true},
+			{Code: `<article role="input" onClick={fn} />`, Tsx: true},
+			// ---- The complete abstract-role set: command / composite /
+			//      input / landmark / range / roletype / section /
+			//      sectionhead / select / structure / widget / window. ----
+			{Code: `<p role="command" onClick={fn} />`, Tsx: true},
+			{Code: `<p role="landmark" onClick={fn} />`, Tsx: true},
+			{Code: `<p role="range" onClick={fn} />`, Tsx: true},
+			{Code: `<p role="roletype" onClick={fn} />`, Tsx: true},
+			{Code: `<p role="section" onClick={fn} />`, Tsx: true},
+			{Code: `<p role="sectionhead" onClick={fn} />`, Tsx: true},
+			{Code: `<p role="select" onClick={fn} />`, Tsx: true},
+			{Code: `<p role="structure" onClick={fn} />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1 — spread shapes. Literal-spread is walked by
+			// FindAttributeByName (matching upstream `getProp` default);
+			// non-literal spread is opaque.
+			// ============================================================
+
+			// ---- Literal spread containing role="presentation" — found
+			//      by IsPresentationRole. ----
+			{Code: `<article {...{role: "presentation"}} onClick={fn} />`, Tsx: true},
+			// ---- ShorthandPropertyAssignment containing role — the
+			//      shorthand value is the bound Identifier, which the
+			//      LITERAL_TYPES extractor rejects (Identifier non-undefined
+			//      → null), so it doesn't match. The element is `<div>`
+			//      (no opinion) so the rule bails on the no-opinion arm. ----
+			{Code: `<div {...{role}} onClick={fn} />`, Tsx: true},
+			// ---- Non-literal spread `{...props}` is opaque; element is
+			//      `<div>` (no opinion) so the rule bails on the no-opinion
+			//      arm even without seeing what props carry. ----
+			{Code: `<div {...props} onClick={fn} />`, Tsx: true},
+			// ---- Spread BEFORE direct listener — order doesn't matter. ----
+			{Code: `<div {...props} onClick={fn} />`, Tsx: true},
+			// ---- Multiple spreads + direct presentation role. ----
+			{Code: `<article {...a} {...b} role="presentation" onClick={fn} />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1 — boolean attribute form on an INTERACTIVE
+			// element (upstream `getPropValue(<X onClick/>)` resolves to
+			// boolean true; `!= null` is true; but the inherent-interactive
+			// gate bails). Locks that boolean form is recognized as
+			// "interactive prop present".
+			// ============================================================
+
+			{Code: `<button onClick />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 1 — `<input>` interactive promotion gates on the
+			// bare `{Name: "input"}` AX schema, so EVERY input type bails.
+			// Upstream tests the common types; this samples the rest.
+			// ============================================================
+
+			{Code: `<input type="datetime-local" onClick={fn} />`, Tsx: true},
+			{Code: `<input type="week" onClick={fn} />`, Tsx: true},
+			{Code: `<input type="file" onClick={fn} />`, Tsx: true},
+			{Code: `<input type="password" onClick={fn} />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 2 — nested JSX boundaries. Every opening element
+			// is classified independently; the listener doesn't carry
+			// state across the parent/child boundary.
+			// ============================================================
+
+			// ---- Outer + inner both inherently interactive. ----
+			{Code: `<button onClick={fn}><a href="x" onClick={fn}>x</a></button>`, Tsx: true},
+			// ---- Three-level all-interactive: form > button > a. ----
+			{Code: `<fieldset><button onClick={fn}><a href="x" onClick={fn}>x</a></button></fieldset>`, Tsx: true},
+			// ---- Outer non-interactive WITHOUT handler, inner interactive. ----
+			{Code: `<article><button onClick={fn}>x</button></article>`, Tsx: true},
+
+			// ============================================================
+			// Dimension 2 — real-world component patterns producing
+			// INTERACTIVE roots. Each pattern is its own listener fire.
+			// ============================================================
+
+			// ---- React.forwardRef wrapping interactive root. ----
+			{
+				Code: `const Btn = React.forwardRef((props, ref) => <button ref={ref} onClick={props.onClick} {...props} />);`,
+				Tsx:  true,
+			},
+			// ---- React.memo wrapping interactive root. ----
+			{
+				Code: `const Btn = React.memo(({ id, onClick }) => <button id={id} onClick={onClick}>{id}</button>);`,
+				Tsx:  true,
+			},
+			// ---- HOC wrapping interactive root. ----
+			{
+				Code: `const Enhanced = withTracking(({ value, onClick }) => <button data-value={value} onClick={onClick} />);`,
+				Tsx:  true,
+			},
+			// ---- Custom hook returning interactive root. ----
+			{Code: `function useThing() { return <button onClick={fn} />; }`, Tsx: true},
+			// ---- Class render() returning interactive root. ----
+			{
+				Code: `class Form extends React.Component { render() { return <button onClick={fn}>x</button>; } }`,
+				Tsx:  true,
+			},
+			// ---- Array.map producing interactive children. ----
+			{
+				Code: `const list = items.map(item => <button key={item.id} onClick={() => choose(item)}>{item.label}</button>);`,
+				Tsx:  true,
+			},
+			// ---- Generator yielding interactive elements. ----
+			{
+				Code: `function* render() { yield <button onClick={fn} />; yield <a href="x" onClick={fn} />; }`,
+				Tsx:  true,
+			},
+			// ---- Async function returning interactive element. ----
+			{Code: `async function render() { return <button onClick={fn} />; }`, Tsx: true},
+			// ---- IIFE returning interactive element. ----
+			{Code: `const x = (() => <button onClick={fn} />)();`, Tsx: true},
+			// ---- Fragment with all-interactive children. ----
+			{
+				Code: `const x = (<><button onClick={fn} /><a href="x" onClick={fn} /></>);`,
+				Tsx:  true,
+			},
+			// ---- Conditional with both interactive branches. ----
+			{
+				Code: `const x = cond ? <button onClick={fn} /> : <a href="x" onClick={fn} />;`,
+				Tsx:  true,
+			},
+			// ---- `&&` short-circuit. ----
+			{Code: `const x = cond && <button onClick={fn} />;`, Tsx: true},
+
+			// ============================================================
+			// Dimension 3 — element-type resolution: settings paths.
+			// ============================================================
+
+			// ---- polymorphicPropName: `as` is a literal interactive name. ----
+			{Code: `<Foo as="button" onClick={fn} />`, Tsx: true, Settings: polymorphicSettings},
+			{Code: `<Foo as="a" href="x" onClick={fn} />`, Tsx: true, Settings: polymorphicSettings},
+			{Code: `<Foo as="input" type="text" onClick={fn} />`, Tsx: true, Settings: polymorphicSettings},
+			// ---- polymorphicPropName: empty-string `as=""` is falsy →
+			//      fallback to rawType ("Foo", custom). ----
+			{Code: `<Foo as="" onClick={fn} />`, Tsx: true, Settings: polymorphicSettings},
+			// ---- polymorphicPropName: non-literal `as={x}` → fallback. ----
+			{Code: `<Foo as={someType} onClick={fn} />`, Tsx: true, Settings: polymorphicSettings},
+			// ---- polymorphicPropName: `as` absent → fallback. ----
+			{Code: `<Foo onClick={fn} />`, Tsx: true, Settings: polymorphicSettings},
+			// ---- polymorphicAllowList: Bar NOT in allow-list → no swap,
+			//      stays as Bar (custom). ----
+			{Code: `<Bar as="article" onClick={fn} />`, Tsx: true, Settings: polymorphicAllowListSettings},
+			// ---- polymorphicAllowList: Foo in allow-list → swap to button. ----
+			{Code: `<Foo as="button" onClick={fn} />`, Tsx: true, Settings: polymorphicAllowListSettings},
+
+			// ---- components map: MyButton → button (inherent-interactive). ----
+			{Code: `<MyButton onClick={fn} />`, Tsx: true, Settings: componentsMapSettings},
+			// ---- components map present but element not listed → custom. ----
+			{Code: `<Unmapped onClick={fn} />`, Tsx: true, Settings: componentsMapSettings},
+
+			// ---- Compound element name `<Foo.Bar>` — not a DOM name → custom. ----
+			{Code: `<Foo.Bar onClick={fn} />`, Tsx: true},
+
+			// ============================================================
+			// Options — `handlers` override.
+			// ============================================================
+
+			// ---- handlers=['onClick'] — onMouseDown is NOT in the override. ----
+			{
+				Code:    `<article onMouseDown={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"handlers": []interface{}{"onClick"}},
+			},
+			// ---- handlers=[] — empty list — NOTHING triggers. ----
+			{
+				Code:    `<article onClick={fn} onKeyDown={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"handlers": []interface{}{}},
+			},
+			// ---- handlers override pulling in a NON-default handler. ----
+			{
+				Code:    `<article onClick={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"handlers": []interface{}{"onMouseDown"}},
+			},
+			// ---- Mixed-type handlers array: non-strings silently dropped
+			//      (StringSliceOption defensive filter). Effective list
+			//      is just ['onMouseDown'], so onClick doesn't trigger. ----
+			{
+				Code:    `<article onClick={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"handlers": []interface{}{42, "onMouseDown", nil}},
+			},
+
+			// ============================================================
+			// Options — per-element allow-list filters event handlers.
+			// ============================================================
+
+			// ---- `iframe: ['onLoad']` filters onLoad → no remaining
+			//      interactive props → bail. ----
+			{
+				Code:    `<iframe onLoad={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"iframe": []interface{}{"onLoad"}},
+			},
+			// ---- Allow-list of a non-iframe element — `article: ['onClick']`
+			//      filters onClick. ----
+			{
+				Code:    `<article onClick={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"article": []interface{}{"onClick"}},
+			},
+			// ---- Allow-list does NOT touch a different element. The body
+			//      key only affects <body>, not <article>; the rule reports
+			//      <article onClick> normally — covered in invalid below. ----
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Dimension 1 — attribute VALUE: non-nullish shapes. Locks
+			// every non-null branch of staticEval for the handler-value
+			// scan. Each of these would `getPropValue != null`, so the
+			// hasInteractiveProps gate trips.
+			// ============================================================
+
+			// ---- Boolean attribute form — extractValue null-attr-value
+			//      maps to JS boolean `true`. ----
+			{Code: `<article onClick />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- Identifier value (non-undefined). ----
+			{Code: `<article onClick={someFn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- MemberExpression value. ----
+			{Code: `<article onClick={obj.method} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- Optional-chain member access. ----
+			{Code: `<article onClick={obj?.method} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- CallExpression value. ----
+			{Code: `<article onClick={getHandler()} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- ConditionalExpression value. ----
+			{Code: `<article onClick={cond ? a : b} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- LogicalExpression value. ----
+			{Code: `<article onClick={a || b} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- AsyncArrowFunction value. ----
+			{Code: `<article onClick={async () => {}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- FunctionExpression value. ----
+			{Code: `<article onClick={function() {}} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- Paren-wrapped function — staticEval strips parens. ----
+			{Code: `<article onClick={(() => {})} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- TS `as` cast — TSAsExpression unwrapped to inner value. ----
+			{Code: `<article onClick={fn as any} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- TS `!` non-null assertion. Upstream stringifies inner +
+			//      `!` (e.g. `"fn!"` non-empty string) — `!= null` is true. ----
+			{Code: `<article onClick={fn!} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Dimension 1 — attribute NAME case-insensitivity. Upstream
+			// `getProp` default `ignoreCase: true` — every case variation
+			// of `onClick` matches.
+			// ============================================================
+
+			{Code: `<article onclick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<article ONCLICK={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<article onCLICK={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Dimension 1 — aria-hidden VALUE shapes that do NOT resolve
+			// to boolean true → IsHiddenFromScreenReader returns false →
+			// the rule continues to the report.
+			// ============================================================
+
+			// ---- aria-hidden={false}. ----
+			{Code: `<article aria-hidden={false} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- aria-hidden="false" — jsxAstUtilsLiteralCoerce → bool false. ----
+			{Code: `<article aria-hidden="false" onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- aria-hidden={"false"}. ----
+			{Code: `<article aria-hidden={"false"} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- aria-hidden Identifier (non-undefined) — staticEval
+			//      synthesizes the identifier name as string, NOT boolean
+			//      true. ----
+			{Code: `<article aria-hidden={hiddenVar} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- aria-hidden CallExpression — not statically bool true. ----
+			{Code: `<article aria-hidden={isHidden()} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- aria-hidden Ternary where both branches are NOT bool true —
+			//      upstream's `extract` recursively evaluates the ternary
+			//      (test Identifier "cond" is truthy → take consequent "0",
+			//      a non-bool-true value). NOT hidden → reports. ----
+			{Code: `<article aria-hidden={cond ? 0 : 1} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- aria-hidden TS `!` on bool literal — upstream's
+			//      TSNonNullExpression arm stringifies the inner value and
+			//      appends "!" → "true!" (non-empty string, NOT bool true).
+			//      Locks the `OEKNonNullAssertions` exclusion from
+			//      skipTransparent. ----
+			{Code: `<article aria-hidden={true!} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Dimension 1 — role VALUE shapes that don't pass through any
+			// bail-out arm: IsPresentationRole / IsNonInteractiveRole /
+			// IsInteractiveRole / IsAbstractRole all require the role to
+			// resolve to a literal string via LiteralPropStringValue.
+			// ============================================================
+
+			// ---- role Identifier — non-literal. ----
+			{Code: `<article role={someRole} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role CallExpression — non-literal. ----
+			{Code: `<article role={getRole()} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role ConditionalExpression — even with literal branches
+			//      jsx-ast-utils' LITERAL_TYPES has no Conditional arm →
+			//      null → not a literal string. ----
+			{Code: `<article role={cond ? "presentation" : "article"} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role LogicalExpression — same noop → null. ----
+			{Code: `<article role={a || "none"} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role TemplateExpression whose substitution doesn't
+			//      collapse to a presentation/none/abstract/interactive
+			//      string. ----
+			{Code: "<article role={`status-${x}`} onClick={fn} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- role="NONE" / role="PRESENTATION" — IsPresentationRole
+			//      compares CASE-SENSITIVELY against `"presentation"` /
+			//      `"none"` (upstream `=== 'presentation'`). ----
+			{Code: `<article role="NONE" onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<article role="PRESENTATION" onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+			// ============================================================
+			// Dimension 1 — contentEditable raw-match nuances. The
+			// upstream check is `prop.value.raw === '"true"'`. ANY shape
+			// that doesn't produce exactly that raw string fails the
+			// bail-out.
+			// ============================================================
+
+			// ---- JsxExpression form `={true}` — raw is `{true}`, not `"true"`. ----
+			{Code: `<article contentEditable={true} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- JsxExpression containing the string "true" — raw is
+			//      `{"true"}`, not the bare `"true"`. ----
+			{Code: `<article contentEditable={"true"} onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- NoSubstitutionTemplate form — raw is a template, not
+			//      the string literal. ----
+			{Code: "<article contentEditable={`true`} onClick={fn} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- Case-sensitive raw compare: "True" / "TRUE" don't match. ----
+			{Code: `<article contentEditable="True" onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			{Code: `<article contentEditable="TRUE" onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- Entity-encoded: raw text is NOT entity-decoded for the
+			//      `=== '"true"'` compare. ----
+			{Code: `<article contentEditable="&#116;rue" onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- contentEditable="false" — explicit non-true. ----
+			{Code: `<article contentEditable="false" onClick={fn} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+			// ---- contentEditable in a LITERAL spread — upstream's
+			//      `prop?.value?.raw` looks up the literal JsxAttribute
+			//      shape; a PropertyAssignment inside a spread doesn't
+			//      synthesize a `.value.raw`, so IsContentEditable returns
+			//      false. ----
+			{
+				Code:   `<article {...{contentEditable: "true"}} onClick={fn} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+
+			// ============================================================
+			// Dimension 1 — spread shapes. Literal-spread of an event
+			// handler IS walked by FindAttributeByName (upstream `getProp`
+			// default).
+			// ============================================================
+
+			{
+				Code:   `<article {...{onClick: fn}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- ShorthandPropertyAssignment `{onClick}` — getProp walks
+			//      it (the value is the bound Identifier, but PROPERTY KEY
+			//      `onClick` matches name). ----
+			{
+				Code:   `<article {...{onClick}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- Direct onClick + spread of literal aria-hidden={false} —
+			//      spread reveals aria-hidden but as bool false, not true
+			//      → not hidden → report. ----
+			{
+				Code:   `<article onClick={fn} {...{"aria-hidden": false}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+
+			// ============================================================
+			// Dimension 2 — same-tag nested boundary. Each opening
+			// element classifies independently; the inner `<article>`
+			// doesn't bleed past the outer's classification.
+			// ============================================================
+
+			// ---- Outer non-interactive WITHOUT handler → no report.
+			//      Inner non-interactive WITH handler → report on the
+			//      inner only. ----
+			{
+				Code: `<article>` + "\n" +
+					`  <article onClick={fn} />` + "\n" +
+					`</article>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noNoninteractiveElementInteractions",
+					Message:   errorMessage,
+					Line:      2,
+					Column:    3,
+				}},
+			},
+			// ---- Both outer and inner non-interactive WITH handlers →
+			//      two reports. ----
+			{
+				Code: `<article onClick={fn}>` + "\n" +
+					`  <section onClick={fn} aria-label="x" />` + "\n" +
+					`</article>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNoninteractiveElementInteractions", Message: errorMessage, Line: 1, Column: 1},
+					{MessageId: "noNoninteractiveElementInteractions", Message: errorMessage, Line: 2, Column: 3},
+				},
+			},
+
+			// ============================================================
+			// Dimension 2 — position assertions: multi-line, fragment.
+			// ============================================================
+
+			// ---- Multi-line opening element — Line/Column anchor to `<`. ----
+			{
+				Code: `<article` + "\n" +
+					`  onClick={fn}` + "\n" +
+					`/>;`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noNoninteractiveElementInteractions",
+					Message:   errorMessage,
+					Line:      1,
+					Column:    1,
+				}},
+			},
+			// ---- Two same-line non-interactive elements both report. ----
+			{
+				Code: `<><article onClick={fn} /><section onClick={fn} aria-label="x" /></>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNoninteractiveElementInteractions", Message: errorMessage, Line: 1, Column: 3},
+					{MessageId: "noNoninteractiveElementInteractions", Message: errorMessage, Line: 1, Column: 27},
+				},
+			},
+			// ---- Nested non-interactive child inside interactive parent
+			//      fires on its own opening element. ----
+			{
+				Code: `<button onClick={fn}>` + "\n" +
+					`  <article onClick={fn} />` + "\n" +
+					`</button>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noNoninteractiveElementInteractions",
+					Message:   errorMessage,
+					Line:      2,
+					Column:    3,
+				}},
+			},
+
+			// ============================================================
+			// Dimension 2 — real-world component patterns producing
+			// NON-INTERACTIVE roots. Each is its own listener invocation.
+			// ============================================================
+
+			// ---- React.forwardRef wrapping non-interactive root. ----
+			{
+				Code:   `const Card = React.forwardRef((props, ref) => <article ref={ref} onClick={props.onClick} {...props} />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- React.memo wrapping non-interactive root. ----
+			{
+				Code:   `const Pane = React.memo(({ id, onClick }) => <article id={id} onClick={onClick} />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- HOC wrapping non-interactive root. ----
+			{
+				Code:   `const Enhanced = withTracking(({ value, onClick }) => <p data-value={value} onClick={onClick} />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Custom hook returning non-interactive root. ----
+			{
+				Code:   `function useThing() { return <article onClick={fn} />; }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Class render() returning non-interactive root. ----
+			{
+				Code:   `class Pane extends React.Component { render() { return <article onClick={this.onClick}>x</article>; } }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Array.map producing non-interactive children. ----
+			{
+				Code:   `const list = items.map(item => <li key={item.id} onClick={fn}>{item.label}</li>);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Generator yielding non-interactive elements (2 reports). ----
+			{
+				Code:   `function* render() { yield <article onClick={fn} />; yield <li onClick={fn} />; }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos, expectedErrorAnyPos},
+			},
+			// ---- Async function returning non-interactive root. ----
+			{
+				Code:   `async function render() { return <article onClick={fn} />; }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- IIFE returning non-interactive root. ----
+			{
+				Code:   `const x = (() => <article onClick={fn} />)();`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Conditional with one non-interactive branch. ----
+			{
+				Code:   `const x = cond ? <article onClick={fn} /> : null;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos},
+			},
+			// ---- Fragment with mixed interactive / non-interactive
+			//      children — only the non-interactive ones report. ----
+			{
+				Code:   `const x = (<><button onClick={fn} /><article onClick={fn} /><a href="x" onClick={fn} /><li onClick={fn} /></>);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrorAnyPos, expectedErrorAnyPos},
+			},
+			// ---- Two-component file: A reports at line 1, B reports at line 2. ----
+			{
+				Code: `function A() { return <article onClick={fn} />; }` + "\n" +
+					`function B() { return <section onClick={fn} aria-label="x" />; }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNoninteractiveElementInteractions", Message: errorMessage, Line: 1},
+					{MessageId: "noNoninteractiveElementInteractions", Message: errorMessage, Line: 2},
+				},
+			},
+
+			// ============================================================
+			// Dimension 3 — settings paths producing non-interactive roots.
+			// ============================================================
+
+			// ---- polymorphicPropName: <Foo as="article"> → article. ----
+			{
+				Code:     `<Foo as="article" onClick={fn} />`,
+				Tsx:      true,
+				Settings: polymorphicSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- polymorphicPropName: <Foo as="li">. ----
+			{
+				Code:     `<Foo as="li" onClick={fn} />`,
+				Tsx:      true,
+				Settings: polymorphicSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- polymorphicAllowList: Foo allowed → swap to "article". ----
+			{
+				Code:     `<Foo as="article" onClick={fn} />`,
+				Tsx:      true,
+				Settings: polymorphicAllowListSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- components map: <MyArticle> → article. ----
+			{
+				Code:     `<MyArticle onClick={fn} />`,
+				Tsx:      true,
+				Settings: componentsMapSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- components map: <MyDiv> → div (no opinion); BUT with a
+			//      non-interactive role attribute, the role-driven
+			//      classification kicks in. ----
+			{
+				Code:     `<MyDiv role="article" onClick={fn} />`,
+				Tsx:      true,
+				Settings: componentsMapSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+			},
+
+			// ============================================================
+			// Options — `handlers` override pulling in a non-default
+			// handler.
+			// ============================================================
+
+			// ---- handlers=['onSubmit'] — onSubmit is not in default but
+			//      explicit override pulls it in. ----
+			{
+				Code:    `<article onSubmit={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"handlers": []interface{}{"onSubmit"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- handlers + per-element allow-list combined. onClick is
+			//      in handlers, NOT in iframe's allow-list → still reports. ----
+			{
+				Code: `<iframe onClick={fn} />`,
+				Tsx:  true,
+				Options: map[string]interface{}{
+					"handlers": []interface{}{"onClick", "onLoad", "onError"},
+					"iframe":   []interface{}{"onLoad", "onError"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- Allow-list of a DIFFERENT element doesn't affect this
+			//      one. `body: ['onLoad']` only applies to <body>; <article
+			//      onClick> trips normally. ----
+			{
+				Code:    `<article onClick={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"body": []interface{}{"onLoad"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+			},
+
+			// ============================================================
+			// Filter case-sensitivity quirk: upstream's `includes` uses
+			// strict equality, but `getProp` is ignoreCase by default.
+			// ----------------------------------------------------------
+			// `<iframe ONLOAD={fn}/>` with `iframe: ['onLoad']`:
+			//   - filter:  propName(attr) = "ONLOAD"; includes(['onLoad'], "ONLOAD") = false → KEPT.
+			//   - has-prop: getProp(attrs, 'onLoad') ignoreCase → matches "ONLOAD" → trigger.
+			// Different casing on the user's part DOES NOT escape the rule.
+			// ============================================================
+
+			{
+				Code:    `<iframe ONLOAD={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"iframe": []interface{}{"onLoad"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+			},
+
+			// ============================================================
+			// Per-element allow-list filters EVERY downstream classifier
+			// (not just the handler scan). When the allow-list strips a
+			// state attribute, the corresponding classifier sees a
+			// different shape and the rule's verdict changes.
+			// ============================================================
+
+			// ---- `article: ['aria-hidden']` strips aria-hidden BEFORE the
+			//      IsHiddenFromScreenReader check, so the rule no longer
+			//      sees the element as hidden and reports. Locks in the
+			//      attrs-passthrough for IsHiddenFromScreenReader. ----
+			{
+				Code:    `<article aria-hidden onClick={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"article": []interface{}{"aria-hidden"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			{
+				Code:    `<article aria-hidden={true} onClick={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"article": []interface{}{"aria-hidden"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- `article: ['role']` strips role BEFORE the
+			//      IsPresentationRole / IsAbstractRole checks. ----
+			{
+				Code:    `<article role="presentation" onClick={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"article": []interface{}{"role"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+			},
+			// ---- `article: ['contentEditable']` strips contentEditable
+			//      BEFORE the IsContentEditable check. ----
+			{
+				Code:    `<article contentEditable="true" onClick={fn} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"article": []interface{}{"contentEditable"}},
+				Errors:  []rule_tester.InvalidTestCaseError{expectedError},
+			},
+		},
+	)
+}

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions_upstream_test.go
@@ -1,0 +1,594 @@
+package no_noninteractive_element_interactions
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedError mirrors upstream's `expectedError` constant — the single
+// shape every invalid case in the rule produces. Centralized so a future
+// error-text tweak touches one place.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "noNoninteractiveElementInteractions",
+	Message:   errorMessage,
+	Line:      1,
+	Column:    1,
+}
+
+// recommendedConfig mirrors `configs.recommended.rules['jsx-a11y/no-noninteractive-element-interactions'][1]`.
+// Source: eslint-plugin-jsx-a11y/src/index.js.
+//
+// The `alert` and `dialog` entries are dead in upstream — `hasOwn(config,
+// type)` consults the resolved ELEMENT name (via getElementType), not the
+// role; `<alert>` is not a real DOM element, and `<dialog>` is a real
+// element but its role-driven exemption isn't what upstream's allow-list is
+// designed for. They're preserved here for byte-for-byte parity.
+var recommendedConfig = map[string]interface{}{
+	"handlers": []interface{}{
+		"onClick", "onError", "onLoad",
+		"onMouseDown", "onMouseUp",
+		"onKeyPress", "onKeyDown", "onKeyUp",
+	},
+	"alert":  []interface{}{"onKeyUp", "onKeyDown", "onKeyPress"},
+	"body":   []interface{}{"onError", "onLoad"},
+	"dialog": []interface{}{"onKeyUp", "onKeyDown", "onKeyPress"},
+	"iframe": []interface{}{"onError", "onLoad"},
+	"img":    []interface{}{"onError", "onLoad"},
+}
+
+// strictConfig mirrors `configs.strict.rules['jsx-a11y/no-noninteractive-element-interactions'][1]`.
+// No `handlers` override — falls back to defaultInteractiveProps (focus +
+// image + keyboard + mouse). Source: eslint-plugin-jsx-a11y/src/index.js.
+var strictConfig = map[string]interface{}{
+	"body":   []interface{}{"onError", "onLoad"},
+	"iframe": []interface{}{"onError", "onLoad"},
+	"img":    []interface{}{"onError", "onLoad"},
+}
+
+// imageComponentsSettings mirrors upstream's
+//
+//	settings: { 'jsx-a11y': { components: { Image: 'img' } } }
+//
+// so `<Image>` resolves to `img` and the rule treats it as a non-interactive
+// DOM element (`img` is in `nonInteractiveElementAXSchemas`).
+var imageComponentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Image": "img",
+		},
+	},
+}
+
+// buttonComponentsSettings mirrors upstream's
+//
+//	settings: { 'jsx-a11y': { components: { Button: 'button' } } }
+//
+// — `<Button>` resolves to `button` and the rule treats it as an interactive
+// DOM element, so the `<Button onClick={...} />` valid case lands on the
+// inherent-interactive bail-out.
+var buttonComponentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Button": "button",
+		},
+	},
+}
+
+// alwaysValid mirrors upstream's `alwaysValid` array verbatim — valid under
+// EVERY option combination. Order matches the upstream file so a future
+// audit can grep across both side-by-side.
+func alwaysValid() []rule_tester.ValidTestCase {
+	return []rule_tester.ValidTestCase{
+		// ---- Custom components — element type isn't in aria-query's
+		//      `dom` map → upstream short-circuits before checking
+		//      interactivity. ----
+		{Code: `<TestComponent onClick={doFoo} />`, Tsx: true},
+		{Code: `<Button onClick={doFoo} />`, Tsx: true},
+		{Code: `<Image onClick={() => void 0} />;`, Tsx: true},
+		{Code: `<Button onClick={() => void 0} />;`, Tsx: true, Settings: buttonComponentsSettings},
+
+		// ---- All flavors of input — `<input>` resolves to an interactive
+		//      element via aria-query's elementAXObjects schema (the bare
+		//      `{Name: "input"}` entry matches every type). ----
+		{Code: `<input onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="button" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="checkbox" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="color" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="date" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="datetime" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="datetime-local" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="email" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="file" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="image" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="month" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="number" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="password" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="radio" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="range" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="reset" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="search" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="submit" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="tel" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="text" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="time" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="url" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="week" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="hidden" onClick={() => void 0} />`, Tsx: true},
+
+		// ---- Interactive elements (anchor / button / option / select /
+		//      textarea / area / body / menuitem / tr). ----
+		{Code: `<a onClick={() => void 0} />`, Tsx: true},
+		{Code: `<a onClick={() => {}} />;`, Tsx: true},
+		{Code: `<a tabIndex="0" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<a onClick={() => void 0} href="http://x.y.z" />`, Tsx: true},
+		{Code: `<a onClick={() => void 0} href="http://x.y.z" tabIndex="0" />`, Tsx: true},
+		{Code: `<area onClick={() => {}} />;`, Tsx: true},
+		{Code: `<body onClick={() => {}} />;`, Tsx: true},
+		{Code: `<button onClick={() => void 0} className="foo" />`, Tsx: true},
+		{Code: `<menuitem onClick={() => {}} />;`, Tsx: true},
+		{Code: `<option onClick={() => void 0} className="foo" />`, Tsx: true},
+		{Code: `<select onClick={() => void 0} className="foo" />`, Tsx: true},
+		{Code: `<textarea onClick={() => void 0} className="foo" />`, Tsx: true},
+		{Code: `<tr onClick={() => {}} />;`, Tsx: true},
+
+		// ---- HTML elements with neither an interactive nor non-interactive
+		//      valence (static / "no opinion"). aria-query has no entry for
+		//      these in either schema, so the rule lands on the
+		//      `(!isNonInteractiveElement && !isNonInteractiveRole)` arm and
+		//      bails. ----
+		{Code: `<acronym onClick={() => {}} />;`, Tsx: true},
+		{Code: `<applet onClick={() => {}} />;`, Tsx: true},
+		{Code: `<audio onClick={() => {}} />;`, Tsx: true},
+		{Code: `<b onClick={() => {}} />;`, Tsx: true},
+		{Code: `<base onClick={() => {}} />;`, Tsx: true},
+		{Code: `<bdi onClick={() => {}} />;`, Tsx: true},
+		{Code: `<bdo onClick={() => {}} />;`, Tsx: true},
+		{Code: `<big onClick={() => {}} />;`, Tsx: true},
+		{Code: `<blink onClick={() => {}} />;`, Tsx: true},
+		{Code: `<body onLoad={() => {}} />;`, Tsx: true},
+		{Code: `<canvas onClick={() => {}} />;`, Tsx: true},
+		{Code: `<center onClick={() => {}} />;`, Tsx: true},
+		{Code: `<cite onClick={() => {}} />;`, Tsx: true},
+		{Code: `<col onClick={() => {}} />;`, Tsx: true},
+		{Code: `<colgroup onClick={() => {}} />;`, Tsx: true},
+		{Code: `<content onClick={() => {}} />;`, Tsx: true},
+		{Code: `<data onClick={() => {}} />;`, Tsx: true},
+		{Code: `<datalist onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div />;`, Tsx: true},
+		{Code: `<div className="foo" />;`, Tsx: true},
+		{Code: `<div className="foo" {...props} />;`, Tsx: true},
+		{Code: `<div onClick={() => void 0} aria-hidden />;`, Tsx: true},
+		{Code: `<div onClick={() => void 0} aria-hidden={true} />;`, Tsx: true},
+		{Code: `<div onClick={() => void 0} />;`, Tsx: true},
+		{Code: `<div onClick={() => void 0} role={undefined} />;`, Tsx: true},
+		{Code: `<div onClick={() => void 0} {...props} />;`, Tsx: true},
+		{Code: `<div onClick={null} />;`, Tsx: true},
+		{Code: `<div onKeyUp={() => void 0} aria-hidden={false} />;`, Tsx: true},
+		{Code: `<embed onClick={() => {}} />;`, Tsx: true},
+		{Code: `<font onClick={() => {}} />;`, Tsx: true},
+		{Code: `<font onSubmit={() => {}} />;`, Tsx: true},
+		{Code: `<form onSubmit={() => {}} />;`, Tsx: true},
+		{Code: `
+				<form onSubmit={this.handleSubmit.bind(this)} method="POST">
+					<button type="submit">
+							Save
+					</button>
+				</form>
+			`, Tsx: true},
+		{Code: `<frame onClick={() => {}} />;`, Tsx: true},
+		{Code: `<frameset onClick={() => {}} />;`, Tsx: true},
+		{Code: `<head onClick={() => {}} />;`, Tsx: true},
+		{Code: `<header onClick={() => {}} />;`, Tsx: true},
+		{Code: `<hgroup onClick={() => {}} />;`, Tsx: true},
+		{Code: `<i onClick={() => {}} />;`, Tsx: true},
+		{Code: `<iframe onLoad={() => {}} />;`, Tsx: true},
+		{Code: `
+				<iframe
+					name="embeddedExternalPayment"
+					ref="embeddedExternalPayment"
+					style={iframeStyle}
+					onLoad={this.handleLoadIframe}
+				/>
+			`, Tsx: true},
+		{Code: `<img {...props} onError={() => {}} />;`, Tsx: true},
+		{Code: `<img onLoad={() => {}} />;`, Tsx: true},
+		{Code: `<img src={currentPhoto.imageUrl} onLoad={this.handleImageLoad} alt="for review" />`, Tsx: true},
+		{Code: `
+					<img
+					ref={this.ref}
+					className="c-responsive-image-placeholder__image"
+					src={src}
+					alt={alt}
+					data-test-id="test-id"
+					onLoad={this.fetchCompleteImage}
+				/>
+			`, Tsx: true},
+		{Code: `<kbd onClick={() => {}} />;`, Tsx: true},
+		{Code: `<keygen onClick={() => {}} />;`, Tsx: true},
+		{Code: `<link onClick={() => {}} />;`, Tsx: true},
+		{Code: `<main onClick={null} />;`, Tsx: true},
+		{Code: `<map onClick={() => {}} />;`, Tsx: true},
+		{Code: `<meta onClick={() => {}} />;`, Tsx: true},
+		{Code: `<noembed onClick={() => {}} />;`, Tsx: true},
+		{Code: `<noscript onClick={() => {}} />;`, Tsx: true},
+		{Code: `<object onClick={() => {}} />;`, Tsx: true},
+		{Code: `<param onClick={() => {}} />;`, Tsx: true},
+		{Code: `<picture onClick={() => {}} />;`, Tsx: true},
+		{Code: `<q onClick={() => {}} />;`, Tsx: true},
+		{Code: `<rp onClick={() => {}} />;`, Tsx: true},
+		{Code: `<rt onClick={() => {}} />;`, Tsx: true},
+		{Code: `<rtc onClick={() => {}} />;`, Tsx: true},
+		{Code: `<s onClick={() => {}} />;`, Tsx: true},
+		{Code: `<samp onClick={() => {}} />;`, Tsx: true},
+		{Code: `<script onClick={() => {}} />;`, Tsx: true},
+		{Code: `<section onClick={() => {}} />;`, Tsx: true},
+		{Code: `<small onClick={() => {}} />;`, Tsx: true},
+		{Code: `<source onClick={() => {}} />;`, Tsx: true},
+		{Code: `<spacer onClick={() => {}} />;`, Tsx: true},
+		{Code: `<span onClick={() => {}} />;`, Tsx: true},
+		{Code: `<strike onClick={() => {}} />;`, Tsx: true},
+		{Code: `<style onClick={() => {}} />;`, Tsx: true},
+		{Code: `<summary onClick={() => {}} />;`, Tsx: true},
+		{Code: `<th onClick={() => {}} />;`, Tsx: true},
+		{Code: `<title onClick={() => {}} />;`, Tsx: true},
+		{Code: `<track onClick={() => {}} />;`, Tsx: true},
+		{Code: `<td onClick={() => {}} />;`, Tsx: true},
+		{Code: `<tt onClick={() => {}} />;`, Tsx: true},
+		{Code: `<u onClick={() => {}} />;`, Tsx: true},
+		{Code: `<var onClick={() => {}} />;`, Tsx: true},
+		{Code: `<video onClick={() => {}} />;`, Tsx: true},
+		{Code: `<wbr onClick={() => {}} />;`, Tsx: true},
+		{Code: `<xmp onClick={() => {}} />;`, Tsx: true},
+
+		// ---- HTML elements attributed with an interactive role. ----
+		{Code: `<div role="button" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="checkbox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="columnheader" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="combobox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="grid" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="gridcell" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="link" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="listbox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="menu" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="menubar" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="menuitem" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="menuitemcheckbox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="menuitemradio" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="option" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="progressbar" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="radio" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="radiogroup" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="row" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="rowheader" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="scrollbar" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="searchbox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="slider" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="spinbutton" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="switch" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="tab" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="textbox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="treeitem" onClick={() => {}} />;`, Tsx: true},
+
+		// ---- presentation / none roles → intentional static semantics. ----
+		{Code: `<div role="presentation" onClick={() => {}} />;`, Tsx: true},
+
+		// ---- Abstract roles (the rule has no opinion). ----
+		{Code: `<div role="command" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="composite" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="input" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="landmark" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="range" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="roletype" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="sectionhead" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="select" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="structure" onClick={() => {}} />;`, Tsx: true},
+		// `tablist` / `toolbar` / `tree` / `treegrid` are concrete INTERACTIVE
+		// roles (interactiveRolesSet), so they land on the inherent-interactive
+		// arm rather than the abstract-role arm — observable result identical.
+		{Code: `<div role="tablist" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="toolbar" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="tree" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="treegrid" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="widget" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="window" onClick={() => {}} />;`, Tsx: true},
+
+		// ---- Non-triggering handlers on a non-interactive role —
+		//      handler not in the recommended/strict handlers list, so the
+		//      rule short-circuits at hasInteractiveProps. ----
+		{Code: `<div role="article" onCopy={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onCut={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onPaste={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onCompositionEnd={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onCompositionStart={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onCompositionUpdate={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onChange={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onInput={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onSubmit={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onSelect={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onTouchCancel={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onTouchEnd={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onTouchMove={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onTouchStart={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onScroll={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onWheel={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onAbort={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onCanPlay={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onCanPlayThrough={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onDurationChange={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onEmptied={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onEncrypted={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onEnded={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onLoadedData={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onLoadedMetadata={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onLoadStart={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onPause={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onPlay={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onPlaying={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onProgress={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onRateChange={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onSeeked={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onSeeking={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onStalled={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onSuspend={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onTimeUpdate={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onVolumeChange={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onWaiting={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onAnimationStart={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onAnimationEnd={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onAnimationIteration={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onTransitionEnd={() => {}} />;`, Tsx: true},
+	}
+}
+
+// neverValid mirrors upstream's `neverValid` array verbatim — invalid under
+// EVERY option combination. Order matches the upstream file.
+func neverValid() []rule_tester.InvalidTestCase {
+	cases := []struct {
+		Code     string
+		Settings map[string]interface{}
+	}{
+		// ---- HTML elements with an inherent, non-interactive role. ----
+		{Code: `<main onClick={() => void 0} />;`},
+		{Code: `<address onClick={() => {}} />;`},
+		{Code: `<article onClick={() => {}} />;`},
+		{Code: `<aside onClick={() => {}} />;`},
+		{Code: `<blockquote onClick={() => {}} />;`},
+		{Code: `<br onClick={() => {}} />;`},
+		{Code: `<caption onClick={() => {}} />;`},
+		{Code: `<code onClick={() => {}} />;`},
+		{Code: `<dd onClick={() => {}} />;`},
+		{Code: `<del onClick={() => {}} />;`},
+		{Code: `<details onClick={() => {}} />;`},
+		{Code: `<dfn onClick={() => {}} />;`},
+		{Code: `<dl onClick={() => {}} />;`},
+		{Code: `<dir onClick={() => {}} />;`},
+		{Code: `<dt onClick={() => {}} />;`},
+		{Code: `<em onClick={() => {}} />;`},
+		{Code: `<fieldset onClick={() => {}} />;`},
+		{Code: `<figcaption onClick={() => {}} />;`},
+		{Code: `<figure onClick={() => {}} />;`},
+		{Code: `<footer onClick={() => {}} />;`},
+		{Code: `<form onClick={() => {}} />;`},
+		{Code: `<h1 onClick={() => {}} />;`},
+		{Code: `<h2 onClick={() => {}} />;`},
+		{Code: `<h3 onClick={() => {}} />;`},
+		{Code: `<h4 onClick={() => {}} />;`},
+		{Code: `<h5 onClick={() => {}} />;`},
+		{Code: `<h6 onClick={() => {}} />;`},
+		{Code: `<hr onClick={() => {}} />;`},
+		{Code: `<html onClick={() => {}} />;`},
+		{Code: `<iframe onClick={() => {}} />;`},
+		{Code: `<img onClick={() => {}} />;`},
+		{Code: `<ins onClick={() => {}} />;`},
+		{Code: `<label onClick={() => {}} />;`},
+		{Code: `<legend onClick={() => {}} />;`},
+		{Code: `<li onClick={() => {}} />;`},
+		{Code: `<mark onClick={() => {}} />;`},
+		{Code: `<marquee onClick={() => {}} />;`},
+		{Code: `<menu onClick={() => {}} />;`},
+		{Code: `<meter onClick={() => {}} />;`},
+		{Code: `<nav onClick={() => {}} />;`},
+		{Code: `<ol onClick={() => {}} />;`},
+		{Code: `<optgroup onClick={() => {}} />;`},
+		{Code: `<output onClick={() => {}} />;`},
+		{Code: `<p onClick={() => {}} />;`},
+		{Code: `<pre onClick={() => {}} />;`},
+		{Code: `<progress onClick={() => {}} />;`},
+		{Code: `<ruby onClick={() => {}} />;`},
+		{Code: `<section onClick={() => {}} aria-label="Aardvark" />;`},
+		{Code: `<section onClick={() => {}} aria-labelledby="js_1" />;`},
+		{Code: `<strong onClick={() => {}} />;`},
+		{Code: `<sub onClick={() => {}} />;`},
+		{Code: `<sup onClick={() => {}} />;`},
+		{Code: `<table onClick={() => {}} />;`},
+		{Code: `<tbody onClick={() => {}} />;`},
+		{Code: `<tfoot onClick={() => {}} />;`},
+		{Code: `<thead onClick={() => {}} />;`},
+		{Code: `<time onClick={() => {}} />;`},
+		{Code: `<ul onClick={() => {}} />;`},
+		// `contentEditable="false"` — the raw value isn't `"true"`, so the
+		// IsContentEditable bail-out does NOT fire and the rule reports.
+		{Code: `<ul contentEditable="false" onClick={() => {}} />;`},
+		// `contentEditable` boolean form — no `.value.raw`, so the
+		// IsContentEditable check is also false and the rule reports.
+		{Code: `<article contentEditable onClick={() => {}} />;`},
+		// `contentEditable` boolean form on a `role="article"` div — same
+		// reasoning as above.
+		{Code: `<div contentEditable role="article" onKeyDown={() => {}} />;`},
+
+		// ---- HTML elements attributed with a non-interactive role. ----
+		{Code: `<div role="alert" onClick={() => {}} />;`},
+		{Code: `<div role="alertdialog" onClick={() => {}} />;`},
+		{Code: `<div role="application" onClick={() => {}} />;`},
+		{Code: `<div role="banner" onClick={() => {}} />;`},
+		{Code: `<div role="cell" onClick={() => {}} />;`},
+		{Code: `<div role="complementary" onClick={() => {}} />;`},
+		{Code: `<div role="contentinfo" onClick={() => {}} />;`},
+		{Code: `<div role="definition" onClick={() => {}} />;`},
+		{Code: `<div role="dialog" onClick={() => {}} />;`},
+		{Code: `<div role="directory" onClick={() => {}} />;`},
+		{Code: `<div role="document" onClick={() => {}} />;`},
+		{Code: `<div role="feed" onClick={() => {}} />;`},
+		{Code: `<div role="figure" onClick={() => {}} />;`},
+		{Code: `<div role="form" onClick={() => {}} />;`},
+		{Code: `<div role="group" onClick={() => {}} />;`},
+		{Code: `<div role="heading" onClick={() => {}} />;`},
+		{Code: `<div role="img" onClick={() => {}} />;`},
+		{Code: `<div role="list" onClick={() => {}} />;`},
+		{Code: `<div role="listitem" onClick={() => {}} />;`},
+		{Code: `<div role="log" onClick={() => {}} />;`},
+		{Code: `<div role="main" onClick={() => {}} />;`},
+		{Code: `<div role="marquee" onClick={() => {}} />;`},
+		{Code: `<div role="math" onClick={() => {}} />;`},
+		{Code: `<div role="navigation" onClick={() => {}} />;`},
+		{Code: `<div role="note" onClick={() => {}} />;`},
+		{Code: `<div role="region" onClick={() => {}} />;`},
+		{Code: `<div role="rowgroup" onClick={() => {}} />;`},
+		{Code: `<div role="search" onClick={() => {}} />;`},
+		{Code: `<div role="separator" onClick={() => {}} />;`},
+		{Code: `<div role="status" onClick={() => {}} />;`},
+		{Code: `<div role="table" onClick={() => {}} />;`},
+		{Code: `<div role="tabpanel" onClick={() => {}} />;`},
+		{Code: `<div role="term" onClick={() => {}} />;`},
+		{Code: `<div role="timer" onClick={() => {}} />;`},
+		{Code: `<div role="tooltip" onClick={() => {}} />;`},
+
+		// ---- Triggering handlers on a non-interactive role. ----
+		{Code: `<div role="article" onKeyDown={() => {}} />;`},
+		{Code: `<div role="article" onKeyPress={() => {}} />;`},
+		{Code: `<div role="article" onKeyUp={() => {}} />;`},
+		{Code: `<div role="article" onClick={() => {}} />;`},
+		{Code: `<div role="article" onLoad={() => {}} />;`},
+		{Code: `<div role="article" onError={() => {}} />;`},
+		{Code: `<div role="article" onMouseDown={() => {}} />;`},
+		{Code: `<div role="article" onMouseUp={() => {}} />;`},
+
+		// ---- Custom component resolved to a non-interactive DOM via
+		//      `settings['jsx-a11y'].components`. ----
+		{Code: `<Image onClick={() => void 0} />;`, Settings: imageComponentsSettings},
+	}
+
+	out := make([]rule_tester.InvalidTestCase, len(cases))
+	for i, c := range cases {
+		out[i] = rule_tester.InvalidTestCase{
+			Code:     c.Code,
+			Tsx:      true,
+			Settings: c.Settings,
+			Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+		}
+	}
+	return out
+}
+
+// recommendedExtraValid mirrors the extra `valid` cases the upstream
+// recommended suite appends after `alwaysValid` — every handler not in
+// recommended's `handlers` list short-circuits at `hasInteractiveProps`.
+//
+// Under recommended `handlers = ['onClick', 'onError', 'onLoad',
+// 'onMouseDown', 'onMouseUp', 'onKeyPress', 'onKeyDown', 'onKeyUp']`, all of
+// these handler names are OUTSIDE the list, so each case is valid.
+func recommendedExtraValid() []rule_tester.ValidTestCase {
+	handlers := []string{
+		"onCopy", "onCut", "onPaste",
+		"onCompositionEnd", "onCompositionStart", "onCompositionUpdate",
+		"onFocus", "onBlur",
+		"onChange", "onInput", "onSubmit",
+		"onContextMenu", "onDblClick", "onDoubleClick",
+		"onDrag", "onDragEnd", "onDragEnter", "onDragExit",
+		"onDragLeave", "onDragOver", "onDragStart", "onDrop",
+		"onMouseEnter", "onMouseLeave", "onMouseMove", "onMouseOut", "onMouseOver",
+		"onSelect",
+		"onTouchCancel", "onTouchEnd", "onTouchMove", "onTouchStart",
+		"onScroll", "onWheel",
+		"onAbort", "onCanPlay", "onCanPlayThrough", "onDurationChange",
+		"onEmptied", "onEncrypted", "onEnded", "onLoadedData",
+		"onLoadedMetadata", "onLoadStart", "onPause", "onPlay", "onPlaying",
+		"onProgress", "onRateChange", "onSeeked", "onSeeking", "onStalled",
+		"onSuspend", "onTimeUpdate", "onVolumeChange", "onWaiting",
+		"onAnimationStart", "onAnimationEnd", "onAnimationIteration",
+		"onTransitionEnd",
+	}
+	out := make([]rule_tester.ValidTestCase, len(handlers))
+	for i, h := range handlers {
+		out[i] = rule_tester.ValidTestCase{
+			Code: "<div role=\"article\" " + h + "={() => {}} />;",
+			Tsx:  true,
+		}
+	}
+	return out
+}
+
+// strictExtraInvalid mirrors the extra `invalid` cases the upstream strict
+// suite appends after `neverValid`. Strict has no `handlers` override, so
+// the rule falls back to defaultInteractiveProps (focus + image + keyboard
+// + mouse). These handlers are in that default but NOT in recommended's
+// `handlers` list, so they fail under strict only.
+func strictExtraInvalid() []rule_tester.InvalidTestCase {
+	handlers := []string{
+		"onFocus", "onBlur",
+		"onContextMenu", "onDblClick", "onDoubleClick",
+		"onDrag", "onDragEnd", "onDragEnter", "onDragExit",
+		"onDragLeave", "onDragOver", "onDragStart", "onDrop",
+		"onMouseEnter", "onMouseLeave", "onMouseMove",
+		"onMouseOut", "onMouseOver",
+	}
+	out := make([]rule_tester.InvalidTestCase, len(handlers))
+	for i, h := range handlers {
+		out[i] = rule_tester.InvalidTestCase{
+			Code:   "<div role=\"article\" " + h + "={() => {}} />;",
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		}
+	}
+	return out
+}
+
+// applyOptionsValid sets `Options` on every case — mirrors upstream's
+// `ruleOptionsMapperFactory(options)`.
+func applyOptionsValid(cases []rule_tester.ValidTestCase, opts map[string]interface{}) []rule_tester.ValidTestCase {
+	out := make([]rule_tester.ValidTestCase, len(cases))
+	for i, c := range cases {
+		c.Options = opts
+		out[i] = c
+	}
+	return out
+}
+
+func applyOptionsInvalid(cases []rule_tester.InvalidTestCase, opts map[string]interface{}) []rule_tester.InvalidTestCase {
+	out := make([]rule_tester.InvalidTestCase, len(cases))
+	for i, c := range cases {
+		c.Options = opts
+		out[i] = c
+	}
+	return out
+}
+
+// TestNoNoninteractiveElementInteractionsUpstreamRecommended mirrors
+// upstream's `no-noninteractive-element-interactions:recommended` suite —
+// the same valid/invalid arrays the upstream `ruleTester.run` block feeds.
+func TestNoNoninteractiveElementInteractionsUpstreamRecommended(t *testing.T) {
+	valid := append([]rule_tester.ValidTestCase{}, alwaysValid()...)
+	valid = append(valid, recommendedExtraValid()...)
+	valid = applyOptionsValid(valid, recommendedConfig)
+
+	invalid := applyOptionsInvalid(neverValid(), recommendedConfig)
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+		&NoNoninteractiveElementInteractionsRule, valid, invalid)
+}
+
+// TestNoNoninteractiveElementInteractionsUpstreamStrict mirrors upstream's
+// `no-noninteractive-element-interactions:strict` suite — strict has no
+// `handlers` override, so it adds focus / contextMenu / etc. invalid cases.
+func TestNoNoninteractiveElementInteractionsUpstreamStrict(t *testing.T) {
+	valid := applyOptionsValid(alwaysValid(), strictConfig)
+
+	invalid := append([]rule_tester.InvalidTestCase{}, neverValid()...)
+	invalid = append(invalid, strictExtraInvalid()...)
+	invalid = applyOptionsInvalid(invalid, strictConfig)
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+		&NoNoninteractiveElementInteractionsRule, valid, invalid)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -178,6 +178,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-element-interactions.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-tabindex.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-redundant-roles.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/scope.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-element-interactions.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-element-interactions.test.ts
@@ -1,0 +1,467 @@
+import { RuleTester } from '../rule-tester';
+
+const errorMessage =
+  'Non-interactive elements should not be assigned mouse or keyboard event listeners.';
+const expectedError = { message: errorMessage };
+
+// Mirrors `configs.recommended.rules['jsx-a11y/no-noninteractive-element-interactions'][1]`
+// from eslint-plugin-jsx-a11y/src/index.js.
+const recommendedOptions = [
+  {
+    handlers: [
+      'onClick',
+      'onError',
+      'onLoad',
+      'onMouseDown',
+      'onMouseUp',
+      'onKeyPress',
+      'onKeyDown',
+      'onKeyUp',
+    ],
+    alert: ['onKeyUp', 'onKeyDown', 'onKeyPress'],
+    body: ['onError', 'onLoad'],
+    dialog: ['onKeyUp', 'onKeyDown', 'onKeyPress'],
+    iframe: ['onError', 'onLoad'],
+    img: ['onError', 'onLoad'],
+  },
+];
+
+// Mirrors `configs.strict.rules['jsx-a11y/no-noninteractive-element-interactions'][1]`.
+// Strict has no `handlers` override → defaultInteractiveProps (focus + image
+// + keyboard + mouse) apply.
+const strictOptions = [
+  {
+    body: ['onError', 'onLoad'],
+    iframe: ['onError', 'onLoad'],
+    img: ['onError', 'onLoad'],
+  },
+];
+
+const imageComponentsSettings = {
+  'jsx-a11y': {
+    components: {
+      Image: 'img',
+    },
+  },
+};
+
+const buttonComponentsSettings = {
+  'jsx-a11y': {
+    components: {
+      Button: 'button',
+    },
+  },
+};
+
+const articleComponentsSettings = {
+  'jsx-a11y': {
+    components: {
+      MyArticle: 'article',
+    },
+  },
+};
+
+const polymorphicSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+  },
+};
+
+new RuleTester().run('no-noninteractive-element-interactions', null as never, {
+  valid: [
+    // ============================================================
+    // Recommended config — alwaysValid sample (mirrors upstream).
+    // ============================================================
+    { code: '<TestComponent onClick={doFoo} />', options: recommendedOptions },
+    { code: '<Button onClick={doFoo} />', options: recommendedOptions },
+    { code: '<Image onClick={() => void 0} />;', options: recommendedOptions },
+    {
+      code: '<Button onClick={() => void 0} />;',
+      settings: buttonComponentsSettings,
+      options: recommendedOptions,
+    },
+
+    // Inherent-interactive input (every type).
+    {
+      code: '<input onClick={() => void 0} />',
+      options: recommendedOptions,
+    },
+    {
+      code: '<input type="button" onClick={() => void 0} />',
+      options: recommendedOptions,
+    },
+    {
+      code: '<input type="checkbox" onClick={() => void 0} />',
+      options: recommendedOptions,
+    },
+    {
+      code: '<input type="hidden" onClick={() => void 0} />',
+      options: recommendedOptions,
+    },
+    {
+      code: '<input type="text" onClick={() => void 0} />',
+      options: recommendedOptions,
+    },
+
+    // Interactive elements (anchor / button / option / etc.).
+    {
+      code: '<a onClick={() => void 0} href="http://x.y.z" />',
+      options: recommendedOptions,
+    },
+    {
+      code: '<button onClick={() => void 0} className="foo" />',
+      options: recommendedOptions,
+    },
+    { code: '<menuitem onClick={() => {}} />;', options: recommendedOptions },
+    { code: '<area onClick={() => {}} />;', options: recommendedOptions },
+    { code: '<tr onClick={() => {}} />;', options: recommendedOptions },
+
+    // Plain <div> — no opinion (no role, not classified as non-interactive).
+    { code: '<div onClick={() => void 0} />;', options: recommendedOptions },
+    {
+      code: '<div onClick={() => void 0} role={undefined} />;',
+      options: recommendedOptions,
+    },
+    { code: '<div onClick={null} />;', options: recommendedOptions },
+    {
+      code: '<div onClick={() => void 0} aria-hidden />;',
+      options: recommendedOptions,
+    },
+    {
+      code: '<div onClick={() => void 0} {...props} />;',
+      options: recommendedOptions,
+    },
+
+    // Static elements (no opinion).
+    { code: '<canvas onClick={() => {}} />;', options: recommendedOptions },
+    { code: '<embed onClick={() => {}} />;', options: recommendedOptions },
+    { code: '<span onClick={() => {}} />;', options: recommendedOptions },
+    { code: '<header onClick={() => {}} />;', options: recommendedOptions },
+
+    // body + per-element allow-list: onLoad filtered → bail.
+    { code: '<body onLoad={() => {}} />;', options: recommendedOptions },
+    // iframe + per-element allow-list: onLoad filtered.
+    { code: '<iframe onLoad={() => {}} />;', options: recommendedOptions },
+    // img + onLoad / onError filtered → bail.
+    { code: '<img onLoad={() => {}} />;', options: recommendedOptions },
+    {
+      code: '<img src={currentPhoto.imageUrl} onLoad={this.handleImageLoad} alt="for review" />',
+      options: recommendedOptions,
+    },
+
+    // Interactive roles on a `<div>` — bail.
+    {
+      code: '<div role="button" onClick={() => {}} />;',
+      options: recommendedOptions,
+    },
+    {
+      code: '<div role="link" onClick={() => {}} />;',
+      options: recommendedOptions,
+    },
+    {
+      code: '<div role="menuitem" onClick={() => {}} />;',
+      options: recommendedOptions,
+    },
+    {
+      code: '<div role="presentation" onClick={() => {}} />;',
+      options: recommendedOptions,
+    },
+
+    // Abstract roles — bail.
+    {
+      code: '<div role="command" onClick={() => {}} />;',
+      options: recommendedOptions,
+    },
+    {
+      code: '<div role="widget" onClick={() => {}} />;',
+      options: recommendedOptions,
+    },
+    {
+      code: '<div role="window" onClick={() => {}} />;',
+      options: recommendedOptions,
+    },
+
+    // Non-triggering handler — onCopy isn't in recommended's `handlers`.
+    {
+      code: '<div role="article" onCopy={() => {}} />;',
+      options: recommendedOptions,
+    },
+    {
+      code: '<div role="article" onFocus={() => {}} />;',
+      options: recommendedOptions,
+    },
+    {
+      code: '<div role="article" onSubmit={() => {}} />;',
+      options: recommendedOptions,
+    },
+
+    // ============================================================
+    // Default options (no `handlers` override) — focus + image +
+    // keyboard + mouse trigger.
+    // ============================================================
+    { code: '<article onCopy={fn} />' },
+    { code: '<article onSubmit={fn} />' },
+
+    // ============================================================
+    // contentEditable bail-out — raw match against `"true"`.
+    // ============================================================
+    { code: '<article contentEditable="true" onClick={fn} />' },
+    { code: '<div role="article" contenteditable="true" onClick={fn} />' },
+
+    // ============================================================
+    // IsHiddenFromScreenReader / IsPresentationRole.
+    // ============================================================
+    { code: '<article aria-hidden onClick={fn} />' },
+    { code: '<article aria-hidden={true} onClick={fn} />' },
+    { code: '<article aria-hidden="true" onClick={fn} />' },
+    { code: '<article role="presentation" onClick={fn} />' },
+    { code: '<article role="none" onClick={fn} />' },
+
+    // ============================================================
+    // Options: explicit `handlers` override / empty array.
+    // ============================================================
+    {
+      code: '<article onMouseDown={fn} />',
+      options: [{ handlers: ['onClick'] }],
+    },
+    {
+      code: '<article onClick={fn} />',
+      options: [{ handlers: [] }],
+    },
+    // Per-element allow-list.
+    {
+      code: '<article onClick={fn} />',
+      options: [{ article: ['onClick'] }],
+    },
+
+    // ============================================================
+    // Settings: polymorphic / components.
+    // ============================================================
+    {
+      code: '<Foo as="button" onClick={() => void 0} />',
+      settings: polymorphicSettings,
+    },
+    {
+      code: '<Foo as="input" type="text" onClick={() => void 0} />',
+      settings: polymorphicSettings,
+    },
+    {
+      code: '<MyButton onClick={() => void 0} />',
+      settings: buttonComponentsSettings,
+    },
+  ],
+  invalid: [
+    // ============================================================
+    // Recommended config — neverValid sample (mirrors upstream).
+    // ============================================================
+    {
+      code: '<main onClick={() => void 0} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<address onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<article onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<aside onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<br onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<li onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<ul onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<iframe onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<img onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<form onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<h1 onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<table onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+
+    // contentEditable nuances.
+    {
+      code: '<ul contentEditable="false" onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<article contentEditable onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<div contentEditable role="article" onKeyDown={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+
+    // Non-interactive roles.
+    {
+      code: '<div role="alert" onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<div role="article" onClick={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<div role="article" onLoad={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<div role="article" onError={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<div role="article" onKeyDown={() => {}} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+
+    // Custom component → DOM (settings).
+    {
+      code: '<Image onClick={() => void 0} />;',
+      settings: imageComponentsSettings,
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Strict config — focus / contextMenu / etc. fire under default.
+    // ============================================================
+    {
+      code: '<div role="article" onFocus={() => {}} />;',
+      options: strictOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<div role="article" onContextMenu={() => {}} />;',
+      options: strictOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<div role="article" onMouseEnter={() => {}} />;',
+      options: strictOptions,
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Default options (no override) — focus + image + keyboard +
+    // mouse handlers trigger; non-default handlers (clipboard, form,
+    // touch …) do NOT.
+    // ============================================================
+    { code: '<article onClick={fn} />', errors: [expectedError] },
+    { code: '<article onLoad={fn} />', errors: [expectedError] },
+    { code: '<article onError={fn} />', errors: [expectedError] },
+    { code: '<article onFocus={fn} />', errors: [expectedError] },
+    { code: '<article onKeyDown={fn} />', errors: [expectedError] },
+
+    // contentEditable raw-match nuances.
+    {
+      code: '<article contentEditable={true} onClick={fn} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<article contentEditable="True" onClick={fn} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<article contentEditable={"true"} onClick={fn} />',
+      errors: [expectedError],
+    },
+
+    // role="NONE" / role="PRESENTATION" — case-sensitive.
+    {
+      code: '<article role="NONE" onClick={fn} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<article role="PRESENTATION" onClick={fn} />',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Spread shapes — literal-spread of onClick walks the literal.
+    // ============================================================
+    {
+      code: '<article {...{onClick: fn}} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<article {...{onClick}} />',
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Settings: polymorphic / components.
+    // ============================================================
+    {
+      code: '<Foo as="article" onClick={() => void 0} />',
+      settings: polymorphicSettings,
+      errors: [expectedError],
+    },
+    {
+      code: '<MyArticle onClick={() => void 0} />',
+      settings: articleComponentsSettings,
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // Options: explicit `handlers` override pulls in non-default.
+    // ============================================================
+    {
+      code: '<article onSubmit={fn} />',
+      options: [{ handlers: ['onSubmit'] }],
+      errors: [expectedError],
+    },
+    // handlers + per-element allow-list combined.
+    {
+      code: '<iframe onClick={fn} />',
+      options: [
+        { handlers: ['onClick', 'onLoad'], iframe: ['onLoad', 'onError'] },
+      ],
+      errors: [expectedError],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -399,6 +399,7 @@ tabindex
 noninteractive
 progressbar
 contentinfo
+contenteditable
 alertdialog
 focusable
 columnheader


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/no-noninteractive-element-interactions` rule from `eslint-plugin-jsx-a11y` to rslint.

The rule reports a JSX opening element when a non-interactive element (e.g. `<article>`, `<li>`, `<p>`, or a `<div>` with a non-interactive ARIA role) carries a mouse / keyboard / focus / image event handler — these elements convey content semantics and assigning interactive listeners breaks the platform a11y model.

Shared helpers added to `internal/plugins/jsx_a11y/jsxa11yutil/`:

- `EventHandlersMouse` / `Keyboard` / `Focus` / `Image` — granular handler groups split out of `InteractiveEventHandlerNames`, so sister rules (`no-static-element-interactions`, …) can compose their own defaults.
- `IsAbstractRole` — mirrors upstream `isAbstractRole`, gated on `LiteralPropStringValue` against the 12 aria-query abstract roles (`command`, `composite`, `input`, `landmark`, `range`, `roletype`, `section`, `sectionhead`, `select`, `structure`, `widget`, `window`).
- `IsContentEditable` — mirrors upstream's strict `prop?.value?.raw === '"true"'` semantics: only the bare `contentEditable="true"` string-literal form bails.
- `IsHiddenFromScreenReaderFromTagAttrs` — attrs-based variant of `IsHiddenFromScreenReader`, used by callers that filter attributes before downstream classification (e.g. the per-element allow-list in this rule).

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-interactions.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/no-noninteractive-element-interactions.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).