### PR TITLE
feat: port rule jsx-a11y/no-static-element-interactions

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -26,6 +26,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_redundant_roles"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_static_element_interactions"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/tabindex_no_positive"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -58,6 +59,7 @@ func GetAllRules() []rule.Rule {
 		no_noninteractive_element_interactions.NoNoninteractiveElementInteractionsRule,
 		no_noninteractive_tabindex.NoNoninteractiveTabindexRule,
 		no_redundant_roles.NoRedundantRolesRule,
+		no_static_element_interactions.NoStaticElementInteractionsRule,
 		scope.ScopeRule,
 		tabindex_no_positive.TabindexNoPositiveRule,
 	}

--- a/internal/plugins/jsx_a11y/jsxa11yutil/event_handlers.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/event_handlers.go
@@ -68,3 +68,24 @@ var InteractiveEventHandlerNames = func() []string {
 	out = append(out, EventHandlersKeyboard...)
 	return out
 }()
+
+// DefaultStaticInteractionHandlers mirrors upstream's
+// `defaultInteractiveProps` constant in `no-static-element-interactions`:
+//
+//	[].concat(
+//	  eventHandlersByType.focus,
+//	  eventHandlersByType.keyboard,
+//	  eventHandlersByType.mouse,
+//	);
+//
+// Composed from the per-group slices above to keep the source-of-truth in one
+// place. Order matches the upstream concat (focus → keyboard → mouse);
+// consumers iterate to check `hasProp + non-null value`, so order is
+// semantically irrelevant.
+var DefaultStaticInteractionHandlers = func() []string {
+	out := make([]string, 0, len(EventHandlersFocus)+len(EventHandlersKeyboard)+len(EventHandlersMouse))
+	out = append(out, EventHandlersFocus...)
+	out = append(out, EventHandlersKeyboard...)
+	out = append(out, EventHandlersMouse...)
+	return out
+}()

--- a/internal/plugins/jsx_a11y/jsxa11yutil/interactive.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/interactive.go
@@ -368,7 +368,7 @@ func IsInteractiveElement(tagName string, attrs []*ast.Node) bool {
 // rather than the simpler [LiteralStringValue]: this picks up upstream's
 // TemplateExpression-with-substitutions synthesis (each substitution's
 // LITERAL_TYPES extraction concatenated against the quasi text) and the
-// `null` literal → "null" magic string. Matters for `` role={`button${''}`} ``
+// `null` literal → "null" magic string. Matters for “ role={`button${”}`} “
 // and `role={null}` corner cases — uncommon, but covered by upstream's
 // `getLiteralPropValue` and therefore in scope for parity.
 func IsInteractiveRole(_ string, attrs []*ast.Node) bool {
@@ -463,8 +463,8 @@ func IsNonInteractiveRole(tagName string, attrs []*ast.Node) bool {
 // `new Set(roles.keys().filter((role) => roles.get(role).abstract))` -
 // every aria-query role whose definition carries `abstract: true`. These
 // roles are not assignable to HTML elements at runtime; some rules (e.g.
-// no-noninteractive-element-interactions) treat them as "no opinion"
-// short-circuits.
+// no-noninteractive-element-interactions, no-static-element-interactions)
+// treat them as "no opinion" short-circuits.
 //
 // Source: https://github.com/A11yance/aria-query/blob/main/src/etc/roles/abstract/
 var abstractRolesSet = map[string]struct{}{
@@ -496,8 +496,11 @@ var abstractRolesSet = map[string]struct{}{
 //     ConditionalExpression, …) silently produce a `false` here.
 //   - Set membership is whole-string and case-sensitive — upstream does NOT
 //     lowercase or split on whitespace, unlike the interactive/non-interactive
-//     role predicates. `role=" widget "` (with surrounding whitespace) and
-//     `role="WIDGET"` therefore do NOT match. Mirror.
+//     role predicates. `role="widget radio"` (multi-role) and `role="WIDGET"`
+//     (case-variant) therefore do NOT match. Mirror.
+//   - TS-wrapped non-literal shapes (`role={x as "widget"}`) likewise return
+//     false — `getLiteralPropValue` maps TSAsExpression / TSNonNullExpression
+//     to null, never to the inner string.
 func IsAbstractRole(tagName string, attrs []*ast.Node) bool {
 	if !IsDOMElement(tagName) {
 		return false

--- a/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions.go
+++ b/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions.go
@@ -1,0 +1,198 @@
+// Package no_static_element_interactions ports eslint-plugin-jsx-a11y's
+// `no-static-element-interactions` rule. The rule flags HTML elements that
+// carry an interactive event handler (default: focus + keyboard + mouse
+// handlers) but lack an interactive ARIA role — visible static elements
+// dispatching to mouse / keyboard listeners without a role are invisible
+// to assistive technology.
+//
+// Upstream signature:
+//
+//	options: {
+//	  handlers?:              string[]  (default: focus + keyboard + mouse handlers)
+//	  allowExpressionValues?: boolean   (default: undefined / false-ish)
+//	}
+//
+// Trigger sequence — each predicate is checked in order against the JSX
+// opening element. Bail-outs return without reporting:
+//
+//  1. Type isn't an aria-query DOM element → bail (custom components).
+//  2. No interactive event handler attached with a non-null value (mirrors
+//     `hasProp(attrs, h) && getPropValue(getProp(attrs, h)) != null` for the
+//     `handlers` list) → bail.
+//  3. Element is hidden from screen readers (`aria-hidden={true}` or
+//     `<input type="hidden">`) → bail.
+//  4. Element role resolves to `presentation` / `none` → bail.
+//  5. Element is inherently interactive, OR carries an interactive role,
+//     OR is inherently non-interactive, OR carries a non-interactive role,
+//     OR carries an abstract role → bail.
+//  6. `allowExpressionValues` is true AND `role` is non-literal → bail.
+//     Upstream's "special case for ternary with literals on both side"
+//     inside the same if-block returns regardless of which arm matches,
+//     so the observable behavior collapses to "any non-literal role under
+//     allowExpressionValues=true is exempt"; we mirror only the observable.
+//  7. Otherwise → REPORT on the JSX opening element node.
+//
+// Diagnostic text mirrors upstream verbatim:
+//
+//	"Avoid non-native interactive elements. If using native HTML is not
+//	possible, add an appropriate role and support for tabbing, mouse,
+//	keyboard, and touch inputs to an interactive content element."
+package no_static_element_interactions
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// errorMessage mirrors upstream's `errorMessage` string verbatim.
+const errorMessage = "Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element."
+
+// options holds the parsed configuration. `Handlers` is nil iff the user
+// did not provide the option at all — the listener then falls back to
+// [jsxa11yutil.DefaultStaticInteractionHandlers]. An explicit empty array
+// (`handlers: []`) is preserved as a non-nil empty slice so the listener
+// can mirror upstream's `[].some(...)` → false short-circuit (no handler
+// matches → never reports).
+type options struct {
+	Handlers              []string
+	HandlersProvided      bool
+	AllowExpressionValues bool
+}
+
+func parseOptions(raw any) options {
+	opts := options{}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	if v, ok := m["handlers"]; ok {
+		opts.HandlersProvided = true
+		opts.Handlers = jsxa11yutil.StringSliceOption(v)
+		if opts.Handlers == nil {
+			// StringSliceOption returns nil for non-array shapes; preserve
+			// "user supplied something" so the fallback to the default
+			// list does not silently kick back in.
+			opts.Handlers = []string{}
+		}
+	}
+	if v, ok := m["allowExpressionValues"].(bool); ok {
+		opts.AllowExpressionValues = v
+	}
+	return opts
+}
+
+// hasNonNullInteractiveHandler mirrors upstream's
+//
+//	handlers.some((prop) =>
+//	  hasProp(attributes, prop)
+//	  && getPropValue(getProp(attributes, prop)) != null
+//	)
+//
+// Iteration order mirrors upstream byte-for-byte: outer loop over `handlers`,
+// inner loop over `attrs` short-circuiting on the FIRST matching JsxAttribute
+// (jsx-ast-utils' `getProp` is `Array.prototype.find`, so duplicate JSX
+// attributes — invalid source, but tsgo still parses them — are ignored past
+// the first occurrence). `!= null` is JS loose equality and excludes both
+// `null` and `undefined`, so `<div onClick={null} />` and
+// `<div onClick={undefined} />` do NOT count as interactive.
+//
+// `hasProp` / `getProp` default to spreadStrict=true, so JsxSpreadAttribute
+// nodes are opaque — only direct JsxAttribute children participate. Name
+// comparison is case-insensitive to mirror upstream's `ignoreCase: true`.
+func hasNonNullInteractiveHandler(attrs []*ast.Node, handlers []string) bool {
+	for _, h := range handlers {
+		for _, attr := range attrs {
+			if attr.Kind != ast.KindJsxAttribute {
+				continue
+			}
+			if !strings.EqualFold(reactutil.GetJsxPropName(attr), h) {
+				continue
+			}
+			// First direct attribute with a matching name — `getProp`'s
+			// `Array.find` returns this one. If its value is non-null
+			// the handler counts; otherwise upstream moves to the next
+			// handler without inspecting subsequent duplicate attributes.
+			if !jsxa11yutil.PropValueIsNullish(attr) {
+				return true
+			}
+			break
+		}
+	}
+	return false
+}
+
+var NoStaticElementInteractionsRule = rule.Rule{
+	Name: "jsx-a11y/no-static-element-interactions",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		handlers := opts.Handlers
+		if !opts.HandlersProvided {
+			handlers = jsxa11yutil.DefaultStaticInteractionHandlers
+		}
+
+		check := func(node *ast.Node) {
+			attrs := reactutil.GetJsxElementAttributes(node)
+			elementType := jsxa11yutil.GetElementType(node, ctx.Settings)
+
+			// Step 1: type must be a known HTML element (aria-query's `dom`).
+			if !jsxa11yutil.IsDOMElement(elementType) {
+				return
+			}
+
+			// Step 2: at least one configured handler must be attached with
+			// a non-null value. Upstream collapses `!hasInteractiveProps` /
+			// `isHiddenFromScreenReader` / `isPresentationRole` into one
+			// boolean OR; we keep them as discrete returns for readability
+			// — same observable behavior.
+			if !hasNonNullInteractiveHandler(attrs, handlers) {
+				return
+			}
+
+			getElementType := func(child *ast.Node) string {
+				return jsxa11yutil.GetElementType(child, ctx.Settings)
+			}
+			if jsxa11yutil.IsHiddenFromScreenReader(node, getElementType) {
+				return
+			}
+
+			if jsxa11yutil.IsPresentationRole(attrs) {
+				return
+			}
+
+			// Step 3: any of the five "already accessible / abstract /
+			// non-interactive" classifications exempts the element.
+			if jsxa11yutil.IsInteractiveElement(elementType, attrs) ||
+				jsxa11yutil.IsInteractiveRole(elementType, attrs) ||
+				jsxa11yutil.IsNonInteractiveElement(elementType, attrs) ||
+				jsxa11yutil.IsNonInteractiveRole(elementType, attrs) ||
+				jsxa11yutil.IsAbstractRole(elementType, attrs) {
+				return
+			}
+
+			// Step 4: allowExpressionValues + non-literal `role` → skip.
+			// Upstream's inner "ConditionalExpression with two Literal arms"
+			// branch returns regardless of which arm matches, so the
+			// surrounding if-block reduces to an unconditional skip
+			// whenever `IsNonLiteralProperty` matches. Mirror the
+			// observable behavior; the inner check is dead.
+			if opts.AllowExpressionValues && jsxa11yutil.IsNonLiteralProperty(attrs, "role") {
+				return
+			}
+
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noStaticElementInteractions",
+				Description: errorMessage,
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions.md
+++ b/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions.md
@@ -1,0 +1,123 @@
+# no-static-element-interactions
+
+## Rule Details
+
+Static HTML elements such as `<div>` and `<span>` carry no semantic meaning.
+Attaching mouse / keyboard / focus event handlers to them without an
+interactive ARIA `role` makes the element invisible to assistive technology
+— screen-reader and keyboard-only users cannot tell that the element is
+supposed to respond to interaction. Prefer a semantic element (`<button>`,
+`<a href>`, `<input>`, …); if that is not possible, give the element an
+appropriate `role` and the keyboard support the role implies.
+
+The rule reports a JSX opening element when **all** of the following hold:
+
+- The resolved element name is in the HTML DOM set (custom React components
+  are skipped — the rule does not know what low-level element they render).
+- The element declares at least one interactive event handler from the
+  configured `handlers` list (default: every focus, keyboard, and mouse
+  handler exposed by `jsx-ast-utils`), and that handler's value statically
+  resolves to something other than `null` / `undefined`.
+- The element is not hidden from screen readers (no `aria-hidden={true}` /
+  `aria-hidden="true"`, not an `<input type="hidden">`).
+- The `role` attribute, when statically a literal string, is not
+  `presentation` or `none`.
+- The element is neither inherently interactive (e.g. `<button>`,
+  `<a href>`, `<input type="button">`) nor inherently non-interactive
+  (e.g. `<article>`, `<li>`, `<p>`); its `role` does not resolve to an
+  interactive, non-interactive, or abstract ARIA role.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div onClick={() => {}} />
+<span onKeyDown={() => {}} />
+<a onClick={() => {}} />
+<section onClick={() => {}} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<button onClick={() => {}} />
+<a href="/profile" onClick={() => {}} />
+<input type="button" onClick={() => {}} />
+<div role="button" tabIndex={0} onClick={() => {}} />
+<div role="presentation" onClick={() => {}} />
+<div onClick={null} />
+<article onClick={() => {}} />
+```
+
+## Rule Options
+
+### `handlers`
+
+Type: `string[]`. Default: `["onFocus", "onBlur", "onKeyDown", "onKeyPress", "onKeyUp", "onClick", "onContextMenu", "onDblClick", "onDoubleClick", "onDrag", "onDragEnd", "onDragEnter", "onDragExit", "onDragLeave", "onDragOver", "onDragStart", "onDrop", "onMouseDown", "onMouseEnter", "onMouseLeave", "onMouseMove", "onMouseOut", "onMouseOver", "onMouseUp"]`. The upstream `recommended` preset narrows this to `["onClick", "onMouseDown", "onMouseUp", "onKeyPress", "onKeyDown", "onKeyUp"]`.
+
+Overrides the list of event-handler prop names the rule treats as
+"interactive". Only attributes whose name (case-insensitive) is in this
+list participate in the check. An empty array (`handlers: []`) disables
+the rule — no handler ever matches.
+
+Examples of **incorrect** code with `{ "handlers": ["onCustomClick"] }`:
+
+```json
+{ "jsx-a11y/no-static-element-interactions": ["error", { "handlers": ["onCustomClick"] }] }
+```
+
+```jsx
+<div onCustomClick={() => {}} />
+```
+
+Examples of **correct** code with `{ "handlers": ["onCustomClick"] }`:
+
+```json
+{ "jsx-a11y/no-static-element-interactions": ["error", { "handlers": ["onCustomClick"] }] }
+```
+
+```jsx
+<div onClick={() => {}} />
+```
+
+### `allowExpressionValues`
+
+Type: `boolean`. Default: `false`. The upstream `recommended` preset sets
+this to `true`.
+
+When `true`, an element whose `role` attribute is a non-literal expression
+(e.g. `role={ROLE_BUTTON}`, `role={isButton ? "button" : "link"}`) is
+exempt — the rule cannot statically determine whether the role is
+interactive, and the option opts into trusting the developer. Note that
+`role={undefined}` is treated as a literal-equivalent and is **not**
+exempted by this option.
+
+Examples of **correct** code with `{ "allowExpressionValues": true }`:
+
+```json
+{ "jsx-a11y/no-static-element-interactions": ["error", { "allowExpressionValues": true }] }
+```
+
+```jsx
+<div role={ROLE_BUTTON} onClick={() => {}} />
+<div role={isButton ? "button" : "link"} onClick={() => {}} />
+```
+
+Examples of **incorrect** code with `{ "allowExpressionValues": false }`:
+
+```json
+{ "jsx-a11y/no-static-element-interactions": ["error", { "allowExpressionValues": false }] }
+```
+
+```jsx
+<div role={ROLE_BUTTON} onClick={() => {}} />
+```
+
+## Resources
+
+- [WCAG 4.1.2 — Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+- [WAI-ARIA — Widget Roles](https://www.w3.org/TR/wai-aria-1.2/#widget_roles)
+- [MDN — ARIA: button role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/no-static-element-interactions](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md)

--- a/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions_extras_test.go
@@ -1,0 +1,1162 @@
+package no_static_element_interactions
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoStaticElementInteractionsPositions locks the diagnostic anchor: the
+// rule reports on the JSX opening element node (paired form) or
+// self-closing element node (single-tag form). Upstream's listener is
+// `JSXOpeningElement` (in ESTree, fires once per element regardless of
+// form), so the report range covers the opening tag — `<` through the
+// matching `>` / `/>`. Two cases per shape: a single-line baseline and a
+// multi-line variant where the opening tag spans several lines.
+func TestNoStaticElementInteractionsPositions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+		// Self-closing — report spans <div … />.
+		{
+			Code: `<div onClick={() => {}} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noStaticElementInteractions",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 27,
+			}},
+		},
+		// Paired form — report spans <div …> only (not the whole element).
+		{
+			Code: `<div onClick={() => {}}>label</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noStaticElementInteractions",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 25,
+			}},
+		},
+		// Multi-line self-closing.
+		{
+			Code: "<div\n  onClick={() => {}}\n/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noStaticElementInteractions",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 3, EndColumn: 3,
+			}},
+		},
+		// Multi-line paired form.
+		{
+			Code: "<div\n  onClick={() => {}}\n>label</div>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noStaticElementInteractions",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 3, EndColumn: 2,
+			}},
+		},
+	})
+}
+
+// TestNoStaticElementInteractionsListenerBoundary locks that the listener
+// fires independently for each JSX opening element — nested JSX
+// hierarchies produce one report per qualifying ancestor, with each
+// report anchored at its own opening tag. Without this, a regression that
+// "bleeds" the outer report into the inner traversal (or vice versa)
+// would silently fold them into one diagnostic.
+func TestNoStaticElementInteractionsListenerBoundary(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+		// Three levels of nesting; outer + middle + inner each report.
+		{
+			Code: "<div onClick={() => {}}>\n  <span onClick={() => {}}>\n    <a onClick={() => {}} />\n  </span>\n</div>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1},
+				{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 2, Column: 3},
+				{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 3, Column: 5},
+			},
+		},
+	})
+}
+
+// TestNoStaticElementInteractionsHandlersOption locks the `handlers` option
+// branches that upstream's test suite doesn't directly exercise (apart from
+// the implicit recommended-vs-strict comparison). Covers:
+//   - User-supplied handler list (the directly-named handler matches; the
+//     un-listed default handler does NOT).
+//   - Explicit empty `handlers: []` — upstream's `[].some(...)` short-circuits
+//     to false, so no handler ever matches and the rule never reports.
+//   - Options JSON path: both bare-object (single-option CLI shape) and
+//     array-wrapped (multi-element rule_tester shape).
+func TestNoStaticElementInteractionsHandlersOption(t *testing.T) {
+	customHandlersBareObject := map[string]interface{}{
+		"handlers": []interface{}{"onCustomClick"},
+	}
+	customHandlersArrayWrapped := []interface{}{
+		map[string]interface{}{
+			"handlers": []interface{}{"onCustomClick"},
+		},
+	}
+	emptyHandlersBareObject := map[string]interface{}{
+		"handlers": []interface{}{},
+	}
+	emptyHandlersArrayWrapped := []interface{}{
+		map[string]interface{}{
+			"handlers": []interface{}{},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// onClick is NOT in the custom handler list → no interactive prop.
+			{Code: `<div onClick={() => {}} />`, Tsx: true, Options: customHandlersBareObject},
+			{Code: `<div onClick={() => {}} />`, Tsx: true, Options: customHandlersArrayWrapped},
+			// Empty handlers list → upstream `[].some(...)` is false → no report.
+			{Code: `<div onClick={() => {}} />`, Tsx: true, Options: emptyHandlersBareObject},
+			{Code: `<div onClick={() => {}} />`, Tsx: true, Options: emptyHandlersArrayWrapped},
+			{Code: `<div onClick={() => {}} onKeyDown={() => {}} />`, Tsx: true, Options: emptyHandlersBareObject},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Custom handler matches the rename.
+			{
+				Code:    `<div onCustomClick={() => {}} />`,
+				Tsx:     true,
+				Options: customHandlersBareObject,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticElementInteractions",
+					Message:   errorMessage,
+					Line:      1, Column: 1,
+				}},
+			},
+			{
+				Code:    `<div onCustomClick={() => {}} />`,
+				Tsx:     true,
+				Options: customHandlersArrayWrapped,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "noStaticElementInteractions",
+					Message:   errorMessage,
+					Line:      1, Column: 1,
+				}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsAllowExpressionValuesMatrix locks the
+// `allowExpressionValues` branch upstream tests on a single fixture
+// (`role={ROLE_BUTTON}`), expanded to the role-expression shapes
+// IsNonLiteralProperty actually classifies.
+//
+// Upstream IsNonLiteralProperty:
+//   - StringLiteral attribute value `role="button"`         → false (literal)
+//   - JsxExpression Identifier `role={x}`                   → true (non-literal)
+//   - JsxExpression Identifier `role={undefined}`           → false (literal-equivalent)
+//   - JsxExpression JsxText (unreachable in practice)       → false
+//   - JsxExpression anything-else (incl. Literal, Member,
+//     Call, Conditional, BinaryExpression, ...)             → true (non-literal)
+//
+// Under allowExpressionValues=true, every "true" classification skips.
+// Under allowExpressionValues=false (or absent), the rule continues to
+// IsInteractiveRole / IsNonInteractiveRole / IsAbstractRole, which only
+// resolve literal-typed string values — so all non-literal `role` shapes
+// fall through to REPORT under defaults.
+func TestNoStaticElementInteractionsAllowExpressionValuesMatrix(t *testing.T) {
+	allowTrue := map[string]interface{}{"allowExpressionValues": true}
+	allowFalse := map[string]interface{}{"allowExpressionValues": false}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// Identifier → non-literal → allowed.
+			{Code: `<div role={ROLE} onClick={() => {}} />`, Tsx: true, Options: allowTrue},
+			// MemberExpression → non-literal → allowed.
+			{Code: `<div role={obj.role} onClick={() => {}} />`, Tsx: true, Options: allowTrue},
+			// CallExpression → non-literal → allowed.
+			{Code: `<div role={getRole()} onClick={() => {}} />`, Tsx: true, Options: allowTrue},
+			// ConditionalExpression w/ two literals → non-literal under
+			// upstream's IsNonLiteralProperty (Conditional ≠ Literal/Identifier-undefined/JSXText).
+			{Code: `<div role={x ? "button" : "link"} onClick={() => {}} />`, Tsx: true, Options: allowTrue},
+			// BinaryExpression → non-literal → allowed.
+			{Code: `<div role={"button" + ""} onClick={() => {}} />`, Tsx: true, Options: allowTrue},
+			// LogicalExpression → non-literal → allowed.
+			{Code: `<div role={a || "button"} onClick={() => {}} />`, Tsx: true, Options: allowTrue},
+			// `{null}` inside JsxExpression — upstream's IsNonLiteralProperty
+			// treats anything other than StringLiteral / `undefined` / JsxText
+			// as non-literal, so `null` also falls into the skip arm.
+			{Code: `<div role={null} onClick={() => {}} />`, Tsx: true, Options: allowTrue},
+		},
+		[]rule_tester.InvalidTestCase{
+			// allowExpressionValues=false — Identifier role can't resolve to
+			// a literal, so IsInteractiveRole / IsNonInteractiveRole / IsAbstractRole
+			// all return false → REPORT.
+			{
+				Code:    `<div role={ROLE} onClick={() => {}} />`,
+				Tsx:     true,
+				Options: allowFalse,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `<div role={undefined}>` — upstream's IsNonLiteralProperty
+			// short-circuits on `Identifier 'undefined'` to FALSE (literal-equivalent).
+			// allowExpressionValues=true cannot exempt this — it falls through
+			// to IsInteractiveRole etc., none of which match → REPORT.
+			{
+				Code:    `<div role={undefined} onClick={() => {}} />`,
+				Tsx:     true,
+				Options: allowTrue,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `role="..."` (direct StringLiteral attribute) — IsNonLiteralProperty
+			// short-circuits to FALSE (literal). The string is "button"
+			// resolves through IsInteractiveRole; "notarole" doesn't. Pick
+			// "notarole" so we trip REPORT regardless of allowExpressionValues.
+			{
+				Code:    `<div role="notarole" onClick={() => {}} />`,
+				Tsx:     true,
+				Options: allowTrue,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsEdgeShapes locks the Dimension-4 universal
+// edge shapes our prep walk identified.
+func TestNoStaticElementInteractionsEdgeShapes(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// `onClick={undefined}` — upstream `getPropValue` resolves to JS
+			// undefined → `!= null` is false → no interactive prop → exempt.
+			{Code: `<div onClick={undefined} />`, Tsx: true},
+			// `<div onClick={null} />` — upstream getPropValue → JS null →
+			// `!= null` is false → exempt. (Also in upstream suite.)
+			{Code: `<div onClick={null} />`, Tsx: true},
+			// `onClick={void 0}` — JS `void 0` evaluates to undefined; under
+			// jsx-ast-utils' staticEval `void` produces undefined → `!= null`
+			// false → exempt.
+			{Code: `<div onClick={void 0} />`, Tsx: true},
+			// `aria-hidden` (boolean-form) on a static element with click —
+			// upstream short-circuits via isHiddenFromScreenReader.
+			{Code: `<div onClick={() => {}} aria-hidden />`, Tsx: true},
+			// Custom component (not in dom set) → exempt step 1.
+			{Code: `<MyComp onClick={() => {}} />`, Tsx: true},
+			// `<div role="presentation" onClick={...}>` — IsPresentationRole.
+			{Code: `<div role="presentation" onClick={() => {}} />`, Tsx: true},
+			// `<div role="none" onClick={...}>` — same as presentation.
+			{Code: `<div role="none" onClick={() => {}} />`, Tsx: true},
+			// Spread-only handler — hasProp / getProp default spreadStrict=true,
+			// so `{...{onClick: () => {}}}` is INVISIBLE to the rule.
+			{Code: `<div {...{onClick: () => {}}} />`, Tsx: true},
+			// Direct handler + spread elsewhere — spread doesn't change the
+			// resolution; onClick still resolves to the literal.
+			{Code: `<div onClick={null} {...props} />`, Tsx: true},
+			// Boolean-form handler — but with a literal value that resolves
+			// `null`-ish. Boolean-form `<div onClick />` → upstream extractValue
+			// resolves to JS `true`. `true != null` → TRUE → REPORTS. Locked
+			// in invalid section below.
+			//
+			// Inherent-interactive container: `<th>` with onClick is exempt
+			// via IsInteractiveElement.
+			{Code: `<th onClick={() => {}} />`, Tsx: true},
+			// Mixed-case role — IsInteractiveRole lowercases before lookup;
+			// `<div role="BUTTON" onClick={...}>` → exempt.
+			{Code: `<div role="BUTTON" onClick={() => {}} />`, Tsx: true},
+			// Role template literal — `role={`button`}` → LiteralPropStringValue
+			// extracts "button" → IsInteractiveRole returns true → exempt.
+			{Code: "<div role={`button`} onClick={() => {}} />", Tsx: true},
+			// Role wrapped StringLiteral `role={"button"}` — literalPropValue
+			// returns "button" → exempt via IsInteractiveRole.
+			{Code: `<div role={"button"} onClick={() => {}} />`, Tsx: true},
+			// Space-separated roles where the first valid role is interactive.
+			{Code: `<div role="button heading" onClick={() => {}} />`, Tsx: true},
+			// Space-separated roles where the first valid role is non-interactive
+			// (article) — IsNonInteractiveRole short-circuits before
+			// IsAbstractRole, but the result is still exempt.
+			{Code: `<div role="article button" onClick={() => {}} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Boolean-form handler `<div onClick />` — upstream extractValue
+			// resolves to JS `true`; `true != null` → matches → REPORT.
+			{
+				Code:   `<div onClick />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// onFocus is in the default focus+keyboard+mouse list (only
+			// reported under :strict / no-options).
+			{
+				Code:   `<div onFocus={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `<header>` always reports — IsNonInteractiveElement returns
+			// false (upstream's banner-landmark-context guard).
+			{
+				Code:   `<header onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Space-separated roles where the first valid role is unknown
+			// — falls through every classification → REPORT.
+			{
+				Code:   `<div role="notarole" onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Multiple handlers on the same element — ONE diagnostic per
+			// element (rule reports on the element node, not per-handler).
+			{
+				Code:   `<div onClick={() => {}} onKeyDown={() => {}} onMouseUp={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsOptionParsing locks the Options JSON path —
+// the rule MUST accept both the bare-object form (matches the single-option
+// CLI shape after config.go unwraps the array) and the array-wrapped form
+// (matches the multi-element rule_tester shape). Also covers nil / empty /
+// malformed shapes so a future refactor of parseOptions can't regress them.
+func TestNoStaticElementInteractionsOptionParsing(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// nil options — defaults: full focus+keyboard+mouse handlers,
+			// allowExpressionValues=falsy. Validates the "options absent"
+			// path doesn't short-circuit to no-default-handlers.
+			{Code: `<TestComponent onClick={() => {}} />`, Tsx: true},
+			// Empty options object — same as nil. allowExpressionValues
+			// stays false; handlers stays as default.
+			{Code: `<TestComponent onClick={() => {}} />`, Tsx: true, Options: map[string]interface{}{}},
+			{Code: `<TestComponent onClick={() => {}} />`, Tsx: true, Options: []interface{}{}},
+			// Malformed handlers value — non-array shape should be treated
+			// as "user provided something" but produce an empty list →
+			// never reports.
+			{Code: `<div onClick={() => {}} />`, Tsx: true, Options: map[string]interface{}{"handlers": "not-an-array"}},
+			{Code: `<div onClick={() => {}} />`, Tsx: true, Options: map[string]interface{}{"handlers": 0}},
+			// Malformed allowExpressionValues value — non-bool ignored →
+			// stays falsy. Rule path falls through (no skip), but onClick on
+			// <button> is exempt via IsInteractiveElement → valid.
+			{Code: `<button onClick={() => {}} />`, Tsx: true, Options: map[string]interface{}{"allowExpressionValues": "true"}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Single-option bare-object form (CLI-shape after config.go unwrap).
+			{
+				Code:    `<div onClick={() => {}} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"allowExpressionValues": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Array-wrapped form (multi-element rule_tester shape).
+			{
+				Code:    `<div onClick={() => {}} />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"allowExpressionValues": false}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `handlers: ["onCustomClick"]` matches and reports.
+			{
+				Code:    `<div onCustomClick={() => {}} />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"handlers": []interface{}{"onCustomClick"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsTSWrappers locks tsgo-only AST shapes that
+// upstream's ESTree parser doesn't produce — TS non-null assertion, `as`
+// cast, satisfies, parenthesized expressions on the handler / role values.
+// Upstream's staticEval (via PropValueIsNullish / LiteralPropStringValue)
+// is expected to look through these wrappers; the explicit cases protect
+// against a regression where the wrapper unwrap is skipped.
+func TestNoStaticElementInteractionsTSWrappers(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// Function-cast handler resolves to a non-null function → upstream
+			// reports, but the element is `<button>` (inherently interactive) → exempt.
+			{Code: `<button onClick={(() => {}) as any} />`, Tsx: true},
+			// `role` value through `as` cast → LiteralPropStringValue
+			// returns "" (literalPropValue routes through OEKNonNullAssertions
+			// strip; `as` is dropped via SkipOuterExpressions). Confirm:
+			// `<div role={"button" as any} onClick={...}>` should exempt via
+			// IsInteractiveRole if our LiteralPropStringValue handles `as`.
+			//
+			// Upstream's `getLiteralPropValue` maps TSAsExpression to noop → null,
+			// so the role wouldn't resolve to "button" upstream. We mirror
+			// upstream's stricter behavior — REPORT this case (locked in
+			// invalid section below).
+			//
+			// Parenthesized handler resolves through the paren — `<button>`
+			// is inherently interactive → exempt.
+			{Code: `<button onClick={((() => {}))} />`, Tsx: true},
+			// Parenthesized role value `role={("button")}` → LiteralPropStringValue
+			// handles paren unwrap → exempt via IsInteractiveRole.
+			{Code: `<div role={("button")} onClick={() => {}} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// `role` through `as` cast → upstream's `getLiteralPropValue`
+			// returns null → IsInteractiveRole returns false → REPORT.
+			{
+				Code:   `<div role={"button" as any} onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `role` through non-null assertion → same as `as` cast.
+			{
+				Code:   `<div role={"button"!} onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Parenthesized handler on static element — resolves through
+			// the paren → onClick != null → REPORT.
+			{
+				Code:   `<div onClick={((() => {}))} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsUpstreamBranchLockIns locks behavioral
+// branches that exist in the upstream source but are not covered by the
+// upstream test file. Each test below names the upstream code branch it
+// pins; a future refactor that flips the branch behavior fails these tests.
+func TestNoStaticElementInteractionsUpstreamBranchLockIns(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream `hasInteractiveProps` short-circuit arm
+			// `getPropValue(...) != null` — even though `<div onChange={x} />`
+			// has a non-null `onChange`, `onChange` is NOT in any of the
+			// default focus/keyboard/mouse lists → handler.some(...) is false.
+			{Code: `<div onChange={() => {}} />`, Tsx: true},
+
+			// Locks in upstream `isAbstractRole` arm — `role="widget"` etc.
+			// short-circuit before `isInteractiveRole` / `isNonInteractiveRole`.
+			// `widget` is abstract but isn't in either set, so without the
+			// IsAbstractRole check the rule would fall through and REPORT.
+			{Code: `<div role="widget" onClick={() => {}} />`, Tsx: true},
+
+			// Locks in upstream IsHiddenFromScreenReader's `<input
+			// type="hidden">` branch (the type-aware path, not aria-hidden).
+			// `<input>` is inherently interactive too — IsInteractiveElement
+			// short-circuits before reaching the hidden-screen-reader check —
+			// so flip to `<input type="hidden" onCopy={...} />` (onCopy is
+			// not in any default handler list, but onClick is). Use onClick
+			// here to ensure IsHiddenFromScreenReader is what saves us.
+			{Code: `<input type="hidden" onClick={() => {}} />`, Tsx: true},
+
+			// Locks in upstream `isInteractiveElement` first-match arm —
+			// `<input type="button">` matches the `{name: "input",
+			// attributes: [{name: "type", value: "button"}]}` schema and
+			// exits before IsInteractiveRole even runs.
+			{Code: `<input type="button" onClick={() => {}} />`, Tsx: true},
+
+			// Locks in upstream `isInteractiveElement`'s no-attribute schema
+			// path — `<button onClick={...}>` matches `{name: "button"}` with
+			// no required attributes (vacuous every-true predicate).
+			{Code: `<button onClick={() => {}} />`, Tsx: true},
+
+			// Locks in upstream IsNonInteractiveRole's "first valid role" walk
+			// — `role="invalid article"` skips "invalid" (not in allRolesSet)
+			// then matches "article" as non-interactive.
+			{Code: `<div role="invalid article" onClick={() => {}} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Locks in upstream's behavior on `<div role="">` (empty string
+			// — no valid role found). IsInteractiveRole / IsNonInteractiveRole /
+			// IsAbstractRole all see "" as the literal value; none match → REPORT.
+			{
+				Code:   `<div role="" onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+
+			// Locks in upstream's IsInteractiveRole "first valid role" walk
+			// — `role="invalid notarole"` skips both ("invalid" / "notarole"
+			// not in allRolesSet) → returns false. Same for non-interactive
+			// and abstract → REPORT.
+			{
+				Code:   `<div role="invalid notarole" onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+
+			// Locks the listener distinguishing self-closing from paired form
+			// without a "wrapper" indirection that would hide the report on
+			// JsxOpeningElement when the parent is a JsxElement.
+			{
+				Code:   `<div onClick={() => {}}></div>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 25}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsRealHandlerShapes locks the staticEval-driven
+// classification of handler values that appear in real React codebases —
+// member access (`this.handleClick`), call expressions (`useCallback(...)`),
+// conditional expressions, logical operators, nullish coalescing, async /
+// generator / class-field arrow function values, and bound methods. Each
+// shape is checked under the "handler is statically non-null" gate
+// (`PropValueIsNullish`), so a regression in staticEval that flips one of
+// these classifications would silently change the rule's behavior on the
+// most common React patterns.
+//
+// Reference: jsxa11yutil/static_eval.go covers Identifier (jvString of name),
+// PropertyAccessExpression / ElementAccessExpression (jvString "(member)"),
+// CallExpression (jvString "(call)"), ArrowFunction / FunctionExpression /
+// ClassExpression (jvFn), BinaryExpression with `&&` / `||` / `??`,
+// ConditionalExpression (eager-eval the matched arm), and NonNullExpression
+// (string of inner + "!"). NewExpression / Object / Array map to truthy.
+func TestNoStaticElementInteractionsRealHandlerShapes(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// `cond ? null : null` — both arms null; ConditionalExpression
+			// statically evaluates the truthy arm (cond resolves truthy as
+			// Identifier jvString), result is jvNull → nullish → no handler match.
+			{Code: `<div onClick={cond ? null : null} />`, Tsx: true},
+			// Truthy condition + null arm: cond is Identifier (truthy) → eager
+			// eval whenTrue → jvNull → nullish → no match.
+			{Code: `<div onClick={cond ? null : someHandler} />`, Tsx: true},
+			// Truthy condition + undefined arm: same as above with jvUndef.
+			{Code: `<div onClick={cond ? undefined : someHandler} />`, Tsx: true},
+			// Logical `&&` with falsy left — left is falsy (false literal),
+			// staticEvalBinary returns left (jvBool false) → !jsTruthy → nullish? NO!
+			// jvBool(false) is NOT jvNull/jvUndef/jvUnknown, so PropValueIsNullish
+			// returns false → has handler → REPORT.
+			//
+			// (Locked under invalid below.)
+			//
+			// Logical `||` with truthy left: returns left → jvString from Identifier → REPORT.
+			//
+			// Nullish coalesce where left is non-nullable: returns left.
+			//
+			// `<a href>` boolean form — schema only checks attribute existence,
+			// not value, so this matches interactive schema → exempt.
+			{Code: `<a href onClick={() => {}} />`, Tsx: true},
+			// `<a href="">` — empty href string still satisfies the
+			// "attribute exists" schema check → interactive → exempt.
+			{Code: `<a href="" onClick={() => {}} />`, Tsx: true},
+			// `<a href={undefined}>` — attribute exists, schema matches → exempt.
+			{Code: `<a href={undefined} onClick={() => {}} />`, Tsx: true},
+			// `<a href={null}>` — same as above, attribute existence only.
+			{Code: `<a href={null} onClick={() => {}} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Member access — staticEval returns jvString "(member)" → truthy
+			// → not nullish → REPORT. Locks the most common real-world handler shape.
+			{
+				Code:   `<div onClick={this.handleClick} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Deep member access (handlers.section.onClick).
+			{
+				Code:   `<div onClick={handlers.section.onClick} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Computed member access (`handlers[name]`).
+			{
+				Code:   `<div onClick={handlers[name]} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Call expression (the useCallback / useMemo / withErrorBoundary
+			// pattern). staticEval returns jvString "(call)" → REPORT.
+			{
+				Code:   `<div onClick={getHandler()} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			{
+				Code:   `<div onClick={useCallback(() => {}, [])} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Bound method — CallExpression of `.bind(this)`.
+			{
+				Code:   `<div onClick={this.handler.bind(this)} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Optional chain on member — tsgo flags the optional, kind is
+			// still PropertyAccessExpression → jvString → REPORT.
+			{
+				Code:   `<div onClick={handlers?.onClick} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Async arrow function — ArrowFunction kind → jvFn → REPORT.
+			{
+				Code:   `<div onClick={async () => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Function expression.
+			{
+				Code:   `<div onClick={function() {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Named function expression.
+			{
+				Code:   `<div onClick={function named() {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Identifier alone (most common real-world shape — destructured
+			// handler bound at the top of the component).
+			{
+				Code:   `<div onClick={memoizedHandler} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Conditional with non-null arms — both arms are truthy via
+			// Identifier resolution; ConditionalExpression eagerly evaluates
+			// the matched arm (cond is Identifier, jvTruthy → eval whenTrue).
+			{
+				Code:   `<div onClick={cond ? handler1 : handler2} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Logical `&&` with non-null left — staticEvalBinary's `&&`
+			// returns the right when left truthy; Identifier left → truthy
+			// → right Identifier → jvString → REPORT.
+			{
+				Code:   `<div onClick={cond && handler} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Logical `||` — returns left if truthy; Identifier left truthy
+			// → returns left → jvString → REPORT.
+			{
+				Code:   `<div onClick={handler || defaultHandler} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Nullish coalesce — left is non-null Identifier (jvString) →
+			// staticEvalBinary returns left → REPORT.
+			{
+				Code:   `<div onClick={handler ?? defaultHandler} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// New expression — staticEval returns jsTruthy → not nullish.
+			{
+				Code:   `<div onClick={new Handler()} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Inline arrow with side-effect body.
+			{
+				Code:   `<div onClick={(e) => { e.stopPropagation(); handler(e); }} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsPolymorphicSettings locks the
+// `jsx-a11y.polymorphicPropName` / `polymorphicAllowList` settings: a custom
+// component is resolved through its polymorphic prop (`as`, `is`, `forwardedAs`, ...)
+// before the DOM-set membership check, mirroring upstream getElementType's
+// behavior. Real-world design systems rely on this resolution pattern to
+// expose a single component that renders to different underlying HTML tags.
+func TestNoStaticElementInteractionsPolymorphicSettings(t *testing.T) {
+	asPolymorphic := map[string]interface{}{
+		"jsx-a11y": map[string]interface{}{
+			"polymorphicPropName": "as",
+		},
+	}
+	asPolymorphicAllowList := map[string]interface{}{
+		"jsx-a11y": map[string]interface{}{
+			"polymorphicPropName":  "as",
+			"polymorphicAllowList": []interface{}{"Box"},
+		},
+	}
+	isPolymorphic := map[string]interface{}{
+		"jsx-a11y": map[string]interface{}{
+			"polymorphicPropName": "is",
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// `<Foo as="button">` — resolves to "button" (interactive) → exempt.
+			{Code: `<Foo as="button" onClick={() => {}} />`, Tsx: true, Settings: asPolymorphic},
+			// `<Foo as="article">` — non-interactive element → exempt.
+			{Code: `<Foo as="article" onClick={() => {}} />`, Tsx: true, Settings: asPolymorphic},
+			// Different polymorphic prop name (`is` instead of `as`).
+			{Code: `<Foo is="button" onClick={() => {}} />`, Tsx: true, Settings: isPolymorphic},
+			// AllowList: `Box` is in the list, gets polymorphic resolution.
+			//   `<Box as="button">` → "button" → exempt.
+			{Code: `<Box as="button" onClick={() => {}} />`, Tsx: true, Settings: asPolymorphicAllowList},
+			// AllowList: `Foo` is NOT in the list, polymorphic resolution
+			// is SKIPPED → rawType stays "Foo" (custom component) → exempt
+			// step 1 (not in dom).
+			{Code: `<Foo as="div" onClick={() => {}} />`, Tsx: true, Settings: asPolymorphicAllowList},
+			// `<Foo>` without polymorphic prop set — no rewrite, stays "Foo"
+			// (custom component) → exempt.
+			{Code: `<Foo onClick={() => {}} />`, Tsx: true, Settings: asPolymorphic},
+			// Polymorphic prop with non-literal value — can't resolve → stays "Foo" → exempt.
+			{Code: `<Foo as={tagName} onClick={() => {}} />`, Tsx: true, Settings: asPolymorphic},
+		},
+		[]rule_tester.InvalidTestCase{
+			// `<Foo as="div">` — resolves to "div" (static) → REPORT.
+			{
+				Code:     `<Foo as="div" onClick={() => {}} />`,
+				Tsx:      true,
+				Settings: asPolymorphic,
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `<Foo as="span">` — span is static → REPORT.
+			{
+				Code:     `<Foo as="span" onClick={() => {}} />`,
+				Tsx:      true,
+				Settings: asPolymorphic,
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// AllowList: Box is in the list, resolves to "div" → REPORT.
+			{
+				Code:     `<Box as="div" onClick={() => {}} />`,
+				Tsx:      true,
+				Settings: asPolymorphicAllowList,
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Custom polymorphic prop name `is`.
+			{
+				Code:     `<Foo is="span" onClick={() => {}} />`,
+				Tsx:      true,
+				Settings: isPolymorphic,
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsComponentsRemapping locks the
+// `jsx-a11y.components` map: a JSX component name is rewritten to its
+// configured HTML element before the DOM-set + interactivity checks. This
+// is the canonical way teams say "our `<TextLink>` is an `<a href>`" — the
+// rule must honor the mapping in both directions (remap to interactive ⇒
+// exempt; remap to static ⇒ report).
+func TestNoStaticElementInteractionsComponentsRemapping(t *testing.T) {
+	componentsMap := map[string]interface{}{
+		"jsx-a11y": map[string]interface{}{
+			"components": map[string]interface{}{
+				"Box":      "div",
+				"Heading":  "h1",
+				"TextLink": "a",
+				"MyButton": "button",
+				"Input":    "input",
+				"Stack":    "section",
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// MyButton → button (inherently interactive).
+			{Code: `<MyButton onClick={() => {}} />`, Tsx: true, Settings: componentsMap},
+			// Input → input (inherently interactive).
+			{Code: `<Input onClick={() => {}} />`, Tsx: true, Settings: componentsMap},
+			// TextLink with href (interactive `<a>` schema).
+			{Code: `<TextLink href="/" onClick={() => {}} />`, Tsx: true, Settings: componentsMap},
+			// Heading → h1 (non-interactive HTML element).
+			{Code: `<Heading onClick={() => {}} />`, Tsx: true, Settings: componentsMap},
+			// Box → div with interactive role → exempt.
+			{Code: `<Box role="button" onClick={() => {}} />`, Tsx: true, Settings: componentsMap},
+			// Box with presentation role → exempt.
+			{Code: `<Box role="presentation" onClick={() => {}} />`, Tsx: true, Settings: componentsMap},
+			// Stack → section with aria-label → exempt (non-interactive schema).
+			{Code: `<Stack aria-label="A" onClick={() => {}} />`, Tsx: true, Settings: componentsMap},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Box → div (static, no role) → REPORT.
+			{
+				Code:     `<Box onClick={() => {}} />`,
+				Tsx:      true,
+				Settings: componentsMap,
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// TextLink → a (no href, no role) → REPORT.
+			{
+				Code:     `<TextLink onClick={() => {}} />`,
+				Tsx:      true,
+				Settings: componentsMap,
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Stack → section (without aria-label, falls through non-interactive
+			// schema) → REPORT.
+			{
+				Code:     `<Stack onClick={() => {}} />`,
+				Tsx:      true,
+				Settings: componentsMap,
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsRoleSemantics locks the role-attribute
+// classification semantics: case-insensitive role lookup, space-separated
+// multi-role first-wins, the FIRST valid (in allRolesSet) role wins, and
+// unknown roles fall through to REPORT.
+//
+// These branches exist in upstream's IsInteractiveRole / IsNonInteractiveRole /
+// IsAbstractRole but the upstream test file only covers them at the
+// per-role level — not the cross-class interaction (e.g. abstract role
+// listed first vs second) or the case-sensitivity boundary.
+func TestNoStaticElementInteractionsRoleSemantics(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// Mixed-case roles — upstream lowercases before lookup.
+			{Code: `<div role="Button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role="BUTTON" onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role="BuTtOn" onClick={() => {}} />`, Tsx: true},
+			// Multi-role, first valid is interactive — exempt via IsInteractiveRole.
+			{Code: `<div role="button heading" onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role="link article" onClick={() => {}} />`, Tsx: true},
+			// Multi-role, first valid is non-interactive (article) — exempt
+			// via IsNonInteractiveRole; the trailing button does not "rescue".
+			{Code: `<div role="article button" onClick={() => {}} />`, Tsx: true},
+			// Skip invalid role names in the space-split, find first valid.
+			{Code: `<div role="invalid button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<div role="invalid notarole article" onClick={() => {}} />`, Tsx: true},
+			// First valid is abstract → exempt via IsAbstractRole.
+			{Code: `<div role="widget button" onClick={() => {}} />`, Tsx: true},
+			// Cross-class: inherently interactive element with non-interactive
+			// role attribute — IsInteractiveElement fires first.
+			{Code: `<button role="article" onClick={() => {}} />`, Tsx: true},
+			// Inherently interactive `<a href>` with abstract role on it.
+			{Code: `<a href="/" role="widget" onClick={() => {}} />`, Tsx: true},
+			// Inherently non-interactive `<article>` with interactive role.
+			{Code: `<article role="button" onClick={() => {}} />`, Tsx: true},
+			// `role` with leading/trailing whitespace — String(value)
+			// .toLowerCase().split(' ') preserves an empty leading entry
+			// from " button" which fails allRolesSet, then finds "button".
+			{Code: `<div role=" button" onClick={() => {}} />`, Tsx: true},
+			// Multi-role with abstract first then non-interactive.
+			{Code: `<div role="widget article" onClick={() => {}} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Empty role attribute — split → [""], filter to valid → empty →
+			// none of the classifications match → REPORT.
+			{
+				Code:   `<div role="" onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// All invalid role names.
+			{
+				Code:   `<div role="bogus another-bogus" onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Whitespace-only role.
+			{
+				Code:   `<div role="   " onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsAriaHiddenVariants locks the
+// IsHiddenFromScreenReader gate's value classification — `=== true` is
+// upstream's strict comparison, so only the actual JS boolean true (or
+// jsxAstUtilsLiteralCoerce'd "true"/boolean-form) exempts.
+func TestNoStaticElementInteractionsAriaHiddenVariants(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// Boolean form, expression, string-coerced — all exempt.
+			{Code: `<div onClick={() => {}} aria-hidden />`, Tsx: true},
+			{Code: `<div onClick={() => {}} aria-hidden={true} />`, Tsx: true},
+			{Code: `<div onClick={() => {}} aria-hidden="true" />`, Tsx: true},
+			// String "TRUE" case-insensitively coerced — exempt.
+			{Code: `<div onClick={() => {}} aria-hidden="TRUE" />`, Tsx: true},
+			// Wrapped string literal in expression — staticEval routes through
+			// "true" coercion → boolean true.
+			{Code: `<div onClick={() => {}} aria-hidden={"true"} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// `aria-hidden={false}` — strict `=== true` fails → NOT hidden → REPORT.
+			{
+				Code:   `<div onClick={() => {}} aria-hidden={false} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `aria-hidden="false"` — string coerces to bool false → NOT hidden → REPORT.
+			{
+				Code:   `<div onClick={() => {}} aria-hidden="false" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `aria-hidden={1}` — number 1 is NOT strict `=== true` → NOT hidden → REPORT.
+			{
+				Code:   `<div onClick={() => {}} aria-hidden={1} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `aria-hidden={someVar}` — Identifier resolves to jvString (not bool)
+			// → NOT hidden → REPORT.
+			{
+				Code:   `<div onClick={() => {}} aria-hidden={isHidden} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `aria-hidden={null}` — null is NOT strict true → NOT hidden → REPORT.
+			{
+				Code:   `<div onClick={() => {}} aria-hidden={null} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsInputSchemaVariants locks every
+// interactiveElementRoleSchemas entry for `<input>` — the most-tested
+// element shape upstream covers, but the cross-product with the rule's
+// "static handler" check (vs interactive-supports-focus's "interactive
+// role" check) deserves an independent suite.
+//
+// Each input type in the interactive schema must be exempt under
+// no-static-element-interactions because IsInteractiveElement returns
+// true → step 3 of the rule short-circuits.
+func TestNoStaticElementInteractionsInputSchemaVariants(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// `<input>` with no `type` — the input schema is matched via
+			// `{name: "input"}` schemas (multiple schemas with attribute
+			// predicates; the bare `<input>` falls through every type-aware
+			// schema. BUT upstream considers `<input onClick>` valid; the
+			// listener matches the broader input schema in aria-query.
+			//
+			// In our impl, the broader `<input>` (no type) does NOT match
+			// the type-aware schemas. Whether it ends up exempt depends on
+			// other classifications. Upstream's test:
+			//   { code: '<input onClick={() => void 0} />' }
+			// is in alwaysValid, so we expect exempt.
+			{Code: `<input onClick={() => {}} />`, Tsx: true},
+			// All `type` values that appear in interactiveElementRoleSchemas
+			// or are general inputs (covered by interactive schemas).
+			{Code: `<input type="text" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="email" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="search" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="tel" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="url" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="password" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="button" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="checkbox" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="image" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="number" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="radio" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="range" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="reset" onClick={() => {}} />`, Tsx: true},
+			{Code: `<input type="submit" onClick={() => {}} />`, Tsx: true},
+			// `type="hidden"` — exempt via IsHiddenFromScreenReader BEFORE
+			// the interactive-element check.
+			{Code: `<input type="hidden" onClick={() => {}} />`, Tsx: true},
+			// Direct-string type attribute case-insensitivity.
+			{Code: `<input type="TEXT" onClick={() => {}} />`, Tsx: true},
+			// Type as wrapped expression `type={"button"}` — LiteralPropStringValue
+			// resolves through JsxExpression → "button" → schema matches.
+			{Code: `<input type={"button"} onClick={() => {}} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{},
+	)
+}
+
+// TestNoStaticElementInteractionsMultiHandlerCombinations locks the
+// outer-loop-over-handlers semantics: per handler, the FIRST matching
+// direct JsxAttribute decides whether that handler counts. Mixed null /
+// non-null combinations across different handler names exercise the
+// short-circuit boundary.
+func TestNoStaticElementInteractionsMultiHandlerCombinations(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// All handlers null — no match anywhere.
+			{Code: `<div onClick={null} onMouseDown={null} onKeyDown={null} />`, Tsx: true},
+			// All handlers undefined.
+			{Code: `<div onClick={undefined} onMouseDown={undefined} onKeyDown={undefined} />`, Tsx: true},
+			// Mix of null + undefined + void 0.
+			{Code: `<div onClick={null} onMouseDown={undefined} onKeyDown={void 0} />`, Tsx: true},
+			// Null handler + non-handler-list prop (onChange not in default).
+			{Code: `<div onClick={null} onChange={() => {}} />`, Tsx: true},
+			// Null handler + non-handler-list prop (multiple).
+			{Code: `<div onClick={null} onChange={() => {}} onScroll={() => {}} onSubmit={() => {}} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// First handler non-null wins → REPORT.
+			{
+				Code:   `<div onClick={() => {}} onMouseDown={null} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Later handler non-null also wins (handler iteration order).
+			{
+				Code:   `<div onClick={null} onMouseDown={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// All handlers non-null — only one report on the element.
+			{
+				Code:   `<div onClick={() => {}} onKeyDown={() => {}} onMouseDown={() => {}} onKeyUp={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Mixed null/non-null where the FIRST listed in attrs is null,
+			// later one is non-null.
+			{
+				Code:   `<div onKeyDown={null} onClick={null} onMouseUp={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Non-handler-list prop is non-null but a handler-list prop is also
+			// non-null → REPORT.
+			{
+				Code:   `<div onChange={() => {}} onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsJsxStructuralEdgeCases locks JSX
+// structural shapes that real codebases use but upstream's test file does
+// not exercise — fragments wrapping reportable elements, attribute-level
+// comments, generic JSX component invocations, and ternary-rendered JSX
+// children. Each pattern should report only on the qualifying inner JSX
+// element, leaving the wrapper / fragment / Generic / conditional shell
+// untouched.
+func TestNoStaticElementInteractionsJsxStructuralEdgeCases(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// Empty fragment — listener doesn't fire on fragment opening.
+			{Code: `<></>`, Tsx: true},
+			// Fragment with non-reportable children.
+			{Code: `<><div /><button onClick={() => {}} /></>`, Tsx: true},
+			// Generic JSX component invocation — not in dom set → exempt.
+			{Code: `<Component<string> onClick={() => {}} />`, Tsx: true},
+			{Code: `<Generic<A, B> onClick={() => {}} />`, Tsx: true},
+			// JSX as render-prop child (the prop's value is JSX, the OUTER
+			// is React.Fragment — neither qualifying).
+			{Code: `<><div /></>`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Fragment wrapping a reportable inner element — only the inner reports.
+			{
+				Code:   `<><div onClick={() => {}} /></>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 3}},
+			},
+			// Fragment with two reportable children — two reports.
+			{
+				Code: `<><div onClick={() => {}} /><span onClick={() => {}} /></>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 3},
+					{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 29},
+				},
+			},
+			// Ternary-rendered JSX where only the static branch qualifies.
+			//   `<button>` is interactive (exempt).
+			//   `<div onClick>` qualifies → REPORT.
+			{
+				Code: `<>{cond ? <button onClick={() => {}} /> : <div onClick={() => {}} />}</>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 43},
+				},
+			},
+			// Attribute-level comment between handler attrs — comments are
+			// trivia, AST walking must still find the onClick attribute.
+			{
+				Code:   "<div /* a */ onClick={() => {}} /* b */ />",
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// Sibling reportable elements at different lines.
+			{
+				Code: "<div>\n  <div onClick={() => {}} />\n  <span onClick={() => {}} />\n</div>",
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 2, Column: 3},
+					{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 3, Column: 3},
+				},
+			},
+			// Conditional rendering: `{cond && <span onClick={...} />}` inside
+			// a container — only the span reports.
+			{
+				Code: `<div>{cond && <span onClick={() => {}} />}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 15},
+				},
+			},
+			// Logical OR rendering pattern.
+			{
+				Code: `<div>{primary || <span onClick={() => {}} />}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 18},
+				},
+			},
+		},
+	)
+}
+
+// TestNoStaticElementInteractionsAnchorSchemaVariants locks the `<a>`
+// interactive schema — the `{name: "a", attributes: [{name: "href"}]}`
+// predicate matches on "attribute exists" regardless of value, so
+// `<a href={anything}>` is inherently interactive. Upstream tests only
+// cover `<a href="http://...">` and bare `<a>`; the value-shape boundary
+// (empty string, null/undefined value, boolean form, expression) is on us.
+func TestNoStaticElementInteractionsAnchorSchemaVariants(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+		[]rule_tester.ValidTestCase{
+			// Plain URL.
+			{Code: `<a href="/" onClick={() => {}} />`, Tsx: true},
+			{Code: `<a href="http://example.com" onClick={() => {}} />`, Tsx: true},
+			{Code: `<a href="#anchor" onClick={() => {}} />`, Tsx: true},
+			// Empty href — schema only checks attribute existence.
+			{Code: `<a href="" onClick={() => {}} />`, Tsx: true},
+			// Boolean form `<a href>` — JsxAttribute exists, schema matches.
+			{Code: `<a href onClick={() => {}} />`, Tsx: true},
+			// Expression-typed href (Identifier).
+			{Code: `<a href={url} onClick={() => {}} />`, Tsx: true},
+			// Expression with null/undefined.
+			{Code: `<a href={null} onClick={() => {}} />`, Tsx: true},
+			{Code: `<a href={undefined} onClick={() => {}} />`, Tsx: true},
+			// Template literal href.
+			{Code: "<a href={`/path/${id}`} onClick={() => {}} />", Tsx: true},
+			// Ternary href.
+			{Code: `<a href={cond ? "/a" : "/b"} onClick={() => {}} />`, Tsx: true},
+			// `<area href>` — same interactive schema as `<a href>`.
+			{Code: `<area href="/" onClick={() => {}} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// `<a>` with no href — not in interactive schema → REPORT.
+			{
+				Code:   `<a onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+			// `<area>` with no href — same.
+			{
+				Code:   `<area onClick={() => {}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noStaticElementInteractions", Message: errorMessage, Line: 1, Column: 1}},
+			},
+		},
+	)
+}

--- a/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions_upstream_test.go
@@ -1,0 +1,849 @@
+package no_static_element_interactions
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedError is the single shape every invalid case in this rule
+// produces. Shared with the extras suite via package scope.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "noStaticElementInteractions",
+	Message:   errorMessage,
+}
+
+// componentsSettings mirrors upstream's
+//
+//	settings: { 'jsx-a11y': { components: { Button: 'button', TestComponent: 'div' } } }
+//
+// `<Button>` resolves to `button` (interactive, exempt) and `<TestComponent>`
+// resolves to `div` (static, no role → reported).
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Button":        "button",
+			"TestComponent": "div",
+		},
+	},
+}
+
+// recommendedOptions mirrors upstream's
+//
+//	configs.recommended.rules['jsx-a11y/no-static-element-interactions'][1]
+//
+// — the option object passed by the recommended preset. The recommended
+// `handlers` list is a narrower subset of the default (focus + keyboard +
+// mouse), and `allowExpressionValues: true` opts into the non-literal-role
+// skip.
+//
+// Source: eslint-plugin-jsx-a11y/src/index.js.
+var recommendedOptions = []interface{}{
+	map[string]interface{}{
+		"handlers": []interface{}{
+			"onClick",
+			"onMouseDown",
+			"onMouseUp",
+			"onKeyPress",
+			"onKeyDown",
+			"onKeyUp",
+		},
+		"allowExpressionValues": true,
+	},
+}
+
+// allowExpressionValuesTrueOptions mirrors upstream's
+// `[{ allowExpressionValues: true }]` — a per-test option override on top of
+// the default `handlers` list (no recommended-narrowed handler subset).
+var allowExpressionValuesTrueOptions = []interface{}{
+	map[string]interface{}{
+		"allowExpressionValues": true,
+	},
+}
+
+// allowExpressionValuesFalseOptions mirrors upstream's
+// `[{ allowExpressionValues: false }]`.
+var allowExpressionValuesFalseOptions = []interface{}{
+	map[string]interface{}{
+		"allowExpressionValues": false,
+	},
+}
+
+// TestNoStaticElementInteractionsUpstream covers the full valid / invalid
+// suite migrated 1:1 from upstream eslint-plugin-jsx-a11y's
+// `__tests__/src/rules/no-static-element-interactions-test.js`. Upstream
+// runs two configurations of the same suite:
+//
+//   - `:recommended` — recommendedOptions (narrowed `handlers`,
+//     `allowExpressionValues: true`)
+//   - `:strict`      — no options (defaults: full focus+keyboard+mouse
+//     handler list, allowExpressionValues falsy)
+//
+// Both configurations are run as one Go test, with each upstream case
+// duplicated under both option shapes when the upstream suite did so. Order
+// inside each group mirrors the upstream file so a future audit can grep
+// across both side-by-side.
+//
+// Anything NOT in upstream's test file — TS wrappers, position assertions,
+// listener-boundary repeats, options JSON-path matrix, etc. — lives in
+// no_static_element_interactions_extras_test.go.
+func TestNoStaticElementInteractionsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// alwaysValid (run under both :recommended and :strict)
+		// ============================================================
+		// Custom component — TestComponent has no setting here, treated
+		// as a higher-level component (not in dom). Exempt by step 1.
+		{Code: `<TestComponent onClick={doFoo} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<TestComponent onClick={doFoo} />`, Tsx: true},
+		// `Button` is a JSX-component name, not in dom set → exempt step 1.
+		{Code: `<Button onClick={doFoo} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<Button onClick={doFoo} />`, Tsx: true},
+		// Same, with components setting → resolves to "button" (inherently interactive).
+		{Code: `<Button onClick={doFoo} />`, Tsx: true, Options: recommendedOptions, Settings: componentsSettings},
+		{Code: `<Button onClick={doFoo} />`, Tsx: true, Settings: componentsSettings},
+		// No interactive handlers attached.
+		{Code: `<div />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div />;`, Tsx: true},
+		{Code: `<div className="foo" />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div className="foo" />;`, Tsx: true},
+		// Spread is opaque (hasProp/getProp skip spreads), no direct
+		// handler → no interactive props → exempt.
+		{Code: `<div className="foo" {...props} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div className="foo" {...props} />;`, Tsx: true},
+		// `aria-hidden` short-circuits via isHiddenFromScreenReader.
+		{Code: `<div onClick={() => void 0} aria-hidden />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onClick={() => void 0} aria-hidden />;`, Tsx: true},
+		{Code: `<div onClick={() => void 0} aria-hidden={true} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onClick={() => void 0} aria-hidden={true} />;`, Tsx: true},
+		// onClick={null} → getPropValue → null → `!= null` is false → no
+		// interactive prop → exempt.
+		{Code: `<div onClick={null} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onClick={null} />;`, Tsx: true},
+
+		// All flavors of input — inherently interactive (matches
+		// interactiveElementRoleSchemas / interactiveElementAXSchemas).
+		{Code: `<input onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="button" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="button" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="checkbox" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="checkbox" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="color" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="color" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="date" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="date" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="datetime" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="datetime" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="datetime-local" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="datetime-local" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="email" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="email" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="file" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="file" onClick={() => void 0} />`, Tsx: true},
+		// `<input type="hidden">` — IsHiddenFromScreenReader returns true.
+		{Code: `<input type="hidden" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="hidden" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="image" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="image" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="month" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="month" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="number" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="number" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="password" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="password" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="radio" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="radio" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="range" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="range" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="reset" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="reset" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="search" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="search" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="submit" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="submit" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="tel" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="tel" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="text" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="text" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="time" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="time" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="url" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="url" onClick={() => void 0} />`, Tsx: true},
+		{Code: `<input type="week" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<input type="week" onClick={() => void 0} />`, Tsx: true},
+
+		// Inherently interactive elements with handlers.
+		{Code: `<button onClick={() => void 0} className="foo" />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<button onClick={() => void 0} className="foo" />`, Tsx: true},
+		{Code: `<datalist onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<datalist onClick={() => {}} />;`, Tsx: true},
+		{Code: `<menuitem onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<menuitem onClick={() => {}} />;`, Tsx: true},
+		{Code: `<option onClick={() => void 0} className="foo" />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<option onClick={() => void 0} className="foo" />`, Tsx: true},
+		{Code: `<select onClick={() => void 0} className="foo" />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<select onClick={() => void 0} className="foo" />`, Tsx: true},
+		{Code: `<textarea onClick={() => void 0} className="foo" />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<textarea onClick={() => void 0} className="foo" />`, Tsx: true},
+		{Code: `<a onClick={() => void 0} href="http://x.y.z" />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<a onClick={() => void 0} href="http://x.y.z" />`, Tsx: true},
+		{Code: `<a onClick={() => void 0} href="http://x.y.z" tabIndex="0" />`, Tsx: true, Options: recommendedOptions},
+		{Code: `<a onClick={() => void 0} href="http://x.y.z" tabIndex="0" />`, Tsx: true},
+		// `<audio>` etc. — non-interactive HTML elements (matched by
+		// nonInteractiveElementAXSchemas or strictNonInteractive role
+		// schemas).
+		{Code: `<audio onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<audio onClick={() => {}} />;`, Tsx: true},
+		{Code: `<form onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<form onClick={() => {}} />;`, Tsx: true},
+		{Code: `<form onSubmit={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<form onSubmit={() => {}} />;`, Tsx: true},
+
+		// Interactive role attribute on <div>.
+		{Code: `<div role="button" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="button" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="checkbox" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="checkbox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="columnheader" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="columnheader" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="combobox" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="combobox" onClick={() => {}} />;`, Tsx: true},
+		// `form` is a non-interactive role (presence in the non-interactive
+		// set → IsNonInteractiveRole returns true → exempt).
+		{Code: `<div role="form" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="form" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="gridcell" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="gridcell" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="link" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="link" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="menuitem" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="menuitem" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="menuitemcheckbox" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="menuitemcheckbox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="menuitemradio" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="menuitemradio" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="option" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="option" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="radio" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="radio" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="rowheader" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="rowheader" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="searchbox" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="searchbox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="slider" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="slider" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="spinbutton" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="spinbutton" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="switch" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="switch" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="tab" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="tab" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="textbox" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="textbox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="treeitem" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="treeitem" onClick={() => {}} />;`, Tsx: true},
+
+		// Presentation roles — IsPresentationRole short-circuit.
+		{Code: `<div role="presentation" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="presentation" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="presentation" onKeyDown={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="presentation" onKeyDown={() => {}} />;`, Tsx: true},
+
+		// HTML elements with inherent non-interactive role.
+		{Code: `<address onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<address onClick={() => {}} />;`, Tsx: true},
+		{Code: `<article onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<article onClick={() => {}} />;`, Tsx: true},
+		{Code: `<article onDblClick={() => void 0} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<article onDblClick={() => void 0} />;`, Tsx: true},
+		{Code: `<aside onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<aside onClick={() => {}} />;`, Tsx: true},
+		{Code: `<blockquote onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<blockquote onClick={() => {}} />;`, Tsx: true},
+		{Code: `<br onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<br onClick={() => {}} />;`, Tsx: true},
+		{Code: `<canvas onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<canvas onClick={() => {}} />;`, Tsx: true},
+		{Code: `<caption onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<caption onClick={() => {}} />;`, Tsx: true},
+		{Code: `<code onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<code onClick={() => {}} />;`, Tsx: true},
+		{Code: `<dd onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<dd onClick={() => {}} />;`, Tsx: true},
+		{Code: `<del onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<del onClick={() => {}} />;`, Tsx: true},
+		{Code: `<details onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<details onClick={() => {}} />;`, Tsx: true},
+		{Code: `<dfn onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<dfn onClick={() => {}} />;`, Tsx: true},
+		{Code: `<dir onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<dir onClick={() => {}} />;`, Tsx: true},
+		{Code: `<dl onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<dl onClick={() => {}} />;`, Tsx: true},
+		{Code: `<dt onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<dt onClick={() => {}} />;`, Tsx: true},
+		{Code: `<em onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<em onClick={() => {}} />;`, Tsx: true},
+		{Code: `<embed onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<embed onClick={() => {}} />;`, Tsx: true},
+		{Code: `<fieldset onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<fieldset onClick={() => {}} />;`, Tsx: true},
+		{Code: `<figcaption onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<figcaption onClick={() => {}} />;`, Tsx: true},
+		{Code: `<figure onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<figure onClick={() => {}} />;`, Tsx: true},
+		{Code: `<footer onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<footer onClick={() => {}} />;`, Tsx: true},
+		{Code: `<h1 onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<h1 onClick={() => {}} />;`, Tsx: true},
+		{Code: `<h2 onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<h2 onClick={() => {}} />;`, Tsx: true},
+		{Code: `<h3 onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<h3 onClick={() => {}} />;`, Tsx: true},
+		{Code: `<h4 onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<h4 onClick={() => {}} />;`, Tsx: true},
+		{Code: `<h5 onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<h5 onClick={() => {}} />;`, Tsx: true},
+		{Code: `<h6 onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<h6 onClick={() => {}} />;`, Tsx: true},
+		{Code: `<hr onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<hr onClick={() => {}} />;`, Tsx: true},
+		{Code: `<html onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<html onClick={() => {}} />;`, Tsx: true},
+		{Code: `<iframe onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<iframe onClick={() => {}} />;`, Tsx: true},
+		{Code: `<img onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<img onClick={() => {}} />;`, Tsx: true},
+		{Code: `<ins onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<ins onClick={() => {}} />;`, Tsx: true},
+		{Code: `<label onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<label onClick={() => {}} />;`, Tsx: true},
+		{Code: `<legend onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<legend onClick={() => {}} />;`, Tsx: true},
+		{Code: `<li onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<li onClick={() => {}} />;`, Tsx: true},
+		{Code: `<main onClick={() => void 0} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<main onClick={() => void 0} />;`, Tsx: true},
+		{Code: `<mark onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<mark onClick={() => {}} />;`, Tsx: true},
+		{Code: `<marquee onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<marquee onClick={() => {}} />;`, Tsx: true},
+		{Code: `<menu onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<menu onClick={() => {}} />;`, Tsx: true},
+		{Code: `<meter onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<meter onClick={() => {}} />;`, Tsx: true},
+		{Code: `<nav onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<nav onClick={() => {}} />;`, Tsx: true},
+		{Code: `<ol onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<ol onClick={() => {}} />;`, Tsx: true},
+		{Code: `<optgroup onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<optgroup onClick={() => {}} />;`, Tsx: true},
+		{Code: `<output onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<output onClick={() => {}} />;`, Tsx: true},
+		{Code: `<p onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<p onClick={() => {}} />;`, Tsx: true},
+		{Code: `<pre onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<pre onClick={() => {}} />;`, Tsx: true},
+		{Code: `<progress onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<progress onClick={() => {}} />;`, Tsx: true},
+		{Code: `<ruby onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<ruby onClick={() => {}} />;`, Tsx: true},
+		// `<section>` is non-interactive ONLY when paired with
+		// aria-label / aria-labelledby (per strictNonInteractive schema).
+		{Code: `<section onClick={() => {}} aria-label="Aa" />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<section onClick={() => {}} aria-label="Aa" />;`, Tsx: true},
+		{Code: `<section onClick={() => {}} aria-labelledby="js_1" />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<section onClick={() => {}} aria-labelledby="js_1" />;`, Tsx: true},
+		{Code: `<strong onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<strong onClick={() => {}} />;`, Tsx: true},
+		{Code: `<sub onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<sub onClick={() => {}} />;`, Tsx: true},
+		{Code: `<summary onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<summary onClick={() => {}} />;`, Tsx: true},
+		{Code: `<sup onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<sup onClick={() => {}} />;`, Tsx: true},
+		{Code: `<table onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<table onClick={() => {}} />;`, Tsx: true},
+		{Code: `<tbody onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<tbody onClick={() => {}} />;`, Tsx: true},
+		{Code: `<tfoot onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<tfoot onClick={() => {}} />;`, Tsx: true},
+		// `<th>` is inherently interactive (gridcell). `<thead>` non-interactive AX.
+		{Code: `<th onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<th onClick={() => {}} />;`, Tsx: true},
+		{Code: `<thead onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<thead onClick={() => {}} />;`, Tsx: true},
+		{Code: `<time onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<time onClick={() => {}} />;`, Tsx: true},
+		// `<tr>` is inherently interactive via interactiveElementRoleSchemas.
+		{Code: `<tr onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<tr onClick={() => {}} />;`, Tsx: true},
+		{Code: `<video onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<video onClick={() => {}} />;`, Tsx: true},
+		{Code: `<ul onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<ul onClick={() => {}} />;`, Tsx: true},
+
+		// Abstract roles — IsAbstractRole short-circuit.
+		{Code: `<div role="command" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="command" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="composite" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="composite" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="input" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="input" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="landmark" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="landmark" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="range" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="range" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="roletype" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="roletype" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="sectionhead" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="sectionhead" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="select" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="select" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="structure" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="structure" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="widget" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="widget" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="window" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="window" onClick={() => {}} />;`, Tsx: true},
+
+		// Non-interactive role attributes on <div>.
+		{Code: `<div role="alert" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="alert" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="alertdialog" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="alertdialog" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="application" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="application" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="article" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="article" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="banner" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="banner" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="cell" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="cell" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="complementary" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="complementary" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="contentinfo" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="contentinfo" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="definition" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="definition" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="dialog" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="dialog" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="directory" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="directory" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="document" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="document" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="feed" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="feed" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="figure" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="figure" onClick={() => {}} />;`, Tsx: true},
+		// `grid` is interactive (a widget descendant in interactiveRolesSet).
+		{Code: `<div role="grid" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="grid" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="group" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="group" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="heading" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="heading" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="img" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="img" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="list" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="list" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="listbox" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="listbox" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="listitem" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="listitem" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="log" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="log" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="main" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="main" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="marquee" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="marquee" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="math" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="math" onClick={() => {}} />;`, Tsx: true},
+		// `menu` / `menubar` are interactive (widget descendants).
+		{Code: `<div role="menu" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="menu" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="menubar" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="menubar" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="navigation" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="navigation" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="note" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="note" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="progressbar" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="progressbar" onClick={() => {}} />;`, Tsx: true},
+		// `radiogroup` is interactive (widget descendant).
+		{Code: `<div role="radiogroup" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="radiogroup" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="region" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="region" onClick={() => {}} />;`, Tsx: true},
+		// `row` is interactive (widget descendant).
+		{Code: `<div role="row" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="row" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="rowgroup" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="rowgroup" onClick={() => {}} />;`, Tsx: true},
+		// `section` is in upstream's abstractRoles (yes — it overlaps).
+		// Resolved via IsAbstractRole first, since abstract roles are
+		// checked in the OR with the four interactive/non-interactive
+		// classifications — observable result: exempt.
+		{Code: `<div role="section" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="section" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="search" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="search" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="separator" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="separator" onClick={() => {}} />;`, Tsx: true},
+		// `scrollbar` is interactive (widget descendant).
+		{Code: `<div role="scrollbar" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="scrollbar" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="status" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="status" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="table" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="table" onClick={() => {}} />;`, Tsx: true},
+		// `tablist` is interactive (widget descendant).
+		{Code: `<div role="tablist" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="tablist" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="tabpanel" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="tabpanel" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="term" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="term" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="timer" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="timer" onClick={() => {}} />;`, Tsx: true},
+		// `toolbar` is interactive (widget descendant, plus axobject).
+		{Code: `<div role="toolbar" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="toolbar" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="tooltip" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="tooltip" onClick={() => {}} />;`, Tsx: true},
+		// `tree` / `treegrid` are interactive (widget descendants).
+		{Code: `<div role="tree" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="tree" onClick={() => {}} />;`, Tsx: true},
+		{Code: `<div role="treegrid" onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div role="treegrid" onClick={() => {}} />;`, Tsx: true},
+
+		// All the possible handlers — none of them is in either the
+		// recommended `handlers` list NOR the default focus+keyboard+mouse
+		// list (these are clipboard / composition / change / form / touch /
+		// scroll / wheel / media / animation handlers). hasInteractiveProps
+		// → false → exempt.
+		{Code: `<div onCopy={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onCopy={() => {}} />;`, Tsx: true},
+		{Code: `<div onCut={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onCut={() => {}} />;`, Tsx: true},
+		{Code: `<div onPaste={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onPaste={() => {}} />;`, Tsx: true},
+		{Code: `<div onCompositionEnd={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onCompositionEnd={() => {}} />;`, Tsx: true},
+		{Code: `<div onCompositionStart={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onCompositionStart={() => {}} />;`, Tsx: true},
+		{Code: `<div onCompositionUpdate={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onCompositionUpdate={() => {}} />;`, Tsx: true},
+		{Code: `<div onChange={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onChange={() => {}} />;`, Tsx: true},
+		{Code: `<div onInput={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onInput={() => {}} />;`, Tsx: true},
+		{Code: `<div onSubmit={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onSubmit={() => {}} />;`, Tsx: true},
+		{Code: `<div onSelect={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onSelect={() => {}} />;`, Tsx: true},
+		{Code: `<div onTouchCancel={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onTouchCancel={() => {}} />;`, Tsx: true},
+		{Code: `<div onTouchEnd={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onTouchEnd={() => {}} />;`, Tsx: true},
+		{Code: `<div onTouchMove={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onTouchMove={() => {}} />;`, Tsx: true},
+		{Code: `<div onTouchStart={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onTouchStart={() => {}} />;`, Tsx: true},
+		{Code: `<div onScroll={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onScroll={() => {}} />;`, Tsx: true},
+		{Code: `<div onWheel={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onWheel={() => {}} />;`, Tsx: true},
+		{Code: `<div onAbort={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onAbort={() => {}} />;`, Tsx: true},
+		{Code: `<div onCanPlay={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onCanPlay={() => {}} />;`, Tsx: true},
+		{Code: `<div onCanPlayThrough={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onCanPlayThrough={() => {}} />;`, Tsx: true},
+		{Code: `<div onDurationChange={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDurationChange={() => {}} />;`, Tsx: true},
+		{Code: `<div onEmptied={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onEmptied={() => {}} />;`, Tsx: true},
+		{Code: `<div onEncrypted={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onEncrypted={() => {}} />;`, Tsx: true},
+		{Code: `<div onEnded={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onEnded={() => {}} />;`, Tsx: true},
+		{Code: `<div onError={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onError={() => {}} />;`, Tsx: true},
+		{Code: `<div onLoadedData={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onLoadedData={() => {}} />;`, Tsx: true},
+		{Code: `<div onLoadedMetadata={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onLoadedMetadata={() => {}} />;`, Tsx: true},
+		{Code: `<div onLoadStart={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onLoadStart={() => {}} />;`, Tsx: true},
+		{Code: `<div onPause={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onPause={() => {}} />;`, Tsx: true},
+		{Code: `<div onPlay={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onPlay={() => {}} />;`, Tsx: true},
+		{Code: `<div onPlaying={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onPlaying={() => {}} />;`, Tsx: true},
+		{Code: `<div onProgress={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onProgress={() => {}} />;`, Tsx: true},
+		{Code: `<div onRateChange={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onRateChange={() => {}} />;`, Tsx: true},
+		{Code: `<div onSeeked={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onSeeked={() => {}} />;`, Tsx: true},
+		{Code: `<div onSeeking={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onSeeking={() => {}} />;`, Tsx: true},
+		{Code: `<div onStalled={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onStalled={() => {}} />;`, Tsx: true},
+		{Code: `<div onSuspend={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onSuspend={() => {}} />;`, Tsx: true},
+		{Code: `<div onTimeUpdate={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onTimeUpdate={() => {}} />;`, Tsx: true},
+		{Code: `<div onVolumeChange={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onVolumeChange={() => {}} />;`, Tsx: true},
+		{Code: `<div onWaiting={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onWaiting={() => {}} />;`, Tsx: true},
+		{Code: `<div onLoad={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onLoad={() => {}} />;`, Tsx: true},
+		{Code: `<div onAnimationStart={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onAnimationStart={() => {}} />;`, Tsx: true},
+		{Code: `<div onAnimationEnd={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onAnimationEnd={() => {}} />;`, Tsx: true},
+		{Code: `<div onAnimationIteration={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onAnimationIteration={() => {}} />;`, Tsx: true},
+		{Code: `<div onTransitionEnd={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onTransitionEnd={() => {}} />;`, Tsx: true},
+
+		// ============================================================
+		// recommended-only valid (under recommendedOptions: narrowed
+		// handlers + allowExpressionValues=true)
+		// ============================================================
+		// Handlers that exist in the DEFAULT focus+keyboard+mouse list but
+		// NOT in recommendedOptions.handlers — these are reported under
+		// :strict (see invalid section) but exempt here.
+		{Code: `<div onFocus={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onBlur={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onContextMenu={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDblClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDoubleClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDrag={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDragEnd={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDragEnter={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDragExit={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDragLeave={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDragOver={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDragStart={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onDrop={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onMouseEnter={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onMouseLeave={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onMouseMove={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onMouseOut={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div onMouseOver={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+
+		// Expression-typed role under :recommended — allowExpressionValues=true
+		// → IsNonLiteralProperty skip.
+		{Code: `<div role={ROLE_BUTTON} onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions},
+		{Code: `<div  {...this.props} role={this.props.role} onKeyPress={e => this.handleKeyPress(e)}>{this.props.children}</div>`, Tsx: true, Options: recommendedOptions},
+		// allowExpressionValues=true override + default handlers.
+		{Code: `<div role={BUTTON} onClick={() => {}} />;`, Tsx: true, Options: allowExpressionValuesTrueOptions},
+		// Ternary with literal arms under allowExpressionValues=true:
+		// IsNonLiteralProperty returns true → skip (the "two-literal-arms"
+		// branch upstream returns unconditionally, so observable behavior is
+		// the same).
+		{Code: `<div role={isButton ? "button" : "link"} onClick={() => {}} />;`, Tsx: true, Options: allowExpressionValuesTrueOptions},
+		// Upstream's test file lists these next two cases under VALID with a
+		// stray `errors` field that the upstream RuleTester ignores on valid
+		// cases. Mirror as valid.
+		{Code: `<div role={isButton ? "button" : LINK} onClick={() => {}} />;`, Tsx: true, Options: allowExpressionValuesTrueOptions},
+		{Code: `<div role={isButton ? BUTTON : LINK} onClick={() => {}} />;`, Tsx: true, Options: allowExpressionValuesTrueOptions},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// neverValid (run under both :recommended and :strict)
+		// ============================================================
+		// `<div onClick={...} />` — static, no role, hasInteractiveProps → REPORT.
+		{Code: `<div onClick={() => void 0} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onClick={() => void 0} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `role={undefined}` — IsNonLiteralProperty returns false ("undefined"
+		// identifier matches the upstream JSXExpressionContainer escape arm),
+		// so allowExpressionValues doesn't kick in even under :recommended.
+		// IsInteractiveRole on `undefined` → false. Fall through → REPORT.
+		{Code: `<div onClick={() => void 0} role={undefined} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onClick={() => void 0} role={undefined} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Spread is opaque to hasProp / getProp under default
+		// spreadStrict=true; the direct `onClick` is what matches.
+		{Code: `<div onClick={() => void 0} {...props} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onClick={() => void 0} {...props} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `aria-hidden={false}` — IsHiddenFromScreenReader returns false
+		// (only `=== true` exempts). onKeyUp is in both handler lists.
+		{Code: `<div onKeyUp={() => void 0} aria-hidden={false} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onKeyUp={() => void 0} aria-hidden={false} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// Static elements with no inherent role.
+		{Code: `<a onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<a onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<a onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<a onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<a tabIndex="0" onClick={() => void 0} />`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<a tabIndex="0" onClick={() => void 0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<acronym onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<acronym onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<applet onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<applet onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<area onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<area onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<b onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<b onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<base onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<base onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<bdi onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<bdi onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<bdo onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<bdo onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<big onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<big onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<blink onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<blink onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<body onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<body onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<center onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<center onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<cite onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<cite onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<col onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<col onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<colgroup onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<colgroup onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<content onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<content onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<data onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<data onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<font onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<font onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<frame onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<frame onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<frameset onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<frameset onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<head onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<head onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `<header>` always returns false from IsNonInteractiveElement
+		// (upstream's banner-landmark-context note). Falls through to REPORT.
+		{Code: `<header onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<header onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<hgroup onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<hgroup onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<i onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<i onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<kbd onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<kbd onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<keygen onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<keygen onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<map onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<map onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<meta onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<meta onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<noembed onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<noembed onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<noscript onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<noscript onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<object onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<object onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<param onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<param onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<picture onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<picture onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<q onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<q onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<rp onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<rp onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<rt onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<rt onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<rtc onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<rtc onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<s onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<s onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<samp onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<samp onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<script onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<script onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Bare `<section>` (no aria-label / aria-labelledby) — does not match
+		// the non-interactive section schema → REPORT.
+		{Code: `<section onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<section onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<small onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<small onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<source onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<source onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<spacer onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<spacer onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<span onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<span onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<strike onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<strike onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<style onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<style onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<title onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<title onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<track onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<track onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<tt onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<tt onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<u onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<u onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<var onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<var onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<wbr onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<wbr onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<xmp onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<xmp onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// Keyboard / mouse handler variants present in both handler lists.
+		{Code: `<div onKeyDown={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onKeyDown={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onKeyPress={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onKeyPress={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onKeyUp={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onKeyUp={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onClick={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onMouseDown={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onMouseDown={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onMouseUp={() => {}} />;`, Tsx: true, Options: recommendedOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onMouseUp={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Custom component remapped to <div> via settings.
+		{Code: `<TestComponent onClick={doFoo} />`, Tsx: true, Options: recommendedOptions, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<TestComponent onClick={doFoo} />`, Tsx: true, Settings: componentsSettings, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// strict-only invalid (no options → defaults: full focus +
+		// keyboard + mouse handler list, allowExpressionValues falsy)
+		// ============================================================
+		// Handlers from the default focus+keyboard+mouse list that are NOT
+		// in recommendedOptions.handlers → reported only under :strict.
+		{Code: `<div onContextMenu={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onDblClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onDoubleClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onDrag={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onDragEnd={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onDragEnter={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onDragExit={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onDragLeave={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onDragOver={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onDragStart={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onDrop={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onMouseEnter={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onMouseLeave={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onMouseMove={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onMouseOut={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div onMouseOver={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// Without allowExpressionValues=true, non-literal `role` is no
+		// longer a skip. IsInteractiveRole on a non-literal returns false →
+		// REPORT.
+		{Code: `<div role={ROLE_BUTTON} onClick={() => {}} />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div  {...this.props} role={this.props.role} onKeyPress={e => this.handleKeyPress(e)}>{this.props.children}</div>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Explicit allowExpressionValues=false — same outcome as defaults.
+		{Code: `<div role={BUTTON} onClick={() => {}} />;`, Tsx: true, Options: allowExpressionValuesFalseOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Ternary with literal arms but allowExpressionValues=false → IsInteractiveRole
+		// on a ConditionalExpression returns false → REPORT.
+		{Code: `<div role={isButton ? "button" : "link"} onClick={() => {}} />;`, Tsx: true, Options: allowExpressionValuesFalseOptions, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -182,6 +182,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-element-interactions.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-tabindex.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-redundant-roles.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/no-static-element-interactions.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/scope.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/tabindex-no-positive.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-static-element-interactions.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-static-element-interactions.test.ts
@@ -1,0 +1,269 @@
+import { RuleTester } from '../rule-tester';
+
+const errorMessage =
+  'Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element.';
+const expectedError = { message: errorMessage };
+
+const componentsSettings = {
+  'jsx-a11y': {
+    components: {
+      Button: 'button',
+      TestComponent: 'div',
+    },
+  },
+};
+
+const recommendedOptions = [
+  {
+    handlers: [
+      'onClick',
+      'onMouseDown',
+      'onMouseUp',
+      'onKeyPress',
+      'onKeyDown',
+      'onKeyUp',
+    ],
+    allowExpressionValues: true,
+  },
+];
+
+const allowExpressionValuesTrueOptions = [{ allowExpressionValues: true }];
+const allowExpressionValuesFalseOptions = [{ allowExpressionValues: false }];
+
+new RuleTester().run('no-static-element-interactions', null as never, {
+  valid: [
+    // ============================================================
+    // Upstream alwaysValid (run under both :strict and :recommended)
+    // ============================================================
+    // Custom JSX components — not in dom set → exempt.
+    { code: '<TestComponent onClick={doFoo} />' },
+    { code: '<Button onClick={doFoo} />' },
+    { code: '<Button onClick={doFoo} />', settings: componentsSettings },
+    // No interactive handlers.
+    { code: '<div />;' },
+    { code: '<div className="foo" />;' },
+    { code: '<div className="foo" {...props} />;' },
+    // aria-hidden short-circuit.
+    { code: '<div onClick={() => void 0} aria-hidden />;' },
+    { code: '<div onClick={() => void 0} aria-hidden={true} />;' },
+    // null handler — getPropValue returns null → `!= null` is false.
+    { code: '<div onClick={null} />;' },
+
+    // Inherently interactive HTML elements.
+    { code: '<input onClick={() => void 0} />' },
+    { code: '<input type="button" onClick={() => void 0} />' },
+    { code: '<input type="checkbox" onClick={() => void 0} />' },
+    { code: '<input type="text" onClick={() => void 0} />' },
+    { code: '<input type="hidden" onClick={() => void 0} />' },
+    { code: '<button onClick={() => void 0} className="foo" />' },
+    { code: '<select onClick={() => void 0} className="foo" />' },
+    { code: '<textarea onClick={() => void 0} className="foo" />' },
+    { code: '<a onClick={() => void 0} href="http://x.y.z" />' },
+    { code: '<a onClick={() => void 0} href="http://x.y.z" tabIndex="0" />' },
+
+    // Interactive role attribute on <div>.
+    { code: '<div role="button" onClick={() => {}} />;' },
+    { code: '<div role="checkbox" onClick={() => {}} />;' },
+    { code: '<div role="link" onClick={() => {}} />;' },
+    { code: '<div role="menuitem" onClick={() => {}} />;' },
+    { code: '<div role="tab" onClick={() => {}} />;' },
+    { code: '<div role="textbox" onClick={() => {}} />;' },
+    { code: '<div role="treeitem" onClick={() => {}} />;' },
+
+    // Presentation roles.
+    { code: '<div role="presentation" onClick={() => {}} />;' },
+    { code: '<div role="presentation" onKeyDown={() => {}} />;' },
+
+    // HTML elements with inherent non-interactive role.
+    { code: '<article onClick={() => {}} />;' },
+    { code: '<aside onClick={() => {}} />;' },
+    { code: '<blockquote onClick={() => {}} />;' },
+    { code: '<h1 onClick={() => {}} />;' },
+    { code: '<li onClick={() => {}} />;' },
+    { code: '<main onClick={() => void 0} />;' },
+    { code: '<nav onClick={() => {}} />;' },
+    { code: '<p onClick={() => {}} />;' },
+    { code: '<table onClick={() => {}} />;' },
+    { code: '<section onClick={() => {}} aria-label="Aa" />;' },
+
+    // Abstract roles.
+    { code: '<div role="command" onClick={() => {}} />;' },
+    { code: '<div role="widget" onClick={() => {}} />;' },
+    { code: '<div role="window" onClick={() => {}} />;' },
+    { code: '<div role="composite" onClick={() => {}} />;' },
+
+    // Non-interactive role attribute on <div>.
+    { code: '<div role="alert" onClick={() => {}} />;' },
+    { code: '<div role="article" onClick={() => {}} />;' },
+    { code: '<div role="dialog" onClick={() => {}} />;' },
+    { code: '<div role="document" onClick={() => {}} />;' },
+    { code: '<div role="banner" onClick={() => {}} />;' },
+    { code: '<div role="form" onClick={() => {}} />;' },
+
+    // Non-triggering handlers (clipboard / composition / change / touch /
+    // scroll / wheel / media / animation) — none in any handler list.
+    { code: '<div onCopy={() => {}} />;' },
+    { code: '<div onCut={() => {}} />;' },
+    { code: '<div onPaste={() => {}} />;' },
+    { code: '<div onChange={() => {}} />;' },
+    { code: '<div onSubmit={() => {}} />;' },
+    { code: '<div onScroll={() => {}} />;' },
+    { code: '<div onTouchStart={() => {}} />;' },
+    { code: '<div onAnimationStart={() => {}} />;' },
+
+    // ============================================================
+    // recommended-only valid (narrowed handlers + allowExpressionValues=true)
+    // ============================================================
+    // Handlers in the default list but NOT in recommended.handlers.
+    { code: '<div onFocus={() => {}} />;', options: recommendedOptions },
+    { code: '<div onBlur={() => {}} />;', options: recommendedOptions },
+    { code: '<div onContextMenu={() => {}} />;', options: recommendedOptions },
+    { code: '<div onDblClick={() => {}} />;', options: recommendedOptions },
+    { code: '<div onDrag={() => {}} />;', options: recommendedOptions },
+    { code: '<div onMouseEnter={() => {}} />;', options: recommendedOptions },
+    { code: '<div onMouseLeave={() => {}} />;', options: recommendedOptions },
+
+    // allowExpressionValues=true — non-literal role exempt.
+    {
+      code: '<div role={ROLE_BUTTON} onClick={() => {}} />;',
+      options: recommendedOptions,
+    },
+    {
+      code: '<div  {...this.props} role={this.props.role} onKeyPress={e => this.handleKeyPress(e)}>{this.props.children}</div>',
+      options: recommendedOptions,
+    },
+    {
+      code: '<div role={BUTTON} onClick={() => {}} />;',
+      options: allowExpressionValuesTrueOptions,
+    },
+    {
+      code: '<div role={isButton ? "button" : "link"} onClick={() => {}} />;',
+      options: allowExpressionValuesTrueOptions,
+    },
+    {
+      code: '<div role={isButton ? "button" : LINK} onClick={() => {}} />;',
+      options: allowExpressionValuesTrueOptions,
+    },
+    {
+      code: '<div role={isButton ? BUTTON : LINK} onClick={() => {}} />;',
+      options: allowExpressionValuesTrueOptions,
+    },
+  ],
+
+  invalid: [
+    // ============================================================
+    // Upstream neverValid (under both :strict and :recommended)
+    // ============================================================
+    {
+      code: '<div onClick={() => void 0} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div onClick={() => void 0} />;',
+      options: recommendedOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<div onClick={() => void 0} role={undefined} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div onClick={() => void 0} {...props} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div onKeyUp={() => void 0} aria-hidden={false} />;',
+      errors: [expectedError],
+    },
+
+    // Static elements without inherent role.
+    { code: '<a onClick={() => {}} />;', errors: [expectedError] },
+    {
+      code: '<a tabIndex="0" onClick={() => void 0} />',
+      errors: [expectedError],
+    },
+    { code: '<acronym onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<b onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<bdi onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<blink onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<body onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<center onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<cite onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<colgroup onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<font onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<head onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<header onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<hgroup onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<i onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<kbd onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<map onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<meta onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<noscript onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<object onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<picture onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<q onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<rp onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<s onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<samp onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<script onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<section onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<small onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<span onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<spacer onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<style onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<title onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<u onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<var onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<wbr onClick={() => {}} />;', errors: [expectedError] },
+
+    // Keyboard / mouse handler variants present in BOTH lists.
+    { code: '<div onKeyDown={() => {}} />;', errors: [expectedError] },
+    { code: '<div onKeyPress={() => {}} />;', errors: [expectedError] },
+    { code: '<div onKeyUp={() => {}} />;', errors: [expectedError] },
+    { code: '<div onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<div onMouseDown={() => {}} />;', errors: [expectedError] },
+    { code: '<div onMouseUp={() => {}} />;', errors: [expectedError] },
+    // Custom component remapped to <div>.
+    {
+      code: '<TestComponent onClick={doFoo} />',
+      settings: componentsSettings,
+      errors: [expectedError],
+    },
+
+    // ============================================================
+    // strict-only invalid (defaults — full focus+keyboard+mouse handlers)
+    // ============================================================
+    { code: '<div onContextMenu={() => {}} />;', errors: [expectedError] },
+    { code: '<div onDblClick={() => {}} />;', errors: [expectedError] },
+    { code: '<div onDoubleClick={() => {}} />;', errors: [expectedError] },
+    { code: '<div onDrag={() => {}} />;', errors: [expectedError] },
+    { code: '<div onDragEnd={() => {}} />;', errors: [expectedError] },
+    { code: '<div onDragEnter={() => {}} />;', errors: [expectedError] },
+    { code: '<div onDragExit={() => {}} />;', errors: [expectedError] },
+    { code: '<div onDragLeave={() => {}} />;', errors: [expectedError] },
+    { code: '<div onDragOver={() => {}} />;', errors: [expectedError] },
+    { code: '<div onDragStart={() => {}} />;', errors: [expectedError] },
+    { code: '<div onDrop={() => {}} />;', errors: [expectedError] },
+    { code: '<div onMouseEnter={() => {}} />;', errors: [expectedError] },
+    { code: '<div onMouseLeave={() => {}} />;', errors: [expectedError] },
+    { code: '<div onMouseMove={() => {}} />;', errors: [expectedError] },
+    { code: '<div onMouseOut={() => {}} />;', errors: [expectedError] },
+    { code: '<div onMouseOver={() => {}} />;', errors: [expectedError] },
+
+    // Non-literal `role` without allowExpressionValues=true.
+    {
+      code: '<div role={ROLE_BUTTON} onClick={() => {}} />;',
+      errors: [expectedError],
+    },
+    {
+      code: '<div role={BUTTON} onClick={() => {}} />;',
+      options: allowExpressionValuesFalseOptions,
+      errors: [expectedError],
+    },
+    {
+      code: '<div role={isButton ? "button" : "link"} onClick={() => {}} />;',
+      options: allowExpressionValuesFalseOptions,
+      errors: [expectedError],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -132,6 +132,7 @@ noopener
 noopenernoreferrer
 noreferrer
 noregabi
+notarole
 notcool
 notunique
 nsec


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/no-static-element-interactions` rule from `eslint-plugin-jsx-a11y` to rslint. The rule flags static HTML elements (`<div>`, `<span>`, `<a>` without `href`, …) that carry an interactive event handler (default: focus + keyboard + mouse handlers) but lack an interactive ARIA `role` — visible static elements dispatching mouse / keyboard events without a role are invisible to assistive technology.

### Helpers added to `jsxa11yutil`

- `DefaultStaticInteractionHandlers` — mirrors upstream's `defaultInteractiveProps` (focus + keyboard + mouse handlers, 24 entries).
- `IsAbstractRole` — mirrors upstream's `isAbstractRole`; uses the 12 WAI-ARIA abstract roles (`command`, `composite`, `input`, `landmark`, `range`, `roletype`, `section`, `sectionhead`, `select`, `structure`, `widget`, `window`).

### Tests

- `_upstream_test.go` — 1:1 migration of upstream's full `:recommended` + `:strict` suites.
- `_extras_test.go` — 17 Test functions covering positions, listener boundaries, options matrix, real-world handler shapes (member access / call expressions / conditionals / logical operators / nullish coalescing / async / function expressions / new), polymorphic `as` + components remapping, role attribute edge cases, `aria-hidden` value variants, `<input>` / `<a>` schema matrix, multi-handler null/non-null combinations, JSX structural edge cases (fragments, generic components, comments, ternary-rendered children), TS wrappers, and upstream-source branch lock-ins.
- JS-side `rstest` mirrors the upstream test cases.

Verified by running the built binary on `rsbuild` (0 violations across 1221 files — no candidates) and `rspack` (2 real violations on identical static-`<div>`-with-`onClick` patterns in `tests/e2e/cases/react/{basic,with-babel}/src/CountProvider.jsx`, both true positives). Manual grep across both repos confirms 0 false positives and 0 false negatives.

## Related Links

- ESLint rule documentation: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md
- ESLint rule source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/no-static-element-interactions.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).