### PR TITLE
fix: move Windows Go build to self-hosted runner to avoid disk-full

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -6,7 +6,10 @@ inputs:
     description: Go version range to set up.
     required: true
   cache-name:
-    description: Name of scoped cache for this set up.
+    description: >
+      Name of scoped cache for this set up. On self-hosted Windows runners it
+      also derives the GOCACHE / TEMP subdirectory path under the runner work
+      disk, so it must not contain path separators (`\` or `/`).
     default: 'cache'
 
 runs:
@@ -65,3 +68,23 @@ runs:
         if (Test-Path $toolchainPath) {
           Get-ChildItem -Path $toolchainPath -Filter "toolchain*" -Directory | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
         }
+
+    # Relocate GOCACHE / TEMP / GOTMPDIR off the small system drive on
+    # self-hosted Windows runners. Required when compiling Go projects whose
+    # build cache and $WORK temp directory would exceed the system drive's
+    # free space (e.g. anything that pulls in the typescript-go shim). Paths
+    # are derived from `cache-name` to keep concurrent jobs on the same runner
+    # isolated.
+    - name: Relocate Go cache & temp (self-hosted Windows)
+      if: runner.environment == 'self-hosted' && runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $base = 'C:\Users\ContainerAdministrator\runner\_work'
+        $goCache = Join-Path $base "go\${{ inputs.cache-name }}"
+        $temp    = Join-Path $base "temp\${{ inputs.cache-name }}"
+        New-Item -ItemType Directory -Force -Path $goCache, $temp | Out-Null
+
+        "GOCACHE=$goCache" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+        "TEMP=$temp"       | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+        "TMP=$temp"        | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+        "GOTMPDIR=$temp"   | Out-File -Append -Encoding utf8 $env:GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,19 +73,6 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-name: ci-go-windows
 
-      - name: Relocate Go build cache & temp to runner work disk
-        shell: pwsh
-        run: |
-          $base = 'C:\Users\ContainerAdministrator\runner\_work'
-          $goCache = Join-Path $base 'go\cache'
-          $temp    = Join-Path $base 'temp'
-          New-Item -ItemType Directory -Force -Path $goCache, $temp | Out-Null
-
-          "GOCACHE=$goCache" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
-          "TEMP=$temp"       | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
-          "TMP=$temp"        | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
-          "GOTMPDIR=$temp"   | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
-
       - name: Unit Test
         shell: pwsh
         run: |
@@ -122,26 +109,52 @@ jobs:
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
+  build-rslint-windows:
+    name: Build rslint.exe (Windows)
+    runs-on: rspack-windows-2022-large
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+          fetch-depth: 1
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: 1.26.0
+          cache-name: ci-go-windows-build
+
+      - name: Build rslint.exe
+        shell: pwsh
+        run: go build -o packages/rslint/bin/rslint.exe ./cmd/rslint
+
+      - name: Upload rslint.exe
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ci-test-rslint-windows-amd64
+          path: packages/rslint/bin/rslint.exe
+          retention-days: 1
+          if-no-files-found: error
+
   test-node-windows:
     name: Test npm packages (windows-latest)
     runs-on: windows-latest
+    needs: build-rslint-windows
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
 
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-        with:
-          go-version: 1.26.0
-          cache-name: ci-go-windows-node
-
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
 
-      - name: Build Go binary
-        run: go build -o packages/rslint/bin/rslint.exe ./cmd/rslint
+      - name: Download rslint.exe
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ci-test-rslint-windows-amd64
+          path: packages/rslint/bin
 
       - name: Build JS packages
         shell: bash
@@ -338,6 +351,7 @@ jobs:
     needs:
       - test-go
       - test-go-windows
+      - build-rslint-windows
       - test-node
       - test-node-windows
       - lint


### PR DESCRIPTION
## Summary

Recent PRs merged into main are failing on `Test npm packages (windows-latest)` with `compile: writing output: There is not enough space on the disk.` during `go build ./cmd/rslint` — the typescript-go shim build graph (1.2 GB / 4500+ `.go` files) produces `$WORK` temp files that exceed the free space on the GitHub-hosted `windows-2025` runner's system drive.

Fix:

- Add a new `build-rslint-windows` job on the self-hosted `rspack-windows-2022-large` runner (already proven to compile typescript-go in `test-go-windows`)
- Upload `rslint.exe` as an artifact (`ci-test-rslint-windows-amd64`)
- `test-node-windows` now downloads the artifact and runs the vscode e2e tests with no Go toolchain involved. It stays on `windows-latest` because self-hosted Windows cannot run vscode e2e tests
- Consolidate the GOCACHE / TEMP / GOTMPDIR relocation logic into `./.github/actions/setup-go`, gated by `runner.environment == 'self-hosted' && runner.os == 'Windows'`, with paths derived from `cache-name`. All self-hosted Windows Go jobs now share the same behavior, and future extensions (e.g. GOCACHE persistence) live in one place

The artifact name `ci-test-rslint-windows-amd64` is double-isolated from release.yml's `win32-x64-rslint` family (different prefix, Go-style naming) to avoid future maintenance collisions.

## Test plan

- [ ] CI is green
- [ ] `build-rslint-windows` produces the `rslint.exe` artifact
- [ ] `test-node-windows` downloads the artifact and completes the vscode e2e tests without invoking `go build`
- [ ] `test-go-windows` keeps passing with no behavioral change (same `setup-go` action, relocate auto-enabled)