### PR TITLE
feat: port rule jsx-a11y/role-has-required-aria-props

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -27,6 +27,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_redundant_roles"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_static_element_interactions"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/role_has_required_aria_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/tabindex_no_positive"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -60,6 +61,7 @@ func GetAllRules() []rule.Rule {
 		no_noninteractive_tabindex.NoNoninteractiveTabindexRule,
 		no_redundant_roles.NoRedundantRolesRule,
 		no_static_element_interactions.NoStaticElementInteractionsRule,
+		role_has_required_aria_props.RoleHasRequiredAriaPropsRule,
 		scope.ScopeRule,
 		tabindex_no_positive.TabindexNoPositiveRule,
 	}

--- a/internal/plugins/jsx_a11y/jsxa11yutil/roles.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/roles.go
@@ -74,3 +74,137 @@ func IsValidAriaRole(role string) bool {
 	_, ok := AriaRoleNonAbstractSet[role]
 	return ok
 }
+
+// AriaRoleRequiredProps is the list of (role, required ARIA props) pairs for
+// every non-abstract ARIA role whose `requiredProps` set is non-empty.
+// Mirrors `aria-query`'s `roles.get(role).requiredProps` keys, with the keys
+// preserved in insertion order so error messages match upstream's
+// `String(Object.keys(requiredProps))` (= comma-joined) output byte-for-byte.
+//
+// Roles whose `requiredProps` map is empty (e.g. `button`, `link`, `cell`)
+// are intentionally absent — the upstream rule's
+// `if (requiredProps.length > 0)` gate filters them out, and the rule never
+// emits diagnostics for those roles. Keeping them out of this table mirrors
+// that gate as a data-structure rather than an extra runtime check.
+//
+// Source: https://github.com/A11yance/aria-query/tree/main/src/etc/roles
+// (per-role `requiredProps` map; abstract roles excluded).
+var AriaRoleRequiredProps = []struct {
+	Role  string
+	Props []string
+}{
+	{"checkbox", []string{"aria-checked"}},
+	{"combobox", []string{"aria-controls", "aria-expanded"}},
+	{"heading", []string{"aria-level"}},
+	{"menuitemcheckbox", []string{"aria-checked"}},
+	{"menuitemradio", []string{"aria-checked"}},
+	{"meter", []string{"aria-valuenow"}},
+	{"option", []string{"aria-selected"}},
+	{"radio", []string{"aria-checked"}},
+	{"scrollbar", []string{"aria-controls", "aria-valuenow"}},
+	{"slider", []string{"aria-valuenow"}},
+	{"switch", []string{"aria-checked"}},
+	{"treeitem", []string{"aria-selected"}},
+}
+
+// ariaRoleRequiredPropsMap is the indexed view of AriaRoleRequiredProps —
+// O(1) lookup of a role's required props slice. Returns (nil, false) for
+// roles with no required props (absent from the table); callers should treat
+// that as upstream's `requiredProps.length > 0` gate failing, i.e. skip the
+// role.
+var ariaRoleRequiredPropsMap = func() map[string][]string {
+	m := make(map[string][]string, len(AriaRoleRequiredProps))
+	for _, e := range AriaRoleRequiredProps {
+		m[e.Role] = e.Props
+	}
+	return m
+}()
+
+// AriaRoleRequiredPropsFor returns the required ARIA props for `role`.
+// Returns (nil, false) when the role has no required props or is unknown.
+// Used by jsx-a11y/role-has-required-aria-props to gate on upstream's
+// `if (requiredProps.length > 0)` condition.
+func AriaRoleRequiredPropsFor(role string) ([]string, bool) {
+	v, ok := ariaRoleRequiredPropsMap[role]
+	return v, ok
+}
+
+// SemanticRoleConcept describes one (element-name, attributes) → roles
+// mapping derived from `axobject-query`'s `elementAXObjects` joined with
+// `AXObjectRoles`. The result is the set of ARIA roles that the given HTML
+// element naturally implies — what jsx-a11y's `isSemanticRoleElement`
+// upstream consults to skip the required-props check when the element
+// already provides the role's semantics by virtue of its tag (e.g.
+// `<input type="checkbox">` already provides the `checkbox` role).
+//
+// The table is filtered to entries where at least one mapped role appears
+// in [AriaRoleRequiredProps]. Entries whose roles all have empty
+// `requiredProps` are dropped — the rule's `validRoles.forEach(role => ...)`
+// loop never fires on those roles anyway, so the semantic skip would have
+// no observable effect.
+//
+// Source: https://github.com/A11yance/axobject-query/tree/main/src
+type SemanticRoleConcept struct {
+	// Name is the HTML element name (`input`, `select`, `h1`, ...).
+	Name string
+	// Attributes are the (name, value) pairs that ALL must match on the JSX
+	// element for the concept to apply. An entry with Value == "" means the
+	// attribute presence alone is enough; entries derived from
+	// `axobject-query` always carry a value, so the empty-Value path is
+	// dead code today but preserved to mirror upstream's
+	// `cAttr.value !== undefined ? ... : true` branch.
+	Attributes []SemanticRoleAttribute
+	// Roles is the set of ARIA roles this concept implies.
+	Roles []string
+}
+
+// SemanticRoleAttribute is one (name, value) pair in a SemanticRoleConcept's
+// attribute requirement list. Comparisons against the JSX element's
+// attributes are case-sensitive — mirrors upstream `cAttr.name === propName(attr)`
+// and `cAttr.value === getLiteralPropValue(attr)`.
+type SemanticRoleAttribute struct {
+	Name  string
+	Value string
+}
+
+// SemanticRoleConcepts is the table consulted by
+// `jsx-a11y/role-has-required-aria-props` to skip elements that natively
+// imply the role on their `role` attribute. See [SemanticRoleConcept] for
+// the filter / derivation criterion.
+//
+// Generated from `axobject-query` v4 by joining `elementAXObjects` (concept
+// → axObjects) with `AXObjectRoles` (axObject → roles), then keeping every
+// (concept, joined-roles) entry where at least one role in the joined set
+// has non-empty `requiredProps`.
+//
+// Order matches the live `axobject-query` iteration order so a future
+// audit can diff against `axobject-query`'s `elementAXObjects` map.
+var SemanticRoleConcepts = []SemanticRoleConcept{
+	{
+		Name:       "input",
+		Attributes: []SemanticRoleAttribute{{Name: "type", Value: "checkbox"}},
+		Roles:      []string{"checkbox", "switch"},
+	},
+	{
+		Name:       "select",
+		Attributes: nil,
+		Roles:      []string{"combobox", "listbox"},
+	},
+	{Name: "h1", Roles: []string{"heading"}},
+	{Name: "h2", Roles: []string{"heading"}},
+	{Name: "h3", Roles: []string{"heading"}},
+	{Name: "h4", Roles: []string{"heading"}},
+	{Name: "h5", Roles: []string{"heading"}},
+	{Name: "h6", Roles: []string{"heading"}},
+	{Name: "option", Roles: []string{"option"}},
+	{
+		Name:       "input",
+		Attributes: []SemanticRoleAttribute{{Name: "type", Value: "radio"}},
+		Roles:      []string{"radio"},
+	},
+	{
+		Name:       "input",
+		Attributes: []SemanticRoleAttribute{{Name: "type", Value: "range"}},
+		Roles:      []string{"slider"},
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props.go
+++ b/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props.go
@@ -1,0 +1,327 @@
+// cspell:ignore eading
+
+// Package role_has_required_aria_props ports eslint-plugin-jsx-a11y's
+// `role-has-required-aria-props` rule. The rule listens on every JSX
+// `role` attribute whose value is a literal-typed string, and reports
+// when one of the named ARIA roles is missing its `requiredProps`
+// (per aria-query's `roles.get(role).requiredProps`).
+//
+// Trigger order — mirrors upstream's `JSXAttribute` listener step-for-step:
+//
+//  1. `propName(attribute).toLowerCase() !== 'role'` → skip. We use
+//     `strings.EqualFold` against "role" to match jsx-ast-utils'
+//     case-insensitive comparison.
+//  2. `!dom.get(elementType)` → skip. The element type is resolved via
+//     `jsxa11yutil.GetElementType` (which honors the `components` and
+//     `polymorphicPropName` jsx-a11y settings); the DOM-element membership
+//     check uses `jsxa11yutil.IsDOMElement`. Custom components and
+//     unknown element names are skipped.
+//  3. Literal-value extraction in priority order — array → string →
+//     bool/number → undef/NoLit:
+//       a. `LiteralPropArrayAsString` handles `<div role={[...]}>`
+//          shapes (upstream's LITERAL_TYPES.ArrayExpression evaluates
+//          elements and `,`-joins via `String([...])`).
+//       b. `LiteralPropStringValue` handles string-typed literal values
+//          including the direct attribute form with HTML entity decoding
+//          (`<div role="&#104;eading">` → "heading"), JsxExpression-wrapped
+//          strings, the `null`-magic-string override, and template-synthesized
+//          strings.
+//       c. `LiteralPropAriaValue` is the fallback for boolean / number /
+//          BigInt literal values (stringified via JS `String()`), and the
+//          short-circuit `NoLit` / `Undef` arms that skip:
+//            - boolean-form attribute `<div role />` returns
+//              `Bool{true}` which stringifies to `"true"` (not a role).
+//            - explicit `{undefined}` → `Undef` → skip.
+//            - non-literal expression (Identifier, Logical, Conditional,
+//              Call, Member, Binary, TS-wrapper, ...) → `NoLit` → skip.
+//          Explicit `{null}` is NOT skipped here: it's handled by
+//          step (b) via the LITERAL_TYPES.Literal override → magic
+//          string `"null"`, which then falls through to step 4.
+//  4. Lowercase and ASCII-space-split the role value. Then filter to the
+//     tokens that exist in aria-query's non-abstract role set.
+//  5. `isSemanticRoleElement(elementType, attributes)` → skip. The
+//     check uses the un-normalized (i.e. NOT lowercased) `roleAttrValue`
+//     for comparison against axobject-query's role-name table, so
+//     `<select role="combobox" />` is skipped but `<select role="COMBOBOX" />`
+//     is NOT — see Phase 1 step 6 below for the lock-in test.
+//  6. For each valid role with non-empty `requiredProps`, check that
+//     every required prop is present as a JSX attribute (via
+//     `jsxa11yutil.FindAttributeByName`, which honors literal-spread
+//     object expansion). If any required prop is missing, emit a
+//     diagnostic on the role attribute node, with the role name
+//     lowercased (`role.toLowerCase()`) and the required-props list
+//     comma-joined (matching JS `String(array)` semantics).
+//
+// Phase 1 Step 6 — observable divergences from upstream:
+//   - None. The rule is a thin port of the upstream `JSXAttribute`
+//     listener. The only nuance is that upstream's `isSemanticRoleElement`
+//     uses the raw (case-preserved) `roleAttrValue` while the
+//     `validRoles` filter uses the lowercased form — so
+//     `<select role="COMBOBOX" />` reports (validRoles → "combobox" via
+//     lowercase split, but isSemanticRoleElement comparing "COMBOBOX" to
+//     aria-query's lowercase "combobox" returns false). We mirror that
+//     quirk verbatim.
+package role_has_required_aria_props
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// errorMessage mirrors upstream's `errorMessage(role, requiredProps)`
+// template byte-for-byte. `requiredProps` is `String(array)`-joined (i.e.
+// JS `Array.prototype.toString()` semantics, which uses ",") and then
+// lowercased — aria-query's prop names are already lowercase, so the
+// `.toLowerCase()` call is a defensive no-op upstream that we mirror by
+// constructing the joined string directly in lowercase.
+func errorMessage(role string, requiredProps []string) string {
+	return fmt.Sprintf(
+		`Elements with the ARIA role "%s" must have the following attributes defined: %s`,
+		role,
+		strings.Join(requiredProps, ","),
+	)
+}
+
+// isSemanticRoleElement mirrors upstream's `isSemanticRoleElement(type,
+// attributes)`:
+//
+//	elementAXObjects.forEach((axObjects, concept) => {
+//	  if (concept.name === type && concept.attributes.every(matches)) {
+//	    for axObject in axObjects:
+//	      for role in AXObjectRoles.get(axObject):
+//	        if role.name === roleAttrValue: return true
+//	  }
+//	});
+//
+// We pre-joined the (concept → axObjects → roles) chain into
+// `jsxa11yutil.SemanticRoleConcepts` so the runtime check is a flat
+// concept-by-concept scan.
+//
+// Key parity notes:
+//
+//   - The concept-attribute name comparison is CASE-SENSITIVE
+//     (`cAttr.name === propName(attr)` in upstream — `propName` returns
+//     the raw AST name without case normalization). Upstream's outer
+//     `name !== 'role'` check lowercases, but the inner concept-attribute
+//     matcher does not. So `<input Type="checkbox" role="switch" />`
+//     (capital T) does NOT match the input/type=checkbox concept.
+//   - The concept-attribute value comparison uses upstream's
+//     `getLiteralPropValue(attr)` — i.e. only literal-typed values
+//     count; dynamic / identifier values silently fail to match.
+//     Implemented here via [jsxa11yutil.LiteralPropStringValue], which
+//     mirrors the LITERAL_TYPES extractor for string-typed results.
+//   - The role-name comparison is the raw `roleAttrValue`, NOT the
+//     lowercased / space-split form. So `<select role="COMBOBOX" />`
+//     fails the semantic skip even though the validRoles filter sees
+//     "combobox".
+func isSemanticRoleElement(elementType string, attrs []*ast.Node, roleAttrValue string) bool {
+	for i := range jsxa11yutil.SemanticRoleConcepts {
+		concept := &jsxa11yutil.SemanticRoleConcepts[i]
+		if concept.Name != elementType {
+			continue
+		}
+		// All concept attributes must match an attribute on the JSX element.
+		allMatch := true
+		for _, cAttr := range concept.Attributes {
+			matched := false
+			for _, attr := range attrs {
+				if attr.Kind != ast.KindJsxAttribute {
+					// JsxSpreadAttribute is opaque — upstream's
+					// `attribute.some(...)` filters on `attr.type ===
+					// 'JSXAttribute'`. Match by skipping spreads here.
+					continue
+				}
+				if reactutil.GetJsxPropName(attr) != cAttr.Name {
+					continue
+				}
+				// Name matches. If the concept attribute carries a value,
+				// the JSX attribute's literal value must match exactly
+				// (case-sensitive). When the concept attribute has no
+				// value (cAttr.Value == ""), name match alone is enough.
+				if cAttr.Value != "" {
+					attrValue, ok := jsxa11yutil.LiteralPropStringValue(attr)
+					if !ok || attrValue != cAttr.Value {
+						continue
+					}
+				}
+				matched = true
+				break
+			}
+			if !matched {
+				allMatch = false
+				break
+			}
+		}
+		if !allMatch {
+			continue
+		}
+		// Concept matches. Check if the role's name is among the concept's
+		// implied roles.
+		for _, r := range concept.Roles {
+			if r == roleAttrValue {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var RoleHasRequiredAriaPropsRule = rule.Rule{
+	Name: "jsx-a11y/role-has-required-aria-props",
+	Run: func(ctx rule.RuleContext, _ any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindJsxAttribute: func(attr *ast.Node) {
+				// Step 1: name === 'role' (case-insensitive — mirrors
+				// upstream `propName(attribute).toLowerCase() !== 'role'`).
+				if !strings.EqualFold(reactutil.GetJsxPropName(attr), "role") {
+					return
+				}
+
+				// Step 2: resolve element type and gate on dom.get(type).
+				parent := reactutil.GetJsxParentElement(attr)
+				if parent == nil {
+					return
+				}
+				elementType := jsxa11yutil.GetElementType(parent, ctx.Settings)
+				if !jsxa11yutil.IsDOMElement(elementType) {
+					return
+				}
+
+				// Step 3: literal value extraction. We need the upstream
+				// `getLiteralPropValue` "undefined vs null vs other"
+				// trichotomy:
+				//   - boolean-form attribute → returns true (boolean)
+				//   - explicit `{undefined}` → returns undefined
+				//   - non-literal expression → returns null
+				//   - direct string attribute → returns the parsed (entity-decoded) text
+				//   - everything else → proceed (stringified via JS String())
+				//
+				// Three helpers cover this, in priority order:
+				//
+				//  1. `LiteralPropArrayAsString` — array values
+				//     (`<div role={["x"]}>`). Upstream's
+				//     LITERAL_TYPES.ArrayExpression evaluates elements via
+				//     the full TYPES evaluator and `,`-joins per
+				//     `String([...])`. `LiteralPropAriaValue` keeps arrays
+				//     as NoLit, so the array path must be checked FIRST.
+				//
+				//  2. `LiteralPropStringValue` — string-typed results,
+				//     including direct-attribute strings with HTML entity
+				//     decoding (`<div role="&#104;eading">` → "heading"),
+				//     JsxExpression-wrapped strings (`<div role={"x"}>`),
+				//     `null` keyword (LITERAL_TYPES.Literal override →
+				//     magic string `"null"`), and TemplateExpression
+				//     synthesized strings.
+				//
+				//     CRITICAL: do NOT skip directly to LiteralPropAriaValue
+				//     for the string case — that path reads
+				//     `StringLiteral.Text` raw, so it misses HTML entity
+				//     decoding on direct JSX attribute strings (where the
+				//     `&…;` is part of the source). babel / @typescript-eslint
+				//     JSX parsers expose decoded text on the AST; tsgo
+				//     preserves the raw source. The decode happens inside
+				//     `directAttributeStringValue` (called by
+				//     `LiteralPropStringValue`).
+				//
+				//  3. `LiteralPropAriaValue` — fallback for non-string
+				//     literal types (boolean, number, BigInt) and the
+				//     short-circuit cases (NoLit / Undef → skip).
+				//
+				// `isStringValue` tracks whether the original literal was
+				// a JS string (as opposed to array / number / boolean).
+				// Upstream's `isSemanticRoleElement` compares
+				// `role.name === roleAttrValue` with strict equality, so
+				// `role.name` (always a string) only matches when the
+				// extracted value is a string. We skip the semantic
+				// check entirely for non-string values to preserve that
+				// asymmetry.
+				var roleAttrValue string
+				var isStringValue bool
+				if arrStr, isArr := jsxa11yutil.LiteralPropArrayAsString(attr); isArr {
+					// Array — upstream's strict-equality check against
+					// `role.name` (a string) is always false, so
+					// isStringValue stays false.
+					roleAttrValue = arrStr
+				} else if str, ok := jsxa11yutil.LiteralPropStringValue(attr); ok {
+					// String — direct or JsxExpression-wrapped or magic
+					// "null" or template-synthesized. Entity-decoded by
+					// directAttributeStringValue for the direct form.
+					roleAttrValue = str
+					isStringValue = true
+				} else {
+					value := jsxa11yutil.LiteralPropAriaValue(attr)
+					if value.Kind == jsxa11yutil.AriaLiteralNoLit ||
+						value.Kind == jsxa11yutil.AriaLiteralUndef {
+						return
+					}
+					// Boolean / Number / BigInt — stringify per JS String()
+					// semantics but keep isStringValue false because the
+					// original literal wasn't a string.
+					roleAttrValue = jsxa11yutil.AriaLiteralValueAsJSString(value)
+				}
+
+				// Step 4: normalize (lowercase + ASCII-space split) and
+				// keep only the tokens that are recognized non-abstract
+				// ARIA roles per aria-query's `roles.keys()`. Upstream
+				// uses `.split(' ')` (single ASCII space, NOT `\s+`), so
+				// tabs / newlines / multiple spaces produce empty or
+				// non-matching tokens that fall out at this filter step.
+				normalized := strings.Split(strings.ToLower(roleAttrValue), " ")
+				validRoles := make([]string, 0, len(normalized))
+				for _, tok := range normalized {
+					if jsxa11yutil.IsValidAriaRole(tok) {
+						validRoles = append(validRoles, tok)
+					}
+				}
+				if len(validRoles) == 0 {
+					return
+				}
+
+				// Step 5: semantic-role skip. Uses the un-normalized
+				// (case-preserved) roleAttrValue — see the
+				// isSemanticRoleElement docstring for the quirk
+				// rationale. Skip entirely when the original literal
+				// wasn't a string — upstream's strict-equality
+				// comparison against `role.name` (always a string) is
+				// always false for array / number / boolean values, so
+				// the semantic skip never fires on those shapes.
+				attrs := reactutil.GetJsxElementAttributes(parent)
+				if isStringValue && isSemanticRoleElement(elementType, attrs, roleAttrValue) {
+					return
+				}
+
+				// Step 6: required-props check. For each valid role with
+				// non-empty requiredProps (per aria-query's
+				// `requiredProps` map), verify every required prop is
+				// present as a JSX attribute. Missing → report. Upstream
+				// emits one diagnostic per failing role; we mirror by
+				// reporting inside the per-role loop without breaking.
+				for _, role := range validRoles {
+					required, ok := jsxa11yutil.AriaRoleRequiredPropsFor(role)
+					if !ok {
+						continue
+					}
+					hasAll := true
+					for _, prop := range required {
+						if jsxa11yutil.FindAttributeByName(attrs, prop) == nil {
+							hasAll = false
+							break
+						}
+					}
+					if hasAll {
+						continue
+					}
+					ctx.ReportNode(attr, rule.RuleMessage{
+						Id:          "role-has-required-aria-props",
+						Description: errorMessage(role, required),
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props.md
+++ b/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props.md
@@ -1,0 +1,48 @@
+# role-has-required-aria-props
+
+## Rule Details
+
+Elements with ARIA roles must have every required `aria-*` attribute for that role defined. The required-attributes table is sourced from [`aria-query`](https://github.com/A11yance/aria-query)'s `rolesMap`.
+
+The rule reads each JSX attribute named `role` (case-insensitive). When the attribute's value is a literal string, it lowercases the value and splits on single ASCII spaces. For each space-delimited token that is a recognized non-abstract ARIA role with non-empty required attributes, it verifies that every required `aria-*` attribute is present on the same element. Tokens that are not valid ARIA roles, and roles whose required-attribute set is empty (e.g. `button`, `row`), are ignored.
+
+Elements that natively imply the role are skipped. For example, `<input type="checkbox">` already provides the `checkbox` role, so `<input type="checkbox" role="switch" />` is not flagged for missing `aria-checked`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div role="checkbox" />
+<div role="combobox" />
+<div role="heading" />
+<div role="option" />
+<div role="scrollbar" aria-valuemax aria-valuemin />
+<span role="checkbox" aria-labelledby="foo" tabindex="0"></span>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div />
+<div role={role} />
+<div role="row" />
+<div role="heading" aria-level={2} />
+<span role="checkbox" aria-checked="false" aria-labelledby="foo" tabindex="0"></span>
+<input type="checkbox" role="switch" />
+```
+
+## Rule Options
+
+This rule takes no options.
+
+## Accessibility guidelines
+
+- [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+
+### Resources
+
+- [ARIA Spec, Roles](https://www.w3.org/TR/wai-aria/#roles)
+- [Chrome Audit Rules, AX_ARIA_03](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_03)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/role-has-required-aria-props](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-has-required-aria-props.md)

--- a/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props_extras_test.go
@@ -1,0 +1,874 @@
+// cspell:ignore eading inspectable
+
+package role_has_required_aria_props
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestRoleHasRequiredAriaPropsExtras covers cases NOT in upstream's
+// `__tests__/src/rules/role-has-required-aria-props-test.js` — universal
+// edge shapes (Dimension 4 of the port skill), tsgo AST quirks, and
+// lock-in tests for each branch in the upstream `JSXAttribute` listener
+// that the upstream test file leaves uncovered.
+func TestRoleHasRequiredAriaPropsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RoleHasRequiredAriaPropsRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// Boolean-form / null / boolean-coerced role values — every
+			// shape that String()-coerces to a non-role token, so
+			// validRoles ends up empty and the rule skips.
+			// ============================================================
+
+			// `<div role />` (boolean form) — getLiteralPropValue returns
+			// true (boolean), `String(true)` = "true", which isn't a
+			// valid role token → validRoles empty → skip. Upstream's
+			// aria-role reports this; role-has-required-aria-props does
+			// not.
+			{Code: `<div role />`, Tsx: true},
+			// `<div role={null} />` — LITERAL_TYPES.Literal override →
+			// magic string "null". Not a valid role → skip.
+			{Code: `<div role={null} />`, Tsx: true},
+			// `<div role={true} />` / `<div role={false} />` — String()
+			// coerces to "true"/"false", neither is a valid role.
+			{Code: `<div role={true} />`, Tsx: true},
+			{Code: `<div role={false} />`, Tsx: true},
+			// `<div role="" />` — empty string, splits to [""], not a
+			// valid role.
+			{Code: `<div role="" />`, Tsx: true},
+
+			// ============================================================
+			// JsxExpression-wrapped string literal — same handling as
+			// direct string. Slider needs aria-valuenow which IS present.
+			// ============================================================
+			{Code: `<div role={"slider"} aria-valuenow={50} />`, Tsx: true},
+
+			// ============================================================
+			// Lowercase normalization — role="HEADING" still validates as
+			// "heading" via the String.toLowerCase().split path, and
+			// aria-level is present.
+			// ============================================================
+			{Code: `<div role="HEADING" aria-level={2} />`, Tsx: true},
+
+			// ============================================================
+			// Space-separated multiple roles — both heading and slider
+			// have their required props satisfied. Locks in the
+			// `normalized.split(' ')` + per-role forEach branches.
+			// ============================================================
+			{
+				Code: `<div role="heading slider" aria-level={2} aria-valuenow={5} />`,
+				Tsx:  true,
+			},
+
+			// ============================================================
+			// Mixed valid + invalid token — only "heading" is in
+			// roleKeys; the "invalid-role" token is filtered out by the
+			// validRoles filter. aria-level present → pass. Locks in the
+			// upstream `.filter(...)` arm.
+			// ============================================================
+			{Code: `<div role="heading invalid-role" aria-level={2} />`, Tsx: true},
+
+			// ============================================================
+			// Semantic-role skip — every concept entry in
+			// `jsxa11yutil.SemanticRoleConcepts` must be exercised so a
+			// future axobject-query refresh that removes a row trips a
+			// test. None of these need their normally-required props
+			// because the semantic skip bypasses the check.
+			// ============================================================
+
+			// `<select>` → ["combobox", "listbox"]; both should skip.
+			{Code: `<select role="combobox" />`, Tsx: true},
+			{Code: `<select role="listbox" />`, Tsx: true},
+			// `<option>` → ["option"]; option has aria-selected as required.
+			{Code: `<option role="option" />`, Tsx: true},
+			// `<h1>` … `<h6>` → ["heading"]; heading needs aria-level but
+			// the semantic skip bypasses the check.
+			{Code: `<h1 role="heading" />`, Tsx: true},
+			{Code: `<h2 role="heading" />`, Tsx: true},
+			{Code: `<h3 role="heading" />`, Tsx: true},
+			{Code: `<h4 role="heading" />`, Tsx: true},
+			{Code: `<h5 role="heading" />`, Tsx: true},
+			{Code: `<h6 role="heading" />`, Tsx: true},
+			// `<input type="radio" role="radio" />` — radio needs
+			// aria-checked but the semantic skip kicks in.
+			{Code: `<input type="radio" role="radio" />`, Tsx: true},
+			// `<input type="range" role="slider" />` — slider needs
+			// aria-valuenow but the semantic skip kicks in.
+			{Code: `<input type="range" role="slider" />`, Tsx: true},
+
+			// ============================================================
+			// JsxExpression-wrapped `type` attribute on input — the inner
+			// expression is a string literal, so LiteralPropStringValue
+			// resolves "checkbox" and the concept-attribute match
+			// succeeds. Locks in the upstream `getLiteralPropValue(attr)`
+			// path inside isSemanticRoleElement.
+			// ============================================================
+			{Code: `<input type={"checkbox"} role="switch" />`, Tsx: true},
+
+			// ============================================================
+			// Array literal role — upstream's LITERAL_TYPES.ArrayExpression
+			// evaluates elements via TYPES and `,`-joins per
+			// `String([...])`. Empty array → "" → empty split token →
+			// validRoles empty → skip.
+			// ============================================================
+			{Code: `<div role={[]} />`, Tsx: true},
+			// Array with single token that comma-joins to a non-role
+			// string — `["heading,slider"]` joins to `"heading,slider"`,
+			// which split on space yields one token containing comma →
+			// not a valid role → skip.
+			{Code: `<div role={["heading,slider"]} />`, Tsx: true},
+			// Multi-element array — `["heading", "slider"]` joins to
+			// `"heading,slider"`, same result.
+			{Code: `<div role={["heading", "slider"]} />`, Tsx: true},
+
+			// ============================================================
+			// Backtick template literal without substitutions — upstream
+			// treats `\`heading\`` the same as a string literal (no
+			// boolean coerce), so role="heading" requires aria-level.
+			// ============================================================
+			{Code: "<div role={`heading`} aria-level={2} />", Tsx: true},
+
+			// ============================================================
+			// Template with substitution — staticEvalTemplate synthesizes
+			// a placeholder string like "heading{x}" which doesn't match
+			// any valid role token. validRoles = []. Skip.
+			// ============================================================
+			{Code: "<div role={`heading${x}`} />", Tsx: true},
+
+			// ============================================================
+			// Parenthesized expressions — tsgo preserves; upstream's
+			// ESTree parser flattens. LiteralPropAriaValue strips parens
+			// so the inner string literal still resolves.
+			// ============================================================
+			{Code: `<div role={("row")} />`, Tsx: true},
+			{Code: `<div role={(("heading"))} aria-level={2} />`, Tsx: true},
+
+			// ============================================================
+			// TypeScript wrappers — `as` / `satisfies` / non-null `!` all
+			// noop → NoLit in LITERAL_TYPES → skip. Locks in upstream's
+			// TS-wrapper handling: even though the inner literal would
+			// otherwise be inspectable, the wrapper makes the value opaque
+			// to the literal extractor.
+			// ============================================================
+			{Code: `<div role={"heading" as const} />`, Tsx: true},
+			{Code: `<div role={"heading" as string} />`, Tsx: true},
+			{Code: `<div role={"heading"!} />`, Tsx: true},
+			{Code: `<div role={"heading" satisfies string} />`, Tsx: true},
+
+			// ============================================================
+			// Member access / optional chain / call expression role value
+			// — all LITERAL_TYPES noop → NoLit → skip. These represent
+			// real-world patterns where the role is computed.
+			// ============================================================
+			{Code: `<div role={obj.role} />`, Tsx: true},
+			{Code: `<div role={obj?.role} />`, Tsx: true},
+			{Code: `<div role={getRole()} />`, Tsx: true},
+			{Code: `<div role={obj.deep?.nested?.role} />`, Tsx: true},
+			{Code: `<div role={cond ? "checkbox" : "radio"} />`, Tsx: true},
+			// String concat — LITERAL_TYPES.BinaryExpression noop for `+`.
+			// Even though staticEval could resolve "head" + "ing", the
+			// literal-extractor path doesn't.
+			{Code: `<div role={"head" + "ing"} />`, Tsx: true},
+			// Nullish coalescing / logical falls through to noop too.
+			{Code: `<div role={role ?? "button"} />`, Tsx: true},
+
+			// ============================================================
+			// Numeric / BigInt role values — String coerce to numeric
+			// digits which aren't valid roles. validRoles empty → skip.
+			// ============================================================
+			{Code: `<div role={0} />`, Tsx: true},
+			{Code: `<div role={42} />`, Tsx: true},
+			{Code: `<div role={1.5} />`, Tsx: true},
+			{Code: `<div role={42n} />`, Tsx: true},
+			// `NaN` / `Infinity` are Identifiers (not numeric literals)
+			// → LITERAL_TYPES.Identifier returns null for non-undefined
+			// identifiers → skip.
+			{Code: `<div role={NaN} />`, Tsx: true},
+			{Code: `<div role={Infinity} />`, Tsx: true},
+
+			// ============================================================
+			// Whitespace-only role values — single space splits to ["", ""],
+			// validRoles empty.
+			// ============================================================
+			{Code: `<div role=" " />`, Tsx: true},
+			{Code: `<div role="   " />`, Tsx: true},
+			// Tabs / newlines in role — upstream splits on single ASCII
+			// space only, so non-space whitespace stays in the token and
+			// the token isn't a valid role.
+			{Code: "<div role=\"heading\tslider\" />", Tsx: true},
+
+			// ============================================================
+			// HTML entity decoding on DIRECT string attribute — JSX
+			// parsers decode `&#NN;` / `&NAME;` at parse time, so
+			// `<div role="&#104;eading">` resolves to "heading" and the
+			// aria-level requirement applies. tsgo doesn't decode by
+			// default — the LiteralPropStringValue helper invokes
+			// `jsxtransforms.DecodeEntities` to realign. The {…}-wrapped
+			// form is a JS string literal (NOT JSX attribute text), so
+			// it does NOT get entity-decoded — that's tested by the
+			// invalid case below.
+			// ============================================================
+			{Code: `<div role="&#104;eading" aria-level={2} />`, Tsx: true},
+
+			// ============================================================
+			// Required-prop presence-check semantics — upstream `getProp`
+			// returns the JsxAttribute when the name matches, regardless
+			// of value type. So presence (not value validity) is what
+			// matters for the required-props check. Every shape below
+			// counts as "present".
+			// ============================================================
+			// Boolean form: `<div role="checkbox" aria-checked />` →
+			// aria-checked has no value (null in upstream's getProp), but
+			// the attribute exists → present.
+			{Code: `<div role="checkbox" aria-checked />`, Tsx: true},
+			// `={null}` / `={undefined}` — attribute exists with a value
+			// expression, even if the value is nullish.
+			{Code: `<div role="checkbox" aria-checked={null} />`, Tsx: true},
+			{Code: `<div role="checkbox" aria-checked={undefined} />`, Tsx: true},
+			// `={true}` / `={false}` — booleans count as present.
+			{Code: `<div role="checkbox" aria-checked={true} />`, Tsx: true},
+			{Code: `<div role="checkbox" aria-checked={false} />`, Tsx: true},
+			// Case-insensitive name lookup — `getProp` uses ignoreCase:true
+			// by default.
+			{Code: `<div role="checkbox" Aria-Checked="false" />`, Tsx: true},
+			{Code: `<div role="checkbox" ARIA-CHECKED="false" />`, Tsx: true},
+			// Literal-object spread with computed-IDENTIFIER key — upstream's
+			// `getProp` matches `{[ariaChecked]: "false"}` by inspecting
+			// the inner Identifier without consulting the `computed`
+			// flag. This is upstream's quirk: bracket-wrapped Identifier
+			// `[someIdent]` reads as a matchable key, even though at
+			// runtime the bracket form evaluates the expression.
+			// (Symbolic — won't compile as TypeScript without ariaChecked
+			// in scope, so we test via a runnable shape with an in-scope
+			// const.)
+			// Note: kebab-case names like `aria-checked` are NOT legal
+			// JS identifiers, so the only way to have aria-checked in a
+			// literal-object spread is via a string-literal key (which
+			// upstream does NOT match — see the invalid case below).
+
+			// ============================================================
+			// Multi-required-prop role with both satisfied — combobox
+			// needs aria-controls AND aria-expanded.
+			// ============================================================
+			{
+				Code: `<div role="combobox" aria-controls="list" aria-expanded={true} />`,
+				Tsx:  true,
+			},
+			{
+				Code: `<div role="scrollbar" aria-controls="content" aria-valuenow={50} />`,
+				Tsx:  true,
+			},
+
+			// ============================================================
+			// JSX-namespaced tag (svg:rect) — IsDOMElement returns false
+			// because aria-query's dom map keys on bare HTML tag names.
+			// Skip without checking required props.
+			// ============================================================
+			{Code: `<svg:rect role="checkbox" />`, Tsx: true},
+
+			// ============================================================
+			// Member-expression tag (Foo.Bar) — non-DOM → skip.
+			// ============================================================
+			{Code: `<Foo.Bar role="checkbox" />`, Tsx: true},
+			{Code: `<Foo.Bar.Baz role="checkbox" />`, Tsx: true},
+
+			// ============================================================
+			// SVG tag (not in aria-query's dom map) — `<svg>` is not a
+			// recognized DOM element per aria-query, so the rule skips.
+			// ============================================================
+			{Code: `<svg role="checkbox" />`, Tsx: true},
+
+			// ============================================================
+			// Multi-line JSX with required prop present — the rule fires
+			// per attribute regardless of source-level newlines.
+			// ============================================================
+			{
+				Code: "<div\n  role=\"heading\"\n  aria-level={2}\n/>",
+				Tsx:  true,
+			},
+
+			// ============================================================
+			// JSX inside a conditional / ternary / map — listener fires
+			// on the inner element's attributes regardless of nesting.
+			// These are real-world rendering patterns.
+			// ============================================================
+			{Code: `<div>{cond && <span role="row" />}</div>`, Tsx: true},
+			{Code: `<div>{cond ? <span role="row" /> : null}</div>`, Tsx: true},
+			{Code: `<>{[1,2].map(x => <span key={x} role="row" />)}</>`, Tsx: true},
+
+			// ============================================================
+			// JSX fragment around role-bearing elements — fragment has
+			// no attributes; inner role attribute fires normally.
+			// ============================================================
+			{Code: `<><div role="row" /></>`, Tsx: true},
+
+			// ============================================================
+			// Roles WITHOUT required props on DOM elements — should NOT
+			// report. Sanity-check that the rule doesn't accidentally
+			// flag roles whose requiredProps set is empty.
+			// ============================================================
+			{Code: `<div role="button" />`, Tsx: true},
+			{Code: `<div role="link" />`, Tsx: true},
+			{Code: `<div role="alert" />`, Tsx: true},
+			{Code: `<div role="presentation" />`, Tsx: true},
+			{Code: `<div role="none" />`, Tsx: true},
+			{Code: `<div role="dialog" />`, Tsx: true},
+			{Code: `<div role="tabpanel" />`, Tsx: true},
+			{Code: `<div role="alertdialog" />`, Tsx: true},
+
+			// ============================================================
+			// `<button role="checkbox" aria-checked="false" />` — button
+			// is a DOM element. Button as concept maps only to ["button"]
+			// (not in SemanticRoleConcepts since button has no required
+			// props), so no semantic skip for "checkbox". aria-checked
+			// IS present → no report.
+			// ============================================================
+			{Code: `<button role="checkbox" aria-checked="false" />`, Tsx: true},
+
+			// ============================================================
+			// Anchor with non-required-props role — anchor is DOM; role
+			// "tab" has no required props → no report.
+			// ============================================================
+			{Code: `<a href="#" role="tab" />`, Tsx: true},
+
+			// ============================================================
+			// `<input>` without role — no role attribute means the
+			// listener doesn't fire on a role match. No report.
+			// ============================================================
+			{Code: `<input type="checkbox" />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Space-separated multiple roles, BOTH missing required
+			// props → two diagnostics, one per role, in upstream-forEach
+			// order. Locks in the per-role report loop branch upstream
+			// doesn't test.
+			// ============================================================
+			{
+				Code: `<div role="heading slider" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "role-has-required-aria-props",
+						Message:   errorMessage("heading", []string{"aria-level"}),
+						Line:      1, Column: 6,
+					},
+					{
+						MessageId: "role-has-required-aria-props",
+						Message:   errorMessage("slider", []string{"aria-valuenow"}),
+						Line:      1, Column: 6,
+					},
+				},
+			},
+
+			// ============================================================
+			// Mixed: one role satisfied, one missing — only the failing
+			// role reports. heading has aria-level; slider missing
+			// aria-valuenow.
+			// ============================================================
+			{
+				Code: `<div role="heading slider" aria-level={2} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("slider", []string{"aria-valuenow"}),
+					Line:      1, Column: 6,
+				}},
+			},
+
+			// ============================================================
+			// Uppercase role value → toLowerCase()-normalized for
+			// validRoles filter, so "HEADING" is treated as "heading"
+			// and the missing aria-level still reports. Locks in the
+			// `.toLowerCase().split(' ')` step.
+			// ============================================================
+			{
+				Code: `<div role="HEADING" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("heading", []string{"aria-level"}),
+					Line:      1, Column: 6,
+				}},
+			},
+
+			// ============================================================
+			// Uppercase role value on a semantic-role element: the
+			// semantic-role check uses the RAW (case-preserved) value,
+			// so it does NOT skip; the validRoles filter still reports.
+			// `<select role="COMBOBOX" />`: roleAttrValue = "COMBOBOX",
+			// isSemanticRoleElement comparing "COMBOBOX" to aria-query's
+			// lowercase "combobox" returns false → no skip → missing
+			// required props reported. Locks in the case-sensitivity
+			// quirk between the two paths.
+			// ============================================================
+			{
+				Code: `<select role="COMBOBOX" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("combobox", []string{"aria-controls", "aria-expanded"}),
+					Line:      1, Column: 9,
+				}},
+			},
+
+			// ============================================================
+			// JsxExpression-wrapped string literal as role value — same
+			// handling as direct string. slider missing aria-valuenow.
+			// ============================================================
+			{
+				Code: `<div role={"slider"} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("slider", []string{"aria-valuenow"}),
+					Line:      1, Column: 6,
+				}},
+			},
+
+			// ============================================================
+			// `<input type="CHECKBOX" role="switch" />` — concept-attribute
+			// value match is case-sensitive ("CHECKBOX" != "checkbox") →
+			// semantic skip fails → "switch" requires aria-checked,
+			// missing → report. Locks in case-sensitive value comparison
+			// inside isSemanticRoleElement.
+			// ============================================================
+			{
+				Code: `<input type="CHECKBOX" role="switch" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("switch", []string{"aria-checked"}),
+					Line:      1, Column: 24,
+				}},
+			},
+
+			// ============================================================
+			// Dynamic `type={typeVar}` on input — LiteralPropStringValue
+			// returns ("", false) for the type prop, so the
+			// concept-attribute value match fails → semantic skip fails
+			// → switch requires aria-checked, missing → report. Locks in
+			// the "dynamic value, no semantic skip" branch.
+			// ============================================================
+			{
+				Code: `<input type={typeVar} role="switch" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("switch", []string{"aria-checked"}),
+					Line:      1, Column: 23,
+				}},
+			},
+
+			// ============================================================
+			// Bare `<input role="checkbox" />` without type=checkbox —
+			// the concept requires the type attribute to match, so no
+			// semantic skip; missing aria-checked reports. Locks in the
+			// "attribute absent → concept doesn't match" branch.
+			// ============================================================
+			{
+				Code: `<input role="checkbox" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("checkbox", []string{"aria-checked"}),
+					Line:      1, Column: 8,
+				}},
+			},
+
+			// ============================================================
+			// Array literal role on a semantic-role element — upstream's
+			// strict `role.name === roleAttrValue` comparison treats
+			// the array value as NOT a string, so the semantic skip
+			// MUST NOT fire even though the joined string would have
+			// matched. `<input type="checkbox" role={["switch"]} />`:
+			// validRoles = ["switch"], semantic skip refuses (array
+			// value), missing aria-checked → report.
+			// ============================================================
+			{
+				Code: `<input type="checkbox" role={["switch"]} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("switch", []string{"aria-checked"}),
+					Line:      1, Column: 24,
+				}},
+			},
+			// Same shape with `["checkbox"]` instead of `["switch"]` —
+			// no semantic skip; checkbox needs aria-checked → report.
+			{
+				Code: `<select role={["combobox"]} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("combobox", []string{"aria-controls", "aria-expanded"}),
+					Line:      1, Column: 9,
+				}},
+			},
+
+			// ============================================================
+			// Array role with valid token but missing required props —
+			// `<div role={["heading"]} />` joins to "heading", validRoles
+			// = ["heading"], missing aria-level → report.
+			// ============================================================
+			{
+				Code: `<div role={["heading"]} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("heading", []string{"aria-level"}),
+					Line:      1, Column: 6,
+				}},
+			},
+
+			// ============================================================
+			// Literal-spread with STRING-LITERAL key — upstream's
+			// `getProp` only walks Identifier-typed keys. `aria-checked`
+			// can't be a JS Identifier (hyphenated names aren't legal),
+			// so the only way to put aria-* in a literal spread is via
+			// a string-literal key — which getProp does NOT match. The
+			// rule therefore reports as if aria-checked is absent, even
+			// though the spread "logically" provides it. Locks in
+			// upstream's quirky-but-deliberate Identifier-only key
+			// match.
+			// ============================================================
+			{
+				Code: `<div role="checkbox" {...{"aria-checked": "false"}} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("checkbox", []string{"aria-checked"}),
+					Line:      1, Column: 6,
+				}},
+			},
+
+			// ============================================================
+			// Non-literal spread — opaque. FindAttributeByName cannot see
+			// inside `{...someObj}`, so the required-prop is treated as
+			// absent → report. Locks in the upstream `getProp`
+			// strict-spread behavior.
+			// ============================================================
+			{
+				Code: `<div role="checkbox" {...someObj} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("checkbox", []string{"aria-checked"}),
+					Line:      1, Column: 6,
+				}},
+			},
+
+			// ============================================================
+			// Mixed case attribute name in concept — upstream's
+			// `cAttr.name === propName(attr)` is case-SENSITIVE
+			// ("type" != "Type"), so `<input Type="checkbox">` does NOT
+			// match the input/type=checkbox concept → no semantic
+			// skip → switch's aria-checked missing → report.
+			// ============================================================
+			{
+				Code: `<input Type="checkbox" role="switch" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("switch", []string{"aria-checked"}),
+					Line:      1, Column: 24,
+				}},
+			},
+
+			// ============================================================
+			// Nested JSX — each role attribute fires its own listener
+			// invocation independently, so a missing required-prop on
+			// the inner element reports without interference from the
+			// outer element's role.
+			// ============================================================
+			{
+				Code: `<div role="heading" aria-level={2}><span role="checkbox" /></div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("checkbox", []string{"aria-checked"}),
+					Line:      1, Column: 42,
+				}},
+			},
+
+			// ============================================================
+			// Backtick template with substitution — upstream's
+			// TemplateLiteral extractor synthesizes a placeholder string
+			// like "heading{x}" which split on space won't yield
+			// "heading" as a token. validRoles = []. Skip. But a
+			// pure-quasi template (no substitution) is a string and
+			// IS extractable — covered in the valid section.
+			// ============================================================
+			// (No invalid case for the with-substitution form — it's a
+			// valid case because validRoles is empty.)
+
+			// ============================================================
+			// Per-role data-table lock-in for the 6 roles upstream's
+			// invalid suite doesn't exercise. The generated
+			// `basicValidityTests` test that EACH role passes when its
+			// required props are present, but that suite builds the JSX
+			// FROM the same data table — so a typo in the table would
+			// produce a matching JSX and silently pass. Invalid tests
+			// where the prop is GENUINELY ABSENT lock in the prop name.
+			// ============================================================
+
+			// menuitemcheckbox — requires aria-checked.
+			{
+				Code: `<div role="menuitemcheckbox" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("menuitemcheckbox", []string{"aria-checked"}),
+					Line:      1, Column: 6,
+				}},
+			},
+			// menuitemradio — requires aria-checked.
+			{
+				Code: `<div role="menuitemradio" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("menuitemradio", []string{"aria-checked"}),
+					Line:      1, Column: 6,
+				}},
+			},
+			// meter — requires aria-valuenow.
+			{
+				Code: `<div role="meter" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("meter", []string{"aria-valuenow"}),
+					Line:      1, Column: 6,
+				}},
+			},
+			// radio — requires aria-checked. Use <div> rather than
+			// <input type="radio"> to avoid the semantic skip.
+			{
+				Code: `<div role="radio" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("radio", []string{"aria-checked"}),
+					Line:      1, Column: 6,
+				}},
+			},
+			// switch — requires aria-checked. Use <div> rather than
+			// <input type="checkbox"> (which maps to ["checkbox", "switch"]
+			// via semantic skip).
+			{
+				Code: `<div role="switch" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("switch", []string{"aria-checked"}),
+					Line:      1, Column: 6,
+				}},
+			},
+			// treeitem — requires aria-selected.
+			{
+				Code: `<div role="treeitem" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("treeitem", []string{"aria-selected"}),
+					Line:      1, Column: 6,
+				}},
+			},
+
+			// ============================================================
+			// Multi-required-prop partial satisfaction — combobox with
+			// only ONE of its two required props present still reports.
+			// Locks in the `requiredProps.every(...)` short-circuit
+			// (which means "fail on first missing prop").
+			// ============================================================
+			{
+				Code: `<div role="combobox" aria-controls="list" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("combobox", []string{"aria-controls", "aria-expanded"}),
+					Line:      1, Column: 6,
+				}},
+			},
+			{
+				Code: `<div role="combobox" aria-expanded={true} />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("combobox", []string{"aria-controls", "aria-expanded"}),
+					Line:      1, Column: 6,
+				}},
+			},
+
+			// ============================================================
+			// HTML entity decoding via the JsxExpression form — a JS
+			// string literal inside `{…}` is NOT entity-decoded
+			// (entities are a JSX-attribute-text feature, not a JS
+			// string feature). So `<div role={"&#104;eading"} />` has
+			// the literal value `&#104;eading` (12 chars), which is NOT
+			// a valid role → validRoles empty → skip → no report.
+			// (Valid case — confirms the asymmetry between direct and
+			// JsxExpression-wrapped string forms.)
+			// ============================================================
+			// (No invalid case — this is asserted by the valid case in
+			// the corresponding section above; the JsxExpression-wrapped
+			// form does NOT decode, so it doesn't trigger a "heading"
+			// validRoles entry.)
+
+			// ============================================================
+			// Switch role on input WITHOUT type=checkbox — the semantic
+			// concept requires type=checkbox specifically, so other
+			// input types do not trigger the skip. aria-checked missing →
+			// report. Locks in the "concept attribute value must match
+			// exactly" branch.
+			// ============================================================
+			{
+				Code: `<input type="text" role="switch" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("switch", []string{"aria-checked"}),
+					Line:      1, Column: 20,
+				}},
+			},
+			// Slider role on input WITHOUT type=range — similar pattern.
+			{
+				Code: `<input type="number" role="slider" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("slider", []string{"aria-valuenow"}),
+					Line:      1, Column: 22,
+				}},
+			},
+			// Radio role on input WITHOUT type=radio — similar.
+			{
+				Code: `<input type="text" role="radio" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("radio", []string{"aria-checked"}),
+					Line:      1, Column: 20,
+				}},
+			},
+
+			// ============================================================
+			// Multi-line JSX with missing required prop — verifies that
+			// the column / line assertion still works when the role
+			// attribute is on a non-first line. Real-world prettier-formatted
+			// JSX wraps long elements across multiple lines.
+			// ============================================================
+			{
+				Code: "<div\n  role=\"checkbox\"\n/>",
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("checkbox", []string{"aria-checked"}),
+					Line:      2, Column: 3,
+				}},
+			},
+
+			// ============================================================
+			// Required prop present elsewhere on the parent's siblings
+			// does NOT count — the rule only inspects the element's own
+			// attributes. Sanity check.
+			// ============================================================
+			{
+				Code: `<div aria-checked="true"><span role="checkbox" /></div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("checkbox", []string{"aria-checked"}),
+					Line:      1, Column: 32,
+				}},
+			},
+
+			// ============================================================
+			// Nested role-bearing elements inside conditional / map —
+			// real-world rendering pattern. Each inner role fires
+			// independently.
+			// ============================================================
+			{
+				Code: `<div>{cond && <span role="checkbox" />}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("checkbox", []string{"aria-checked"}),
+					Line:      1, Column: 21,
+				}},
+			},
+			{
+				Code: `<>{[1,2].map(x => <span key={x} role="checkbox" />)}</>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("checkbox", []string{"aria-checked"}),
+					Line:      1, Column: 33,
+				}},
+			},
+
+			// ============================================================
+			// HTML entity decoding on a value pointing at a checkbox-like
+			// pattern (`&#115;` is 's' → "&#115;witch" → "switch") —
+			// confirms entity decoding happens at literal extraction.
+			// ============================================================
+			{
+				Code: `<div role="&#115;witch" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("switch", []string{"aria-checked"}),
+					Line:      1, Column: 6,
+				}},
+			},
+
+			// ============================================================
+			// Spread + explicit role, where required prop is genuinely
+			// absent (spread is opaque). Locks in non-literal spread →
+			// opaque behavior.
+			// ============================================================
+			{
+				Code: `<div {...spreadProps} role="combobox" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("combobox", []string{"aria-controls", "aria-expanded"}),
+					Line:      1, Column: 23,
+				}},
+			},
+
+			// ============================================================
+			// Outer element with required prop + inner element with
+			// missing required prop on the SAME role. Outer should not
+			// "donate" its aria-checked to the inner element's check.
+			// ============================================================
+			{
+				Code: `<div role="checkbox" aria-checked="true"><span role="checkbox" /></div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("checkbox", []string{"aria-checked"}),
+					Line:      1, Column: 48,
+				}},
+			},
+
+			// ============================================================
+			// Heading role on multiple deeply nested elements — each
+			// reports independently.
+			// ============================================================
+			{
+				Code: `<div><div><span role="heading" /></div></div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "role-has-required-aria-props",
+					Message:   errorMessage("heading", []string{"aria-level"}),
+					Line:      1, Column: 17,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props_upstream_test.go
@@ -1,0 +1,308 @@
+// cspell:ignore chcked expandd valuemax valuemin valuenow
+
+package role_has_required_aria_props
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// componentsSettings mirrors upstream's
+//
+//	const componentsSettings = {
+//	  'jsx-a11y': { components: { MyComponent: 'div' } },
+//	};
+//
+// — used by the `<MyComponent role="..." />` cases to resolve
+// MyComponent → div before the rule applies.
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"MyComponent": "div",
+		},
+	},
+}
+
+// TestRoleHasRequiredAriaPropsUpstream mirrors upstream's
+// `__tests__/src/rules/role-has-required-aria-props-test.js` valid / invalid
+// suite 1:1 and in upstream order. Anything NOT in upstream's file lives
+// in role_has_required_aria_props_extras_test.go.
+func TestRoleHasRequiredAriaPropsUpstream(t *testing.T) {
+	// ---- Generated valid cases — one per non-abstract role.
+	//
+	// Upstream's `basicValidityTests` synthesizes
+	//   `<div role="${role.toLowerCase()}" ${requiredProps.join(' ')} />`
+	// for every non-abstract ARIA role, asserting that EVERY role passes
+	// when its required props are present (or trivially passes when no
+	// required props apply). Sourced from `jsxa11yutil.AriaRoleNonAbstract`
+	// so the role list stays in sync with upstream aria-query data.
+	roleRequiredMap := make(map[string][]string, len(jsxa11yutil.AriaRoleRequiredProps))
+	for _, e := range jsxa11yutil.AriaRoleRequiredProps {
+		roleRequiredMap[e.Role] = e.Props
+	}
+	generatedValid := make([]rule_tester.ValidTestCase, 0, len(jsxa11yutil.AriaRoleNonAbstract))
+	for _, role := range jsxa11yutil.AriaRoleNonAbstract {
+		var propChain string
+		if required := roleRequiredMap[role]; len(required) > 0 {
+			propChain = " " + strings.Join(required, " ")
+		}
+		generatedValid = append(generatedValid, rule_tester.ValidTestCase{
+			Code: `<div role="` + role + `"` + propChain + ` />`,
+			Tsx:  true,
+		})
+	}
+
+	valid := []rule_tester.ValidTestCase{
+		// ---- Upstream test file — `valid` section, in upstream order. ----
+
+		// Custom component without role → name === 'role' check fails on
+		// `baz`; the rule never sees a role attribute on Bar.
+		{Code: `<Bar baz />`, Tsx: true},
+		// Custom component WITH role (no components-map setting) →
+		// elementType resolves to "MyComponent", IsDOMElement("MyComponent")
+		// false → skip.
+		{Code: `<MyComponent role="combobox" />`, Tsx: true},
+		// No role attribute at all.
+		{Code: `<div />`, Tsx: true},
+		{Code: `<div></div>`, Tsx: true},
+		// Non-literal role value (Identifier / LogicalExpression /
+		// CallExpression / ...) — LITERAL_TYPES noop → null → skip.
+		{Code: `<div role={role} />`, Tsx: true},
+		{Code: `<div role={role || "button"} />`, Tsx: true},
+		{Code: `<div role={role || "foobar"} />`, Tsx: true},
+		// Valid role with no required props (`row`) — validRoles forEach
+		// runs but the role's requiredProps is empty, so no report.
+		{Code: `<div role="row" />`, Tsx: true},
+		// Valid role with all required props — passes the
+		// FindAttributeByName check on every prop.
+		{
+			Code: `<span role="checkbox" aria-checked="false" aria-labelledby="foo" tabindex="0"></span>`,
+			Tsx:  true,
+		},
+		// Spread-before-type input with role="checkbox" — the type attribute
+		// is on the element regardless of spread ordering, so
+		// isSemanticRoleElement("input", ...) returns true via the
+		// type=checkbox concept → skip.
+		{
+			Code: `<input role="checkbox" aria-checked="false" aria-labelledby="foo" tabindex="0" {...props} type="checkbox" />`,
+			Tsx:  true,
+		},
+		// <input type="checkbox" role="switch" /> — input/type=checkbox
+		// concept maps to roles ["checkbox", "switch"]; "switch" is in the
+		// set → isSemanticRoleElement true → skip (no aria-checked needed).
+		{Code: `<input type="checkbox" role="switch" />`, Tsx: true},
+		// MyComponent → div via components setting; role="checkbox" with
+		// aria-checked present → all required props satisfied.
+		{
+			Code:     `<MyComponent role="checkbox" aria-checked="false" aria-labelledby="foo" tabindex="0" />`,
+			Tsx:      true,
+			Settings: componentsSettings,
+		},
+		// heading + aria-level via JsxExpression-wrapped numeric literal.
+		{Code: `<div role="heading" aria-level={2} />`, Tsx: true},
+		// heading + aria-level via direct string literal — FindAttributeByName
+		// only checks presence, not value type, so both forms pass.
+		{Code: `<div role="heading" aria-level="3" />`, Tsx: true},
+	}
+	valid = append(valid, generatedValid...)
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- Upstream test file — `invalid` section, in upstream order. ----
+
+		// SLIDER — requires aria-valuenow.
+		{
+			Code: `<div role="slider" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("slider", []string{"aria-valuenow"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		{
+			Code: `<div role="slider" aria-valuemax />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("slider", []string{"aria-valuenow"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		{
+			Code: `<div role="slider" aria-valuemax aria-valuemin />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("slider", []string{"aria-valuenow"}),
+				Line:      1, Column: 6,
+			}},
+		},
+
+		// CHECKBOX — requires aria-checked.
+		{
+			Code: `<div role="checkbox" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("checkbox", []string{"aria-checked"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		// "checked" (HTML, not ARIA) does NOT count — FindAttributeByName
+		// looks up "aria-checked" verbatim.
+		{
+			Code: `<div role="checkbox" checked />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("checkbox", []string{"aria-checked"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		// Misspelled aria attr (aria-chcked) does NOT satisfy aria-checked.
+		{
+			Code: `<div role="checkbox" aria-chcked />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("checkbox", []string{"aria-checked"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		// span (not input[type=checkbox]) → no semantic skip; missing
+		// aria-checked fails.
+		{
+			Code: `<span role="checkbox" aria-labelledby="foo" tabindex="0"></span>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("checkbox", []string{"aria-checked"}),
+				Line:      1, Column: 7,
+			}},
+		},
+
+		// COMBOBOX — requires aria-controls AND aria-expanded.
+		{
+			Code: `<div role="combobox" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("combobox", []string{"aria-controls", "aria-expanded"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		// "expanded" (HTML, not aria-expanded) does NOT count.
+		{
+			Code: `<div role="combobox" expanded />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("combobox", []string{"aria-controls", "aria-expanded"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		// Misspelled aria-expandd does NOT satisfy aria-expanded.
+		{
+			Code: `<div role="combobox" aria-expandd />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("combobox", []string{"aria-controls", "aria-expanded"}),
+				Line:      1, Column: 6,
+			}},
+		},
+
+		// SCROLLBAR — requires aria-controls AND aria-valuenow.
+		{
+			Code: `<div role="scrollbar" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("scrollbar", []string{"aria-controls", "aria-valuenow"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		{
+			Code: `<div role="scrollbar" aria-valuemax />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("scrollbar", []string{"aria-controls", "aria-valuenow"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		{
+			Code: `<div role="scrollbar" aria-valuemax aria-valuemin />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("scrollbar", []string{"aria-controls", "aria-valuenow"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		// aria-valuemax + aria-valuenow → still missing aria-controls.
+		{
+			Code: `<div role="scrollbar" aria-valuemax aria-valuenow />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("scrollbar", []string{"aria-controls", "aria-valuenow"}),
+				Line:      1, Column: 6,
+			}},
+		},
+		// aria-valuemin + aria-valuenow → still missing aria-controls.
+		{
+			Code: `<div role="scrollbar" aria-valuemin aria-valuenow />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("scrollbar", []string{"aria-controls", "aria-valuenow"}),
+				Line:      1, Column: 6,
+			}},
+		},
+
+		// HEADING — requires aria-level.
+		{
+			Code: `<div role="heading" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("heading", []string{"aria-level"}),
+				Line:      1, Column: 6,
+			}},
+		},
+
+		// OPTION — requires aria-selected. Note: the <option> HTML element
+		// natively maps to role "option" via the semantic-role-element
+		// check, BUT only when the tag is literally `<option>`. `<div
+		// role="option" />` does not get the semantic skip.
+		{
+			Code: `<div role="option" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("option", []string{"aria-selected"}),
+				Line:      1, Column: 6,
+			}},
+		},
+
+		// Custom element MyComponent → div via components setting; combobox
+		// requires aria-controls + aria-expanded, neither present.
+		{
+			Code:     `<MyComponent role="combobox" />`,
+			Tsx:      true,
+			Settings: componentsSettings,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "role-has-required-aria-props",
+				Message:   errorMessage("combobox", []string{"aria-controls", "aria-expanded"}),
+				Line:      1, Column: 14,
+			}},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RoleHasRequiredAriaPropsRule, valid, invalid)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -183,6 +183,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-tabindex.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-redundant-roles.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-static-element-interactions.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/role-has-required-aria-props.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/scope.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/tabindex-no-positive.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/role-has-required-aria-props.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/role-has-required-aria-props.test.ts
@@ -1,0 +1,311 @@
+import { RuleTester } from '../rule-tester';
+
+// (role, requiredProps) — mirrors aria-query's per-role `requiredProps`
+// keys for every non-abstract role with at least one required prop.
+// The order of the values matches `Object.keys(requiredProps)` (= aria-query
+// insertion order), so the comma-joined error message matches upstream
+// byte-for-byte. Mirrors the Go-side `jsxa11yutil.AriaRoleRequiredProps`.
+const roleRequiredProps: Record<string, string[]> = {
+  checkbox: ['aria-checked'],
+  combobox: ['aria-controls', 'aria-expanded'],
+  heading: ['aria-level'],
+  menuitemcheckbox: ['aria-checked'],
+  menuitemradio: ['aria-checked'],
+  meter: ['aria-valuenow'],
+  option: ['aria-selected'],
+  radio: ['aria-checked'],
+  scrollbar: ['aria-controls', 'aria-valuenow'],
+  slider: ['aria-valuenow'],
+  switch: ['aria-checked'],
+  treeitem: ['aria-selected'],
+};
+
+const errorMessage = (role: string, required: string[]) =>
+  `Elements with the ARIA role "${role}" must have the following attributes defined: ${required.join(',')}`;
+
+const componentsSettings = {
+  'jsx-a11y': {
+    components: { MyComponent: 'div' },
+  },
+};
+
+// aria-query's `roles.keys()` non-abstract subset — same list as
+// `jsxa11yutil.AriaRoleNonAbstract`. Used to synthesize a "valid for every
+// role with its required props" suite, mirroring upstream's
+// `createTests(validRoleTests)`.
+const validRoles = [
+  'alert',
+  'alertdialog',
+  'application',
+  'article',
+  'banner',
+  'blockquote',
+  'button',
+  'caption',
+  'cell',
+  'checkbox',
+  'code',
+  'columnheader',
+  'combobox',
+  'complementary',
+  'contentinfo',
+  'definition',
+  'deletion',
+  'dialog',
+  'directory',
+  'document',
+  'emphasis',
+  'feed',
+  'figure',
+  'form',
+  'generic',
+  'grid',
+  'gridcell',
+  'group',
+  'heading',
+  'img',
+  'insertion',
+  'link',
+  'list',
+  'listbox',
+  'listitem',
+  'log',
+  'main',
+  'mark',
+  'marquee',
+  'math',
+  'menu',
+  'menubar',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'meter',
+  'navigation',
+  'none',
+  'note',
+  'option',
+  'paragraph',
+  'presentation',
+  'progressbar',
+  'radio',
+  'radiogroup',
+  'region',
+  'row',
+  'rowgroup',
+  'rowheader',
+  'scrollbar',
+  'search',
+  'searchbox',
+  'separator',
+  'slider',
+  'spinbutton',
+  'status',
+  'strong',
+  'subscript',
+  'superscript',
+  'switch',
+  'tab',
+  'table',
+  'tablist',
+  'tabpanel',
+  'term',
+  'textbox',
+  'time',
+  'timer',
+  'toolbar',
+  'tooltip',
+  'tree',
+  'treegrid',
+  'treeitem',
+  // DPUB-ARIA.
+  'doc-abstract',
+  'doc-acknowledgments',
+  'doc-afterword',
+  'doc-appendix',
+  'doc-backlink',
+  'doc-biblioentry',
+  'doc-bibliography',
+  'doc-biblioref',
+  'doc-chapter',
+  'doc-colophon',
+  'doc-conclusion',
+  'doc-cover',
+  'doc-credit',
+  'doc-credits',
+  'doc-dedication',
+  'doc-endnote',
+  'doc-endnotes',
+  'doc-epigraph',
+  'doc-epilogue',
+  'doc-errata',
+  'doc-example',
+  'doc-footnote',
+  'doc-foreword',
+  'doc-glossary',
+  'doc-glossref',
+  'doc-index',
+  'doc-introduction',
+  'doc-noteref',
+  'doc-notice',
+  'doc-pagebreak',
+  'doc-pagefooter',
+  'doc-pageheader',
+  'doc-pagelist',
+  'doc-part',
+  'doc-preface',
+  'doc-prologue',
+  'doc-pullquote',
+  'doc-qna',
+  'doc-subtitle',
+  'doc-tip',
+  'doc-toc',
+  // Graphics-ARIA.
+  'graphics-document',
+  'graphics-object',
+  'graphics-symbol',
+];
+
+new RuleTester().run('role-has-required-aria-props', null as never, {
+  valid: [
+    // Upstream test file — order preserved.
+    { code: '<Bar baz />' },
+    { code: '<MyComponent role="combobox" />' },
+    { code: '<div />' },
+    { code: '<div></div>' },
+    { code: '<div role={role} />' },
+    { code: '<div role={role || "button"} />' },
+    { code: '<div role={role || "foobar"} />' },
+    { code: '<div role="row" />' },
+    {
+      code: '<span role="checkbox" aria-checked="false" aria-labelledby="foo" tabindex="0"></span>',
+    },
+    {
+      code: '<input role="checkbox" aria-checked="false" aria-labelledby="foo" tabindex="0" {...props} type="checkbox" />',
+    },
+    { code: '<input type="checkbox" role="switch" />' },
+    {
+      code: '<MyComponent role="checkbox" aria-checked="false" aria-labelledby="foo" tabindex="0" />',
+      settings: componentsSettings,
+    },
+    { code: '<div role="heading" aria-level={2} />' },
+    { code: '<div role="heading" aria-level="3" />' },
+    // Generated valid cases — one per non-abstract role with required props.
+    ...validRoles.map((role) => {
+      const required = roleRequiredProps[role] ?? [];
+      const propChain = required.length === 0 ? '' : ` ${required.join(' ')}`;
+      return { code: `<div role="${role}"${propChain} />` };
+    }),
+  ],
+  invalid: [
+    // SLIDER.
+    {
+      code: '<div role="slider" />',
+      errors: [{ message: errorMessage('slider', roleRequiredProps.slider) }],
+    },
+    {
+      code: '<div role="slider" aria-valuemax />',
+      errors: [{ message: errorMessage('slider', roleRequiredProps.slider) }],
+    },
+    {
+      code: '<div role="slider" aria-valuemax aria-valuemin />',
+      errors: [{ message: errorMessage('slider', roleRequiredProps.slider) }],
+    },
+
+    // CHECKBOX.
+    {
+      code: '<div role="checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', roleRequiredProps.checkbox) },
+      ],
+    },
+    {
+      code: '<div role="checkbox" checked />',
+      errors: [
+        { message: errorMessage('checkbox', roleRequiredProps.checkbox) },
+      ],
+    },
+    {
+      code: '<div role="checkbox" aria-chcked />',
+      errors: [
+        { message: errorMessage('checkbox', roleRequiredProps.checkbox) },
+      ],
+    },
+    {
+      code: '<span role="checkbox" aria-labelledby="foo" tabindex="0"></span>',
+      errors: [
+        { message: errorMessage('checkbox', roleRequiredProps.checkbox) },
+      ],
+    },
+
+    // COMBOBOX.
+    {
+      code: '<div role="combobox" />',
+      errors: [
+        { message: errorMessage('combobox', roleRequiredProps.combobox) },
+      ],
+    },
+    {
+      code: '<div role="combobox" expanded />',
+      errors: [
+        { message: errorMessage('combobox', roleRequiredProps.combobox) },
+      ],
+    },
+    {
+      code: '<div role="combobox" aria-expandd />',
+      errors: [
+        { message: errorMessage('combobox', roleRequiredProps.combobox) },
+      ],
+    },
+
+    // SCROLLBAR.
+    {
+      code: '<div role="scrollbar" />',
+      errors: [
+        { message: errorMessage('scrollbar', roleRequiredProps.scrollbar) },
+      ],
+    },
+    {
+      code: '<div role="scrollbar" aria-valuemax />',
+      errors: [
+        { message: errorMessage('scrollbar', roleRequiredProps.scrollbar) },
+      ],
+    },
+    {
+      code: '<div role="scrollbar" aria-valuemax aria-valuemin />',
+      errors: [
+        { message: errorMessage('scrollbar', roleRequiredProps.scrollbar) },
+      ],
+    },
+    {
+      code: '<div role="scrollbar" aria-valuemax aria-valuenow />',
+      errors: [
+        { message: errorMessage('scrollbar', roleRequiredProps.scrollbar) },
+      ],
+    },
+    {
+      code: '<div role="scrollbar" aria-valuemin aria-valuenow />',
+      errors: [
+        { message: errorMessage('scrollbar', roleRequiredProps.scrollbar) },
+      ],
+    },
+
+    // HEADING / OPTION.
+    {
+      code: '<div role="heading" />',
+      errors: [{ message: errorMessage('heading', roleRequiredProps.heading) }],
+    },
+    {
+      code: '<div role="option" />',
+      errors: [{ message: errorMessage('option', roleRequiredProps.option) }],
+    },
+
+    // Custom element + components map.
+    {
+      code: '<MyComponent role="combobox" />',
+      settings: componentsSettings,
+      errors: [
+        { message: errorMessage('combobox', roleRequiredProps.combobox) },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/role-has-required-aria-props` rule from `eslint-plugin-jsx-a11y` to rslint. It reports when a JSX element's literal `role` attribute names an ARIA role whose required `aria-*` properties (per [`aria-query`](https://github.com/A11yance/aria-query)'s `rolesMap.requiredProps`) are missing on the element. Elements that natively imply the role (e.g. `<input type="checkbox">` already provides the `checkbox` role) are skipped via an `axobject-query`-derived semantic-role table.

Added data to `jsxa11yutil/roles.go`:

- `AriaRoleRequiredProps` — the 12 non-abstract roles with non-empty `requiredProps`.
- `SemanticRoleConcepts` — the 11 (element-tag, attrs) → roles entries from `axobject-query`'s `elementAXObjects` ⨝ `AXObjectRoles`, filtered to entries whose role set intersects `AriaRoleRequiredProps`.

Tests split into `*_upstream_test.go` (1:1 with upstream `__tests__`) and `*_extras_test.go` (universal edge shapes, semantic-walk lock-ins, real-world JSX patterns, per-role data-table assertions for the 6 roles the upstream suite doesn't exercise).

## Related Links

- ESLint plugin rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-has-required-aria-props.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/role-has-required-aria-props.js
- Upstream tests: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/__tests__/src/rules/role-has-required-aria-props-test.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).