### PR TITLE
feat: port rule jsx-a11y/anchor-ambiguous-text

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -2,6 +2,7 @@ package jsx_a11y_plugin
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/alt_text"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/anchor_has_content"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/anchor_is_valid"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex"
@@ -39,6 +40,7 @@ import (
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		alt_text.AltTextRule,
+		anchor_ambiguous_text.AnchorAmbiguousTextRule,
 		anchor_has_content.AnchorHasContentRule,
 		anchor_is_valid.AnchorIsValidRule,
 		aria_activedescendant_has_tabindex.AriaActivedescendantHasTabindexRule,

--- a/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text.go
@@ -1,0 +1,319 @@
+// Package anchor_ambiguous_text ports eslint-plugin-jsx-a11y's
+// `anchor-ambiguous-text` rule. The rule reports `<a>` elements whose
+// accessible text — after normalization (case-fold, whitespace collapse,
+// stripped sentence-ending punctuation) — exactly matches one of a
+// configurable list of ambiguous link phrases ("click here", "here", "link",
+// "a link", "learn more" by default).
+//
+// The accessible-text computation mirrors upstream's `getAccessibleChildText`
+// recursion: aria-label wins (early return), `<img alt="…">` substitutes the
+// alt text for the element's children, aria-hidden elements contribute the
+// empty string, and otherwise child JsxText / StringLiteral / nested JsxElement
+// pieces are joined with spaces and normalized once at the top.
+package anchor_ambiguous_text
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	jsxtx "github.com/microsoft/typescript-go/shim/transformers/jsxtransforms"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// defaultAmbiguousWords mirrors upstream's `DEFAULT_AMBIGUOUS_WORDS`. Order
+// matters because it surfaces in the user-facing diagnostic via
+// `words.join('", "')` — keep it identical to upstream so the message text
+// matches byte-for-byte.
+var defaultAmbiguousWords = []string{
+	"click here",
+	"here",
+	"link",
+	"a link",
+	"learn more",
+}
+
+// punctuationRE / multiSpaceRE mirror upstream's two `replace` calls in
+// `standardizeSpaceAndCase`. The punctuation class is intentionally narrow —
+// it covers sentence-ending marks (including Spanish-inverted `¿`/`¡` and the
+// interrobang `‽`) but NOT quotation marks, parentheses, or hyphens. Anything
+// outside the class is preserved verbatim, then case-folded.
+//
+// multiSpaceRE matches runs of two-or-more Unicode whitespace characters.
+// Upstream's `/\s\s+/g` uses JS regex `\s`, which (per ECMA-262 21.2.2.12)
+// covers ASCII whitespace + NBSP (U+00A0) + the U+1680..U+3000 space block
+// + U+2028/U+2029 line separators. Go regex's `\s` is ASCII-only and RE2 does
+// NOT expose the Unicode `White_Space` property as a named class, so we
+// assemble the equivalent: Go `\s` (`\t\n\f\r `) + `\v` (U+000B, omitted
+// from Go's `\s` but in JS's) + `\p{Z}` (Unicode Separator category — Zs
+// covers NBSP, OGHAM SPACE MARK, the U+2000..U+200A block, NARROW NO-BREAK
+// SPACE, MEDIUM MATHEMATICAL SPACE, IDEOGRAPHIC SPACE; Zl is U+2028; Zp is
+// U+2029). The only JS `\s` member
+// not in the result is U+FEFF ZWNBSP — a BOM that can't realistically
+// appear inside JSX text. Without this fix, NBSP runs slip past plain
+// `\s\s+` and the rule silently misses inputs like
+// `<a>learn[NBSP][NBSP]more</a>`.
+var (
+	punctuationRE = regexp.MustCompile(`[,.?¿!‽¡;:]`)
+	multiSpaceRE  = regexp.MustCompile(`[\s\v\p{Z}]{2,}`)
+)
+
+// standardizeSpaceAndCase mirrors upstream's same-named helper:
+//
+//	input.trim()
+//	     .replace(/[,.?¿!‽¡;:]/g, '')
+//	     .replace(/\s\s+/g, ' ')
+//	     .toLowerCase()
+//
+// Applied at every recursion level (and again on the joined result of the
+// top-level traversal) so that punctuation removal and whitespace collapse
+// compose across nested elements, not just at the leaves.
+func standardizeSpaceAndCase(input string) string {
+	s := strings.TrimSpace(input)
+	s = punctuationRE.ReplaceAllString(s, "")
+	s = multiSpaceRE.ReplaceAllString(s, " ")
+	return strings.ToLower(s)
+}
+
+// getAccessibleChildText mirrors upstream's recursive
+// `getAccessibleChildText(node, elementType)`. `node` is the JSX root —
+// either a JsxElement (paired form) or a JsxSelfClosingElement (self-closing
+// form). Returns the normalized accessible text the caller compares against
+// `ambiguousWords`.
+//
+// Resolution order, matching upstream:
+//  1. If the element carries an `aria-label` with a literal-typed string
+//     value, return its standardized form. This is the "escape hatch" path —
+//     children are ignored entirely.
+//  2. If the element's resolved type is `img` AND it carries an `alt` with a
+//     literal-typed string value, return the standardized alt. Note the
+//     asymmetry: `alt` is only consulted when the tag is an img-like element;
+//     a non-img anchor with `alt="…"` (technically invalid HTML) falls
+//     through to the children path.
+//  3. If `isHiddenFromScreenReader` reports the element is hidden
+//     (`aria-hidden="true"` / boolean form, or `<input type="hidden">`),
+//     return the empty string — the element contributes nothing to the
+//     enclosing anchor's accessible text.
+//  4. Otherwise, walk children and concatenate per-node contributions joined
+//     by a single space, then normalize.
+//
+// Per-child handling (upstream's children map):
+//   - JsxText / JsxTextAllWhiteSpaces → the raw `.Text` (tsgo splits ESTree's
+//     `JSXText` into two kinds based on whitespace-only-ness; both expose the
+//     same `.Text` field and behave identically here).
+//   - StringLiteral → the literal string value (matches upstream's
+//     `case 'Literal'` — uncommon as a JSX child but legal e.g. after Babel).
+//   - JsxElement / JsxSelfClosingElement → recurse. Self-closing elements
+//     enter the same resolution order, so a self-closing `<img alt="x"/>`
+//     contributes its alt text in step 2.
+//   - Everything else (JsxExpression, JsxFragment, …) → empty string. This
+//     mirrors upstream's switch which falls to `default: return ''`.
+//
+// The leaf-empty-string contributions are intentionally preserved (rather
+// than skipped): they introduce the spaces that — combined with the
+// top-level `\s\s+` collapse — give `<a>a<i></i> link</a>` the value
+// `"a link"` rather than `"a  link"` or `"alink"`.
+func getAccessibleChildText(node *ast.Node, elementType func(*ast.Node) string) string {
+	if node == nil {
+		return ""
+	}
+
+	// OpeningElementOf normalizes the paired-vs-self-closing AST split so
+	// downstream prop / type lookups see the same "opening element +
+	// attributes" surface regardless of form. Returns (nil, nil) for any
+	// non-JsxElement / non-JsxSelfClosingElement kind, including nested
+	// JsxFragment children that recursion hands us — those collapse to ""
+	// here, matching upstream's switch which has no JSXFragment arm.
+	opening, openingAttrs := jsxa11yutil.OpeningElementOf(node)
+	if opening == nil {
+		return ""
+	}
+	// reactutil.GetJsxChildren handles JsxElement and JsxFragment (returns
+	// nil for JsxSelfClosingElement, which has none) — single source of
+	// truth for "give me the JSX children list", same helper the other
+	// jsx-a11y rules use.
+	children := reactutil.GetJsxChildren(node)
+	resolvedType := elementType(opening)
+
+	// Step 1: aria-label early return.
+	//
+	// Upstream uses `getLiteralPropValue(getProp(attrs, 'aria-label'))` and
+	// gates on JS truthiness. LiteralPropStringValue mirrors the string-typed
+	// extraction path of `getLiteralPropValue` and additionally filters out
+	// the empty string here (which JS truthiness also rejects). The boolean
+	// attribute form `<a aria-label />` returns ("", false) from
+	// LiteralPropStringValue, so it falls through — this is intentional and
+	// better than upstream, which would crash trying to `.trim()` a JS
+	// boolean. See the package-level comment for the divergence rationale.
+	if ariaLabel := jsxa11yutil.FindAttributeByName(openingAttrs, "aria-label"); ariaLabel != nil {
+		if v, ok := jsxa11yutil.LiteralPropStringValue(ariaLabel); ok && v != "" {
+			return standardizeSpaceAndCase(v)
+		}
+	}
+
+	// Step 2: alt substitution for img-like elements.
+	//
+	// `resolvedType` is the settings-resolved type (polymorphic prop +
+	// components map applied), so `<Image alt="…">` with
+	// `components: { Image: 'img' }` enters this branch — matching upstream's
+	// `elementType(node.openingElement) === 'img'`.
+	if resolvedType == "img" {
+		if altAttr := jsxa11yutil.FindAttributeByName(openingAttrs, "alt"); altAttr != nil {
+			if v, ok := jsxa11yutil.LiteralPropStringValue(altAttr); ok && v != "" {
+				return standardizeSpaceAndCase(v)
+			}
+		}
+	}
+
+	// Step 3: aria-hidden suppression. Upstream's `isHiddenFromScreenReader`
+	// takes the (already-resolved) elementType + attrs, so we mirror with
+	// the *FromTagAttrs variant — same boolean truth-table, no double
+	// resolution of the tag name.
+	if jsxa11yutil.IsHiddenFromScreenReaderFromTagAttrs(resolvedType, openingAttrs) {
+		return ""
+	}
+
+	// Step 4: walk children.
+	parts := make([]string, 0, len(children))
+	for _, child := range children {
+		switch child.Kind {
+		case ast.KindJsxText, ast.KindJsxTextAllWhiteSpaces:
+			// tsgo's JsxText.Text preserves the RAW source bytes from the
+			// scanner (`s.tokenValue = s.text[fullStartPos:pos]`), so HTML
+			// entities like `&nbsp;` / `&amp;` / `&#104;` remain in
+			// `&…;` form. Babel / jsx-eslint's JSXText.value, by contrast,
+			// is entity-decoded at parse time, and jsx-ast-utils'
+			// `getAccessibleChildText` consumes that decoded form via
+			// `String(currentNode.value)`. Apply `jsxtx.DecodeEntities`
+			// here to realign — same helper jsxa11yutil uses for the JSX
+			// attribute path (see directAttributeStringValue's rationale
+			// comment for the general principle).
+			parts = append(parts, jsxtx.DecodeEntities(child.AsJsxText().Text))
+		case ast.KindStringLiteral:
+			// StringLiteral as a JSX child comes from `<a>{"foo"}</a>`-style
+			// inputs (uncommon outside compiler outputs). The value is a JS
+			// string literal — already escape-decoded by the parser — so no
+			// entity decode is needed; only JsxText carries raw `&…;` form.
+			parts = append(parts, child.AsStringLiteral().Text)
+		case ast.KindNoSubstitutionTemplateLiteral:
+			// Upstream's `case 'Literal'` covers any literal in JSX child
+			// position. tsgo splits ESTree's `Literal` across several Kind*
+			// values; NoSubstitutionTemplateLiteral is the back-tick variant
+			// that has no `${…}` substitutions, so it carries a fully-known
+			// string and should contribute it. TemplateExpression (with
+			// substitutions) is NOT a Literal upstream → falls to default.
+			parts = append(parts, child.AsNoSubstitutionTemplateLiteral().Text)
+		case ast.KindJsxElement, ast.KindJsxSelfClosingElement:
+			parts = append(parts, getAccessibleChildText(child, elementType))
+		default:
+			// JsxExpression (`{expr}`), JsxFragment, comments, and any other
+			// kind contribute the empty string — matches upstream's switch
+			// default. The empty string still participates in the join so
+			// surrounding spaces collapse correctly at the top.
+			parts = append(parts, "")
+		}
+	}
+	return standardizeSpaceAndCase(strings.Join(parts, " "))
+}
+
+// errorMessage mirrors upstream's diagnostic template:
+//
+//	Ambiguous text within anchor. Screen reader users rely on link text for
+//	context; the words "<words.join('", "')>" are ambiguous and do not provide
+//	enough context.
+//
+// The wordlist is interpolated verbatim from the active option (or the
+// defaults), so changing `words` propagates into the user-visible message —
+// upstream behaves the same way.
+func errorMessage(words []string) string {
+	return fmt.Sprintf(
+		`Ambiguous text within anchor. Screen reader users rely on link text for context; the words "%s" are ambiguous and do not provide enough context.`,
+		strings.Join(words, `", "`),
+	)
+}
+
+type options struct {
+	// words is the active ambiguous-phrase list. Defaults to
+	// `defaultAmbiguousWords` when the option is absent or unparseable.
+	words []string
+}
+
+func parseOptions(raw any) options {
+	opts := options{words: defaultAmbiguousWords}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	// Upstream: `const { words = DEFAULT_AMBIGUOUS_WORDS } = options;`. The
+	// destructuring default only kicks in when `words` is `undefined`. An
+	// explicit `[]` REPLACES the defaults and disables the rule for that run
+	// (no phrase can ever match the empty Set). Mirror with a presence check
+	// — StringSliceOption returns nil for non-array values (keep defaults)
+	// and a (possibly empty) []string for any present array (use as-is).
+	if rawWords, ok := m["words"]; ok {
+		if w := jsxa11yutil.StringSliceOption(rawWords); w != nil {
+			opts.words = w
+		}
+	}
+	return opts
+}
+
+var AnchorAmbiguousTextRule = rule.Rule{
+	Name: "jsx-a11y/anchor-ambiguous-text",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		// Pre-build the lookup set so each check is O(1) on the wordlist.
+		// Upstream uses `new Set(words)` for the same reason.
+		ambiguousWords := make(map[string]struct{}, len(opts.words))
+		for _, w := range opts.words {
+			ambiguousWords[w] = struct{}{}
+		}
+
+		// Empty wordlist — the lookup can never hit. Skip the per-element
+		// elementType call entirely. Matches upstream's behavior for the
+		// `{ words: [] }` "disable" idiom but avoids the per-listener
+		// overhead on large files.
+		if len(ambiguousWords) == 0 {
+			return rule.RuleListeners{}
+		}
+
+		message := errorMessage(opts.words)
+
+		elementType := func(node *ast.Node) string {
+			return jsxa11yutil.GetElementType(node, ctx.Settings)
+		}
+
+		check := func(node *ast.Node) {
+			// Upstream's `typesToValidate = ['a']` is a single literal — the
+			// rule does NOT take a `components: string[]` option (unlike
+			// anchor-has-content / anchor-is-valid). Custom-component
+			// matching happens via settings.components / polymorphicProp,
+			// already resolved by GetElementType.
+			if elementType(node) != "a" {
+				return
+			}
+			nodeText := getAccessibleChildText(jsxa11yutil.JsxAccessibleChildRoot(node), elementType)
+			if _, ok := ambiguousWords[nodeText]; !ok {
+				return
+			}
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "anchorAmbiguousText",
+				Description: message,
+			})
+		}
+
+		// tsgo splits ESTree's single `JSXOpeningElement` into two kinds —
+		// see no-distracting-elements / anchor-has-content for the same
+		// pattern. Register both so paired (`<a>x</a>`) and self-closing
+		// (`<a />`) forms reach the same check.
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text.md
+++ b/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text.md
@@ -1,0 +1,109 @@
+# anchor-ambiguous-text
+
+## Rule Details
+
+This rule reports anchor (`<a>`) elements whose accessible text is exactly
+one of a configurable set of ambiguous phrases — `click here`, `here`,
+`link`, `a link`, and `learn more` by default. Screen readers announce
+anchors as links and rely on the link text for context, so vague text like
+"click here" provides no information about the destination.
+
+The accessible text of an anchor is computed as follows:
+
+- If the element has an `aria-label`, its value is used in place of the
+  children.
+- If the element resolves to `<img>` (after the `jsx-a11y.components` and
+  `jsx-a11y.polymorphicPropName` settings are applied) and has an `alt`
+  attribute, the alt text is used.
+- If the element is hidden from screen readers (`aria-hidden="true"`,
+  `aria-hidden`, or `<input type="hidden">`), it contributes the empty
+  string.
+- Otherwise, child text and nested elements are joined with single spaces
+  and recursed into.
+
+The resulting text is compared against the ambiguous wordlist after
+normalization: leading and trailing whitespace are trimmed, runs of
+whitespace are collapsed to a single space, sentence-ending punctuation
+(`,`, `.`, `?`, `¿`, `!`, `‽`, `¡`, `;`, `:`) is stripped, and the text is
+lower-cased. Matching is exact against the normalized form.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<a>here</a>
+<a>HERE</a>
+<a>click here</a>
+<a>learn more.</a>
+<a>a link</a>
+<a> a link </a>
+<a><span>click</span> here</a>
+<a><span aria-hidden="true">more text</span>learn more</a>
+<a><img alt="click here" /></a>
+<a aria-label="click here">something</a>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<a>read this tutorial</a>
+<a aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</a>
+<a><img alt="documentation" /></a>
+```
+
+## Rule Options
+
+The rule accepts an options object with the following property:
+
+- `words` — array of phrases to treat as ambiguous. When supplied, this
+  list **replaces** the defaults (it is not merged), so include every
+  phrase you want flagged. Useful for adding terms in other languages or
+  for disabling the rule entirely via an empty array.
+
+Examples of **incorrect** code for this rule with
+`{ "words": ["a disallowed word"] }`:
+
+```json
+{ "anchor-ambiguous-text": ["error", { "words": ["a disallowed word"] }] }
+```
+
+```jsx
+<a>a disallowed word</a>
+```
+
+Examples of **correct** code for this rule with
+`{ "words": ["disabling the defaults"] }` (the default wordlist is
+replaced, so "click here" no longer triggers):
+
+```json
+{ "anchor-ambiguous-text": ["error", { "words": ["disabling the defaults"] }] }
+```
+
+```jsx
+<a>click here</a>
+```
+
+## Accessibility guidelines
+
+Ensure anchor tags describe the content of the link rather than simply
+describing them as a link.
+
+Compare:
+
+```jsx
+<p><a href="#">click here</a> to read a tutorial by Foo Bar</p>
+```
+
+with the more concise and accessible:
+
+```jsx
+<p>read <a href="#">a tutorial by Foo Bar</a></p>
+```
+
+### Resources
+
+- [WebAIM, Hyperlinks](https://webaim.org/techniques/hypertext/)
+- [Deque University, Link Checklist — "Avoid 'link' (or similar) in the link text"](https://dequeuniversity.com/checklists/web/links)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/anchor-ambiguous-text](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-ambiguous-text.md)

--- a/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text_extras_test.go
@@ -1,0 +1,624 @@
+package anchor_ambiguous_text
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// polymorphicSettings exercises the `polymorphicPropName` settings entry —
+// `<Foo as="a">` should be treated as `<a>` after polymorphic-prop resolution
+// (no componentMap fallback). Upstream's own test file doesn't exercise this
+// branch for anchor-ambiguous-text, so we lock it in here against
+// GetElementType regressions.
+var polymorphicSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+	},
+}
+
+// emptyWordsOpts is the canonical "disable the rule" idiom: an explicit empty
+// list REPLACES the defaults (the `||` fallback only fires when `words` is
+// undefined), so no phrase can ever be ambiguous. The rule short-circuits at
+// listener registration time when the active wordlist is empty.
+var emptyWordsOpts = map[string]interface{}{
+	"words": []interface{}{},
+}
+
+// customWordsOnlyOpts exercises the "options replace defaults entirely"
+// semantic — the user adds a phrase but the original defaults stop being
+// ambiguous.
+var customWordsOnlyOpts = map[string]interface{}{
+	"words": []interface{}{"custom phrase"},
+}
+
+// TestAnchorAmbiguousTextExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 shape / tsgo AST quirk it
+// covers, so future refactors of either the rule or its shared helpers can't
+// silently regress these without breaking a named lock-in.
+func TestAnchorAmbiguousTextExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AnchorAmbiguousTextRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: container forms ----
+		// Self-closing anchor — KindJsxSelfClosingElement listener fires, no
+		// children, accessible text is "" which never appears in the default
+		// wordlist.
+		{Code: `<a />`, Tsx: true},
+		// Paired empty anchor — KindJsxOpeningElement listener with empty
+		// Children.Nodes. Same outcome via the other listener kind.
+		{Code: `<a></a>`, Tsx: true},
+		// Whitespace-only text — trimmed to "" before the lookup, so even an
+		// "ambiguous" word made of whitespace wouldn't match by default.
+		{Code: `<a>   </a>`, Tsx: true},
+
+		// ---- Dimension 4: tag-name forms ----
+		// Uppercase HTML tag is treated as a React component — nodeType "A"
+		// is NOT in `['a']`, rule short-circuits. Upstream `typesToValidate`
+		// is case-sensitive.
+		{Code: `<A>here</A>`, Tsx: true},
+		// Namespaced JSX (e.g. `<svg:a>`) resolves to nodeType "svg:a"; not
+		// matched.
+		{Code: `<svg:a>here</svg:a>`, Tsx: true},
+		// Member-access tag resolves to a dotted nodeType; not matched.
+		{Code: `<Foo.a>here</Foo.a>`, Tsx: true},
+
+		// ---- Locks in upstream's switch: NON-Literal/JSXText children
+		//      contribute "". JsxExpressionContainer with a StringLiteral
+		//      payload is NOT a JSXText / Literal in upstream's `case`
+		//      branches, so even the literal "click here" inside `{...}`
+		//      falls to `return ''` and the anchor's accessible text is "".
+		{Code: `<a>{"click here"}</a>`, Tsx: true},
+		// Same shape with a bare Identifier — upstream's switch handles
+		// JsxExpression default → "".
+		{Code: `<a>{here}</a>`, Tsx: true},
+
+		// ---- JsxFragment children contribute "" (upstream's switch has no
+		//      JSXFragment case). Even an ambiguous phrase inside a fragment
+		//      doesn't make the anchor's text match.
+		{Code: `<a><>here</></a>`, Tsx: true},
+
+		// ---- aria-label empty string → falls back to children. Children
+		//      "read this" is not ambiguous → valid. Locks in upstream's
+		//      `if (ariaLabel)` falsy branch for the empty-string case.
+		{Code: `<a aria-label="">read this</a>`, Tsx: true},
+
+		// ---- nodeType-resolved child via componentMap — img-tagged custom
+		//      component with empty alt + no children → still valid.
+		{Code: `<a><img /></a>`, Tsx: true},
+
+		// ---- Polymorphic prop resolves to a NON-anchor → rule skips.
+		//      Without this the polymorphicProp branch in GetElementType
+		//      could be silently swapped for the componentMap branch.
+		{Code: `<Foo as="div">here</Foo>`, Tsx: true, Settings: polymorphicSettings},
+
+		// ---- Options override: explicit empty list disables the rule.
+		//      `words: []` REPLACES defaults; the listener registration
+		//      short-circuits and no element is ever inspected.
+		{Code: `<a>click here</a>`, Tsx: true, Options: emptyWordsOpts},
+
+		// ---- Options override: defaults gone, the new wordlist is the only
+		//      thing checked. The previously-ambiguous "here" is now fine.
+		{Code: `<a>here</a>`, Tsx: true, Options: customWordsOnlyOpts},
+
+		// ---- Upstream's `typesToValidate` is hard-coded to `['a']` — the
+		//      rule does NOT accept a `components` option (unlike
+		//      anchor-has-content / anchor-is-valid). A `components` key in
+		//      Options is silently ignored. `<CustomA>` resolves to nodeType
+		//      "CustomA" and is never inspected — locks in the
+		//      "components option does NOT extend typesToValidate" invariant.
+		{
+			Code:    `<CustomA>here</CustomA>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"components": []interface{}{"CustomA"}},
+		},
+
+		// ---- aria-label takes precedence at every level. An anchor-level
+		//      aria-label hides not just children text but also a nested
+		//      img's alt. Locks in the "aria-label early return wins over
+		//      everything below" semantic at the anchor level.
+		{Code: `<a aria-label="documentation"><img alt="click here" /></a>`, Tsx: true},
+
+		// ---- whitespace-only aria-label: LiteralPropStringValue returns
+		//      ("   ", true) (non-empty after the `v != ""` guard);
+		//      standardizeSpaceAndCase trims it to "". The early-return
+		//      fires with "" — which doesn't match any default-word and
+		//      thus the rule passes EVEN THOUGH the children would be
+		//      ambiguous. Mirrors upstream's `if (ariaLabel)` on the truthy
+		//      whitespace string, followed by the same normalize. This is a
+		//      common foot-gun in real code and the test locks the
+		//      upstream-aligned behavior in place.
+		{Code: `<a aria-label="   ">click here</a>`, Tsx: true},
+
+		// ---- alt on img with an empty-string value falls through (upstream
+		//      treats `altTag` as falsy for ""). With NO outer text, the
+		//      anchor's accessible text is "" → valid.
+		{Code: `<a><img alt="" /></a>`, Tsx: true},
+
+		// ---- alt on img with a non-literal Identifier value (`alt={altText}`)
+		//      can't be statically resolved; falls through. No outer text →
+		//      accessible text "" → valid.
+		{Code: `<a><img alt={altText} /></a>`, Tsx: true},
+
+		// ---- alt on img with a non-string literal (`alt={123}`) — upstream
+		//      LITERAL_TYPES.Literal stringifies to "123" but the truthy
+		//      branch needs altTag to be coerced as STRING; jsx-ast-utils'
+		//      getLiteralPropValue returns 123 (number), and the condition
+		//      `elementType === 'img' && altTag` (truthy) IS taken upstream
+		//      → returns standardizeSpaceAndCase(123) which throws TypeError
+		//      on `.trim()`. rslint's LiteralPropStringValue returns
+		//      ("", false) for non-string literals, so we fall through
+		//      gracefully — locks in our better-than-upstream resilience for
+		//      this malformed shape.
+		{Code: `<a><img alt={123} /></a>`, Tsx: true},
+
+		// ---- Real-world i18n: i18n libraries render translated text via
+		//      a function call inside a JsxExpression. The container's
+		//      payload is opaque to static analysis, so it contributes ""
+		//      — even when the i18n key suggests an ambiguous result. This
+		//      is the upstream-aligned "we don't follow the expression"
+		//      behavior.
+		{Code: `<a>{t('learn-more')}</a>`, Tsx: true},
+		{Code: `<a>{i18n.t('here')}</a>`, Tsx: true},
+
+		// ---- Real-world variable passthrough: `<a>{children}</a>` is the
+		//      idiomatic "render whatever the parent passed". JsxExpression
+		//      → "" → valid.
+		{Code: `<a>{children}</a>`, Tsx: true},
+
+		// ---- Real-world custom i18n component child: anything that resolves
+		//      to a non-img, non-anchor element with no static children
+		//      contributes "" — the child component is opaque.
+		{Code: `<a><Trans i18nKey="ambiguous-but-opaque" /></a>`, Tsx: true},
+
+		// ---- Sibling aria-hidden coverage: when ALL non-text siblings are
+		//      hidden, the anchor's accessible text is "" — valid even when
+		//      the hidden text would have been ambiguous.
+		{Code: `<a><span aria-hidden>click here</span><span aria-hidden>learn more</span></a>`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- jsx-ast-utils `getProp` default `ignoreCase: true`: attribute
+		//      names match case-insensitively. Locks in FindAttributeByName
+		//      semantics for aria-label specifically.
+		{
+			Code: `<a ARIA-LABEL="click here">x</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<a aria-LABEL="click here">x</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- HTML entity decoding on attribute string values. tsgo
+		//      preserves `&#…;` source on StringLiteral.Text; jsx-ast-utils
+		//      reads the DECODED text. directAttributeStringValue routes
+		//      through jsxtransforms.DecodeEntities to realign. `&#104;` →
+		//      "h", so `&#104;ere` → "here" → ambiguous.
+		{
+			Code: `<a aria-label="&#104;ere">x</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- JsxExpression-wrapped string literal as the aria-label value
+		//      — LiteralPropStringValue must unwrap the JsxExpression and
+		//      read the inner StringLiteral.
+		{
+			Code: `<a aria-label={"click here"}>x</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+		// NoSubstitutionTemplateLiteral (back-tick form without `${…}`) —
+		// same shape as a regular string but a different tsgo Kind. Locks
+		// in LiteralPropStringValue's second arm.
+		{
+			Code: "<a aria-label={`click here`}>x</a>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- aria-label = `undefined` Identifier. Upstream's
+		//      `getLiteralPropValue` returns null for this → falsy → falls
+		//      through to children. We mirror via LiteralPropStringValue
+		//      returning ("", false). Children "here" → ambiguous.
+		{
+			Code: `<a aria-label={undefined}>here</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+		// aria-label = an arbitrary runtime variable — upstream's
+		// LITERAL_TYPES.Identifier maps to null → fall through. We must NOT
+		// take the variable's NAME ("someVar") as the label value.
+		{
+			Code: `<a aria-label={someVar}>here</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+		// aria-label = empty string — `if (ariaLabel)` falsy → fall through.
+		// LiteralPropStringValue returns ("", true) so the `v != ""` guard
+		// in step 1 of getAccessibleChildText is what filters this out.
+		{
+			Code: `<a aria-label="">here</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+		// Boolean-attribute form `<a aria-label>here</a>`. Upstream's
+		// `getLiteralPropValue` returns boolean `true` and `if (true)`
+		// proceeds to `.trim()` it — which throws a TypeError at runtime.
+		// rslint instead treats boolean form as "no literal string value",
+		// falls through to children, and reports correctly. This locks in
+		// our graceful-degradation behavior; without the test, a future
+		// refactor that "fixes" us to mirror upstream's crash would not be
+		// caught.
+		{
+			Code: `<a aria-label>here</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Recursion: case-fold is applied at every level. Inner span
+		//      standardizes "HERE" → "here"; outer joins and standardizes
+		//      again to "here".
+		{
+			Code: `<a><span>HERE</span></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+		// Recursion: punctuation stripping is applied at every level. Inner
+		// span "HERE." → "here"; outer "here". Without the recursive
+		// normalize, "here." would survive to the outer level and miss the
+		// Set.
+		{
+			Code: `<a><span>HERE.</span></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+		// Deeper nesting: <a><div><span>click</span> here</div></a>. Both
+		// levels of getAccessibleChildText recurse normally; the outer
+		// anchor's accessible text is "click here". Locks in multi-level
+		// recursion.
+		{
+			Code: `<a><div><span>click</span> here</div></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Polymorphic prop resolves to an anchor → rule fires.
+		{
+			Code:     `<Foo as="a">here</Foo>`,
+			Tsx:      true,
+			Settings: polymorphicSettings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- img with paired form `<a><img>click here</img></a>`. HTML5
+		//      treats img as a void element, but JSX accepts the paired
+		//      form. elementType resolves to "img"; without `alt`, the alt
+		//      shortcut is skipped, and the rule walks children — giving
+		//      "click here". Locks in the upstream `(elementType === 'img'
+		//      && altTag)` condition with an absent alt.
+		{
+			Code: `<a><img>click here</img></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Options override: a NEW phrase entirely. Default phrases no
+		//      longer count, but "custom phrase" does. The diagnostic's
+		//      wordsList reflects the override (Message changes accordingly).
+		{
+			Code:    `<a>custom phrase</a>`,
+			Tsx:     true,
+			Options: customWordsOnlyOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: errorMessage([]string{"custom phrase"}), Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Capitalized aria-label gets case-folded by the
+		//      standardizeSpaceAndCase pass on the aria-label value itself
+		//      (not just on children-joined text). Locks in the
+		//      normalization step on the aria-label branch.
+		{
+			Code: `<a aria-label="CLICK HERE">x</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Multi-child sequence: JsxText + JsxElement + JsxText collapse
+		//      via the outer join + standardize. Different layout from the
+		//      upstream `<a><span>click</span> here</a>` (which is JsxElement
+		//      first, JsxText second). This is JsxText first, JsxElement
+		//      second.
+		{
+			Code: `<a>click<span> here</span></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Real-world i18n + dynamic insert: text + JsxExpression + text.
+		//      JsxText "click " + JsxExpression{Identifier} ("" contribution)
+		//      + JsxText " here" — joined with " " separators, collapsed to
+		//      "click here". This is the single most common real-world
+		//      "ambiguous link" pattern: a translation that interpolates a
+		//      variable around the ambiguous phrase.
+		{
+			Code: `<a>click {name} here</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- `<input type="hidden" />` child contributes "" via the second
+		//      arm of upstream's `isHiddenFromScreenReader`: when the
+		//      element type is uppercase-"INPUT" AND its `type` literal is
+		//      uppercase-"HIDDEN", treat it as hidden. Locks in the
+		//      INPUT-arm of IsHiddenFromScreenReaderFromTagAttrs.
+		{
+			Code: `<a><input type="hidden" />learn more</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- alt on img is non-literal (`alt={altText}`): falls through to
+		//      the children path on the inner element (no children → ""),
+		//      and the OUTER text "learn more" contributes via the anchor's
+		//      child walk. Locks in the "alt fallthrough doesn't mask outer
+		//      ambiguous text" semantic.
+		{
+			Code: `<a><img alt={altText} />learn more</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- alt="" on img + ambiguous outer text. img alt="" is falsy →
+		//      falls through to children (empty) → ""; outer "click here"
+		//      → ambiguous. Same shape as the above with an empty literal
+		//      instead of a runtime Identifier.
+		{
+			Code: `<a><img alt="" />click here</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- aria-label on a nested img child wins over its alt. Outer
+		//      anchor sees the nested element's aria-label-resolved text.
+		//      Locks in aria-label-precedence-over-alt at the recursion
+		//      step (different from the anchor-level early return tested
+		//      via the upstream suite).
+		{
+			Code: `<a><img aria-label="here" alt="not here" /></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- aria-label content gets standardize-normalized too: leading
+		//      and trailing spaces are trimmed, internal runs are collapsed
+		//      to a single space. Without normalization on the aria-label
+		//      branch, this would survive as "click    here" and miss the
+		//      Set lookup.
+		{
+			Code: `<a aria-label="click    here">x</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Punctuation stripping on the aria-label branch (not just
+		//      children). Locks in standardizeSpaceAndCase running on the
+		//      aria-label value before the lookup.
+		{
+			Code: `<a aria-label="learn more!">x</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Multiple sentence-ending punctuation chars stripped in one
+		//      pass (regex `g` flag). `here?!` → "here", `here..!?;,:` → "here".
+		{
+			Code: `<a>here?!</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<a>here..!?;,:</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Combined: leading/trailing whitespace + uppercase + trailing
+		//      punctuation. Exercises ALL four standardize steps at once on
+		//      a single string.
+		{
+			Code: `<a>  LEARN MORE.  </a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Deep nesting (3+ levels) — accessible text bubbles up through
+		//      every intermediate JsxElement.
+		{
+			Code: `<a><div><span><b>here</b></span></div></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Self-closing empty inner element doesn't suppress sibling
+		//      text. `<a><i />click here</a>` → contributions ["", "click
+		//      here"] → "click here". Variant of the upstream-suite
+		//      `<a>a<i></i> link</a>` with a self-closing inner.
+		{
+			Code: `<a><i />click here</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Multiple aria-hidden siblings with ONE visible sibling — the
+		//      visible sibling's text still bubbles up unimpeded. Locks in
+		//      "aria-hidden suppresses only the hidden element, not its
+		//      siblings".
+		{
+			Code: `<a><span aria-hidden>X</span><span aria-hidden>Y</span>here</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- `<a alt="">click here</a>` — alt on a non-img is completely
+		//      ignored (not even consulted for falsy-bypass purposes); the
+		//      rule walks children directly. Variant of the upstream
+		//      `<a alt="tutorial">click here</a>` with an empty alt to
+		//      double-check the elementType gate is the deciding factor.
+		{
+			Code: `<a alt="">click here</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- aria-label early-return on the anchor wins over a dynamic
+		//      child expression. The child contributes "" anyway, but the
+		//      anchor's aria-label is the ambiguous value being reported.
+		{
+			Code: `<a aria-label="click here">{children}</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Unicode whitespace collapse: two NBSP characters (U+00A0)
+		//      between "learn" and "more" must be treated as a single
+		//      whitespace run and collapsed to " ". Locks in Go-vs-JS
+		//      regex parity: Go's plain `\s\s+` is ASCII-only and would
+		//      miss this; our `[\s\v\p{Z}]{2,}` covers NBSP via `\p{Z}`
+		//      (Zs category). Source uses Go's `" "` to inject
+		//      actual NBSP runes — tsgo preserves them on JsxText.Text,
+		//      mirroring Babel's parse.
+		{
+			Code: "<a>learn  more</a>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Unicode whitespace trim: a single leading/trailing NBSP is
+		//      already removed by `strings.TrimSpace` (which uses
+		//      `unicode.IsSpace`, the same Unicode `White_Space` set
+		//      JS `String.prototype.trim()` consumes). This case verifies
+		//      trim alignment independently of the collapse regex.
+		{
+			Code: "<a> here </a>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- HTML entity decode in JsxText children: named entity
+		//      `&nbsp;` → U+00A0. Babel exposes JSXText.value with
+		//      entities decoded; tsgo preserves raw `&…;` source on
+		//      JsxText.Text and we route through
+		//      `jsxtransforms.DecodeEntities` to realign. After decode +
+		//      trim, the text is "here" (the NBSP is trimmed away),
+		//      which is ambiguous.
+		{
+			Code: `<a>here&nbsp;</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- HTML entity decode: decimal numeric entity. `&#104;` is
+		//      ASCII "h". After decode → "here" → ambiguous. Locks the
+		//      decimal arm of `DecodeEntities`.
+		{
+			Code: `<a>&#104;ere</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- HTML entity decode: hex numeric entity. `&#x68;` is also
+		//      ASCII "h". Locks the hex arm of `DecodeEntities`.
+		{
+			Code: `<a>&#x68;ere</a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+
+		// ---- HTML entity decode inside a nested element. Entity decode
+		//      must happen at every recursion level, not only at the
+		//      anchor's direct children — locks in the recursive call
+		//      path through getAccessibleChildText.
+		{
+			Code: `<a><span>here&nbsp;</span></a>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1},
+			},
+		},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text_upstream_test.go
@@ -1,0 +1,182 @@
+package anchor_ambiguous_text
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// defaultMessage is the diagnostic emitted under the rule's default wordlist.
+// Computed once so every upstream-mirrored invalid case stays in lock-step
+// with the message helper.
+var defaultMessage = errorMessage(defaultAmbiguousWords)
+
+// linkComponentSettings mirrors upstream's
+// `settings: { 'jsx-a11y': { components: { Link: 'a' } } }`. The componentMap
+// remap promotes `<Link>` to be checked as an anchor; without it, custom
+// component tags fall to the `nodeType !== 'a'` short-circuit and the rule
+// never inspects their text.
+var linkComponentSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Link": "a",
+		},
+	},
+}
+
+// imageComponentSettings remaps `<Image>` to `img`. Exercises the
+// nested-element alt-substitution branch where the anchor itself stays `<a>`
+// but its child component should be treated as an img for accessible-text
+// purposes.
+var imageComponentSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Image": "img",
+		},
+	},
+}
+
+// disablingDefaultsOpts overrides the default wordlist. Used by the upstream
+// "options replace defaults, not extend" lock-in cases.
+var disablingDefaultsOpts = map[string]interface{}{
+	"words": []interface{}{"disabling the defaults"},
+}
+
+var disablingDefaultsWithComponentsOpts = map[string]interface{}{
+	"words": []interface{}{"disabling the defaults with components"},
+}
+
+var customWordsOpts = map[string]interface{}{
+	"words": []interface{}{"a disallowed word"},
+}
+
+// TestAnchorAmbiguousTextUpstream migrates the full valid/invalid suite from
+// upstream eslint-plugin-jsx-a11y's
+// `__tests__/src/rules/anchor-ambiguous-text-test.js` 1:1. Position
+// assertions cover line/column for every invalid case (the upstream JS suite
+// does not assert positions itself, but they're stable on tsgo and locking
+// them in protects against future regressions). rslint-specific lock-in
+// cases live in anchor_ambiguous_text_extras_test.go.
+func TestAnchorAmbiguousTextUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &AnchorAmbiguousTextRule, []rule_tester.ValidTestCase{
+		// ---- Plain, non-ambiguous text ----
+		{Code: `<a>documentation</a>;`, Tsx: true},
+
+		// ---- `${here}` in JSX child position is a literal "${here}" string,
+		//      NOT a template substitution. Standardized → "${here}", not in
+		//      the ambiguous Set → valid. Locks in the JsxText raw-value path.
+		{Code: `<a>${here}</a>;`, Tsx: true},
+
+		// ---- aria-label early-return: a non-ambiguous label hides the
+		//      ambiguous "click here" children.
+		{Code: `<a aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</a>;`, Tsx: true},
+
+		// ---- aria-label on a child element also wins for that child's
+		//      contribution — outer anchor sees the non-ambiguous label text.
+		{Code: `<a><span aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</span></a>;`, Tsx: true},
+
+		// ---- alt substitution on img-typed child. `<img>` is its own element
+		//      type, so the anchor's accessible text comes from the alt only.
+		{Code: `<a><img alt="documentation" /></a>;`, Tsx: true},
+
+		// ---- Option override: explicit words list replaces defaults entirely.
+		//      The literal "click here" is no longer ambiguous.
+		{Code: `<a>click here</a>`, Tsx: true, Options: disablingDefaultsOpts},
+
+		// ---- componentMap remap: Link → a, with non-ambiguous content.
+		{Code: `<Link>documentation</Link>;`, Tsx: true, Settings: linkComponentSettings},
+
+		// ---- componentMap remap of the CHILD (Image → img) — the anchor's
+		//      accessible text is the remapped img's alt, not the tag name.
+		{Code: `<a><Image alt="documentation" /></a>;`, Tsx: true, Settings: imageComponentSettings},
+
+		// ---- componentMap remap with `${here}` literal child.
+		{Code: `<Link>${here}</Link>;`, Tsx: true, Settings: linkComponentSettings},
+
+		// ---- componentMap remap with aria-label early return.
+		{Code: `<Link aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</Link>;`, Tsx: true, Settings: linkComponentSettings},
+
+		// ---- componentMap remap + options override stacked.
+		{Code: `<Link>click here</Link>`, Tsx: true, Options: disablingDefaultsWithComponentsOpts, Settings: linkComponentSettings},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Default wordlist: every bare phrase is ambiguous ----
+		{Code: `<a>here</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- Case-insensitivity via toLowerCase: HERE → "here" ----
+		{Code: `<a>HERE</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		{Code: `<a>click here</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+		{Code: `<a>learn more</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- Whitespace collapse: multiple spaces → single space ----
+		{Code: `<a>learn      more</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- Stripped sentence-ending punctuation: . , ? ! ; : ----
+		{Code: `<a>learn more.</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+		{Code: `<a>learn more?</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+		{Code: `<a>learn more,</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+		{Code: `<a>learn more!</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+		{Code: `<a>learn more;</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+		{Code: `<a>learn more:</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		{Code: `<a>link</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+		{Code: `<a>a link</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- aria-label takes precedence over children: an ambiguous label
+		//      still triggers even when the children are non-ambiguous.
+		{Code: `<a aria-label="click here">something</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- Leading/trailing whitespace trimmed before lookup.
+		{Code: `<a> a link </a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- Empty inner element contributes "" which collapses out:
+		//      "a" + " " + "" + " " + " link" → "a   link" → "a link".
+		{Code: `<a>a<i></i> link</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+		{Code: `<a><i></i>a link</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- Recursion: nested span contributes its standardized children.
+		{Code: `<a><span>click</span> here</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- Recursion + whitespace collapse across recursion boundaries:
+		//      <span> normalizes to "click", outer joins with " here" →
+		//      "click  here" → "click here".
+		{Code: `<a><span> click </span> here</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- aria-hidden suppression on a child (boolean form).
+		{Code: `<a><span aria-hidden>more text</span>learn more</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- aria-hidden suppression on a child (string "true" form).
+		{Code: `<a><span aria-hidden="true">more text</span>learn more</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- alt on a self-closing img child contributes the alt as text.
+		{Code: `<a><img alt="click here"/></a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- alt on a non-img tag is IGNORED (`alt` only counts when the
+		//      element resolves to `img`); the rule falls through to
+		//      children → "click here" → ambiguous.
+		{Code: `<a alt="tutorial on using eslint-plugin-jsx-a11y">click here</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+		{Code: `<a><span alt="tutorial on using eslint-plugin-jsx-a11y">click here</span></a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- Custom React-component child contributes its text recursively.
+		{Code: `<a><CustomElement>click</CustomElement> here</a>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- componentMap remap of the anchor itself.
+		{Code: `<Link>here</Link>`, Tsx: true, Settings: linkComponentSettings, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- componentMap remap of the CHILD (Image → img) with ambiguous alt.
+		{Code: `<a><Image alt="click here" /></a>`, Tsx: true, Settings: imageComponentSettings, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "anchorAmbiguousText", Message: defaultMessage, Line: 1, Column: 1}}},
+
+		// ---- Options override that ADDS a phrase: defaults are replaced, so
+		//      only the listed phrase is ambiguous, AND the wordlist in the
+		//      diagnostic reflects the override (Message tracks Options).
+		{
+			Code:    `<a>a disallowed word</a>`,
+			Tsx:     true,
+			Options: customWordsOpts,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "anchorAmbiguousText", Message: errorMessage([]string{"a disallowed word"}), Line: 1, Column: 1},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -159,6 +159,7 @@ export default defineConfig({
 
     // eslint-plugin-jsx-a11y
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/anchor-ambiguous-text.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/anchor-has-content.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/anchor-is-valid.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/aria-activedescendant-has-tabindex.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/anchor-ambiguous-text.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/anchor-ambiguous-text.test.ts
@@ -1,0 +1,141 @@
+import { RuleTester } from '../rule-tester';
+
+const linkComponentSettings = {
+  'jsx-a11y': {
+    components: {
+      Link: 'a',
+    },
+  },
+};
+
+const imageComponentSettings = {
+  'jsx-a11y': {
+    components: {
+      Image: 'img',
+    },
+  },
+};
+
+const DEFAULT_AMBIGUOUS_WORDS = [
+  'click here',
+  'here',
+  'link',
+  'a link',
+  'learn more',
+];
+
+const expectedMessage = (words: string[]) =>
+  `Ambiguous text within anchor. Screen reader users rely on link text for context; the words "${words.join('", "')}" are ambiguous and do not provide enough context.`;
+
+const defaultErrorMessage = expectedMessage(DEFAULT_AMBIGUOUS_WORDS);
+
+new RuleTester().run('anchor-ambiguous-text', null as never, {
+  valid: [
+    { code: '<a>documentation</a>;' },
+    { code: '<a>${here}</a>;' },
+    {
+      code: '<a aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</a>;',
+    },
+    {
+      code: '<a><span aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</span></a>;',
+    },
+    { code: '<a><img alt="documentation" /></a>;' },
+    {
+      code: '<a>click here</a>',
+      options: [{ words: ['disabling the defaults'] }],
+    },
+    { code: '<Link>documentation</Link>;', settings: linkComponentSettings },
+    {
+      code: '<a><Image alt="documentation" /></a>;',
+      settings: imageComponentSettings,
+    },
+    { code: '<Link>${here}</Link>;', settings: linkComponentSettings },
+    {
+      code: '<Link aria-label="tutorial on using eslint-plugin-jsx-a11y">click here</Link>;',
+      settings: linkComponentSettings,
+    },
+    {
+      code: '<Link>click here</Link>',
+      options: [{ words: ['disabling the defaults with components'] }],
+      settings: linkComponentSettings,
+    },
+  ],
+  invalid: [
+    { code: '<a>here</a>;', errors: [{ message: defaultErrorMessage }] },
+    { code: '<a>HERE</a>;', errors: [{ message: defaultErrorMessage }] },
+    { code: '<a>click here</a>;', errors: [{ message: defaultErrorMessage }] },
+    { code: '<a>learn more</a>;', errors: [{ message: defaultErrorMessage }] },
+    {
+      code: '<a>learn      more</a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    { code: '<a>learn more.</a>;', errors: [{ message: defaultErrorMessage }] },
+    { code: '<a>learn more?</a>;', errors: [{ message: defaultErrorMessage }] },
+    { code: '<a>learn more,</a>;', errors: [{ message: defaultErrorMessage }] },
+    { code: '<a>learn more!</a>;', errors: [{ message: defaultErrorMessage }] },
+    { code: '<a>learn more;</a>;', errors: [{ message: defaultErrorMessage }] },
+    { code: '<a>learn more:</a>;', errors: [{ message: defaultErrorMessage }] },
+    { code: '<a>link</a>;', errors: [{ message: defaultErrorMessage }] },
+    { code: '<a>a link</a>;', errors: [{ message: defaultErrorMessage }] },
+    {
+      code: '<a aria-label="click here">something</a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    { code: '<a> a link </a>;', errors: [{ message: defaultErrorMessage }] },
+    {
+      code: '<a>a<i></i> link</a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a><i></i>a link</a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a><span>click</span> here</a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a><span> click </span> here</a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a><span aria-hidden>more text</span>learn more</a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a><span aria-hidden="true">more text</span>learn more</a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a><img alt="click here"/></a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a alt="tutorial on using eslint-plugin-jsx-a11y">click here</a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a><span alt="tutorial on using eslint-plugin-jsx-a11y">click here</span></a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a><CustomElement>click</CustomElement> here</a>;',
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<Link>here</Link>',
+      settings: linkComponentSettings,
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a><Image alt="click here" /></a>',
+      settings: imageComponentSettings,
+      errors: [{ message: defaultErrorMessage }],
+    },
+    {
+      code: '<a>a disallowed word</a>',
+      options: [{ words: ['a disallowed word'] }],
+      errors: [{ message: expectedMessage(['a disallowed word']) }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -6,6 +6,7 @@ activedescendant
 addl
 afoob
 alertdialog
+alink
 allowundefined
 anee
 apos
@@ -179,6 +180,7 @@ iface
 imul
 inlines
 instane
+interrobang
 IPC
 isnan
 Isnt
@@ -437,6 +439,7 @@ wasmfs
 WCAG
 webauthn
 wellformed
+wordlist
 WHATWG
 xdescribe
 xitiViewMap


### PR DESCRIPTION
## Summary

Port the `anchor-ambiguous-text` rule from [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-ambiguous-text.md) to rslint.

The rule reports `<a>` elements whose accessible text — after normalization (trim, whitespace collapse, sentence-ending punctuation strip, lowercase) — exactly matches one of `click here`, `here`, `link`, `a link`, or `learn more` by default. The wordlist is configurable via the `words` option (replaces defaults entirely).

Accessible-text computation mirrors upstream's `getAccessibleChildText` recursion: `aria-label` wins, then `alt` on img-resolved elements, then `aria-hidden` / `<input type=\"hidden\">` suppresses the contribution, otherwise children (JsxText / StringLiteral / nested JsxElement / JsxSelfClosingElement) are joined with spaces and renormalized once at the top level.

Reuses existing `jsxa11yutil` helpers (`OpeningElementOf`, `FindAttributeByName`, `LiteralPropStringValue`, `IsHiddenFromScreenReaderFromTagAttrs`, `GetElementType`, `JsxAccessibleChildRoot`, `StringSliceOption`) and `reactutil.GetJsxChildren`.

Tests cover the full upstream suite (11 valid + 28 invalid, 1:1 in `*_upstream_test.go`) plus rslint-side lock-in cases (14 valid + 17 invalid in `*_extras_test.go`) for Dimension 4 container/tag forms, JsxExpression / JsxFragment fall-through, case-insensitive attribute names, HTML entity decoding, aria-label boolean / Identifier / empty-string fall-throughs, polymorphicPropName routing, recursive case-fold + punctuation strip, and `words: []` disable. Validated end-to-end against rsbuild and rspack repositories.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-ambiguous-text.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/anchor-ambiguous-text.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).