### PR TITLE
feat: port rule @typescript-eslint/no-unsafe-declaration-merging

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_argument"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_assignment"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_call"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_declaration_merging"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_enum_comparison"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_member_access"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_return"
@@ -583,6 +584,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-argument", no_unsafe_argument.NoUnsafeArgumentRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-assignment", no_unsafe_assignment.NoUnsafeAssignmentRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-call", no_unsafe_call.NoUnsafeCallRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-declaration-merging", no_unsafe_declaration_merging.NoUnsafeDeclarationMergingRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-enum-comparison", no_unsafe_enum_comparison.NoUnsafeEnumComparisonRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-member-access", no_unsafe_member_access.NoUnsafeMemberAccessRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-return", no_unsafe_return.NoUnsafeReturnRule)

--- a/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging.go
+++ b/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging.go
@@ -1,0 +1,115 @@
+package no_unsafe_declaration_merging
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildUnsafeMergingMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unsafeMerging",
+		Description: "Unsafe declaration merging between classes and interfaces.",
+	}
+}
+
+// nearestLocalsContainer climbs from the given node's parent to the nearest
+// ancestor that owns a Locals SymbolTable. Used only for the `export default
+// class Foo {}` fallback to look up the module-scope binding via GetLocals —
+// GetLocals requires a LocalsContainer, whereas utils.FindEnclosingScope
+// (used for the same-scope merge check) returns ModuleBlock / SourceFile /
+// function-like nodes which is the right granularity for scope comparison
+// but not always a LocalsContainer.
+func nearestLocalsContainer(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	p := node.Parent
+	for p != nil && !ast.IsLocalsContainer(p) {
+		p = p.Parent
+	}
+	return p
+}
+
+var NoUnsafeDeclarationMergingRule = rule.CreateRule(rule.Rule{
+	Name:             "no-unsafe-declaration-merging",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// reportIfUnsafeMerge mirrors upstream's scope-manager probe in
+		// behavior while using tsgo's TypeChecker as the symbol source.
+		//
+		// Upstream does two things that look like implementation details
+		// but are part of the rule's observable contract; we reproduce
+		// both:
+		//
+		//   1. The interface listener calls sourceCode.getScope(node),
+		//      which for a generic interface returns the type-parameter
+		//      scope. That scope does not contain the interface's own
+		//      name, so the lookup fails and the listener returns
+		//      without reporting. ESLint thus skips the interface side
+		//      whenever the interface has type parameters; the class
+		//      listener uses .upper and is not affected.
+		//
+		//   2. Both listeners look up the name in a single lexical scope.
+		//      A class and interface that share a name only count as
+		//      "merging" if they live in the same enclosing scope (same
+		//      SourceFile, same namespace block, same `declare module`
+		//      block, …). Cross-`declare module` blocks and external-
+		//      module class augmentation therefore never fire upstream,
+		//      even though TypeScript really does merge the symbols.
+		//
+		// We keep TypeChecker.GetSymbolAtLocation as the source of truth
+		// for "is there a merge at all", then filter symbol.Declarations
+		// down to those sharing the same enclosing LocalsContainer as
+		// the current declaration. The filter is what implements (2);
+		// the early return on type parameters implements (1).
+		reportIfUnsafeMerge := func(declNode *ast.Node, name *ast.Node, unsafeKind ast.Kind) {
+			if name == nil {
+				return
+			}
+
+			if declNode.Kind == ast.KindInterfaceDeclaration {
+				iface := declNode.AsInterfaceDeclaration()
+				if iface.TypeParameters != nil && len(iface.TypeParameters.Nodes) > 0 {
+					return
+				}
+			}
+
+			symbol := ctx.TypeChecker.GetSymbolAtLocation(name)
+			// `export default class Foo {}` binds the class to the synthetic
+			// __default symbol; the module-scope `Foo` local (which is what
+			// merges with `interface Foo {}`) is a separate symbol in the
+			// enclosing LocalsContainer. Recover it before the merge check.
+			if symbol != nil && symbol.Name == ast.InternalSymbolNameDefault {
+				if container := nearestLocalsContainer(declNode); container != nil {
+					if local := ast.GetLocals(container)[name.Text()]; local != nil {
+						symbol = local
+					}
+				}
+			}
+			if symbol == nil || len(symbol.Declarations) <= 1 {
+				return
+			}
+
+			scope := utils.FindEnclosingScope(declNode)
+			for _, decl := range symbol.Declarations {
+				if decl == declNode || decl.Kind != unsafeKind {
+					continue
+				}
+				if utils.FindEnclosingScope(decl) == scope {
+					ctx.ReportNode(name, buildUnsafeMergingMessage())
+					return
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindClassDeclaration: func(node *ast.Node) {
+				reportIfUnsafeMerge(node, node.AsClassDeclaration().Name(), ast.KindInterfaceDeclaration)
+			},
+			ast.KindInterfaceDeclaration: func(node *ast.Node) {
+				reportIfUnsafeMerge(node, node.AsInterfaceDeclaration().Name(), ast.KindClassDeclaration)
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging.md
+++ b/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging.md
@@ -1,0 +1,72 @@
+# no-unsafe-declaration-merging
+
+## Rule Details
+
+Disallows unsafe declaration merging between a class and an interface. TypeScript allows a class and an interface that share the same name in the same scope to merge into a single declaration. Properties declared on the interface are added to the resulting type without forcing the class to actually initialize them, so accessing such a property on a class instance type-checks but throws `Cannot read properties of undefined` at runtime.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+interface Foo {}
+class Foo {}
+```
+
+```typescript
+class Foo {}
+interface Foo {}
+```
+
+```typescript
+declare global {
+  interface Foo {}
+  class Foo {}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+interface Foo {}
+class Bar implements Foo {}
+```
+
+```typescript
+namespace Foo {}
+namespace Foo {}
+```
+
+```typescript
+enum Foo {}
+namespace Foo {}
+```
+
+```typescript
+namespace Qux {}
+function Qux() {}
+```
+
+```typescript
+const Foo = class {};
+```
+
+```typescript
+interface Foo {
+  props: string;
+}
+
+function bar() {
+  return class Foo {};
+}
+```
+
+```typescript
+declare global {
+  interface Foo {}
+}
+
+class Foo {}
+```
+
+## Original Documentation
+
+- [typescript-eslint no-unsafe-declaration-merging](https://typescript-eslint.io/rules/no-unsafe-declaration-merging)

--- a/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging_extras_test.go
@@ -1,0 +1,472 @@
+// TestNoUnsafeDeclarationMergingExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Every expected output here was
+// verified against upstream's reference implementation (ESLint +
+// @typescript-eslint/eslint-plugin) — diagnostic count, position, and
+// messageId match byte-for-byte. The cases extend the upstream Layer 1
+// migration along three axes:
+//
+//   - Dimension 4 universal edge shapes: receiver wrappers, declaration
+//     container forms (class expression vs class declaration, anonymous
+//     default export, generics with / without constraints), modifiers
+//     (declare, abstract, export), and nesting boundaries (function /
+//     arrow body, class static block, deeply nested namespaces, different
+//     namespaces with the same names).
+//   - Upstream branch lock-ins: every reachable branch in the upstream
+//     listener (`if (node.id)`, `defs.length <= 1`, `defs.some(... ===
+//     unsafeKind)`, the type-parameter-scope detour on the interface side)
+//     has at least one input that exercises it.
+//   - Real-user shapes: cross-`declare module` blocks, ambient-module
+//     augmentation of external classes, and the default-export class
+//     binding pattern (`export default class Foo {}`) where tsgo binds the
+//     class to the synthetic `__default` symbol — all forms that show up
+//     in real codebases (rsbuild / rspack augmentation patterns) and
+//     would silently regress if the same-container filtering or the
+//     default-export local-binding fallback were broken.
+package no_unsafe_declaration_merging
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnsafeDeclarationMergingExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeDeclarationMergingRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: Declaration container forms — class expression must not trigger ----
+		// KindClassExpression is not KindClassDeclaration; only the declaration listener runs.
+		{Code: `
+interface Foo {}
+const A = class Foo {};
+`},
+
+		// ---- Dimension 4: Declaration container forms — anonymous default-export class ----
+		// Upstream `if (node.id)` short-circuits when the class has no name; rslint's name == nil check does the same.
+		{Code: `
+interface Foo {}
+export default class {}
+`},
+
+		// ---- Dimension 4: Nesting boundaries — class inside function body, interface at file level ----
+		// Different enclosing LocalsContainer (function body vs SourceFile); not a merge.
+		{Code: `
+interface Foo {}
+function bar() {
+  class Foo {}
+  return Foo;
+}
+`},
+
+		// ---- Dimension 4: Nesting boundaries — interface inside function body, class at file level ----
+		{Code: `
+class Foo {}
+function bar() {
+  interface Foo {
+    x: number;
+  }
+  return null as unknown as Foo;
+}
+`},
+
+		// ---- Dimension 4: Nesting boundaries — interface inside an arrow body ----
+		{Code: `
+class Foo {}
+const bar = () => {
+  interface Foo { x: number }
+  return null as unknown as Foo;
+};
+`},
+
+		// ---- Dimension 4: Nesting boundaries — interface inside a class static block ----
+		{Code: `
+class Holder {
+  static {
+    interface Foo {}
+    type _ = Foo;
+  }
+}
+class Foo {}
+`},
+
+		// ---- Dimension 4: Nesting boundaries — different namespaces with the same names ----
+		// Each namespace block is its own LocalsContainer.
+		{Code: `
+namespace A {
+  class Foo {
+    x = 1;
+  }
+}
+namespace B {
+  interface Foo {
+    y: number;
+  }
+}
+`},
+
+		// ---- Branch lock-in: defs.length <= 1 (class side) — single class with no peer.
+		{Code: `
+class Foo {
+  bar() {}
+}
+`},
+
+		// ---- Branch lock-in: defs.length <= 1 (interface side).
+		{Code: `
+interface Foo {
+  x: number;
+}
+`},
+
+		// ---- Branch lock-in: defs > 1 but no class peer — class + namespace merge is safe.
+		{Code: `
+class Foo {}
+namespace Foo {
+  export const bar = 1;
+}
+`},
+
+		// ---- Branch lock-in: defs > 1 but no class peer (interface side) — interface + namespace.
+		{Code: `
+interface Foo {
+  x: number;
+}
+namespace Foo {
+  export const y = 1;
+}
+`},
+
+		// ---- Branch lock-in: multiple interfaces merging into one symbol with no class — safe.
+		{Code: `
+interface Foo {
+  x: number;
+}
+interface Foo {
+  y: string;
+}
+`},
+
+		// ---- Branch lock-in: function + class in different namespaces, no merge.
+		{Code: `
+namespace ns {
+  function Foo() {}
+}
+namespace ns {
+  class Bar {}
+}
+`},
+
+		// ---- Branch lock-in: enum + class with different names — distinct symbols.
+		{Code: `
+enum Status {}
+class Worker {}
+`},
+
+		// ---- Branch lock-in: type alias does not participate in declaration merging with classes.
+		{Code: `
+type Bar = number;
+class Foo {}
+`},
+
+		// ---- Real-user: class implements a separately-named interface — the canonical safe form.
+		{Code: `
+interface IFoo {
+  bar(): void;
+}
+class Foo implements IFoo {
+  bar() {}
+}
+`},
+
+		// ---- Real-user: cross-block `declare module` with the same module name ----
+		// Each `declare module "X"` block is an independent LocalsContainer. Matches upstream's
+		// scope-manager behavior of treating each block as its own scope.
+		{Code: `
+declare module "lib" {
+  interface Foo {}
+}
+declare module "lib" {
+  class Foo {}
+}
+`},
+
+		// ---- Real-user: cross-block `declare module` with different module names ----
+		{Code: `
+declare module "a" {
+  interface Foo {}
+}
+declare module "b" {
+  class Foo {}
+}
+`},
+
+		// ---- Real-user: ambient-module augmentation of an external class (rspack/rsbuild pattern) ----
+		// Adding an interface declaration to a third-party module's class is idiomatic for
+		// native-binding-style packages. The class lives in another file/module, so the
+		// interface and class are in different LocalsContainers — not a merge for this rule.
+		{Code: `
+declare module "@external/lib" {
+  class Compiler {}
+}
+declare module "@external/lib" {
+  interface Compiler {
+    __augmented?: string;
+  }
+}
+`},
+
+		// ---- Real-user: declared variable + function — no class/interface involvement.
+		{Code: `
+declare const Foo: number;
+function foo() {}
+`},
+
+		// ---- Real-user: declare global { interface Foo {} } + module-local class Foo ----
+		// Upstream test #8 covers this; reproduced here in case the listener gate changes.
+		{Code: `
+declare global {
+  interface Foo {}
+}
+
+class Foo {}
+`},
+
+		// ---- Real-user: declare global { class Foo {} } at the top + interface in nested namespace ----
+		{Code: `
+declare global {
+  class Foo {}
+}
+
+namespace nested {
+  interface Foo { x: number }
+}
+`},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Branch lock-in: class + interface inside the same namespace ----
+		{
+			Code: `
+namespace Bar {
+  interface Foo {}
+  class Foo {}
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 3, Column: 13},
+				{MessageId: "unsafeMerging", Line: 4, Column: 9},
+			},
+		},
+
+		// ---- Dimension 4: Nesting — three-level nested namespace; same-container filter still finds the merge.
+		{
+			Code: `
+namespace Outer {
+  namespace Middle {
+    namespace Inner {
+      interface Foo {}
+      class Foo {}
+    }
+  }
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 5, Column: 17},
+				{MessageId: "unsafeMerging", Line: 6, Column: 13},
+			},
+		},
+
+		// ---- Dimension 4: Graceful degradation — multiple interfaces all reported, class reported once.
+		{
+			Code: `
+interface Foo {
+  x: number;
+}
+interface Foo {
+  y: string;
+}
+class Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 2, Column: 11},
+				{MessageId: "unsafeMerging", Line: 5, Column: 11},
+				{MessageId: "unsafeMerging", Line: 8, Column: 7},
+			},
+		},
+
+		// ---- Real-user: class + interface inside a single `declare module` block — merges within the block.
+		{
+			Code: `
+declare module "foo" {
+  interface Bar {}
+  class Bar {}
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 3, Column: 13},
+				{MessageId: "unsafeMerging", Line: 4, Column: 9},
+			},
+		},
+
+		// ---- Dimension 4: Modifiers — exported class + exported interface.
+		{
+			Code: `
+export interface Foo {}
+export class Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 2, Column: 18},
+				{MessageId: "unsafeMerging", Line: 3, Column: 14},
+			},
+		},
+
+		// ---- Dimension 4: Modifiers — `declare class` still participates.
+		{
+			Code: `
+declare class Foo {}
+interface Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 2, Column: 15},
+				{MessageId: "unsafeMerging", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Dimension 4: Modifiers — `abstract class` still participates.
+		{
+			Code: `
+abstract class Foo {}
+interface Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 2, Column: 16},
+				{MessageId: "unsafeMerging", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- D4: generic interface + generic class — only the class side is reported ----
+		// Upstream calls sourceCode.getScope(InterfaceDeclaration), which for a generic interface
+		// returns the type-parameter scope. `Foo` is not in that scope, so the lookup fails and
+		// the interface listener silently returns. The class listener uses .upper and is not
+		// affected. rslint mirrors this asymmetry: interface listener returns when the interface
+		// has TypeParameters.
+		{
+			Code: `
+interface Foo<T> {
+  x: T;
+}
+class Foo<T> {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 5, Column: 7},
+			},
+		},
+
+		// ---- D4: generic interface (one type param) + non-generic class — same asymmetry.
+		{
+			Code: `
+interface Foo<T> {}
+class Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 3, Column: 7},
+			},
+		},
+
+		// ---- D4: generic interface with two type parameters — same asymmetry.
+		{
+			Code: `
+interface Foo<T, U> {}
+class Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 3, Column: 7},
+			},
+		},
+
+		// ---- D4: generic interface with a constrained type parameter and heritage clauses.
+		// `<T extends Base> extends IBase` still triggers the type-parameter-scope detour on the
+		// interface side, so only the class is reported.
+		{
+			Code: `
+class Base {}
+interface IBase {}
+interface Foo<T extends Base> extends IBase {
+  x: T;
+}
+class Foo<T extends Base> extends Base implements IBase {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 7, Column: 7},
+			},
+		},
+
+		// ---- D4: non-generic interface + generic class — interface side IS reported ----
+		// The asymmetry only kicks in when the interface itself carries type parameters; class
+		// generics are irrelevant. Both sides are reported here.
+		{
+			Code: `
+interface Foo {}
+class Foo<T> {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 2, Column: 11},
+				{MessageId: "unsafeMerging", Line: 3, Column: 7},
+			},
+		},
+
+		// ---- Real-user: class declared before interface (reversed order), both with bodies.
+		{
+			Code: `
+class Foo {
+  bar() {}
+}
+interface Foo {
+  baz: number;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 2, Column: 7},
+				{MessageId: "unsafeMerging", Line: 5, Column: 11},
+			},
+		},
+
+		// ---- Branch lock-in: `export default class Foo {}` + `interface Foo {}` ----
+		// tsgo binds the named default-export class to the synthetic `__default` symbol; the
+		// module-scope `Foo` local (which actually merges) is a separate symbol in the enclosing
+		// LocalsContainer. The rule's fallback retrieves it via ast.GetLocals(container)[name].
+		{
+			Code: `
+export default class Foo {}
+interface Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 2, Column: 22},
+				{MessageId: "unsafeMerging", Line: 3, Column: 11},
+			},
+		},
+
+		// Same merge but with interface first — class still recovered via local-binding fallback.
+		{
+			Code: `
+interface Foo {}
+export default class Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 2, Column: 11},
+				{MessageId: "unsafeMerging", Line: 3, Column: 22},
+			},
+		},
+
+		// Same merge but with multiple interfaces — each one is reported plus the default-export class.
+		{
+			Code: `
+export default class Foo {}
+interface Foo {}
+interface Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 2, Column: 22},
+				{MessageId: "unsafeMerging", Line: 3, Column: 11},
+				{MessageId: "unsafeMerging", Line: 4, Column: 11},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging_upstream_test.go
@@ -1,0 +1,122 @@
+// TestNoUnsafeDeclarationMergingUpstream migrates the full valid/invalid
+// suite from upstream
+// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-unsafe-declaration-merging.test.ts
+// 1:1. Position assertions cover line/column for every invalid case. rslint
+// specific lock-in cases live in
+// no_unsafe_declaration_merging_extras_test.go.
+package no_unsafe_declaration_merging
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnsafeDeclarationMergingUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeDeclarationMergingRule, []rule_tester.ValidTestCase{
+		// ---- valid ----
+		{Code: `
+interface Foo {}
+class Bar implements Foo {}
+`},
+		{Code: `
+namespace Foo {}
+namespace Foo {}
+`},
+		{Code: `
+enum Foo {}
+namespace Foo {}
+`},
+		{Code: `
+namespace Fooo {}
+function Foo() {}
+`},
+		{Code: `
+const Foo = class {};
+`},
+		{Code: `
+interface Foo {
+  props: string;
+}
+
+function bar() {
+  return class Foo {};
+}
+`},
+		{Code: `
+interface Foo {
+  props: string;
+}
+
+(function bar() {
+  class Foo {}
+})();
+`},
+		{Code: `
+declare global {
+  interface Foo {}
+}
+
+class Foo {}
+`},
+	}, []rule_tester.InvalidTestCase{
+		// ---- invalid ----
+		{
+			Code: `
+interface Foo {}
+class Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unsafeMerging",
+					Line:      2,
+					Column:    11,
+				},
+				{
+					MessageId: "unsafeMerging",
+					Line:      3,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code: `
+class Foo {}
+interface Foo {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unsafeMerging",
+					Line:      2,
+					Column:    7,
+				},
+				{
+					MessageId: "unsafeMerging",
+					Line:      3,
+					Column:    11,
+				},
+			},
+		},
+		{
+			Code: `
+declare global {
+  interface Foo {}
+  class Foo {}
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unsafeMerging",
+					Line:      3,
+					Column:    13,
+				},
+				{
+					MessageId: "unsafeMerging",
+					Line:      4,
+					Column:    9,
+				},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -300,7 +300,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-unsafe-argument.test.ts',
     // './tests/typescript-eslint/rules/no-unsafe-assignment.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-call.test.ts',
-    // './tests/typescript-eslint/rules/no-unsafe-declaration-merging.test.ts',
+    './tests/typescript-eslint/rules/no-unsafe-declaration-merging.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-enum-comparison.test.ts',
     // './tests/typescript-eslint/rules/no-unsafe-function-type.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-member-access.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unsafe-declaration-merging.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unsafe-declaration-merging.test.ts.snap
@@ -1,0 +1,135 @@
+// Rstest Snapshot v1
+
+exports[`no-unsafe-declaration-merging > invalid 1`] = `
+{
+  "code": "
+interface Foo {}
+class Foo {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe declaration merging between classes and interfaces.",
+      "messageId": "unsafeMerging",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-declaration-merging",
+    },
+    {
+      "message": "Unsafe declaration merging between classes and interfaces.",
+      "messageId": "unsafeMerging",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-declaration-merging",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-declaration-merging > invalid 2`] = `
+{
+  "code": "
+class Foo {}
+interface Foo {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe declaration merging between classes and interfaces.",
+      "messageId": "unsafeMerging",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 2,
+        },
+        "start": {
+          "column": 7,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-declaration-merging",
+    },
+    {
+      "message": "Unsafe declaration merging between classes and interfaces.",
+      "messageId": "unsafeMerging",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-declaration-merging",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-declaration-merging > invalid 3`] = `
+{
+  "code": "
+declare global {
+  interface Foo {}
+  class Foo {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe declaration merging between classes and interfaces.",
+      "messageId": "unsafeMerging",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-declaration-merging",
+    },
+    {
+      "message": "Unsafe declaration merging between classes and interfaces.",
+      "messageId": "unsafeMerging",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-declaration-merging",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -133,6 +133,7 @@ focusability
 focusable
 Fooa
 Fooab
+Fooo
 foobarbaz
 foopy
 foos


### PR DESCRIPTION
## Summary

Port the [`@typescript-eslint/no-unsafe-declaration-merging`](https://typescript-eslint.io/rules/no-unsafe-declaration-merging) rule to rslint.

The rule disallows declaration merging between a class and an interface that share the same name in the same scope. TypeScript permits this kind of merge, but interface properties end up on the class instance type without forcing the class to initialize them — accessing such a property type-checks while throwing `Cannot read properties of undefined` at runtime.

### Implementation notes

rslint uses `TypeChecker.GetSymbolAtLocation` as the symbol source and mirrors upstream's scope-manager semantics through:

- **Same-LocalsContainer filtering** on `symbol.Declarations`: only count merges within one lexical scope, matching ESLint's single-scope lookup. Cross-`declare module` blocks and external-module class augmentation therefore do not fire.
- **Early return on the interface side** when the interface carries type parameters: matches ESLint's `getScope(InterfaceDeclaration)` returning the type-parameter scope and failing the name lookup.
- **`__default` symbol fallback** for `export default class Foo {}`: recovers the module-scope `Foo` local via `IsLocalsContainer` + `GetLocals` so the named default-export side of the merge is reported (matches ESLint's two-position output).

### Test coverage

- `_upstream_test.go`: 11 cases migrated 1:1 from the upstream test file (8 valid + 3 invalid).
- `_extras_test.go`: 22 valid + 16 invalid covering Dimension 4 universal edge shapes (declaration container forms, nesting boundaries, generic-interface variants, modifiers), upstream branch lock-ins, and real-user shapes (cross-`declare module` blocks, ambient-module augmentation patterns).

All 38 extras expectations were verified three-way against ESLint reference output (expected ≡ ESLint ≡ rslint). Differential validation on rsbuild (1357 ts files) and rspack (538 ts files) shows zero diagnostic difference within rslint's scan range.

## Related Links

- Rule docs: https://typescript-eslint.io/rules/no-unsafe-declaration-merging
- Source: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unsafe-declaration-merging.ts
- Tests (upstream): https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-unsafe-declaration-merging.test.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).