### PR TITLE
feat: add typescript base preset

### DIFF
--- a/packages/rslint/src/configs/index.ts
+++ b/packages/rslint/src/configs/index.ts
@@ -1,5 +1,4 @@
-import type { RslintConfigEntry } from '../define-config.js';
-import { recommended as tsRecommended } from './typescript.js';
+import { base as tsBase, recommended as tsRecommended } from './typescript.js';
 import { recommended as jsRecommended } from './javascript.js';
 import { recommended as reactRecommended } from './react.js';
 import { recommended as reactHooksRecommended } from './react-hooks.js';
@@ -9,42 +8,38 @@ import { recommended as jestRecommended } from './jest.js';
 import { recommended as unicornRecommended } from './unicorn.js';
 import { recommended as jsxA11yRecommended } from './jsx-a11y.js';
 
-interface PluginExport {
-  configs: { recommended: RslintConfigEntry };
-}
-
-export const ts: PluginExport = {
-  configs: { recommended: tsRecommended },
+export const ts = {
+  configs: { base: tsBase, recommended: tsRecommended },
 };
 
-export const js: PluginExport = {
+export const js = {
   configs: { recommended: jsRecommended },
 };
 
-export const reactPlugin: PluginExport = {
+export const reactPlugin = {
   configs: { recommended: reactRecommended },
 };
 
-export const reactHooksPlugin: PluginExport = {
+export const reactHooksPlugin = {
   configs: { recommended: reactHooksRecommended },
 };
 
-export const importPlugin: PluginExport = {
+export const importPlugin = {
   configs: { recommended: importRecommended },
 };
 
-export const promisePlugin: PluginExport = {
+export const promisePlugin = {
   configs: { recommended: promiseRecommended },
 };
 
-export const jestPlugin: PluginExport = {
+export const jestPlugin = {
   configs: { recommended: jestRecommended },
 };
 
-export const unicornPlugin: PluginExport = {
+export const unicornPlugin = {
   configs: { recommended: unicornRecommended },
 };
 
-export const jsxA11yPlugin: PluginExport = {
+export const jsxA11yPlugin = {
   configs: { recommended: jsxA11yRecommended },
 };

--- a/packages/rslint/src/configs/typescript.ts
+++ b/packages/rslint/src/configs/typescript.ts
@@ -1,12 +1,16 @@
 import type { RslintConfigEntry } from '../define-config.js';
 
+const base: RslintConfigEntry = {
+  files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+  plugins: ['@typescript-eslint'],
+};
+
 // Aligned with official @typescript-eslint/recommended.
 // Includes the eslint-recommended override layer (disables core rules handled by TS,
 // enables TS-beneficial rules).
 // Rules commented out with "not implemented" are in the official preset but not yet available.
 const recommended: RslintConfigEntry = {
-  files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
-  plugins: ['@typescript-eslint'],
+  ...base,
   languageOptions: {
     parserOptions: {
       projectService: true,
@@ -122,4 +126,4 @@ const recommended: RslintConfigEntry = {
   },
 };
 
-export { recommended };
+export { base, recommended };


### PR DESCRIPTION
## Summary

Extract the shared `files` and `plugins` fields out of `recommended` into a new `base` preset, and have `recommended` reuse it via spread. This makes the shared TypeScript file globs and plugin declaration available for downstream composition (e.g., future `strict` / `stylistic` presets, or user configs that want to layer their own rules on the same target set).

`languageOptions.parserOptions.projectService: true` is intentionally left on `recommended` rather than pulled into `base`, mirroring the upstream `@typescript-eslint` split where `base` only covers the minimal parser/plugin wiring and `projectService` is layered on by type-checked presets / users.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).