### PR TITLE
feat: port rule @typescript-eslint/no-wrapper-object-types

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,6 +93,7 @@ import (
 	ts_no_useless_constructor "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_constructor"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_empty_export"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_var_requires"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_wrapper_object_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/non_nullable_type_assertion_style"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/only_throw_error"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/parameter_properties"
@@ -600,6 +601,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-constructor", ts_no_useless_constructor.NoUselessConstructorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-empty-export", no_useless_empty_export.NoUselessEmptyExportRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-var-requires", no_var_requires.NoVarRequiresRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-wrapper-object-types", no_wrapper_object_types.NoWrapperObjectTypesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/non-nullable-type-assertion-style", non_nullable_type_assertion_style.NonNullableTypeAssertionStyleRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/only-throw-error", only_throw_error.OnlyThrowErrorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/parameter-properties", parameter_properties.ParameterPropertiesRule)

--- a/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type.go
+++ b/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type.go
@@ -2,6 +2,7 @@ package no_unsafe_function_type
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/typescriptutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -23,7 +24,7 @@ var NoUnsafeFunctionTypeRule = rule.CreateRule(rule.Rule{
 			if ident.AsIdentifier().Text != "Function" {
 				return
 			}
-			if !isReferenceToGlobalFunction(ctx, ident) {
+			if !typescriptutil.IsReferenceToGlobalIdentifier(ctx, ident) {
 				return
 			}
 			ctx.ReportNode(ident, buildBannedFunctionTypeMessage())
@@ -38,7 +39,7 @@ var NoUnsafeFunctionTypeRule = rule.CreateRule(rule.Rule{
 				checkBannedType(ref.TypeName)
 			},
 			ast.KindExpressionWithTypeArguments: func(node *ast.Node) {
-				if !isInRelevantHeritageClause(node) {
+				if !typescriptutil.IsClassImplementsOrInterfaceExtends(node) {
 					return
 				}
 				expr := node.AsExpressionWithTypeArguments()
@@ -50,67 +51,3 @@ var NoUnsafeFunctionTypeRule = rule.CreateRule(rule.Rule{
 		}
 	},
 })
-
-// isInRelevantHeritageClause reports whether the ExpressionWithTypeArguments
-// sits in a heritage position that the upstream rule listens to:
-//   - `class X implements ...` (matches upstream `TSClassImplements`)
-//   - `interface X extends ...` (matches upstream `TSInterfaceHeritage`)
-//
-// `class X extends ...` is intentionally excluded: upstream does not register
-// a listener for it, so a `Function` reference in that position is left alone.
-// Non-heritage uses of ExpressionWithTypeArguments (e.g. JSDoc type contexts)
-// are also rejected because upstream's listener set never matches them.
-func isInRelevantHeritageClause(node *ast.Node) bool {
-	parent := node.Parent
-	if parent == nil || !ast.IsHeritageClause(parent) {
-		return false
-	}
-	grand := parent.Parent
-	switch {
-	case grand == nil:
-		return false
-	case ast.IsInterfaceDeclaration(grand):
-		return parent.AsHeritageClause().Token == ast.KindExtendsKeyword
-	case ast.IsClassLike(grand):
-		return parent.AsHeritageClause().Token == ast.KindImplementsKeyword
-	}
-	return false
-}
-
-// isReferenceToGlobalFunction mirrors upstream's `isReferenceToGlobalFunction`:
-// the identifier counts as referring to the global `Function` only when no
-// user-source declaration in the *current file* provides it. We approximate
-// ESLint's `!ref?.resolved?.defs.length` via the tsgo checker: if the resolved
-// symbol has any declaration whose source file is the same as the file being
-// linted, the reference is treated as locally bound; otherwise — including the
-// unresolved case — it counts as the lib.d.ts-provided global.
-//
-// Restricting the match to the current source file matches ESLint scope
-// manager semantics: a `declare global { interface Function {...} }` written
-// in another file is ambient — it merges into the global symbol at the type
-// checker level but does NOT create a `def` in the current file's scope
-// manager. Accepting "any user-source declaration" (regardless of file) would
-// be a false-negative because the upstream rule still fires in that case.
-//
-// Same-file declaration merging (e.g. an `interface Function` in this file
-// that augments the lib type) and same-file imports (`import { Function }`)
-// are both honored because their `Declarations` entries live in the file
-// being linted.
-func isReferenceToGlobalFunction(ctx rule.RuleContext, ident *ast.Node) bool {
-	if ctx.TypeChecker == nil {
-		return true
-	}
-	sym := ctx.TypeChecker.GetSymbolAtLocation(ident)
-	if sym == nil || len(sym.Declarations) == 0 {
-		return true
-	}
-	for _, decl := range sym.Declarations {
-		if decl == nil {
-			continue
-		}
-		if ast.GetSourceFileOfNode(decl) == ctx.SourceFile {
-			return false
-		}
-	}
-	return true
-}

--- a/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types.go
+++ b/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types.go
@@ -1,0 +1,82 @@
+package no_wrapper_object_types
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/typescriptutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// classNames mirrors the upstream `classNames` Set verbatim. Order is
+// alphabetical so a `grep` of "Object" or "Symbol" lands on the canonical
+// entry rather than a comment.
+var classNames = map[string]struct{}{
+	"BigInt":  {},
+	"Boolean": {},
+	"Number":  {},
+	"Object":  {},
+	"String":  {},
+	"Symbol":  {},
+}
+
+func buildBannedClassTypeMessage(typeName, preferred string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "bannedClassType",
+		Description: "Prefer using the primitive `" + preferred + "` as a type name, rather than the upper-cased `" + typeName + "`.",
+		Data: map[string]string{
+			"preferred": preferred,
+			"typeName":  typeName,
+		},
+	}
+}
+
+var NoWrapperObjectTypesRule = rule.CreateRule(rule.Rule{
+	Name:             "no-wrapper-object-types",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// checkBannedTypes mirrors upstream's local `checkBannedTypes` —
+		// `node` is the inner Identifier the rule visits (TypeReference's
+		// TypeName, or ExpressionWithTypeArguments's Expression). `includeFix`
+		// is true only for TSTypeReference, matching upstream's listener wiring.
+		checkBannedTypes := func(node *ast.Node, includeFix bool) {
+			if node == nil || node.Kind != ast.KindIdentifier {
+				return
+			}
+			typeName := node.AsIdentifier().Text
+			if _, banned := classNames[typeName]; !banned {
+				return
+			}
+			if !typescriptutil.IsReferenceToGlobalIdentifier(ctx, node) {
+				return
+			}
+			preferred := strings.ToLower(typeName)
+			msg := buildBannedClassTypeMessage(typeName, preferred)
+			if includeFix {
+				ctx.ReportNodeWithFixes(node, msg, rule.RuleFixReplace(ctx.SourceFile, node, preferred))
+				return
+			}
+			ctx.ReportNode(node, msg)
+		}
+
+		return rule.RuleListeners{
+			ast.KindTypeReference: func(node *ast.Node) {
+				ref := node.AsTypeReferenceNode()
+				if ref == nil {
+					return
+				}
+				checkBannedTypes(ref.TypeName, true)
+			},
+			ast.KindExpressionWithTypeArguments: func(node *ast.Node) {
+				if !typescriptutil.IsClassImplementsOrInterfaceExtends(node) {
+					return
+				}
+				expr := node.AsExpressionWithTypeArguments()
+				if expr == nil {
+					return
+				}
+				checkBannedTypes(expr.Expression, false)
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types.md
+++ b/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types.md
@@ -1,0 +1,40 @@
+# no-wrapper-object-types
+
+## Rule Details
+
+Disallow using the upper-cased built-in primitive class wrappers — `BigInt`, `Boolean`, `Number`, `Object`, `String`, and `Symbol` — as type names. The lower-cased primitive forms (`bigint`, `boolean`, `number`, `object`, `string`, `symbol`) are the safe choice in every case: primitives are compared by value and have predictable truthiness, while the wrapper objects are compared by reference and are always truthy.
+
+A local declaration with the same name (a `type` alias, `interface`, or `class`) shadows the global wrapper, in which case the reference is no longer the unsafe built-in and is not reported.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+let myBigInt: BigInt;
+let myBoolean: Boolean;
+let myNumber: Number;
+let myString: String;
+let mySymbol: Symbol;
+let myObject: Object;
+
+class MyClass implements Number {}
+
+interface MyInterface extends Number {}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+let myBigint: bigint;
+let myBoolean: boolean;
+let myNumber: number;
+let myString: string;
+let mySymbol: symbol;
+let myObject: object;
+
+type Number = 0 | 1;
+let value: Number;
+```
+
+## Original Documentation
+
+- [typescript-eslint no-wrapper-object-types](https://typescript-eslint.io/rules/no-wrapper-object-types)

--- a/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types_extras_test.go
+++ b/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types_extras_test.go
@@ -1,0 +1,803 @@
+// TestNoWrapperObjectTypesExtras locks in branches and edge shapes that the
+// upstream test suite does not exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+package no_wrapper_object_types
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoWrapperObjectTypesExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoWrapperObjectTypesRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: identifier text outside the banned set ----
+		// Locks in upstream checkBannedTypes() arm: classNames.has(typeName)
+		// is false. Any other identifier passes silently.
+		{Code: `let value: NumberOrString;`},
+		{Code: `let value: ObjectLike;`},
+		{Code: `let value: NotABoolean;`},
+
+		// ---- Dimension 4: qualified type name (TypeName.Kind !== Identifier) ----
+		// Locks in upstream checkBannedTypes() arm: node.type === Identifier
+		// is false for `A.Number`, so the qualified form is not reported.
+		{Code: `
+      namespace A { export type Number = 0 | 1; }
+      let value: A.Number;
+    `},
+		{Code: `
+      namespace Outer {
+        export namespace Inner {
+          export type Symbol = 'a' | 'b';
+        }
+      }
+      let value: Outer.Inner.Symbol;
+    `},
+
+		// ---- Branch lock-in: IsReferenceToGlobalIdentifier() — user-source def in module scope ----
+		// `export {}` forces module scope, so a local `type Number` no longer
+		// collides with the global one. tsgo's checker then resolves the
+		// reference to the user-source declaration, and the rule must stay
+		// silent.
+		{Code: `
+      export {};
+      type Number = 0 | 1;
+      let value: Number;
+    `},
+		{Code: `
+      export {};
+      class String {}
+      let value: String;
+    `},
+		{Code: `
+      export {};
+      interface Object { foo: string; }
+      let value: Object;
+    `},
+
+		// ---- Branch lock-in: nested block scope shadow ----
+		// Mirrors the upstream "scope-introducing brace block" pattern from
+		// `no-unsafe-function-type` but for the wrapper-object names.
+		{Code: `
+      {
+        type Number = 0 | 1;
+        let value: Number;
+      }
+    `},
+		{Code: `
+      {
+        class Boolean {}
+        let value: Boolean;
+      }
+    `},
+
+		// ---- Branch lock-in: same-file declaration merging via interface ----
+		// A local `interface Object` in the same file declarations augment
+		// the global. IsReferenceToGlobalIdentifier's same-file check
+		// silences the rule.
+		{Code: `
+      export {};
+      interface Number {
+        customField: string;
+      }
+      let value: Number;
+    `},
+
+		// ---- Branch lock-in: typeof X is a TypeQuery, not a TypeReference ----
+		// Upstream does not listen to TSTypeQuery. The inner `Number` is part
+		// of an EntityName, never a TypeReference, so nothing fires.
+		{Code: `let value: typeof Number;`},
+		{Code: `let value: typeof String;`},
+		{Code: `let value: typeof globalThis.Number;`},
+
+		// ---- Branch lock-in: `class extends X` is OUT of scope ----
+		// Upstream registers TSClassImplements + TSInterfaceHeritage, NOT a
+		// class-extends listener. tsgo's KindExpressionWithTypeArguments is
+		// shared with `class extends`, so the rule must filter on
+		// HeritageClause.Token to avoid reporting here. (Upstream's own valid
+		// suite includes `class MyClass extends Number {}` for the same
+		// reason.)
+		{Code: `class Foo extends Number {}`},
+		{Code: `class Foo extends Boolean {}`},
+		{Code: `const Cls = class extends Object {};`},
+
+		// ---- Dimension 4: identifier in value position ----
+		// `new Number(0)` / `Number.MAX_VALUE` / `Symbol.iterator` reference
+		// the wrappers as values, not as type references. Neither listener
+		// fires.
+		{Code: `const wrapped = new Number(0);`},
+		{Code: `const big = Number.MAX_VALUE;`},
+		{Code: `const sym = Symbol.iterator;`},
+
+		// ---- Dimension 4: nested local shadow inside an arrow body ----
+		{Code: `
+      const f = () => {
+        type Number = (x: number) => number;
+        const g: Number = x => x;
+        return g;
+      };
+    `},
+
+		// ---- Branch lock-in: namespace body shadow ----
+		// Namespaces introduce their own scope; tsgo's checker resolves to
+		// the local Number rather than the global one.
+		{Code: `
+      namespace Inner {
+        type Number = 0 | 1;
+        export let g: Number;
+      }
+    `},
+
+		// ---- Branch lock-in: same-file global augmentation ----
+		// `declare global { interface Number {...} }` in the SAME file as the
+		// reference is a user def in the current file's scope manager —
+		// upstream silences the rule.
+		{Code: `
+      declare global {
+        interface Number {
+          customField: string;
+        }
+      }
+      let value: Number;
+      export {};
+    `},
+
+		// ---- Real-user: wrapper in JSDoc-style type-arg position via TypeQuery ----
+		// `typeof v` where v: { Number: any } — inner identifier is a member
+		// access on a TypeQuery, not a TypeReference.
+		{Code: `
+      declare const lib: { Number: number };
+      let value: typeof lib.Number;
+    `},
+
+		// ---- Branch lock-in: type parameter named after a banned wrapper ----
+		// `function f<Number>(x: Number)` — the inner Number resolves via
+		// GetSymbolAtLocation to the type parameter, whose declaration lives
+		// in the current source file. Verified across function / type alias /
+		// class / interface containers so each type-parameter scope is
+		// exercised.
+		{Code: `function f<Number>(x: Number): Number { return x; }`},
+		{Code: `type Box<Number> = { value: Number };`},
+		{Code: `class C<Number> { value!: Number; }`},
+		{Code: `interface I<Number> { value: Number }`},
+
+		// ---- Branch lock-in: `infer X` introduces a fresh binding inside
+		// the conditional's extends arm. Mirrors the upstream valid pattern
+		// (`infer Function`) but with banned wrapper names. tsgo resolves
+		// each reference to its infer-bound type parameter, so the rule
+		// stays silent.
+		{Code: `type Unwrap<T> = T extends Promise<infer Number> ? Number : never;`},
+		{Code: `type Unwrap<T> = T extends infer String ? String : never;`},
+
+		// ---- Branch lock-in: type parameter constraint mentions banned name
+		// but resolves to the constraint's local declaration ----
+		// `<Number extends number>` — the type parameter's constraint type
+		// `number` is fine; the inner reference resolves to the type
+		// parameter, not the lib `Number` interface.
+		{Code: `function pick<Number extends number>(x: Number): Number { return x; }`},
+
+		// ---- Branch lock-in: import-equals shadow ----
+		// `import Number = require(...)` introduces a value/namespace
+		// binding. utils.IsShadowed walks SourceFile statements and
+		// recognizes KindImportEqualsDeclaration; the reference resolves
+		// locally.
+		{Code: `
+      import Number = require('node:util');
+      let value: typeof Number;
+    `},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: parenthesized type wrapper ----
+		// tsgo preserves KindParenthesizedType around the inner TypeReference.
+		// The listener fires on the inner TypeReference regardless.
+		{
+			Code:   `let value: (Number);`,
+			Output: []string{`let value: (number);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 13},
+			},
+		},
+		{
+			Code:   `let value: ((String));`,
+			Output: []string{`let value: ((string));`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 14},
+			},
+		},
+
+		// ---- Dimension 4: array / tuple / generic wrappers ----
+		{
+			Code:   `let value: Number[];`,
+			Output: []string{`let value: number[];`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:   `let value: Array<Boolean>;`,
+			Output: []string{`let value: Array<boolean>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:   `let value: ReadonlyArray<Symbol>;`,
+			Output: []string{`let value: ReadonlyArray<symbol>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 26},
+			},
+		},
+
+		// ---- Dimension 4: parameter / return / property type positions ----
+		{
+			Code:   `function f(x: Number) {}`,
+			Output: []string{`function f(x: number) {}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code:   `function f(): String { return ''; }`,
+			Output: []string{`function f(): string { return ''; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code: `
+        interface Holder {
+          v: Object;
+        }
+      `,
+			Output: []string{`
+        interface Holder {
+          v: object;
+        }
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 3, Column: 14},
+			},
+		},
+
+		// ---- Branch lock-in: class declaration vs class expression heritage ----
+		// Locks in: the heritage-clause filter recognizes both class forms.
+		{
+			Code: `const Cls = class implements Object {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 30},
+			},
+		},
+
+		// ---- Branch lock-in: extends + implements with banned name in implements only ----
+		// `class extends Bar implements Number` — only the implements clause
+		// reports; the (legitimate) extends clause does not.
+		{
+			Code: `
+        class Bar {}
+        class Foo extends Bar implements Number {}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 3, Column: 42},
+			},
+		},
+
+		// ---- Branch lock-in: multiple implements, banned name is one of them ----
+		{
+			Code: `
+        interface Other {}
+        class Foo implements Other, Number {}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 3, Column: 37},
+			},
+		},
+
+		// ---- Branch lock-in: implements lists every banned name in order ----
+		// Each ExpressionWithTypeArguments is its own listener visit; the
+		// rule reports every match independently and preserves source order.
+		{
+			Code: `class Foo implements BigInt, Boolean, Number, Object, String, Symbol {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 22},
+				{MessageId: "bannedClassType", Line: 1, Column: 30},
+				{MessageId: "bannedClassType", Line: 1, Column: 39},
+				{MessageId: "bannedClassType", Line: 1, Column: 47},
+				{MessageId: "bannedClassType", Line: 1, Column: 55},
+				{MessageId: "bannedClassType", Line: 1, Column: 63},
+			},
+		},
+
+		// ---- Dimension 4: same-kind nesting (interface in interface) ----
+		// Both outer-uses of Number must be reported independently — the
+		// listener visits each ExpressionWithTypeArguments separately.
+		{
+			Code: `
+        interface A extends Number {}
+        interface B extends Number {}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 2, Column: 29},
+				{MessageId: "bannedClassType", Line: 3, Column: 29},
+			},
+		},
+
+		// ---- Branch lock-in: nested type position inside generic ----
+		{
+			Code:   `let value: Promise<Number>;`,
+			Output: []string{`let value: Promise<number>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 20},
+			},
+		},
+		{
+			Code:   `let value: Map<String, Number>;`,
+			Output: []string{`let value: Map<string, number>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 16},
+				{MessageId: "bannedClassType", Line: 1, Column: 24},
+			},
+		},
+
+		// ---- Real-user: factory returning wrapper type ----
+		{
+			Code:   `type Factory = () => String;`,
+			Output: []string{`type Factory = () => string;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 22},
+			},
+		},
+
+		// ---- Real-user: wrapper as a generic constraint ----
+		{
+			Code:   `function id<T extends String>(x: T): T { return x; }`,
+			Output: []string{`function id<T extends string>(x: T): T { return x; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 23},
+			},
+		},
+
+		// ---- Dimension 4: type assertion / satisfies wrappers ----
+		// Both put a wrapper in a TypeNode position whose immediate parent
+		// is a value expression. The TypeReference must still be visited.
+		{
+			Code:   `const v = 'x' as String;`,
+			Output: []string{`const v = 'x' as string;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:   `const v = 0 satisfies Number;`,
+			Output: []string{`const v = 0 satisfies number;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 23},
+			},
+		},
+
+		// ---- Branch lock-in: conditional type's extends clause ----
+		// `T extends Number` puts Number in a TypeNode position inside the
+		// conditional. Both check-type and extends-type sides are visited.
+		{
+			Code:   `type IsNum<T> = T extends Number ? true : false;`,
+			Output: []string{`type IsNum<T> = T extends number ? true : false;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 27},
+			},
+		},
+
+		// ---- Branch lock-in: keyof / mapped type ----
+		{
+			Code:   `type Keys = keyof Number;`,
+			Output: []string{`type Keys = keyof number;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 19},
+			},
+		},
+		{
+			Code:   `type Rec = { [k: string]: Object };`,
+			Output: []string{`type Rec = { [k: string]: object };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 27},
+			},
+		},
+
+		// ---- Branch lock-in: type-parameter default ----
+		{
+			Code:   `type Box<T = Number> = { value: T };`,
+			Output: []string{`type Box<T = number> = { value: T };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 14},
+			},
+		},
+
+		// ---- Branch lock-in: readonly array of wrapper ----
+		{
+			Code:   `let value: readonly String[];`,
+			Output: []string{`let value: readonly string[];`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 21},
+			},
+		},
+
+		// ---- Branch lock-in: nested class members ----
+		// All four positions are real user shapes worth locking in: field,
+		// method param, method return, getter return, setter param.
+		{
+			Code: `
+        class C {
+          handler: Number;
+          run(s: String): Boolean {
+            return false as Boolean;
+          }
+          get sym(): Symbol {
+            return Symbol() as Symbol;
+          }
+          set sym(v: Symbol) {}
+        }
+      `,
+			Output: []string{`
+        class C {
+          handler: number;
+          run(s: string): boolean {
+            return false as boolean;
+          }
+          get sym(): symbol {
+            return Symbol() as symbol;
+          }
+          set sym(v: symbol) {}
+        }
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 3, Column: 20},
+				{MessageId: "bannedClassType", Line: 4, Column: 18},
+				{MessageId: "bannedClassType", Line: 4, Column: 27},
+				{MessageId: "bannedClassType", Line: 5, Column: 29},
+				{MessageId: "bannedClassType", Line: 7, Column: 22},
+				{MessageId: "bannedClassType", Line: 8, Column: 32},
+				{MessageId: "bannedClassType", Line: 10, Column: 22},
+			},
+		},
+
+		// ---- Branch lock-in: explicit type argument in a call / new expression ----
+		{
+			Code:   `declare function foo<T>(): T; foo<Number>();`,
+			Output: []string{`declare function foo<T>(): T; foo<number>();`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 35},
+			},
+		},
+		{
+			Code:   `class Box<T> { value!: T } new Box<Object>();`,
+			Output: []string{`class Box<T> { value!: T } new Box<object>();`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 36},
+			},
+		},
+
+		// ---- Dimension 4: top-level type alias with wrapper as RHS ----
+		// The simplest real-user shape — a direct type alias.
+		{
+			Code:   `type Bag = Object;`,
+			Output: []string{`type Bag = object;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+			},
+		},
+
+		// ---- Branch lock-in: type-predicate target ----
+		// `x is Object` puts Object in the type-predicate's TypeNode slot.
+		{
+			Code:   `function isObj(x: unknown): x is Object { return typeof x === 'object'; }`,
+			Output: []string{`function isObj(x: unknown): x is object { return typeof x === 'object'; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 34},
+			},
+		},
+
+		// ---- Branch lock-in: BigInt and Symbol round-trip ----
+		// The two wrappers not covered by upstream's `Number/Symbol` union
+		// case get their own simple round-trip lock-ins.
+		{
+			Code:   `let value: BigInt[];`,
+			Output: []string{`let value: bigint[];`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:   `let value: Symbol | undefined;`,
+			Output: []string{`let value: symbol | undefined;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+			},
+		},
+
+		// ---- Branch lock-in: same banned identifier appears more than once ----
+		// Each occurrence is an independent listener visit; both fix sites
+		// are applied in one rule_tester pass.
+		{
+			Code:   `type Pair = [Number, Number];`,
+			Output: []string{`type Pair = [number, number];`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 14},
+				{MessageId: "bannedClassType", Line: 1, Column: 22},
+			},
+		},
+
+		// ---- Real-user: abstract class implementing a wrapper ----
+		// Verifies the abstract-modifier on the class doesn't suppress the
+		// implements visit.
+		{
+			Code: `abstract class A implements Object { abstract m(): void; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 29},
+			},
+		},
+
+		// ---- Branch lock-in: message data has both preferred and typeName ----
+		// Locks in the message text on at least one case so future refactors
+		// can't drop the `data` fields.
+		{
+			Code:   `let value: Object;`,
+			Output: []string{`let value: object;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bannedClassType",
+					Message:   "Prefer using the primitive `object` as a type name, rather than the upper-cased `Object`.",
+					Line:      1,
+					Column:    12,
+				},
+			},
+		},
+
+		// ---- Dimension 4: function-type literal / constructor-type literal ----
+		// Parameter and return type slots inside a function-type-literal
+		// expression are TypeReference visits. Same for `new (...) => T`.
+		{
+			Code:   `let fn: (x: Number) => String;`,
+			Output: []string{`let fn: (x: number) => string;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 13},
+				{MessageId: "bannedClassType", Line: 1, Column: 24},
+			},
+		},
+		{
+			Code:   `let ctor: new (x: Boolean) => Object;`,
+			Output: []string{`let ctor: new (x: boolean) => object;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 19},
+				{MessageId: "bannedClassType", Line: 1, Column: 31},
+			},
+		},
+
+		// ---- Branch lock-in: interface method / index / construct signatures ----
+		// Each parameter and return type inside an interface member is its
+		// own TypeReference visit. tsgo represents these via separate
+		// signature kinds, so we verify the listener fans out across them.
+		{
+			Code: `
+        interface API {
+          on(handler: Number): void;
+          new (cb: Boolean): String;
+          [key: string]: Object;
+        }
+      `,
+			Output: []string{`
+        interface API {
+          on(handler: number): void;
+          new (cb: boolean): string;
+          [key: string]: object;
+        }
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 3, Column: 23},
+				{MessageId: "bannedClassType", Line: 4, Column: 20},
+				{MessageId: "bannedClassType", Line: 4, Column: 30},
+				{MessageId: "bannedClassType", Line: 5, Column: 26},
+			},
+		},
+
+		// ---- Dimension 4: labeled tuple elements + rest tuple ----
+		// `[a: Number, b: String]` — labeled tuple element wraps the
+		// TypeReference in a NamedTupleMember. The inner listener still
+		// fires because the TypeReference itself is unchanged.
+		{
+			Code:   `let pair: [first: Number, second: String];`,
+			Output: []string{`let pair: [first: number, second: string];`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 19},
+				{MessageId: "bannedClassType", Line: 1, Column: 35},
+			},
+		},
+		{
+			Code:   `let rest: [String, ...Number[]];`,
+			Output: []string{`let rest: [string, ...number[]];`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+				{MessageId: "bannedClassType", Line: 1, Column: 23},
+			},
+		},
+
+		// ---- Branch lock-in: optional / rest / default-typed parameters ----
+		{
+			Code:   `function f(a?: Number, ...rest: String[]) { return a; }`,
+			Output: []string{`function f(a?: number, ...rest: string[]) { return a; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 16},
+				{MessageId: "bannedClassType", Line: 1, Column: 33},
+			},
+		},
+
+		// ---- Branch lock-in: deep nesting through stdlib generics ----
+		// Locks in that the listener keeps firing at every depth — each
+		// nested TypeReference is its own visit, not gated by some outer
+		// "already reported" cache.
+		{
+			Code:   `let value: Promise<Map<String, ReadonlyArray<Awaited<Number>>>>;`,
+			Output: []string{`let value: Promise<Map<string, ReadonlyArray<Awaited<number>>>>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 24},
+				{MessageId: "bannedClassType", Line: 1, Column: 54},
+			},
+		},
+
+		// ---- Branch lock-in: heritage clauses with type arguments ----
+		// `class X implements Foo<T>` keeps `Foo` on the ExpressionWithTypeArguments
+		// listener; type-argument list does not change the expression-side
+		// match. Mirrors upstream's listener wiring exactly.
+		{
+			Code: `class X implements Number<string> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 20},
+			},
+		},
+		{
+			Code: `interface X extends Number<string> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 21},
+			},
+		},
+
+		// ---- Branch lock-in: interface multi-extends, mix of clean and banned ----
+		// Each ExpressionWithTypeArguments in the extends list is visited
+		// independently; only the banned ones report.
+		{
+			Code: `
+        interface Other {}
+        interface X extends Other, Number, String {}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 3, Column: 36},
+				{MessageId: "bannedClassType", Line: 3, Column: 44},
+			},
+		},
+
+		// ---- Branch lock-in: declare global wrapping a TypeReference ----
+		// `declare global { interface I { x: Number } }` — the inner
+		// TypeReference is a nested TypeReference inside a ModuleBlock.
+		// The walker reaches it and reports.
+		{
+			Code: `
+        declare global {
+          interface External {
+            value: Number;
+          }
+        }
+        export {};
+      `,
+			Output: []string{`
+        declare global {
+          interface External {
+            value: number;
+          }
+        }
+        export {};
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 4, Column: 20},
+			},
+		},
+
+		// ---- Branch lock-in: a banned name appears as the constraint type ----
+		// `<T extends Number>` — the constraint is a TypeReference. The
+		// type parameter T does not introduce a Number shadow here.
+		{
+			Code:   `function g<T extends Number>(x: T): T { return x; }`,
+			Output: []string{`function g<T extends number>(x: T): T { return x; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 22},
+			},
+		},
+
+		// ---- Branch lock-in: mapped type with banned name in value side ----
+		{
+			Code:   `type Mapped<T> = { [K in keyof T]: Number };`,
+			Output: []string{`type Mapped<T> = { [K in keyof T]: number };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 36},
+			},
+		},
+
+		// ---- Branch lock-in: template literal type with wrapper in args ----
+		// `Capitalize<String>` — utility types use the same TypeReference
+		// path, regardless of being lib-provided string-manipulating types.
+		{
+			Code:   `type Cap = Capitalize<String>;`,
+			Output: []string{`type Cap = Capitalize<string>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 23},
+			},
+		},
+
+		// ---- Branch lock-in: chained as / satisfies wrappers ----
+		// `x as Number as unknown` — only the inner `Number` is a
+		// TypeReference; the outer `unknown` is fine.
+		{
+			Code:   `const v = (0 as Number) as unknown;`,
+			Output: []string{`const v = (0 as number) as unknown;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 17},
+			},
+		},
+
+		// ---- Branch lock-in: object method shorthand return type ----
+		// `{ m(): Number { return 0 } }` — methods on object literals
+		// (not classes) put the return-type TypeReference in a slightly
+		// different parent chain. Verified independently.
+		{
+			Code:   `const o = { m(): Number { return 0 as any; } };`,
+			Output: []string{`const o = { m(): number { return 0 as any; } };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 18},
+			},
+		},
+
+		// ---- Real-user: arrow function as class-field property ----
+		// `prop = (x: Number) => x` — class-field arrow puts parameters
+		// in a separate AST shape than a regular method. The TypeReference
+		// fires from inside the arrow's parameter list.
+		{
+			Code: `
+        class K {
+          prop = (x: Number): String => '' + x;
+        }
+      `,
+			Output: []string{`
+        class K {
+          prop = (x: number): string => '' + x;
+        }
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 3, Column: 22},
+				{MessageId: "bannedClassType", Line: 3, Column: 31},
+			},
+		},
+
+		// ---- Real-user: outer shadow does NOT cover inner reference ----
+		// In the outer scope `let v: Number` reports because no shadow is in
+		// scope. The nested block declares a local `type Number` — only
+		// references inside that block are silenced. This locks in that the
+		// lexical walk doesn't wrongly silence sibling references.
+		{
+			Code: `
+        let outer: Number;
+        {
+          type Number = 0 | 1;
+          let inner: Number;
+        }
+      `,
+			Output: []string{`
+        let outer: number;
+        {
+          type Number = 0 | 1;
+          let inner: Number;
+        }
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 2, Column: 20},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types_upstream_test.go
@@ -1,0 +1,173 @@
+// TestNoWrapperObjectTypesUpstream migrates every `valid` / `invalid` case
+// from
+// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-wrapper-object-types.test.ts
+// verbatim. Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in
+// no_wrapper_object_types_extras_test.go.
+package no_wrapper_object_types
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoWrapperObjectTypesUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoWrapperObjectTypesRule, []rule_tester.ValidTestCase{
+		{Code: `let value: NumberLike;`},
+		{Code: `let value: Other;`},
+		{Code: `let value: bigint;`},
+		{Code: `let value: boolean;`},
+		{Code: `let value: never;`},
+		{Code: `let value: null;`},
+		{Code: `let value: number;`},
+		{Code: `let value: symbol;`},
+		{Code: `let value: undefined;`},
+		{Code: `let value: unknown;`},
+		{Code: `let value: void;`},
+		{Code: `let value: () => void;`},
+		{Code: `let value: () => () => void;`},
+		{Code: `let Bigint;`},
+		{Code: `let Boolean;`},
+		{Code: `let Never;`},
+		{Code: `let Null;`},
+		{Code: `let Number;`},
+		{Code: `let Symbol;`},
+		{Code: `let Undefined;`},
+		{Code: `let Unknown;`},
+		{Code: `let Void;`},
+		{Code: `interface Bigint {}`},
+		{Code: `interface Boolean {}`},
+		{Code: `interface Never {}`},
+		{Code: `interface Null {}`},
+		{Code: `interface Number {}`},
+		{Code: `interface Symbol {}`},
+		{Code: `interface Undefined {}`},
+		{Code: `interface Unknown {}`},
+		{Code: `interface Void {}`},
+		{Code: `type Bigint = {};`},
+		{Code: `type Boolean = {};`},
+		{Code: `type Never = {};`},
+		{Code: `type Null = {};`},
+		{Code: `type Number = {};`},
+		{Code: `type Symbol = {};`},
+		{Code: `type Undefined = {};`},
+		{Code: `type Unknown = {};`},
+		{Code: `type Void = {};`},
+		{Code: `class MyClass extends Number {}`},
+		{Code: `
+      type Number = 0 | 1;
+      let value: Number;
+    `},
+		{Code: `
+      type Bigint = 0 | 1;
+      let value: Bigint;
+    `},
+		{Code: `
+      type T<Symbol> = Symbol;
+      type U<UU> = UU extends T<infer Function> ? Function : never;
+    `},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:   `let value: BigInt;`,
+			Output: []string{`let value: bigint;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:   `let value: Boolean;`,
+			Output: []string{`let value: boolean;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:   `let value: Number;`,
+			Output: []string{`let value: number;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:   `let value: Object;`,
+			Output: []string{`let value: object;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:   `let value: String;`,
+			Output: []string{`let value: string;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:   `let value: Symbol;`,
+			Output: []string{`let value: symbol;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:   `let value: Number | Symbol;`,
+			Output: []string{`let value: number | symbol;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 12},
+				{MessageId: "bannedClassType", Line: 1, Column: 21},
+			},
+		},
+		{
+			Code:   `let value: { property: Number };`,
+			Output: []string{`let value: { property: number };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 24},
+			},
+		},
+		{
+			Code:   `0 as Number;`,
+			Output: []string{`0 as number;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `type MyType = Number;`,
+			Output: []string{`type MyType = number;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code:   `type MyType = [Number];`,
+			Output: []string{`type MyType = [number];`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 16},
+			},
+		},
+		{
+			// `class implements` heritage — no autofix per upstream.
+			Code: `class MyClass implements Number {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 26},
+			},
+		},
+		{
+			// `interface extends` heritage — no autofix per upstream.
+			Code: `interface MyInterface extends Number {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 31},
+			},
+		},
+		{
+			Code:   `type MyType = Number & String;`,
+			Output: []string{`type MyType = number & string;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedClassType", Line: 1, Column: 15},
+				{MessageId: "bannedClassType", Line: 1, Column: 24},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/typescriptutil/typescriptutil.go
+++ b/internal/plugins/typescript/typescriptutil/typescriptutil.go
@@ -1,0 +1,157 @@
+// Package typescriptutil collects helpers shared across rules in the
+// @typescript-eslint plugin. Anything specific to a single rule stays with
+// the rule; whatever a second rule needs (or would naturally re-implement
+// with the same semantics) lives here.
+package typescriptutil
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// IsReferenceToGlobalIdentifier mirrors typescript-eslint's
+// `isReferenceToGlobalFunction` helper: an identifier counts as referring to
+// a lib.d.ts-provided global only when no user-source declaration in the
+// *current file* provides a binding for it.
+//
+// The check is layered to match the upstream ESLint scope-manager behavior
+// across the cases tsgo's TypeChecker handles inconsistently:
+//
+//  1. The TypeChecker side — if `GetSymbolAtLocation` resolves the
+//     identifier to a symbol whose declarations include any from the current
+//     source file, treat the reference as locally bound. This covers
+//     declaration merging (e.g. a same-file `interface Function {...}` that
+//     augments the lib type) and value-side bindings (`class`, `let`,
+//     `function`).
+//
+//  2. The lexical scope side — if any enclosing block, function body,
+//     module declaration, or SourceFile statement list directly declares a
+//     `type` alias, `interface`, `class`, `enum`, `namespace`, `var`,
+//     `let`, `const`, `function`, or `import` with the same identifier
+//     name, treat the reference as locally bound. This catches the
+//     script-scope cases where a `type Number = 0 | 1` collides with the
+//     lib `interface Number` and tsgo's checker resolves to the lib symbol
+//     anyway — upstream's ESLint scope manager sees the local def and
+//     stays silent.
+//
+// Returns true only when neither path finds a local binding (or the
+// TypeChecker is unavailable AND the lexical walk also fails), matching
+// upstream's "unresolved means global" fallback.
+func IsReferenceToGlobalIdentifier(ctx rule.RuleContext, ident *ast.Node) bool {
+	if ident == nil || ident.Kind != ast.KindIdentifier {
+		return true
+	}
+	name := ident.AsIdentifier().Text
+
+	if ctx.TypeChecker != nil {
+		if sym := ctx.TypeChecker.GetSymbolAtLocation(ident); sym != nil {
+			for _, decl := range sym.Declarations {
+				if decl == nil {
+					continue
+				}
+				if ast.GetSourceFileOfNode(decl) == ctx.SourceFile {
+					return false
+				}
+			}
+		}
+	}
+
+	if hasLocalTypeOrValueDeclaration(ident, name) {
+		return false
+	}
+
+	return true
+}
+
+// hasLocalTypeOrValueDeclaration walks from `ident` to the SourceFile,
+// returning true when any enclosing scope holds a declaration that binds
+// `name`. Unlike `utils.IsShadowed`, this also recognizes TypeScript-only
+// type bindings — `type` aliases and `interface` declarations — that
+// upstream's ESLint scope manager treats as shadows but tsgo's TypeChecker
+// can miss when they conflict with a lib-provided global.
+func hasLocalTypeOrValueDeclaration(ident *ast.Node, name string) bool {
+	if utils.IsShadowed(ident, name) {
+		return true
+	}
+	for current := ident.Parent; current != nil; current = current.Parent {
+		switch current.Kind {
+		case ast.KindSourceFile:
+			sf := current.AsSourceFile()
+			if sf != nil && sf.Statements != nil {
+				if hasTypeOrInterfaceInStatements(sf.Statements.Nodes, name) {
+					return true
+				}
+			}
+			return false
+		case ast.KindBlock:
+			block := current.AsBlock()
+			if block != nil && block.Statements != nil {
+				if hasTypeOrInterfaceInStatements(block.Statements.Nodes, name) {
+					return true
+				}
+			}
+		case ast.KindModuleBlock:
+			modBlock := current.AsModuleBlock()
+			if modBlock != nil && modBlock.Statements != nil {
+				if hasTypeOrInterfaceInStatements(modBlock.Statements.Nodes, name) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// hasTypeOrInterfaceInStatements scans a flat statement list for a
+// `type X = ...` or `interface X { ... }` declaration with the given name.
+// All other shadow shapes (var/let/const/function/class/enum/module/import)
+// are already covered by `utils.IsShadowed`; this helper is the type-only
+// extension.
+func hasTypeOrInterfaceInStatements(statements []*ast.Node, name string) bool {
+	for _, stmt := range statements {
+		if stmt == nil {
+			continue
+		}
+		switch stmt.Kind {
+		case ast.KindTypeAliasDeclaration:
+			if n := stmt.Name(); n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+				return true
+			}
+		case ast.KindInterfaceDeclaration:
+			if n := stmt.Name(); n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsClassImplementsOrInterfaceExtends reports whether the given
+// `ExpressionWithTypeArguments` sits in a heritage position the
+// typescript-eslint rules listen to as `TSClassImplements` or
+// `TSInterfaceHeritage`:
+//
+//   - `class X implements ...`
+//   - `interface X extends ...`
+//
+// `class X extends ...` is intentionally excluded: upstream does not register
+// a listener for it. Non-heritage uses of `ExpressionWithTypeArguments` (e.g.
+// JSDoc-style type contexts) are also rejected because upstream's listener
+// set never matches them.
+func IsClassImplementsOrInterfaceExtends(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil || !ast.IsHeritageClause(parent) {
+		return false
+	}
+	grand := parent.Parent
+	switch {
+	case grand == nil:
+		return false
+	case ast.IsInterfaceDeclaration(grand):
+		return parent.AsHeritageClause().Token == ast.KindExtendsKeyword
+	case ast.IsClassLike(grand):
+		return parent.AsHeritageClause().Token == ast.KindImplementsKeyword
+	}
+	return false
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -319,7 +319,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-useless-constructor.test.ts',
     // './tests/typescript-eslint/rules/no-useless-empty-export.test.ts',
     // './tests/typescript-eslint/rules/no-var-requires.test.ts',
-    // './tests/typescript-eslint/rules/no-wrapper-object-types.test.ts',
+    './tests/typescript-eslint/rules/no-wrapper-object-types.test.ts',
     './tests/typescript-eslint/rules/non-nullable-type-assertion-style.test.ts',
     './tests/typescript-eslint/rules/only-throw-error.test.ts',
     './tests/typescript-eslint/rules/parameter-properties.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-wrapper-object-types.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-wrapper-object-types.test.ts.snap
@@ -1,0 +1,409 @@
+// Rstest Snapshot v1
+
+exports[`no-wrapper-object-types > invalid 1`] = `
+{
+  "code": "let value: BigInt;",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`bigint\` as a type name, rather than the upper-cased \`BigInt\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: bigint;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 2`] = `
+{
+  "code": "let value: Boolean;",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`boolean\` as a type name, rather than the upper-cased \`Boolean\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: boolean;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 3`] = `
+{
+  "code": "let value: Number;",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`number\` as a type name, rather than the upper-cased \`Number\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: number;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 4`] = `
+{
+  "code": "let value: Object;",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`object\` as a type name, rather than the upper-cased \`Object\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: object;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 5`] = `
+{
+  "code": "let value: String;",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`string\` as a type name, rather than the upper-cased \`String\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: string;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 6`] = `
+{
+  "code": "let value: Symbol;",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`symbol\` as a type name, rather than the upper-cased \`Symbol\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: symbol;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 7`] = `
+{
+  "code": "let value: Number | Symbol;",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`number\` as a type name, rather than the upper-cased \`Number\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+    {
+      "message": "Prefer using the primitive \`symbol\` as a type name, rather than the upper-cased \`Symbol\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": "let value: number | symbol;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 8`] = `
+{
+  "code": "let value: { property: Number };",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`number\` as a type name, rather than the upper-cased \`Number\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: { property: number };",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 9`] = `
+{
+  "code": "0 as Number;",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`number\` as a type name, rather than the upper-cased \`Number\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "0 as number;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 10`] = `
+{
+  "code": "type MyType = Number;",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`number\` as a type name, rather than the upper-cased \`Number\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type MyType = number;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 11`] = `
+{
+  "code": "type MyType = [Number];",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`number\` as a type name, rather than the upper-cased \`Number\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type MyType = [number];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 12`] = `
+{
+  "code": "class MyClass implements Number {}",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`number\` as a type name, rather than the upper-cased \`Number\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 13`] = `
+{
+  "code": "interface MyInterface extends Number {}",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`number\` as a type name, rather than the upper-cased \`Number\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-wrapper-object-types > invalid 14`] = `
+{
+  "code": "type MyType = Number & String;",
+  "diagnostics": [
+    {
+      "message": "Prefer using the primitive \`number\` as a type name, rather than the upper-cased \`Number\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+    {
+      "message": "Prefer using the primitive \`string\` as a type name, rather than the upper-cased \`String\`.",
+      "messageId": "bannedClassType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-wrapper-object-types",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": "type MyType = number & string;",
+  "ruleCount": 1,
+}
+`;

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -362,6 +362,7 @@ splitwords
 spreadassignment
 spreadelement
 stdjson
+stdlib
 stmts
 stringutil
 stub
@@ -399,6 +400,7 @@ tsoptions
 tspath
 tsutils
 typeparam
+typescriptutil
 unaliased
 unbnound
 uncast


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-wrapper-object-types` rule from typescript-eslint to rslint.

The rule disallows using the upper-cased built-in primitive class wrappers — `BigInt`, `Boolean`, `Number`, `Object`, `String`, `Symbol` — as type names, and recommends their lower-cased primitive forms instead. Autofix is offered for `TSTypeReference` positions; `class implements` / `interface extends` references are reported without a fix (matching upstream).

A reusable `IsReferenceToGlobalIdentifier` helper (ESLint `isReferenceToGlobalFunction` equivalent) was extracted to a new `internal/plugins/typescript/typescriptutil/` package, and `no-unsafe-function-type` was refactored to use it.

## Related Links

- ESLint rule: https://typescript-eslint.io/rules/no-wrapper-object-types
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-wrapper-object-types.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).