### PR TITLE
feat: port rule jsx-a11y/no-interactive-element-to-noninteractive-role

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -23,6 +23,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_access_key"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_autofocus"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_distracting_elements"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_redundant_roles"
@@ -57,6 +58,7 @@ func GetAllRules() []rule.Rule {
 		no_access_key.NoAccessKeyRule,
 		no_autofocus.NoAutofocusRule,
 		no_distracting_elements.NoDistractingElementsRule,
+		no_interactive_element_to_noninteractive_role.NoInteractiveElementToNoninteractiveRoleRule,
 		no_noninteractive_element_interactions.NoNoninteractiveElementInteractionsRule,
 		no_noninteractive_tabindex.NoNoninteractiveTabindexRule,
 		no_redundant_roles.NoRedundantRolesRule,

--- a/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role.go
+++ b/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role.go
@@ -1,0 +1,165 @@
+// Package no_interactive_element_to_noninteractive_role ports
+// eslint-plugin-jsx-a11y's `no-interactive-element-to-noninteractive-role`
+// rule. The rule flags inherently interactive HTML elements (e.g. `<a
+// href>`, `<button>`, `<input>`, …) that are assigned a non-interactive or
+// presentation ARIA role — collapsing the platform-supplied a11y semantics
+// of the underlying control to a content container is a strong signal of
+// misuse since screen-reader / keyboard users no longer recognize the
+// affordance.
+//
+// Upstream signature:
+//
+//	options: {
+//	  [tagName: string]: string[]     // per-element allowed-role override
+//	}
+//
+// The single options object is an arbitrary tag-name → allowed-roles map.
+// The recommended preset ships `{ tr: ['none', 'presentation'], canvas:
+// ['img'] }` (so `<tr role="presentation" />` and `<canvas role="img" />`
+// are exempt under recommended but flagged under strict).
+//
+// Trigger sequence — for every JsxAttribute named `role` on a JSX opening /
+// self-closing element. Bail-outs return without reporting:
+//
+//  1. Attribute name (post-namespace serialization) is not literally `role`
+//     → bail. Mirrors upstream `propName(attribute) !== 'role'`, which —
+//     because `propName` stringifies `JSXNamespacedName` to `ns:name` —
+//     skips namespaced forms like `<div mynamespace:role="term" />`.
+//  2. Tag isn't in aria-query's `dom` map → bail. Custom JSX components
+//     (`<Button />`) and unknown tags are exempted because we can't know
+//     what low-level DOM they render to.
+//  3. `options[type]` exists AND contains the FIRST role attribute's
+//     LITERAL value → bail. Mirrors upstream's
+//     `includes(allowedRoles[type], role)` — array.includes uses
+//     SameValueZero so a `null` (non-literal) role never matches a
+//     `string[]` allow-list, which collapses the check to a no-op for
+//     non-literal `role` expressions.
+//  4. Element is inherently interactive AND (role is non-interactive OR
+//     role is presentation) → REPORT on the listener-current JsxAttribute
+//     node.
+//
+// Diagnostic text mirrors upstream verbatim:
+//
+//	"Interactive elements should not be assigned non-interactive roles."
+//
+// Reports happen at the JsxAttribute, not the opening element — upstream
+// uses `node: attribute` in `context.report`. For duplicate `role`
+// attributes on the same element (invalid React, parseable JSX), each
+// listener invocation evaluates against the FIRST role attribute (via
+// `getProp(attrs, 'role')`), so both attributes get reported with the same
+// underlying classification — mirror.
+package no_interactive_element_to_noninteractive_role
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// errorMessage mirrors upstream's `errorMessage` string verbatim.
+const errorMessage = "Interactive elements should not be assigned non-interactive roles."
+
+// options carries the per-element allowed-role overrides. Each key is a tag
+// name and each value is a list of role strings that are exempt from the
+// rule for that tag. Keys whose value is not an array of strings are
+// silently ignored (JSON schema would reject them upstream, so the filter
+// is defensive).
+type options struct {
+	allowedRoles map[string][]string
+}
+
+func parseOptions(raw any) options {
+	opts := options{}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	for key, v := range m {
+		if parsed := jsxa11yutil.StringSliceOption(v); parsed != nil {
+			if opts.allowedRoles == nil {
+				opts.allowedRoles = make(map[string][]string)
+			}
+			opts.allowedRoles[key] = parsed
+		}
+	}
+	return opts
+}
+
+var NoInteractiveElementToNoninteractiveRoleRule = rule.Rule{
+	Name: "jsx-a11y/no-interactive-element-to-noninteractive-role",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		return rule.RuleListeners{
+			ast.KindJsxAttribute: func(attr *ast.Node) {
+				// Upstream `propName(attribute) !== 'role'`. Case-sensitive
+				// match — upstream's `propName` returns the JSXIdentifier
+				// text verbatim, and `<X ROLE="…" />` therefore does NOT
+				// trigger this rule (the `role` attribute on a tag with
+				// uppercase ROLE is parsed as the literal name `ROLE`).
+				// For JSXNamespacedName (`mynamespace:role`), `propName`
+				// returns the colon-joined form (`"mynamespace:role"`),
+				// which also fails the equality check. Mirror via the
+				// same colon-joined serialization in
+				// [reactutil.GetJsxPropName].
+				if reactutil.GetJsxPropName(attr) != "role" {
+					return
+				}
+
+				parent := reactutil.GetJsxParentElement(attr)
+				if parent == nil {
+					return
+				}
+				attrs := reactutil.GetJsxElementAttributes(parent)
+				elementType := jsxa11yutil.GetElementType(parent, ctx.Settings)
+
+				// Step 1: custom components / unknown tags — exempt.
+				// Upstream `!dom.has(type)`.
+				if !jsxa11yutil.IsDOMElement(elementType) {
+					return
+				}
+
+				// Step 2: per-element override. Upstream uses
+				// `getLiteralPropValue(getProp(attrs, 'role'))`, which
+				// resolves to the FIRST role attribute on the element
+				// (NOT necessarily the listener-current one — matters
+				// only for duplicate-role forms). Routing through
+				// `FindAttributeByName` + `LiteralPropStringValue`
+				// mirrors that exactly, including literal-spread walks
+				// (`{...{ role: "img" }}`).
+				//
+				// `includes(allowedRoles[type], role)` uses
+				// SameValueZero, so a non-literal role (LiteralPropStringValue
+				// returns ok=false) can never match a `string[]` allow-list
+				// — the check collapses to no-op in that case, which is what
+				// we want.
+				if allowed, ok := opts.allowedRoles[elementType]; ok {
+					firstRoleAttr := jsxa11yutil.FindAttributeByName(attrs, "role")
+					if role, hasLiteral := jsxa11yutil.LiteralPropStringValue(firstRoleAttr); hasLiteral {
+						if slices.Contains(allowed, role) {
+							return
+						}
+					}
+				}
+
+				// Step 3: interactive element + non-interactive / presentation
+				// role → report. All three predicates are tag-aware and
+				// share the FILTERED `attrs` view; the role classifiers
+				// internally extract from the first role attribute via
+				// `getLiteralPropValue(getProp(attrs, 'role'))`.
+				if jsxa11yutil.IsInteractiveElement(elementType, attrs) &&
+					(jsxa11yutil.IsNonInteractiveRole(elementType, attrs) ||
+						jsxa11yutil.IsPresentationRole(attrs)) {
+					ctx.ReportNode(attr, rule.RuleMessage{
+						Id:          "noInteractiveElementToNoninteractiveRole",
+						Description: errorMessage,
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role.md
+++ b/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role.md
@@ -1,0 +1,94 @@
+# no-interactive-element-to-noninteractive-role
+
+## Rule Details
+
+Inherently interactive HTML elements such as `<a href>`, `<button>`,
+`<input>`, `<select>`, and `<textarea>` carry assistive-technology
+semantics that non-interactive ARIA roles (`img`, `listitem`, `article`,
+`presentation`, `none`, …) explicitly remove. Assigning a non-interactive
+or presentation role to an interactive control hides its affordance from
+screen-reader and keyboard users — they can no longer tell that the
+element responds to interaction.
+
+If a non-interactive role is genuinely desired for the surrounding
+container, wrap the interactive element in a separate non-interactive
+container instead of demoting the control itself.
+
+The rule fires on every `role` JSX attribute when **all** of the following
+hold:
+
+- The resolved element name is in the HTML DOM set (custom React
+  components are skipped — the rule does not know what low-level element
+  they render).
+- The attribute name is literally `role` (case-sensitive); namespaced
+  attributes such as `mynamespace:role` are not checked.
+- The element / `role` combination does not match an entry in the
+  per-element allow-list (see Rule Options below).
+- The element is inherently interactive (e.g. `<button>`, `<a href>`,
+  `<input>`, `<select>`, `<textarea>`).
+- The `role` attribute, when statically a literal string, resolves to a
+  non-interactive role (`img`, `listitem`, `article`, …) OR to
+  `presentation` / `none`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<a href="http://example.com" role="img" />
+<input type="text" role="listitem" />
+<button role="article">Save</button>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<a href="http://example.com" role="button" />
+<button>Save</button>
+<div role="article">
+  <button>Save</button>
+</div>
+```
+
+## Rule Options
+
+### Per-element allow-list
+
+Type: `{ [tagName: string]: string[] }`. Default: not set. The upstream
+`recommended` preset sets `tr: ["none", "presentation"]` and `canvas:
+["img"]`; the `strict` preset omits the allow-list entirely.
+
+Each key is an HTML element name and each value is an array of role
+strings exempt from the rule for that element. A non-string entry in the
+array is silently ignored. Non-array values are also ignored — only
+`string[]` allow-lists are honored.
+
+Examples of **correct** code with `{ "tr": ["none", "presentation"] }`:
+
+```json
+{ "jsx-a11y/no-interactive-element-to-noninteractive-role": ["error", { "tr": ["none", "presentation"] }] }
+```
+
+```jsx
+<tr role="presentation" />
+<tr role="none" />
+```
+
+Examples of **incorrect** code with `{ "tr": ["none", "presentation"] }`:
+
+```json
+{ "jsx-a11y/no-interactive-element-to-noninteractive-role": ["error", { "tr": ["none", "presentation"] }] }
+```
+
+```jsx
+<tr role="img" />
+```
+
+## Resources
+
+- [WCAG 4.1.2 — Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+- [WAI-ARIA — Widget Roles](https://www.w3.org/TR/wai-aria-1.2/#widget_roles)
+- [WAI-ARIA — Non-interactive Content Roles](https://www.w3.org/TR/wai-aria-1.2/#document_structure_roles)
+- [MDN — Using ARIA: Roles, states, and properties](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/no-interactive-element-to-noninteractive-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-interactive-element-to-noninteractive-role.md)

--- a/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role_extras_test.go
@@ -1,0 +1,552 @@
+package no_interactive_element_to_noninteractive_role
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoInteractiveElementToNoninteractiveRolePositions locks the
+// diagnostic anchor: the rule reports on the JsxAttribute itself (NOT the
+// opening element). Upstream's `context.report({ node: attribute, … })`
+// makes the report range cover `role="…"`, so a multi-line opening tag
+// still anchors the report on the role attribute's line / column.
+func TestNoInteractiveElementToNoninteractiveRolePositions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+		// Self-closing — report on `role="img"` between `href="…"` and `/>`.
+		{
+			Code: `<a href="http://x.y.z" role="img" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noInteractiveElementToNoninteractiveRole",
+				Message:   errorMessage,
+				Line:      1, Column: 24, EndLine: 1, EndColumn: 34,
+			}},
+		},
+		// Paired form — report on `role="img"` only (not whole element).
+		{
+			Code: `<a href="http://x.y.z" role="img">x</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noInteractiveElementToNoninteractiveRole",
+				Message:   errorMessage,
+				Line:      1, Column: 24, EndLine: 1, EndColumn: 34,
+			}},
+		},
+		// Multi-line opening tag — report still anchors to the role
+		// attribute on its own line.
+		{
+			Code: "<a\n  href=\"http://x.y.z\"\n  role=\"img\"\n/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noInteractiveElementToNoninteractiveRole",
+				Message:   errorMessage,
+				Line:      3, Column: 3, EndLine: 3, EndColumn: 13,
+			}},
+		},
+		// Tab-indented role — column counts each leading tab as one,
+		// matching tsgo's char-offset semantics.
+		{
+			Code: "<a\n\thref=\"x\"\n\trole=\"img\"\n/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noInteractiveElementToNoninteractiveRole",
+				Message:   errorMessage,
+				Line:      3, Column: 2, EndLine: 3, EndColumn: 12,
+			}},
+		},
+	})
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleListenerBoundary locks
+// that the listener fires independently for each JsxAttribute named
+// `role` — nested JSX hierarchies produce one report per qualifying
+// ancestor, with each report anchored on its own role attribute.
+func TestNoInteractiveElementToNoninteractiveRoleListenerBoundary(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+		// Two nested interactive-with-noninteractive-role elements — both
+		// should report independently.
+		{
+			Code: "<a href=\"x\" role=\"img\">\n  <button role=\"img\" />\n</a>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage, Line: 1, Column: 13},
+				{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage, Line: 2, Column: 11},
+			},
+		},
+		// Three-level nesting — outer + middle + inner each report
+		// against their own role attribute, never bleeding across.
+		{
+			Code: "<a href=\"x\" role=\"img\">\n  <button role=\"listitem\">\n    <select role=\"article\" />\n  </button>\n</a>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage, Line: 1, Column: 13},
+				{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage, Line: 2, Column: 11},
+				{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage, Line: 3, Column: 13},
+			},
+		},
+	})
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleEdgeShapes mirrors the
+// Universal Edge Shapes checklist (Dimension 4) — spread / namespaced /
+// boolean / non-literal / template shapes around the `role` attribute
+// exercise corners upstream tests rarely cover.
+func TestNoInteractiveElementToNoninteractiveRoleEdgeShapes(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+		[]rule_tester.ValidTestCase{
+			// Boolean form `<a href="x" role />` — `getLiteralPropValue`
+			// returns boolean true, not a string. Both
+			// `isNonInteractiveRole` and `isPresentationRole` return
+			// false, so no report.
+			{Code: `<a href="x" role />`, Tsx: true},
+			// Non-literal role expressions — all noop in LITERAL_TYPES.
+			{Code: `<a href="x" role={someRole} />`, Tsx: true},
+			{Code: `<a href="x" role={cond ? "img" : "button"} />`, Tsx: true},
+			{Code: `<a href="x" role={getRole()} />`, Tsx: true},
+			{Code: `<a href="x" role={obj.role} />`, Tsx: true},
+			{Code: `<a href="x" role={"img" + ""} />`, Tsx: true},
+			{Code: `<a href="x" role={"img" || "button"} />`, Tsx: true},
+			// `role={null}` — LITERAL_TYPES.Literal maps null to the
+			// string "null", not a role name → no report.
+			{Code: `<a href="x" role={null} />`, Tsx: true},
+			// Capital `ROLE` is a different attribute name — upstream's
+			// `propName(attr) !== 'role'` is case-sensitive.
+			{Code: `<a href="x" ROLE="img" />`, Tsx: true},
+			// Self-closing on a custom JSX component — not in dom map.
+			{Code: `<MyButton role="img" />`, Tsx: true},
+			// Namespaced role attribute — `propName` serializes to
+			// `"ns:role"`, which isn't `"role"`.
+			{Code: `<a href="x" ns:role="img" />`, Tsx: true},
+			// Literal-spread that does NOT contain `role` — interactive
+			// role on the JsxAttribute wins.
+			{Code: `<a href="x" {...rest} role="button" />`, Tsx: true},
+			// Template literal without substitutions resolves to "button".
+			{Code: "<a href=\"x\" role={`button`} />", Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Template literal extracts to "img" — locks in the
+			// template-literal arm.
+			{
+				Code:   "<a href=\"x\" role={`img`} />",
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Duplicate role attributes — both report. tsgo parses both,
+			// and each listener invocation classifies via the FIRST
+			// role attribute.
+			{
+				Code: `<a href="x" role="img" role="button" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage},
+					{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage},
+				},
+			},
+			// Multi-role `role="img button"` — `IsNonInteractiveRole`
+			// takes the first VALID role (img) → non-interactive.
+			{
+				Code:   `<a href="x" role="img button" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+		})
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleOptionParsing locks the
+// JSON-shape paths the CLI / JS-config feed:
+//
+//   - Single-option array: `["error", {tr:[...]}]` is unwrapped by
+//     config.go to a bare map.
+//   - Array-wrapped: matches rule_tester's multi-element shape.
+//
+// Without this suite, a regression where `parseOptions` only handles
+// `[]interface{}` would silently fall back to defaults on every CLI
+// invocation.
+func TestNoInteractiveElementToNoninteractiveRoleOptionParsing(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+		[]rule_tester.ValidTestCase{
+			// Bare map — CLI single-option shape.
+			{
+				Code:    `<tr role="presentation" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tr": []interface{}{"none", "presentation"}},
+			},
+			// Array-wrapped — rule_tester multi-option shape.
+			{
+				Code:    `<canvas role="img" />`,
+				Tsx:     true,
+				Options: []interface{}{map[string]interface{}{"canvas": []interface{}{"img"}}},
+			},
+			// Per-element override exempts only the configured roles.
+			{
+				Code:    `<tr role="none" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tr": []interface{}{"none", "presentation"}},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Override doesn't exempt other roles on the same tag.
+			{
+				Code:    `<tr role="img" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tr": []interface{}{"none", "presentation"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Override on `tr` doesn't help `<a href>`.
+			{
+				Code:    `<a href="x" role="img" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tr": []interface{}{"none", "presentation"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Empty options map — strict semantics.
+			{
+				Code:    `<canvas role="img" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Nil options.
+			{
+				Code:   `<canvas role="img" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+		})
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleRoleExpressionShapes locks
+// the rule's behavior across every tsgo-specific wrapper around a
+// `role={…}` expression value. tsgo preserves several AST shapes that
+// ESTree flattens at parse time, and `LiteralPropStringValue` has to
+// route them correctly into upstream's `getLiteralPropValue` semantics
+// — a regression that strips the wrong wrapper would silently shift the
+// rule's surface (over- or under-reporting). Each row pins one shape.
+func TestNoInteractiveElementToNoninteractiveRoleRoleExpressionShapes(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+		[]rule_tester.ValidTestCase{
+			// `as` / `satisfies` / non-null wrappers map to noop in
+			// jsx-ast-utils' LITERAL_TYPES → null → no classification →
+			// no report. tsgo preserves these wrappers as discrete AST
+			// nodes (vs ESTree flattening some); the literal extractor
+			// must NOT peel them.
+			{Code: `<a href="x" role={"img" as const} />`, Tsx: true},
+			{Code: `<a href="x" role={"img" as Role} />`, Tsx: true},
+			{Code: `<a href="x" role={"img" satisfies string} />`, Tsx: true},
+			// Identifier from a local binding — non-literal in
+			// LITERAL_TYPES sense. tsgo's symbol resolution doesn't
+			// participate in literal extraction.
+			{
+				Code: "const r = 'img';\nconst el = <a href=\"x\" role={r} />;",
+				Tsx:  true,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// `role={"img"}` — JsxExpression wrapping a StringLiteral.
+			// tsgo represents this as JsxExpression > StringLiteral
+			// (no implicit unwrap); the extractor must recurse through.
+			{
+				Code:   `<a href="x" role={"img"} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// `role={("img")}` — single paren wrap. tsgo preserves
+			// ParenthesizedExpression; ESTree flattens. The extractor
+			// must strip parens for parity.
+			{
+				Code:   `<a href="x" role={("img")} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Multi-level parens.
+			{
+				Code:   `<a href="x" role={(("img"))} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// HTML entity in the raw string — `&#105;` decodes to `i`,
+			// producing "img". tsgo's StringLiteral.Text preserves the
+			// raw `&…;` source; the literal extractor decodes via
+			// `jsxtransforms.DecodeEntities`.
+			{
+				Code:   `<a href="x" role="&#105;mg" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+		})
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleRoleStringBoundaries locks
+// `IsNonInteractiveRole`'s string-handling edges. Upstream does
+// `String(value).toLowerCase().split(' ')` then takes the FIRST valid
+// role. The combination of single-space split (not `\s+`) and "first
+// valid role wins" produces several non-obvious classifications that a
+// Go re-implementation could easily flip:
+//
+//   - case-folding: `"IMG"` and `"Img"` both classify as `img`
+//   - empty string → no token → no classification
+//   - leading/trailing space → split yields `""` token; skipped
+//   - multi-space → empty internal tokens; skipped
+//   - invalid-then-valid → invalid token skipped, valid wins
+func TestNoInteractiveElementToNoninteractiveRoleRoleStringBoundaries(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+		[]rule_tester.ValidTestCase{
+			// Empty role string — no valid role token → no classification.
+			{Code: `<a href="x" role="" />`, Tsx: true},
+			// All-whitespace role — same.
+			{Code: `<a href="x" role="   " />`, Tsx: true},
+			// Unknown role name — not in role set, no classification.
+			{Code: `<a href="x" role="foobar" />`, Tsx: true},
+			// All-invalid space-separated — no token resolves.
+			{Code: `<a href="x" role="xxx yyy zzz" />`, Tsx: true},
+			// First valid is interactive (`button`) → no report.
+			{Code: `<a href="x" role="xxx button img" />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Case-folded — upstream `.toLowerCase()` normalizes.
+			{
+				Code:   `<a href="x" role="IMG" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			{
+				Code:   `<a href="x" role="Img" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Leading space — split produces `["", "img"]`; second
+			// token wins. Locks in the "single-space split" semantics.
+			{
+				Code:   `<a href="x" role=" img" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Trailing space — split produces `["img", ""]`; first wins.
+			{
+				Code:   `<a href="x" role="img " />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Multiple internal spaces — `["img", "", "button"]`; first
+			// valid token "img" wins.
+			{
+				Code:   `<a href="x" role="img  button" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// First invalid, second valid non-interactive.
+			{
+				Code:   `<a href="x" role="xxx img" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+		})
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleOptionRobustness locks
+// `parseOptions`' behavior on misshapen / borderline option payloads
+// that the JSON schema doesn't fully constrain at the rule layer. None
+// of these should panic or report inconsistently:
+//
+//   - empty array value (`{tr: []}`) — no role exempted, strict semantics
+//   - non-array value (`{tr: "presentation"}`) — silently ignored
+//   - mixed-type array (`{tr: ["none", 123, null]}`) — non-strings dropped
+//   - option key case mismatch (`{TR: [...]}` vs tag `<tr>`) — does NOT match
+//   - option role-value case mismatch (`{tr: ["Presentation"]}` vs `role="presentation"`)
+func TestNoInteractiveElementToNoninteractiveRoleOptionRobustness(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+		[]rule_tester.ValidTestCase{
+			// Mixed-type array — only "presentation" survives, exempting
+			// the case.
+			{
+				Code:    `<tr role="presentation" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tr": []interface{}{"none", 123, nil, "presentation"}},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Empty array — no role exempted under that key.
+			{
+				Code:    `<tr role="presentation" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tr": []interface{}{}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Non-array value — `StringSliceOption` returns nil, key is
+			// silently dropped from `allowedRoles`.
+			{
+				Code:    `<tr role="presentation" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tr": "presentation"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Mixed-type array containing only the WRONG roles — still
+			// reports.
+			{
+				Code:    `<tr role="presentation" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tr": []interface{}{"none", 123, nil}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Option key case mismatch — `getElementType` returns "tr"
+			// (lowercased tag); option key "TR" doesn't match.
+			{
+				Code:    `<tr role="presentation" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"TR": []interface{}{"presentation"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Option role-value case mismatch — `slices.Contains` is
+			// case-sensitive; "Presentation" doesn't match "presentation".
+			{
+				Code:    `<tr role="presentation" />`,
+				Tsx:     true,
+				Options: map[string]interface{}{"tr": []interface{}{"Presentation"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+		})
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleContainerForms locks
+// listener triggering across real-world React patterns — JSX inside
+// fragments / ternaries / array maps / arrow bodies / conditional
+// renders. The rule must fire identically regardless of the surrounding
+// expression context. A regression that hooked into `JsxOpeningElement`
+// rather than `JsxAttribute` would silently drop these.
+func TestNoInteractiveElementToNoninteractiveRoleContainerForms(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule, []rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			// Inside a JsxFragment (`<>…</>`).
+			{
+				Code:   `<><a href="x" role="img" /></>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Inside a ternary returned from a JsxExpression child.
+			{
+				Code:   `<div>{cond ? <a href="x" role="img" /> : null}</div>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Inside an arrow function body, common in `.map(…)`.
+			{
+				Code:   `const r = items.map(x => <a href={x} role="img" />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Returned from a function declaration body.
+			{
+				Code:   `function R() { return <button role="article">x</button>; }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Paren-wrapped JSX expression — `({<a … />})` form.
+			{
+				Code:   `const x = (<a href="x" role="img" />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+		})
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleInteractiveGate locks
+// `IsInteractiveElement`'s ATTRIBUTE-DEPENDENT classification. `<a>` is
+// interactive only when it has an `href` attribute — both
+// `IsInteractiveElement` and our rule must respect that. A regression
+// where the schema's required-attribute predicate is lost would either
+// silently exempt `<a href="x" role="img" />` or wrongly flag
+// `<a role="img" />`.
+//
+// The all-flavors-of-input cases live in upstream's neverValid; this
+// suite locks `<a>`'s href-dependency separately because it's the most
+// common case the schema gate decides on.
+func TestNoInteractiveElementToNoninteractiveRoleInteractiveGate(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+		[]rule_tester.ValidTestCase{
+			// `<a>` without `href` — schema gate fails →
+			// `IsInteractiveElement` returns false → no report.
+			{Code: `<a role="img" />`, Tsx: true},
+			{Code: `<a role="listitem" />`, Tsx: true},
+			// `<a tabIndex>` without `href` — tabIndex alone doesn't
+			// make `<a>` interactive in aria-query's schema.
+			{Code: `<a tabIndex="0" role="img" />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// `<a href="x">` — href present → interactive → report.
+			{
+				Code:   `<a href="x" role="img" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// `<a href={x}>` — href present (value irrelevant to schema).
+			{
+				Code:   `<a href={someUrl} role="img" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// `<a href />` — boolean form; `hasProp` matches regardless
+			// of value, so `<a>` is interactive.
+			{
+				Code:   `<a href role="img" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// `<a href="">` — empty string is still a present `href`.
+			{
+				Code:   `<a href="" role="img" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+		})
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleMixedRealWorld captures
+// real-world JSX shapes — multiple a11y props, event handlers, spread
+// + role ordering — that a rule operating only on simple attribute
+// lists could mishandle. Each case is a "looks like real code" pattern
+// users would actually write.
+func TestNoInteractiveElementToNoninteractiveRoleMixedRealWorld(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+		[]rule_tester.ValidTestCase{
+			// Interactive role + event handlers + className mixed — no
+			// non-interactive role anywhere; not reported.
+			{Code: `<a href="x" role="button" className="cta" onClick={f} aria-label="Go" />`, Tsx: true},
+			// Spread before AND after a `role="button"` — interactive,
+			// not reported.
+			{Code: `<a href="x" {...a} role="button" {...b} />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Real-world: developer slapping role="img" on a button +
+			// onClick handler. Single report on the `role` attribute,
+			// the rest of the attributes are noise.
+			{
+				Code: `<button role="img" onClick={f} aria-label="x" className="icon" />`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage},
+				},
+			},
+			// Spread before role="img" on `<a href>` — spread is opaque,
+			// the JsxAttribute fires normally.
+			{
+				Code:   `<a href="x" {...rest} role="img" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Spread AFTER role="img" — same.
+			{
+				Code:   `<a href="x" role="img" {...rest} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+			// Multiple non-interactive props mixed in — only the `role`
+			// triggers; one report.
+			{
+				Code:   `<select role="article" aria-hidden={false} onClick={f} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
+			},
+		})
+}

--- a/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role_upstream_test.go
@@ -1,0 +1,483 @@
+package no_interactive_element_to_noninteractive_role
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedError mirrors upstream's `expectedError` constant — the single
+// shape every invalid case in the rule produces. Centralized so a future
+// error-text tweak touches one place.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "noInteractiveElementToNoninteractiveRole",
+	Message:   errorMessage,
+}
+
+// componentsSettings mirrors upstream's
+//
+//	settings: { 'jsx-a11y': { components: { Button: 'button', Link: 'a' } } }
+//
+// so `<Button>` resolves to `button` (interactive) and `<Link>` resolves
+// to `a` (interactive when `href` is present).
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Button": "button",
+			"Link":   "a",
+		},
+	},
+}
+
+// recommendedConfig mirrors `configs.recommended.rules['jsx-a11y/no-interactive-element-to-noninteractive-role'][1]`
+// from eslint-plugin-jsx-a11y/src/index.js.
+var recommendedConfig = map[string]interface{}{
+	"tr":     []interface{}{"none", "presentation"},
+	"canvas": []interface{}{"img"},
+}
+
+// alwaysValid mirrors upstream's `alwaysValid` array verbatim — valid under
+// EVERY option combination. Order matches the upstream file so a future
+// audit can grep across both side-by-side.
+func alwaysValid() []rule_tester.ValidTestCase {
+	return []rule_tester.ValidTestCase{
+		// ---- Custom components — element type isn't in aria-query's
+		//      `dom` map → upstream short-circuits before the report. ----
+		{Code: `<TestComponent onClick={doFoo} />`, Tsx: true},
+		{Code: `<Button onClick={doFoo} />`, Tsx: true},
+
+		// ---- Interactive elements with an interactive role. ----
+		{Code: `<a href="http://x.y.z" role="button" />`, Tsx: true},
+		{Code: `<a href="http://x.y.z" tabIndex="0" role="button" />`, Tsx: true},
+		{Code: `<button className="foo" role="button" />`, Tsx: true},
+
+		// ---- All flavors of input with an interactive role. ----
+		{Code: `<input role="button" />`, Tsx: true},
+		{Code: `<input type="button" role="button" />`, Tsx: true},
+		{Code: `<input type="checkbox" role="button" />`, Tsx: true},
+		{Code: `<input type="color" role="button" />`, Tsx: true},
+		{Code: `<input type="date" role="button" />`, Tsx: true},
+		{Code: `<input type="datetime" role="button" />`, Tsx: true},
+		{Code: `<input type="datetime-local" role="button" />`, Tsx: true},
+		{Code: `<input type="email" role="button" />`, Tsx: true},
+		{Code: `<input type="file" role="button" />`, Tsx: true},
+		{Code: `<input type="image" role="button" />`, Tsx: true},
+		{Code: `<input type="month" role="button" />`, Tsx: true},
+		{Code: `<input type="number" role="button" />`, Tsx: true},
+		{Code: `<input type="password" role="button" />`, Tsx: true},
+		{Code: `<input type="radio" role="button" />`, Tsx: true},
+		{Code: `<input type="range" role="button" />`, Tsx: true},
+		{Code: `<input type="reset" role="button" />`, Tsx: true},
+		{Code: `<input type="search" role="button" />`, Tsx: true},
+		{Code: `<input type="submit" role="button" />`, Tsx: true},
+		{Code: `<input type="tel" role="button" />`, Tsx: true},
+		{Code: `<input type="text" role="button" />`, Tsx: true},
+		{Code: `<input type="time" role="button" />`, Tsx: true},
+		{Code: `<input type="url" role="button" />`, Tsx: true},
+		{Code: `<input type="week" role="button" />`, Tsx: true},
+		{Code: `<input type="hidden" role="button" />`, Tsx: true},
+
+		// ---- End all flavors of input. ----
+		{Code: `<menuitem role="button" />;`, Tsx: true},
+		{Code: `<option className="foo" role="button" />`, Tsx: true},
+		{Code: `<select className="foo" role="button" />`, Tsx: true},
+		{Code: `<textarea className="foo" role="button" />`, Tsx: true},
+		{Code: `<tr role="button" />;`, Tsx: true},
+
+		// ---- HTML elements with neither an interactive or non-interactive valence (static). ----
+		{Code: `<a role="button" />`, Tsx: true},
+		{Code: `<a role="img" />;`, Tsx: true},
+		{Code: `<a tabIndex="0" role="button" />`, Tsx: true},
+		{Code: `<a tabIndex="0" role="img" />`, Tsx: true},
+		{Code: `<acronym role="button" />;`, Tsx: true},
+		{Code: `<address role="button" />;`, Tsx: true},
+		{Code: `<applet role="button" />;`, Tsx: true},
+		{Code: `<aside role="button" />;`, Tsx: true},
+		{Code: `<audio role="button" />;`, Tsx: true},
+		{Code: `<b role="button" />;`, Tsx: true},
+		{Code: `<base role="button" />;`, Tsx: true},
+		{Code: `<bdi role="button" />;`, Tsx: true},
+		{Code: `<bdo role="button" />;`, Tsx: true},
+		{Code: `<big role="button" />;`, Tsx: true},
+		{Code: `<blink role="button" />;`, Tsx: true},
+		{Code: `<blockquote role="button" />;`, Tsx: true},
+		{Code: `<body role="button" />;`, Tsx: true},
+		{Code: `<br role="button" />;`, Tsx: true},
+		{Code: `<canvas role="button" />;`, Tsx: true},
+		{Code: `<caption role="button" />;`, Tsx: true},
+		{Code: `<center role="button" />;`, Tsx: true},
+		{Code: `<cite role="button" />;`, Tsx: true},
+		{Code: `<code role="button" />;`, Tsx: true},
+		{Code: `<col role="button" />;`, Tsx: true},
+		{Code: `<colgroup role="button" />;`, Tsx: true},
+		{Code: `<content role="button" />;`, Tsx: true},
+		{Code: `<data role="button" />;`, Tsx: true},
+		{Code: `<datalist role="button" />;`, Tsx: true},
+		{Code: `<del role="button" />;`, Tsx: true},
+		{Code: `<details role="button" />;`, Tsx: true},
+		{Code: `<dir role="button" />;`, Tsx: true},
+		{Code: `<div role="button" />;`, Tsx: true},
+		{Code: `<div className="foo" role="button" />;`, Tsx: true},
+		{Code: `<div className="foo" {...props} role="button" />;`, Tsx: true},
+		{Code: `<div aria-hidden role="button" />;`, Tsx: true},
+		{Code: `<div aria-hidden={true} role="button" />;`, Tsx: true},
+		{Code: `<div role="button" />;`, Tsx: true},
+		// Duplicate role attributes: first `role={undefined}` resolves
+		// to undefined via `getLiteralPropValue`, but `<div>` is not
+		// interactive so the report check never fires for either
+		// listener invocation.
+		{Code: `<div role={undefined} role="button" />;`, Tsx: true},
+		{Code: `<div {...props} role="button" />;`, Tsx: true},
+		{Code: `<div onKeyUp={() => void 0} aria-hidden={false} role="button" />;`, Tsx: true},
+		{Code: `<dl role="button" />;`, Tsx: true},
+		{Code: `<em role="button" />;`, Tsx: true},
+		{Code: `<embed role="button" />;`, Tsx: true},
+		{Code: `<figcaption role="button" />;`, Tsx: true},
+		{Code: `<font role="button" />;`, Tsx: true},
+		{Code: `<footer role="button" />;`, Tsx: true},
+		{Code: `<frameset role="button" />;`, Tsx: true},
+		{Code: `<head role="button" />;`, Tsx: true},
+		{Code: `<header role="button" />;`, Tsx: true},
+		{Code: `<hgroup role="button" />;`, Tsx: true},
+		{Code: `<html role="button" />;`, Tsx: true},
+		{Code: `<i role="button" />;`, Tsx: true},
+		{Code: `<iframe role="button" />;`, Tsx: true},
+		{Code: `<ins role="button" />;`, Tsx: true},
+		{Code: `<kbd role="button" />;`, Tsx: true},
+		{Code: `<keygen role="button" />;`, Tsx: true},
+		{Code: `<label role="button" />;`, Tsx: true},
+		{Code: `<legend role="button" />;`, Tsx: true},
+		{Code: `<link role="button" />;`, Tsx: true},
+		{Code: `<map role="button" />;`, Tsx: true},
+		{Code: `<mark role="button" />;`, Tsx: true},
+		{Code: `<marquee role="button" />;`, Tsx: true},
+		{Code: `<menu role="button" />;`, Tsx: true},
+		{Code: `<meta role="button" />;`, Tsx: true},
+		{Code: `<meter role="button" />;`, Tsx: true},
+		{Code: `<noembed role="button" />;`, Tsx: true},
+		{Code: `<noscript role="button" />;`, Tsx: true},
+		{Code: `<object role="button" />;`, Tsx: true},
+		{Code: `<optgroup role="button" />;`, Tsx: true},
+		{Code: `<output role="button" />;`, Tsx: true},
+		{Code: `<p role="button" />;`, Tsx: true},
+		{Code: `<param role="button" />;`, Tsx: true},
+		{Code: `<picture role="button" />;`, Tsx: true},
+		{Code: `<pre role="button" />;`, Tsx: true},
+		{Code: `<progress role="button" />;`, Tsx: true},
+		{Code: `<q role="button" />;`, Tsx: true},
+		{Code: `<rp role="button" />;`, Tsx: true},
+		{Code: `<rt role="button" />;`, Tsx: true},
+		{Code: `<rtc role="button" />;`, Tsx: true},
+		{Code: `<ruby role="button" />;`, Tsx: true},
+		{Code: `<s role="button" />;`, Tsx: true},
+		{Code: `<samp role="button" />;`, Tsx: true},
+		{Code: `<script role="button" />;`, Tsx: true},
+		{Code: `<section role="button" />;`, Tsx: true},
+		{Code: `<small role="button" />;`, Tsx: true},
+		{Code: `<source role="button" />;`, Tsx: true},
+		{Code: `<spacer role="button" />;`, Tsx: true},
+		{Code: `<span role="button" />;`, Tsx: true},
+		{Code: `<strike role="button" />;`, Tsx: true},
+		{Code: `<strong role="button" />;`, Tsx: true},
+		{Code: `<style role="button" />;`, Tsx: true},
+		{Code: `<sub role="button" />;`, Tsx: true},
+		{Code: `<summary role="button" />;`, Tsx: true},
+		{Code: `<sup role="button" />;`, Tsx: true},
+		{Code: `<th role="button" />;`, Tsx: true},
+		{Code: `<time role="button" />;`, Tsx: true},
+		{Code: `<title role="button" />;`, Tsx: true},
+		{Code: `<track role="button" />;`, Tsx: true},
+		{Code: `<tt role="button" />;`, Tsx: true},
+		{Code: `<u role="button" />;`, Tsx: true},
+		{Code: `<var role="button" />;`, Tsx: true},
+		{Code: `<video role="button" />;`, Tsx: true},
+		{Code: `<wbr role="button" />;`, Tsx: true},
+		{Code: `<xmp role="button" />;`, Tsx: true},
+
+		// ---- HTML elements attributed with an interactive role. ----
+		{Code: `<div role="button" />;`, Tsx: true},
+		{Code: `<div role="checkbox" />;`, Tsx: true},
+		{Code: `<div role="columnheader" />;`, Tsx: true},
+		{Code: `<div role="combobox" />;`, Tsx: true},
+		{Code: `<div role="grid" />;`, Tsx: true},
+		{Code: `<div role="gridcell" />;`, Tsx: true},
+		{Code: `<div role="link" />;`, Tsx: true},
+		{Code: `<div role="listbox" />;`, Tsx: true},
+		{Code: `<div role="menu" />;`, Tsx: true},
+		{Code: `<div role="menubar" />;`, Tsx: true},
+		{Code: `<div role="menuitem" />;`, Tsx: true},
+		{Code: `<div role="menuitemcheckbox" />;`, Tsx: true},
+		{Code: `<div role="menuitemradio" />;`, Tsx: true},
+		{Code: `<div role="option" />;`, Tsx: true},
+		{Code: `<div role="progressbar" />;`, Tsx: true},
+		{Code: `<div role="radio" />;`, Tsx: true},
+		{Code: `<div role="radiogroup" />;`, Tsx: true},
+		{Code: `<div role="row" />;`, Tsx: true},
+		{Code: `<div role="rowheader" />;`, Tsx: true},
+		{Code: `<div role="searchbox" />;`, Tsx: true},
+		{Code: `<div role="slider" />;`, Tsx: true},
+		{Code: `<div role="spinbutton" />;`, Tsx: true},
+		{Code: `<div role="switch" />;`, Tsx: true},
+		{Code: `<div role="tab" />;`, Tsx: true},
+		{Code: `<div role="textbox" />;`, Tsx: true},
+		{Code: `<div role="treeitem" />;`, Tsx: true},
+
+		// ---- Presentation role on a non-interactive element. ----
+		{Code: `<div role="presentation" />;`, Tsx: true},
+
+		// ---- HTML elements attributed with an abstract role. ----
+		{Code: `<div role="command" />;`, Tsx: true},
+		{Code: `<div role="composite" />;`, Tsx: true},
+		{Code: `<div role="input" />;`, Tsx: true},
+		{Code: `<div role="landmark" />;`, Tsx: true},
+		{Code: `<div role="range" />;`, Tsx: true},
+		{Code: `<div role="roletype" />;`, Tsx: true},
+		{Code: `<div role="section" />;`, Tsx: true},
+		{Code: `<div role="sectionhead" />;`, Tsx: true},
+		{Code: `<div role="select" />;`, Tsx: true},
+		{Code: `<div role="structure" />;`, Tsx: true},
+		{Code: `<div role="tablist" />;`, Tsx: true},
+		{Code: `<div role="toolbar" />;`, Tsx: true},
+		{Code: `<div role="tree" />;`, Tsx: true},
+		{Code: `<div role="treegrid" />;`, Tsx: true},
+		{Code: `<div role="widget" />;`, Tsx: true},
+		{Code: `<div role="window" />;`, Tsx: true},
+
+		// ---- HTML elements with an inherent, non-interactive role,
+		//      assigned an interactive role. ----
+		{Code: `<main role="button" />;`, Tsx: true},
+		{Code: `<area role="button" />;`, Tsx: true},
+		{Code: `<article role="button" />;`, Tsx: true},
+		{Code: `<article role="button" />;`, Tsx: true},
+		{Code: `<dd role="button" />;`, Tsx: true},
+		{Code: `<dfn role="button" />;`, Tsx: true},
+		{Code: `<dt role="button" />;`, Tsx: true},
+		{Code: `<fieldset role="button" />;`, Tsx: true},
+		{Code: `<figure role="button" />;`, Tsx: true},
+		{Code: `<form role="button" />;`, Tsx: true},
+		{Code: `<frame role="button" />;`, Tsx: true},
+		{Code: `<h1 role="button" />;`, Tsx: true},
+		{Code: `<h2 role="button" />;`, Tsx: true},
+		{Code: `<h3 role="button" />;`, Tsx: true},
+		{Code: `<h4 role="button" />;`, Tsx: true},
+		{Code: `<h5 role="button" />;`, Tsx: true},
+		{Code: `<h6 role="button" />;`, Tsx: true},
+		{Code: `<hr role="button" />;`, Tsx: true},
+		{Code: `<img role="button" />;`, Tsx: true},
+		{Code: `<li role="button" />;`, Tsx: true},
+		{Code: `<li role="presentation" />;`, Tsx: true},
+		{Code: `<nav role="button" />;`, Tsx: true},
+		{Code: `<ol role="button" />;`, Tsx: true},
+		{Code: `<table role="button" />;`, Tsx: true},
+		{Code: `<tbody role="button" />;`, Tsx: true},
+		{Code: `<td role="button" />;`, Tsx: true},
+		{Code: `<tfoot role="button" />;`, Tsx: true},
+		{Code: `<thead role="button" />;`, Tsx: true},
+		{Code: `<ul role="button" />;`, Tsx: true},
+
+		// ---- HTML elements attributed with a non-interactive role
+		//      (element is non-interactive itself, so check fails on
+		//      the interactive-element gate). ----
+		{Code: `<div role="alert" />;`, Tsx: true},
+		{Code: `<div role="alertdialog" />;`, Tsx: true},
+		{Code: `<div role="application" />;`, Tsx: true},
+		{Code: `<div role="article" />;`, Tsx: true},
+		{Code: `<div role="banner" />;`, Tsx: true},
+		{Code: `<div role="cell" />;`, Tsx: true},
+		{Code: `<div role="complementary" />;`, Tsx: true},
+		{Code: `<div role="contentinfo" />;`, Tsx: true},
+		{Code: `<div role="definition" />;`, Tsx: true},
+		{Code: `<div role="dialog" />;`, Tsx: true},
+		{Code: `<div role="directory" />;`, Tsx: true},
+		{Code: `<div role="document" />;`, Tsx: true},
+		{Code: `<div role="feed" />;`, Tsx: true},
+		{Code: `<div role="figure" />;`, Tsx: true},
+		{Code: `<div role="form" />;`, Tsx: true},
+		{Code: `<div role="group" />;`, Tsx: true},
+		{Code: `<div role="heading" />;`, Tsx: true},
+		{Code: `<div role="img" />;`, Tsx: true},
+		{Code: `<div role="list" />;`, Tsx: true},
+		{Code: `<div role="listitem" />;`, Tsx: true},
+		{Code: `<div role="log" />;`, Tsx: true},
+		{Code: `<div role="main" />;`, Tsx: true},
+		{Code: `<div role="marquee" />;`, Tsx: true},
+		{Code: `<div role="math" />;`, Tsx: true},
+		{Code: `<div role="navigation" />;`, Tsx: true},
+		{Code: `<div role="note" />;`, Tsx: true},
+		{Code: `<div role="region" />;`, Tsx: true},
+		{Code: `<div role="rowgroup" />;`, Tsx: true},
+		{Code: `<div role="search" />;`, Tsx: true},
+		{Code: `<div role="separator" />;`, Tsx: true},
+		{Code: `<div role="scrollbar" />;`, Tsx: true},
+		{Code: `<div role="status" />;`, Tsx: true},
+		{Code: `<div role="table" />;`, Tsx: true},
+		{Code: `<div role="tabpanel" />;`, Tsx: true},
+		{Code: `<div role="term" />;`, Tsx: true},
+		{Code: `<div role="timer" />;`, Tsx: true},
+		{Code: `<div role="tooltip" />;`, Tsx: true},
+
+		// ---- Namespaced roles are not checked. ----
+		{Code: `<div mynamespace:role="term" />`, Tsx: true},
+		{Code: `<input mynamespace:role="img" />`, Tsx: true},
+
+		// ---- Custom components with explicit aria-mapped settings. ----
+		{Code: `<Link href="http://x.y.z" role="img" />`, Tsx: true},
+		{Code: `<Link href="http://x.y.z" />`, Tsx: true, Settings: componentsSettings},
+		{Code: `<Button onClick={doFoo} />`, Tsx: true, Settings: componentsSettings},
+	}
+}
+
+// neverValid mirrors upstream's `neverValid` array verbatim — invalid under
+// every option combination (recommended OR strict). Order matches the
+// upstream file.
+func neverValid() []rule_tester.InvalidTestCase {
+	return []rule_tester.InvalidTestCase{
+		// ---- Interactive elements + non-interactive role. ----
+		{Code: `<a href="http://x.y.z" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<a href="http://x.y.z" tabIndex="0" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- All flavors of input + role="img". ----
+		{Code: `<input role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="img" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="checkbox" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="color" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="date" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="datetime" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="datetime-local" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="email" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="file" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="hidden" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="image" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="month" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="number" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="password" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="radio" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="range" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="reset" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="search" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="submit" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="tel" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="text" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="time" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="url" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="week" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- End all flavors of input. ----
+		{Code: `<menuitem role="img" />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<option className="foo" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<select className="foo" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<textarea className="foo" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<tr role="img" />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Interactive elements + role="listitem". ----
+		{Code: `<a href="http://x.y.z" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<a href="http://x.y.z" tabIndex="0" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- All flavors of input + role="listitem". ----
+		{Code: `<input role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="listitem" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="checkbox" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="color" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="date" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="datetime" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="datetime-local" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="email" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="file" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="image" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="month" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="number" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="password" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="radio" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="range" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="reset" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="search" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="submit" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="tel" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="text" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="time" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="url" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input type="week" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- End all flavors of input. ----
+		{Code: `<menuitem role="listitem" />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<option className="foo" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<select className="foo" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<textarea className="foo" role="listitem" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<tr role="listitem" />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ---- Custom element resolved to `a` via settings. ----
+		{Code: `<Link href="http://x.y.z" role="img" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}, Settings: componentsSettings},
+	}
+}
+
+// recommendedExtraValid mirrors the three additional valid cases that
+// upstream's `:recommended` suite appends on top of `alwaysValid` — they
+// rely on `recommendedConfig`'s `tr`/`canvas` overrides AND on
+// `<Component>` being a non-DOM tag.
+func recommendedExtraValid() []rule_tester.ValidTestCase {
+	return []rule_tester.ValidTestCase{
+		{Code: `<tr role="presentation" />;`, Tsx: true},
+		{Code: `<canvas role="img" />;`, Tsx: true},
+		{Code: `<Component role="presentation" />;`, Tsx: true},
+	}
+}
+
+// strictExtraInvalid mirrors the two additional invalid cases that
+// upstream's `:strict` suite appends on top of `neverValid` — under
+// strict, `tr` + presentation and `canvas` + img both report because
+// the `recommendedConfig` allow-list is absent.
+func strictExtraInvalid() []rule_tester.InvalidTestCase {
+	return []rule_tester.InvalidTestCase{
+		{Code: `<tr role="presentation" />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<canvas role="img" />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+	}
+}
+
+// applyOptionsValid sets `Options` on every case — mirrors upstream's
+// `ruleOptionsMapperFactory(options)`.
+func applyOptionsValid(cases []rule_tester.ValidTestCase, opts map[string]interface{}) []rule_tester.ValidTestCase {
+	out := make([]rule_tester.ValidTestCase, len(cases))
+	for i, c := range cases {
+		c.Options = opts
+		out[i] = c
+	}
+	return out
+}
+
+func applyOptionsInvalid(cases []rule_tester.InvalidTestCase, opts map[string]interface{}) []rule_tester.InvalidTestCase {
+	out := make([]rule_tester.InvalidTestCase, len(cases))
+	for i, c := range cases {
+		c.Options = opts
+		out[i] = c
+	}
+	return out
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleUpstreamRecommended mirrors
+// upstream's `no-interactive-element-to-noninteractive-role:recommended`
+// suite — alwaysValid + 3 recommended-config extras, neverValid as-is.
+func TestNoInteractiveElementToNoninteractiveRoleUpstreamRecommended(t *testing.T) {
+	valid := append([]rule_tester.ValidTestCase{}, alwaysValid()...)
+	valid = append(valid, recommendedExtraValid()...)
+	valid = applyOptionsValid(valid, recommendedConfig)
+
+	invalid := applyOptionsInvalid(neverValid(), recommendedConfig)
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+		&NoInteractiveElementToNoninteractiveRoleRule, valid, invalid)
+}
+
+// TestNoInteractiveElementToNoninteractiveRoleUpstreamStrict mirrors
+// upstream's `no-interactive-element-to-noninteractive-role:strict` suite
+// — no options, alwaysValid as-is, neverValid + 2 extras (tr+presentation,
+// canvas+img).
+func TestNoInteractiveElementToNoninteractiveRoleUpstreamStrict(t *testing.T) {
+	valid := alwaysValid()
+
+	invalid := append([]rule_tester.InvalidTestCase{}, neverValid()...)
+	invalid = append(invalid, strictExtraInvalid()...)
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+		&NoInteractiveElementToNoninteractiveRoleRule, valid, invalid)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -179,6 +179,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/no-interactive-element-to-noninteractive-role.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-element-interactions.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-tabindex.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-redundant-roles.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-interactive-element-to-noninteractive-role.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-interactive-element-to-noninteractive-role.test.ts
@@ -1,0 +1,204 @@
+import { RuleTester } from '../rule-tester';
+
+const errorMessage =
+  'Interactive elements should not be assigned non-interactive roles.';
+const expectedError = { message: errorMessage };
+
+const componentsSettings = {
+  'jsx-a11y': {
+    components: {
+      Button: 'button',
+      Link: 'a',
+    },
+  },
+};
+
+// Mirrors `configs.recommended.rules['jsx-a11y/no-interactive-element-to-noninteractive-role'][1]`.
+const recommendedOptions = [
+  {
+    tr: ['none', 'presentation'],
+    canvas: ['img'],
+  },
+];
+
+new RuleTester().run(
+  'no-interactive-element-to-noninteractive-role',
+  null as never,
+  {
+    valid: [
+      // ============================================================
+      // Upstream alwaysValid (run under both :recommended and :strict)
+      // ============================================================
+      // Custom JSX components — element type isn't in aria-query's dom map.
+      { code: '<TestComponent onClick={doFoo} />' },
+      { code: '<Button onClick={doFoo} />' },
+
+      // Interactive elements with an interactive role.
+      { code: '<a href="http://x.y.z" role="button" />' },
+      { code: '<a href="http://x.y.z" tabIndex="0" role="button" />' },
+      { code: '<button className="foo" role="button" />' },
+
+      // All flavors of input with role="button".
+      { code: '<input role="button" />' },
+      { code: '<input type="button" role="button" />' },
+      { code: '<input type="checkbox" role="button" />' },
+      { code: '<input type="color" role="button" />' },
+      { code: '<input type="date" role="button" />' },
+      { code: '<input type="datetime" role="button" />' },
+      { code: '<input type="datetime-local" role="button" />' },
+      { code: '<input type="email" role="button" />' },
+      { code: '<input type="file" role="button" />' },
+      { code: '<input type="image" role="button" />' },
+      { code: '<input type="month" role="button" />' },
+      { code: '<input type="number" role="button" />' },
+      { code: '<input type="password" role="button" />' },
+      { code: '<input type="radio" role="button" />' },
+      { code: '<input type="range" role="button" />' },
+      { code: '<input type="reset" role="button" />' },
+      { code: '<input type="search" role="button" />' },
+      { code: '<input type="submit" role="button" />' },
+      { code: '<input type="tel" role="button" />' },
+      { code: '<input type="text" role="button" />' },
+      { code: '<input type="time" role="button" />' },
+      { code: '<input type="url" role="button" />' },
+      { code: '<input type="week" role="button" />' },
+      { code: '<input type="hidden" role="button" />' },
+
+      // Other inherently interactive controls.
+      { code: '<menuitem role="button" />;' },
+      { code: '<option className="foo" role="button" />' },
+      { code: '<select className="foo" role="button" />' },
+      { code: '<textarea className="foo" role="button" />' },
+      { code: '<tr role="button" />;' },
+
+      // HTML elements with neither interactive nor non-interactive valence.
+      { code: '<a role="button" />' },
+      { code: '<a role="img" />;' },
+      { code: '<a tabIndex="0" role="button" />' },
+      { code: '<a tabIndex="0" role="img" />' },
+      { code: '<div role="button" />;' },
+      { code: '<div role={undefined} role="button" />;' },
+      { code: '<div role="img" />;' },
+      { code: '<canvas role="button" />;' },
+
+      // Non-DOM custom components are exempt.
+      { code: '<MyButton role="img" />' },
+
+      // Namespaced roles — propName isn't literally `role`.
+      { code: '<div mynamespace:role="term" />' },
+      { code: '<input mynamespace:role="img" />' },
+
+      // Components with explicit aria mapping.
+      { code: '<Link href="http://x.y.z" role="img" />' },
+      { code: '<Link href="http://x.y.z" />', settings: componentsSettings },
+      { code: '<Button onClick={doFoo} />', settings: componentsSettings },
+
+      // ============================================================
+      // Recommended-only valid (tr / canvas allow-list, non-DOM component)
+      // ============================================================
+      {
+        code: '<tr role="presentation" />;',
+        options: recommendedOptions,
+      },
+      {
+        code: '<canvas role="img" />;',
+        options: recommendedOptions,
+      },
+      {
+        code: '<Component role="presentation" />;',
+        options: recommendedOptions,
+      },
+    ],
+    invalid: [
+      // ============================================================
+      // Upstream neverValid — invalid in both recommended and strict
+      // ============================================================
+      // Interactive elements + non-interactive role.
+      {
+        code: '<a href="http://x.y.z" role="img" />',
+        errors: [expectedError],
+      },
+      {
+        code: '<a href="http://x.y.z" tabIndex="0" role="img" />',
+        errors: [expectedError],
+      },
+
+      // All flavors of input + role="img".
+      { code: '<input role="img" />', errors: [expectedError] },
+      { code: '<input type="img" role="img" />', errors: [expectedError] },
+      { code: '<input type="checkbox" role="img" />', errors: [expectedError] },
+      { code: '<input type="color" role="img" />', errors: [expectedError] },
+      { code: '<input type="date" role="img" />', errors: [expectedError] },
+      { code: '<input type="datetime" role="img" />', errors: [expectedError] },
+      {
+        code: '<input type="datetime-local" role="img" />',
+        errors: [expectedError],
+      },
+      { code: '<input type="email" role="img" />', errors: [expectedError] },
+      { code: '<input type="file" role="img" />', errors: [expectedError] },
+      { code: '<input type="hidden" role="img" />', errors: [expectedError] },
+      { code: '<input type="image" role="img" />', errors: [expectedError] },
+      { code: '<input type="month" role="img" />', errors: [expectedError] },
+      { code: '<input type="number" role="img" />', errors: [expectedError] },
+      { code: '<input type="password" role="img" />', errors: [expectedError] },
+      { code: '<input type="radio" role="img" />', errors: [expectedError] },
+      { code: '<input type="range" role="img" />', errors: [expectedError] },
+      { code: '<input type="reset" role="img" />', errors: [expectedError] },
+      { code: '<input type="search" role="img" />', errors: [expectedError] },
+      { code: '<input type="submit" role="img" />', errors: [expectedError] },
+      { code: '<input type="tel" role="img" />', errors: [expectedError] },
+      { code: '<input type="text" role="img" />', errors: [expectedError] },
+      { code: '<input type="time" role="img" />', errors: [expectedError] },
+      { code: '<input type="url" role="img" />', errors: [expectedError] },
+      { code: '<input type="week" role="img" />', errors: [expectedError] },
+      { code: '<menuitem role="img" />;', errors: [expectedError] },
+      {
+        code: '<option className="foo" role="img" />',
+        errors: [expectedError],
+      },
+      {
+        code: '<select className="foo" role="img" />',
+        errors: [expectedError],
+      },
+      {
+        code: '<textarea className="foo" role="img" />',
+        errors: [expectedError],
+      },
+      { code: '<tr role="img" />;', errors: [expectedError] },
+
+      // Interactive elements + role="listitem".
+      {
+        code: '<a href="http://x.y.z" role="listitem" />',
+        errors: [expectedError],
+      },
+      {
+        code: '<a href="http://x.y.z" tabIndex="0" role="listitem" />',
+        errors: [expectedError],
+      },
+      { code: '<input role="listitem" />', errors: [expectedError] },
+      {
+        code: '<input type="listitem" role="listitem" />',
+        errors: [expectedError],
+      },
+      {
+        code: '<input type="checkbox" role="listitem" />',
+        errors: [expectedError],
+      },
+      { code: '<menuitem role="listitem" />;', errors: [expectedError] },
+      { code: '<tr role="listitem" />;', errors: [expectedError] },
+
+      // Custom element resolved to <a> via settings.
+      {
+        code: '<Link href="http://x.y.z" role="img" />',
+        settings: componentsSettings,
+        errors: [expectedError],
+      },
+
+      // ============================================================
+      // Strict-only invalid (no allowed-roles override for tr / canvas)
+      // ============================================================
+      { code: '<tr role="presentation" />;', errors: [expectedError] },
+      { code: '<canvas role="img" />;', errors: [expectedError] },
+    ],
+  },
+);

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -448,3 +448,4 @@ onmouseover
 onmouseout
 onfocus
 onblur
+mynamespace


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/no-interactive-element-to-noninteractive-role` rule from `eslint-plugin-jsx-a11y` to rslint.

The rule flags inherently interactive HTML elements (e.g. `<a href>`, `<button>`, `<input>`, `<select>`, `<textarea>`) that are assigned a non-interactive or presentation ARIA role — collapsing the platform-supplied a11y semantics of the underlying control to a content container hides the affordance from screen-reader and keyboard users.

Implementation mirrors upstream byte-for-byte: listener on `JSXAttribute` named `role`, bail-out on non-DOM tags / per-element allow-list / non-interactive elements, then report on the JsxAttribute when the element is interactive and the role resolves to non-interactive or `presentation` / `none`. Helpers (`IsInteractiveElement`, `IsNonInteractiveRole`, `IsPresentationRole`, `GetElementType`, `IsDOMElement`, `LiteralPropStringValue`, `FindAttributeByName`) are all reused from `jsxa11yutil` — no new shared utilities required.

Test coverage:

- **319 cases** ported 1:1 from upstream (`alwaysValid` + `recommendedExtraValid` + `neverValid` + `strictExtraInvalid`), organized into `:recommended` / `:strict` suites.
- **72 cases** of extras across 10 test functions covering tsgo AST wrapper shapes (`as` / `satisfies` / `!` / paren / HTML entity), role-string boundaries (case-folding, multi-space split, invalid-then-valid), option robustness (empty array / non-array / mixed types / key case), React container forms (Fragment / ternary / map / arrow / paren), interactive-element gate (`<a>` href dependency), and real-world mixed attribute patterns.

Validated against `web-infra-dev/rsbuild` (0 errors) and `web-infra-dev/rspack` (0 errors — 2 `<svg role="img">` correctly skipped by `!dom.has('svg')` gate).

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-interactive-element-to-noninteractive-role.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/no-interactive-element-to-noninteractive-role.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).