### PR TITLE
feat: port rule jsx-a11y/prefer-tag-over-role

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -31,6 +31,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_redundant_roles"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_static_element_interactions"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/prefer_tag_over_role"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/role_has_required_aria_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/role_supports_aria_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/scope"
@@ -70,6 +71,7 @@ func GetAllRules() []rule.Rule {
 		no_noninteractive_tabindex.NoNoninteractiveTabindexRule,
 		no_redundant_roles.NoRedundantRolesRule,
 		no_static_element_interactions.NoStaticElementInteractionsRule,
+		prefer_tag_over_role.PreferTagOverRoleRule,
 		role_has_required_aria_props.RoleHasRequiredAriaPropsRule,
 		role_supports_aria_props.RoleSupportsAriaPropsRule,
 		scope.ScopeRule,

--- a/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role.go
+++ b/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role.go
@@ -1,0 +1,207 @@
+// cspell:ignore heckbox
+
+// Package prefer_tag_over_role ports eslint-plugin-jsx-a11y's
+// `prefer-tag-over-role` rule. The rule flags a JSX element whose explicit
+// `role` attribute matches an ARIA role for which a semantic HTML element
+// already exists — e.g. `<div role="checkbox" />` should be `<input
+// type="checkbox">`, `<span role="heading" />` should be `<h1>` ... `<h6>`.
+//
+// The rule has no options. The diagnostic message is verbatim:
+//
+//	Use {{tag}} instead of the "{{role}}" role to ensure accessibility across all devices.
+//
+// Trigger: a JsxOpeningElement / JsxSelfClosingElement whose
+//
+//  1. has a literal-resolvable `role` attribute (the LAST whitespace-separated
+//     token is consulted, mirroring upstream `getLastPropValue`),
+//  2. that token names a non-abstract ARIA role with at least one semantic
+//     HTML element mapping in `aria-query`'s `roleElements`, AND
+//  3. the element's effective tag (after `getElementType` —
+//     `polymorphicPropName` + `components` map resolution) is NOT the `name`
+//     of any of those semantic elements.
+//
+// Listener gate parity: upstream listens on `JSXOpeningElement` only — ESTree
+// wraps both paired and self-closing forms under that node. tsgo splits them
+// into KindJsxOpeningElement (paired) and KindJsxSelfClosingElement
+// (self-closing), so we register both kinds — see [no_redundant_roles] for
+// the same pattern.
+package prefer_tag_over_role
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	jsxtx "github.com/microsoft/typescript-go/shim/transformers/jsxtransforms"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type roleEntry struct {
+	// formatted is the comma-and-or-joined tag list rendered exactly as
+	// upstream `formatTag` + the `, or `-trailing join produces. Pre-computed
+	// here because the table is data-only and never depends on user input.
+	formatted string
+	// tagNames is the set of HTML element names this role's semantic
+	// implementations span, in insertion order with duplicates removed.
+	// Upstream's matched-tag check is `matchedTags.some(tag.name ===
+	// elementType(node))` — names only, attributes are NOT inspected for the
+	// match (they only appear in the diagnostic message). Duplicates would
+	// repeat the same `name === ...` comparison, so we deduplicate.
+	tagNames []string
+}
+
+// roleElementTable is derived from aria-query@5.x roleElementMap.
+// Each entry pre-computes:
+//  1. formatted: the tag list rendered exactly as upstream prefer-tag-over-role.js
+//     composes it for the diagnostic message (formatTag + ", or " join).
+//  2. tagNames: the set of HTML element names (ordered, deduplicated) used for
+//     the upstream matchedTags.some(tag.name === elementType(node)) check.
+//
+// Source: aria-query 5.x — `roleElementMap` is built from `rolesMap` by
+// concatenating each role's baseConcepts + relatedConcepts and keeping only
+// the concepts whose module === "HTML". `formatTag` in upstream takes ONLY
+// the first element of `attributes` — the rest are ignored even when the
+// role concept lists multiple constraints (e.g. textbox's input variants).
+// We mirror byte-for-byte; quirks like `<input list=...>` for textbox /
+// searchbox / combobox or `<img alt=...>` for the img role are upstream-
+// observable behavior, not bugs we're "fixing" silently.
+var roleElementTable = map[string]roleEntry{
+	"article":       {formatted: `<article>`, tagNames: []string{"article"}},
+	"banner":        {formatted: `<header>`, tagNames: []string{"header"}},
+	"blockquote":    {formatted: `<blockquote>`, tagNames: []string{"blockquote"}},
+	"button":        {formatted: `<input type="button">, <input type="image">, <input type="reset">, <input type="submit">, or <button>`, tagNames: []string{"input", "button"}},
+	"caption":       {formatted: `<caption>`, tagNames: []string{"caption"}},
+	"cell":          {formatted: `<td>`, tagNames: []string{"td"}},
+	"checkbox":      {formatted: `<input type="checkbox">`, tagNames: []string{"input"}},
+	"code":          {formatted: `<code>`, tagNames: []string{"code"}},
+	"columnheader":  {formatted: `<th>, <th scope="col">, or <th scope="colgroup">`, tagNames: []string{"th"}},
+	"combobox":      {formatted: `<input list=...>, <input list=...>, <input list=...>, <input list=...>, <input list=...>, <input list=...>, or <select multiple=...>`, tagNames: []string{"input", "select"}},
+	"complementary": {formatted: `<aside>, <aside aria-label=...>, or <aside aria-labelledby=...>`, tagNames: []string{"aside"}},
+	"contentinfo":   {formatted: `<footer>`, tagNames: []string{"footer"}},
+	"definition":    {formatted: `<dd>`, tagNames: []string{"dd"}},
+	"deletion":      {formatted: `<del>`, tagNames: []string{"del"}},
+	"dialog":        {formatted: `<dialog>`, tagNames: []string{"dialog"}},
+	"document":      {formatted: `<html>`, tagNames: []string{"html"}},
+	"emphasis":      {formatted: `<em>`, tagNames: []string{"em"}},
+	"figure":        {formatted: `<figure>`, tagNames: []string{"figure"}},
+	"form":          {formatted: `<form aria-label=...>, <form aria-labelledby=...>, or <form name=...>`, tagNames: []string{"form"}},
+	"generic":       {formatted: `<a>, <area>, <aside>, <b>, <bdo>, <body>, <data>, <div>, <footer>, <header>, <hgroup>, <i>, <pre>, <q>, <samp>, <section>, <small>, <span>, or <u>`, tagNames: []string{"a", "area", "aside", "b", "bdo", "body", "data", "div", "footer", "header", "hgroup", "i", "pre", "q", "samp", "section", "small", "span", "u"}},
+	"gridcell":      {formatted: `<td>`, tagNames: []string{"td"}},
+	"group":         {formatted: `<details>, <fieldset>, <optgroup>, or <address>`, tagNames: []string{"details", "fieldset", "optgroup", "address"}},
+	"heading":       {formatted: `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`, tagNames: []string{"h1", "h2", "h3", "h4", "h5", "h6"}},
+	"img":           {formatted: `<img alt=...>, or <img alt=...>`, tagNames: []string{"img"}},
+	"insertion":     {formatted: `<ins>`, tagNames: []string{"ins"}},
+	"link":          {formatted: `<a href=...>, or <area href=...>`, tagNames: []string{"a", "area"}},
+	"list":          {formatted: `<menu>, <ol>, or <ul>`, tagNames: []string{"menu", "ol", "ul"}},
+	"listbox":       {formatted: `<select size=...>, <select multiple=...>, or <datalist>`, tagNames: []string{"select", "datalist"}},
+	"listitem":      {formatted: `<li>`, tagNames: []string{"li"}},
+	"main":          {formatted: `<main>`, tagNames: []string{"main"}},
+	"mark":          {formatted: `<mark>`, tagNames: []string{"mark"}},
+	"math":          {formatted: `<math>`, tagNames: []string{"math"}},
+	"meter":         {formatted: `<meter>`, tagNames: []string{"meter"}},
+	"navigation":    {formatted: `<nav>`, tagNames: []string{"nav"}},
+	"option":        {formatted: `<option>`, tagNames: []string{"option"}},
+	"paragraph":     {formatted: `<p>`, tagNames: []string{"p"}},
+	"presentation":  {formatted: `<img alt=...>`, tagNames: []string{"img"}},
+	"progressbar":   {formatted: `<progress>`, tagNames: []string{"progress"}},
+	"radio":         {formatted: `<input type="radio">`, tagNames: []string{"input"}},
+	"region":        {formatted: `<section aria-label=...>, or <section aria-labelledby=...>`, tagNames: []string{"section"}},
+	"row":           {formatted: `<tr>`, tagNames: []string{"tr"}},
+	"rowgroup":      {formatted: `<tbody>, <tfoot>, or <thead>`, tagNames: []string{"tbody", "tfoot", "thead"}},
+	"rowheader":     {formatted: `<th scope="row">, or <th scope="rowgroup">`, tagNames: []string{"th"}},
+	"searchbox":     {formatted: `<input list=...>`, tagNames: []string{"input"}},
+	"separator":     {formatted: `<hr>`, tagNames: []string{"hr"}},
+	"slider":        {formatted: `<input type="range">`, tagNames: []string{"input"}},
+	"spinbutton":    {formatted: `<input type="number">`, tagNames: []string{"input"}},
+	"status":        {formatted: `<output>`, tagNames: []string{"output"}},
+	"strong":        {formatted: `<strong>`, tagNames: []string{"strong"}},
+	"subscript":     {formatted: `<sub>`, tagNames: []string{"sub"}},
+	"superscript":   {formatted: `<sup>`, tagNames: []string{"sup"}},
+	"table":         {formatted: `<table>`, tagNames: []string{"table"}},
+	"term":          {formatted: `<dfn>, or <dt>`, tagNames: []string{"dfn", "dt"}},
+	"textbox":       {formatted: `<input type=...>, <input list=...>, <input list=...>, <input list=...>, <input list=...>, or <textarea>`, tagNames: []string{"input", "textarea"}},
+	"time":          {formatted: `<time>`, tagNames: []string{"time"}},
+}
+
+func errorMessage(tag, role string) string {
+	return "Use " + tag + ` instead of the "` + role + `" role to ensure accessibility across all devices.`
+}
+
+// extractRoleString mirrors upstream `getPropValue(role)` (full
+// jsx-ast-utils staticEval), with one tsgo-specific patch: on the direct
+// `<X role="...">` shape, decode HTML entities so `role="&#99;heckbox"`
+// resolves to "checkbox" like ESTree's JSX parser would expose it.
+// PropStaticStringValue itself reads StringLiteral.Text verbatim, but
+// every other direct-attribute consumer in jsxa11yutil already routes
+// through DecodeEntities for parity. Non-direct shapes (`role={...}`,
+// spread literal, binary, call, member, ...) carry JS string literals
+// and need no decode — delegate to PropStaticStringValue.
+func extractRoleString(roleAttr *ast.Node) (string, bool) {
+	if roleAttr.Kind == ast.KindJsxAttribute {
+		init := roleAttr.AsJsxAttribute().Initializer
+		if init != nil && init.Kind == ast.KindStringLiteral {
+			return jsxtx.DecodeEntities(init.AsStringLiteral().Text), true
+		}
+	}
+	return jsxa11yutil.PropStaticStringValue(roleAttr)
+}
+
+// lastSpaceSeparatedToken mirrors upstream `getLastPropValue`'s tail
+// extraction: split a non-empty role string on whitespace and take the last
+// token. ESLint's roleElements is keyed by single role names (`checkbox`,
+// `heading`, …); a multi-role attribute like `role="button checkbox"` is
+// matched against the LAST token only. Returns the input unchanged when no
+// space is present.
+//
+// Note that `strings.LastIndexByte(s, ' ')` is intentionally used (NOT
+// `strings.LastIndexFunc(s, unicode.IsSpace)`): jsx-ast-utils' upstream
+// equivalent (`String.prototype.lastIndexOf(' ')`) only matches the ASCII
+// SPACE U+0020, not other whitespace such as tab / NBSP. Mirror byte-for-byte.
+func lastSpaceSeparatedToken(s string) string {
+	if i := strings.LastIndexByte(s, ' '); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
+var PreferTagOverRoleRule = rule.Rule{
+	Name: "jsx-a11y/prefer-tag-over-role",
+	Run: func(ctx rule.RuleContext, _ any) rule.RuleListeners {
+		check := func(node *ast.Node) {
+			attrs := reactutil.GetJsxElementAttributes(node)
+			roleAttr := jsxa11yutil.FindAttributeByName(attrs, "role")
+			if roleAttr == nil {
+				return
+			}
+			rawRole, ok := extractRoleString(roleAttr)
+			if !ok || rawRole == "" {
+				return
+			}
+			// `getLastPropValue` returns the empty string when the input ends
+			// with a space (`"button "` → ""). Upstream then fails the
+			// `roleElements.get("")` lookup and skips. We do the same — empty
+			// keys are not present in roleElementTable.
+			role := lastSpaceSeparatedToken(rawRole)
+			entry, ok := roleElementTable[role]
+			if !ok {
+				return
+			}
+			elementType := jsxa11yutil.GetElementType(node, ctx.Settings)
+			for _, name := range entry.tagNames {
+				if name == elementType {
+					return
+				}
+			}
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "preferTagOverRole",
+				Description: errorMessage(entry.formatted, role),
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role.md
+++ b/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role.md
@@ -1,0 +1,70 @@
+# prefer-tag-over-role
+
+## Rule Details
+
+This rule enforces that an explicit ARIA
+[`role`](https://www.w3.org/TR/wai-aria-1.2/#role_definitions) is not used in
+place of a semantic HTML element that already provides that role natively.
+Native elements expose their semantics to assistive technology automatically
+and come with built-in keyboard, focus, and form behavior — re-declaring the
+role on a generic container loses those affordances and adds another way for
+the implementation to diverge from the announced role.
+
+The rule fires on a JSX opening element when **all** of the following hold:
+
+- The element carries a `role` attribute whose value resolves to a non-empty
+  string.
+- The LAST whitespace-separated token of that string is a non-abstract ARIA
+  role with one or more semantic HTML element mappings (`heading` → `<h1>` …
+  `<h6>`, `checkbox` → `<input type="checkbox">`, `link` → `<a href=...>` /
+  `<area href=...>`, etc.).
+- The element's effective tag name (after resolving
+  `settings['jsx-a11y'].polymorphicPropName` and
+  `settings['jsx-a11y'].components`) is NOT one of those semantic HTML
+  elements.
+
+Non-literal role values (Identifiers, CallExpressions, template literals
+with substitutions, etc.) cannot be statically determined to a string and
+never trigger the rule. The `role` attribute name is matched
+case-insensitively, matching `getProp`'s default. Multi-token role values
+(`role="button checkbox"`) are matched on the LAST token only —
+`role="button checkbox"` is treated as `role="checkbox"` for the purpose of
+this rule. Whitespace inside a role string is interpreted as the ASCII space
+character `U+0020`; tabs and other Unicode whitespace are part of the token.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div role="checkbox" />
+<div role="heading" />
+<div role="link" />
+<div role="rowgroup" />
+<div role="banner" />
+<span role="checkbox" />
+<other role="checkbox" />
+<div role="button checkbox" />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div />
+<div role="unknown" />
+<other />
+<img role="img" />
+<input role="checkbox" />
+```
+
+## Accessibility guidelines
+
+- [WAI-ARIA Roles model](https://www.w3.org/TR/wai-aria-1.2/#role_definitions)
+- [Using ARIA — Rule 1: If you can use a native HTML element](https://www.w3.org/TR/using-aria/#rule1)
+
+### Resources
+
+- [MDN — WAI-ARIA Roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles)
+- [aria-query `roleElements` map](https://github.com/A11yance/aria-query)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/prefer-tag-over-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/prefer-tag-over-role.md)

--- a/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role_extras_test.go
@@ -1,0 +1,1040 @@
+// cspell:ignore heckbox eading
+
+package prefer_tag_over_role
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// This file holds every test case that is NOT a 1:1 mirror of upstream's own
+// test file. Upstream-parity cases live in `prefer_tag_over_role_upstream_test.go`
+// so it stays trivially comparable against future upstream updates via diff.
+//
+// Cases are grouped by the Dimension 1–4 / semantic-walk axis they cover; the
+// inline comments name the specific upstream branch / AST edge they protect.
+
+// polymorphicSettings exercises the `polymorphicPropName` setting — the rule
+// must consult the polymorphic prop (here `as`) to derive the effective HTML
+// element name before consulting roleElements.tagNames for membership.
+// Upstream's own test file doesn't cover this path.
+var polymorphicSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+	},
+}
+
+// componentsSettings exercises the `components` settings map — `<MyButton>`
+// resolves to nodeType "button" via the user-supplied component → tag map.
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"MyButton": "button",
+			"MyHeader": "header",
+			"NotAnImg": "div",
+		},
+	},
+}
+
+// helper for invalid cases that aren't at line 1, column 1 (multi-line code,
+// declaration-prefixed JSX).
+func expectedErrAt(role, tag string, line, col int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "preferTagOverRole",
+		Message:   errorMessage(tag, role),
+		Line:      line,
+		Column:    col,
+	}
+}
+
+// TestPreferTagOverRoleExtras locks in branches that upstream's test file
+// doesn't exercise but are reachable through the rule's listener gate.
+func TestPreferTagOverRoleExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferTagOverRoleRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// Dimension 1: AST shapes that DON'T resolve to a literal-typed
+			//              string role → rule short-circuits before any
+			//              roleElements lookup.
+			// ============================================================
+
+			// ---- No role attribute → rule never fires.
+			//      Locks in upstream `if (!role) return;` arm 1. ----
+			{Code: `<div />`, Tsx: true},
+			{Code: `<span />`, Tsx: true},
+
+			// ---- Boolean form `<div role />` — PropStaticStringValue sees a
+			//      JsxAttribute with no Initializer → ("", false) → skip.
+			//      Upstream would crash on `(true).lastIndexOf(' ')` for the
+			//      boolean-attr extracted value; we are strictly safer. ----
+			{Code: `<div role />`, Tsx: true},
+
+			// ---- Empty string role — passes the !ok check (ok=true, str="")
+			//      and trips the `rawRole == ""` short-circuit. Mirrors
+			//      upstream `if (!propValue) return;`. ----
+			{Code: `<div role="" />`, Tsx: true},
+			{Code: `<div role={""} />`, Tsx: true},
+
+			// ---- Trailing space — getLastPropValue returns "" via
+			//      lastIndexOf+substring → roleElements.get("") undefined →
+			//      skip. Locks in the boundary at i+1 == len(s). ----
+			{Code: `<div role="checkbox " />`, Tsx: true},
+
+			// ---- Identifier value (`role={x}`) — PropStaticStringValue
+			//      synthesizes the identifier NAME as a string ("x"); "x"
+			//      isn't a real ARIA role, so roleElements.get fails → skip.
+			//      Locks the helper's "identifier-to-name-string" behavior
+			//      against future refactors that might silently flip it. ----
+			{Code: `<div role={someRole} />`, Tsx: true},
+			{Code: `<button role={x} />`, Tsx: true},
+
+			// ---- LogicalExpression `r || "checkbox"` — staticEval(r) returns
+			//      the identifier name "r" (truthy string), so the OR short-
+			//      circuits to "r"; "r" isn't a role → skip. Locks in
+			//      staticEval's Logical short-circuit and the Identifier-as-
+			//      name-string synthesis. ----
+			{Code: `<div role={r || "checkbox"} />`, Tsx: true},
+			// ---- CallExpression / MemberExpression role — staticEval emits
+			//      stable placeholders ("(call)" / "(member)") that are not
+			//      ARIA roles → skip. Locks in the synthesized-string shape;
+			//      a future change that lets these resolve to a real role
+			//      would unexpectedly start reporting. ----
+			{Code: `<div role={getRole()} />`, Tsx: true},
+			{Code: `<div role={config.role} />`, Tsx: true},
+
+			// ---- Non-string literal under a JsxExpression — boolean, null,
+			//      undefined, number all fall outside the jvString classification
+			//      and are silently skipped. Upstream's getPropValue would
+			//      return these and then `.lastIndexOf` would throw; we are
+			//      strictly safer.
+			//      ----
+			{Code: `<div role={true} />`, Tsx: true},
+			{Code: `<div role={false} />`, Tsx: true},
+			{Code: `<div role={null} />`, Tsx: true},
+			{Code: `<div role={undefined} />`, Tsx: true},
+			{Code: `<div role={42} />`, Tsx: true},
+
+			// ---- Role names that aren't in roleElements.
+			//      Locks upstream's `if (!matchedTagsSet) return;` arm. ----
+			{Code: `<div role="unknown" />`, Tsx: true},
+			{Code: `<div role="not-a-real-role" />`, Tsx: true},
+			// Multi-token where the LAST token isn't a real role.
+			{Code: `<div role="checkbox unknown" />`, Tsx: true},
+			// Abstract roles are in aria-query's rolesMap but NOT in
+			// roleElementMap (their concept lists are empty after the
+			// HTML-only filter). roleElements.get("command") → undefined → skip.
+			{Code: `<div role="command" />`, Tsx: true},
+			{Code: `<div role="widget" />`, Tsx: true},
+			{Code: `<div role="composite" />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 4 / Semantic walk: element already IS the role's
+			//              semantic tag → upstream's `.some()` returns true
+			//              → skip.
+			// ============================================================
+
+			// ---- heading: every h1–h6 should pass (locks in the multi-tag
+			//      `.some()` walk, not just the first entry). ----
+			{Code: `<h1 role="heading" />`, Tsx: true},
+			{Code: `<h2 role="heading" />`, Tsx: true},
+			{Code: `<h3 role="heading" />`, Tsx: true},
+			{Code: `<h4 role="heading" />`, Tsx: true},
+			{Code: `<h5 role="heading" />`, Tsx: true},
+			{Code: `<h6 role="heading" />`, Tsx: true},
+
+			// ---- rowgroup: tbody / tfoot / thead all valid. ----
+			{Code: `<tbody role="rowgroup" />`, Tsx: true},
+			{Code: `<tfoot role="rowgroup" />`, Tsx: true},
+			{Code: `<thead role="rowgroup" />`, Tsx: true},
+
+			// ---- link: a / area both valid. The match is on NAME only —
+			//      upstream's matchedTags.some(tag.name === elementType)
+			//      ignores the role concept's attribute requirements (the
+			//      `href` constraint is purely a formatTag detail). So
+			//      `<a role="link" />` is valid even WITHOUT href; locks
+			//      in that asymmetric behavior. ----
+			{Code: `<a role="link" />`, Tsx: true},
+			{Code: `<area role="link" />`, Tsx: true},
+
+			// ---- banner / header parity: header is the only tag in the
+			//      banner role's mapping. ----
+			{Code: `<header role="banner" />`, Tsx: true},
+
+			// ---- generic role: one entry per name — pick a few spread across
+			//      the list. ----
+			{Code: `<div role="generic" />`, Tsx: true},
+			{Code: `<span role="generic" />`, Tsx: true},
+			{Code: `<body role="generic" />`, Tsx: true},
+			{Code: `<section role="generic" />`, Tsx: true},
+
+			// ---- list role: menu / ol / ul all valid; named match,
+			//      attribute-free. ----
+			{Code: `<menu role="list" />`, Tsx: true},
+			{Code: `<ol role="list" />`, Tsx: true},
+			{Code: `<ul role="list" />`, Tsx: true},
+
+			// ---- term role: dfn / dt both valid. ----
+			{Code: `<dfn role="term" />`, Tsx: true},
+			{Code: `<dt role="term" />`, Tsx: true},
+
+			// ---- listbox: select OR datalist. ----
+			{Code: `<select role="listbox" />`, Tsx: true},
+			{Code: `<datalist role="listbox" />`, Tsx: true},
+
+			// ---- textbox: input OR textarea — locks in the OR-arm. ----
+			{Code: `<input role="textbox" />`, Tsx: true},
+			{Code: `<textarea role="textbox" />`, Tsx: true},
+
+			// ---- combobox: input OR select — locks in the OR-arm. ----
+			{Code: `<input role="combobox" />`, Tsx: true},
+			{Code: `<select role="combobox" />`, Tsx: true},
+
+			// ---- group: details / fieldset / optgroup / address — locks in
+			//      the 4-arm OR walk for completeness. ----
+			{Code: `<details role="group" />`, Tsx: true},
+			{Code: `<fieldset role="group" />`, Tsx: true},
+			{Code: `<optgroup role="group" />`, Tsx: true},
+			{Code: `<address role="group" />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 4 / Semantic walk: polymorphicPropName + components.
+			// ============================================================
+
+			// ---- `<Box as="input" role="checkbox" />` — elementType resolves
+			//      to "input" via polymorphicPropName=as → matches → valid.
+			//      Locks in that GetElementType runs BEFORE the tagNames
+			//      check. ----
+			{Code: `<Box as="input" role="checkbox" />`, Tsx: true, Settings: polymorphicSettings},
+
+			// ---- components map: `<MyHeader role="banner" />` resolves to
+			//      tag "header" → header is in banner.tagNames → valid. ----
+			{Code: `<MyHeader role="banner" />`, Tsx: true, Settings: componentsSettings},
+			// ---- components map: `<MyButton role="button" />` resolves to
+			//      tag "button" → button.tagNames includes "button" → valid.
+			//      Without the settings the same code would REPORT (PascalCase
+			//      element-name fails the tagNames check); the inverse-case
+			//      `<MyComponent role="link" />` lives in invalid below. ----
+			{Code: `<MyButton role="button" />`, Tsx: true, Settings: componentsSettings},
+
+			// ============================================================
+			// Dimension 1: case-sensitivity on the role-name comparison.
+			// ============================================================
+
+			// ---- roleElements lookup is case-SENSITIVE (matches upstream
+			//      `roleElements.get(role)` — JS Map keys are case-sensitive).
+			//      `<div role="CHECKBOX" />` therefore fails the lookup →
+			//      skip. Upstream's own test file doesn't cover this. ----
+			{Code: `<div role="CHECKBOX" />`, Tsx: true},
+			{Code: `<div role="Heading" />`, Tsx: true},
+
+			// ============================================================
+			// Dimension 4: empty role / whitespace-only role.
+			// ============================================================
+
+			// ---- Whitespace-only role string — getLastPropValue:
+			//      lastIndexOf(' ') = len-1 → substring(len) = "" → skip. ----
+			{Code: `<div role=" " />`, Tsx: true},
+			{Code: `<div role="   " />`, Tsx: true},
+
+			// ============================================================
+			// Listener gate: PAIRED vs self-closing — both should be reached.
+			// (Self-closing is covered throughout; verify paired-no-trigger
+			// for an element on the role's tagNames list.)
+			// ============================================================
+
+			// ---- Paired-form `<header role="banner"></header>` — matches
+			//      header → valid. Lock the gate for the paired
+			//      KindJsxOpeningElement listener arm. ----
+			{Code: `<header role="banner"></header>`, Tsx: true},
+
+			// ============================================================
+			// Dimension 4: explicit role on the element's own semantic tag
+			// across all single-tag mappings (regression cordon — locks in
+			// every single-tag role's tagNames against future table edits).
+			// ============================================================
+			{Code: `<article role="article" />`, Tsx: true},
+			{Code: `<blockquote role="blockquote" />`, Tsx: true},
+			{Code: `<caption role="caption" />`, Tsx: true},
+			{Code: `<td role="cell" />`, Tsx: true},
+			{Code: `<code role="code" />`, Tsx: true},
+			{Code: `<th role="columnheader" />`, Tsx: true},
+			{Code: `<aside role="complementary" />`, Tsx: true},
+			{Code: `<footer role="contentinfo" />`, Tsx: true},
+			{Code: `<dd role="definition" />`, Tsx: true},
+			{Code: `<del role="deletion" />`, Tsx: true},
+			{Code: `<dialog role="dialog" />`, Tsx: true},
+			{Code: `<html role="document" />`, Tsx: true},
+			{Code: `<em role="emphasis" />`, Tsx: true},
+			{Code: `<figure role="figure" />`, Tsx: true},
+			{Code: `<form role="form" />`, Tsx: true},
+			{Code: `<td role="gridcell" />`, Tsx: true},
+			{Code: `<ins role="insertion" />`, Tsx: true},
+			{Code: `<li role="listitem" />`, Tsx: true},
+			{Code: `<main role="main" />`, Tsx: true},
+			{Code: `<mark role="mark" />`, Tsx: true},
+			{Code: `<math role="math" />`, Tsx: true},
+			{Code: `<meter role="meter" />`, Tsx: true},
+			{Code: `<nav role="navigation" />`, Tsx: true},
+			{Code: `<option role="option" />`, Tsx: true},
+			{Code: `<p role="paragraph" />`, Tsx: true},
+			{Code: `<img role="presentation" />`, Tsx: true},
+			{Code: `<progress role="progressbar" />`, Tsx: true},
+			{Code: `<input role="radio" />`, Tsx: true},
+			{Code: `<section role="region" />`, Tsx: true},
+			{Code: `<tr role="row" />`, Tsx: true},
+			{Code: `<th role="rowheader" />`, Tsx: true},
+			{Code: `<input role="searchbox" />`, Tsx: true},
+			{Code: `<hr role="separator" />`, Tsx: true},
+			{Code: `<input role="slider" />`, Tsx: true},
+			{Code: `<input role="spinbutton" />`, Tsx: true},
+			{Code: `<output role="status" />`, Tsx: true},
+			{Code: `<strong role="strong" />`, Tsx: true},
+			{Code: `<sub role="subscript" />`, Tsx: true},
+			{Code: `<sup role="superscript" />`, Tsx: true},
+			{Code: `<table role="table" />`, Tsx: true},
+			{Code: `<time role="time" />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Dimension 4: role values inside `{…}` JsxExpression — direct
+			//              literal extraction.
+			// ============================================================
+
+			// ---- `<div role={"checkbox"} />` — JsxExpression wrapping a
+			//      StringLiteral. PropStaticStringValue must reach into the
+			//      expression and return "checkbox"; upstream extracts via
+			//      `extractValue` for the JSXExpressionContainer arm. ----
+			{
+				Code:   `<div role={"checkbox"} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ---- NoSubstitutionTemplateLiteral form — same extraction path.
+			//      Lock in to confirm the helper doesn't restrict to
+			//      KindStringLiteral. ----
+			{
+				Code:   "<div role={`checkbox`} />",
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ---- BinaryExpression resolvable to a literal — `"check" + "box"`
+			//      → "checkbox" via staticEval's PlusToken arm. Upstream's
+			//      getPropValue routes through the same string concatenation
+			//      coercion. ----
+			{
+				Code:   `<div role={"check" + "box"} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ============================================================
+			// Dimension 4: case-insensitive role-ATTRIBUTE-name lookup.
+			// ============================================================
+
+			// ---- `<div ROLE="checkbox" />` — FindAttributeByName uses
+			//      EqualFold, mirroring jsx-ast-utils' default `ignoreCase:
+			//      true`. Locks in case-insensitive attribute-name matching. ----
+			{
+				Code:   `<div ROLE="checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ============================================================
+			// Dimension 4: Spread-attribute literal-spread path.
+			// ============================================================
+
+			// ---- Literal-object spread carries the role attribute.
+			//      FindAttributeByName's literal-spread arm walks the inner
+			//      ObjectLiteralExpression and matches `role`. ----
+			{
+				Code:   `<div {...{role:"checkbox"}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ============================================================
+			// Listener gate: PAIRED form `<X role="...">…</X>` — tsgo splits
+			//                into KindJsxOpeningElement + children, separate
+			//                from the self-closing case. Both arms must fire.
+			// ============================================================
+
+			// ---- Paired form on a div → report on the OPENING element. ----
+			{
+				Code:   `<div role="checkbox"></div>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ---- Paired form on a custom component → report. ----
+			{
+				Code:   `<MyComponent role="heading">child</MyComponent>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`)},
+			},
+
+			// ============================================================
+			// Dimension 4: polymorphicPropName + components — element-name
+			//              resolution must run BEFORE the tagNames check.
+			// ============================================================
+
+			// ---- `<Box as="div" role="checkbox" />` → elementType = "div"
+			//      via polymorphicPropName=as → not in checkbox.tagNames →
+			//      report. ----
+			{
+				Code:     `<Box as="div" role="checkbox" />`,
+				Tsx:      true,
+				Settings: polymorphicSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ---- components map: `<NotAnImg role="img" />` resolves to "div"
+			//      → img.tagNames is just ["img"] → report. Locks
+			//      the components map being consulted by GetElementType. ----
+			{
+				Code:     `<NotAnImg role="img" />`,
+				Tsx:      true,
+				Settings: componentsSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedErr("img", `<img alt=...>, or <img alt=...>`)},
+			},
+
+			// ---- PascalCase custom element (no settings) — elementType =
+			//      "MyComponent" → not in link.tagNames → report. ----
+			{
+				Code:   `<MyComponent role="link" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("link", `<a href=...>, or <area href=...>`)},
+			},
+
+			// ---- Namespaced JSX (`<svg:foo>`) — elementType = "svg:foo" →
+			//      not in any tagNames → report. Locks in the GetElementType
+			//      passthrough for namespaced names. ----
+			{
+				Code:   `<svg:foo role="checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ============================================================
+			// Dimension 4: multi-token role — LAST-token semantics across
+			//              several shapes.
+			// ============================================================
+
+			// ---- 3 tokens — verify lastIndexOf-based extraction (NOT
+			//      first-match). Upstream `getLastPropValue` only consults
+			//      the last token. ----
+			{
+				Code:   `<div role="alert button checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			// ---- Double-space between tokens — still tokenized on single
+			//      ASCII space; lastIndexOf finds the LAST space, so the
+			//      empty inner-token is irrelevant. Last token = "checkbox". ----
+			{
+				Code:   `<div role="button  checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			// ---- Leading space — last token is still the unique role token. ----
+			{
+				Code:   `<div role=" checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ============================================================
+			// Dimension 4: roles whose tagNames list has exactly one entry —
+			//              regression cordon against table edits. Pick a
+			//              representative subset of single-tag roles not
+			//              covered by upstream's invalid table.
+			// ============================================================
+			{
+				Code:   `<div role="article" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("article", `<article>`)},
+			},
+			{
+				Code:   `<div role="paragraph" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("paragraph", `<p>`)},
+			},
+			{
+				Code:   `<div role="navigation" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("navigation", `<nav>`)},
+			},
+			{
+				Code:   `<div role="separator" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("separator", `<hr>`)},
+			},
+			{
+				Code:   `<div role="time" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("time", `<time>`)},
+			},
+
+			// ============================================================
+			// Dimension 4: roles with 2 tagNames — locks in the `, or `
+			//              join shape and exact ordering.
+			// ============================================================
+			{
+				Code:   `<div role="term" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("term", `<dfn>, or <dt>`)},
+			},
+
+			// ============================================================
+			// Dimension 4: roles where formatTag emits a `value` for the
+			//              first attribute — locks in the
+			//              `"\"${value}\""` branch vs the `...` fallback.
+			// ============================================================
+			{
+				Code:   `<div role="radio" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("radio", `<input type="radio">`)},
+			},
+			{
+				Code:   `<div role="slider" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("slider", `<input type="range">`)},
+			},
+			{
+				Code:   `<div role="spinbutton" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("spinbutton", `<input type="number">`)},
+			},
+
+			// ============================================================
+			// Dimension 4: roles where the FIRST attribute is value-less
+			//              (formatTag emits `...`). Locks in the long
+			//              upstream concat for textbox / combobox / etc.
+			// ============================================================
+			{
+				Code:   `<div role="textbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("textbox", `<input type=...>, <input list=...>, <input list=...>, <input list=...>, <input list=...>, or <textarea>`)},
+			},
+			{
+				Code:   `<div role="combobox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("combobox", `<input list=...>, <input list=...>, <input list=...>, <input list=...>, <input list=...>, <input list=...>, or <select multiple=...>`)},
+			},
+			{
+				Code:   `<div role="listbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("listbox", `<select size=...>, <select multiple=...>, or <datalist>`)},
+			},
+			{
+				Code:   `<div role="searchbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("searchbox", `<input list=...>`)},
+			},
+			// ---- generic role: 19 single-name tags → the longest concat. ----
+			{
+				Code:   `<table role="generic" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("generic", `<a>, <area>, <aside>, <b>, <bdo>, <body>, <data>, <div>, <footer>, <header>, <hgroup>, <i>, <pre>, <q>, <samp>, <section>, <small>, <span>, or <u>`)},
+			},
+
+			// ============================================================
+			// tsgo-specific AST shapes (no ESTree analog): TS assertion
+			// wrappers, parenthesized values, NonNull `!` — staticEval's
+			// skipTransparent strips `( )` + `as` + `<T>x` but PRESERVES
+			// `!` (NonNullExpression) and `satisfies`, matching upstream
+			// jsx-ast-utils' getPropValue.
+			// ============================================================
+
+			// ---- `as` wrapper — stripped by staticEval.skipTransparent →
+			//      inner string literal is extracted → report. tsgo-only
+			//      shape (ESTree's parser elides `as`-expressions at parse
+			//      time so upstream never sees them). ----
+			{
+				Code:   `<div role={"checkbox" as any} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			{
+				Code:   `<div role={"checkbox" as const} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			// ---- Paren-wrapped value — staticEval strips parens. ----
+			{
+				Code:   `<div role={("checkbox")} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			{
+				Code:   `<div role={(("checkbox"))} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			// ---- Paren + `as` combination. ----
+			{
+				Code:   `<div role={("checkbox" as string)} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ============================================================
+			// JSX namespace / member-access tag names.
+			// ============================================================
+
+			// ---- `<Foo.Bar role="link" />` — elementType resolves to
+			//      "Foo.Bar" via reactutil.GetJsxElementTypeString's
+			//      PropertyAccessExpression arm → never in link.tagNames →
+			//      report. ----
+			{
+				Code:   `<Foo.Bar role="link" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("link", `<a href=...>, or <area href=...>`)},
+			},
+			// ---- Three-level member access. ----
+			{
+				Code:   `<Foo.Bar.Baz role="heading" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`)},
+			},
+
+			// ============================================================
+			// Element IS in some OTHER role's tagNames but NOT in this
+			// role's — locks in that tagNames lookup is role-specific.
+			// ============================================================
+
+			// ---- `<header role="heading" />` — header is in banner's
+			//      tagNames but NOT heading's → report. ----
+			{
+				Code:   `<header role="heading" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`)},
+			},
+			// ---- `<a role="checkbox" />` — a is in link's tagNames but NOT
+			//      checkbox's → report. ----
+			{
+				Code:   `<a role="checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ============================================================
+			// Listener boundary: nested JSX inside conditional, fragment,
+			// and array-children — listener fires on every JsxOpeningElement
+			// / JsxSelfClosingElement encountered.
+			// ============================================================
+
+			// ---- JSX child of a JSX expression container. ----
+			{
+				Code: `<div>{cond ? <span role="checkbox" /> : null}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedErrAt("checkbox", `<input type="checkbox">`, 1, 14),
+				},
+			},
+			// ---- JSX child of a Fragment. ----
+			{
+				Code: `<><div role="banner" /></>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedErrAt("banner", `<header>`, 1, 3),
+				},
+			},
+			// ---- JSX inside an array literal. ----
+			{
+				Code: `<div>{[<span role="link" key={1} />, <span role="heading" key={2} />]}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedErrAt("link", `<a href=...>, or <area href=...>`, 1, 8),
+					expectedErrAt("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`, 1, 38),
+				},
+			},
+			// ---- Triple-nested JSX with mixed role / non-role siblings —
+			//      each report comes from the same listener entry, not
+			//      from a residual visitor state. ----
+			{
+				Code: `<main>
+  <section role="banner">
+    <div role="rowgroup">
+      <p>ok</p>
+    </div>
+  </section>
+</main>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedErrAt("banner", `<header>`, 2, 3),
+					expectedErrAt("rowgroup", `<tbody>, <tfoot>, or <thead>`, 3, 5),
+				},
+			},
+
+			// ============================================================
+			// LogicalExpression where the LEFT operand statically resolves
+			// to a falsy literal: short-circuits to the RIGHT operand. The
+			// right-hand role string is what reaches roleElements lookup.
+			// Lock in staticEval's `||` truthy-short-circuit arm.
+			// ============================================================
+			{
+				Code:   `<div role={"" || "checkbox"} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			// ---- Nullish coalescing `??` — same path. ----
+			{
+				Code:   `<div role={null ?? "checkbox"} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ============================================================
+			// Dimension 4: line/column assertions on multi-line code.
+			// ============================================================
+
+			// ---- JSX on line 2 — locks in the report position. ----
+			{
+				Code: `
+<div role="checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("checkbox", `<input type="checkbox">`, 2, 1)},
+			},
+			// ---- Indented JSX inside a return — locks column. ----
+			{
+				Code: `function App() {
+  return <div role="link" />;
+}`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("link", `<a href=...>, or <area href=...>`, 2, 10)},
+			},
+
+			// ============================================================
+			// Dimension 4: nested JSX — listener must fire on every match,
+			//              not just outer-most.
+			// ============================================================
+			{
+				Code: `<section>
+  <div role="banner" />
+</section>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("banner", `<header>`, 2, 3)},
+			},
+			{
+				Code: `<div role="heading">
+  <span role="checkbox" />
+</div>`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedErrAt("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`, 1, 1),
+					expectedErrAt("checkbox", `<input type="checkbox">`, 2, 3),
+				},
+			},
+
+			// ============================================================
+			// Dimension 4: button-on-element-that's-not-button — the rule
+			//              should not auto-pair a `<button>` to the `link`
+			//              role (they live in separate roleElements entries).
+			// ============================================================
+			{
+				Code:   `<button role="link" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("link", `<a href=...>, or <area href=...>`)},
+			},
+			// ---- Same direction inverted: `<a role="button" />` — a is NOT
+			//      a button tag; button.tagNames is just [input, button].
+			//      Report. Locks the unidirectional mapping. ----
+			{
+				Code:   `<a role="button" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("button", `<input type="button">, <input type="image">, <input type="reset">, <input type="submit">, or <button>`)},
+			},
+
+			// ============================================================
+			// Dimension 4: column position for declaration-prefixed JSX
+			//              variants — exercise the same shape with arrow
+			//              and class wrappers, both single-line.
+			// ============================================================
+			{
+				Code:   `const x = <div role="rowgroup" />;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("rowgroup", `<tbody>, <tfoot>, or <thead>`, 1, 11)},
+			},
+
+			// ============================================================
+			// HTML entity decoding on the direct `<X role="...">` form —
+			// extractRoleString applies jsxtransforms.DecodeEntities so
+			// `role="&#99;heckbox"` resolves to "checkbox" (same as ESTree's
+			// JSX parser would expose). The `{…}`-wrapped form carries a
+			// JS string literal (not JSX attribute text) and is NOT decoded,
+			// matching jsx-ast-utils.
+			// ============================================================
+
+			// ---- &#99; → "c"; full decoded value "checkbox". ----
+			{
+				Code:   `<div role="&#99;heckbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			// ---- &#32; → ASCII space; decoding yields a multi-token role
+			//      whose LAST token "checkbox" trips the rule. Locks in
+			//      the entity-decode-before-tokenize ordering. ----
+			{
+				Code:   `<div role="button&#32;checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			// ---- Hex entity. ----
+			{
+				Code:   `<div role="&#x68;eading" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`)},
+			},
+
+			// ============================================================
+			// Identifier whose NAME is a real role string — upstream
+			// `getPropValue(Identifier)` synthesizes the identifier name
+			// as a string, so this REPORTS. Locks in PropStaticStringValue's
+			// identifier-name-string behavior; without it, real codebase
+			// patterns like
+			//
+			//	const checkbox = 'checkbox';
+			//	<div role={checkbox} />
+			//
+			// would silently slip past the rule.
+			// ============================================================
+			{
+				Code:   `<div role={checkbox} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			{
+				Code:   `<div role={heading} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`)},
+			},
+			{
+				Code:   `<div role={banner} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("banner", `<header>`)},
+			},
+			// ---- Logical short-circuit to identifier: real-world
+			//      "default role" pattern `role={x || checkbox}` when x is
+			//      empty. staticEval(LogicalExpression) → right operand
+			//      "checkbox" → report. ----
+			{
+				Code:   `<div role={"" || checkbox} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ============================================================
+			// Real-world component patterns — the rule must fire identically
+			// regardless of the enclosing declaration.
+			// ============================================================
+
+			// ---- Function-declaration component. ----
+			{
+				Code: `function Card() {
+  return <div role="checkbox" />;
+}`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("checkbox", `<input type="checkbox">`, 2, 10)},
+			},
+			// ---- Arrow-function component (implicit return). ----
+			{
+				Code:   `const Card = () => <div role="checkbox" />;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("checkbox", `<input type="checkbox">`, 1, 20)},
+			},
+			// ---- Class-component render method. ----
+			{
+				Code: `class Card extends React.Component {
+  render() {
+    return <div role="heading" />;
+  }
+}`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`, 3, 12)},
+			},
+			// ---- React.forwardRef wrap. ----
+			{
+				Code: `const Card = React.forwardRef((props, ref) => (
+  <div ref={ref} role="banner" />
+));`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("banner", `<header>`, 2, 3)},
+			},
+			// ---- React.memo wrap. ----
+			{
+				Code:   `const Card = React.memo(() => <span role="checkbox" />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("checkbox", `<input type="checkbox">`, 1, 31)},
+			},
+			// ---- Custom HOC. ----
+			{
+				Code:   `const Card = withTheme(props => <span role="link" />);`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("link", `<a href=...>, or <area href=...>`, 1, 33)},
+			},
+			// ---- List rendering via .map — JSX inside the callback fires. ----
+			{
+				Code: `function List({ items }) {
+  return items.map(item => <div key={item.id} role="checkbox" />);
+}`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("checkbox", `<input type="checkbox">`, 2, 28)},
+			},
+			// ---- Render-prop pattern. ----
+			{
+				Code:   `<Provider>{() => <div role="rowgroup" />}</Provider>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("rowgroup", `<tbody>, <tfoot>, or <thead>`, 1, 18)},
+			},
+			// ---- Custom hook returning JSX (uncommon but legal). ----
+			{
+				Code: `function useLabel() {
+  return <span role="checkbox" />;
+}`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("checkbox", `<input type="checkbox">`, 2, 10)},
+			},
+			// ---- Composed providers + a deep child. ----
+			{
+				Code: `<ThemeProvider>
+  <Layout>
+    <div role="checkbox" />
+  </Layout>
+</ThemeProvider>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErrAt("checkbox", `<input type="checkbox">`, 3, 5)},
+			},
+
+			// ============================================================
+			// Multiple offending elements in one file — each fires
+			// independently with the correct line/column.
+			// ============================================================
+			{
+				Code: `function App() {
+  return (
+    <div>
+      <span role="checkbox" />
+      <span role="heading" />
+      <span role="banner" />
+    </div>
+  );
+}`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedErrAt("checkbox", `<input type="checkbox">`, 4, 7),
+					expectedErrAt("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`, 5, 7),
+					expectedErrAt("banner", `<header>`, 6, 7),
+				},
+			},
+
+			// ============================================================
+			// Duplicate-role attribute — JSX allows two attributes with
+			// the same name; jsx-ast-utils' getProp returns the FIRST.
+			// FindAttributeByName mirrors that, so the diagnostic
+			// corresponds to the FIRST role value.
+			// ============================================================
+			{
+				Code:   `<div role="checkbox" role="banner" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+
+			// ============================================================
+			// Spread-vs-explicit ordering. FindAttributeByName scans in
+			// source order; the first JsxAttribute or literal-object spread
+			// containing the prop wins. Non-literal spread (`{...props}`)
+			// is opaque under upstream's strict default — does NOT shadow
+			// later explicit attributes.
+			// ============================================================
+
+			// ---- Literal spread comes FIRST and contains the role —
+			//      FindAttributeByName returns the spread's PropertyAssignment,
+			//      not the later explicit attribute. ----
+			{
+				Code:   `<div {...{role:"checkbox"}} role="link" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			// ---- Explicit role first, literal spread after — explicit wins. ----
+			{
+				Code:   `<div role="checkbox" {...{role:"link"}} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			// ---- Non-literal spread before explicit role — spread is
+			//      opaque, explicit role wins. ----
+			{
+				Code:   `<div {...props} role="checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			// ---- Non-literal spread AFTER explicit role — explicit wins. ----
+			{
+				Code:   `<span role="heading" {...rest} />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`)},
+			},
+
+			// ============================================================
+			// Design-system "Box as=…" real-world pattern via
+			// polymorphicPropName resolution to a non-semantic element.
+			// ============================================================
+			{
+				Code:     `<Box as="span" role="banner" />`,
+				Tsx:      true,
+				Settings: polymorphicSettings,
+				Errors:   []rule_tester.InvalidTestCaseError{expectedErr("banner", `<header>`)},
+			},
+
+			// ============================================================
+			// PascalCase tag vs lowercase native tag — Header is a custom
+			// component, NOT the HTML <header>, so the heading role on it
+			// still reports.
+			// ============================================================
+			{
+				Code:   `<Header role="heading" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`)},
+			},
+
+			// ============================================================
+			// Multi-role attribute where ONLY the last token names an
+			// invalid role — the rule reports the entire role-token even
+			// if earlier tokens look "fine". Locks in upstream
+			// getLastPropValue's "ignore all but the last" semantics.
+			// ============================================================
+			{
+				Code:   `<div role="presentation banner" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("banner", `<header>`)},
+			},
+
+			// ============================================================
+			// Element resolves through BOTH polymorphicPropName AND the
+			// components map — the polymorphic prop wins (it's consulted
+			// first in GetElementType), so the components map is only used
+			// when the polymorphic prop is absent.
+			// ============================================================
+			{
+				Code: `<Box as="span" role="heading" />`,
+				Tsx:  true,
+				Settings: map[string]interface{}{
+					"jsx-a11y": map[string]interface{}{
+						"polymorphicPropName": "as",
+						"components": map[string]interface{}{
+							"Box": "h1",
+						},
+					},
+				},
+				// "as" overrides "components", so elementType = "span",
+				// NOT "h1". span ∉ heading.tagNames → report.
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`)},
+			},
+		},
+	)
+}

--- a/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role_upstream_test.go
@@ -1,0 +1,84 @@
+package prefer_tag_over_role
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedErr matches upstream's `expectedError(role, tag)` — the rule
+// reports at the JsxOpeningElement / JsxSelfClosingElement; for top-level
+// JSX expressions in these tests that's line 1, column 1.
+func expectedErr(role, tag string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "preferTagOverRole",
+		Message:   errorMessage(tag, role),
+		Line:      1,
+		Column:    1,
+	}
+}
+
+// TestPreferTagOverRoleUpstream mirrors the entire upstream test file
+// (`__tests__/src/rules/prefer-tag-over-role-test.js` in
+// eslint-plugin-jsx-a11y) — every `valid` and `invalid` entry is migrated
+// 1:1. Lock-in tests for edge cases upstream doesn't cover (Dimensions 1–4,
+// semantic-walk branches) live in
+// `prefer_tag_over_role_extras_test.go` so this file stays trivially
+// diff-comparable against future upstream updates.
+func TestPreferTagOverRoleUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferTagOverRoleRule,
+		[]rule_tester.ValidTestCase{
+			// ---- valid ----
+			{Code: `<div />;`, Tsx: true},
+			{Code: `<div role="unknown" />;`, Tsx: true},
+			{Code: `<div role="also unknown" />;`, Tsx: true},
+			{Code: `<other />`, Tsx: true},
+			{Code: `<img role="img" />`, Tsx: true},
+			{Code: `<input role="checkbox" />`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- invalid ----
+			{
+				Code:   `<div role="checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			{
+				Code:   `<div role="button checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			{
+				Code:   `<div role="heading" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("heading", `<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>`)},
+			},
+			{
+				Code:   `<div role="link" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("link", `<a href=...>, or <area href=...>`)},
+			},
+			{
+				Code:   `<div role="rowgroup" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("rowgroup", `<tbody>, <tfoot>, or <thead>`)},
+			},
+			{
+				Code:   `<span role="checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			{
+				Code:   `<other role="checkbox" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("checkbox", `<input type="checkbox">`)},
+			},
+			{
+				Code:   `<div role="banner" />`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{expectedErr("banner", `<header>`)},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -188,6 +188,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-tabindex.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-redundant-roles.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-static-element-interactions.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/prefer-tag-over-role.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/role-has-required-aria-props.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/role-supports-aria-props.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/scope.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/prefer-tag-over-role.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/prefer-tag-over-role.test.ts
@@ -1,0 +1,430 @@
+import { RuleTester } from '../rule-tester';
+
+const errorMessage = (role: string, tag: string): string =>
+  `Use ${tag} instead of the "${role}" role to ensure accessibility across all devices.`;
+
+const polymorphicSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+  },
+};
+
+const componentsSettings = {
+  'jsx-a11y': {
+    components: {
+      MyHeader: 'header',
+      NotAnImg: 'div',
+    },
+  },
+};
+
+new RuleTester().run('prefer-tag-over-role', null as never, {
+  valid: [
+    // ============================================================
+    // Upstream valid set (mirrors __tests__/.../prefer-tag-over-role-test.js).
+    // ============================================================
+    { code: '<div />;' },
+    { code: '<div role="unknown" />;' },
+    { code: '<div role="also unknown" />;' },
+    { code: '<other />' },
+    { code: '<img role="img" />' },
+    { code: '<input role="checkbox" />' },
+
+    // ============================================================
+    // Non-literal role values short-circuit before any roleElements lookup.
+    // ============================================================
+    { code: '<div role={someRole} />' },
+    { code: '<div role={r || "checkbox"} />' },
+    { code: '<div role={getRole()} />' },
+    { code: '<div role={config.role} />' },
+    { code: '<div role />' },
+    { code: '<div role="" />' },
+    { code: '<div role={""} />' },
+    { code: '<div role={true} />' },
+    { code: '<div role={null} />' },
+    { code: '<div role={42} />' },
+
+    // ============================================================
+    // Element already IS one of the role's semantic tags → upstream's
+    // `.some()` short-circuits → skip.
+    // ============================================================
+    { code: '<h1 role="heading" />' },
+    { code: '<h6 role="heading" />' },
+    { code: '<tbody role="rowgroup" />' },
+    { code: '<thead role="rowgroup" />' },
+    { code: '<tfoot role="rowgroup" />' },
+    { code: '<a role="link" />' }, // href not required for the name match
+    { code: '<area role="link" />' },
+    { code: '<header role="banner" />' },
+    { code: '<input role="textbox" />' },
+    { code: '<textarea role="textbox" />' },
+    { code: '<select role="combobox" />' },
+    { code: '<input role="combobox" />' },
+    { code: '<select role="listbox" />' },
+    { code: '<datalist role="listbox" />' },
+
+    // ============================================================
+    // Case-sensitive roleElements lookup — `CHECKBOX` is not a key.
+    // ============================================================
+    { code: '<div role="CHECKBOX" />' },
+    { code: '<div role="Heading" />' },
+
+    // ============================================================
+    // polymorphicPropName: <Box as="input" role="checkbox" /> resolves
+    // to elementType "input" → input is in checkbox.tagNames → valid.
+    // ============================================================
+    {
+      code: '<Box as="input" role="checkbox" />',
+      settings: polymorphicSettings,
+    },
+
+    // ============================================================
+    // components map: <MyHeader role="banner" /> resolves to header.
+    // ============================================================
+    {
+      code: '<MyHeader role="banner" />',
+      settings: componentsSettings,
+    },
+
+    // ============================================================
+    // Unknown / abstract roles: not in roleElementMap → skip.
+    // ============================================================
+    { code: '<div role="not-a-real-role" />' },
+    { code: '<div role="checkbox unknown" />' }, // last token unknown
+    { code: '<div role="command" />' }, // abstract
+    { code: '<div role="widget" />' }, // abstract
+    { code: '<div role="composite" />' }, // abstract
+
+    // ============================================================
+    // Trailing / whitespace-only role string.
+    // ============================================================
+    { code: '<div role="checkbox " />' }, // trailing space → "" → skip
+    { code: '<div role=" " />' },
+  ],
+  invalid: [
+    // ============================================================
+    // Upstream invalid set.
+    // ============================================================
+    {
+      code: '<div role="checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<div role="button checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<div role="heading" />',
+      errors: [
+        {
+          message: errorMessage(
+            'heading',
+            '<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>',
+          ),
+        },
+      ],
+    },
+    {
+      code: '<div role="link" />',
+      errors: [
+        {
+          message: errorMessage('link', '<a href=...>, or <area href=...>'),
+        },
+      ],
+    },
+    {
+      code: '<div role="rowgroup" />',
+      errors: [
+        {
+          message: errorMessage('rowgroup', '<tbody>, <tfoot>, or <thead>'),
+        },
+      ],
+    },
+    {
+      code: '<span role="checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<other role="checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<div role="banner" />',
+      errors: [{ message: errorMessage('banner', '<header>') }],
+    },
+
+    // ============================================================
+    // role inside `{…}` JsxExpression — literal extraction must apply.
+    // ============================================================
+    {
+      code: '<div role={"checkbox"} />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<div role={`checkbox`} />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<div role={"check" + "box"} />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // Case-insensitive role-ATTRIBUTE-name match.
+    // ============================================================
+    {
+      code: '<div ROLE="checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // Literal-object spread.
+    // ============================================================
+    {
+      code: '<div {...{role:"checkbox"}} />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // Paired form `<X role="…">…</X>` — opening element is reported.
+    // ============================================================
+    {
+      code: '<div role="checkbox"></div>',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // polymorphicPropName + components map: element-name resolution
+    // happens BEFORE tagNames check.
+    // ============================================================
+    {
+      code: '<Box as="div" role="checkbox" />',
+      settings: polymorphicSettings,
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<NotAnImg role="img" />',
+      settings: componentsSettings,
+      errors: [
+        {
+          message: errorMessage('img', '<img alt=...>, or <img alt=...>'),
+        },
+      ],
+    },
+
+    // ============================================================
+    // PascalCase custom element / namespaced JSX — neither in tagNames.
+    // ============================================================
+    {
+      code: '<MyComponent role="link" />',
+      errors: [
+        {
+          message: errorMessage('link', '<a href=...>, or <area href=...>'),
+        },
+      ],
+    },
+    {
+      code: '<svg:foo role="checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // Multi-token role — LAST token semantics.
+    // ============================================================
+    {
+      code: '<div role="alert button checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<div role=" checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // Element-vs-role mismatches across single-tag mappings.
+    // ============================================================
+    {
+      code: '<div role="article" />',
+      errors: [{ message: errorMessage('article', '<article>') }],
+    },
+    {
+      code: '<div role="navigation" />',
+      errors: [{ message: errorMessage('navigation', '<nav>') }],
+    },
+    {
+      code: '<div role="separator" />',
+      errors: [{ message: errorMessage('separator', '<hr>') }],
+    },
+    {
+      code: '<div role="paragraph" />',
+      errors: [{ message: errorMessage('paragraph', '<p>') }],
+    },
+
+    // ============================================================
+    // Roles where formatTag emits the value-less `...` fallback.
+    // ============================================================
+    {
+      code: '<div role="textbox" />',
+      errors: [
+        {
+          message: errorMessage(
+            'textbox',
+            '<input type=...>, <input list=...>, <input list=...>, <input list=...>, <input list=...>, or <textarea>',
+          ),
+        },
+      ],
+    },
+    {
+      code: '<div role="searchbox" />',
+      errors: [{ message: errorMessage('searchbox', '<input list=...>') }],
+    },
+
+    // ============================================================
+    // button-on-element-that's-not-button (unidirectional).
+    // ============================================================
+    {
+      code: '<button role="link" />',
+      errors: [
+        {
+          message: errorMessage('link', '<a href=...>, or <area href=...>'),
+        },
+      ],
+    },
+    {
+      code: '<a role="button" />',
+      errors: [
+        {
+          message: errorMessage(
+            'button',
+            '<input type="button">, <input type="image">, <input type="reset">, <input type="submit">, or <button>',
+          ),
+        },
+      ],
+    },
+
+    // ============================================================
+    // HTML entity decoding on direct attributes — extractRoleString
+    // patches the decode so &#99; → "c", entire value "checkbox".
+    // ============================================================
+    {
+      code: '<div role="&#99;heckbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<div role="button&#32;checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // Identifier whose NAME happens to be a role string — upstream's
+    // getPropValue returns the bare name. Real codebase pattern:
+    //   const checkbox = 'checkbox'; <div role={checkbox} />
+    // ============================================================
+    {
+      code: '<div role={checkbox} />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<div role={"" || checkbox} />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // Duplicate-role attribute — FIRST occurrence wins (matches
+    // jsx-ast-utils' getProp).
+    // ============================================================
+    {
+      code: '<div role="checkbox" role="banner" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // Spread + explicit role ordering.
+    // ============================================================
+    {
+      code: '<div {...{role:"checkbox"}} role="link" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: '<div {...props} role="checkbox" />',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // Real-world component patterns.
+    // ============================================================
+    {
+      code: 'function Card() { return <div role="checkbox" />; }',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+    {
+      code: 'const Card = () => <div role="heading" />;',
+      errors: [
+        {
+          message: errorMessage(
+            'heading',
+            '<h1>, <h2>, <h3>, <h4>, <h5>, or <h6>',
+          ),
+        },
+      ],
+    },
+    {
+      code: 'const Card = React.memo(() => <span role="checkbox" />);',
+      errors: [
+        { message: errorMessage('checkbox', '<input type="checkbox">') },
+      ],
+    },
+
+    // ============================================================
+    // Multi-role last-token semantics on a non-checkbox last token.
+    // ============================================================
+    {
+      code: '<div role="presentation banner" />',
+      errors: [{ message: errorMessage('banner', '<header>') }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -4,6 +4,7 @@ accesskey
 accum
 activedescendant
 addl
+affordances
 afoob
 alertdialog
 alink


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/prefer-tag-over-role` rule from eslint-plugin-jsx-a11y to rslint. The rule enforces using semantic HTML elements over the ARIA `role` attribute (e.g. `<input type="checkbox">` instead of `<div role="checkbox">`).

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/prefer-tag-over-role.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/prefer-tag-over-role.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).