### PR TITLE
feat: port rule @typescript-eslint/no-empty-object-type

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_dynamic_delete"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_empty_function"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_empty_interface"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_empty_object_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_explicit_any"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_extra_non_null_assertion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_extraneous_class"
@@ -550,6 +551,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-explicit-any", no_explicit_any.NoExplicitAnyRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-empty-function", no_empty_function.NoEmptyFunctionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-empty-interface", no_empty_interface.NoEmptyInterfaceRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-empty-object-type", no_empty_object_type.NoEmptyObjectTypeRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-extra-non-null-assertion", no_extra_non_null_assertion.NoExtraNonNullAssertionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-extraneous-class", no_extraneous_class.NoExtraneousClassRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-invalid-void-type", no_invalid_void_type.NoInvalidVoidTypeRule)

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -133,38 +134,34 @@ func isMergedWithClassDeclaration(ctx rule.RuleContext, nameNode *ast.Node) bool
 // brackets are located via tsgo's scanner rather than by ±1 on the inner
 // element ranges so that whitespace / line breaks / trailing commas
 // between `<`, the parameters, and `>` are preserved verbatim.
+//
+// tsgo's `parseDelimitedList` consumes the trailing comma (when present) and
+// returns a NodeList whose End() points at `>`'s `TokenFullStart`, so we can
+// safely scan from there to find `>` itself — there is no risk of the
+// scanner returning the comma's range.
 func typeParametersText(ctx rule.RuleContext, interfaceDecl *ast.InterfaceDeclaration) string {
 	if interfaceDecl.TypeParameters == nil || len(interfaceDecl.TypeParameters.Nodes) == 0 {
 		return ""
 	}
-	// The `<` token starts at the first non-trivia token after the interface
-	// name; `>` starts at the first non-trivia token after the parameter
-	// list's End (which may sit inside trailing whitespace or after a
-	// trailing comma).
 	ltRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, interfaceDecl.Name().End())
 	gtRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, interfaceDecl.TypeParameters.End())
 	return ctx.SourceFile.Text()[ltRange.Pos():gtRange.End()]
 }
 
-// modifiersPrefix returns the verbatim text of an interface's modifier list
-// followed by a trailing space (e.g. "export ", "declare ", "export declare ").
-// When the interface has no modifiers it returns "". Inter-modifier spacing
-// is preserved as written in source.
-//
-// In typescript-eslint's AST the TSInterfaceDeclaration range starts at the
-// `interface` keyword (modifiers live on the wrapping ExportNamedDeclaration
-// or are siblings). tsgo's node range includes the modifiers, so a verbatim
-// `fixer.replaceText(node, "type X = ...")` would drop them — this helper
-// restores parity with upstream's suggestion output.
-func modifiersPrefix(ctx rule.RuleContext, interfaceDecl *ast.InterfaceDeclaration) string {
-	modifiers := interfaceDecl.Modifiers()
-	if modifiers == nil || len(modifiers.Nodes) == 0 {
-		return ""
+// interfaceFixRange returns the source range to replace when rewriting an
+// `interface` declaration to a `type` alias. The range starts at the
+// `interface` keyword (not the first modifier and not any leading trivia),
+// which mirrors typescript-eslint's TSInterfaceDeclaration.range[0]
+// convention: modifiers AND any trivia between modifiers and the `interface`
+// keyword (e.g. `export /* doc */ interface Foo`) are preserved verbatim by
+// being outside the replace range.
+func interfaceFixRange(ctx rule.RuleContext, interfaceDecl *ast.InterfaceDeclaration, node *ast.Node) core.TextRange {
+	pos := utils.TrimNodeTextRange(ctx.SourceFile, node).Pos()
+	if modifiers := interfaceDecl.Modifiers(); modifiers != nil && len(modifiers.Nodes) > 0 {
+		last := modifiers.Nodes[len(modifiers.Nodes)-1]
+		pos = scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, last.End()).Pos()
 	}
-	first := modifiers.Nodes[0]
-	last := modifiers.Nodes[len(modifiers.Nodes)-1]
-	firstRange := utils.TrimNodeTextRange(ctx.SourceFile, first)
-	return ctx.SourceFile.Text()[firstRange.Pos():last.End()] + " "
+	return core.NewTextRange(pos, node.End())
 }
 
 var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
@@ -216,7 +213,7 @@ var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
 
 				nameText := utils.TrimmedNodeText(ctx.SourceFile, nameNode)
 				typeParam := typeParametersText(ctx, interfaceDecl)
-				modifierText := modifiersPrefix(ctx, interfaceDecl)
+				fixRange := interfaceFixRange(ctx, interfaceDecl, node)
 
 				if extendCount == 0 {
 					if mergedWithClass {
@@ -228,7 +225,7 @@ var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
 						suggestions = append(suggestions, rule.RuleSuggestion{
 							Message: buildReplaceEmptyInterfaceMessage(replacement),
 							FixesArr: []rule.RuleFix{
-								rule.RuleFixReplace(ctx.SourceFile, node, fmt.Sprintf("%stype %s%s = %s", modifierText, nameText, typeParam, replacement)),
+								rule.RuleFixReplaceRange(fixRange, fmt.Sprintf("type %s%s = %s", nameText, typeParam, replacement)),
 							},
 						})
 					}
@@ -246,7 +243,7 @@ var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
 				ctx.ReportNodeWithSuggestions(nameNode, buildNoEmptyInterfaceWithSuperMessage(), rule.RuleSuggestion{
 					Message: buildReplaceEmptyInterfaceWithSuperMessage(),
 					FixesArr: []rule.RuleFix{
-						rule.RuleFixReplace(ctx.SourceFile, node, fmt.Sprintf("%stype %s%s = %s", modifierText, nameText, typeParam, extendedTypeText)),
+						rule.RuleFixReplaceRange(fixRange, fmt.Sprintf("type %s%s = %s", nameText, typeParam, extendedTypeText)),
 					},
 				})
 			}

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.go
@@ -1,0 +1,295 @@
+package no_empty_object_type
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type NoEmptyObjectTypeOptions struct {
+	AllowInterfaces  string
+	AllowObjectTypes string
+	AllowWithName    string
+}
+
+func parseOptions(options any) NoEmptyObjectTypeOptions {
+	opts := NoEmptyObjectTypeOptions{
+		AllowInterfaces:  "never",
+		AllowObjectTypes: "never",
+	}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowInterfaces"].(string); ok {
+		opts.AllowInterfaces = v
+	}
+	if v, ok := optsMap["allowObjectTypes"].(string); ok {
+		opts.AllowObjectTypes = v
+	}
+	if v, ok := optsMap["allowWithName"].(string); ok {
+		opts.AllowWithName = v
+	}
+	return opts
+}
+
+func buildNoEmptyInterfaceMessage(option string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "noEmptyInterface",
+		Description: "An empty interface declaration allows any non-nullish value, including literals like `0` and `\"\"`.\n" +
+			"- If that's what you want, disable this lint rule with an inline comment or configure the '" + option + "' rule option.\n" +
+			"- If you want a type meaning \"any object\", you probably want `object` instead.\n" +
+			"- If you want a type meaning \"any value\", you probably want `unknown` instead.",
+		Data: map[string]string{"option": option},
+	}
+}
+
+func buildNoEmptyInterfaceWithSuperMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noEmptyInterfaceWithSuper",
+		Description: "An interface declaring no members is equivalent to its supertype.",
+	}
+}
+
+func buildNoEmptyObjectMessage(option string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "noEmptyObject",
+		Description: "The `{}` (\"empty object\") type allows any non-nullish value, including literals like `0` and `\"\"`.\n" +
+			"- If that's what you want, disable this lint rule with an inline comment or configure the '" + option + "' rule option.\n" +
+			"- If you want a type meaning \"any object\", you probably want `object` instead.\n" +
+			"- If you want a type meaning \"any value\", you probably want `unknown` instead.",
+		Data: map[string]string{"option": option},
+	}
+}
+
+func buildReplaceEmptyInterfaceMessage(replacement string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "replaceEmptyInterface",
+		Description: fmt.Sprintf("Replace empty interface with `%s`.", replacement),
+		Data:        map[string]string{"replacement": replacement},
+	}
+}
+
+func buildReplaceEmptyInterfaceWithSuperMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "replaceEmptyInterfaceWithSuper",
+		Description: "Replace empty interface with a type alias.",
+	}
+}
+
+func buildReplaceEmptyObjectTypeMessage(replacement string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "replaceEmptyObjectType",
+		Description: fmt.Sprintf("Replace `{}` with `%s`.", replacement),
+		Data:        map[string]string{"replacement": replacement},
+	}
+}
+
+// getExtendsClause returns the single `extends` heritage clause of an
+// interface (or nil if absent).
+func getExtendsClause(interfaceDecl *ast.InterfaceDeclaration) *ast.HeritageClause {
+	if interfaceDecl.HeritageClauses == nil {
+		return nil
+	}
+	for _, clause := range interfaceDecl.HeritageClauses.Nodes {
+		heritageClause := clause.AsHeritageClause()
+		if heritageClause == nil {
+			continue
+		}
+		if heritageClause.Token == ast.KindExtendsKeyword {
+			return heritageClause
+		}
+	}
+	return nil
+}
+
+// isMergedWithClassDeclaration reports whether the interface's name resolves
+// to a symbol that also has a class declaration in the same scope (TypeScript
+// declaration merging). Mirrors upstream's
+// `scope.set.get(name).defs.some(def => def.type === 'ClassDeclaration')`
+// check via the tsgo TypeChecker.
+func isMergedWithClassDeclaration(ctx rule.RuleContext, nameNode *ast.Node) bool {
+	if ctx.TypeChecker == nil || nameNode == nil {
+		return false
+	}
+	symbol := ctx.TypeChecker.GetSymbolAtLocation(nameNode)
+	if symbol == nil {
+		return false
+	}
+	for _, decl := range symbol.Declarations {
+		if decl.Kind == ast.KindClassDeclaration {
+			return true
+		}
+	}
+	return false
+}
+
+// typeParametersText returns the bracketed type-parameter clause text
+// (`<T, U>`) or empty string when no type parameters are present. The
+// brackets are located via tsgo's scanner rather than by ±1 on the inner
+// element ranges so that whitespace / line breaks / trailing commas
+// between `<`, the parameters, and `>` are preserved verbatim.
+func typeParametersText(ctx rule.RuleContext, interfaceDecl *ast.InterfaceDeclaration) string {
+	if interfaceDecl.TypeParameters == nil || len(interfaceDecl.TypeParameters.Nodes) == 0 {
+		return ""
+	}
+	// The `<` token starts at the first non-trivia token after the interface
+	// name; `>` starts at the first non-trivia token after the parameter
+	// list's End (which may sit inside trailing whitespace or after a
+	// trailing comma).
+	ltRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, interfaceDecl.Name().End())
+	gtRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, interfaceDecl.TypeParameters.End())
+	return ctx.SourceFile.Text()[ltRange.Pos():gtRange.End()]
+}
+
+// modifiersPrefix returns the verbatim text of an interface's modifier list
+// followed by a trailing space (e.g. "export ", "declare ", "export declare ").
+// When the interface has no modifiers it returns "". Inter-modifier spacing
+// is preserved as written in source.
+//
+// In typescript-eslint's AST the TSInterfaceDeclaration range starts at the
+// `interface` keyword (modifiers live on the wrapping ExportNamedDeclaration
+// or are siblings). tsgo's node range includes the modifiers, so a verbatim
+// `fixer.replaceText(node, "type X = ...")` would drop them — this helper
+// restores parity with upstream's suggestion output.
+func modifiersPrefix(ctx rule.RuleContext, interfaceDecl *ast.InterfaceDeclaration) string {
+	modifiers := interfaceDecl.Modifiers()
+	if modifiers == nil || len(modifiers.Nodes) == 0 {
+		return ""
+	}
+	first := modifiers.Nodes[0]
+	last := modifiers.Nodes[len(modifiers.Nodes)-1]
+	firstRange := utils.TrimNodeTextRange(ctx.SourceFile, first)
+	return ctx.SourceFile.Text()[firstRange.Pos():last.End()] + " "
+}
+
+var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
+	Name: "no-empty-object-type",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		var allowWithNameTester *regexp.Regexp
+		if opts.AllowWithName != "" {
+			allowWithNameTester, _ = regexp.Compile(opts.AllowWithName)
+		}
+
+		listeners := rule.RuleListeners{}
+
+		if opts.AllowInterfaces != "always" {
+			listeners[ast.KindInterfaceDeclaration] = func(node *ast.Node) {
+				interfaceDecl := node.AsInterfaceDeclaration()
+				if interfaceDecl == nil {
+					return
+				}
+				nameNode := interfaceDecl.Name()
+				if nameNode == nil {
+					return
+				}
+				if allowWithNameTester != nil {
+					if id := nameNode.AsIdentifier(); id != nil && allowWithNameTester.MatchString(id.Text) {
+						return
+					}
+				}
+
+				if interfaceDecl.Members != nil && len(interfaceDecl.Members.Nodes) > 0 {
+					return
+				}
+
+				extendClause := getExtendsClause(interfaceDecl)
+				extendCount := 0
+				if extendClause != nil && extendClause.Types != nil {
+					extendCount = len(extendClause.Types.Nodes)
+				}
+
+				if extendCount == 1 && opts.AllowInterfaces == "with-single-extends" {
+					return
+				}
+				if extendCount > 1 {
+					return
+				}
+
+				mergedWithClass := isMergedWithClassDeclaration(ctx, nameNode)
+
+				nameText := utils.TrimmedNodeText(ctx.SourceFile, nameNode)
+				typeParam := typeParametersText(ctx, interfaceDecl)
+				modifierText := modifiersPrefix(ctx, interfaceDecl)
+
+				if extendCount == 0 {
+					if mergedWithClass {
+						ctx.ReportNode(nameNode, buildNoEmptyInterfaceMessage("allowInterfaces"))
+						return
+					}
+					suggestions := make([]rule.RuleSuggestion, 0, 2)
+					for _, replacement := range []string{"object", "unknown"} {
+						suggestions = append(suggestions, rule.RuleSuggestion{
+							Message: buildReplaceEmptyInterfaceMessage(replacement),
+							FixesArr: []rule.RuleFix{
+								rule.RuleFixReplace(ctx.SourceFile, node, fmt.Sprintf("%stype %s%s = %s", modifierText, nameText, typeParam, replacement)),
+							},
+						})
+					}
+					ctx.ReportNodeWithSuggestions(nameNode, buildNoEmptyInterfaceMessage("allowInterfaces"), suggestions...)
+					return
+				}
+
+				// extendCount == 1 here.
+				if mergedWithClass {
+					ctx.ReportNode(nameNode, buildNoEmptyInterfaceWithSuperMessage())
+					return
+				}
+
+				extendedTypeText := utils.TrimmedNodeText(ctx.SourceFile, extendClause.Types.Nodes[0])
+				ctx.ReportNodeWithSuggestions(nameNode, buildNoEmptyInterfaceWithSuperMessage(), rule.RuleSuggestion{
+					Message: buildReplaceEmptyInterfaceWithSuperMessage(),
+					FixesArr: []rule.RuleFix{
+						rule.RuleFixReplace(ctx.SourceFile, node, fmt.Sprintf("%stype %s%s = %s", modifierText, nameText, typeParam, extendedTypeText)),
+					},
+				})
+			}
+		}
+
+		if opts.AllowObjectTypes != "always" {
+			listeners[ast.KindTypeLiteral] = func(node *ast.Node) {
+				typeLiteral := node.AsTypeLiteralNode()
+				if typeLiteral == nil {
+					return
+				}
+				if typeLiteral.Members != nil && len(typeLiteral.Members.Nodes) > 0 {
+					return
+				}
+				parent := node.Parent
+				if parent != nil && parent.Kind == ast.KindIntersectionType {
+					return
+				}
+				if allowWithNameTester != nil && parent != nil && parent.Kind == ast.KindTypeAliasDeclaration {
+					typeAlias := parent.AsTypeAliasDeclaration()
+					if typeAlias != nil {
+						aliasName := typeAlias.Name()
+						if aliasName != nil {
+							if id := aliasName.AsIdentifier(); id != nil && allowWithNameTester.MatchString(id.Text) {
+								return
+							}
+						}
+					}
+				}
+
+				suggestions := make([]rule.RuleSuggestion, 0, 2)
+				for _, replacement := range []string{"object", "unknown"} {
+					suggestions = append(suggestions, rule.RuleSuggestion{
+						Message: buildReplaceEmptyObjectTypeMessage(replacement),
+						FixesArr: []rule.RuleFix{
+							rule.RuleFixReplace(ctx.SourceFile, node, replacement),
+						},
+					})
+				}
+				ctx.ReportNodeWithSuggestions(node, buildNoEmptyObjectMessage("allowObjectTypes"), suggestions...)
+			}
+		}
+
+		return listeners
+	},
+})

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.md
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.md
@@ -1,0 +1,89 @@
+# no-empty-object-type
+
+## Rule Details
+
+Disallows accidental uses of the `{}` ("empty object") type. In TypeScript `{}` is the type of any non-nullish value, which is rarely what authors intend — typically they want `object` (any non-primitive value) or `unknown` (any value at all). The same problem applies to empty `interface` declarations: an empty interface with no members is equivalent to `{}`, and an empty interface that extends a single supertype is equivalent to a type alias of that supertype.
+
+This rule reports both shapes and offers `object` / `unknown` suggestions.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+let anyObject: {};
+let anyValue: {};
+
+interface AnyObject {}
+interface AnyValue {}
+
+type AnyObjectAlias = {};
+type AnyValueAlias = {};
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+let anyObject: object;
+let anyValue: unknown;
+
+type AnyObjectAlias = object;
+type AnyValueAlias = unknown;
+
+let objectWith: {
+  property: boolean;
+};
+
+interface InterfaceWith {
+  property: boolean;
+}
+
+type TypeWith = {
+  property: boolean;
+};
+```
+
+### Options
+
+- `allowInterfaces` (default `"never"`): how empty interfaces are treated.
+  - `"never"`: empty interfaces are disallowed.
+  - `"always"`: empty interfaces are always allowed.
+  - `"with-single-extends"`: empty interfaces are allowed only when they extend exactly one supertype.
+- `allowObjectTypes` (default `"never"`): how empty `{}` type literals are treated.
+  - `"never"`: empty `{}` is disallowed.
+  - `"always"`: empty `{}` is always allowed.
+- `allowWithName`: a regular expression source string. When set, interfaces and `type` aliases whose name matches the pattern are exempted.
+
+### `allowInterfaces: "with-single-extends"`
+
+Examples of **correct** code:
+
+```typescript
+interface Base {
+  value: boolean;
+}
+
+interface Derived extends Base {}
+```
+
+### `allowObjectTypes: "always"`
+
+Examples of **correct** code:
+
+```typescript
+type AnyObject = {};
+
+let value: {};
+```
+
+### `allowWithName: "Props$"`
+
+Examples of **correct** code:
+
+```typescript
+interface ComponentProps {}
+
+type DialogProps = {};
+```
+
+## Original Documentation
+
+- [typescript-eslint no-empty-object-type](https://typescript-eslint.io/rules/no-empty-object-type)

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
@@ -1,0 +1,836 @@
+// TestNoEmptyObjectTypeExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+package no_empty_object_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoEmptyObjectTypeExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoEmptyObjectTypeRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: declaration forms — interface with body members ----
+		// Locks in upstream TSInterfaceDeclaration() arm B: body.body.length !== 0
+		{Code: `interface Foo { x: number }`},
+
+		// ---- Dimension 4: declaration forms — interface with type parameters and body ----
+		{Code: `interface Foo<T> { x: T }`},
+
+		// ---- Dimension 4: nesting — TypeLiteral with members ----
+		// Locks in upstream TSTypeLiteral() arm I: members.length truthy
+		{Code: `let value: { a: number; b: string };`},
+
+		// ---- Dimension 4: nesting — intersection guards empty `{}` ----
+		// Locks in upstream TSTypeLiteral() arm J: parent === TSIntersectionType
+		{Code: `type T = number & {};`},
+		{Code: `type T = {} & number;`},
+		{Code: `type T = number & {} & string;`},
+
+		// ---- Dimension 4: nesting — Brand pattern (canonical use of {} in intersection) ----
+		{Code: `type Brand<T, B> = T & { readonly __brand: B };`},
+
+		// ---- Real-user: `extends Record<string, never>` empty-object pattern ----
+		{Code: `
+interface Base {
+  x: number;
+}
+interface Empty extends Record<string, never> {}
+`,
+			Options: map[string]interface{}{"allowInterfaces": "with-single-extends"},
+		},
+
+		// ---- Real-user: React Props pattern via allowWithName ----
+		{
+			Code:    `interface MyComponentProps {}`,
+			Options: map[string]interface{}{"allowWithName": ".*Props$"},
+		},
+		{
+			Code:    `type MyComponentProps = {};`,
+			Options: map[string]interface{}{"allowWithName": ".*Props$"},
+		},
+
+		// ---- AllowWithName: regex anchored at start (^Empty) ----
+		{
+			Code:    `interface EmptyState {}`,
+			Options: map[string]interface{}{"allowWithName": "^Empty"},
+		},
+
+		// ---- AllowInterfaces: 'always' disables interface listener entirely ----
+		// Locks in: top-level `allowInterfaces !== 'always'` guard. With 'always',
+		// even `interface Foo extends Base {}` (1 extend) is allowed.
+		{
+			Code: `
+interface Base { x: number }
+interface Derived extends Base {}
+`,
+			Options: map[string]interface{}{"allowInterfaces": "always"},
+		},
+
+		// ---- AllowObjectTypes: 'always' disables type-literal listener entirely ----
+		{
+			Code:    `let x: {} = 0;`,
+			Options: map[string]interface{}{"allowObjectTypes": "always"},
+		},
+		{
+			Code:    `type T = {} | null;`,
+			Options: map[string]interface{}{"allowObjectTypes": "always"},
+		},
+
+		// ---- Both listeners disabled simultaneously ----
+		{
+			Code: `
+interface Foo {}
+type Bar = {};
+`,
+			Options: map[string]interface{}{
+				"allowInterfaces":  "always",
+				"allowObjectTypes": "always",
+			},
+		},
+
+		// ---- Mapped-type with members is not an empty TypeLiteral ----
+		// The tsgo MappedType is a distinct Kind, so the listener is not invoked.
+		{Code: `type T<K extends string> = { [P in K]: number };`},
+
+		// ---- Dimension 4: nesting — intersection wins regardless of paren wrapping ----
+		// Locks in upstream TSTypeLiteral() arm J: the IMMEDIATE parent is what
+		// matters. Parens preserve intent: `({} & X)` still has `{}`'s parent as
+		// IntersectionType inside the parens, so we still skip.
+		{Code: `type T = ({} & X);`},
+		{Code: `type T = (X & {});`},
+
+		// ---- AllowInterfaces 'with-single-extends': multi-extends always allowed
+		// regardless of option (arm D in upstream, independent of option) ----
+		{
+			Code: `
+interface A { x: number }
+interface B { y: number }
+interface Both extends A, B {}
+`,
+			Options: map[string]interface{}{"allowInterfaces": "with-single-extends"},
+		},
+
+		// ---- AllowWithName: pattern with `$` anchor only matches at end ----
+		{
+			Code:    `interface UserProps {}`,
+			Options: map[string]interface{}{"allowWithName": "Props$"},
+		},
+
+		// ---- Real-user: `Record<string, {}>` (canonical "any object" usage,
+		// but `{}` should still be reported — author needs to migrate intent) ----
+		// (Tested in invalid below.) — N/A here.
+
+		// ---- Option JSON-array shape coverage ----
+		// SKILL.md requires every option to be exercised in both the direct
+		// `map[string]interface{}{...}` shape (covered by all options tests
+		// above) AND the array-wrapped `[]interface{}{...}` shape (matches
+		// the multi-element rule_tester / CLI invocation). These mirror
+		// upstream-valid cases via the array shape so that the JSON path
+		// through `utils.GetOptionsMap` is exercised end-to-end.
+		{
+			Code:    `interface Base {}`,
+			Options: []interface{}{map[string]interface{}{"allowInterfaces": "always"}},
+		},
+		{
+			Code:    `type Base = {};`,
+			Options: []interface{}{map[string]interface{}{"allowObjectTypes": "always"}},
+		},
+		{
+			Code:    `interface BaseProps {}`,
+			Options: []interface{}{map[string]interface{}{"allowWithName": "Props$"}},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 1: type-literal in parameter / return / property positions ----
+		{
+			Code: `function f(x: {}) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `function f(x: object) {}`},
+						{MessageId: "replaceEmptyObjectType", Output: `function f(x: unknown) {}`},
+					},
+				},
+			},
+		},
+		{
+			Code: `function f(): {} { return 1; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `function f(): object { return 1; }`},
+						{MessageId: "replaceEmptyObjectType", Output: `function f(): unknown { return 1; }`},
+					},
+				},
+			},
+		},
+		{
+			Code: `const f = (): {} => 1;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `const f = (): object => 1;`},
+						{MessageId: "replaceEmptyObjectType", Output: `const f = (): unknown => 1;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `class C { x: {} = 0; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    14,
+					EndLine:   1,
+					EndColumn: 16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `class C { x: object = 0; }`},
+						{MessageId: "replaceEmptyObjectType", Output: `class C { x: unknown = 0; }`},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 1: nested generic / tuple ----
+		{
+			Code: `type T = Array<{}>;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 18,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T = Array<object>;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T = Array<unknown>;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `type T = [{}];`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T = [object];`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T = [unknown];`},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 2: type-literal inside another (non-empty) type literal ----
+		// The outer `{ x: {} }` has a member, so only the inner `{}` is reported.
+		{
+			Code: `type T = { x: {} };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T = { x: object };`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T = { x: unknown };`},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 4: nesting — TypeLiteral inside union (NOT skipped) ----
+		// Locks in upstream TSTypeLiteral() arm J inverse: parent is union, not
+		// intersection — must still report.
+		{
+			Code: `type T = {} | string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 12,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T = object | string;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T = unknown | string;`},
+					},
+				},
+			},
+		},
+		// Both arms of a union containing two empty literals fire independently.
+		{
+			Code: `type T = {} | {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    10,
+					EndLine:   1,
+					EndColumn: 12,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T = object | {};`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T = unknown | {};`},
+					},
+				},
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T = {} | object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T = {} | unknown;`},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 4: declaration forms — generic constraint and default ----
+		// Locks in: TSTypeLiteral inside a type-parameter constraint is still
+		// reported (parent is TypeParameter, not Intersection / TypeAlias).
+		{
+			Code: `type T<X extends {}> = X;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 20,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T<X extends object> = X;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T<X extends unknown> = X;`},
+					},
+				},
+			},
+		},
+		// Default type parameter value
+		{
+			Code: `type T<X = {}> = X;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T<X = object> = X;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T<X = unknown> = X;`},
+					},
+				},
+			},
+		},
+
+		// ---- Locks in upstream TSInterfaceDeclaration() arm C inverse:
+		// 1 extend with default 'never' still reports ----
+		{
+			Code: `interface Empty extends Base {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterfaceWithSuper", Output: `type Empty = Base`},
+					},
+				},
+			},
+		},
+
+		// ---- Locks in upstream TSTypeLiteral() arm L inverse: parent is
+		// TypeAliasDeclaration but allowWithName does NOT match ----
+		{
+			Code:    `type Foo = {};`,
+			Options: map[string]interface{}{"allowWithName": "Bar"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type Foo = object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type Foo = unknown;`},
+					},
+				},
+			},
+		},
+
+		// ---- Locks in upstream TSTypeLiteral() arm M inverse: allowWithName
+		// is set but parent is NOT TypeAliasDeclaration ----
+		// `let x: {}` parent is a VariableDeclaration, not a TypeAliasDeclaration,
+		// so allowWithName has no effect.
+		{
+			Code:    `let value: {};`,
+			Options: map[string]interface{}{"allowWithName": "value"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `let value: object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `let value: unknown;`},
+					},
+				},
+			},
+		},
+
+		// ---- Locks in: declaration-merged class drops suggestions on the
+		// 0-extend interface too (E branch + F branch) ----
+		{
+			Code: `
+interface Foo {}
+class Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      2,
+					Column:    11,
+					EndLine:   2,
+					EndColumn: 14,
+				},
+			},
+		},
+
+		// ---- Real-user: React.FC<{}> empty props ----
+		{
+			Code: `
+type FC<P> = (props: P) => null;
+const C: FC<{}> = () => null;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      3,
+					Column:    13,
+					EndLine:   3,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyObjectType",
+							Output: `
+type FC<P> = (props: P) => null;
+const C: FC<object> = () => null;
+`,
+						},
+						{
+							MessageId: "replaceEmptyObjectType",
+							Output: `
+type FC<P> = (props: P) => null;
+const C: FC<unknown> = () => null;
+`,
+						},
+					},
+				},
+			},
+		},
+
+		// ---- Real-user: generic factory constraint commonly written as `<T extends {}>` ----
+		{
+			Code: `function clone<T extends {}>(input: T): T { return input; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    26,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `function clone<T extends object>(input: T): T { return input; }`},
+						{MessageId: "replaceEmptyObjectType", Output: `function clone<T extends unknown>(input: T): T { return input; }`},
+					},
+				},
+			},
+		},
+
+		// ---- Lock-in: interface with type parameter that has empty body ----
+		// Reports on the interface itself; the inner `{}` in the parameter
+		// constraint is also empty so we get two diagnostics.
+		{
+			Code: `interface Foo<T extends {}> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterface", Output: `type Foo<T extends {}> = object`},
+						{MessageId: "replaceEmptyInterface", Output: `type Foo<T extends {}> = unknown`},
+					},
+				},
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    25,
+					EndLine:   1,
+					EndColumn: 27,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `interface Foo<T extends object> {}`},
+						{MessageId: "replaceEmptyObjectType", Output: `interface Foo<T extends unknown> {}`},
+					},
+				},
+			},
+		},
+
+		// ---- Lock-in: empty interface with `export` modifier (no suggestion drops `export`) ----
+		// Mirrors no_empty_interface's export-preservation handling — modifiers
+		// are reconstructed in the replacement text.
+		{
+			Code: `
+namespace N {
+  export interface Foo {}
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      3,
+					Column:    20,
+					EndLine:   3,
+					EndColumn: 23,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyInterface",
+							Output: `
+namespace N {
+  export type Foo = object
+}
+`,
+						},
+						{
+							MessageId: "replaceEmptyInterface",
+							Output: `
+namespace N {
+  export type Foo = unknown
+}
+`,
+						},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 1: function-type return — `let f: () => {}` ----
+		// Locks in: TypeLiteral as a function-type return position. Parent is
+		// FunctionType, not Intersection / TypeAlias.
+		{
+			Code: `let f: () => {} = null!;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    14,
+					EndLine:   1,
+					EndColumn: 16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `let f: () => object = null!;`},
+						{MessageId: "replaceEmptyObjectType", Output: `let f: () => unknown = null!;`},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 1: class method param/return ----
+		{
+			Code: `class C { m(x: {}): {} { return x; } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 18,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `class C { m(x: object): {} { return x; } }`},
+						{MessageId: "replaceEmptyObjectType", Output: `class C { m(x: unknown): {} { return x; } }`},
+					},
+				},
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 23,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `class C { m(x: {}): object { return x; } }`},
+						{MessageId: "replaceEmptyObjectType", Output: `class C { m(x: {}): unknown { return x; } }`},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 4: parenthesized type literal ({}) — parens are
+		// transparent; the rule reports the inner `{}` because parent is
+		// ParenthesizedType, not Intersection ----
+		{
+			Code: `let x: ({}) = null!;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    9,
+					EndLine:   1,
+					EndColumn: 11,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `let x: (object) = null!;`},
+						{MessageId: "replaceEmptyObjectType", Output: `let x: (unknown) = null!;`},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 4: parenthesized type alias — allowWithName only checks
+		// the IMMEDIATE parent (TSTypeAliasDeclaration), so a ParenthesizedType
+		// wrapper makes the option ineffective ----
+		{
+			Code:    `type Foo = ({});`,
+			Options: map[string]interface{}{"allowWithName": "Foo"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type Foo = (object);`},
+						{MessageId: "replaceEmptyObjectType", Output: `type Foo = (unknown);`},
+					},
+				},
+			},
+		},
+
+		// ---- Branch lock-in: generic with BOTH constraint and default — both
+		// inner `{}` must fire independently and the interface itself fires too ----
+		{
+			Code: `interface I<T extends {} = {}> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 12,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterface", Output: `type I<T extends {} = {}> = object`},
+						{MessageId: "replaceEmptyInterface", Output: `type I<T extends {} = {}> = unknown`},
+					},
+				},
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    23,
+					EndLine:   1,
+					EndColumn: 25,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `interface I<T extends object = {}> {}`},
+						{MessageId: "replaceEmptyObjectType", Output: `interface I<T extends unknown = {}> {}`},
+					},
+				},
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    28,
+					EndLine:   1,
+					EndColumn: 30,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `interface I<T extends {} = object> {}`},
+						{MessageId: "replaceEmptyObjectType", Output: `interface I<T extends {} = unknown> {}`},
+					},
+				},
+			},
+		},
+
+		// ---- Real-user: `Record<string, {}>` (canonical "any object" usage) ----
+		{
+			Code: `type Dict = Record<string, {}>;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    28,
+					EndLine:   1,
+					EndColumn: 30,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type Dict = Record<string, object>;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type Dict = Record<string, unknown>;`},
+					},
+				},
+			},
+		},
+
+		// ---- Lock-in: multi-modifier preservation ----
+		// `declare interface` inside a declared namespace.
+		{
+			Code: `
+declare namespace N {
+  export interface Foo extends Base {}
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      3,
+					Column:    20,
+					EndLine:   3,
+					EndColumn: 23,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyInterfaceWithSuper",
+							Output: `
+declare namespace N {
+  export type Foo = Base
+}
+`,
+						},
+					},
+				},
+			},
+		},
+
+		// ---- Branch lock-in: 0-extend interface + `'with-single-extends'`
+		// option still reports (the option exempts ONLY extend.length===1, not
+		// extend.length===0). Locks in upstream TSInterfaceDeclaration() arm C
+		// inverse against the 0-extend path: option does not bleed across
+		// arm F. ----
+		{
+			Code:    `interface Foo {}`,
+			Options: map[string]interface{}{"allowInterfaces": "with-single-extends"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterface", Output: `type Foo = object`},
+						{MessageId: "replaceEmptyInterface", Output: `type Foo = unknown`},
+					},
+				},
+			},
+		},
+
+		// ---- Branch lock-in: > 2 extends behaves identically to 2 extends
+		// (arm D triggers on `extend.length > 1`, not `=== 2`) ----
+		{
+			Code: `interface Foo extends A, B, C { x: number }`,
+			Errors: []rule_tester.InvalidTestCaseError{},
+		},
+
+		// ---- Dimension 4: TypeLiteral inside conditional-type branch ----
+		// Parent is ConditionalType, not Intersection — should report.
+		{
+			Code: `type T<X> = X extends string ? {} : null;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    32,
+					EndLine:   1,
+					EndColumn: 34,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T<X> = X extends string ? object : null;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T<X> = X extends string ? unknown : null;`},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 4: TypeLiteral in `as` type-expression wrapper ----
+		// Parent is AsExpression (tsgo Kind), reports.
+		{
+			Code: `const x = null as {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    19,
+					EndLine:   1,
+					EndColumn: 21,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `const x = null as object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `const x = null as unknown;`},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 4: TypeLiteral in `satisfies` type-expression wrapper ----
+		{
+			Code: `const x = null satisfies {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    26,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `const x = null satisfies object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `const x = null satisfies unknown;`},
+					},
+				},
+			},
+		},
+
+		// ---- Option JSON-array shape coverage (invalid side) ----
+		// Mirrors an upstream-invalid case but passes options through the
+		// `[]interface{}{...}` shape to exercise `utils.GetOptionsMap`'s
+		// multi-element path end-to-end.
+		{
+			Code:    `type Base = {};`,
+			Options: []interface{}{map[string]interface{}{"allowObjectTypes": "never"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type Base = object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type Base = unknown;`},
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
@@ -145,6 +145,187 @@ interface Both extends A, B {}
 			Options: []interface{}{map[string]interface{}{"allowWithName": "Props$"}},
 		},
 	}, []rule_tester.InvalidTestCase{
+		// ---- PR review feedback lock-ins ----
+		// These lock in three behaviors that gemini-code-assist[bot] raised
+		// concerns about during PR review; the rule must keep matching
+		// upstream typescript-eslint v8.45.0 in all three.
+
+		// (1) Trailing comma in type parameters: `interface Foo<T,> {}`. tsgo's
+		// `parseDelimitedList` consumes the comma and positions End() at `>`,
+		// so the scanner-based `<>` capture in `typeParametersText` round-trips
+		// the trailing comma into the suggestion verbatim. Lock that in.
+		{
+			Code: `interface Foo<T,> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterface", Output: `type Foo<T,> = object`},
+						{MessageId: "replaceEmptyInterface", Output: `type Foo<T,> = unknown`},
+					},
+				},
+			},
+		},
+
+		// (2) Comment between modifier and `interface` keyword must be
+		// preserved in the suggestion. The fix replace-range starts at the
+		// `interface` keyword (via scanner), so any trivia between modifiers
+		// and `interface` falls outside the range and survives verbatim.
+		{
+			Code: `
+namespace N {
+  export /* hello */ interface Foo {}
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      3,
+					Column:    32,
+					EndLine:   3,
+					EndColumn: 35,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyInterface",
+							Output: `
+namespace N {
+  export /* hello */ type Foo = object
+}
+`,
+						},
+						{
+							MessageId: "replaceEmptyInterface",
+							Output: `
+namespace N {
+  export /* hello */ type Foo = unknown
+}
+`,
+						},
+					},
+				},
+			},
+		},
+
+		// (3) `string & ({})` — the parenthesized `{}`'s immediate parent is
+		// `ParenthesizedType`, not `IntersectionType`. Upstream's
+		// `node.parent.type === 'TSIntersectionType'` is an immediate-parent
+		// check, so this case is REPORTED upstream — and so must we be. Lock
+		// in the no-paren-unwrapping behavior.
+		{
+			Code: `type T = string & ({});`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 22,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T = string & (object);`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T = string & (unknown);`},
+					},
+				},
+			},
+		},
+
+		// ---- Additional Dimension 4 lock-ins identified during self-review ----
+
+		// `keyof {}` — TypeOperator parent, reports.
+		{
+			Code: `type T = keyof {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 18,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T = keyof object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T = keyof unknown;`},
+					},
+				},
+			},
+		},
+
+		// `infer U extends {}` — `{}` is the constraint of an `infer` declaration
+		// inside a conditional type. Parent is InferType.
+		{
+			Code: `type T<X> = X extends infer U extends {} ? U : never;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    39,
+					EndLine:   1,
+					EndColumn: 41,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T<X> = X extends infer U extends object ? U : never;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T<X> = X extends infer U extends unknown ? U : never;`},
+					},
+				},
+			},
+		},
+
+		// Mapped-type value `{}` — `{[P in K]: {}}`. The OUTER is a MappedType
+		// (KindMappedType, not KindTypeLiteral), so it isn't visited; the inner
+		// `{}` is a regular TypeLiteral and gets reported.
+		{
+			Code: `type T<K extends string> = { [P in K]: {} };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    40,
+					EndLine:   1,
+					EndColumn: 42,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type T<K extends string> = { [P in K]: object };`},
+						{MessageId: "replaceEmptyObjectType", Output: `type T<K extends string> = { [P in K]: unknown };`},
+					},
+				},
+			},
+		},
+
+		// Namespace-qualified extends — `interface I extends X.Y {}`. The
+		// extended-type capture must preserve the dotted form.
+		{
+			Code: `interface Foo extends Ns.Inner {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterfaceWithSuper", Output: `type Foo = Ns.Inner`},
+					},
+				},
+			},
+		},
+
+		// Generic-namespace-qualified extends — `interface I extends X.Y<T> {}`.
+		{
+			Code: `interface Foo<T> extends Ns.Inner<T> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterfaceWithSuper", Output: `type Foo<T> = Ns.Inner<T>`},
+					},
+				},
+			},
+		},
+
 		// ---- Dimension 1: type-literal in parameter / return / property positions ----
 		{
 			Code: `function f(x: {}) {}`,

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_upstream_test.go
@@ -1,0 +1,535 @@
+// TestNoEmptyObjectTypeUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/tests/rules/no-empty-object-type.test.ts 1:1.
+// Position assertions cover line/column for every invalid case. rslint-specific
+// lock-in cases live in the no_empty_object_type_extras_test.go file(s).
+package no_empty_object_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoEmptyObjectTypeUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoEmptyObjectTypeRule, []rule_tester.ValidTestCase{
+		{Code: `
+interface Base {
+  name: string;
+}
+`},
+		{Code: `
+interface Base {
+  name: string;
+}
+
+interface Derived {
+  age: number;
+}
+
+// valid because extending multiple interfaces can be used instead of a union type
+interface Both extends Base, Derived {}
+`},
+		{
+			Code:    `interface Base {}`,
+			Options: map[string]interface{}{"allowInterfaces": "always"},
+		},
+		{
+			Code: `
+interface Base {
+  name: string;
+}
+
+interface Derived extends Base {}
+`,
+			Options: map[string]interface{}{"allowInterfaces": "with-single-extends"},
+		},
+		{
+			Code: `
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+class Derived {}
+`,
+			Options: map[string]interface{}{"allowInterfaces": "with-single-extends"},
+		},
+		{Code: `let value: object;`},
+		{Code: `let value: Object;`},
+		{Code: `let value: { inner: true };`},
+		{Code: `type MyNonNullable<T> = T & {};`},
+		{
+			Code:    `type Base = {};`,
+			Options: map[string]interface{}{"allowObjectTypes": "always"},
+		},
+		{
+			Code:    `type Base = {};`,
+			Options: map[string]interface{}{"allowWithName": "Base"},
+		},
+		{
+			Code:    `type BaseProps = {};`,
+			Options: map[string]interface{}{"allowWithName": "Props$"},
+		},
+		{
+			Code:    `interface Base {}`,
+			Options: map[string]interface{}{"allowWithName": "Base"},
+		},
+		{
+			Code:    `interface BaseProps {}`,
+			Options: map[string]interface{}{"allowWithName": "Props$"},
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `interface Base {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterface", Output: `type Base = object`},
+						{MessageId: "replaceEmptyInterface", Output: `type Base = unknown`},
+					},
+				},
+			},
+		},
+		{
+			Code:    `interface Base {}`,
+			Options: map[string]interface{}{"allowInterfaces": "never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterface", Output: `type Base = object`},
+						{MessageId: "replaceEmptyInterface", Output: `type Base = unknown`},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+class Other {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      6,
+					Column:    11,
+					EndLine:   6,
+					EndColumn: 18,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyInterfaceWithSuper",
+							Output: `
+interface Base {
+  props: string;
+}
+
+type Derived = Base
+
+class Other {}
+`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+class Derived {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      6,
+					Column:    11,
+					EndLine:   6,
+					EndColumn: 18,
+				},
+			},
+		},
+		{
+			Code: `
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+const derived = class Derived {};
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      6,
+					Column:    11,
+					EndLine:   6,
+					EndColumn: 18,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyInterfaceWithSuper",
+							Output: `
+interface Base {
+  props: string;
+}
+
+type Derived = Base
+
+const derived = class Derived {};
+`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+interface Base {
+  name: string;
+}
+
+interface Derived extends Base {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      6,
+					Column:    11,
+					EndLine:   6,
+					EndColumn: 18,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyInterfaceWithSuper",
+							Output: `
+interface Base {
+  name: string;
+}
+
+type Derived = Base
+`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `interface Base extends Array<number> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterfaceWithSuper", Output: `type Base = Array<number>`},
+					},
+				},
+			},
+		},
+		{
+			Code: `interface Base extends Array<number | {}> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterfaceWithSuper", Output: `type Base = Array<number | {}>`},
+					},
+				},
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    39,
+					EndLine:   1,
+					EndColumn: 41,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `interface Base extends Array<number | object> {}`},
+						{MessageId: "replaceEmptyObjectType", Output: `interface Base extends Array<number | unknown> {}`},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+interface Derived {
+  property: string;
+}
+interface Base extends Array<Derived> {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      5,
+					Column:    11,
+					EndLine:   5,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyInterfaceWithSuper",
+							Output: `
+interface Derived {
+  property: string;
+}
+type Base = Array<Derived>
+`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+type R = Record<string, unknown>;
+interface Base extends R {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      3,
+					Column:    11,
+					EndLine:   3,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyInterfaceWithSuper",
+							Output: `
+type R = Record<string, unknown>;
+type Base = R
+`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `interface Base<T> extends Derived<T> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterfaceWithSuper", Output: `type Base<T> = Derived<T>`},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+declare namespace BaseAndDerived {
+  type Base = typeof base;
+  export interface Derived extends Base {}
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterfaceWithSuper",
+					Line:      4,
+					Column:    20,
+					EndLine:   4,
+					EndColumn: 27,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyInterfaceWithSuper",
+							Output: `
+declare namespace BaseAndDerived {
+  type Base = typeof base;
+  export type Derived = Base
+}
+`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `type Base = {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type Base = object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type Base = unknown;`},
+					},
+				},
+			},
+		},
+		{
+			Code:    `type Base = {};`,
+			Options: map[string]interface{}{"allowObjectTypes": "never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type Base = object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type Base = unknown;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `let value: {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `let value: object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `let value: unknown;`},
+					},
+				},
+			},
+		},
+		{
+			Code:    `let value: {};`,
+			Options: map[string]interface{}{"allowObjectTypes": "never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 14,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `let value: object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `let value: unknown;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+let value: {
+  /* ... */
+};
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      2,
+					Column:    12,
+					EndLine:   4,
+					EndColumn: 2,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "replaceEmptyObjectType",
+							Output: `
+let value: object;
+`,
+						},
+						{
+							MessageId: "replaceEmptyObjectType",
+							Output: `
+let value: unknown;
+`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `type MyUnion<T> = T | {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    23,
+					EndLine:   1,
+					EndColumn: 25,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type MyUnion<T> = T | object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type MyUnion<T> = T | unknown;`},
+					},
+				},
+			},
+		},
+		{
+			Code:    `type Base = {} | null;`,
+			Options: map[string]interface{}{"allowWithName": "Base"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type Base = object | null;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type Base = unknown | null;`},
+					},
+				},
+			},
+		},
+		{
+			Code:    `type Base = {};`,
+			Options: map[string]interface{}{"allowWithName": "Mismatch"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyObject",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyObjectType", Output: `type Base = object;`},
+						{MessageId: "replaceEmptyObjectType", Output: `type Base = unknown;`},
+					},
+				},
+			},
+		},
+		{
+			Code:    `interface Base {}`,
+			Options: map[string]interface{}{"allowWithName": ".*Props$"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterface", Output: `type Base = object`},
+						{MessageId: "replaceEmptyInterface", Output: `type Base = unknown`},
+					},
+				},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -254,7 +254,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-dynamic-delete.test.ts',
     './tests/typescript-eslint/rules/no-empty-function.test.ts',
     './tests/typescript-eslint/rules/no-empty-interface.test.ts',
-    // './tests/typescript-eslint/rules/no-empty-object-type.test.ts',
+    './tests/typescript-eslint/rules/no-empty-object-type.test.ts',
     './tests/typescript-eslint/rules/no-explicit-any.test.ts',
     './tests/typescript-eslint/rules/no-extra-non-null-assertion.test.ts',
     './tests/typescript-eslint/rules/no-extraneous-class.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-empty-object-type.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-empty-object-type.test.ts.snap
@@ -1,0 +1,645 @@
+// Rstest Snapshot v1
+
+exports[`no-empty-object-type > invalid 1`] = `
+{
+  "code": "interface Base {}",
+  "diagnostics": [
+    {
+      "message": "An empty interface declaration allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyInterface",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 2`] = `
+{
+  "code": "interface Base {}",
+  "diagnostics": [
+    {
+      "message": "An empty interface declaration allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyInterface",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 3`] = `
+{
+  "code": "
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+class Other {}
+      ",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 6,
+        },
+        "start": {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 4`] = `
+{
+  "code": "
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+class Derived {}
+      ",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 6,
+        },
+        "start": {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 5`] = `
+{
+  "code": "
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+const derived = class Derived {};
+      ",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 6,
+        },
+        "start": {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 6`] = `
+{
+  "code": "
+interface Base {
+  name: string;
+}
+
+interface Derived extends Base {}
+      ",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 6,
+        },
+        "start": {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 7`] = `
+{
+  "code": "interface Base extends Array<number> {}",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 8`] = `
+{
+  "code": "interface Base extends Array<number | {}> {}",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 9`] = `
+{
+  "code": "
+interface Derived {
+  property: string;
+}
+interface Base extends Array<Derived> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 10`] = `
+{
+  "code": "
+type R = Record<string, unknown>;
+interface Base extends R {}
+      ",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 11`] = `
+{
+  "code": "interface Base<T> extends Derived<T> {}",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 12`] = `
+{
+  "code": "
+declare namespace BaseAndDerived {
+  type Base = typeof base;
+  export interface Derived extends Base {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "An interface declaring no members is equivalent to its supertype.",
+      "messageId": "noEmptyInterfaceWithSuper",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 4,
+        },
+        "start": {
+          "column": 20,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 13`] = `
+{
+  "code": "type Base = {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 14`] = `
+{
+  "code": "type Base = {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 15`] = `
+{
+  "code": "let value: {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 16`] = `
+{
+  "code": "let value: {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 17`] = `
+{
+  "code": "
+let value: {
+  /* ... */
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 18`] = `
+{
+  "code": "type MyUnion<T> = T | {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 19`] = `
+{
+  "code": "type Base = {} | null;",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 20`] = `
+{
+  "code": "type Base = {};",
+  "diagnostics": [
+    {
+      "message": "The \`{}\` ("empty object") type allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyObject",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-object-type > invalid 21`] = `
+{
+  "code": "interface Base {}",
+  "diagnostics": [
+    {
+      "message": "An empty interface declaration allows any non-nullish value, including literals like \`0\` and \`""\`.
+- If that's what you want, disable this lint rule with an inline comment or configure the 'allowInterfaces' rule option.
+- If you want a type meaning "any object", you probably want \`object\` instead.
+- If you want a type meaning "any value", you probably want \`unknown\` instead.",
+      "messageId": "noEmptyInterface",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-empty-object-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the [`@typescript-eslint/no-empty-object-type`](https://typescript-eslint.io/rules/no-empty-object-type) rule from typescript-eslint to rslint.

The rule disallows accidental uses of the \`{}\` (\"empty object\") type — which actually means \"any non-nullish value\" in TypeScript and is rarely what authors intend. It also flags empty \`interface\` declarations (with or without a single \`extends\` clause), offering \`object\` / \`unknown\` suggestions or a type-alias rewrite.

Options aligned 1:1 with upstream:
- \`allowInterfaces\`: \`'never'\` (default) | \`'always'\` | \`'with-single-extends'\`
- \`allowObjectTypes\`: \`'never'\` (default) | \`'always'\`
- \`allowWithName\`: regex source string

The rule has been validated against real-world codebases (\`rsbuild\`, \`rspack\`) — every diagnostic reproduces the corresponding upstream behavior with no false positives or false negatives.

## Related Links

- ESLint rule: https://typescript-eslint.io/rules/no-empty-object-type
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-empty-object-type.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).