### PR TITLE
test: share TypeScript program across rule_tester cases

### DIFF
--- a/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus_extras_test.go
@@ -62,7 +62,7 @@ func extrasFocusableSuggestionsTwo(outZero, outNegOne string) []rule_tester.Inva
 // file — tsgo↔ESTree AST differences, position assertions, configuration
 // edges, and lock-ins for branches the upstream suite doesn't exercise.
 func TestInteractiveSupportsFocusExtras(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &InteractiveSupportsFocusRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &InteractiveSupportsFocusRule,
 		[]rule_tester.ValidTestCase{
 			// ---- Custom (non-DOM) components — rule bails at the `dom.has(type)` gate.
 			{Code: `<MyComp role="button" onClick={() => {}} />`, Tsx: true},

--- a/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus_upstream_test.go
@@ -379,7 +379,7 @@ func TestInteractiveSupportsFocusUpstreamRecommended(t *testing.T) {
 	invalid = append(invalid, applyOptionsInvalid(failCases(recommendedTabbable, triggeringHandlers, tabbableMessage), opts)...)
 	invalid = append(invalid, applyOptionsInvalid(failCases(filterRoles(interactiveRolesForTests, recommendedTabbable), triggeringHandlers, focusableMessage), opts)...)
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &InteractiveSupportsFocusRule, valid, invalid)
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &InteractiveSupportsFocusRule, valid, invalid)
 }
 
 // TestInteractiveSupportsFocusUpstreamStrict mirrors upstream's
@@ -396,5 +396,5 @@ func TestInteractiveSupportsFocusUpstreamStrict(t *testing.T) {
 	invalid = append(invalid, applyOptionsInvalid(failCases(strictTabbable, triggeringHandlers, tabbableMessage), opts)...)
 	invalid = append(invalid, applyOptionsInvalid(failCases(filterRoles(interactiveRolesForTests, strictTabbable), triggeringHandlers, focusableMessage), opts)...)
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &InteractiveSupportsFocusRule, valid, invalid)
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &InteractiveSupportsFocusRule, valid, invalid)
 }

--- a/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role_extras_test.go
@@ -13,7 +13,7 @@ import (
 // makes the report range cover `role="…"`, so a multi-line opening tag
 // still anchors the report on the role attribute's line / column.
 func TestNoInteractiveElementToNoninteractiveRolePositions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
 		// Self-closing — report on `role="img"` between `href="…"` and `/>`.
 		{
 			Code: `<a href="http://x.y.z" role="img" />`,
@@ -64,7 +64,7 @@ func TestNoInteractiveElementToNoninteractiveRolePositions(t *testing.T) {
 // `role` — nested JSX hierarchies produce one report per qualifying
 // ancestor, with each report anchored on its own role attribute.
 func TestNoInteractiveElementToNoninteractiveRoleListenerBoundary(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
 		// Two nested interactive-with-noninteractive-role elements — both
 		// should report independently.
 		{
@@ -94,7 +94,7 @@ func TestNoInteractiveElementToNoninteractiveRoleListenerBoundary(t *testing.T) 
 // boolean / non-literal / template shapes around the `role` attribute
 // exercise corners upstream tests rarely cover.
 func TestNoInteractiveElementToNoninteractiveRoleEdgeShapes(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Boolean form `<a href="x" role />` — `getLiteralPropValue`
 			// returns boolean true, not a string. Both
@@ -165,7 +165,7 @@ func TestNoInteractiveElementToNoninteractiveRoleEdgeShapes(t *testing.T) {
 // `[]interface{}` would silently fall back to defaults on every CLI
 // invocation.
 func TestNoInteractiveElementToNoninteractiveRoleOptionParsing(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Bare map — CLI single-option shape.
 			{
@@ -225,7 +225,7 @@ func TestNoInteractiveElementToNoninteractiveRoleOptionParsing(t *testing.T) {
 // — a regression that strips the wrong wrapper would silently shift the
 // rule's surface (over- or under-reporting). Each row pins one shape.
 func TestNoInteractiveElementToNoninteractiveRoleRoleExpressionShapes(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// `as` / `satisfies` / non-null wrappers map to noop in
 			// jsx-ast-utils' LITERAL_TYPES → null → no classification →
@@ -291,7 +291,7 @@ func TestNoInteractiveElementToNoninteractiveRoleRoleExpressionShapes(t *testing
 //   - multi-space → empty internal tokens; skipped
 //   - invalid-then-valid → invalid token skipped, valid wins
 func TestNoInteractiveElementToNoninteractiveRoleRoleStringBoundaries(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Empty role string — no valid role token → no classification.
 			{Code: `<a href="x" role="" />`, Tsx: true},
@@ -356,7 +356,7 @@ func TestNoInteractiveElementToNoninteractiveRoleRoleStringBoundaries(t *testing
 //   - option key case mismatch (`{TR: [...]}` vs tag `<tr>`) — does NOT match
 //   - option role-value case mismatch (`{tr: ["Presentation"]}` vs `role="presentation"`)
 func TestNoInteractiveElementToNoninteractiveRoleOptionRobustness(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Mixed-type array — only "presentation" survives, exempting
 			// the case.
@@ -416,7 +416,7 @@ func TestNoInteractiveElementToNoninteractiveRoleOptionRobustness(t *testing.T) 
 // expression context. A regression that hooked into `JsxOpeningElement`
 // rather than `JsxAttribute` would silently drop these.
 func TestNoInteractiveElementToNoninteractiveRoleContainerForms(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule, []rule_tester.ValidTestCase{},
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule, []rule_tester.ValidTestCase{},
 		[]rule_tester.InvalidTestCase{
 			// Inside a JsxFragment (`<>…</>`).
 			{
@@ -463,7 +463,7 @@ func TestNoInteractiveElementToNoninteractiveRoleContainerForms(t *testing.T) {
 // suite locks `<a>`'s href-dependency separately because it's the most
 // common case the schema gate decides on.
 func TestNoInteractiveElementToNoninteractiveRoleInteractiveGate(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// `<a>` without `href` — schema gate fails →
 			// `IsInteractiveElement` returns false → no report.
@@ -508,7 +508,7 @@ func TestNoInteractiveElementToNoninteractiveRoleInteractiveGate(t *testing.T) {
 // lists could mishandle. Each case is a "looks like real code" pattern
 // users would actually write.
 func TestNoInteractiveElementToNoninteractiveRoleMixedRealWorld(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Interactive role + event handlers + className mixed — no
 			// non-interactive role anywhere; not reported.

--- a/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role_upstream_test.go
@@ -464,7 +464,7 @@ func TestNoInteractiveElementToNoninteractiveRoleUpstreamRecommended(t *testing.
 
 	invalid := applyOptionsInvalid(neverValid(), recommendedConfig)
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t,
 		&NoInteractiveElementToNoninteractiveRoleRule, valid, invalid)
 }
 
@@ -478,6 +478,6 @@ func TestNoInteractiveElementToNoninteractiveRoleUpstreamStrict(t *testing.T) {
 	invalid := append([]rule_tester.InvalidTestCase{}, neverValid()...)
 	invalid = append(invalid, strictExtraInvalid()...)
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t,
 		&NoInteractiveElementToNoninteractiveRoleRule, valid, invalid)
 }

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions_extras_test.go
@@ -73,7 +73,7 @@ var componentsMapSettings = map[string]interface{}{
 // upstream's test file doesn't exercise but are reachable through the
 // rule's listener gate.
 func TestNoNoninteractiveElementInteractionsExtras(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t,
 		&NoNoninteractiveElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// ============================================================

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions_upstream_test.go
@@ -575,7 +575,7 @@ func TestNoNoninteractiveElementInteractionsUpstreamRecommended(t *testing.T) {
 
 	invalid := applyOptionsInvalid(neverValid(), recommendedConfig)
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t,
 		&NoNoninteractiveElementInteractionsRule, valid, invalid)
 }
 
@@ -589,6 +589,6 @@ func TestNoNoninteractiveElementInteractionsUpstreamStrict(t *testing.T) {
 	invalid = append(invalid, strictExtraInvalid()...)
 	invalid = applyOptionsInvalid(invalid, strictConfig)
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t,
 		&NoNoninteractiveElementInteractionsRule, valid, invalid)
 }

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role_extras_test.go
@@ -15,7 +15,7 @@ import (
 // makes the report range cover `role="…"`, so a multi-line opening tag
 // still anchors the report on the role attribute's line / column.
 func TestNoNoninteractiveElementToInteractiveRolePositions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
 		// Self-closing — report on `role="button"` between the tag name and `/>`.
 		{
 			Code: `<article role="button" />`,
@@ -66,7 +66,7 @@ func TestNoNoninteractiveElementToInteractiveRolePositions(t *testing.T) {
 // nested JSX hierarchies produce one report per qualifying ancestor, with
 // each report anchored on its own role attribute.
 func TestNoNoninteractiveElementToInteractiveRoleListenerBoundary(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
 		// Two nested non-interactive-with-interactive-role elements — both
 		// should report independently.
 		{
@@ -96,7 +96,7 @@ func TestNoNoninteractiveElementToInteractiveRoleListenerBoundary(t *testing.T) 
 // boolean / non-literal / template shapes around the `role` attribute
 // exercise corners upstream tests rarely cover.
 func TestNoNoninteractiveElementToInteractiveRoleEdgeShapes(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Boolean form `<article role />` — `getLiteralPropValue`
 			// returns boolean true, not a string. `IsInteractiveRole`
@@ -167,7 +167,7 @@ func TestNoNoninteractiveElementToInteractiveRoleEdgeShapes(t *testing.T) {
 // `[]interface{}` would silently fall back to defaults on every CLI
 // invocation.
 func TestNoNoninteractiveElementToInteractiveRoleOptionParsing(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Bare map — CLI single-option shape.
 			{
@@ -223,7 +223,7 @@ func TestNoNoninteractiveElementToInteractiveRoleOptionParsing(t *testing.T) {
 // the rule's behavior across every tsgo-specific wrapper around a
 // `role={…}` expression value. Each row pins one shape.
 func TestNoNoninteractiveElementToInteractiveRoleRoleExpressionShapes(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// `as` / `satisfies` / non-null wrappers map to noop in
 			// jsx-ast-utils' LITERAL_TYPES → null → no classification.
@@ -275,7 +275,7 @@ func TestNoNoninteractiveElementToInteractiveRoleRoleExpressionShapes(t *testing
 // valid role wins" produces several non-obvious classifications that a
 // Go re-implementation could easily flip.
 func TestNoNoninteractiveElementToInteractiveRoleRoleStringBoundaries(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Empty role string — no valid role token → no classification.
 			{Code: `<article role="" />`, Tsx: true},
@@ -341,7 +341,7 @@ func TestNoNoninteractiveElementToInteractiveRoleRoleStringBoundaries(t *testing
 //     lowercasing — `role="Menu"` (lowercases to "menu") matches an
 //     allow-list entry "menu" exactly.
 func TestNoNoninteractiveElementToInteractiveRoleOptionRobustness(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Mixed-type array — only "menu" survives, exempting the case.
 			{
@@ -409,7 +409,7 @@ func TestNoNoninteractiveElementToInteractiveRoleOptionRobustness(t *testing.T) 
 // renders. The rule must fire identically regardless of the surrounding
 // expression context.
 func TestNoNoninteractiveElementToInteractiveRoleContainerForms(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule, []rule_tester.ValidTestCase{},
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule, []rule_tester.ValidTestCase{},
 		[]rule_tester.InvalidTestCase{
 			// Inside a JsxFragment (`<>…</>`).
 			{
@@ -452,7 +452,7 @@ func TestNoNoninteractiveElementToInteractiveRoleContainerForms(t *testing.T) {
 // is lost would either silently flag `<img role="button" />` without alt
 // or silently exempt `<img alt="x" role="button" />` (or the form variants).
 func TestNoNoninteractiveElementToInteractiveRoleNonInteractiveGate(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// `<form>` without aria-label / aria-labelledby / name — schema
 			// gate fails → `IsNonInteractiveElement` returns false (the
@@ -502,7 +502,7 @@ func TestNoNoninteractiveElementToInteractiveRoleNonInteractiveGate(t *testing.T
 // + role ordering — that a rule operating only on simple attribute
 // lists could mishandle.
 func TestNoNoninteractiveElementToInteractiveRoleMixedRealWorld(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Non-interactive role on a non-interactive element — fine.
 			{Code: `<article role="article" className="card" onClick={f} aria-label="Card" />`, Tsx: true},
@@ -566,7 +566,7 @@ func TestNoNoninteractiveElementToInteractiveRoleMixedRealWorld(t *testing.T) {
 //     `getExplicitRole` lowercases before comparing. Sibling rule would
 //     NOT match (raw-value comparison is case-sensitive).
 func TestNoNoninteractiveElementToInteractiveRoleAllowListSemantics(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Uppercase role value — `getExplicitRole` lowercases →
 			// matches "menu" in allow-list. Locks in the upstream
@@ -639,7 +639,7 @@ func TestNoNoninteractiveElementToInteractiveRolePolymorphicSettings(t *testing.
 		},
 	}
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Without settings — `<Box>` is a custom component, no dom.has match.
 			{Code: `<Box as="article" role="button" />`, Tsx: true},
@@ -729,7 +729,7 @@ func TestNoNoninteractiveElementToInteractiveRoleComponentsMappingEdges(t *testi
 		},
 	}
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Map key is case-sensitive — `<article>` (lower) doesn't match
 			// "Article" key in components map; goes through with rawType "article"
@@ -769,7 +769,7 @@ func TestNoNoninteractiveElementToInteractiveRoleComponentsMappingEdges(t *testi
 // statements (or skipped JSX inside callable bodies) would silently
 // miss every JSX inside a real React codebase.
 func TestNoNoninteractiveElementToInteractiveRoleHOCAndComponentBodies(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{},
 		[]rule_tester.InvalidTestCase{
 			// forwardRef arrow body.
@@ -838,7 +838,7 @@ func TestNoNoninteractiveElementToInteractiveRoleHOCAndComponentBodies(t *testin
 // container with a header, body, and footer, each containing its own
 // nested JSX.
 func TestNoNoninteractiveElementToInteractiveRoleDeepNesting(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule, []rule_tester.ValidTestCase{},
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule, []rule_tester.ValidTestCase{},
 		[]rule_tester.InvalidTestCase{
 			// 4 violations across 5 nested levels (Card → CardHeader → h1;
 			// Card → CardBody → article → h2; Card → CardFooter → ul → li).
@@ -918,7 +918,7 @@ func TestNoNoninteractiveElementToInteractiveRoleDeepNesting(t *testing.T) {
 // report per matching JsxAttribute regardless of the surrounding control
 // flow's static reachability.
 func TestNoNoninteractiveElementToInteractiveRoleConditionalRendering(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule, []rule_tester.ValidTestCase{},
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule, []rule_tester.ValidTestCase{},
 		[]rule_tester.InvalidTestCase{
 			// `&&` short-circuit.
 			{
@@ -997,7 +997,7 @@ func TestNoNoninteractiveElementToInteractiveRoleConditionalRendering(t *testing
 // to a string by mistake (silently changing classification) — `as`,
 // `satisfies`, JSX generic type parameters, TS const assertions, etc.
 func TestNoNoninteractiveElementToInteractiveRoleTSXTypeSystemShapes(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// `as` casting the whole JSX element — outer cast doesn't affect
 			// rule (rule fires on attribute regardless).
@@ -1065,7 +1065,7 @@ func TestNoNoninteractiveElementToInteractiveRoleTSXTypeSystemShapes(t *testing.
 // probes a different unicode shape that could classify differently
 // under a Go reimplementation.
 func TestNoNoninteractiveElementToInteractiveRoleUnicodeInRoleValue(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// CJK in role — not a real ARIA role → no classification.
 			{Code: `<article role="按钮" />`, Tsx: true},
@@ -1122,7 +1122,7 @@ func TestNoNoninteractiveElementToInteractiveRoleAllowListMultiTag(t *testing.T)
 		"fieldset": []interface{}{"radiogroup"},
 	}
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// Each tag exempts only its own configured roles.
 			{Code: `<ul role="menu" />`, Tsx: true, Options: multiTagAllowList},
@@ -1174,7 +1174,7 @@ func TestNoNoninteractiveElementToInteractiveRoleAllowListMultiTag(t *testing.T)
 // subset. A regression in [interactiveRolesSet] / [allRolesSet] (e.g.,
 // loss of DPub interactive roles) would silently let these slip past.
 func TestNoNoninteractiveElementToInteractiveRoleExtendedRoleClassification(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
 			// DPub non-interactive on non-interactive element — no report.
 			{Code: `<article role="doc-chapter" />`, Tsx: true},

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role_upstream_test.go
@@ -567,7 +567,7 @@ func TestNoNoninteractiveElementToInteractiveRoleUpstreamRecommended(t *testing.
 
 	invalid := applyOptionsInvalid(neverValid(), recommendedConfig)
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t,
 		&NoNoninteractiveElementToInteractiveRoleRule, valid, invalid)
 }
 
@@ -581,6 +581,6 @@ func TestNoNoninteractiveElementToInteractiveRoleUpstreamStrict(t *testing.T) {
 	invalid := append([]rule_tester.InvalidTestCase{}, neverValid()...)
 	invalid = append(invalid, recommendedStrictDelta()...)
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t,
 		&NoNoninteractiveElementToInteractiveRoleRule, valid, invalid)
 }

--- a/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions_extras_test.go
@@ -15,7 +15,7 @@ import (
 // matching `>` / `/>`. Two cases per shape: a single-line baseline and a
 // multi-line variant where the opening tag spans several lines.
 func TestNoStaticElementInteractionsPositions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
 		// Self-closing — report spans <div … />.
 		{
 			Code: `<div onClick={() => {}} />`,
@@ -66,7 +66,7 @@ func TestNoStaticElementInteractionsPositions(t *testing.T) {
 // "bleeds" the outer report into the inner traversal (or vice versa)
 // would silently fold them into one diagnostic.
 func TestNoStaticElementInteractionsListenerBoundary(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
 		// Three levels of nesting; outer + middle + inner each report.
 		{
 			Code: "<div onClick={() => {}}>\n  <span onClick={() => {}}>\n    <a onClick={() => {}} />\n  </span>\n</div>",
@@ -107,7 +107,7 @@ func TestNoStaticElementInteractionsHandlersOption(t *testing.T) {
 		},
 	}
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// onClick is NOT in the custom handler list → no interactive prop.
 			{Code: `<div onClick={() => {}} />`, Tsx: true, Options: customHandlersBareObject},
@@ -165,7 +165,7 @@ func TestNoStaticElementInteractionsAllowExpressionValuesMatrix(t *testing.T) {
 	allowTrue := map[string]interface{}{"allowExpressionValues": true}
 	allowFalse := map[string]interface{}{"allowExpressionValues": false}
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// Identifier → non-literal → allowed.
 			{Code: `<div role={ROLE} onClick={() => {}} />`, Tsx: true, Options: allowTrue},
@@ -222,7 +222,7 @@ func TestNoStaticElementInteractionsAllowExpressionValuesMatrix(t *testing.T) {
 // TestNoStaticElementInteractionsEdgeShapes locks the Dimension-4 universal
 // edge shapes our prep walk identified.
 func TestNoStaticElementInteractionsEdgeShapes(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// `onClick={undefined}` — upstream `getPropValue` resolves to JS
 			// undefined → `!= null` is false → no interactive prop → exempt.
@@ -319,7 +319,7 @@ func TestNoStaticElementInteractionsEdgeShapes(t *testing.T) {
 // (matches the multi-element rule_tester shape). Also covers nil / empty /
 // malformed shapes so a future refactor of parseOptions can't regress them.
 func TestNoStaticElementInteractionsOptionParsing(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// nil options — defaults: full focus+keyboard+mouse handlers,
 			// allowExpressionValues=falsy. Validates the "options absent"
@@ -372,7 +372,7 @@ func TestNoStaticElementInteractionsOptionParsing(t *testing.T) {
 // is expected to look through these wrappers; the explicit cases protect
 // against a regression where the wrapper unwrap is skipped.
 func TestNoStaticElementInteractionsTSWrappers(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// Function-cast handler resolves to a non-null function → upstream
 			// reports, but the element is `<button>` (inherently interactive) → exempt.
@@ -425,7 +425,7 @@ func TestNoStaticElementInteractionsTSWrappers(t *testing.T) {
 // upstream test file. Each test below names the upstream code branch it
 // pins; a future refactor that flips the branch behavior fails these tests.
 func TestNoStaticElementInteractionsUpstreamBranchLockIns(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// Locks in upstream `hasInteractiveProps` short-circuit arm
 			// `getPropValue(...) != null` — even though `<div onChange={x} />`
@@ -513,7 +513,7 @@ func TestNoStaticElementInteractionsUpstreamBranchLockIns(t *testing.T) {
 // ConditionalExpression (eager-eval the matched arm), and NonNullExpression
 // (string of inner + "!"). NewExpression / Object / Array map to truthy.
 func TestNoStaticElementInteractionsRealHandlerShapes(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// `cond ? null : null` — both arms null; ConditionalExpression
 			// statically evaluates the truthy arm (cond resolves truthy as
@@ -686,7 +686,7 @@ func TestNoStaticElementInteractionsPolymorphicSettings(t *testing.T) {
 		},
 	}
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// `<Foo as="button">` — resolves to "button" (interactive) → exempt.
 			{Code: `<Foo as="button" onClick={() => {}} />`, Tsx: true, Settings: asPolymorphic},
@@ -760,7 +760,7 @@ func TestNoStaticElementInteractionsComponentsRemapping(t *testing.T) {
 		},
 	}
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// MyButton → button (inherently interactive).
 			{Code: `<MyButton onClick={() => {}} />`, Tsx: true, Settings: componentsMap},
@@ -814,7 +814,7 @@ func TestNoStaticElementInteractionsComponentsRemapping(t *testing.T) {
 // per-role level — not the cross-class interaction (e.g. abstract role
 // listed first vs second) or the case-sensitivity boundary.
 func TestNoStaticElementInteractionsRoleSemantics(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// Mixed-case roles — upstream lowercases before lookup.
 			{Code: `<div role="Button" onClick={() => {}} />`, Tsx: true},
@@ -874,7 +874,7 @@ func TestNoStaticElementInteractionsRoleSemantics(t *testing.T) {
 // upstream's strict comparison, so only the actual JS boolean true (or
 // jsxAstUtilsLiteralCoerce'd "true"/boolean-form) exempts.
 func TestNoStaticElementInteractionsAriaHiddenVariants(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// Boolean form, expression, string-coerced — all exempt.
 			{Code: `<div onClick={() => {}} aria-hidden />`, Tsx: true},
@@ -932,7 +932,7 @@ func TestNoStaticElementInteractionsAriaHiddenVariants(t *testing.T) {
 // no-static-element-interactions because IsInteractiveElement returns
 // true → step 3 of the rule short-circuits.
 func TestNoStaticElementInteractionsInputSchemaVariants(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// `<input>` with no `type` — the input schema is matched via
 			// `{name: "input"}` schemas (multiple schemas with attribute
@@ -981,7 +981,7 @@ func TestNoStaticElementInteractionsInputSchemaVariants(t *testing.T) {
 // non-null combinations across different handler names exercise the
 // short-circuit boundary.
 func TestNoStaticElementInteractionsMultiHandlerCombinations(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// All handlers null — no match anywhere.
 			{Code: `<div onClick={null} onMouseDown={null} onKeyDown={null} />`, Tsx: true},
@@ -1039,7 +1039,7 @@ func TestNoStaticElementInteractionsMultiHandlerCombinations(t *testing.T) {
 // element, leaving the wrapper / fragment / Generic / conditional shell
 // untouched.
 func TestNoStaticElementInteractionsJsxStructuralEdgeCases(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// Empty fragment — listener doesn't fire on fragment opening.
 			{Code: `<></>`, Tsx: true},
@@ -1122,7 +1122,7 @@ func TestNoStaticElementInteractionsJsxStructuralEdgeCases(t *testing.T) {
 // cover `<a href="http://...">` and bare `<a>`; the value-shape boundary
 // (empty string, null/undefined value, boolean form, expression) is on us.
 func TestNoStaticElementInteractionsAnchorSchemaVariants(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule,
 		[]rule_tester.ValidTestCase{
 			// Plain URL.
 			{Code: `<a href="/" onClick={() => {}} />`, Tsx: true},

--- a/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions_upstream_test.go
@@ -89,7 +89,7 @@ var allowExpressionValuesFalseOptions = []interface{}{
 // listener-boundary repeats, options JSON-path matrix, etc. — lives in
 // no_static_element_interactions_extras_test.go.
 func TestNoStaticElementInteractionsUpstream(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &NoStaticElementInteractionsRule, []rule_tester.ValidTestCase{
 		// ============================================================
 		// alwaysValid (run under both :recommended and :strict)
 		// ============================================================

--- a/internal/plugins/jsx_a11y/rules/role_supports_aria_props/role_supports_aria_props_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/role_supports_aria_props/role_supports_aria_props_extras_test.go
@@ -31,7 +31,7 @@ var polymorphicSettings = map[string]interface{}{
 // lock-in tests for each branch in the upstream `JSXOpeningElement`
 // listener that the upstream test file leaves uncovered.
 func TestRoleSupportsAriaPropsExtras(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RoleSupportsAriaPropsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &RoleSupportsAriaPropsRule,
 		[]rule_tester.ValidTestCase{
 			// ============================================================
 			// Step 3 — non-string / non-literal role values short-circuit.
@@ -387,7 +387,7 @@ var componentsAndPolymorphic = map[string]interface{}{
 // Each group lives behind a comment marker `============= GROUP X =============`;
 // individual cases name the upstream branch / scenario / quirk they protect.
 func TestRoleSupportsAriaPropsRobust(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RoleSupportsAriaPropsRule,
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &RoleSupportsAriaPropsRule,
 		[]rule_tester.ValidTestCase{
 			// =============================================================
 			// GROUP A — Real-world component patterns. Designed around

--- a/internal/plugins/jsx_a11y/rules/role_supports_aria_props/role_supports_aria_props_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/role_supports_aria_props/role_supports_aria_props_upstream_test.go
@@ -825,5 +825,5 @@ func TestRoleSupportsAriaPropsUpstream(t *testing.T) {
 	valid = append(valid, gv...)
 	invalid = append(invalid, gi...)
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RoleSupportsAriaPropsRule, valid, invalid)
+	rule_tester.RunRuleTesterBatched(fixtures.GetRootDir(), "tsconfig.json", t, &RoleSupportsAriaPropsRule, valid, invalid)
 }

--- a/internal/rule_tester/rule_tester_batched.go
+++ b/internal/rule_tester/rule_tester_batched.go
@@ -1,0 +1,311 @@
+// cspell:ignore batchable subtest
+package rule_tester
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"gotest.tools/v3/assert"
+)
+
+// RunRuleTesterBatched is a drop-in replacement for RunRuleTester that
+// amortizes the cost of building TypeScript programs across every test case.
+//
+// Mechanism:
+//
+//  1. Every batchable case (no custom FileName / TSConfig) is written into a
+//     single shared overlay VFS as a uniquely-named file under rootDir.
+//  2. We build ONE program containing the lib + all case files.
+//  3. We run linter.RunLinter ONCE with Scope.Dirs = [rootDir]. This uses
+//     the framework's existing fast path (isDirAllowed — pure prefix check,
+//     no os.Stat), so the per-call cost stays O(N) instead of the O(N²)
+//     blow-up that Scope.Files triggers via its os.Stat fallback.
+//  4. OnDiagnostic routes each diagnostic into a map keyed by SourceFile
+//     path. Each subtest then looks up its own diagnostics from this map.
+//
+// Falls back to per-case standalone build for cases with custom FileName /
+// TSConfig, and for the 2nd+ iteration of auto-fix loops (post-fix source
+// no longer matches the overlay).
+func RunRuleTesterBatched(rootDir string, tsconfigPath string, t *testing.T, r *rule.Rule, validTestCases []ValidTestCase, invalidTestCases []InvalidTestCase) {
+	t.Parallel()
+
+	onlyMode := slices.ContainsFunc(validTestCases, func(c ValidTestCase) bool { return c.Only }) ||
+		slices.ContainsFunc(invalidTestCases, func(c InvalidTestCase) bool { return c.Only })
+
+	type caseRef struct {
+		kind     string // "v" or "i"
+		idx      int
+		options  any
+		settings map[string]interface{}
+	}
+
+	overlay := make(map[string]string)
+	pathToCase := make(map[string]caseRef)
+	validPaths := make([]string, len(validTestCases))
+	invalidPaths := make([]string, len(invalidTestCases))
+
+	for i, c := range validTestCases {
+		if c.FileName != "" || c.TSConfig != "" {
+			continue
+		}
+		p := batchedFilePath(rootDir, "v", i, c.Tsx)
+		overlay[p] = c.Code
+		validPaths[i] = p
+		pathToCase[p] = caseRef{kind: "v", idx: i, options: c.Options, settings: c.Settings}
+	}
+	for i, c := range invalidTestCases {
+		if c.FileName != "" || c.TSConfig != "" {
+			continue
+		}
+		p := batchedFilePath(rootDir, "i", i, c.Tsx)
+		overlay[p] = c.Code
+		invalidPaths[i] = p
+		pathToCase[p] = caseRef{kind: "i", idx: i, options: c.Options, settings: c.Settings}
+	}
+
+	diagsByPath := make(map[string][]rule.RuleDiagnostic)
+	sharedLintOk := false
+
+	if len(overlay) > 0 {
+		fs := utils.NewOverlayVFS(bundled.WrapFS(osvfs.FS()), overlay)
+		host := utils.CreateCompilerHost(rootDir, fs)
+		program, err := utils.CreateProgram(true, fs, rootDir, tsconfigPath, host)
+		if err != nil {
+			t.Logf("RunRuleTesterBatched: shared program build failed, falling back per-case: %v", err)
+		} else {
+			var mu sync.Mutex
+			_, lintErr := linter.RunLinter(linter.RunLinterOptions{
+				Programs:       []*compiler.Program{program},
+				SingleThreaded: true,
+				// Scope.Dirs uses the framework's tspath.StartsWithDirectory
+				// prefix check — no os.Stat fallback, so walk cost is O(N)
+				// over program files rather than O(N) per case.
+				Scope:        linter.FileScope{Dirs: []string{rootDir}},
+				ExcludePaths: []string{},
+				GetRulesForFile: func(sf *ast.SourceFile) []linter.ConfiguredRule {
+					ref, ok := pathToCase[sf.FileName()]
+					if !ok {
+						// Real fixture files (empty react.tsx / file.ts)
+						// or anything else under rootDir that's not one of
+						// our virtual cases — no rule, no diagnostics.
+						return nil
+					}
+					caseOptions := ref.options
+					caseSettings := ref.settings
+					return []linter.ConfiguredRule{{
+						Name:     "test",
+						Settings: caseSettings,
+						Severity: rule.SeverityError,
+						Run: func(ctx rule.RuleContext) rule.RuleListeners {
+							return r.Run(ctx, caseOptions)
+						},
+					}}
+				},
+				OnDiagnostic: func(d rule.RuleDiagnostic) {
+					mu.Lock()
+					defer mu.Unlock()
+					p := d.SourceFile.FileName()
+					diagsByPath[p] = append(diagsByPath[p], d)
+				},
+			})
+			assert.NilError(t, lintErr, "error running shared linter")
+			sharedLintOk = true
+		}
+	}
+
+	canBatchValid := func(i int, c ValidTestCase) bool {
+		return sharedLintOk && validPaths[i] != "" && c.TSConfig == "" && c.FileName == ""
+	}
+	canBatchInvalid := func(i int, c InvalidTestCase) bool {
+		return sharedLintOk && invalidPaths[i] != "" && c.TSConfig == "" && c.FileName == ""
+	}
+
+	lintStandalone := func(t *testing.T, code string, options any, settings map[string]interface{}, tsconfigOverride, fileName string) []rule.RuleDiagnostic {
+		var mu sync.Mutex
+		out := make([]rule.RuleDiagnostic, 0, 3)
+
+		fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+		host := utils.CreateCompilerHost(rootDir, fs)
+
+		tsc := tsconfigPath
+		if tsconfigOverride != "" {
+			tsc = tsconfigOverride
+		}
+
+		program, err := utils.CreateProgram(true, fs, rootDir, tsc, host)
+		assert.NilError(t, err, "couldn't create program. code: "+code)
+
+		sf := program.GetSourceFile(fileName)
+		_, err = linter.RunLinter(linter.RunLinterOptions{
+			Programs:       []*compiler.Program{program},
+			SingleThreaded: true,
+			Scope:          linter.FileScope{Files: []string{sf.FileName()}},
+			ExcludePaths:   []string{},
+			GetRulesForFile: func(sf *ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     "test",
+					Settings: settings,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return r.Run(ctx, options)
+					},
+				}}
+			},
+			OnDiagnostic: func(d rule.RuleDiagnostic) {
+				mu.Lock()
+				defer mu.Unlock()
+				out = append(out, d)
+			},
+		})
+		assert.NilError(t, err, "error running linter (standalone). code:\n", code)
+		return out
+	}
+
+	for i, testCase := range validTestCases {
+		t.Run("valid-"+strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			if (onlyMode && !testCase.Only) || testCase.Skip {
+				t.SkipNow()
+			}
+
+			var diagnostics []rule.RuleDiagnostic
+			if canBatchValid(i, testCase) {
+				diagnostics = diagsByPath[validPaths[i]]
+			} else {
+				fileName := defaultFileName(testCase.Tsx, testCase.FileName)
+				diagnostics = lintStandalone(t, testCase.Code, testCase.Options, testCase.Settings, testCase.TSConfig, fileName)
+			}
+
+			if len(diagnostics) != 0 {
+				t.Errorf("Expected valid test case not to contain errors. Code:\n%v", testCase.Code)
+				for j, d := range diagnostics {
+					t.Errorf("error %v - (%v-%v) %v", j+1, d.Range.Pos(), d.Range.End(), d.Message.Description)
+				}
+				t.FailNow()
+			}
+		})
+	}
+
+	for i, testCase := range invalidTestCases {
+		t.Run("invalid-"+strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			if (onlyMode && !testCase.Only) || testCase.Skip {
+				t.SkipNow()
+			}
+
+			fileName := defaultFileName(testCase.Tsx, testCase.FileName)
+
+			var initialDiagnostics []rule.RuleDiagnostic
+			outputs := make([]string, 0, 1)
+			code := testCase.Code
+
+			for it := range 10 {
+				var diagnostics []rule.RuleDiagnostic
+				if it == 0 && canBatchInvalid(i, testCase) {
+					diagnostics = diagsByPath[invalidPaths[i]]
+				} else {
+					diagnostics = lintStandalone(t, code, testCase.Options, testCase.Settings, testCase.TSConfig, fileName)
+				}
+				if it == 0 {
+					initialDiagnostics = diagnostics
+				}
+
+				fixedCode, _, fixed := linter.ApplyRuleFixes(code, diagnostics)
+				if !fixed {
+					break
+				}
+				code = fixedCode
+				outputs = append(outputs, fixedCode)
+			}
+
+			if len(testCase.Output) == len(outputs) {
+				for j, expected := range testCase.Output {
+					assert.Equal(t, expected, outputs[j], "Expected code after fix")
+				}
+			} else {
+				t.Errorf("Expected to have %v outputs but had %v: %v", len(testCase.Output), len(outputs), outputs)
+			}
+
+			if len(initialDiagnostics) != len(testCase.Errors) {
+				t.Fatalf("Expected invalid test case to contain exactly %v errors (reported %v errors - %v). Code:\n%v", len(testCase.Errors), len(initialDiagnostics), initialDiagnostics, testCase.Code)
+			}
+
+			for ei, expected := range testCase.Errors {
+				diagnostic := initialDiagnostics[ei]
+
+				if expected.MessageId != diagnostic.Message.Id {
+					t.Errorf("Invalid message id %v. Expected %v", diagnostic.Message.Id, expected.MessageId)
+				}
+				if expected.Message != "" && expected.Message != diagnostic.Message.Description {
+					t.Errorf("Invalid message text %q. Expected %q", diagnostic.Message.Description, expected.Message)
+				}
+
+				lineIndex, columnIndex := scanner.GetECMALineAndUTF16CharacterOfPosition(diagnostic.SourceFile, diagnostic.Range.Pos())
+				line, column := lineIndex+1, int(columnIndex)+1
+				endLineIndex, endColumnIndex := scanner.GetECMALineAndUTF16CharacterOfPosition(diagnostic.SourceFile, diagnostic.Range.End())
+				endLine, endColumn := endLineIndex+1, int(endColumnIndex)+1
+
+				if expected.Line != 0 && expected.Line != line {
+					t.Errorf("Error line should be %v. Got %v", expected.Line, line)
+				}
+				if expected.Column != 0 && expected.Column != column {
+					t.Errorf("Error column should be %v. Got %v", expected.Column, column)
+				}
+				if expected.EndLine != 0 && expected.EndLine != endLine {
+					t.Errorf("Error end line should be %v. Got %v", expected.EndLine, endLine)
+				}
+				if expected.EndColumn != 0 && expected.EndColumn != endColumn {
+					t.Errorf("Error end column should be %v. Got %v", expected.EndColumn, endColumn)
+				}
+
+				suggestionsCount := 0
+				if diagnostic.Suggestions != nil {
+					suggestionsCount = len(*diagnostic.Suggestions)
+				}
+				if len(expected.Suggestions) != suggestionsCount {
+					t.Errorf("Expected to have %v suggestions but had %v", len(expected.Suggestions), suggestionsCount)
+				} else {
+					for si, expectedSuggestion := range expected.Suggestions {
+						suggestion := (*diagnostic.Suggestions)[si]
+						if expectedSuggestion.MessageId != suggestion.Message.Id {
+							t.Errorf("Invalid suggestion message id %v. Expected %v", suggestion.Message.Id, expectedSuggestion.MessageId)
+						} else {
+							output, _, _ := linter.ApplyRuleFixes(testCase.Code, []rule.RuleSuggestion{suggestion})
+							assert.Equal(t, expectedSuggestion.Output, output, "Expected code after suggestion fix")
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func batchedFilePath(rootDir, kind string, i int, tsx bool) string {
+	ext := ".ts"
+	if tsx {
+		ext = ".tsx"
+	}
+	return tspath.ResolvePath(rootDir, fmt.Sprintf("__batched_%s_%d%s", kind, i, ext))
+}
+
+func defaultFileName(tsx bool, override string) string {
+	if override != "" {
+		return override
+	}
+	if tsx {
+		return "react.tsx"
+	}
+	return "file.ts"
+}


### PR DESCRIPTION
## Summary

Each `rule_tester` case used to build its own typescript-go program (loads `lib.d.ts` + module resolution from scratch). For Cartesian-product test suites this dominated CI runtime — `jsx-a11y/role-supports-aria-props` alone was **42s** locally, **146s** on Windows CI.

This PR rewrites `RunRuleTesterBatched` to use a **single shared program + single batched lint pass**:

1. Every batchable case is written into a shared overlay VFS as a uniquely-named file under `rootDir`
2. ONE program is built containing the lib + all case files
3. `linter.RunLinter` runs ONCE with `Scope.Dirs = [rootDir]`
4. `OnDiagnostic` routes diagnostics into a `map[path][]Diagnostic`
5. Each subtest looks up its own diagnostics from this map

### Two bottlenecks eliminated using only existing framework API

| Bottleneck | Why it was bad | How the new design removes it |
|---|---|---|
| **B1**: `lib.d.ts` repeated parse/bind | One program per case = one full lib reload per case | Single program → lib loaded once. typescript-go's `BindOnce` (`sync.Once`) makes this safe by design. |
| **B2**: linter walk + `os.Stat` fallback | `Scope.Files` triggers `isFileAllowed` → `os.Stat` for every program file that doesn't string-match (N-1 stat fails per lint × N lints = O(N²)) | `Scope.Dirs` routes through `isDirAllowed` — pure `tspath.StartsWithDirectory` prefix check, no `os.Stat`. Walk stays O(N) total, not O(N²). |

**Nothing in `internal/linter` changes.** Both bottlenecks are addressed using public API the framework already exposes.

### Performance (M1 Max, vs original `RunRuleTester`)

| Rule | Cases | Original | New batched | Speedup |
|---|---|---|---|---|
| `role_supports_aria_props` | 6903 | 42.5s | **1.5s** | **27.7x** |
| `interactive_supports_focus` | 2825 | 18.4s | **1.0s** | **18.8x** |
| `no_noninteractive_element_interactions` | 859 | 6.6s | **1.3s** | 5.2x |
| `no_noninteractive_element_to_interactive_role` | 925 | 7.2s | **1.5s** | 5.0x |
| `no_interactive_element_to_noninteractive_role` | 705 | 5.5s | **1.2s** | 4.6x |
| `no_static_element_interactions` | 835 | 6.3s | **1.4s** | 4.6x |
| **Total** | **13,252** | **86.5s** | **7.8s** | **11.07x** |

Speedup scales with case count — large Cartesian-product suites see ~20-28x, smaller suites still see 4-5x. No package regresses.

### Windows expectation

The previous chunk-based version regressed Windows CI (+15min on Test Go Windows). Root cause: each chunk did a fresh lib parse (~22s on Windows) and `Scope.Files` triggered N² `os.Stat` calls. Both are eliminated in this design, so Windows should see the largest absolute gain. Will be verified by this PR's CI run.

### Correctness

`PASS` / `FAIL` / `SKIP` subtest names for all 6 migrated packages (**13,252 subtests**) are **byte-identical** to the original `RunRuleTester` output, verified by `diff`-ing sorted name lists from a strict before/after run (sed-toggled the test files between `RunRuleTester` and `RunRuleTesterBatched`, ran each, diffed). No silent false-passes.

### Fallback paths (unchanged from previous iteration)

Cases that can't share the program transparently degrade to per-case standalone build:
- Test case sets a custom `FileName` or `TSConfig`
- Shared program build fails (e.g. a case has a syntax error that aborts `CreateProgram`)
- 2nd+ iteration of an auto-fix loop (post-fix source no longer matches the overlay)

The 6 migrated rules emit only `RuleSuggestion`, never `RuleFix`, so the auto-fix fallback path is never exercised in practice.

### Rules deliberately NOT migrated

- `prefer_optional_chain`, `prefer_nullish_coalescing` — use `ctx.TypeChecker`. Sharing a program means sharing a checker; lazy-state race risk under `t.Parallel` needs separate validation.
- `one_var`, `prefer_nullish_coalescing` — heavy auto-fix; second fix iteration falls back, defeating most of the savings.

These three account for another ~19s on CI; can be tackled separately once the type-checker concurrency model is verified.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).