### PR TITLE
ci: disable Swatinem/rust-cache cache-bin to fix flaky macos rust jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,11 @@ jobs:
         with:
           workspaces: '.'
           cache-on-failure: true
+          # Workaround for Swatinem/rust-cache#341: on the new macos runner image
+          # caching ~/.cargo/bin restores a broken `cargo` shim that resolves to
+          # rustup-init, causing `cargo fmt`/`clippy` to fail with
+          # "unexpected argument 'fmt' found / Usage: rustup-init[EXE] [OPTIONS]".
+          cache-bin: 'false'
 
       - name: Check formatting
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Summary

- Set `cache-bin: 'false'` on the `Swatinem/rust-cache` step in `Test Rust` so the macOS Rust job stops failing intermittently with `error: unexpected argument 'fmt' found / Usage: rustup-init[EXE] [OPTIONS]`.
- Add an inline comment so the workaround can be removed once the upstream issues are fixed.

## Why

The new GitHub macOS runner image (`20260511.0048+`) ships a Homebrew rustup whose `~/.cargo/bin/cargo` is a broken `rustup-init` shim. Since `Swatinem/rust-cache` v2.8 enabled `cache-bin: true` by default ([Swatinem/rust-cache#325](https://github.com/Swatinem/rust-cache/pull/325)), the shim is cached and restored across runs, so `cargo fmt` / `cargo clippy` resolve to `rustup-init` and fail.

The failure is intermittent because the runner pool still mixes old and new images — runs landing on a new image fail, reruns on an old image pass without code changes. This matches recent CI history on `main` (e.g. runs `25898979192`, `25848992830`, `25847270202`).

Tracked upstream:
- https://github.com/Swatinem/rust-cache/issues/341
- https://github.com/actions/runner-images/issues/14099

The reporter of #341 confirmed `cache-bin: 'false'` restores green builds. Impact on cache hit rate is negligible (only `~/.cargo/bin` is excluded; workspace target/ caching is unchanged).

## Test plan

- [ ] CI green on this PR (especially `Test Rust (macos-latest)`)
- [ ] Re-run a few times to confirm the flake is gone across runner pool members