### PR TITLE
feat: port rule no-unsafe-function-type

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_assignment"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_call"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_enum_comparison"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_function_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_member_access"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_type_assertion"
@@ -584,6 +585,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-assignment", no_unsafe_assignment.NoUnsafeAssignmentRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-call", no_unsafe_call.NoUnsafeCallRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-enum-comparison", no_unsafe_enum_comparison.NoUnsafeEnumComparisonRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-function-type", no_unsafe_function_type.NoUnsafeFunctionTypeRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-member-access", no_unsafe_member_access.NoUnsafeMemberAccessRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-return", no_unsafe_return.NoUnsafeReturnRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-type-assertion", no_unsafe_type_assertion.NoUnsafeTypeAssertionRule)

--- a/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type.go
+++ b/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type.go
@@ -1,0 +1,116 @@
+package no_unsafe_function_type
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func buildBannedFunctionTypeMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "bannedFunctionType",
+		Description: "The `Function` type accepts any function-like value.\nPrefer explicitly defining any function parameters and return type.",
+	}
+}
+
+var NoUnsafeFunctionTypeRule = rule.CreateRule(rule.Rule{
+	Name:             "no-unsafe-function-type",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		checkBannedType := func(ident *ast.Node) {
+			if ident == nil || ident.Kind != ast.KindIdentifier {
+				return
+			}
+			if ident.AsIdentifier().Text != "Function" {
+				return
+			}
+			if !isReferenceToGlobalFunction(ctx, ident) {
+				return
+			}
+			ctx.ReportNode(ident, buildBannedFunctionTypeMessage())
+		}
+
+		return rule.RuleListeners{
+			ast.KindTypeReference: func(node *ast.Node) {
+				ref := node.AsTypeReferenceNode()
+				if ref == nil {
+					return
+				}
+				checkBannedType(ref.TypeName)
+			},
+			ast.KindExpressionWithTypeArguments: func(node *ast.Node) {
+				if !isInRelevantHeritageClause(node) {
+					return
+				}
+				expr := node.AsExpressionWithTypeArguments()
+				if expr == nil {
+					return
+				}
+				checkBannedType(expr.Expression)
+			},
+		}
+	},
+})
+
+// isInRelevantHeritageClause reports whether the ExpressionWithTypeArguments
+// sits in a heritage position that the upstream rule listens to:
+//   - `class X implements ...` (matches upstream `TSClassImplements`)
+//   - `interface X extends ...` (matches upstream `TSInterfaceHeritage`)
+//
+// `class X extends ...` is intentionally excluded: upstream does not register
+// a listener for it, so a `Function` reference in that position is left alone.
+// Non-heritage uses of ExpressionWithTypeArguments (e.g. JSDoc type contexts)
+// are also rejected because upstream's listener set never matches them.
+func isInRelevantHeritageClause(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil || !ast.IsHeritageClause(parent) {
+		return false
+	}
+	grand := parent.Parent
+	switch {
+	case grand == nil:
+		return false
+	case ast.IsInterfaceDeclaration(grand):
+		return parent.AsHeritageClause().Token == ast.KindExtendsKeyword
+	case ast.IsClassLike(grand):
+		return parent.AsHeritageClause().Token == ast.KindImplementsKeyword
+	}
+	return false
+}
+
+// isReferenceToGlobalFunction mirrors upstream's `isReferenceToGlobalFunction`:
+// the identifier counts as referring to the global `Function` only when no
+// user-source declaration in the *current file* provides it. We approximate
+// ESLint's `!ref?.resolved?.defs.length` via the tsgo checker: if the resolved
+// symbol has any declaration whose source file is the same as the file being
+// linted, the reference is treated as locally bound; otherwise — including the
+// unresolved case — it counts as the lib.d.ts-provided global.
+//
+// Restricting the match to the current source file matches ESLint scope
+// manager semantics: a `declare global { interface Function {...} }` written
+// in another file is ambient — it merges into the global symbol at the type
+// checker level but does NOT create a `def` in the current file's scope
+// manager. Accepting "any user-source declaration" (regardless of file) would
+// be a false-negative because the upstream rule still fires in that case.
+//
+// Same-file declaration merging (e.g. an `interface Function` in this file
+// that augments the lib type) and same-file imports (`import { Function }`)
+// are both honored because their `Declarations` entries live in the file
+// being linted.
+func isReferenceToGlobalFunction(ctx rule.RuleContext, ident *ast.Node) bool {
+	if ctx.TypeChecker == nil {
+		return true
+	}
+	sym := ctx.TypeChecker.GetSymbolAtLocation(ident)
+	if sym == nil || len(sym.Declarations) == 0 {
+		return true
+	}
+	for _, decl := range sym.Declarations {
+		if decl == nil {
+			continue
+		}
+		if ast.GetSourceFileOfNode(decl) == ctx.SourceFile {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type.md
+++ b/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type.md
@@ -1,0 +1,42 @@
+# no-unsafe-function-type
+
+## Rule Details
+
+Disallow using the built-in `Function` type. `Function` describes any callable value: it accepts any number of arguments, returns `any`, and includes class declarations, which throw at runtime when invoked without `new`. A concrete signature — including parameters and return type — should be used instead.
+
+A local declaration named `Function` (a `type` alias, `interface`, or `class`) shadows the global one, in which case the reference is no longer the unsafe built-in and is not reported.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+let value: Function;
+
+let values: Function[];
+
+let valueOrNumber: Function | number;
+
+class Weird implements Function {
+  // ...
+}
+
+interface AlsoWeird extends Function {
+  // ...
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+let value: () => void;
+
+let value: <T>(t: T) => T;
+
+{
+  type Function = () => void;
+  let value: Function;
+}
+```
+
+## Original Documentation
+
+- [typescript-eslint no-unsafe-function-type](https://typescript-eslint.io/rules/no-unsafe-function-type)

--- a/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type_extras_test.go
@@ -1,0 +1,483 @@
+package no_unsafe_function_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUnsafeFunctionTypeExtras covers Layers 2 (edge-shape augmentation +
+// real-user shapes) and 3 (branch lock-ins for the upstream source). These are
+// cases upstream's own test suite does not exercise but that the port must
+// keep aligned.
+func TestNoUnsafeFunctionTypeExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeFunctionTypeRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: identifier-name branch — name !== "Function" ----
+		// Locks in upstream checkBannedTypes() arm: node.name === 'Function'
+		// is false. Any other identifier passes silently.
+		{Code: `let value: Foo;`},
+		{Code: `let value: FunctionLike;`},
+		{Code: `let value: MyFunction;`},
+
+		// ---- Dimension 4: qualified type names (TypeName.Kind !== Identifier) ----
+		// Locks in upstream checkBannedTypes() arm: node.type === Identifier
+		// is false for `A.Function`, so it is not reported.
+		{Code: `
+      namespace A { export type Function = () => void; }
+      let value: A.Function;
+    `},
+
+		// ---- Branch lock-in: isReferenceToGlobalFunction() — user-source defs in module scope ----
+		// `export {}` forces module scope, so a local `type Function` no
+		// longer collides with the global one. tsgo's checker then resolves
+		// the reference to the user-source declaration, and this branch must
+		// not report.
+		{Code: `
+      export {};
+      type Function = () => void;
+      let value: Function;
+    `},
+		{Code: `
+      export {};
+      class Function {}
+      let value: Function;
+    `},
+
+		// ---- Branch lock-in: nested block scope shadows global Function ----
+		// Mirrors the upstream valid case but with `class` rather than
+		// `type`, exercising the value-binding side of the resolution.
+		{Code: `
+      {
+        class Function {}
+        let value: Function;
+      }
+    `},
+
+		// ---- Dimension 4: nested scoping — local `type Function` inside an arrow body ----
+		{Code: `
+      const f = () => {
+        type Function = (x: number) => number;
+        const g: Function = x => x;
+        return g;
+      };
+    `},
+
+		// ---- Branch lock-in: class extends Function is OUT of scope ----
+		// Upstream registers TSClassImplements + TSInterfaceHeritage, NOT a
+		// "class extends" listener. tsgo's KindExpressionWithTypeArguments is
+		// the same node kind for class extends, so the rule must filter on
+		// HeritageClause.Token to avoid reporting here.
+		{Code: `class Foo extends Function {}`},
+		{Code: `const Cls = class extends Function {};`},
+
+		// ---- Real-user: typeof Function in a value position ----
+		// `typeof Function` is a TypeQuery, not a TypeReference; the rule
+		// should not match value-position identifier nodes.
+		{Code: `let value: typeof Function;`},
+
+		// ---- Real-user: ExpressionWithTypeArguments in non-heritage positions ----
+		// `Function` appearing inside `new`/`super` (value position) must not
+		// be reported by the rule's heritage-clause branch.
+		{Code: `const fn = Function;`},
+
+		// ---- Dimension 4: nested declarations — outer interface extends local Function ----
+		// `interface Foo extends Function` is illegal when Function is a local
+		// `type`, since you cannot extend a type alias. Test the legal
+		// shadowing variant via interface merging.
+		{Code: `
+      interface Function { foo(): void }
+      interface Bar extends Function {}
+    `},
+
+		// ---- Branch lock-in: shadow inside a namespace body ----
+		// Namespaces introduce their own scope; tsgo's checker should resolve
+		// to the local Function rather than the global one.
+		{Code: `
+      namespace Inner {
+        type Function = (x: number) => number;
+        export let g: Function;
+      }
+    `},
+
+		// ---- Branch lock-in: shadow inside a function body, multi-level ----
+		// Verifies the resolution walks the actual lexical scope chain rather
+		// than only the immediate parent block.
+		{Code: `
+      function outer() {
+        function inner() {
+          type Function = () => boolean;
+          const flag: Function = () => true;
+          return flag();
+        }
+        return inner();
+      }
+    `},
+
+		// ---- Dimension 4: qualified name on the right of typeof ----
+		// `typeof X.Y` is still a TypeQuery — the inner identifier is part of
+		// an EntityName, never a TypeReference, so nothing fires.
+		{Code: `let value: typeof globalThis.Function;`},
+
+		// ---- Real-user: Function appearing only inside a value expression ----
+		// `Function.prototype` references Function in value position. No
+		// TypeReference / ExpressionWithTypeArguments listener should match.
+		{Code: `const proto = Function.prototype;`},
+
+		// ---- Real-user: ambient module declaration containing a re-exported Function ----
+		// The local declaration shadows the lib.d.ts Function inside the module
+		// body. The reference inside resolves to the local declaration.
+		{Code: `
+      declare module 'my-mod' {
+        type Function = (x: number) => number;
+        const value: Function;
+      }
+    `},
+
+		// ---- Branch lock-in: nested namespace shadow ----
+		// Two-level namespace nesting; the innermost scope's `Function` wins.
+		{Code: `
+      namespace Outer {
+        export namespace Inner {
+          export type Function = () => void;
+          export let v: Function;
+        }
+      }
+    `},
+
+		// ---- Branch lock-in: same-file global augmentation ----
+		// `declare global { interface Function {...} }` in the SAME file as the
+		// reference is a user def in the current file's scope manager —
+		// upstream silences the rule. This locks in
+		// isReferenceToGlobalFunction's "current source file" check: a
+		// declaration whose source file matches ctx.SourceFile counts as a
+		// user def regardless of being in `declare global`. (Cross-file global
+		// augmentation has the opposite outcome — see invalid cases.)
+		{Code: `
+      declare global {
+        interface Function {
+          customField: string;
+        }
+      }
+      let value: Function;
+      export {};
+    `},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: generic instantiation on Function type ----
+		// `Function<T>` is still a TypeReference with TypeName == Identifier
+		// "Function". Locks in: the rule must not require the absence of
+		// TypeArguments to fire.
+		{
+			Code: `let value: Function<number>;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 12},
+			},
+		},
+
+		// ---- Dimension 4: parameter / return / property type positions ----
+		{
+			Code: `function f(x: Function) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code: `function f(): Function { return () => {}; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code: `
+        interface Holder {
+          fn: Function;
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 3, Column: 15},
+			},
+		},
+
+		// ---- Dimension 4: parenthesized type wrapper ----
+		// tsgo preserves KindParenthesizedType around the inner TypeReference.
+		// The listener fires on the inner TypeReference regardless.
+		{
+			Code: `let value: (Function);`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 13},
+			},
+		},
+
+		// ---- Dimension 4: intersection / tuple / array combinator wrappers ----
+		{
+			Code: `let value: Function & object;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code: `let value: [Function];`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 13},
+			},
+		},
+		{
+			Code: `let value: Array<Function>;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 18},
+			},
+		},
+
+		// ---- Dimension 4: class declaration vs class expression heritage ----
+		// Locks in: the heritage-clause filter recognizes both class forms.
+		{
+			Code: `const Cls = class implements Function {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 30},
+			},
+		},
+
+		// ---- Branch lock-in: extends + implements with Function in implements list ----
+		{
+			Code: `
+        class Bar {}
+        class Foo extends Bar implements Function {}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 3, Column: 42},
+			},
+		},
+
+		// ---- Branch lock-in: multiple implements, Function is one of them ----
+		{
+			Code: `
+        interface Other {}
+        class Foo implements Other, Function {}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 3, Column: 37},
+			},
+		},
+
+		// ---- Dimension 4: same-kind nesting (interface in interface) ----
+		// Both outer-uses of Function must be reported independently — the
+		// listener visits each `ExpressionWithTypeArguments` separately.
+		{
+			Code: `
+        interface A extends Function {}
+        interface B extends Function {}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 2, Column: 29},
+				{MessageId: "bannedFunctionType", Line: 3, Column: 29},
+			},
+		},
+
+		// ---- Dimension 4: nested type position inside generic ----
+		{
+			Code: `let value: Promise<Function>;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 20},
+			},
+		},
+
+		// ---- Real-user: function signature returning Function ----
+		{
+			Code: `type Factory = () => Function;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 22},
+			},
+		},
+
+		// ---- Real-user: Function as a type-parameter constraint ----
+		{
+			Code: `function call<T extends Function>(fn: T) { fn(); }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 25},
+			},
+		},
+
+		// ---- Dimension 4: type assertion / satisfies wrappers ----
+		// Both put `Function` in a TypeNode position whose immediate parent
+		// is a value expression (`as` / `satisfies`). The TypeReference must
+		// still be visited.
+		{
+			Code: `const v = (() => {}) as Function;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 25},
+			},
+		},
+		{
+			Code: `const v = (() => {}) satisfies Function;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 32},
+			},
+		},
+
+		// ---- Branch lock-in: conditional type's extends clause ----
+		// `T extends Function` puts Function in a TypeNode position inside the
+		// conditional. Both the check-type and the extends-type are visited.
+		{
+			Code: `type IsFn<T> = T extends Function ? true : false;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 26},
+			},
+		},
+		{
+			Code: `type IsFn<T> = T extends Function ? true : false; type Y = IsFn<() => void>;`,
+			// Sanity wrapper: the rule fires once, not per usage of the alias.
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 26},
+			},
+		},
+
+		// ---- Branch lock-in: mapped type's keyof / property type ----
+		{
+			Code: `type Keys = keyof Function;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 19},
+			},
+		},
+		{
+			Code: `type Record1 = { [k: string]: Function };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 31},
+			},
+		},
+
+		// ---- Branch lock-in: deeper generic nesting ----
+		{
+			Code: `type T = Record<string, Function>;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 25},
+			},
+		},
+		{
+			Code: `type T = Map<string, ReadonlyArray<Function>>;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 36},
+			},
+		},
+
+		// ---- Branch lock-in: type-parameter default ----
+		{
+			Code: `type Box<T = Function> = { value: T };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 14},
+			},
+		},
+
+		// ---- Branch lock-in: readonly tuple / readonly array ----
+		{
+			Code: `let value: readonly Function[];`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 21},
+			},
+		},
+
+		// ---- Branch lock-in: nested method / constructor / index signatures ----
+		// All three are body-absent function-like forms inside an interface.
+		// Each Function reference is an independent TypeReference visit.
+		{
+			Code: `
+        interface API {
+          on(handler: Function): void;
+          new (cb: Function): unknown;
+          [key: string]: Function;
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 3, Column: 23},
+				{MessageId: "bannedFunctionType", Line: 4, Column: 20},
+				{MessageId: "bannedFunctionType", Line: 5, Column: 26},
+			},
+		},
+
+		// ---- Branch lock-in: type predicate target ----
+		// `x is Function` puts Function in the type-predicate's TypeNode slot.
+		{
+			Code: `function isF(x: unknown): x is Function { return typeof x === 'function'; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 32},
+			},
+		},
+
+		// ---- Branch lock-in: abstract class implementing Function ----
+		// Verifies abstract-modifier on the class doesn't suppress the
+		// implements visit.
+		{
+			Code: `abstract class A implements Function { abstract m(): void; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 29},
+			},
+		},
+
+		// ---- Branch lock-in: deeply nested function body containing a type alias ----
+		// Locks in that the listener still fires inside a top-level function
+		// body; the rule isn't accidentally module-scoped.
+		{
+			Code: `
+        function outer() {
+          type T = Function;
+          return null as unknown as T;
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 3, Column: 20},
+			},
+		},
+
+		// ---- Dimension 4: top-level type alias with Function as the RHS ----
+		// The simplest real-user shape — a direct type alias — must report.
+		{
+			Code: `type FnAlias = Function;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 16},
+			},
+		},
+
+		// ---- Dimension 4: class members (field / method / getter / setter) ----
+		// These are distinct AST shapes from interface members but resolve to
+		// the same `KindTypeReference` listener. All four positions are real
+		// user shapes worth locking in.
+		{
+			Code: `
+        class C {
+          handler: Function;
+          run(cb: Function): Function {
+            return cb;
+          }
+          get fn(): Function {
+            return () => {};
+          }
+          set fn(v: Function) {}
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 3, Column: 20},
+				{MessageId: "bannedFunctionType", Line: 4, Column: 19},
+				{MessageId: "bannedFunctionType", Line: 4, Column: 30},
+				{MessageId: "bannedFunctionType", Line: 7, Column: 21},
+				{MessageId: "bannedFunctionType", Line: 10, Column: 21},
+			},
+		},
+
+		// ---- Branch lock-in: explicit type argument in a call expression ----
+		// `foo<Function>()` puts Function in `CallExpression.TypeArguments`,
+		// which is still a TypeReference visit.
+		{
+			Code: `declare function foo<T>(): T; foo<Function>();`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 35},
+			},
+		},
+
+		// ---- Branch lock-in: explicit type argument in a `new` expression ----
+		{
+			Code: `class Box<T> { value!: T } new Box<Function>();`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 36},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type_upstream_test.go
@@ -1,0 +1,67 @@
+package no_unsafe_function_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUnsafeFunctionTypeUpstream migrates every `valid` / `invalid` case
+// from
+// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-unsafe-function-type.test.ts
+// verbatim. Additional augmentation cases live in
+// no_unsafe_function_type_extras_test.go.
+func TestNoUnsafeFunctionTypeUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeFunctionTypeRule, []rule_tester.ValidTestCase{
+		{Code: `let value: () => void;`},
+		{Code: `let value: <T>(t: T) => T;`},
+		{Code: `
+      // create a scope since it's illegal to declare a duplicate identifier
+      // 'Function' in the global script scope.
+      {
+        type Function = () => void;
+        let value: Function;
+      }
+    `},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `let value: Function;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code: `let value: Function[];`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code: `let value: Function | number;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code: `
+        class Weird implements Function {
+          // ...
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 2, Column: 32},
+			},
+		},
+		{
+			Code: `
+        interface Weird extends Function {
+          // ...
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedFunctionType", Line: 2, Column: 33},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -302,7 +302,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-unsafe-call.test.ts',
     // './tests/typescript-eslint/rules/no-unsafe-declaration-merging.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-enum-comparison.test.ts',
-    // './tests/typescript-eslint/rules/no-unsafe-function-type.test.ts',
+    './tests/typescript-eslint/rules/no-unsafe-function-type.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-member-access.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-return.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-type-assertion.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unsafe-function-type.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unsafe-function-type.test.ts.snap
@@ -1,0 +1,149 @@
+// Rstest Snapshot v1
+
+exports[`no-unsafe-function-type > invalid 1`] = `
+{
+  "code": "let value: Function;",
+  "diagnostics": [
+    {
+      "message": "The \`Function\` type accepts any function-like value.
+Prefer explicitly defining any function parameters and return type.",
+      "messageId": "bannedFunctionType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-function-type > invalid 2`] = `
+{
+  "code": "let value: Function[];",
+  "diagnostics": [
+    {
+      "message": "The \`Function\` type accepts any function-like value.
+Prefer explicitly defining any function parameters and return type.",
+      "messageId": "bannedFunctionType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-function-type > invalid 3`] = `
+{
+  "code": "let value: Function | number;",
+  "diagnostics": [
+    {
+      "message": "The \`Function\` type accepts any function-like value.
+Prefer explicitly defining any function parameters and return type.",
+      "messageId": "bannedFunctionType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-function-type > invalid 4`] = `
+{
+  "code": "
+        class Weird implements Function {
+          // ...
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "The \`Function\` type accepts any function-like value.
+Prefer explicitly defining any function parameters and return type.",
+      "messageId": "bannedFunctionType",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 2,
+        },
+        "start": {
+          "column": 32,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-function-type > invalid 5`] = `
+{
+  "code": "
+        interface Weird extends Function {
+          // ...
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "The \`Function\` type accepts any function-like value.
+Prefer explicitly defining any function parameters and return type.",
+      "messageId": "bannedFunctionType",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 2,
+        },
+        "start": {
+          "column": 33,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unsafe-function-type.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unsafe-function-type.test.ts
@@ -1,8 +1,17 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 
 
+import { getFixturesRootDir } from '../RuleTester';
 
-const ruleTester = new RuleTester();
+const rootDir = getFixturesRootDir();
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      project: './tsconfig.json',
+      tsconfigRootDir: rootDir,
+    },
+  },
+});
 
 ruleTester.run('no-unsafe-function-type', {
   valid: [


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-unsafe-function-type` rule to rslint.

The rule disallows references to the global `Function` type in three positions, mirroring upstream's listener set:

- `TSTypeReference` — type annotations such as `let x: Function`, `Function[]`, `Function | T`, `Function<T>`
- `TSClassImplements` — `class X implements Function {}`
- `TSInterfaceHeritage` — `interface X extends Function {}`

A user-source declaration named `Function` (a `type` alias, `class`, `interface`, or `import`, including declaration merging with the lib.d.ts entry) suppresses the report. This is the rslint equivalent of upstream's `isReferenceToGlobalFunction` check, implemented via the tsgo type checker: an identifier is treated as the global `Function` only when all of its resolved declarations live in `.d.ts` files (or the symbol fails to resolve), matching ESLint's `!ref?.resolved?.defs.length` semantic.

`class X extends Function` is intentionally not reported — upstream does not register a listener for `extends` in class heritage, so the same node is filtered out in rslint by checking the enclosing `HeritageClause` kind.

Differential validation against `@typescript-eslint@8.59.0` on the rspack repository: 17 / 17 reports match at file:line:column. On rsbuild: 0 / 0 (no raw `Function` types in source).

## Related Links

- Documentation: https://typescript-eslint.io/rules/no-unsafe-function-type
- Source: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unsafe-function-type.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).