### PR TITLE
feat: port rule jsx-a11y/no-aria-hidden-on-focusable

### DIFF
--- a/internal/plugins/jsx_a11y/all.go
+++ b/internal/plugins/jsx_a11y/all.go
@@ -23,6 +23,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/media_has_caption"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_access_key"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_autofocus"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_distracting_elements"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role"
@@ -62,6 +63,7 @@ func GetAllRules() []rule.Rule {
 		media_has_caption.MediaHasCaptionRule,
 		mouse_events_have_key_events.MouseEventsHaveKeyEventsRule,
 		no_access_key.NoAccessKeyRule,
+		no_aria_hidden_on_focusable.NoAriaHiddenOnFocusableRule,
 		no_autofocus.NoAutofocusRule,
 		no_distracting_elements.NoDistractingElementsRule,
 		no_interactive_element_to_noninteractive_role.NoInteractiveElementToNoninteractiveRoleRule,

--- a/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
+++ b/internal/plugins/jsx_a11y/jsxa11yutil/jsxa11yutil.go
@@ -1321,6 +1321,33 @@ func IsHiddenFromScreenReaderFromTagAttrs(elementType string, attrs []*ast.Node)
 			}
 		}
 	}
+	return IsAriaHiddenTrue(attrs)
+}
+
+// IsAriaHiddenTrue mirrors upstream's
+//
+//	getPropValue(getProp(attrs, 'aria-hidden')) === true
+//
+// — the bare aria-hidden truthiness check shared by `isHiddenFromScreenReader`
+// and `no-aria-hidden-on-focusable`. Returns true iff the JSX attribute
+// `aria-hidden` resolves to JS boolean true via jsx-ast-utils' extractValue.
+//
+// The five matching shapes:
+//   - boolean form (`<div aria-hidden />`) — extractValue's null-attribute-value
+//     path → true
+//   - direct StringLiteral "true" / "True" / etc. — case-insensitive
+//     jsxAstUtilsLiteralCoerce coerces to boolean true (entity-decoded first
+//     so `<div aria-hidden="&#116;rue">` matches)
+//   - JsxExpression with literal `true` (`<div aria-hidden={true} />`)
+//   - JsxExpression with string literal "true" — same case-insensitive coerce
+//   - Any expression that staticEval resolves to boolean true (e.g.
+//     `<div aria-hidden={cond ? true : false} />` when `cond` is statically
+//     truthy)
+//
+// Every other shape — `aria-hidden="false"`, `aria-hidden={someVar}`, numeric
+// / null / undefined values, expressions staticEval cannot resolve — returns
+// false. This is upstream's `=== true` (strict) check, not a truthy test.
+func IsAriaHiddenTrue(attrs []*ast.Node) bool {
 	ariaHidden := FindAttributeByName(attrs, "aria-hidden")
 	if ariaHidden == nil {
 		return false

--- a/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable.go
+++ b/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable.go
@@ -1,0 +1,125 @@
+// Package no_aria_hidden_on_focusable ports eslint-plugin-jsx-a11y's
+// `no-aria-hidden-on-focusable` rule. It enforces that `aria-hidden="true"`
+// is not set on a focusable element — pairing the two confuses screen reader
+// users when the element can still be reached by keyboard.
+//
+// Upstream signature:
+//
+//	options: {}   (no options)
+//
+// Trigger sequence on each JsxOpeningElement / JsxSelfClosingElement:
+//
+//  1. `aria-hidden` must resolve to JS boolean `true` via upstream's
+//     `getPropValue(...) === true` (handled by [jsxa11yutil.IsAriaHiddenTrue]).
+//     The boolean-attribute form (`<div aria-hidden />`) counts, as does the
+//     case-insensitive string `"true"` and the explicit `{true}`.
+//  2. The element must be focusable per upstream's `isFocusable(type, attrs)`:
+//     - If `isInteractiveElement(type, attrs)` is true → focusable iff
+//       `tabIndex === undefined || tabIndex >= 0`. Inherently interactive
+//       elements (button, input, textarea, select, anchor-with-href, ...)
+//       skip the rule only when an explicit `tabIndex={-2}`-or-smaller (or
+//       any non-numeric resolved value that isn't `null`) removes them from
+//       focus order.
+//     - Otherwise → focusable iff `tabIndex >= 0`. Non-interactive tags
+//       become focusable only when an explicit `tabIndex` of `0` or greater
+//       is added.
+//
+// `aria-hidden=false` short-circuits step 1 and never reports, regardless of
+// focusability. Nested elements are NOT walked — the rule operates per JSX
+// element, mirroring upstream which intentionally leaves descendant focusable
+// elements under an `aria-hidden` ancestor to other rules.
+//
+// Diagnostic text mirrors upstream verbatim: `aria-hidden="true" must not be
+// set on focusable elements.`
+package no_aria_hidden_on_focusable
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// errorMessage mirrors upstream's `message` field verbatim.
+const errorMessage = `aria-hidden="true" must not be set on focusable elements.`
+
+var NoAriaHiddenOnFocusableRule = rule.Rule{
+	Name: "jsx-a11y/no-aria-hidden-on-focusable",
+	Run: func(ctx rule.RuleContext, _ any) rule.RuleListeners {
+		sourceText := ctx.SourceFile.Text()
+
+		check := func(node *ast.Node) {
+			attrs := reactutil.GetJsxElementAttributes(node)
+			if !jsxa11yutil.IsAriaHiddenTrue(attrs) {
+				return
+			}
+			elementType := jsxa11yutil.GetElementType(node, ctx.Settings)
+			if !isFocusable(elementType, attrs, sourceText) {
+				return
+			}
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noAriaHiddenOnFocusable",
+				Description: errorMessage,
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}
+
+// isFocusable mirrors upstream's `isFocusable(type, attributes)`:
+//
+//	const tabIndex = getTabIndex(getProp(attrs, 'tabIndex'));
+//	if (isInteractiveElement(type, attrs)) {
+//	  return (tabIndex === undefined || tabIndex >= 0);
+//	}
+//	return tabIndex >= 0;
+//
+// upstream's `getTabIndex` returns three observable kinds:
+//
+//   - a Number (step-1 integer or step-2 Number-coercible) — both arms reduce
+//     to `val >= 0`.
+//   - JS `undefined` (step-1 short-circuits: boolean form, empty / NaN string,
+//     boolean literal, non-integer numeric; or step-2 returns undefined via
+//     explicit `{undefined}` / `typeof` / `void`). For interactive elements
+//     this matches the `=== undefined` arm; for non-interactive `>= 0` is
+//     `NaN >= 0` → false.
+//   - JS `null` (step-2 fallthrough for shapes where `TYPES` has no extractor
+//     — `JSXEmptyExpression`, `SatisfiesExpression`, etc.). `null === undefined`
+//     is false but `null >= 0` ToNumber-coerces to `0 >= 0 → true`, so BOTH
+//     arms accept null as focusable.
+//   - A non-numeric resolved string (step-2 `Identifier` non-`undefined`,
+//     `MemberExpression`, `CallExpression`, `TaggedTemplateExpression`, ...).
+//     `string !== undefined` AND `Number(string) → NaN`, so BOTH arms reject.
+//
+// [jsxa11yutil.GetTabIndexEx]'s ambiguous `(0, false, false)` state collapses
+// the last two non-null cases; [jsxa11yutil.HasUpstreamTabIndexValue]
+// distinguishes them by asking `tabIndex !== undefined`. Combining both
+// recovers the four-way classification.
+func isFocusable(elementType string, attrs []*ast.Node, sourceText string) bool {
+	tabIndexAttr := jsxa11yutil.FindAttributeByName(attrs, "tabIndex")
+	val, resolved, nullLike := jsxa11yutil.GetTabIndexEx(tabIndexAttr, sourceText)
+	interactive := jsxa11yutil.IsInteractiveElement(elementType, attrs)
+
+	if resolved {
+		// Numeric result — both arms reduce to `val >= 0`.
+		return val >= 0
+	}
+	if nullLike {
+		// null — `null >= 0` ToNumber-coerces to 0; both arms accept.
+		return true
+	}
+	if !interactive {
+		// Non-interactive arm: `>= 0`. Whether the value is undefined or a
+		// non-numeric resolved string, ToNumber produces NaN → false.
+		return false
+	}
+	// Interactive arm: `=== undefined || >= 0`. The `>= 0` half is already
+	// excluded by resolved=false, nullLike=false (any value that would yield
+	// true would have been resolved or null). So focusability turns purely
+	// on `tabIndex === undefined`.
+	return !jsxa11yutil.HasUpstreamTabIndexValue(attrs, sourceText)
+}

--- a/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable.md
+++ b/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable.md
@@ -1,0 +1,58 @@
+# no-aria-hidden-on-focusable
+
+## Rule Details
+
+Disallow `aria-hidden="true"` from being set on focusable elements. An
+element with `aria-hidden="true"` is removed from the accessibility tree, so
+a screen reader will skip it; if the element is still in the focus order,
+keyboard and screen-reader users can land on a control that announces
+nothing, causing confusion.
+
+The rule fires on a JSX element when **both** of the following hold:
+
+- The `aria-hidden` prop resolves to JS boolean `true`. The boolean
+  attribute form (`<div aria-hidden />`), the case-insensitive strings
+  `"true"` / `"True"` / `"TRUE"`, the explicit `{true}`, and any expression
+  that statically evaluates to `true` all count.
+- The element is focusable per `aria-query`'s element-role map:
+  - **Inherently interactive** elements (`<button>`, `<input>`,
+    `<textarea>`, `<select>`, `<a href>`, `<area href>`, ...) are focusable
+    unless `tabIndex` resolves to a negative integer.
+  - **Non-interactive** elements (`<div>`, `<span>`, `<p>`, ...) and
+    **custom components** become focusable only when `tabIndex` resolves to
+    a non-negative integer.
+
+This rule takes no options.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div aria-hidden="true" tabIndex="0" />
+<input aria-hidden="true" />
+<a href="/" aria-hidden="true" />
+<button aria-hidden="true" />
+<textarea aria-hidden="true" />
+<p tabindex="0" aria-hidden="true">text</p>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div aria-hidden="true" />
+<div onClick={() => void 0} aria-hidden="true" />
+<img aria-hidden="true" />
+<a aria-hidden="false" href="#" />
+<button aria-hidden="true" tabIndex="-1" />
+<button />
+<a href="/" />
+```
+
+## Resources
+
+- [Deque University — `aria-hidden` elements do not contain focusable elements](https://dequeuniversity.com/rules/axe/html/4.4/aria-hidden-focus)
+- [W3C ACT — Element with `aria-hidden` has no content in sequential focus navigation](https://www.w3.org/WAI/standards-guidelines/act/rules/6cfa84/proposed/)
+- [MDN — `aria-hidden`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)
+
+## Original Documentation
+
+- [eslint-plugin-jsx-a11y/no-aria-hidden-on-focusable](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-aria-hidden-on-focusable.md)

--- a/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable_extras_test.go
@@ -1,0 +1,580 @@
+package no_aria_hidden_on_focusable
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// componentsSettings remaps `Btn → button` so `<Btn aria-hidden="true" />`
+// resolves to an inherently interactive element. Locks in that the rule
+// honors the jsx-a11y components map when classifying focusability.
+var componentsSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"components": map[string]interface{}{
+			"Btn": "button",
+		},
+	},
+}
+
+// polymorphicSettings mirrors a `polymorphicPropName: 'as'` config. With it,
+// `<Box as="input" aria-hidden="true" />` resolves to `input`.
+var polymorphicSettings = map[string]interface{}{
+	"jsx-a11y": map[string]interface{}{
+		"polymorphicPropName": "as",
+	},
+}
+
+// TestNoAriaHiddenOnFocusableExtras is the catch-all for everything beyond
+// upstream's small suite (which lives in no_aria_hidden_on_focusable_upstream_test.go).
+// Cases here fall in five groups, kept in one suite so a regression bisects
+// easily:
+//
+//  1. **aria-hidden value-extraction branches** — boolean form, JsxExpression
+//     true/false, case-insensitive "True"/"TRUE", JsxExpression-wrapped string
+//     literals, TS wrappers, non-matching values that must NOT short-circuit
+//     positively. Upstream's `getPropValue === true` has more reachable arms
+//     than its tiny test file covers.
+//  2. **tabIndex value-extraction branches** — negative integers, large
+//     positive, non-integer (silently dropped per upstream's Number.isInteger
+//     guard), empty / boolean / undefined / null shapes, entity-encoded HTML.
+//     Each exercises a distinct GetTabIndexEx exit.
+//  3. **Element kind survey** — every inherently interactive tag (button,
+//     input, textarea, select, option, audio/video with controls, summary,
+//     a-with-href, area-with-href, ...), every inherently non-interactive
+//     tag, and the component / member / polymorphic resolution paths.
+//  4. **Dimension 4 universal edge shapes** — JsxOpeningElement vs
+//     JsxSelfClosingElement, paired elements, spread attributes, nested JSX,
+//     namespaced names, multi-line, comments, position assertions.
+//  5. **Real-world patterns** — modal/dialog/menubar trees, conditional
+//     rendering, .map / .filter, HOC / forwardRef / memo, generator / async /
+//     IIFE bodies, TS generics, hyphenated tags, multi-component files.
+func TestNoAriaHiddenOnFocusableExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoAriaHiddenOnFocusableRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// Group 1: aria-hidden does NOT resolve to true → safe regardless of focus
+		// ============================================================
+		// No aria-hidden at all — first gate.
+		{Code: `<input />`, Tsx: true},
+		{Code: `<button tabIndex="0" />`, Tsx: true},
+		// aria-hidden values that staticEval cannot resolve to boolean true.
+		{Code: `<button aria-hidden={false} />`, Tsx: true},
+		{Code: `<input aria-hidden={false} />`, Tsx: true},
+		{Code: `<button aria-hidden="false" />`, Tsx: true},
+		{Code: `<button aria-hidden="False" />`, Tsx: true},
+		{Code: `<button aria-hidden="FALSE" />`, Tsx: true},
+		{Code: `<button aria-hidden={"false"} />`, Tsx: true},
+		// `{undefined}` extracts to JS undefined under upstream's Identifier
+		// extractor → not === true → safe.
+		{Code: `<button aria-hidden={undefined} />`, Tsx: true},
+		// Numeric: upstream extracts `0` / `1` → not === true → safe.
+		{Code: `<button aria-hidden={0} />`, Tsx: true},
+		{Code: `<button aria-hidden={1} />`, Tsx: true},
+		// String "yes" / "no" / etc — extractValue returns the raw string;
+		// jsxAstUtilsLiteralCoerce only normalizes "true" / "false".
+		{Code: `<button aria-hidden="yes" />`, Tsx: true},
+		// Identifier reference — upstream's Literal extractor returns the
+		// identifier's name as a string. "someVar" !== true → safe.
+		{Code: `<button aria-hidden={someVar} />`, Tsx: true},
+		// Member / Call — upstream synthesizes a non-boolean string → safe.
+		{Code: `<button aria-hidden={obj.x} />`, Tsx: true},
+		{Code: `<button aria-hidden={fn()} />`, Tsx: true},
+		// satisfies is opaque — staticEval returns jvNull → not boolean true.
+		{Code: `<button aria-hidden={true satisfies boolean} />`, Tsx: true},
+		// NoSubstitutionTemplateLiteral does NOT route through
+		// jsxAstUtilsLiteralCoerce, so `` `true` `` stays a string → safe.
+		{Code: "<button aria-hidden={`true`} />", Tsx: true},
+
+		// ============================================================
+		// Group 2: Non-interactive elements without focus-enabling tabIndex
+		// ============================================================
+		// aria-hidden=true on a non-interactive element with NO tabIndex →
+		// tabIndex >= 0 is false → not focusable → safe.
+		{Code: `<div aria-hidden />`, Tsx: true},
+		{Code: `<div aria-hidden={true} />`, Tsx: true},
+		{Code: `<div aria-hidden="true" />`, Tsx: true},
+		{Code: `<div aria-hidden="True" />`, Tsx: true},
+		{Code: `<div aria-hidden="TRUE" />`, Tsx: true},
+		{Code: `<span aria-hidden="true" />`, Tsx: true},
+		{Code: `<p aria-hidden="true" />`, Tsx: true},
+		{Code: `<section aria-hidden="true" />`, Tsx: true},
+		{Code: `<article aria-hidden="true" />`, Tsx: true},
+		// img / br / hr — non-interactive (img is in dom set but not in
+		// interactive role schemas) → safe without tabIndex.
+		{Code: `<img aria-hidden="true" />`, Tsx: true},
+		{Code: `<br aria-hidden="true" />`, Tsx: true},
+		{Code: `<hr aria-hidden="true" />`, Tsx: true},
+		// tabIndex="-1" on non-interactive → -1 < 0 → not focusable → safe.
+		{Code: `<div aria-hidden="true" tabIndex="-1" />`, Tsx: true},
+		{Code: `<div aria-hidden="true" tabIndex={-1} />`, Tsx: true},
+		{Code: `<p aria-hidden="true" tabIndex={-1}>text</p>`, Tsx: true},
+
+		// ============================================================
+		// Group 3: Interactive elements with explicit tabIndex < 0
+		// ============================================================
+		// Inherently interactive tags become NOT focusable when tabIndex is
+		// negative (and resolved). `tabIndex === undefined || tabIndex >= 0`
+		// → false || false → false.
+		{Code: `<button aria-hidden="true" tabIndex={-1} />`, Tsx: true},
+		{Code: `<button aria-hidden="true" tabIndex="-2" />`, Tsx: true},
+		{Code: `<input aria-hidden="true" tabIndex={-1} />`, Tsx: true},
+		{Code: `<input aria-hidden="true" tabIndex="-1" />`, Tsx: true},
+		{Code: `<textarea aria-hidden="true" tabIndex={-1} />`, Tsx: true},
+		{Code: `<select aria-hidden="true" tabIndex={-1} />`, Tsx: true},
+		{Code: `<a href="/" aria-hidden="true" tabIndex={-1} />`, Tsx: true},
+		// area requires href to be interactive.
+		{Code: `<area href="#" aria-hidden="true" tabIndex={-1} />`, Tsx: true},
+
+		// ============================================================
+		// Group 4: Custom components without tabIndex
+		// ============================================================
+		// Custom components fall through `isInteractiveElement` → tabIndex >=
+		// 0 path → without explicit tabIndex → safe.
+		{Code: `<MyButton aria-hidden="true" />`, Tsx: true},
+		{Code: `<UX.Layout aria-hidden="true" />`, Tsx: true},
+		{Code: `<svg:circle aria-hidden="true" />`, Tsx: true},
+		{Code: `<Foo.Bar.Baz aria-hidden="true" />`, Tsx: true},
+		// Custom component with tabIndex < 0 — non-interactive arm rejects.
+		{Code: `<MyButton aria-hidden="true" tabIndex={-1} />`, Tsx: true},
+
+		// ============================================================
+		// Group 5: <a> without href is non-interactive
+		// ============================================================
+		// Per upstream's element-role schemas, anchor requires `href` to count
+		// as interactive. `<a aria-hidden="true" />` without href → tabIndex
+		// >= 0 false → safe.
+		{Code: `<a aria-hidden="true" />`, Tsx: true},
+		{Code: `<area aria-hidden="true" />`, Tsx: true},
+
+		// ============================================================
+		// Group 5b: Interactive elements where tabIndex resolves to a
+		// non-numeric non-undefined value via upstream's step-2 getPropValue
+		// ============================================================
+		// Upstream's `isFocusable` interactive arm is `tabIndex === undefined ||
+		// tabIndex >= 0`. When getTabIndex falls through to step-2 getPropValue
+		// for shapes that LITERAL_TYPES doesn't catch (Identifier non-undefined,
+		// MemberExpression, CallExpression, TaggedTemplate, ...), upstream returns
+		// the synthesized string (`"someVar"`, `"obj.x"`, `"fn()"`, ...). The
+		// strict `=== undefined` check rejects these strings, and
+		// `string >= 0` ToNumbers to NaN → false. Both arms false → NOT focusable.
+		{Code: `<button aria-hidden="true" tabIndex={someVar} />`, Tsx: true},
+		{Code: `<input aria-hidden="true" tabIndex={someVar} />`, Tsx: true},
+		{Code: `<textarea aria-hidden="true" tabIndex={obj.x} />`, Tsx: true},
+		{Code: `<select aria-hidden="true" tabIndex={fn()} />`, Tsx: true},
+		{Code: `<button aria-hidden="true" tabIndex={obj?.x} />`, Tsx: true},
+		// Non-interactive equivalents — same arm, just confirming the
+		// non-interactive path also rejects.
+		{Code: `<div aria-hidden="true" tabIndex={someVar} />`, Tsx: true},
+		{Code: `<div aria-hidden="true" tabIndex={obj.x} />`, Tsx: true},
+		{Code: `<div aria-hidden="true" tabIndex={fn()} />`, Tsx: true},
+
+		// ============================================================
+		// Group 5c: `null` and `undefined` literal value resolution
+		// ============================================================
+		// LITERAL_TYPES.Literal special-cases null → "null" string → step-1
+		// `Number("null")` = NaN → undefined. Interactive arm's `=== undefined`
+		// matches; for non-interactive, NaN >= 0 → false.
+		// Non-interactive — safe.
+		{Code: `<div aria-hidden="true" tabIndex={null} />`, Tsx: true},
+
+		// ============================================================
+		// Group 6: tabIndex value-extraction → undefined → safe for non-interactive
+		// ============================================================
+		// Upstream getTabIndex returns undefined for these shapes; the
+		// non-interactive arm needs a resolved >= 0 to mark focusable.
+		{Code: `<div aria-hidden="true" tabIndex="" />`, Tsx: true},
+		{Code: `<div aria-hidden="true" tabIndex={undefined} />`, Tsx: true},
+		// Boolean tabIndex — upstream's step-1 boolean arm → undefined → safe.
+		{Code: `<div aria-hidden="true" tabIndex={true} />`, Tsx: true},
+		{Code: `<div aria-hidden="true" tabIndex={false} />`, Tsx: true},
+		// Non-integer numeric → upstream Number.isInteger filter → undefined → safe.
+		{Code: `<div aria-hidden="true" tabIndex={1.5} />`, Tsx: true},
+
+		// ============================================================
+		// Group 7: components map — non-DOM resolution
+		// ============================================================
+		// `<Btn aria-hidden="true" tabIndex={-1} />` with `Btn → button`
+		// → resolved as interactive → -1 not focusable → safe.
+		{Code: `<Btn aria-hidden="true" tabIndex={-1} />`, Tsx: true, Settings: componentsSettings},
+
+		// ============================================================
+		// Group 8: polymorphicPropName — `as="button"` resolves
+		// ============================================================
+		// `<Box as="button" aria-hidden="true" tabIndex={-1} />` resolves to
+		// `button` → interactive → -1 → not focusable → safe.
+		{Code: `<Box as="button" aria-hidden="true" tabIndex={-1} />`, Tsx: true, Settings: polymorphicSettings},
+
+		// ============================================================
+		// Group 9: TS wrappers around aria-hidden value
+		// ============================================================
+		// staticEval transparently unwraps parens and TSAsExpression — wrapped
+		// `true` extracts to boolean true → triggers the rule's gate. But
+		// `<div>` (non-interactive, no tabIndex) → not focusable → safe.
+		{Code: `<div aria-hidden={(true)} />`, Tsx: true},
+		{Code: `<div aria-hidden={true as boolean} />`, Tsx: true},
+		// TSNonNullExpression is DIFFERENT: upstream's extractor stringifies
+		// the operand with a trailing `!`, so `{true!}` extracts to the
+		// string `"true!"` — `"true!" === true` is false → aria-hidden gate
+		// fails → safe regardless of focus.
+		{Code: `<div aria-hidden={true!} />`, Tsx: true},
+		{Code: `<button aria-hidden={true!} />`, Tsx: true},
+		{Code: `<input aria-hidden={true!} />`, Tsx: true},
+
+		// ============================================================
+		// Group 10: Spread aria-hidden=true on non-focusable element
+		// ============================================================
+		// JsxSpreadAttribute with string-literal key — jsx-ast-utils' `getProp`
+		// only matches when `key.type === 'Identifier'`, so `{...{"aria-hidden":
+		// true}}` does NOT resolve the aria-hidden attribute. The rule's gate
+		// fails → safe even on a focusable element.
+		{Code: `<div {...{"aria-hidden": true}} />`, Tsx: true},
+		{Code: `<button {...{"aria-hidden": true}} />`, Tsx: true},
+		{Code: `<input {...{"aria-hidden": true}} />`, Tsx: true},
+		// Spread of non-literal object — opaque, no match.
+		{Code: `<button {...props} />`, Tsx: true},
+
+		// ============================================================
+		// Group 11: Empty / malformed JsxExpression
+		// ============================================================
+		// `aria-hidden={}` — empty JsxExpression. staticEval routes to
+		// jvUnknown / jvNull — not boolean true → safe.
+		{Code: `<button aria-hidden={} />`, Tsx: true},
+
+		// ============================================================
+		// Group 12: Nested elements where inner is also aria-hidden=false
+		// ============================================================
+		// `<a href="#" aria-hidden="false"><span aria-hidden="true" /></a>`
+		// — outer is safe (aria-hidden=false), inner span is non-interactive
+		// with no tabIndex → both safe.
+		{Code: `<a href="#" aria-hidden="false"><span aria-hidden="true" /></a>`, Tsx: true},
+
+		// ============================================================
+		// Group 13: Real-world patterns — explicit tabIndex={-1} suppress
+		// ============================================================
+		{
+			Code: `function Decoration() { return <button aria-hidden="true" tabIndex={-1}>icon</button>; }`,
+			Tsx:  true,
+		},
+		{
+			Code: `function Item({active}) { return active ? <button aria-hidden="true" tabIndex={-1}>...</button> : null; }`,
+			Tsx:  true,
+		},
+
+		// ============================================================
+		// Group 14: comments around / inside the prop
+		// ============================================================
+		{Code: `<div /* before */ aria-hidden="true" /* after */ />`, Tsx: true},
+		{Code: `<div aria-hidden={/* true */ true} />`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// Group 1: aria-hidden value-extraction → boolean true
+		// ============================================================
+		// Boolean attribute form (`<button aria-hidden />`) — upstream's
+		// extractValue maps null-attr-value to JS true.
+		{Code: `<button aria-hidden />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// JsxExpression with literal true.
+		{Code: `<button aria-hidden={true} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Case-insensitive string "True" / "TRUE".
+		{Code: `<button aria-hidden="True" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden="TRUE" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// JsxExpression with string literal "true" — jsxAstUtilsLiteralCoerce
+		// applies inside staticEval.
+		{Code: `<button aria-hidden={"true"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden={"True"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 2: Interactive element survey, no tabIndex
+		// ============================================================
+		// Every inherently interactive tag with no tabIndex → undefined ===
+		// undefined → focusable → reports.
+		{Code: `<a href="#" aria-hidden="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<area href="#" aria-hidden="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input aria-hidden="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<select aria-hidden="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<textarea aria-hidden="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 3: Non-interactive made focusable by tabIndex >= 0
+		// ============================================================
+		{Code: `<div aria-hidden="true" tabIndex={0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div aria-hidden="true" tabIndex={1} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<div aria-hidden="true" tabIndex={42} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<span aria-hidden="true" tabIndex="0">x</span>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<p aria-hidden="true" tabIndex="2">x</p>`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 4: Boolean attribute form + interactive
+		// ============================================================
+		{Code: `<input aria-hidden />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<a href="/" aria-hidden />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<select aria-hidden />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 5: TS-wrapped aria-hidden values on interactive
+		// ============================================================
+		// Parens and TSAsExpression are stripped by staticEval — still boolean true.
+		// (TSNonNullExpression behaves differently — see the valid Group 9.)
+		{Code: `<button aria-hidden={(true)} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden={true as boolean} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<input aria-hidden={(true)} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 6: Logical / conditional resolving to boolean true
+		// ============================================================
+		// staticEval evaluates short-circuit operators when both arms are
+		// statically known.
+		{Code: `<button aria-hidden={true && true} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden={false || true} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden={true ? true : false} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 7: (reserved — no spread case fires; spread literals carry
+		// Identifier keys only, and `ariaHidden` (no hyphen) does not match
+		// `aria-hidden` under jsx-ast-utils' Identifier key compare.)
+		// ============================================================
+		// ============================================================
+		// Group 8: Position assertions per container
+		// ============================================================
+		// JsxSelfClosingElement node range — `<input aria-hidden="true" />`
+		// spans columns 1..27 (1-based, end-exclusive).
+		{
+			Code: `<input aria-hidden="true" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAriaHiddenOnFocusable",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 29,
+			}},
+		},
+		// JsxOpeningElement node range — `<button aria-hidden="true">x</button>`
+		// reports on the opening tag only; the JsxOpeningElement spans
+		// columns 1..28 (1-based, end-exclusive).
+		{
+			Code: `<button aria-hidden="true">x</button>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAriaHiddenOnFocusable",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 1, EndColumn: 28,
+			}},
+		},
+		// Multi-line element — position spans the full opening element across lines.
+		{
+			Code: "<button\n  aria-hidden=\"true\"\n  tabIndex={0}\n/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noAriaHiddenOnFocusable",
+				Message:   errorMessage,
+				Line:      1, Column: 1, EndLine: 4, EndColumn: 3,
+			}},
+		},
+
+		// ============================================================
+		// Group 9: Nested element listener fires independently
+		// ============================================================
+		// Outer button and inner anchor each report separately.
+		{
+			Code: `<button aria-hidden="true"><a href="/" aria-hidden="true">x</a></button>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedError, // outer <button>
+				expectedError, // inner <a href>
+			},
+		},
+
+		// ============================================================
+		// Group 10: components map — non-DOM remapped to interactive
+		// ============================================================
+		// `<Btn aria-hidden="true" />` with `Btn → button` → resolves to
+		// interactive → no tabIndex → focusable → reports.
+		{
+			Code:     `<Btn aria-hidden="true" />`,
+			Tsx:      true,
+			Settings: componentsSettings,
+			Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 11: polymorphicPropName resolution
+		// ============================================================
+		// `<Box as="input" aria-hidden="true" />` resolves to `input` →
+		// interactive → no tabIndex → focusable → reports.
+		{
+			Code:     `<Box as="input" aria-hidden="true" />`,
+			Tsx:      true,
+			Settings: polymorphicSettings,
+			Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Even on non-DOM type, if `as` resolves to button → reports.
+		{
+			Code:     `<Box as="button" aria-hidden="true" />`,
+			Tsx:      true,
+			Settings: polymorphicSettings,
+			Errors:   []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 12: Custom component with explicit positive tabIndex
+		// ============================================================
+		// Non-interactive arm: `tabIndex >= 0` → focusable → reports.
+		{Code: `<MyButton aria-hidden="true" tabIndex={0} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<MyButton aria-hidden="true" tabIndex="1" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<UX.Layout aria-hidden="true" tabIndex={3} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 13: Real-world component patterns
+		// ============================================================
+		// Function component returning the offending element.
+		{
+			Code:   `function Icon() { return <button aria-hidden="true">x</button>; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Conditional rendering — only one arm offends.
+		{
+			Code:   `function Foo({cond}) { return cond ? <input aria-hidden="true" /> : <div />; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// .map producing multiple offending elements.
+		{
+			Code:   `const xs = arr.map((x) => <button aria-hidden="true" key={x}>{x}</button>);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// HOC wrapping carrying the offending child.
+		{
+			Code:   `const Wrapped = withTracking(({v}) => <input aria-hidden="true" value={v} />);`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Fragment + && rendering.
+		{
+			Code:   `const x = <>{cond && <button aria-hidden="true" />}</>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Multiple components in one file → each reports.
+		{
+			Code: "function A() { return <input aria-hidden=\"true\" />; }\nfunction B() { return <textarea aria-hidden=\"true\" />; }",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedError, expectedError,
+			},
+		},
+		// Generator / async / IIFE bodies.
+		{
+			Code: `function* render() { yield <input aria-hidden="true" />; yield <textarea aria-hidden="true" />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				expectedError, expectedError,
+			},
+		},
+		{
+			Code:   `async function render() { return <button aria-hidden="true">x</button>; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `const x = (() => <input aria-hidden="true" />)();`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Modal pattern: dialog opens with a focusable but aria-hidden button.
+		{
+			Code:   `function Modal() { return <dialog open><button aria-hidden="true">OK</button></dialog>; }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		// Class component render returning offending element.
+		{
+			Code:   `class Form extends React.Component { render() { return <input aria-hidden="true" />; } }`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 14: TypeScript generic JSX
+		// ============================================================
+		{
+			Code:   `<Cell<{a: number}> aria-hidden="true" tabIndex={0} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 15: Comments around / inside the prop don't suppress
+		// ============================================================
+		{
+			Code:   `<input /* a */ aria-hidden="true" /* b */ />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+		{
+			Code:   `<button aria-hidden={/* truthy */ true} />`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError},
+		},
+
+		// ============================================================
+		// Group 16: tabIndex via expressions that staticEval resolves
+		// ============================================================
+		// Conditional resolving to >= 0 — staticEval evaluates both arms.
+		{Code: `<div aria-hidden="true" tabIndex={true ? 0 : -1} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// String expression coerces to 0 via ToNumber.
+		{Code: `<div aria-hidden="true" tabIndex={"5"} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 17: Multiple offending elements on one render
+		// ============================================================
+		{
+			Code:   `<form><input aria-hidden="true" /><textarea aria-hidden="true" /></form>`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{expectedError, expectedError},
+		},
+
+		// ============================================================
+		// Group 17b: tabIndex shapes whose getTabIndex result is undefined
+		//            (step-1 short-circuits) — interactive arm reports
+		// ============================================================
+		// Upstream getTabIndex returns undefined for these and the interactive
+		// arm's `=== undefined` matches → focusable → reports.
+		{Code: `<button aria-hidden="true" tabIndex="" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden="true" tabIndex={true} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden="true" tabIndex={false} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden="true" tabIndex={1.5} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden="true" tabIndex={undefined} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// TaggedTemplateExpression: LITERAL_TYPES.TaggedTemplateExpression
+		// inherits from TYPES — extracts the inner template text "x", then
+		// step-1 `Number("x")` → NaN → undefined. Interactive → focusable.
+		{Code: "<button aria-hidden=\"true\" tabIndex={tag`x`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `null` literal: LITERAL_TYPES.Literal returns "null" string → step-1
+		// `Number("null")` = NaN → undefined → focusable on interactive.
+		{Code: `<button aria-hidden="true" tabIndex={null} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// TSNonNullExpression: upstream's extractor recurses, the Literal arm
+		// returns the bare `.value` (boolean true), then the outer wraps it
+		// with `+ "!"` → JS template coerces → "true!" string. Step-1
+		// `Number("true!")` = NaN → undefined. Interactive arm matches
+		// `=== undefined` → focusable → reports.
+		{Code: `<button aria-hidden="true" tabIndex={true!} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		{Code: `<button aria-hidden="true" tabIndex={"5"!} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// BinaryExpression: upstream's extractValueFromBinaryExpression
+		// computes the operation (`1+2` → 3, not stringify). step-1 number
+		// `3`, isInteger → 3. `3 >= 0` → focusable → reports.
+		{Code: `<button aria-hidden="true" tabIndex={1+2} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Non-numeric direct attribute string → step-1 NaN → undefined.
+		{Code: `<button aria-hidden="true" tabIndex="abc" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// NoSubstitutionTemplateLiteral with non-numeric text → step-1 NaN → undefined.
+		{Code: "<button aria-hidden=\"true\" tabIndex={`abc`} />", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+
+		// ============================================================
+		// Group 18: Lowercase tabindex on interactive (case-insensitive prop)
+		// ============================================================
+		// jsx-ast-utils' getProp is case-insensitive by default — lowercase
+		// `tabindex` resolves the same as `tabIndex`. Confirms our
+		// FindAttributeByName parity.
+		{Code: `<button aria-hidden="true" tabindex="0" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+	})
+}

--- a/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable_upstream_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable_upstream_test.go
@@ -1,0 +1,61 @@
+package no_aria_hidden_on_focusable
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// expectedError mirrors upstream's `expectedError` object — every invalid
+// case carries the same single diagnostic. Shared with the extras test.
+var expectedError = rule_tester.InvalidTestCaseError{
+	MessageId: "noAriaHiddenOnFocusable",
+	Message:   errorMessage,
+}
+
+// TestNoAriaHiddenOnFocusableUpstream migrates the full upstream suite from
+// eslint-plugin-jsx-a11y's `__tests__/src/rules/no-aria-hidden-on-focusable-test.js`
+// 1:1, preserving case order so a future audit can grep across both
+// side-by-side. rslint-specific lock-ins (value-extraction branches, TS
+// wrappers, position assertions, etc.) live in
+// no_aria_hidden_on_focusable_extras_test.go.
+func TestNoAriaHiddenOnFocusableUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoAriaHiddenOnFocusableRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid ----
+		// div is not interactive; no tabIndex → tabIndex >= 0 is false → not focusable.
+		{Code: `<div aria-hidden="true" />;`, Tsx: true},
+		// div with onClick — onClick alone does NOT make it interactive per
+		// upstream's `isInteractiveElement` (which looks at tagName + aria-query
+		// schemas, not event handlers). Still not focusable.
+		{Code: `<div onClick={() => void 0} aria-hidden="true" />;`, Tsx: true},
+		// img is in the dom set but does not match any interactive role schema
+		// → isInteractiveElement returns false → tabIndex >= 0 is false → safe.
+		{Code: `<img aria-hidden="true" />`, Tsx: true},
+		// aria-hidden="false" → upstream `getPropValue(...) === true` is false,
+		// rule short-circuits before checking focus.
+		{Code: `<a aria-hidden="false" href="#" />`, Tsx: true},
+		// button is interactive; tabIndex="-1" → tabIndex < 0 → !focusable.
+		{Code: `<button aria-hidden="true" tabIndex="-1" />`, Tsx: true},
+		// No aria-hidden at all — the IsAriaHiddenTrue gate fails immediately.
+		{Code: `<button />`, Tsx: true},
+		{Code: `<a href="/" />`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid ----
+		// Non-interactive div made focusable by tabIndex="0" — tabIndex >= 0 → focusable.
+		{Code: `<div aria-hidden="true" tabIndex="0" />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// input is interactive; missing tabIndex → undefined === undefined → focusable.
+		{Code: `<input aria-hidden="true" />;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// `<a>` with `href` matches the interactive-anchor schema → interactive
+		// → no tabIndex → focusable.
+		{Code: `<a href="/" aria-hidden="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// button: inherently interactive, no tabIndex → focusable.
+		{Code: `<button aria-hidden="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// textarea: same — interactive, no tabIndex.
+		{Code: `<textarea aria-hidden="true" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+		// Lowercase `tabindex` — jsx-ast-utils' `getProp` is case-insensitive
+		// by default, so this still resolves to tabIndex=0. p is non-interactive,
+		// `0 >= 0` → focusable.
+		{Code: `<p tabindex="0" aria-hidden="true">text</p>;`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{expectedError}},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -180,6 +180,7 @@ export default defineConfig({
     './tests/eslint-plugin-jsx-a11y/rules/media-has-caption.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/mouse-events-have-key-events.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-access-key.test.ts',
+    './tests/eslint-plugin-jsx-a11y/rules/no-aria-hidden-on-focusable.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-autofocus.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts',
     './tests/eslint-plugin-jsx-a11y/rules/no-interactive-element-to-noninteractive-role.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-aria-hidden-on-focusable.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-aria-hidden-on-focusable.test.ts
@@ -1,0 +1,322 @@
+import { RuleTester } from '../rule-tester';
+
+const errorMessage =
+  'aria-hidden="true" must not be set on focusable elements.';
+const expectedError = { message: errorMessage };
+
+const componentsSettings = {
+  'jsx-a11y': {
+    components: {
+      Btn: 'button',
+    },
+  },
+};
+
+const polymorphicSettings = {
+  'jsx-a11y': {
+    polymorphicPropName: 'as',
+  },
+};
+
+new RuleTester().run('no-aria-hidden-on-focusable', null as never, {
+  valid: [
+    // ---- Upstream valid ----
+    { code: '<div aria-hidden="true" />;' },
+    { code: '<div onClick={() => void 0} aria-hidden="true" />;' },
+    { code: '<img aria-hidden="true" />' },
+    { code: '<a aria-hidden="false" href="#" />' },
+    { code: '<button aria-hidden="true" tabIndex="-1" />' },
+    { code: '<button />' },
+    { code: '<a href="/" />' },
+
+    // ---- aria-hidden does NOT resolve to true → safe regardless of focus ----
+    { code: '<input />' },
+    { code: '<button aria-hidden={false} />' },
+    { code: '<input aria-hidden={false} />' },
+    { code: '<button aria-hidden="false" />' },
+    { code: '<button aria-hidden="FALSE" />' },
+    { code: '<button aria-hidden={"false"} />' },
+    { code: '<button aria-hidden={undefined} />' },
+    { code: '<button aria-hidden={0} />' },
+    { code: '<button aria-hidden="yes" />' },
+    { code: '<button aria-hidden={someVar} />' },
+    { code: '<button aria-hidden={obj.x} />' },
+    { code: '<button aria-hidden={fn()} />' },
+    // TSNonNullExpression stringifies the operand with `!` → "true!" !== true.
+    { code: '<button aria-hidden={true!} />' },
+    { code: '<input aria-hidden={true!} />' },
+
+    // ---- Non-interactive elements without tabIndex ----
+    { code: '<div aria-hidden />' },
+    { code: '<div aria-hidden={true} />' },
+    { code: '<div aria-hidden="True" />' },
+    { code: '<span aria-hidden="true" />' },
+    { code: '<p aria-hidden="true" />' },
+    { code: '<section aria-hidden="true" />' },
+    { code: '<br aria-hidden="true" />' },
+    { code: '<hr aria-hidden="true" />' },
+
+    // ---- Non-interactive with tabIndex < 0 ----
+    { code: '<div aria-hidden="true" tabIndex="-1" />' },
+    { code: '<div aria-hidden="true" tabIndex={-1} />' },
+
+    // ---- Interactive with tabIndex < 0 ----
+    { code: '<button aria-hidden="true" tabIndex={-1} />' },
+    { code: '<button aria-hidden="true" tabIndex="-2" />' },
+    { code: '<input aria-hidden="true" tabIndex={-1} />' },
+    { code: '<textarea aria-hidden="true" tabIndex={-1} />' },
+    { code: '<select aria-hidden="true" tabIndex={-1} />' },
+    { code: '<a href="/" aria-hidden="true" tabIndex={-1} />' },
+
+    // ---- Custom components without explicit positive tabIndex ----
+    { code: '<MyButton aria-hidden="true" />' },
+    { code: '<UX.Layout aria-hidden="true" />' },
+    { code: '<svg:circle aria-hidden="true" />' },
+    { code: '<Foo.Bar.Baz aria-hidden="true" />' },
+    { code: '<MyButton aria-hidden="true" tabIndex={-1} />' },
+
+    // ---- <a> without href is non-interactive ----
+    { code: '<a aria-hidden="true" />' },
+    { code: '<area aria-hidden="true" />' },
+
+    // ---- tabIndex extracts to undefined → non-interactive arm rejects ----
+    { code: '<div aria-hidden="true" tabIndex="" />' },
+    { code: '<div aria-hidden="true" tabIndex={undefined} />' },
+    { code: '<div aria-hidden="true" tabIndex={true} />' },
+    { code: '<div aria-hidden="true" tabIndex={1.5} />' },
+
+    // ---- components map: non-DOM → interactive resolution ----
+    {
+      code: '<Btn aria-hidden="true" tabIndex={-1} />',
+      settings: componentsSettings,
+    },
+
+    // ---- polymorphicPropName ----
+    {
+      code: '<Box as="button" aria-hidden="true" tabIndex={-1} />',
+      settings: polymorphicSettings,
+    },
+
+    // ---- TS wrappers around the aria-hidden value, but element non-focusable ----
+    { code: '<div aria-hidden={(true)} />' },
+    { code: '<div aria-hidden={true as boolean} />' },
+
+    // ---- Spread literal cannot match aria-hidden (Identifier key only, hyphen) ----
+    { code: '<div {...{"aria-hidden": true}} />' },
+    { code: '<button {...{"aria-hidden": true}} />' },
+    { code: '<input {...{"aria-hidden": true}} />' },
+    { code: '<button {...props} />' },
+
+    // ---- Empty / unresolvable expressions ----
+    { code: '<button aria-hidden={} />' },
+
+    // ---- Real-world: explicit tabIndex={-1} suppresses ----
+    {
+      code: 'function Decoration() { return <button aria-hidden="true" tabIndex={-1}>icon</button>; }',
+    },
+
+    // ---- Comments around / inside the prop ----
+    { code: '<div /* before */ aria-hidden="true" /* after */ />' },
+    { code: '<div aria-hidden={/* true */ true} />' },
+  ],
+  invalid: [
+    // ---- Upstream invalid ----
+    {
+      code: '<div aria-hidden="true" tabIndex="0" />;',
+      errors: [expectedError],
+    },
+    { code: '<input aria-hidden="true" />;', errors: [expectedError] },
+    { code: '<a href="/" aria-hidden="true" />', errors: [expectedError] },
+    { code: '<button aria-hidden="true" />', errors: [expectedError] },
+    { code: '<textarea aria-hidden="true" />', errors: [expectedError] },
+    {
+      code: '<p tabindex="0" aria-hidden="true">text</p>;',
+      errors: [expectedError],
+    },
+
+    // ---- aria-hidden value-extraction → boolean true ----
+    { code: '<button aria-hidden />', errors: [expectedError] },
+    { code: '<button aria-hidden={true} />', errors: [expectedError] },
+    { code: '<button aria-hidden="True" />', errors: [expectedError] },
+    { code: '<button aria-hidden="TRUE" />', errors: [expectedError] },
+    { code: '<button aria-hidden={"true"} />', errors: [expectedError] },
+    { code: '<button aria-hidden={"True"} />', errors: [expectedError] },
+
+    // ---- Interactive element survey, no tabIndex ----
+    { code: '<a href="#" aria-hidden="true" />', errors: [expectedError] },
+    { code: '<area href="#" aria-hidden="true" />', errors: [expectedError] },
+    { code: '<select aria-hidden="true" />', errors: [expectedError] },
+
+    // ---- Non-interactive + tabIndex >= 0 ----
+    {
+      code: '<div aria-hidden="true" tabIndex={0} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-hidden="true" tabIndex={1} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-hidden="true" tabIndex={42} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<span aria-hidden="true" tabIndex="0">x</span>',
+      errors: [expectedError],
+    },
+    {
+      code: '<p aria-hidden="true" tabIndex="2">x</p>',
+      errors: [expectedError],
+    },
+
+    // ---- Boolean attribute form + interactive ----
+    { code: '<input aria-hidden />', errors: [expectedError] },
+    { code: '<a href="/" aria-hidden />', errors: [expectedError] },
+    { code: '<select aria-hidden />', errors: [expectedError] },
+
+    // ---- TS wrappers around boolean true on interactive ----
+    { code: '<button aria-hidden={(true)} />', errors: [expectedError] },
+    {
+      code: '<button aria-hidden={true as boolean} />',
+      errors: [expectedError],
+    },
+    { code: '<input aria-hidden={(true)} />', errors: [expectedError] },
+
+    // ---- Logical / conditional resolving to true ----
+    {
+      code: '<button aria-hidden={true && true} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<button aria-hidden={false || true} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<button aria-hidden={true ? true : false} />',
+      errors: [expectedError],
+    },
+
+    // ---- components map remapping to interactive ----
+    {
+      code: '<Btn aria-hidden="true" />',
+      settings: componentsSettings,
+      errors: [expectedError],
+    },
+
+    // ---- polymorphicPropName resolving to interactive ----
+    {
+      code: '<Box as="input" aria-hidden="true" />',
+      settings: polymorphicSettings,
+      errors: [expectedError],
+    },
+    {
+      code: '<Box as="button" aria-hidden="true" />',
+      settings: polymorphicSettings,
+      errors: [expectedError],
+    },
+
+    // ---- Custom component with explicit positive tabIndex ----
+    {
+      code: '<MyButton aria-hidden="true" tabIndex={0} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<MyButton aria-hidden="true" tabIndex="1" />',
+      errors: [expectedError],
+    },
+    {
+      code: '<UX.Layout aria-hidden="true" tabIndex={3} />',
+      errors: [expectedError],
+    },
+
+    // ---- tabIndex via expressions that staticEval resolves ----
+    {
+      code: '<div aria-hidden="true" tabIndex={true ? 0 : -1} />',
+      errors: [expectedError],
+    },
+    {
+      code: '<div aria-hidden="true" tabIndex={"5"} />',
+      errors: [expectedError],
+    },
+
+    // ---- Lowercase tabindex on interactive (case-insensitive prop) ----
+    {
+      code: '<button aria-hidden="true" tabindex="0" />',
+      errors: [expectedError],
+    },
+
+    // ---- Nested elements report independently ----
+    {
+      code: '<button aria-hidden="true"><a href="/" aria-hidden="true">x</a></button>',
+      errors: [expectedError, expectedError],
+    },
+
+    // ---- Multiple offending elements ----
+    {
+      code: '<form><input aria-hidden="true" /><textarea aria-hidden="true" /></form>',
+      errors: [expectedError, expectedError],
+    },
+
+    // ---- Real-world component patterns ----
+    {
+      code: 'function Icon() { return <button aria-hidden="true">x</button>; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'function Foo({cond}) { return cond ? <input aria-hidden="true" /> : <div />; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'const xs = arr.map((x) => <button aria-hidden="true" key={x}>{x}</button>);',
+      errors: [expectedError],
+    },
+    {
+      code: 'const Wrapped = withTracking(({v}) => <input aria-hidden="true" value={v} />);',
+      errors: [expectedError],
+    },
+    {
+      code: 'const x = <>{cond && <button aria-hidden="true" />}</>',
+      errors: [expectedError],
+    },
+    {
+      code: 'function A() { return <input aria-hidden="true" />; }\nfunction B() { return <textarea aria-hidden="true" />; }',
+      errors: [expectedError, expectedError],
+    },
+    {
+      code: 'function* render() { yield <input aria-hidden="true" />; yield <textarea aria-hidden="true" />; }',
+      errors: [expectedError, expectedError],
+    },
+    {
+      code: 'async function render() { return <button aria-hidden="true">x</button>; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'const x = (() => <input aria-hidden="true" />)();',
+      errors: [expectedError],
+    },
+    {
+      code: 'function Modal() { return <dialog open><button aria-hidden="true">OK</button></dialog>; }',
+      errors: [expectedError],
+    },
+    {
+      code: 'class Form extends React.Component { render() { return <input aria-hidden="true" />; } }',
+      errors: [expectedError],
+    },
+
+    // ---- TS generic JSX ----
+    {
+      code: '<Cell<{a: number}> aria-hidden="true" tabIndex={0} />',
+      errors: [expectedError],
+    },
+
+    // ---- Comments don't suppress ----
+    {
+      code: '<input /* a */ aria-hidden="true" /* b */ />',
+      errors: [expectedError],
+    },
+    {
+      code: '<button aria-hidden={/* truthy */ true} />',
+      errors: [expectedError],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -128,6 +128,7 @@ flowto
 fltr
 fluentui
 fname
+focusability
 focusable
 Fooa
 Fooab


### PR DESCRIPTION
## Summary

Port the `jsx-a11y/no-aria-hidden-on-focusable` rule from ESLint to rslint.

The rule disallows `aria-hidden="true"` on focusable elements — pairing the two confuses screen-reader users when the element can still be reached by keyboard. Fires when both (a) `aria-hidden` resolves to JS boolean `true` (boolean form, case-insensitive `"True"`, `{true}`, or any expression statically evaluating to `true`), and (b) the element is focusable per `aria-query`'s element-role schemas: inherently interactive elements (`<button>`, `<input>`, `<a href>`, `<textarea>`, `<select>`, …) unless `tabIndex` resolves to a negative integer, plus non-interactive / custom-component elements that have an explicit `tabIndex >= 0`.

Implementation reuses existing `jsxa11yutil` helpers and extracts a new `IsAriaHiddenTrue` helper out of `IsHiddenFromScreenReaderFromTagAttrs` (the aria-hidden-only check is now used by both rules). Focusability mirrors upstream's `isFocusable` four-way `getTabIndex` classification (Number / undefined / null / non-numeric resolved) by combining `GetTabIndexEx` with `HasUpstreamTabIndexValue`.

## Related Links

- ESLint rule: [eslint-plugin-jsx-a11y/no-aria-hidden-on-focusable](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-aria-hidden-on-focusable.md)
- Source code: [src/rules/no-aria-hidden-on-focusable.js](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/src/rules/no-aria-hidden-on-focusable.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).