### PR TITLE
feat: align jsx-a11y preset with eslint-plugin-jsx-a11y@6.10.x recommended

### DIFF
--- a/packages/rslint/src/configs/jsx-a11y.ts
+++ b/packages/rslint/src/configs/jsx-a11y.ts
@@ -1,6 +1,6 @@
 import type { RslintConfigEntry } from '../define-config.js';
 
-// Aligned with official eslint-plugin-jsx-a11y@6.x recommended.
+// Aligned with official eslint-plugin-jsx-a11y@6.10.x recommended.
 // Rules commented out with "not implemented" are in the official preset but not yet available.
 const recommended: RslintConfigEntry = {
   files: ['**/*.jsx', '**/*.tsx'],
@@ -10,29 +10,101 @@ const recommended: RslintConfigEntry = {
     // 'jsx-a11y/anchor-ambiguous-text': 'off', // not implemented (off in upstream)
     'jsx-a11y/anchor-has-content': 'error',
     'jsx-a11y/anchor-is-valid': 'error',
-    // 'jsx-a11y/aria-activedescendant-has-tabindex': 'error', // not implemented
-    // 'jsx-a11y/aria-props': 'error', // not implemented
-    // 'jsx-a11y/aria-proptypes': 'error', // not implemented
-    // 'jsx-a11y/aria-role': 'error', // not implemented
+    'jsx-a11y/aria-activedescendant-has-tabindex': 'error',
+    'jsx-a11y/aria-props': 'error',
+    'jsx-a11y/aria-proptypes': 'error',
+    'jsx-a11y/aria-role': 'error',
     'jsx-a11y/aria-unsupported-elements': 'error',
     'jsx-a11y/autocomplete-valid': 'error',
-    // 'jsx-a11y/click-events-have-key-events': 'error', // not implemented
-    // 'jsx-a11y/control-has-associated-label': 'off', // not implemented (off in upstream)
+    'jsx-a11y/click-events-have-key-events': 'error',
+    'jsx-a11y/control-has-associated-label': 'off',
     'jsx-a11y/heading-has-content': 'error',
     'jsx-a11y/html-has-lang': 'error',
     'jsx-a11y/iframe-has-title': 'error',
     'jsx-a11y/img-redundant-alt': 'error',
-    // 'jsx-a11y/interactive-supports-focus': 'error', // not implemented
-    // 'jsx-a11y/label-has-associated-control': 'error', // not implemented
+    'jsx-a11y/interactive-supports-focus': [
+      'error',
+      {
+        tabbable: [
+          'button',
+          'checkbox',
+          'link',
+          'searchbox',
+          'spinbutton',
+          'switch',
+          'textbox',
+        ],
+      },
+    ],
+    'jsx-a11y/label-has-associated-control': 'error',
     // 'jsx-a11y/label-has-for': 'off', // not implemented (off in upstream)
     'jsx-a11y/media-has-caption': 'error',
-    // 'jsx-a11y/mouse-events-have-key-events': 'error', // not implemented
+    'jsx-a11y/mouse-events-have-key-events': 'error',
     'jsx-a11y/no-access-key': 'error',
     'jsx-a11y/no-autofocus': 'error',
     'jsx-a11y/no-distracting-elements': 'error',
-    // 'jsx-a11y/no-interactive-element-to-noninteractive-role': 'error', // not implemented
-    // 'jsx-a11y/no-noninteractive-element-interactions': 'error', // not implemented
-    // 'jsx-a11y/no-noninteractive-element-to-interactive-role': 'error', // not implemented
+    'jsx-a11y/no-interactive-element-to-noninteractive-role': [
+      'error',
+      {
+        tr: ['none', 'presentation'],
+        canvas: ['img'],
+      },
+    ],
+    'jsx-a11y/no-noninteractive-element-interactions': [
+      'error',
+      {
+        handlers: [
+          'onClick',
+          'onError',
+          'onLoad',
+          'onMouseDown',
+          'onMouseUp',
+          'onKeyPress',
+          'onKeyDown',
+          'onKeyUp',
+        ],
+        alert: ['onKeyUp', 'onKeyDown', 'onKeyPress'],
+        body: ['onError', 'onLoad'],
+        dialog: ['onKeyUp', 'onKeyDown', 'onKeyPress'],
+        iframe: ['onError', 'onLoad'],
+        img: ['onError', 'onLoad'],
+      },
+    ],
+    'jsx-a11y/no-noninteractive-element-to-interactive-role': [
+      'error',
+      {
+        ul: [
+          'listbox',
+          'menu',
+          'menubar',
+          'radiogroup',
+          'tablist',
+          'tree',
+          'treegrid',
+        ],
+        ol: [
+          'listbox',
+          'menu',
+          'menubar',
+          'radiogroup',
+          'tablist',
+          'tree',
+          'treegrid',
+        ],
+        li: [
+          'menuitem',
+          'menuitemradio',
+          'menuitemcheckbox',
+          'option',
+          'row',
+          'tab',
+          'treeitem',
+        ],
+        table: ['grid'],
+        td: ['gridcell'],
+        fieldset: ['radiogroup', 'presentation'],
+      },
+    ],
     'jsx-a11y/no-noninteractive-tabindex': [
       'error',
       {
@@ -42,9 +114,22 @@ const recommended: RslintConfigEntry = {
       },
     ],
     'jsx-a11y/no-redundant-roles': 'error',
-    // 'jsx-a11y/no-static-element-interactions': 'error', // not implemented
-    // 'jsx-a11y/role-has-required-aria-props': 'error', // not implemented
-    // 'jsx-a11y/role-supports-aria-props': 'error', // not implemented
+    'jsx-a11y/no-static-element-interactions': [
+      'error',
+      {
+        allowExpressionValues: true,
+        handlers: [
+          'onClick',
+          'onMouseDown',
+          'onMouseUp',
+          'onKeyPress',
+          'onKeyDown',
+          'onKeyUp',
+        ],
+      },
+    ],
+    'jsx-a11y/role-has-required-aria-props': 'error',
+    'jsx-a11y/role-supports-aria-props': 'error',
     'jsx-a11y/scope': 'error',
     'jsx-a11y/tabindex-no-positive': 'error',
   },


### PR DESCRIPTION
## Summary

Aligns `packages/rslint/src/configs/jsx-a11y.ts` (`recommended`) with the upstream `eslint-plugin-jsx-a11y@6.10.x` recommended preset:

- Enables 12 rules that were previously commented out as `not implemented` but are now ported (`aria-activedescendant-has-tabindex`, `aria-props`, `aria-proptypes`, `aria-role`, `click-events-have-key-events`, `interactive-supports-focus`, `label-has-associated-control`, `mouse-events-have-key-events`, `no-interactive-element-to-noninteractive-role`, `no-noninteractive-element-interactions`, `no-noninteractive-element-to-interactive-role`, `no-static-element-interactions`, `role-has-required-aria-props`, `role-supports-aria-props`).
- Mirrors upstream's recommended option defaults verbatim for the 5 rules that ship with non-trivial config (`interactive-supports-focus.tabbable`, the per-element role/handler maps for the `no-(non)interactive-element-*` rules, `no-static-element-interactions.{handlers,allowExpressionValues}`).
- Sets `control-has-associated-label` to `'off'` explicitly to match upstream's intentional disable. Options are not aligned for off rules.
- Leaves `anchor-ambiguous-text` and `label-has-for` commented (still not implemented; upstream sets both to `'off'`).

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).