### PR TITLE
feat: port rule @typescript-eslint/no-confusing-non-null-assertion

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_array_constructor"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_array_delete"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_base_to_string"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_confusing_non_null_assertion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_confusing_void_expression"
 	ts_no_dupe_class_members "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_dupe_class_members"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_duplicate_enum_values"
@@ -550,6 +551,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-array-constructor", no_array_constructor.NoArrayConstructorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-array-delete", no_array_delete.NoArrayDeleteRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-base-to-string", no_base_to_string.NoBaseToStringRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-confusing-non-null-assertion", no_confusing_non_null_assertion.NoConfusingNonNullAssertionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-confusing-void-expression", no_confusing_void_expression.NoConfusingVoidExpressionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-dupe-class-members", ts_no_dupe_class_members.NoDupeClassMembersRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-duplicate-enum-values", no_duplicate_enum_values.NoDuplicateEnumValuesRule)

--- a/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion.go
+++ b/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion.go
@@ -1,0 +1,148 @@
+package no_confusing_non_null_assertion
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func buildConfusingAssignMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "confusingAssign",
+		Description: "Confusing combination of non-null assertion and assignment like `a! = b`, which looks very similar to `a != b`.",
+	}
+}
+
+func buildConfusingEqualMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "confusingEqual",
+		Description: "Confusing combination of non-null assertion and equality test like `a! == b`, which looks very similar to `a !== b`.",
+	}
+}
+
+func buildConfusingOperatorMessage(op string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "confusingOperator",
+		Description: "Confusing combination of non-null assertion and `" + op + "` operator like `a! " + op + " b`, which might be misinterpreted as `!(a " + op + " b)`.",
+		Data:        map[string]string{"operator": op},
+	}
+}
+
+func buildNotNeedInAssignMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "notNeedInAssign",
+		Description: "Remove unnecessary non-null assertion (!) in assignment left-hand side.",
+	}
+}
+
+func buildNotNeedInEqualTestMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "notNeedInEqualTest",
+		Description: "Remove unnecessary non-null assertion (!) in equality test.",
+	}
+}
+
+func buildNotNeedInOperatorMessage(op string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "notNeedInOperator",
+		Description: "Remove possibly unnecessary non-null assertion (!) in the left operand of the `" + op + "` operator.",
+		Data:        map[string]string{"operator": op},
+	}
+}
+
+func buildWrapUpLeftMessage(op string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "wrapUpLeft",
+		Description: `Wrap the left-hand side in parentheses to avoid confusion with "` + op + `" operator.`,
+		Data:        map[string]string{"operator": op},
+	}
+}
+
+var NoConfusingNonNullAssertionRule = rule.CreateRule(rule.Rule{
+	Name: "no-confusing-non-null-assertion",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				bin := node.AsBinaryExpression()
+				if bin.OperatorToken == nil {
+					return
+				}
+
+				var operator string
+				var primaryMsg rule.RuleMessage
+				switch bin.OperatorToken.Kind {
+				case ast.KindEqualsToken:
+					operator = "="
+					primaryMsg = buildConfusingAssignMessage()
+				case ast.KindEqualsEqualsToken:
+					operator = "=="
+					primaryMsg = buildConfusingEqualMessage()
+				case ast.KindEqualsEqualsEqualsToken:
+					operator = "==="
+					primaryMsg = buildConfusingEqualMessage()
+				case ast.KindInKeyword:
+					operator = "in"
+					primaryMsg = buildConfusingOperatorMessage(operator)
+				case ast.KindInstanceOfKeyword:
+					operator = "instanceof"
+					primaryMsg = buildConfusingOperatorMessage(operator)
+				default:
+					return
+				}
+
+				left := bin.Left
+				if left == nil {
+					return
+				}
+
+				// Mirror upstream's `getLastToken(node.left).value === '!'` +
+				// `getTokenAfter(node.left).value !== ')'` check. In tsgo,
+				// ParenthesizedExpression is an explicit AST node, so when the
+				// left side is wrapped in parens its End() lands right after
+				// the closing `)`. Probing the byte just before End() collapses
+				// both conditions: the byte is `!` iff the unparenthesized
+				// left ends in a non-null assertion.
+				text := ctx.SourceFile.Text()
+				leftEnd := left.End()
+				if leftEnd < 1 || leftEnd > len(text) || text[leftEnd-1] != '!' {
+					return
+				}
+
+				wrapUpLeftFix := []rule.RuleFix{
+					rule.RuleFixInsertBefore(ctx.SourceFile, left, "("),
+					rule.RuleFixInsertAfter(left, ")"),
+				}
+
+				if left.Kind == ast.KindNonNullExpression {
+					expression := left.AsNonNullExpression().Expression
+					s := scanner.GetScannerForSourceFile(ctx.SourceFile, expression.End())
+					removeBangFix := []rule.RuleFix{rule.RuleFixRemoveRange(s.TokenRange())}
+
+					var suggestions []rule.RuleSuggestion
+					switch bin.OperatorToken.Kind {
+					case ast.KindEqualsToken:
+						suggestions = []rule.RuleSuggestion{
+							{Message: buildNotNeedInAssignMessage(), FixesArr: removeBangFix},
+						}
+					case ast.KindEqualsEqualsToken, ast.KindEqualsEqualsEqualsToken:
+						suggestions = []rule.RuleSuggestion{
+							{Message: buildNotNeedInEqualTestMessage(), FixesArr: removeBangFix},
+						}
+					case ast.KindInKeyword, ast.KindInstanceOfKeyword:
+						suggestions = []rule.RuleSuggestion{
+							{Message: buildNotNeedInOperatorMessage(operator), FixesArr: removeBangFix},
+							{Message: buildWrapUpLeftMessage(operator), FixesArr: wrapUpLeftFix},
+						}
+					}
+					ctx.ReportNodeWithSuggestions(node, primaryMsg, suggestions...)
+					return
+				}
+
+				ctx.ReportNodeWithSuggestions(node, primaryMsg, rule.RuleSuggestion{
+					Message:  buildWrapUpLeftMessage(operator),
+					FixesArr: wrapUpLeftFix,
+				})
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion.md
+++ b/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion.md
@@ -1,0 +1,29 @@
+# no-confusing-non-null-assertion
+
+## Rule Details
+
+Disallow non-null assertion in locations that may be confusing.
+
+A non-null assertion (`!`) placed immediately before `=`, `==`, `===`, `in`, or `instanceof` is visually almost indistinguishable from the operators `!=`, `!==`, `!(... in ...)`, or `!(... instanceof ...)`. This rule flags those combinations and offers suggestions to either remove the assertion or wrap the left-hand side in parentheses to disambiguate.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+a! == b;
+a! === b;
+a! in b;
+a! instanceof b;
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+a == b;
+(1 + foo.num!) == 2;
+foo.bar == 'hello';
+!(a in b);
+```
+
+## Original Documentation
+
+- [typescript-eslint no-confusing-non-null-assertion](https://typescript-eslint.io/rules/no-confusing-non-null-assertion)

--- a/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion_extras_test.go
+++ b/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion_extras_test.go
@@ -1,0 +1,566 @@
+// TestNoConfusingNonNullAssertionExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Each case carries an inline
+// comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk
+// it covers, so future refactors can't silently regress them without breaking
+// a named lock-in.
+package no_confusing_non_null_assertion
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoConfusingNonNullAssertionExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoConfusingNonNullAssertionRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: Receiver / expression wrappers — parenthesized non-null on left ----
+		// tsgo wraps in ParenthesizedExpression; left.End() lands after `)`, not `!`. Must NOT report.
+		{Code: `(a!) == b;`},
+		{Code: `(a!) === b;`},
+		{Code: `(a!) = b;`},
+		{Code: `(a!) in b;`},
+		{Code: `(a!) instanceof b;`},
+		// ---- Dimension 4: Multi-level parens on left ----
+		{Code: `((a!)) == b;`},
+		{Code: `((((a!)))) == b;`},
+		// ---- Tokenizer: greedy `!=` / `!==` match — without intervening space, `!` is consumed into the operator, not into a non-null assertion ----
+		{Code: `a!=b;`},
+		{Code: `a!==b;`},
+		{Code: `a != b;`},
+		{Code: `a !== b;`},
+		// ---- Real-user: type-guard idiom — the very pattern users type instead of `value! == null` — must never be flagged ----
+		{Code: `const value: string | null = null; value! != null;`},
+		{Code: `const value: string | undefined = undefined; value! !== undefined;`},
+		// ---- ForInStatement / ForOfStatement: `in` / `of` here are statement keywords, NOT BinaryExpression operators — listener doesn't fire ----
+		{Code: `for (const k in obj) {}`},
+		{Code: `for (const k of arr) {}`},
+		// ---- Locks in upstream isConfusingOperator() arm "false": non-confusing operators are ignored ----
+		// `!=` and `!==` are the very operators upstream wants users to type instead — they must stay valid.
+		{Code: `a! != b;`},
+		{Code: `a! !== b;`},
+		// Other comparison / arithmetic / logical / nullish / compound-assignment ops are not in the watched set.
+		{Code: `a! < b;`},
+		{Code: `a! > b;`},
+		{Code: `a! <= b;`},
+		{Code: `a! >= b;`},
+		{Code: `a! + b;`},
+		{Code: `a! - b;`},
+		{Code: `a! * b;`},
+		{Code: `a! / b;`},
+		{Code: `a! && b;`},
+		{Code: `a! || b;`},
+		{Code: `a! ?? b;`},
+		{Code: `a! += b;`},
+		{Code: `a! -= b;`},
+		{Code: `a! ??= b;`},
+		{Code: `a! ||= b;`},
+		{Code: `a! &&= b;`},
+		{Code: `a! , b;`},
+		// ---- Locks in upstream leftHandFinalToken arm "no !": left side doesn't end in `!` ----
+		{Code: `a == b;`},
+		{Code: `a === b;`},
+		{Code: `a = b;`},
+		{Code: `a in b;`},
+		{Code: `a instanceof b;`},
+		// ---- Locks in upstream check that only LEFT-side ! triggers (RHS ! is fine) ----
+		{Code: `a == b!;`},
+		{Code: `a === b!;`},
+		{Code: `a in b!;`},
+		{Code: `a instanceof b!;`},
+		// ---- Dimension 4: Receiver wrappers — ! on the wrapper position ----
+		// (a + b!) plus then operator: parens make it valid.
+		{Code: `(a || b!) == c;`},
+		{Code: `(a && b!) === c;`},
+		{Code: `(a + b!) instanceof c;`},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: Double non-null (a!!) on LHS ----
+		// left = NonNullExpression(NonNullExpression(a)); only outer-most `!` is removed by the suggestion.
+		{
+			Code: `a!! == b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `a! == b;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4: Element-access receiver — x[0]! == y ----
+		{
+			Code: `arr[0]! == b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `arr[0] == b;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4: Optional-chain receiver — foo?.bar! == y ----
+		// In tsgo the optional chain is a flag on PropertyAccess, not a wrapper node.
+		// The NonNullExpression sits above it, so left.Kind is NonNullExpression as usual.
+		{
+			Code: `foo?.bar! == b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `foo?.bar == b;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4: Type-assertion receiver — (a as B)! == c ----
+		{
+			Code: `(a as number)! == b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `(a as number) == b;`},
+					},
+				},
+			},
+		},
+		// ---- Locks in upstream switch operator==='===' arm separately from '==' ----
+		{
+			Code: `a + b! === c;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "wrapUpLeft", Output: `(a + b!) === c;`},
+					},
+				},
+			},
+		},
+		// ---- Locks in upstream switch operator==='in' wrapUpLeft suggestion when left.type != TSNonNullExpression ----
+		{
+			Code: `a + b! in c;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingOperator",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "wrapUpLeft", Output: `(a + b!) in c;`},
+					},
+				},
+			},
+		},
+		// ---- Locks in upstream switch operator==='instanceof' wrapUpLeft suggestion when left.type != TSNonNullExpression ----
+		// `+` (precedence 12) binds tighter than `instanceof` (11), so the LHS is BinaryExpression(a + NonNullExpression(b)),
+		// not a NonNullExpression — exercises the wrapUpLeft-only branch.
+		{
+			Code: `a + b! instanceof c;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingOperator",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "wrapUpLeft", Output: `(a + b!) instanceof c;`},
+					},
+				},
+			},
+		},
+		// N/A: upstream's `=` × wrapUpLeft branch (left isn't TSNonNullExpression) is unreachable in
+		// parseable TS — assignment requires an assignable LHS, which a `+`/`||`-style BinaryExpression
+		// is not. Upstream lists the suggestion defensively but has no test for it; rslint inherits
+		// that gap (cannot fixture the case without producing a syntax error).
+		// ---- Real-user: array-element non-null before `instanceof` (closed-issue style) ----
+		{
+			Code: `items[0]! instanceof Foo;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingOperator",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInOperator", Output: `items[0] instanceof Foo;`},
+						{MessageId: "wrapUpLeft", Output: `(items[0]!) instanceof Foo;`},
+					},
+				},
+			},
+		},
+		// ---- Real-user: `this`-qualified field non-null before `===` ----
+		{
+			Code: `this.value! === null;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `this.value === null;`},
+					},
+				},
+			},
+		},
+		// ---- Real-user: call-expression result non-null before `in` ----
+		{
+			Code: `getKey()! in container;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingOperator",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInOperator", Output: `getKey() in container;`},
+						{MessageId: "wrapUpLeft", Output: `(getKey()!) in container;`},
+					},
+				},
+			},
+		},
+		// ---- Locks in nested BinaryExpression: outer flagged, inner skipped ----
+		// Both BinaryExpressions visit the listener; only the outer should fire.
+		{
+			Code: `a! == (b! == c);`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `a == (b! == c);`},
+					},
+				},
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    8,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `a! == (b == c);`},
+					},
+				},
+			},
+		},
+		// ---- Confirms message-text exact format for `in` carries the operator data ----
+		{
+			Code: `a! in b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingOperator",
+					Message:   "Confusing combination of non-null assertion and `in` operator like `a! in b`, which might be misinterpreted as `!(a in b)`.",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInOperator", Output: `a in b;`},
+						{MessageId: "wrapUpLeft", Output: `(a!) in b;`},
+					},
+				},
+			},
+		},
+		// ---- Confirms message-text exact format for `instanceof` carries the operator data ----
+		{
+			Code: `a! instanceof b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingOperator",
+					Message:   "Confusing combination of non-null assertion and `instanceof` operator like `a! instanceof b`, which might be misinterpreted as `!(a instanceof b)`.",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInOperator", Output: `a instanceof b;`},
+						{MessageId: "wrapUpLeft", Output: `(a!) instanceof b;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4 receiver: NewExpression — new Foo()! == bar ----
+		{
+			Code: `new Foo()! == bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `new Foo() == bar;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4 receiver: plain CallExpression — foo()! == bar ----
+		{
+			Code: `foo()! == bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `foo() == bar;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4 receiver: generic call — foo<string>()! == bar (TypeArguments on CallExpression) ----
+		{
+			Code: `declare function foo<T>(): T; foo<string>()! == bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    31,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `declare function foo<T>(): T; foo<string>() == bar;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4 receiver: TaggedTemplateExpression — tag`x`! == bar ----
+		{
+			Code: "foo`x`! == bar;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: "foo`x` == bar;"},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4 receiver: deep chained PropertyAccess — a.b.c.d! == e ----
+		{
+			Code: `a.b.c.d! == e;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `a.b.c.d == e;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4 receiver: chained non-null assertions — a!.b!.c! == d ----
+		// Only the outer-most `!` is removed; the inner ones stay (each ! is a distinct NonNullExpression node).
+		{
+			Code: `a!.b!.c! == d;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `a!.b!.c == d;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4 receiver: `as const` wrapper ----
+		{
+			Code: `(a as const)! == b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `(a as const) == b;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4 receiver: `satisfies` expression (TS-only, distinct AST kind from `as`) ----
+		{
+			Code: `(a satisfies number)! == b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `(a satisfies number) == b;`},
+					},
+				},
+			},
+		},
+		// ---- Dimension 4 receiver: `this` keyword as receiver — this! == null ----
+		{
+			Code: `class C { f() { this! == null; } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `class C { f() { this == null; } }`},
+					},
+				},
+			},
+		},
+		// ---- wrapUpLeft-only branch with TypeOfExpression on LHS (different non-NonNull AST kind) ----
+		{
+			Code: `typeof a! == 'string';`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "wrapUpLeft", Output: `(typeof a!) == 'string';`},
+					},
+				},
+			},
+		},
+		// ---- wrapUpLeft-only branch with VoidExpression on LHS ----
+		{
+			Code: `void a! == b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "wrapUpLeft", Output: `(void a!) == b;`},
+					},
+				},
+			},
+		},
+		// ---- wrapUpLeft-only branch with AwaitExpression on LHS (inside async function) ----
+		{
+			Code: `async function f() { await x! == y; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    22,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "wrapUpLeft", Output: `async function f() { (await x!) == y; }`},
+					},
+				},
+			},
+		},
+		// ---- Whitespace tolerance: extra spaces between `!` and `==` are still flagged (`a !` is still NonNullExpression(a)) ----
+		{
+			Code: `a!  ==  b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `a  ==  b;`},
+					},
+				},
+			},
+		},
+		// ---- Whitespace tolerance: multi-line gap between `!` and the operator ----
+		{
+			Code: "foo()!\n  == bar;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: "foo()\n  == bar;"},
+					},
+				},
+			},
+		},
+		// ---- Context: BinaryExpression as a call-argument — listener fires on the nested BinaryExpression ----
+		{
+			Code: `foo(a! == b);`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    5,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `foo(a == b);`},
+					},
+				},
+			},
+		},
+		// ---- Context: BinaryExpression as a ForStatement condition ----
+		{
+			Code: `for (let i = 0; i! == n; i++) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `for (let i = 0; i == n; i++) {}`},
+					},
+				},
+			},
+		},
+		// ---- Context: BinaryExpression as object-literal property value ----
+		{
+			Code: `const o = { x: a! == b };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `const o = { x: a == b };`},
+					},
+				},
+			},
+		},
+		// ---- Context: BinaryExpression as return expression in arrow body ----
+		{
+			Code: `const f = () => a! == b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    17,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `const f = () => a == b;`},
+					},
+				},
+			},
+		},
+		// ---- Real-user: optional-chain-into-property non-null before `===` (common React-state pattern) ----
+		{
+			Code: `state?.value! === 'pending';`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `state?.value === 'pending';`},
+					},
+				},
+			},
+		},
+		// ---- Real-user: array element instanceof guard (post-find pattern) ----
+		{
+			Code: `(arr.find(x => x.id === id))! instanceof Item;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingOperator",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInOperator", Output: `(arr.find(x => x.id === id)) instanceof Item;`},
+						{MessageId: "wrapUpLeft", Output: `((arr.find(x => x.id === id))!) instanceof Item;`},
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion_upstream_test.go
@@ -1,0 +1,174 @@
+// TestNoConfusingNonNullAssertionUpstream migrates the full valid/invalid
+// suite from upstream
+// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-confusing-non-null-assertion.test.ts
+// 1:1. Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in
+// no_confusing_non_null_assertion_extras_test.go.
+package no_confusing_non_null_assertion
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoConfusingNonNullAssertionUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoConfusingNonNullAssertionRule, []rule_tester.ValidTestCase{
+		{Code: `a == b!;`},
+		{Code: `a = b!;`},
+		{Code: `a !== b;`},
+		{Code: `a != b;`},
+		{Code: `(a + b!) == c;`},
+		{Code: `(a + b!) = c;`},
+		{Code: `(a + b!) in c;`},
+		{Code: `(a || b!) instanceof c;`},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `a! == b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `a == b;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `a! === b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `a === b;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `a + b! == c;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "wrapUpLeft", Output: `(a + b!) == c;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(obj = new new OuterObj().InnerObj).Name! == c;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `(obj = new new OuterObj().InnerObj).Name == c;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(a==b)! ==c;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingEqual",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInEqualTest", Output: `(a==b) ==c;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `a! = b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingAssign",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInAssign", Output: `a = b;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(obj = new new OuterObj().InnerObj).Name! = c;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingAssign",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInAssign", Output: `(obj = new new OuterObj().InnerObj).Name = c;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(a=b)! =c;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingAssign",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInAssign", Output: `(a=b) =c;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `a! in b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingOperator",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInOperator", Output: `a in b;`},
+						{MessageId: "wrapUpLeft", Output: `(a!) in b;`},
+					},
+				},
+			},
+		},
+		{
+			Code: "\na !in b;\n      ",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingOperator",
+					Line:      2,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInOperator", Output: "\na in b;\n      "},
+						{MessageId: "wrapUpLeft", Output: "\n(a !)in b;\n      "},
+					},
+				},
+			},
+		},
+		{
+			Code: `a! instanceof b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "confusingOperator",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "notNeedInOperator", Output: `a instanceof b;`},
+						{MessageId: "wrapUpLeft", Output: `(a!) instanceof b;`},
+					},
+				},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -245,7 +245,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-array-constructor.test.ts',
     './tests/typescript-eslint/rules/no-array-delete.test.ts',
     // './tests/typescript-eslint/rules/no-base-to-string.test.ts',
-    // './tests/typescript-eslint/rules/no-confusing-non-null-assertion.test.ts',
+    './tests/typescript-eslint/rules/no-confusing-non-null-assertion.test.ts',
     './tests/typescript-eslint/rules/no-confusing-void-expression.test.ts',
     // './tests/typescript-eslint/rules/no-deprecated.test.ts',
     './tests/typescript-eslint/rules/no-dupe-class-members.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-confusing-non-null-assertion.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-confusing-non-null-assertion.test.ts.snap
@@ -1,0 +1,289 @@
+// Rstest Snapshot v1
+
+exports[`no-confusing-non-null-assertion > invalid 1`] = `
+{
+  "code": "a! == b;",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and equality test like \`a! == b\`, which looks very similar to \`a !== b\`.",
+      "messageId": "confusingEqual",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-confusing-non-null-assertion > invalid 2`] = `
+{
+  "code": "a! === b;",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and equality test like \`a! == b\`, which looks very similar to \`a !== b\`.",
+      "messageId": "confusingEqual",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-confusing-non-null-assertion > invalid 3`] = `
+{
+  "code": "a + b! == c;",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and equality test like \`a! == b\`, which looks very similar to \`a !== b\`.",
+      "messageId": "confusingEqual",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-confusing-non-null-assertion > invalid 4`] = `
+{
+  "code": "(obj = new new OuterObj().InnerObj).Name! == c;",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and equality test like \`a! == b\`, which looks very similar to \`a !== b\`.",
+      "messageId": "confusingEqual",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-confusing-non-null-assertion > invalid 5`] = `
+{
+  "code": "(a==b)! ==c;",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and equality test like \`a! == b\`, which looks very similar to \`a !== b\`.",
+      "messageId": "confusingEqual",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-confusing-non-null-assertion > invalid 6`] = `
+{
+  "code": "a! = b;",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and assignment like \`a! = b\`, which looks very similar to \`a != b\`.",
+      "messageId": "confusingAssign",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-confusing-non-null-assertion > invalid 7`] = `
+{
+  "code": "(obj = new new OuterObj().InnerObj).Name! = c;",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and assignment like \`a! = b\`, which looks very similar to \`a != b\`.",
+      "messageId": "confusingAssign",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-confusing-non-null-assertion > invalid 8`] = `
+{
+  "code": "(a=b)! =c;",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and assignment like \`a! = b\`, which looks very similar to \`a != b\`.",
+      "messageId": "confusingAssign",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-confusing-non-null-assertion > invalid 9`] = `
+{
+  "code": "a! in b;",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and \`in\` operator like \`a! in b\`, which might be misinterpreted as \`!(a in b)\`.",
+      "messageId": "confusingOperator",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-confusing-non-null-assertion > invalid 10`] = `
+{
+  "code": "
+a !in b;
+      ",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and \`in\` operator like \`a! in b\`, which might be misinterpreted as \`!(a in b)\`.",
+      "messageId": "confusingOperator",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-confusing-non-null-assertion > invalid 11`] = `
+{
+  "code": "a! instanceof b;",
+  "diagnostics": [
+    {
+      "message": "Confusing combination of non-null assertion and \`instanceof\` operator like \`a! instanceof b\`, which might be misinterpreted as \`!(a instanceof b)\`.",
+      "messageId": "confusingOperator",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-confusing-non-null-assertion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the [`@typescript-eslint/no-confusing-non-null-assertion`](https://typescript-eslint.io/rules/no-confusing-non-null-assertion) rule to rslint with 1:1 behavior parity.

The rule flags non-null assertions (`!`) placed immediately before `=`, `==`, `===`, `in`, or `instanceof` — these patterns visually resemble `!=`, `!==`, or negated operators and are easy to misread. Suggestions either remove the assertion or wrap the left-hand side in parentheses.

## Related Links

- typescript-eslint rule: https://typescript-eslint.io/rules/no-confusing-non-null-assertion
- Source: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-confusing-non-null-assertion.ts
- Tests: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-confusing-non-null-assertion.test.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).