### PR TITLE
feat: port rule @typescript-eslint/no-invalid-this

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_implied_eval"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_import_type_side_effects"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_inferrable_types"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_invalid_this"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_invalid_void_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_loop_func"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_magic_numbers"
@@ -566,6 +567,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-empty-object-type", no_empty_object_type.NoEmptyObjectTypeRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-extra-non-null-assertion", no_extra_non_null_assertion.NoExtraNonNullAssertionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-extraneous-class", no_extraneous_class.NoExtraneousClassRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-invalid-this", no_invalid_this.NoInvalidThisRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-invalid-void-type", no_invalid_void_type.NoInvalidVoidTypeRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-floating-promises", no_floating_promises.NoFloatingPromisesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-for-in-array", no_for_in_array.NoForInArrayRule)

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.go
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.go
@@ -1,0 +1,801 @@
+package no_invalid_this
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// NoInvalidThisRule mirrors @typescript-eslint/no-invalid-this, which wraps
+// ESLint core's no-invalid-this with two TypeScript-specific recognitions:
+//   - A function whose signature declares a `this` parameter
+//     (`function foo(this: T)`) has its `this` validity short-circuited to
+//     `true`, matching the upstream `thisIsValidStack` push.
+//   - Class field initializers (regular and `accessor`-modified) are
+//     short-circuited to `true`, since their implicit-function context
+//     binds `this` to the class instance.
+//
+// All other validity decisions delegate to the same parent-walker logic the
+// upstream ESLint rule uses (`isDefaultThisBinding`), with `capIsConstructor`
+// honored at every uppercase-name branch (VariableDeclaration init,
+// AssignmentExpression target, ParameterDeclaration default,
+// BindingElement default).
+//
+// https://typescript-eslint.io/rules/no-invalid-this
+var NoInvalidThisRule = rule.CreateRule(rule.Rule{
+	Name: "no-invalid-this",
+	Run:  run,
+})
+
+type ruleOptions struct {
+	// capIsConstructor: when true (default), a capitalized-name function is
+	// treated as an ES5 constructor and its `this` is considered valid.
+	capIsConstructor bool
+}
+
+func parseOptions(raw any) ruleOptions {
+	opts := ruleOptions{capIsConstructor: true}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	if v, ok := m["capIsConstructor"]; ok {
+		if b, ok := v.(bool); ok {
+			opts.capIsConstructor = b
+		}
+	}
+	return opts
+}
+
+func run(ctx rule.RuleContext, options any) rule.RuleListeners {
+	opts := parseOptions(options)
+	sf := ctx.SourceFile
+
+	// Top-level `this` validity. typescript-eslint's wrapper defaults to
+	// `parserOptions.sourceType: 'module'`, which makes top-level `this`
+	// always invalid. rslint does not expose `sourceType` /
+	// `parserOptions.ecmaFeatures.globalReturn`, so we adopt the same
+	// default and treat top-level `this` as invalid — a framework-layer
+	// consequence of rslint not surfacing parser options, applied
+	// uniformly across rules.
+	topLevelValid := false
+
+	// Stack of `this`-validity flags, one per non-arrow function-like /
+	// class-member container currently on the visitor's path. Arrow functions
+	// inherit the surrounding frame and therefore do NOT push (lexical `this`).
+	var stack []bool
+
+	push := func(valid bool) {
+		stack = append(stack, valid)
+	}
+	pop := func() {
+		if n := len(stack); n > 0 {
+			stack = stack[:n-1]
+		}
+	}
+
+	msg := rule.RuleMessage{
+		Id:          "unexpectedThis",
+		Description: "Unexpected 'this'.",
+	}
+
+	pushFunction := func(node *ast.Node) {
+		push(computeFunctionValid(node, sf, opts.capIsConstructor))
+	}
+
+	// hasComputedKey reports whether a class member uses a `[expr]` computed
+	// key. For Method / Constructor / Get/SetAccessor the wrapper's
+	// FunctionExpression push fires on the FE child of MethodDefinition —
+	// which in ESTree is visited AFTER the computed key. We mirror this by
+	// deferring the push to `ComputedPropertyName:exit`.
+	hasComputedKey := func(node *ast.Node) bool {
+		name := ast.GetNameOfDeclaration(node)
+		return name != nil && name.Kind == ast.KindComputedPropertyName
+	}
+
+	// enterMethodLike defers push past the computed key (if any). Applies
+	// to Method/Constructor/Get/Set whose ESTree counterpart's wrapper push
+	// happens on the FunctionExpression value, AFTER the key visit.
+	enterMethodLike := func(node *ast.Node) {
+		if hasComputedKey(node) {
+			return
+		}
+		push(true)
+	}
+
+	// enterPropertyDeclaration always pushes on entry. The upstream wrapper's
+	// `PropertyDefinition` / `AccessorProperty` listeners push on entry too,
+	// which intentionally — or unintentionally — masks `this` in computed
+	// keys of class fields. We reproduce that behavior verbatim so output
+	// matches `@typescript-eslint/no-invalid-this` byte for byte.
+	enterPropertyDeclaration := func(*ast.Node) {
+		push(true)
+	}
+
+	return rule.RuleListeners{
+		// Non-arrow function-like containers — push a frame whose validity
+		// depends on parameter shape, JSDoc, name, and surrounding context.
+		ast.KindFunctionDeclaration:                      pushFunction,
+		rule.ListenerOnExit(ast.KindFunctionDeclaration): func(*ast.Node) { pop() },
+		ast.KindFunctionExpression:                       pushFunction,
+		rule.ListenerOnExit(ast.KindFunctionExpression):  func(*ast.Node) { pop() },
+
+		// Class members (and equivalent object-literal accessors): `this`
+		// always refers to the class instance / static class object — VALID.
+		// Computed-key members defer the push to ComputedPropertyName:exit
+		// to mirror the upstream wrapper, whose `FunctionExpression`
+		// listener fires on the method's FE value (visited AFTER the key).
+		ast.KindMethodDeclaration:                      enterMethodLike,
+		rule.ListenerOnExit(ast.KindMethodDeclaration): func(*ast.Node) { pop() },
+		ast.KindConstructor:                            enterMethodLike,
+		rule.ListenerOnExit(ast.KindConstructor):       func(*ast.Node) { pop() },
+		ast.KindGetAccessor:                            enterMethodLike,
+		rule.ListenerOnExit(ast.KindGetAccessor):       func(*ast.Node) { pop() },
+		ast.KindSetAccessor:                            enterMethodLike,
+		rule.ListenerOnExit(ast.KindSetAccessor):       func(*ast.Node) { pop() },
+
+		// Class field (regular + `accessor` auto-accessor — tsgo collapses
+		// ESTree's PropertyDefinition / AccessorProperty onto this kind,
+		// distinguishing the latter via `ModifierFlagsAccessor`). Push on
+		// entry verbatim with upstream wrapper's `PropertyDefinition()` /
+		// `AccessorProperty()` listeners — including the wrapper's behavior
+		// of masking `this` in computed keys and decorators.
+		ast.KindPropertyDeclaration:                      enterPropertyDeclaration,
+		rule.ListenerOnExit(ast.KindPropertyDeclaration): func(*ast.Node) { pop() },
+
+		// Deferred push for computed-key method-likes. The matching pop
+		// happens unconditionally on the member's own exit listener, so
+		// the stack stays balanced regardless of whether the push happened
+		// on enter (non-computed) or here (computed). PropertyDeclaration
+		// is intentionally excluded — it pushes on entry.
+		rule.ListenerOnExit(ast.KindComputedPropertyName): func(node *ast.Node) {
+			parent := node.Parent
+			if parent == nil {
+				return
+			}
+			switch parent.Kind {
+			case ast.KindMethodDeclaration, ast.KindConstructor,
+				ast.KindGetAccessor, ast.KindSetAccessor:
+				push(true)
+			}
+		},
+
+		// Class static block: own `this` context bound to the class — VALID.
+		ast.KindClassStaticBlockDeclaration:                      func(*ast.Node) { push(true) },
+		rule.ListenerOnExit(ast.KindClassStaticBlockDeclaration): func(*ast.Node) { pop() },
+
+		// Arrow function: lexical `this`. Intentionally NOT registered so
+		// the enclosing frame governs.
+
+		ast.KindThisKeyword: func(node *ast.Node) {
+			// Decorators on Method / Constructor / Get/Set members are
+			// visited BEFORE the wrapper's FunctionExpression push fires
+			// in ESTree (the wrapper hooks FE entry, not MethodDefinition
+			// entry). tsgo collapses MethodDefinition's FE child into the
+			// member node itself, so our `enterMethodLike` push happens
+			// one visitor tick too early to reproduce that timing. To
+			// compensate, peek one frame deeper when `this` appears inside
+			// such a decorator. PropertyDeclaration is intentionally NOT
+			// in this list: upstream's `PropertyDefinition` / `AccessorProperty`
+			// wrapper listeners DO push on entry, so decorators on fields
+			// see the field's frame (matching our default behavior).
+			skip := 0
+			if isInsideDecoratorOfMethodLike(node) {
+				skip = 1
+			}
+			idx := len(stack) - 1 - skip
+			var valid bool
+			if idx < 0 {
+				valid = topLevelValid
+			} else {
+				valid = stack[idx]
+			}
+			if !valid {
+				ctx.ReportNode(node, msg)
+			}
+		},
+	}
+}
+
+// computeFunctionValid produces the `this`-validity flag pushed when a
+// FunctionDeclaration / FunctionExpression frame is entered. Order matches
+// upstream's combined wrapper+base logic:
+//  1. `this` parameter on the signature → VALID (typescript-eslint wrapper).
+//  2. `@this` JSDoc tag attached to the function (or its statement context)
+//     → VALID.
+//  3. `capIsConstructor: true` AND the function carries an uppercase own name
+//     (`function Foo()` / `var x = function Bar()`) → VALID (ES5 constructor).
+//  4. Otherwise, walk the parent chain via `isDefaultThisBinding` — VALID
+//     iff the surrounding context binds `this` explicitly (method assignment,
+//     `.call`/`.apply`/`.bind`, `Reflect.apply`, array-method `thisArg`, …).
+func computeFunctionValid(node *ast.Node, sf *ast.SourceFile, capIsConstructor bool) bool {
+	if hasThisParameter(node) {
+		return true
+	}
+	if hasJSDocThisTag(node, sf) {
+		return true
+	}
+	if capIsConstructor && isES5Constructor(node) {
+		return true
+	}
+	return !isDefaultThisBinding(node, capIsConstructor)
+}
+
+// hasThisParameter reports whether the function's parameter list begins with
+// (or contains) a `this: T` parameter. Mirrors the upstream wrapper's
+// `params.some(param => param.type === Identifier && param.name === 'this')`.
+// tsgo encodes the `this` parameter as a ParameterDeclaration whose `name`
+// is an Identifier with text `"this"`, which `ast.IsThisParameter` resolves.
+func hasThisParameter(node *ast.Node) bool {
+	for _, p := range node.Parameters() {
+		if ast.IsThisParameter(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// isES5Constructor mirrors ESLint's `isES5Constructor`: a function with an
+// own name whose first character is an uppercase letter is treated as an
+// ES5 constructor under `capIsConstructor: true`. Anonymous functions
+// (no own name) fall through.
+func isES5Constructor(node *ast.Node) bool {
+	var name *ast.Node
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		name = node.AsFunctionDeclaration().Name()
+	case ast.KindFunctionExpression:
+		name = node.AsFunctionExpression().Name()
+	default:
+		return false
+	}
+	if name == nil || !ast.IsIdentifier(name) {
+		return false
+	}
+	return startsWithUpperCase(name.AsIdentifier().Text)
+}
+
+// hasOwnFunctionName reports whether the function has an `id`/name in
+// ESTree terms (used to gate ES5-constructor recognition for the uppercase-
+// variable / uppercase-assignment-target branches: a *named* function
+// expression keeps its own name as the binding, so the uppercase-of-the-
+// surrounding-target heuristic does not apply).
+func hasOwnFunctionName(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return node.AsFunctionDeclaration().Name() != nil
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().Name() != nil
+	}
+	return false
+}
+
+func startsWithUpperCase(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	// ESLint uses `s[0] !== s[0].toLocaleLowerCase()` which captures any
+	// Unicode uppercase letter. Restrict to ASCII for now — the tsgo
+	// fixtures all use ASCII names and the typescript-eslint suite never
+	// exercises the Unicode branch.
+	c := s[0]
+	return c >= 'A' && c <= 'Z'
+}
+
+// thisTagPattern is ESLint's exact pattern: `^[\s*]*@this` applied to a
+// comment's *value*, i.e. with `/*` / `*/` / `//` markers stripped.
+var thisTagPattern = regexp.MustCompile(`(?m)^[\s*]*@this\b`)
+
+// hasJSDocThisTag mirrors `astUtils.hasJSDocThisTag`. Two sources are checked
+// per ESLint:
+//  1. The function's own JSDoc comment — either attached directly, or, when
+//     the function is the value of a transparent expression context (return
+//     statement, variable initializer, call argument, …), the JSDoc attached
+//     to the enclosing statement. eslint-utils's `getJSDocComment` walks up
+//     through such transparent ancestors; we replicate that walk.
+//  2. The function's leading non-JSDoc comments (`getCommentsBefore`) — covers
+//     the callback-with-inline-tag shape `foo(/* @this */ function(){})`,
+//     where the comment sits between the call's `(` and the function and
+//     therefore lives in the function's leading trivia.
+//
+// Together these match every case the upstream test suite exercises:
+//   - `/** @this */ function foo()` (own JSDoc)
+//   - `function foo() { /** @this */ return function bar() {} }` (parent ReturnStatement JSDoc)
+//   - `foo(/* @this */ function(){})` (leading comment between `(` and `function`)
+//
+// Out of scope (and correctly NOT matched): `/** @this */ foo(function(){})`
+// — the JSDoc here belongs to the enclosing CallExpression, not the function
+// argument; ESLint's `getJSDocComment` stops walking at CallExpression
+// parents, so we do too.
+func hasJSDocThisTag(fn *ast.Node, sf *ast.SourceFile) bool {
+	text := sf.Text()
+	if hasThisTagInLeadingComments(fn, text) {
+		return true
+	}
+	// Walk up through transparent statement-context parents. Stop at the
+	// first parent whose comments we should *not* attribute to the function
+	// (e.g. CallExpression — upstream's `getJSDocComment` excludes it).
+	current := fn
+	for {
+		parent := current.Parent
+		// Skip parens and TS expression wrappers — eslint-utils's
+		// `getJSDocComment` keeps walking past them when looking for a
+		// JSDoc anchor, so we do the same.
+		for parent != nil && ast.IsOuterExpression(parent, ast.OEKParentheses|ast.OEKAssertions) {
+			current = parent
+			parent = current.Parent
+		}
+		if parent == nil {
+			return false
+		}
+		switch parent.Kind {
+		case ast.KindReturnStatement, ast.KindExpressionStatement:
+			return hasThisTagInLeadingComments(parent, text)
+		case ast.KindVariableDeclaration:
+			// Walk through VariableDeclarationList → VariableStatement so the
+			// JSDoc on the statement itself is checked. tsgo splits what
+			// ESTree models as a flat VariableDeclaration into three nested
+			// nodes; the user-visible JSDoc anchor is the outermost.
+			grand := parent.Parent
+			if grand != nil && grand.Kind == ast.KindVariableDeclarationList {
+				vs := grand.Parent
+				if vs != nil && vs.Kind == ast.KindVariableStatement {
+					return hasThisTagInLeadingComments(vs, text)
+				}
+			}
+			return hasThisTagInLeadingComments(parent, text)
+		case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment,
+			ast.KindPropertyDeclaration, ast.KindBindingElement, ast.KindParameter:
+			return hasThisTagInLeadingComments(parent, text)
+		case ast.KindBinaryExpression:
+			// Assignment / logical / conditional — defer to the enclosing
+			// statement. Continue walking.
+			current = parent
+			continue
+		case ast.KindConditionalExpression:
+			current = parent
+			continue
+		default:
+			return false
+		}
+	}
+}
+
+// hasThisTagInLeadingComments scans the leading-comment ranges at `node.Pos()`
+// for `@this`. `node.Pos()` in tsgo lands BEFORE the leading trivia, so the
+// scanner returns every comment that visually precedes the node within the
+// current scope. The comment range as tsgo reports it includes the `/*` /
+// `*/` / `//` markers; ESLint's comment objects expose only the value, so
+// we strip the markers before applying the regex.
+func hasThisTagInLeadingComments(node *ast.Node, text string) bool {
+	if node == nil {
+		return false
+	}
+	nodeFactory := &ast.NodeFactory{}
+	for c := range scanner.GetLeadingCommentRanges(nodeFactory, text, node.Pos()) {
+		raw := text[c.Pos():c.End()]
+		value := stripCommentMarkers(raw, c.Kind)
+		if thisTagPattern.MatchString(value) {
+			return true
+		}
+	}
+	return false
+}
+
+// stripCommentMarkers removes `/*`/`*/` from block comments and `//` from
+// line comments, matching ESLint's `comment.value` representation.
+func stripCommentMarkers(raw string, kind ast.Kind) string {
+	switch kind {
+	case ast.KindSingleLineCommentTrivia:
+		return strings.TrimPrefix(raw, "//")
+	case ast.KindMultiLineCommentTrivia:
+		v := strings.TrimPrefix(raw, "/*")
+		v = strings.TrimSuffix(v, "*/")
+		return v
+	}
+	return raw
+}
+
+// isDefaultThisBinding mirrors `astUtils.isDefaultThisBinding` from
+// ESLint core — the parent-chain walk that decides whether a function's
+// `this` is bound by its surrounding context. Returns true when the
+// surrounding context does NOT bind `this` (default binding → global /
+// undefined → invalid).
+//
+// Only `KindParenthesizedExpression` is skipped (ESTree elides parens,
+// so this preserves byte-for-byte parity). TypeScript expression wrappers
+// (`as`, `satisfies`, `!`) are intentionally NOT skipped: upstream's
+// walker has no `TSAsExpression` / `TSSatisfiesExpression` /
+// `TSNonNullExpression` case, so it falls through to `default: return
+// true` (default binding). Treating them opaquely matches that behavior.
+//
+// Method / Constructor / Accessor parents never appear when walking from
+// a Function*Expression in tsgo: tsgo collapses ESTree's
+// `MethodDefinition.value` into the method node itself, so the function
+// and its container are the same node and we push for them via the
+// dedicated KindMethodDeclaration / KindConstructor / KindGet/SetAccessor
+// listeners. The corresponding ESTree branch is therefore unreachable
+// here.
+func isDefaultThisBinding(node *ast.Node, capIsConstructor bool) bool {
+	isAnonymous := !hasOwnFunctionName(node)
+	current := node
+	for {
+		parent := current.Parent
+		for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+			current = parent
+			parent = current.Parent
+		}
+		if parent == nil {
+			return true
+		}
+
+		switch parent.Kind {
+		case ast.KindBinaryExpression:
+			bin := parent.AsBinaryExpression()
+			opKind := bin.OperatorToken.Kind
+			switch opKind {
+			case ast.KindBarBarToken, ast.KindAmpersandAmpersandToken, ast.KindQuestionQuestionToken:
+				// Logical / nullish — transparent (ESLint case "LogicalExpression").
+				current = parent
+				continue
+			case ast.KindEqualsToken:
+				// AssignmentExpression: function is the right-hand value.
+				if bin.Right != current {
+					return true
+				}
+				left := ast.SkipParentheses(bin.Left)
+				if left == nil {
+					return true
+				}
+				if ast.IsPropertyAccessExpression(left) || ast.IsElementAccessExpression(left) {
+					// obj.foo = function(){} / obj['foo'] = function(){}
+					return false
+				}
+				if capIsConstructor && isAnonymous && ast.IsIdentifier(left) &&
+					startsWithUpperCase(left.AsIdentifier().Text) {
+					// Foo = function(){} — assignment to an uppercase variable
+					// (anonymous function) is treated as an ES5 constructor.
+					return false
+				}
+				return true
+			default:
+				return true
+			}
+
+		case ast.KindConditionalExpression:
+			current = parent
+			continue
+
+		case ast.KindReturnStatement:
+			// `return function(){}` is transparent ONLY when the surrounding
+			// function is invoked immediately (IIFE). Otherwise the returned
+			// function escapes to an unknown caller — default binding.
+			fn := ast.GetContainingFunction(parent)
+			if fn == nil || !isCalleeParenOnly(fn) {
+				return true
+			}
+			// ESLint advances `currentNode = func.parent`, which lands on the
+			// IIFE CallExpression (parens are elided in ESTree). In tsgo the
+			// function may be wrapped in `ParenthesizedExpression` / TS
+			// expression assertions, so walk through those to reach the
+			// CallExpression itself.
+			callExpr := findEnclosingCall(fn)
+			if callExpr == nil {
+				return true
+			}
+			current = callExpr
+			continue
+
+		case ast.KindArrowFunction:
+			// `(() => function(){})()` — arrow concise body that's itself
+			// IIFE'd. Same logic as ReturnStatement: only transparent when
+			// the arrow is immediately called.
+			af := parent.AsArrowFunction()
+			if af.Body != current || !isCalleeParenOnly(parent) {
+				return true
+			}
+			callExpr := findEnclosingCall(parent)
+			if callExpr == nil {
+				return true
+			}
+			current = callExpr
+			continue
+
+		case ast.KindPropertyAssignment:
+			pa := parent.AsPropertyAssignment()
+			if pa.Initializer != current {
+				return true
+			}
+			return false
+
+		case ast.KindShorthandPropertyAssignment:
+			// `{Foo = function(){}}` destructuring shorthand with default.
+			// ObjectAssignmentInitializer plays the same role as
+			// AssignmentPattern's right operand in ESTree.
+			spa := parent.AsShorthandPropertyAssignment()
+			if spa.ObjectAssignmentInitializer != current {
+				return true
+			}
+			name := spa.Name()
+			if capIsConstructor && isAnonymous && name != nil && ast.IsIdentifier(name) &&
+				startsWithUpperCase(name.AsIdentifier().Text) {
+				return false
+			}
+			return true
+
+		case ast.KindPropertyDeclaration:
+			pd := parent.AsPropertyDeclaration()
+			if pd.Initializer != current {
+				return true
+			}
+			// ESLint's walker has explicit cases for `Property` /
+			// `PropertyDefinition` / `MethodDefinition` but NOT for
+			// `AccessorProperty`. tsgo collapses both ESTree kinds onto
+			// KindPropertyDeclaration; we re-introduce the distinction here
+			// by checking `ModifierFlagsAccessor`. For auto-accessors a
+			// function-expression initializer falls through to the walker's
+			// default branch (default-bound), matching how upstream's
+			// baseRule walker treats `AccessorProperty` parents.
+			if parent.ModifierFlags()&ast.ModifierFlagsAccessor != 0 {
+				return true
+			}
+			return false
+
+		case ast.KindVariableDeclaration:
+			vd := parent.AsVariableDeclaration()
+			if vd.Initializer != current {
+				return true
+			}
+			if capIsConstructor && isAnonymous {
+				name := vd.Name()
+				if name != nil && ast.IsIdentifier(name) &&
+					startsWithUpperCase(name.AsIdentifier().Text) {
+					return false
+				}
+			}
+			return true
+
+		case ast.KindParameter:
+			pd := parent.AsParameterDeclaration()
+			if pd.Initializer != current {
+				return true
+			}
+			if capIsConstructor && isAnonymous {
+				name := pd.Name()
+				if name != nil && ast.IsIdentifier(name) &&
+					startsWithUpperCase(name.AsIdentifier().Text) {
+					return false
+				}
+			}
+			return true
+
+		case ast.KindBindingElement:
+			be := parent.AsBindingElement()
+			if be.Initializer != current {
+				return true
+			}
+			if capIsConstructor && isAnonymous {
+				name := be.Name()
+				if name != nil && ast.IsIdentifier(name) &&
+					startsWithUpperCase(name.AsIdentifier().Text) {
+					return false
+				}
+			}
+			return true
+
+		case ast.KindPropertyAccessExpression:
+			// `(function(){}).call(obj)` / `.bind(obj)` / `.apply(obj)`.
+			pae := parent.AsPropertyAccessExpression()
+			if pae.Expression != current {
+				return true
+			}
+			name := pae.Name()
+			if name == nil || !ast.IsIdentifier(name) || !isCallApplyBind(name.AsIdentifier().Text) {
+				return true
+			}
+			return !invokesAsCalleeWithNonNullFirstArg(parent)
+
+		case ast.KindElementAccessExpression:
+			// `(function(){})['call'](obj)` / `['bind']` / `['apply']`.
+			eae := parent.AsElementAccessExpression()
+			if eae.Expression != current {
+				return true
+			}
+			methodName, ok := utils.GetStaticExpressionValue(ast.SkipParentheses(eae.ArgumentExpression))
+			if !ok || !isCallApplyBind(methodName) {
+				return true
+			}
+			return !invokesAsCalleeWithNonNullFirstArg(parent)
+
+		case ast.KindCallExpression:
+			// Function passed as an argument to a known thisArg-accepting
+			// callable: `Reflect.apply(fn, ctx, args)`,
+			// `Array.from(iter, fn, ctx)`, `arr.forEach(fn, ctx)`, ….
+			call := parent.AsCallExpression()
+			if call.Arguments == nil {
+				return true
+			}
+			args := call.Arguments.Nodes
+			callee := call.Expression
+
+			if utils.IsSpecificMemberAccess(callee, "Reflect", "apply") {
+				if len(args) != 3 || args[0] != current {
+					return true
+				}
+				return utils.IsNullOrUndefined(args[1])
+			}
+			if utils.IsSpecificMemberAccess(callee, "Array", "from") ||
+				utils.IsSpecificMemberAccess(callee, "Array", "fromAsync") {
+				if len(args) != 3 || args[1] != current {
+					return true
+				}
+				return utils.IsNullOrUndefined(args[2])
+			}
+			if isMethodWhichHasThisArg(callee) {
+				if len(args) != 2 || args[0] != current {
+					return true
+				}
+				return utils.IsNullOrUndefined(args[1])
+			}
+			return true
+
+		default:
+			return true
+		}
+	}
+}
+
+func isCallApplyBind(name string) bool {
+	return name == "call" || name == "apply" || name == "bind"
+}
+
+// isInsideDecoratorOfMethodLike reports whether `thisNode` is positioned
+// inside a `@decorator(...)` expression attached to a method-like class
+// member (`KindMethodDeclaration` / `KindConstructor` / `KindGetAccessor` /
+// `KindSetAccessor`). Decorators on these members run at class-evaluation
+// time, so their `this` resolves to the enclosing scope, NOT the member's
+// own implicit `this`. PropertyDeclaration is excluded — upstream's
+// wrapper pushes for `PropertyDefinition` / `AccessorProperty` on entry,
+// so decorators on fields stay in the field's frame to mirror that.
+//
+// Arrow functions are walked past transparently because their `this` is
+// lexical — `@deco(() => this)` resolves `this` to whatever scope the
+// arrow is defined in (the decorator's scope, which is outside the
+// member). Non-arrow function-likes and class-member boundaries return
+// false: a non-arrow function inside a decorator has its OWN `this`
+// (default-bound), independent of the decorator's host.
+func isInsideDecoratorOfMethodLike(thisNode *ast.Node) bool {
+	current := thisNode.Parent
+	for current != nil {
+		switch current.Kind {
+		case ast.KindDecorator:
+			parent := current.Parent
+			if parent == nil {
+				return false
+			}
+			switch parent.Kind {
+			case ast.KindMethodDeclaration, ast.KindConstructor,
+				ast.KindGetAccessor, ast.KindSetAccessor:
+				return true
+			}
+			return false
+		case ast.KindArrowFunction:
+			// Lexical `this` — keep walking up.
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+			ast.KindMethodDeclaration, ast.KindConstructor,
+			ast.KindGetAccessor, ast.KindSetAccessor,
+			ast.KindPropertyDeclaration,
+			ast.KindClassStaticBlockDeclaration:
+			return false
+		}
+		current = current.Parent
+	}
+	return false
+}
+
+// isCalleeParenOnly mirrors ESLint's `isCallee` — `node.parent` (after
+// stripping ParenthesizedExpression wrappers, which ESTree elides) must
+// be a CallExpression or NewExpression with `node` as the callee. TS
+// expression wrappers (`as` / `satisfies` / `!`) are intentionally NOT
+// stripped to stay byte-for-byte aligned with upstream's walker, which
+// has no case for them and would never treat their parent as a call.
+func isCalleeParenOnly(node *ast.Node) bool {
+	current := node
+	parent := current.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		current = parent
+		parent = current.Parent
+	}
+	if parent == nil {
+		return false
+	}
+	if ast.IsCallExpression(parent) && parent.AsCallExpression().Expression == current {
+		return true
+	}
+	if parent.Kind == ast.KindNewExpression && parent.AsNewExpression().Expression == current {
+		return true
+	}
+	return false
+}
+
+// findEnclosingCall walks up from a function-like that has just been
+// established as the callee of a CallExpression (via `isCalleeParenOnly`)
+// until it reaches that CallExpression. The intermediate hops are
+// ParenthesizedExpression wrappers that tsgo preserves and ESTree elides.
+// Returns nil if no enclosing CallExpression is found.
+func findEnclosingCall(node *ast.Node) *ast.Node {
+	current := node
+	for current.Parent != nil && current.Parent.Kind == ast.KindParenthesizedExpression {
+		current = current.Parent
+	}
+	parent := current.Parent
+	if parent == nil || !ast.IsCallExpression(parent) {
+		return nil
+	}
+	return parent
+}
+
+// invokesAsCalleeWithNonNullFirstArg reports whether `memberAccess` (a
+// PropertyAccess or ElementAccess that resolves to `.call`/`.apply`/`.bind`)
+// is the callee of a CallExpression whose first argument is a real
+// (non-null/undefined) value. Mirrors ESLint's `MemberExpression` branch of
+// `isDefaultThisBinding`, including the maybeCalleeNode-via-ChainExpression
+// dance that tsgo doesn't need (no ChainExpression wrapper).
+func invokesAsCalleeWithNonNullFirstArg(memberAccess *ast.Node) bool {
+	callParent := memberAccess.Parent
+	for callParent != nil && callParent.Kind == ast.KindParenthesizedExpression {
+		callParent = callParent.Parent
+	}
+	if callParent == nil || !ast.IsCallExpression(callParent) {
+		return false
+	}
+	call := callParent.AsCallExpression()
+	if ast.SkipParentheses(call.Expression) != memberAccess {
+		return false
+	}
+	if call.Arguments == nil || len(call.Arguments.Nodes) < 1 {
+		return false
+	}
+	return !utils.IsNullOrUndefined(call.Arguments.Nodes[0])
+}
+
+// arrayMethodsWithThisArg enumerates the standard Array.prototype methods
+// whose second argument is a `thisArg` (matches ESLint's
+// `arrayMethodWithThisArgPattern` /^(?:every|filter|find(?:Last)?(?:Index)?|flatMap|forEach|map|some)$/).
+var arrayMethodsWithThisArg = []string{
+	"every", "filter", "find", "findIndex", "findLast", "findLastIndex",
+	"flatMap", "forEach", "map", "some",
+}
+
+// isMethodWhichHasThisArg reports whether the callee is a member access
+// `<anything>.<name>` where `<name>` is one of the array methods that
+// accept a `thisArg` second parameter. Mirrors ESLint's
+// `isSpecificMemberAccess(node, null, arrayMethodWithThisArgPattern)`.
+func isMethodWhichHasThisArg(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		name := node.AsPropertyAccessExpression().Name()
+		if name == nil || !ast.IsIdentifier(name) {
+			return false
+		}
+		return slices.Contains(arrayMethodsWithThisArg, name.AsIdentifier().Text)
+	case ast.KindElementAccessExpression:
+		argText, ok := utils.GetStaticExpressionValue(
+			ast.SkipParentheses(node.AsElementAccessExpression().ArgumentExpression),
+		)
+		if !ok {
+			return false
+		}
+		return slices.Contains(arrayMethodsWithThisArg, argText)
+	}
+	return false
+}

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.go
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
@@ -88,19 +89,11 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 		push(computeFunctionValid(node, sf, opts.capIsConstructor))
 	}
 
-	// hasComputedKey reports whether a class member uses a `[expr]` computed
-	// key. For Method / Constructor / Get/SetAccessor the wrapper's
-	// FunctionExpression push fires on the FE child of MethodDefinition —
-	// which in ESTree is visited AFTER the computed key. We mirror this by
-	// deferring the push to `ComputedPropertyName:exit`.
-	hasComputedKey := func(node *ast.Node) bool {
-		name := ast.GetNameOfDeclaration(node)
-		return name != nil && name.Kind == ast.KindComputedPropertyName
-	}
-
 	// enterMethodLike defers push past the computed key (if any). Applies
 	// to Method/Constructor/Get/Set whose ESTree counterpart's wrapper push
-	// happens on the FunctionExpression value, AFTER the key visit.
+	// happens on the FunctionExpression value, AFTER the key visit. The
+	// matching deferred push lives in the `ComputedPropertyName:exit`
+	// listener below.
 	enterMethodLike := func(node *ast.Node) {
 		if hasComputedKey(node) {
 			return
@@ -180,12 +173,19 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 			// member node itself, so our `enterMethodLike` push happens
 			// one visitor tick too early to reproduce that timing. To
 			// compensate, peek one frame deeper when `this` appears inside
-			// such a decorator. PropertyDeclaration is intentionally NOT
-			// in this list: upstream's `PropertyDefinition` / `AccessorProperty`
-			// wrapper listeners DO push on entry, so decorators on fields
-			// see the field's frame (matching our default behavior).
+			// such a decorator — but ONLY if the method's frame is actually
+			// on the stack already. A computed-key method-like defers its
+			// push to `ComputedPropertyName:exit`, which runs AFTER the
+			// modifier list (decorators), so at decorator visit time the
+			// stack top is already the surrounding scope and no peek is
+			// needed.
+			//
+			// PropertyDeclaration is intentionally NOT covered here:
+			// upstream's `PropertyDefinition` / `AccessorProperty` wrapper
+			// listeners DO push on entry, so decorators on fields see the
+			// field's frame (matching our default behavior).
 			skip := 0
-			if isInsideDecoratorOfMethodLike(node) {
+			if inside, methodLike := decoratorOfMethodLikeAncestor(node); inside && !hasComputedKey(methodLike) {
 				skip = 1
 			}
 			idx := len(stack) - 1 - skip
@@ -275,16 +275,16 @@ func hasOwnFunctionName(node *ast.Node) bool {
 	return false
 }
 
+// startsWithUpperCase mirrors ESLint's `s[0] !== s[0].toLocaleLowerCase()`:
+// the first rune is uppercase iff it has a different lowercase form. In
+// Unicode terms that's category Lu, plus the rare title-case category Lt
+// (e.g. `Ǆ`). Everything else — lower-case letters, non-cased letters,
+// digits, `_`, `$` — returns false in both halves.
 func startsWithUpperCase(s string) bool {
-	if len(s) == 0 {
-		return false
+	for _, r := range s {
+		return unicode.IsUpper(r) || unicode.IsTitle(r)
 	}
-	// ESLint uses `s[0] !== s[0].toLocaleLowerCase()` which captures any
-	// Unicode uppercase letter. Restrict to ASCII for now — the tsgo
-	// fixtures all use ASCII names and the typescript-eslint suite never
-	// exercises the Unicode branch.
-	c := s[0]
-	return c >= 'A' && c <= 'Z'
+	return false
 }
 
 // thisTagPattern is ESLint's exact pattern: `^[\s*]*@this` applied to a
@@ -654,14 +654,15 @@ func isCallApplyBind(name string) bool {
 	return name == "call" || name == "apply" || name == "bind"
 }
 
-// isInsideDecoratorOfMethodLike reports whether `thisNode` is positioned
+// decoratorOfMethodLikeAncestor reports whether `thisNode` is positioned
 // inside a `@decorator(...)` expression attached to a method-like class
 // member (`KindMethodDeclaration` / `KindConstructor` / `KindGetAccessor` /
-// `KindSetAccessor`). Decorators on these members run at class-evaluation
-// time, so their `this` resolves to the enclosing scope, NOT the member's
-// own implicit `this`. PropertyDeclaration is excluded — upstream's
-// wrapper pushes for `PropertyDefinition` / `AccessorProperty` on entry,
-// so decorators on fields stay in the field's frame to mirror that.
+// `KindSetAccessor`), and returns that member node when so. Decorators on
+// these members run at class-evaluation time, so their `this` resolves to
+// the enclosing scope, NOT the member's own implicit `this`. PropertyDeclaration
+// is excluded — upstream's wrapper pushes for `PropertyDefinition` /
+// `AccessorProperty` on entry, so decorators on fields stay in the field's
+// frame to mirror that.
 //
 // Arrow functions are walked past transparently because their `this` is
 // lexical — `@deco(() => this)` resolves `this` to whatever scope the
@@ -669,21 +670,26 @@ func isCallApplyBind(name string) bool {
 // member). Non-arrow function-likes and class-member boundaries return
 // false: a non-arrow function inside a decorator has its OWN `this`
 // (default-bound), independent of the decorator's host.
-func isInsideDecoratorOfMethodLike(thisNode *ast.Node) bool {
+//
+// The returned `methodLike` node lets the caller distinguish computed-key
+// members (whose frame is deferred to `ComputedPropertyName:exit`) from
+// non-computed ones, since the two require different stack-peek depths at
+// decorator-visit time.
+func decoratorOfMethodLikeAncestor(thisNode *ast.Node) (bool, *ast.Node) {
 	current := thisNode.Parent
 	for current != nil {
 		switch current.Kind {
 		case ast.KindDecorator:
 			parent := current.Parent
 			if parent == nil {
-				return false
+				return false, nil
 			}
 			switch parent.Kind {
 			case ast.KindMethodDeclaration, ast.KindConstructor,
 				ast.KindGetAccessor, ast.KindSetAccessor:
-				return true
+				return true, parent
 			}
-			return false
+			return false, nil
 		case ast.KindArrowFunction:
 			// Lexical `this` — keep walking up.
 		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
@@ -691,19 +697,28 @@ func isInsideDecoratorOfMethodLike(thisNode *ast.Node) bool {
 			ast.KindGetAccessor, ast.KindSetAccessor,
 			ast.KindPropertyDeclaration,
 			ast.KindClassStaticBlockDeclaration:
-			return false
+			return false, nil
 		}
 		current = current.Parent
 	}
-	return false
+	return false, nil
 }
 
-// isCalleeParenOnly mirrors ESLint's `isCallee` — `node.parent` (after
-// stripping ParenthesizedExpression wrappers, which ESTree elides) must
-// be a CallExpression or NewExpression with `node` as the callee. TS
-// expression wrappers (`as` / `satisfies` / `!`) are intentionally NOT
-// stripped to stay byte-for-byte aligned with upstream's walker, which
-// has no case for them and would never treat their parent as a call.
+// hasComputedKey is exposed as a package-level helper so the
+// `KindThisKeyword` listener can re-query it without re-binding through
+// the `run` closure.
+func hasComputedKey(node *ast.Node) bool {
+	name := ast.GetNameOfDeclaration(node)
+	return name != nil && name.Kind == ast.KindComputedPropertyName
+}
+
+// isCalleeParenOnly mirrors ESLint's `isCallee` exactly — `node.parent`
+// (after stripping ParenthesizedExpression wrappers, which ESTree elides)
+// must be a CallExpression with `node` as the callee. NewExpression is
+// NOT accepted: `new fn()` returns the new instance, not what `fn`
+// returns, so it doesn't propagate `this` through the walker's IIFE
+// arms. TS expression wrappers (`as` / `satisfies` / `!`) are also
+// intentionally NOT stripped — upstream's walker has no case for them.
 func isCalleeParenOnly(node *ast.Node) bool {
 	current := node
 	parent := current.Parent
@@ -714,13 +729,7 @@ func isCalleeParenOnly(node *ast.Node) bool {
 	if parent == nil {
 		return false
 	}
-	if ast.IsCallExpression(parent) && parent.AsCallExpression().Expression == current {
-		return true
-	}
-	if parent.Kind == ast.KindNewExpression && parent.AsNewExpression().Expression == current {
-		return true
-	}
-	return false
+	return ast.IsCallExpression(parent) && parent.AsCallExpression().Expression == current
 }
 
 // findEnclosingCall walks up from a function-like that has just been

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.md
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.md
@@ -1,0 +1,200 @@
+# no-invalid-this
+
+Disallow `this` keywords outside of classes or class-like objects.
+
+## Rule Details
+
+Under strict mode, `this` keywords outside of classes or class-like objects might be `undefined` and raise a `TypeError`.
+
+This rule judges from the following conditions whether or not the function is a constructor:
+
+- The name of the function starts with uppercase.
+- The function is assigned to a variable which starts with an uppercase letter.
+- The function is a constructor of ES2015 Classes.
+
+This rule judges from the following conditions whether or not the function is a method:
+
+- The function is on an object literal.
+- The function is assigned to a property.
+- The function is a method / getter / setter of ES2015 Classes.
+
+And this rule allows `this` keywords in functions below:
+
+- The `call` / `apply` / `bind` method of the function is called directly.
+- The function is a callback of array methods (such as `.forEach()`) if `thisArg` is given.
+- The function has an `@this` tag in its JSDoc comment.
+- The function declares an explicit `this` parameter (`function foo(this: SomeType)`).
+
+Otherwise, this rule warns on `this` keywords. It also reports `this` at the top level.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+this.a = 0;
+baz(() => this);
+
+(function () {
+  this.a = 0;
+  baz(() => this);
+})();
+
+function foo() {
+  this.a = 0;
+  baz(() => this);
+}
+
+var foo = function () {
+  this.a = 0;
+  baz(() => this);
+};
+
+foo(function () {
+  this.a = 0;
+  baz(() => this);
+});
+
+obj.foo = () => {
+  // `this` of arrow functions is the outer scope's.
+  this.a = 0;
+};
+
+var obj = {
+  aaa: function () {
+    return function foo() {
+      // There is a method `aaa`, but `foo` is not a method.
+      this.a = 0;
+      baz(() => this);
+    };
+  },
+};
+
+foo.forEach(function () {
+  this.a = 0;
+  baz(() => this);
+});
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+function Foo() {
+  // OK, legacy-style constructor.
+  this.a = 0;
+  baz(() => this);
+}
+
+class Foo {
+  constructor() {
+    this.a = 0;
+    baz(() => this);
+  }
+}
+
+var obj = {
+  foo() {
+    this.a = 0;
+  },
+};
+
+var obj = {
+  get foo() {
+    return this.a;
+  },
+};
+
+Object.defineProperty(obj, 'foo', {
+  value: function foo() {
+    this.a = 0;
+  },
+});
+
+obj.foo = function foo() {
+  this.a = 0;
+};
+
+class Foo {
+  foo() {
+    this.a = 0;
+    baz(() => this);
+  }
+
+  static foo() {
+    this.a = 0;
+    baz(() => this);
+  }
+}
+
+var foo = function foo() {
+  this.a = 0;
+}.bind(obj);
+
+foo.forEach(function () {
+  this.a = 0;
+  baz(() => this);
+}, thisArg);
+
+/** @this Foo */
+function foo() {
+  this.a = 0;
+}
+
+function foo(this: SomeType) {
+  this.a = 0;
+}
+```
+
+## Options
+
+### `capIsConstructor`
+
+**Type:** `boolean` — **Default:** `true`
+
+When `true`, the rule treats a function whose name starts with an uppercase letter (or which is assigned to such a variable) as an ES5 constructor — `this` inside is allowed. Set this option to `false` to treat capitalized-name functions as regular functions.
+
+Examples of **incorrect** code with `{ "capIsConstructor": false }`:
+
+```json
+{ "@typescript-eslint/no-invalid-this": ["error", { "capIsConstructor": false }] }
+```
+
+```typescript
+function Foo() {
+  this.a = 0;
+}
+
+var Bar = function () {
+  this.a = 0;
+};
+
+Baz = function () {
+  this.a = 0;
+};
+```
+
+Examples of **correct** code with `{ "capIsConstructor": false }`:
+
+```json
+{ "@typescript-eslint/no-invalid-this": ["error", { "capIsConstructor": false }] }
+```
+
+```typescript
+obj.Foo = function () {
+  // OK, assigned to a property.
+  this.a = 0;
+};
+
+class Foo {
+  constructor() {
+    this.a = 0;
+  }
+}
+```
+
+## When Not To Use It
+
+If you do not want to be notified about usage of the `this` keyword outside of classes or class-like objects, you can safely disable this rule.
+
+## Original Documentation
+
+- [typescript-eslint no-invalid-this](https://typescript-eslint.io/rules/no-invalid-this)
+- [ESLint no-invalid-this](https://eslint.org/docs/latest/rules/no-invalid-this)

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this_extras_test.go
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this_extras_test.go
@@ -1,0 +1,739 @@
+// TestNoInvalidThisExtras locks in branches and edge shapes that the
+// upstream typescript-eslint test suite doesn't exercise. Each case carries
+// an inline comment pointing at the specific branch / Dimension 4 row /
+// tsgo AST quirk it covers, so future refactors can't silently regress
+// them without breaking a named lock-in.
+package no_invalid_this
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoInvalidThisExtras(t *testing.T) {
+	unexpected := func(line, col int) []rule_tester.InvalidTestCaseError {
+		return []rule_tester.InvalidTestCaseError{
+			{MessageId: "unexpectedThis", Line: line, Column: col},
+		}
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoInvalidThisRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: paren-wrapped receiver on .bind/.call/.apply ----
+			// Parens are elided in ESTree so multi-level wrapping must not
+			// break the `.call`/`.bind`/`.apply` recognition.
+			{Code: `
+((function () {
+  this;
+})).call(obj);
+    `},
+			// ---- Dimension 4: paren chain around obj.foo = (paren-wrapped) ----
+			{Code: `
+obj.foo = ((function () {
+  this;
+}));
+    `},
+			// ---- Dimension 4: element access for `.bind` ----
+			// `obj['bind'](thisArg)` should be recognized just like `obj.bind(thisArg)`.
+			{Code: `
+(function () {
+  this;
+})['bind'](obj);
+    `},
+			// ---- Dimension 4: element access for `.call` ----
+			{Code: `
+(function () {
+  this;
+})['call'](obj);
+    `},
+			// ---- Dimension 4: element access for `.apply` ----
+			{Code: `
+(function () {
+  this;
+})['apply'](obj);
+    `},
+			// ---- Dimension 4: array method recognized through element access ----
+			// `arr['forEach'](fn, thisArg)` mirrors `arr.forEach(fn, thisArg)`.
+			{Code: `
+foo['forEach'](function () {
+  this;
+}, obj);
+    `},
+
+			// ---- Dimension 4: string-literal property key on object literal ----
+			{Code: `
+var obj = {
+  'foo': function () {
+    this;
+  },
+};
+    `},
+			// ---- Dimension 4: numeric-literal property key on object literal ----
+			{Code: `
+var obj = {
+  0: function () {
+    this;
+  },
+};
+    `},
+			// ---- Dimension 4: computed property key on object literal ----
+			{Code: `
+var obj = {
+  [key]: function () {
+    this;
+  },
+};
+    `},
+
+			// ---- Dimension 4: class expression with method ----
+			{Code: `
+const X = class {
+  foo() {
+    this;
+  }
+};
+    `},
+			// ---- Dimension 4: class expression with class field arrow ----
+			{Code: `
+const X = class {
+  foo = () => {
+    this;
+  };
+};
+    `},
+			// ---- Dimension 4: class field function expression ----
+			{Code: `
+class A {
+  foo = function () {
+    this;
+  };
+}
+    `},
+			// ---- Dimension 4: class with computed method key ----
+			{Code: `
+class A {
+  ['foo']() {
+    this;
+  }
+}
+    `},
+			// ---- Dimension 4: computed-key method body still gets a valid frame ----
+			// Even when the key is computed, `this` inside the body is the
+			// instance — confirm the deferred push lands before the body is
+			// visited and not too late.
+			{Code: `
+class A {
+  [Symbol.iterator]() {
+    this;
+  }
+}
+    `},
+			// ---- Dimension 4: computed-key class field body ----
+			{Code: `
+class A {
+  [Symbol.iterator] = function () {
+    this;
+  };
+}
+    `},
+			// ---- Dimension 4: object-literal method with computed key & body using `this` ----
+			// Confirms the computed-key deferral works on object literals too,
+			// where the method body's `this` is the object.
+			{Code: `
+var obj = {
+  ['foo']() {
+    this;
+  },
+};
+    `},
+			// ---- Wrapper-bug lock-in: `this` in computed key of class field is masked ----
+			// Upstream wrapper pushes `valid=true` on `PropertyDefinition` /
+			// `AccessorProperty` entry, which fires BEFORE the computed key
+			// is visited. The wrapper's `ThisExpression` listener then
+			// short-circuits and never delegates to baseRule, so the
+			// otherwise-valid report at top-level is silently masked. rslint
+			// reproduces this behavior verbatim for byte-level alignment with
+			// `@typescript-eslint/no-invalid-this`. A separate Layer-3 test
+			// (the method/accessor counterpart above) confirms that
+			// non-field computed keys still report correctly.
+			{Code: `
+class A {
+  [this.foo] = 1;
+}
+    `},
+			{Code: `
+class A {
+  accessor [this.foo] = 1;
+}
+    `},
+			// ---- Wrapper-bug lock-in: `this` in decorator on a field is masked ----
+			// PropertyDefinition / AccessorProperty push happens on entry,
+			// so decorators on these (visited after entry) see the field's
+			// frame and the report is silently swallowed. Methods don't
+			// share this masking (see Layer-3 method-decorator tests).
+			{Code: `
+class A {
+  @deco(this)
+  foo = 1;
+}
+    `},
+			{Code: `
+class A {
+  @deco(this)
+  accessor foo = 1;
+}
+    `},
+			// ---- Dimension 4: private method ----
+			{Code: `
+class A {
+  #foo() {
+    this;
+  }
+}
+    `},
+			// ---- Dimension 4: static method on class expression ----
+			{Code: `
+const X = class {
+  static foo() {
+    this;
+  }
+};
+    `},
+			// ---- Dimension 4: async method ----
+			{Code: `
+class A {
+  async foo() {
+    this;
+  }
+}
+    `},
+			// ---- Dimension 4: generator method ----
+			{Code: `
+class A {
+  *foo() {
+    this;
+  }
+}
+    `},
+			// ---- Dimension 4: async generator method ----
+			{Code: `
+class A {
+  async *foo() {
+    this;
+  }
+}
+    `},
+			// ---- Dimension 4: getter/setter on class ----
+			{Code: `
+class A {
+  get foo() {
+    return this;
+  }
+  set foo(v) {
+    this.v = v;
+  }
+}
+    `},
+			// ---- Dimension 4: empty class body ----
+			{Code: `
+class A {}
+    `},
+			// ---- Dimension 4: empty function body ----
+			{Code: `
+function foo() {}
+    `},
+			// ---- Dimension 4: abstract bodyless method does not crash ----
+			// Bodyless members never visit `this`, but ensure the visitor
+			// still pops correctly when they appear adjacent to bodied ones.
+			{Code: `
+abstract class A {
+  abstract foo(): void;
+  bar() {
+    this;
+  }
+}
+    `},
+			// ---- Dimension 4: overload signatures ----
+			{Code: `
+function foo(x: number): void;
+function foo(x: string): void;
+function foo(this: any, x: number | string): void {
+  this;
+}
+    `},
+			// ---- Dimension 4: class-in-class (inner method's `this` is inner instance) ----
+			{Code: `
+class A {
+  foo() {
+    class B {
+      bar() {
+        this;
+      }
+    }
+  }
+}
+    `},
+			// ---- Dimension 4: class static block ----
+			{Code: `
+class A {
+  static {
+    this;
+  }
+}
+    `},
+
+			// ---- Branch lock-in: LogicalExpression `&&` (upstream only tests `||`) ----
+			// Locks in upstream isDefaultThisBinding() LogicalExpression arm
+			// with `&&` operator — walker should treat as transparent.
+			{Code: `
+var obj = {
+  foo: maybeFn && function () {
+    this;
+  },
+};
+    `},
+			// ---- Branch lock-in: LogicalExpression `??` (nullish coalescing) ----
+			{Code: `
+var obj = {
+  foo: maybeFn ?? function () {
+    this;
+  },
+};
+    `},
+			// ---- Branch lock-in: nested `||` chains ----
+			{Code: `
+obj.foo = a || b || function () {
+  this;
+};
+    `},
+
+			// ---- Branch lock-in: BindingElement with uppercase name & default function ----
+			// Locks in upstream AssignmentPattern arm for declaration-style
+			// destructuring `var { Ctor = function(){} } = obj` (tsgo:
+			// BindingElement with `name=Ctor`, `initializer=function`).
+			{Code: `
+var { Ctor = function () {
+  this;
+} } = obj;
+    `},
+			// ---- Branch lock-in: BindingElement in array pattern ----
+			{Code: `
+var [Ctor = function () {
+  this;
+}] = arr;
+    `},
+			// ---- Branch lock-in: ShorthandPropertyAssignment with default function ----
+			// `({Ctor = function(){}} = obj)` — assignment-style destructuring.
+			// In tsgo the inner element is a ShorthandPropertyAssignment with
+			// `ObjectAssignmentInitializer`, distinct from BindingElement.
+			{Code: `
+({ Ctor = function () {
+  this;
+} } = obj);
+    `},
+
+			// ---- Branch lock-in: Reflect.apply with non-null thisArg ----
+			// Already covered upstream but lock in element-access form.
+			{Code: `
+Reflect['apply'](
+  function () {
+    this;
+  },
+  obj,
+  [],
+);
+    `},
+			// ---- Branch lock-in: Array.fromAsync with thisArg ----
+			{Code: `
+Array.fromAsync(
+  iter,
+  function () {
+    this;
+  },
+  obj,
+);
+    `},
+
+			// ---- Branch lock-in: findLast / findLastIndex / flatMap (less-tested array methods) ----
+			{Code: `
+foo.findLast(function () {
+  this;
+}, obj);
+    `},
+			{Code: `
+foo.findLastIndex(function () {
+  this;
+}, obj);
+    `},
+			{Code: `
+foo.flatMap(function () {
+  this;
+}, obj);
+    `},
+
+			// ---- Real-user: `this` inside the value position of a class field whose initializer is a paren-wrapped function expression ----
+			// Mirrors the "implicit method" patterns React class components use.
+			{Code: `
+class C {
+  handler = (function () {
+    this;
+  });
+}
+    `},
+			// ---- Real-user: `this` in an arrow callback inside a method ----
+			// Direct hit on lexical-`this` semantics; broken if arrows accidentally push.
+			{Code: `
+class C {
+  foo() {
+    setTimeout(() => {
+      this;
+    });
+  }
+}
+    `},
+			// ---- Real-user: callback wrapped with a typed @this-style JSDoc on the parent statement ----
+			{Code: `
+/** @this Mocha.Context */
+function setup() {
+  this.timeout(100);
+}
+    `},
+		},
+
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: `this` inside a computed method key (class) ----
+			// At class-evaluation time `this` is the surrounding scope, NOT
+			// the method's instance. The wrapper's FunctionExpression
+			// listener fires on the FE child (visited AFTER the key in
+			// ESTree), so the key's `this` is delegated to baseRule, which
+			// reports at top level.
+			{
+				Code: `
+class A {
+  [this.foo]() {}
+}
+      `,
+				Errors: unexpected(3, 4),
+			},
+			// ---- Dimension 4: `this` inside a computed accessor key ----
+			// Same reasoning: get/set accessors are method-like, so the
+			// wrapper masks the key's `this` only via baseRule (which reports).
+			{
+				Code: `
+class A {
+  get [this.foo]() {
+    return 1;
+  }
+}
+      `,
+				Errors: unexpected(3, 8),
+			},
+			// ---- Dimension 4: `this` inside a computed object-literal method key ----
+			{
+				Code: `
+var obj = {
+  [this.foo]() {},
+};
+      `,
+				Errors: unexpected(3, 4),
+			},
+			// ---- Dimension 4: `this` in decorator on a method ----
+			// Decorators on method-likes run at class-evaluation time, so
+			// the wrapper's `FunctionExpression` push (which fires on FE
+			// entry, AFTER decorators in ESTree) doesn't mask them.
+			// rslint compensates for tsgo's MethodDeclaration-is-the-FE
+			// collapse by peeking one frame deeper at `this` inside such
+			// a decorator.
+			{
+				Code: `
+class A {
+  @deco(this)
+  foo() {}
+}
+      `,
+				Errors: unexpected(3, 9),
+			},
+			{
+				Code: `
+class A {
+  @deco(this)
+  get foo() {
+    return 1;
+  }
+}
+      `,
+				Errors: unexpected(3, 9),
+			},
+			// ---- Branch lock-in: TS expression wrappers are opaque to the walker ----
+			// Upstream's `isDefaultThisBinding` has no case for
+			// `TSAsExpression` / `TSSatisfiesExpression` / `TSNonNullExpression`,
+			// so a function wrapped in any of them falls through to the
+			// default branch (default-bound, `this` reported). Locked in
+			// for all three so future "be smart about wrappers" refactors
+			// can't silently flip semantics.
+			{
+				Code: `
+(function () {
+  this;
+}!).call(obj);
+      `,
+				Errors: unexpected(3, 3),
+			},
+			{
+				Code: `
+(function () {
+  this;
+} as () => void).call(obj);
+      `,
+				Errors: unexpected(3, 3),
+			},
+			{
+				Code: `
+(function () {
+  this;
+} satisfies () => void).call(obj);
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Dimension 4: arrow inside decorator on method ----
+			// Arrow's `this` is lexical → captures decorator's scope (outer).
+			// The walker peeks past the arrow when deciding which stack
+			// frame applies.
+			{
+				Code: `
+class A {
+  @deco(() => this)
+  foo() {}
+}
+      `,
+				Errors: unexpected(3, 15),
+			},
+			// ---- Branch lock-in: auto-accessor with function-expression initializer ----
+			// ESLint's walker has no `AccessorProperty` case, so a function
+			// inside `accessor x = function(){}` falls through to default
+			// (default-bound, `this` is invalid). Regular fields stay valid
+			// because the walker DOES recognize `PropertyDefinition`.
+			{
+				Code: `
+class A {
+  accessor foo = function () {
+    this;
+  };
+}
+      `,
+				Errors: unexpected(4, 5),
+			},
+			// ---- Dimension 4: free function nested inside a method body ----
+			// Locks in that the method's frame doesn't shadow the inner
+			// function frame — the inner free function's `this` is reported.
+			{
+				Code: `
+class A {
+  foo() {
+    function bar() {
+      this;
+    }
+  }
+}
+      `,
+				Errors: unexpected(5, 7),
+			},
+			// ---- Dimension 4: free function nested inside an arrow body ----
+			// Arrow doesn't push, but the inner function does. The inner
+			// function is in default-binding context (the arrow body).
+			{
+				Code: `
+const f = () => {
+  function bar() {
+    this;
+  }
+};
+      `,
+				Errors: unexpected(4, 5),
+			},
+			// ---- Dimension 4: async generator at top level ----
+			{
+				Code: `
+async function* gen() {
+  this;
+}
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Dimension 4: arrow in static block — own `this` is class, but a nested function loses it ----
+			{
+				Code: `
+class A {
+  static {
+    function inner() {
+      this;
+    }
+  }
+}
+      `,
+				Errors: unexpected(5, 7),
+			},
+			// ---- Dimension 4: function declared in module top level (no enclosing class) ----
+			{
+				Code: `
+function foo() {
+  this;
+}
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Dimension 4: `.call` with `null` first arg (mirror of upstream `.bind(null)`) ----
+			{
+				Code: `
+(function () {
+  this;
+}).call(null);
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Dimension 4: `.apply` with no args ----
+			{
+				Code: `
+(function () {
+  this;
+}).apply();
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Dimension 4: element-access `.call` with null thisArg ----
+			{
+				Code: `
+(function () {
+  this;
+})['call'](null);
+      `,
+				Errors: unexpected(3, 3),
+			},
+
+			// ---- Branch lock-in: BinaryExpression non-= operator (e.g. +) ----
+			// Function in a non-assignment binary context — default binding.
+			// Locks in upstream isDefaultThisBinding default branch.
+			{
+				Code: `
+var x = 1 + function () {
+  return this;
+}();
+      `,
+				Errors: unexpected(3, 10),
+			},
+			// ---- Branch lock-in: comma operator's right operand ----
+			// tsgo collapses SequenceExpression onto BinaryExpression(',').
+			// ESLint's walker has no SequenceExpression case so it falls
+			// through to `default: return true`; we mirror that and the
+			// function is treated as default-bound.
+			{
+				Code: `
+obj.foo = (0, function () {
+  this;
+});
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Branch lock-in: `.call` without arguments ----
+			{
+				Code: `
+(function () {
+  this;
+}).call();
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Branch lock-in: Reflect.apply with too few args ----
+			{
+				Code: `
+Reflect.apply(function () {
+  this;
+});
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Branch lock-in: Array.from with too few args ----
+			{
+				Code: `
+Array.from([], function () {
+  this;
+});
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Branch lock-in: array method with thisArg=undefined ----
+			{
+				Code: `
+foo.forEach(function () {
+  this;
+}, undefined);
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Branch lock-in: non-callee member access `.call` (not invoked) ----
+			// `(function(){...}).call` without immediate invocation isn't .call binding.
+			{
+				Code: `
+var x = (function () {
+  return this;
+}).call;
+      `,
+				Errors: unexpected(3, 10),
+			},
+			// ---- Branch lock-in: BindingElement with lowercase name & default function ----
+			{
+				Code: `
+var { ctor = function () {
+  this;
+} } = obj;
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Branch lock-in: ShorthandPropertyAssignment with lowercase name & default function ----
+			{
+				Code: `
+({ ctor = function () {
+  this;
+} } = obj);
+      `,
+				Errors: unexpected(3, 3),
+			},
+
+			// ---- Real-user: `this` inside callback to an unknown method ----
+			// `arr.unknown(fn)` — `unknown` isn't in the array-method-with-thisArg
+			// allow list, so the callback's `this` is default-bound.
+			{
+				Code: `
+foo.reduce(function () {
+  this;
+});
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Real-user: chained method call resembles array method but isn't ----
+			{
+				Code: `
+foo.flatten(function () {
+  this;
+}, obj);
+      `,
+				Errors: unexpected(3, 3),
+			},
+			// ---- Real-user: `this` inside the value of a regular variable (no uppercase) ----
+			{
+				Code: `
+var func = function bar() {
+  this;
+};
+      `,
+				Errors: unexpected(3, 3),
+			},
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this_extras_test.go
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this_extras_test.go
@@ -189,6 +189,24 @@ class A {
   accessor foo = 1;
 }
     `},
+			// ---- Lock-in: `this` in decorator of a computed-key method nested in another method ----
+			// `class A { foo() { class B { @deco(this) [bar]() {} } } }`:
+			// `this` in the decorator resolves to `foo`'s frame (the
+			// surrounding scope), which is on top of stack at decorator
+			// visit time because B.bar's frame is deferred until
+			// `ComputedPropertyName:exit`. Without the "skip 0 if computed-key"
+			// branch in the `ThisExpression` listener, the listener would
+			// peek past `foo`'s frame and falsely report.
+			{Code: `
+class A {
+  foo() {
+    class B {
+      @deco(this)
+      [bar]() {}
+    }
+  }
+}
+    `},
 			// ---- Dimension 4: private method ----
 			{Code: `
 class A {
@@ -311,6 +329,23 @@ var obj = {
 obj.foo = a || b || function () {
   this;
 };
+    `},
+
+			// ---- Branch lock-in: Unicode uppercase identifier under capIsConstructor ----
+			// Upstream's `startsWithUpperCase` uses `s[0] !== s[0].toLocaleLowerCase()`,
+			// which captures any non-ASCII uppercase letter (and Lt
+			// title-case letters), not just ASCII A-Z. Anonymous functions
+			// assigned to such a name must therefore be treated as ES5
+			// constructors.
+			{Code: `
+var Ω = function () {
+  this;
+};
+    `},
+			{Code: `
+function Ω() {
+  this;
+}
     `},
 
 			// ---- Branch lock-in: BindingElement with uppercase name & default function ----
@@ -470,6 +505,42 @@ class A {
       `,
 				Errors: unexpected(3, 9),
 			},
+			// ---- Branch lock-in: `this` in decorator on a computed-key method ----
+			// Computed-key method-likes defer their frame push to
+			// `ComputedPropertyName:exit`, which runs AFTER the decorator
+			// visit. The stack top at decorator time is therefore already
+			// the surrounding scope, NOT the method's frame — so the
+			// peek-one-deeper compensation must NOT apply here. Locked in
+			// because forgetting this distinction either over-reports
+			// (peek deeper than necessary) or under-reports.
+			{
+				Code: `
+class A {
+  @deco(this)
+  [bar]() {}
+}
+      `,
+				Errors: unexpected(3, 9),
+			},
+
+			// ---- Branch lock-in: NewExpression is not an IIFE in upstream's walker ----
+			// Upstream's `isCallee` is strictly `parent.type === "CallExpression"`,
+			// so `new (function() { return function() { this; }; })()` does
+			// NOT propagate through the ReturnStatement IIFE arm: the outer
+			// function is a NewExpression callee, not a CallExpression
+			// callee. The inner function therefore falls through to the
+			// walker's default (default-bound, `this` reported).
+			{
+				Code: `
+new (function () {
+  return function () {
+    this;
+  };
+})();
+      `,
+				Errors: unexpected(4, 5),
+			},
+
 			// ---- Branch lock-in: TS expression wrappers are opaque to the walker ----
 			// Upstream's `isDefaultThisBinding` has no case for
 			// `TSAsExpression` / `TSSatisfiesExpression` / `TSNonNullExpression`,

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this_upstream_test.go
@@ -1,0 +1,908 @@
+// TestNoInvalidThisUpstream migrates the full valid/invalid suite from
+// upstream typescript-eslint's
+//
+//	packages/eslint-plugin/tests/rules/no-invalid-this.test.ts
+//
+// 1:1. Position assertions cover line/column for every invalid case
+// (the upstream typescript-eslint suite only asserts messageId, so this
+// layer adds line/column to satisfy the rslint requirement that invalid
+// cases pin position).
+//
+// rslint-specific lock-in cases (Dimension 4 edge shapes, branch lock-ins,
+// real-user issue shapes) live in no_invalid_this_extras_test.go.
+package no_invalid_this
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// objectOption produces the array-wrapped option shape that exercises
+// utils.GetOptionsMap's JSON path. Passing a typed struct directly would
+// short-circuit the JSON round-trip and leave the CLI-facing wiring untested.
+func objectOption(opts map[string]interface{}) []interface{} {
+	return []interface{}{opts}
+}
+
+func TestNoInvalidThisUpstream(t *testing.T) {
+	// `unexpected` is the standard 1-error shape used by single-`this` cases.
+	unexpected := func(line, col int) []rule_tester.InvalidTestCaseError {
+		return []rule_tester.InvalidTestCaseError{
+			{MessageId: "unexpectedThis", Line: line, Column: col},
+		}
+	}
+	// `unexpected2` is the standard 2-error shape: outer `this` + the
+	// trailing `z(x => console.log(x, this));` arrow `this`. Used by the
+	// vast majority of upstream invalid cases.
+	unexpected2 := func(line1, col1, line2, col2 int) []rule_tester.InvalidTestCaseError {
+		return []rule_tester.InvalidTestCaseError{
+			{MessageId: "unexpectedThis", Line: line1, Column: col1},
+			{MessageId: "unexpectedThis", Line: line2, Column: col2},
+		}
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoInvalidThisRule,
+		[]rule_tester.ValidTestCase{
+			// ---- TypeScript-specific: `this` parameter ----
+			{Code: `
+describe('foo', () => {
+  it('does something', function (this: Mocha.Context) {
+    this.timeout(100);
+    // done
+  });
+});
+    `},
+			{Code: `
+      interface SomeType {
+        prop: string;
+      }
+      function foo(this: SomeType) {
+        this.prop;
+      }
+    `},
+			{Code: `
+function foo(this: prop) {
+  this.propMethod();
+}
+    `},
+			{Code: `
+z(function (x, this: context) {
+  console.log(x, this);
+});
+    `},
+
+			// ---- @this JSDoc tag on nested function (eslint #3287) ----
+			{Code: `
+function foo() {
+  /** @this Obj*/ return function bar() {
+    console.log(this);
+    z(x => console.log(x, this));
+  };
+}
+    `},
+
+			// ---- uppercase-named variable initializer (eslint #6824) ----
+			{Code: `
+var Ctor = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+    `},
+
+			// ---- Constructors (capIsConstructor: true is the default) ----
+			{Code: `
+function Foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      `},
+			{
+				Code: `
+function Foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      `,
+				Options: objectOption(map[string]interface{}{}),
+			},
+			{
+				Code: `
+function Foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      `,
+				Options: objectOption(map[string]interface{}{"capIsConstructor": true}),
+			},
+			{Code: `
+var Foo = function Foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      `},
+			{Code: `
+class A {
+  constructor() {
+    console.log(this);
+    z(x => console.log(x, this));
+  }
+}
+      `},
+
+			// ---- On a property ----
+			{Code: `
+var obj = {
+  foo: function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+};
+      `},
+			{Code: `
+var obj = {
+  foo() {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+};
+      `},
+			{Code: `
+var obj = {
+  foo:
+    foo ||
+    function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    },
+};
+      `},
+			{Code: `
+var obj = {
+  foo: hasNative
+    ? foo
+    : function () {
+        console.log(this);
+        z(x => console.log(x, this));
+      },
+};
+      `},
+			{Code: `
+var obj = {
+  foo: (function () {
+    return function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    };
+  })(),
+};
+      `},
+			{Code: `
+Object.defineProperty(obj, 'foo', {
+  value: function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+});
+      `},
+			{Code: `
+Object.defineProperties(obj, {
+  foo: {
+    value: function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    },
+  },
+});
+      `},
+
+			// ---- Assigns to a property ----
+			{Code: `
+obj.foo = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      `},
+			{Code: `
+obj.foo =
+  foo ||
+  function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  };
+      `},
+			{Code: `
+obj.foo = foo
+  ? bar
+  : function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    };
+      `},
+			{Code: `
+obj.foo = (function () {
+  return function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  };
+})();
+      `},
+			{Code: `
+obj.foo = (() =>
+  function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  })();
+      `},
+
+			// ---- Bind/Call/Apply ----
+			{Code: `
+(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}).call(obj);
+    `},
+			{Code: `
+var foo = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}.bind(obj);
+    `},
+			{Code: `
+Reflect.apply(
+  function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+  obj,
+  [],
+);
+    `},
+			{Code: `
+(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}).apply(obj);
+    `},
+
+			// ---- Class Instance Methods ----
+			{Code: `
+class A {
+  foo() {
+    console.log(this);
+    z(x => console.log(x, this));
+  }
+}
+    `},
+
+			// ---- Class Properties (regular fields) ----
+			{Code: `
+class A {
+  b = 0;
+  c = this.b;
+}
+    `},
+			{Code: `
+class A {
+  b = new Array(this, 1, 2, 3);
+}
+    `},
+			{Code: `
+class A {
+  b = () => {
+    console.log(this);
+  };
+}
+    `},
+
+			// ---- Array methods with thisArg ----
+			{Code: `
+Array.from(
+  [],
+  function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+  obj,
+);
+    `},
+			{Code: `
+foo.every(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}, obj);
+    `},
+			{Code: `
+foo.filter(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}, obj);
+    `},
+			{Code: `
+foo.find(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}, obj);
+    `},
+			{Code: `
+foo.findIndex(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}, obj);
+    `},
+			{Code: `
+foo.forEach(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}, obj);
+    `},
+			{Code: `
+foo.map(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}, obj);
+    `},
+			{Code: `
+foo.some(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}, obj);
+    `},
+
+			// ---- @this tag ----
+			{Code: `
+/** @this Obj */ function foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+    `},
+			{Code: `
+foo(
+  /* @this Obj */ function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+);
+    `},
+			{Code: `
+/**
+ * @returns {void}
+ * @this Obj
+ */
+function foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+    `},
+
+			// ---- Uppercase assignment / parameter default / destructuring ----
+			{Code: `
+Ctor = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+    `},
+			{Code: `
+function foo(
+  Ctor = function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+) {}
+    `},
+			{Code: `
+[
+  obj.method = function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+] = a;
+    `},
+
+			// ---- Static methods & auto-accessor class properties ----
+			{Code: `
+class A {
+  static foo() {
+    console.log(this);
+    z(x => console.log(x, this));
+  }
+}
+    `},
+			{Code: `
+class A {
+  a = 5;
+  b = this.a;
+  accessor c = this.a;
+}
+    `},
+		},
+
+		[]rule_tester.InvalidTestCase{
+			// ---- Interface + free function ----
+			{
+				Code: `
+interface SomeType {
+  prop: string;
+}
+function foo() {
+  this.prop;
+}
+      `,
+				Errors: unexpected(6, 3),
+			},
+
+			// ---- Global (top-level `this`) ----
+			{
+				Code: `
+console.log(this);
+z(x => console.log(x, this));
+      `,
+				Errors: unexpected2(2, 13, 3, 23),
+			},
+			{
+				Code: `
+console.log(this);
+z(x => console.log(x, this));
+      `,
+				Errors: unexpected2(2, 13, 3, 23),
+				// Upstream sets parserOptions.ecmaFeatures.globalReturn:true.
+				// rslint does not expose ecmaFeatures; the module-default
+				// behavior gives the same diagnostics so the case still
+				// locks in the expected output. See no_invalid_this.md
+				// "Differences from ESLint" for the broader divergence.
+			},
+
+			// ---- IIFE ----
+			{
+				Code: `
+(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+})();
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+
+			// ---- Just functions ----
+			{
+				Code: `
+function foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+function foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      `,
+				Options: objectOption(map[string]interface{}{"capIsConstructor": false}),
+				Errors:  unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+function Foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      `,
+				Options: objectOption(map[string]interface{}{"capIsConstructor": false}),
+				Errors:  unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+function foo() {
+  'use strict';
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      `,
+				Errors: unexpected2(4, 15, 5, 25),
+			},
+			{
+				Code: `
+function Foo() {
+  'use strict';
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      `,
+				Options: objectOption(map[string]interface{}{"capIsConstructor": false}),
+				Errors:  unexpected2(4, 15, 5, 25),
+			},
+			{
+				// SKIP: rslint does not support ESLint's parserOptions.ecmaFeatures.globalReturn,
+				// without which a top-level `return` is a parse error.
+				Skip: true,
+				Code: `
+return function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+var foo = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}.bar(obj);
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+
+			// ---- Functions in methods ----
+			{
+				Code: `
+var obj = {
+  foo: function () {
+    function foo() {
+      console.log(this);
+      z(x => console.log(x, this));
+    }
+    foo();
+  },
+};
+      `,
+				Errors: unexpected2(5, 19, 6, 29),
+			},
+			{
+				Code: `
+var obj = {
+  foo() {
+    function foo() {
+      console.log(this);
+      z(x => console.log(x, this));
+    }
+    foo();
+  },
+};
+      `,
+				Errors: unexpected2(5, 19, 6, 29),
+			},
+			{
+				Code: `
+var obj = {
+  foo: function () {
+    return function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    };
+  },
+};
+      `,
+				Errors: unexpected2(5, 19, 6, 29),
+			},
+			{
+				Code: `
+var obj = {
+  foo: function () {
+    'use strict';
+    return function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    };
+  },
+};
+      `,
+				Errors: unexpected2(6, 19, 7, 29),
+			},
+			{
+				Code: `
+obj.foo = function () {
+  return function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  };
+};
+      `,
+				Errors: unexpected2(4, 17, 5, 27),
+			},
+			{
+				Code: `
+obj.foo = function () {
+  'use strict';
+  return function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  };
+};
+      `,
+				Errors: unexpected2(5, 17, 6, 27),
+			},
+
+			// ---- Class Methods (function returned from method) ----
+			{
+				Code: `
+class A {
+  foo() {
+    return function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    };
+  }
+}
+      `,
+				Errors: unexpected2(5, 19, 6, 29),
+			},
+
+			// ---- Class Properties (free function in field initializer) ----
+			{
+				Code: `
+class A {
+  b = new Array(1, 2, function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  });
+}
+      `,
+				Errors: unexpected2(4, 17, 5, 27),
+			},
+			{
+				Code: `
+class A {
+  b = () => {
+    function c() {
+      console.log(this);
+      z(x => console.log(x, this));
+    }
+  };
+}
+      `,
+				Errors: unexpected2(5, 19, 6, 29),
+			},
+
+			// ---- Class Static methods (arrows returned from IIFE assigned to obj) ----
+			{
+				Code: `
+obj.foo = (function () {
+  return () => {
+    console.log(this);
+    z(x => console.log(x, this));
+  };
+})();
+      `,
+				Errors: unexpected2(4, 17, 5, 27),
+			},
+			{
+				Code: `
+obj.foo = (() => () => {
+  console.log(this);
+  z(x => console.log(x, this));
+})();
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+
+			// ---- Bind/Call/Apply with null/undefined thisArg ----
+			{
+				Code: `
+var foo = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}.bind(null);
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}).call(undefined);
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}).apply(void 0);
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+
+			// ---- Array methods without thisArg ----
+			{
+				Code: `
+Array.from([], function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+foo.every(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+foo.filter(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+foo.find(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+foo.findIndex(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+foo.forEach(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+foo.map(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+foo.some(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+
+			// ---- Array method with null thisArg ----
+			{
+				Code: `
+foo.forEach(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}, null);
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+
+			// ---- @this tag absent ----
+			{
+				Code: `
+/** @returns {void} */ function foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				// @this on the outer CallExpression doesn't apply to the function argument.
+				Code: `
+/** @this Obj */ foo(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+
+			// ---- capIsConstructor:false disables uppercase recognition ----
+			{
+				Code: `
+var Ctor = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      `,
+				Options: objectOption(map[string]interface{}{"capIsConstructor": false}),
+				Errors:  unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+var func = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+var func = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      `,
+				Options: objectOption(map[string]interface{}{"capIsConstructor": false}),
+				Errors:  unexpected2(3, 15, 4, 25),
+			},
+
+			{
+				Code: `
+Ctor = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      `,
+				Options: objectOption(map[string]interface{}{"capIsConstructor": false}),
+				Errors:  unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+func = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      `,
+				Errors: unexpected2(3, 15, 4, 25),
+			},
+			{
+				Code: `
+func = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      `,
+				Options: objectOption(map[string]interface{}{"capIsConstructor": false}),
+				Errors:  unexpected2(3, 15, 4, 25),
+			},
+
+			{
+				Code: `
+function foo(
+  func = function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+) {}
+      `,
+				Errors: unexpected2(4, 17, 5, 27),
+			},
+
+			{
+				Code: `
+[
+  func = function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+] = a;
+      `,
+				Errors: unexpected2(4, 17, 5, 27),
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -263,7 +263,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-import-type-side-effects.test.ts',
     './tests/typescript-eslint/rules/no-implied-eval.test.ts',
     './tests/typescript-eslint/rules/no-inferrable-types.test.ts',
-    // './tests/typescript-eslint/rules/no-invalid-this.test.ts',
+    './tests/typescript-eslint/rules/no-invalid-this.test.ts',
     './tests/typescript-eslint/rules/no-invalid-void-type.test.ts',
     './tests/typescript-eslint/rules/no-loop-func.test.ts',
     // './tests/typescript-eslint/rules/no-loss-of-precision.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-invalid-this.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-invalid-this.test.ts.snap
@@ -1,0 +1,2050 @@
+// Rstest Snapshot v1
+
+exports[`no-invalid-this > invalid 1`] = `
+{
+  "code": "
+interface SomeType {
+  prop: string;
+}
+function foo() {
+  this.prop;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 2`] = `
+{
+  "code": "
+console.log(this);
+z(x => console.log(x, this));
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 2,
+        },
+        "start": {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 23,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 3`] = `
+{
+  "code": "
+console.log(this);
+z(x => console.log(x, this));
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 2,
+        },
+        "start": {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 23,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 4`] = `
+{
+  "code": "
+(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+})();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 5`] = `
+{
+  "code": "
+function foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 6`] = `
+{
+  "code": "
+function foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 7`] = `
+{
+  "code": "
+function Foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 8`] = `
+{
+  "code": "
+function foo() {
+  'use strict';
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 5,
+        },
+        "start": {
+          "column": 25,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 9`] = `
+{
+  "code": "
+function Foo() {
+  'use strict';
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 5,
+        },
+        "start": {
+          "column": 25,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 10`] = `
+{
+  "code": "
+return function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 11`] = `
+{
+  "code": "
+var foo = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}.bar(obj);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 12`] = `
+{
+  "code": "
+var obj = {
+  foo: function () {
+    function foo() {
+      console.log(this);
+      z(x => console.log(x, this));
+    }
+    foo();
+  },
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 6,
+        },
+        "start": {
+          "column": 29,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 13`] = `
+{
+  "code": "
+var obj = {
+  foo() {
+    function foo() {
+      console.log(this);
+      z(x => console.log(x, this));
+    }
+    foo();
+  },
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 6,
+        },
+        "start": {
+          "column": 29,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 14`] = `
+{
+  "code": "
+var obj = {
+  foo: function () {
+    return function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    };
+  },
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 6,
+        },
+        "start": {
+          "column": 29,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 15`] = `
+{
+  "code": "
+var obj = {
+  foo: function () {
+    'use strict';
+    return function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    };
+  },
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 6,
+        },
+        "start": {
+          "column": 19,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 7,
+        },
+        "start": {
+          "column": 29,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 16`] = `
+{
+  "code": "
+obj.foo = function () {
+  return function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  };
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 5,
+        },
+        "start": {
+          "column": 27,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 17`] = `
+{
+  "code": "
+obj.foo = function () {
+  'use strict';
+  return function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  };
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 5,
+        },
+        "start": {
+          "column": 17,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 6,
+        },
+        "start": {
+          "column": 27,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 18`] = `
+{
+  "code": "
+class A {
+  foo() {
+    return function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    };
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 6,
+        },
+        "start": {
+          "column": 29,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 19`] = `
+{
+  "code": "
+class A {
+  b = new Array(1, 2, function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  });
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 5,
+        },
+        "start": {
+          "column": 27,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 20`] = `
+{
+  "code": "
+class A {
+  b = () => {
+    function c() {
+      console.log(this);
+      z(x => console.log(x, this));
+    }
+  };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 6,
+        },
+        "start": {
+          "column": 29,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 21`] = `
+{
+  "code": "
+obj.foo = (function () {
+  return () => {
+    console.log(this);
+    z(x => console.log(x, this));
+  };
+})();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 5,
+        },
+        "start": {
+          "column": 27,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 22`] = `
+{
+  "code": "
+obj.foo = (() => () => {
+  console.log(this);
+  z(x => console.log(x, this));
+})();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 23`] = `
+{
+  "code": "
+var foo = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}.bind(null);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 24`] = `
+{
+  "code": "
+(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}).call(undefined);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 25`] = `
+{
+  "code": "
+(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}).apply(void 0);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 26`] = `
+{
+  "code": "
+Array.from([], function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 27`] = `
+{
+  "code": "
+foo.every(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 28`] = `
+{
+  "code": "
+foo.filter(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 29`] = `
+{
+  "code": "
+foo.find(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 30`] = `
+{
+  "code": "
+foo.findIndex(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 31`] = `
+{
+  "code": "
+foo.forEach(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 32`] = `
+{
+  "code": "
+foo.map(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 33`] = `
+{
+  "code": "
+foo.some(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 34`] = `
+{
+  "code": "
+foo.forEach(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+}, null);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 35`] = `
+{
+  "code": "
+/** @returns {void} */ function foo() {
+  console.log(this);
+  z(x => console.log(x, this));
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 36`] = `
+{
+  "code": "
+/** @this Obj */ foo(function () {
+  console.log(this);
+  z(x => console.log(x, this));
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 37`] = `
+{
+  "code": "
+var Ctor = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 38`] = `
+{
+  "code": "
+var func = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 39`] = `
+{
+  "code": "
+var func = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 40`] = `
+{
+  "code": "
+Ctor = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 41`] = `
+{
+  "code": "
+func = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 42`] = `
+{
+  "code": "
+func = function () {
+  console.log(this);
+  z(x => console.log(x, this));
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 43`] = `
+{
+  "code": "
+function foo(
+  func = function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 5,
+        },
+        "start": {
+          "column": 27,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-invalid-this > invalid 44`] = `
+{
+  "code": "
+[
+  func = function () {
+    console.log(this);
+    z(x => console.log(x, this));
+  },
+] = a;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+    {
+      "message": "Unexpected 'this'.",
+      "messageId": "unexpectedThis",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 5,
+        },
+        "start": {
+          "column": 27,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-invalid-this",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the [`@typescript-eslint/no-invalid-this`](https://typescript-eslint.io/rules/no-invalid-this) rule from typescript-eslint to rslint.

The rule disallows \`this\` keywords outside of classes or class-like objects. The TypeScript-aware version extends ESLint's core \`no-invalid-this\` with two additional recognitions: functions that declare an explicit \`this\` parameter (\`function foo(this: T)\`) and class auto-accessor field initializers (\`accessor x = ...\`).

The port matches upstream behavior byte-for-byte on the full upstream test suite (47 valid + 44 invalid cases, 1 case using ESLint's \`parserOptions.ecmaFeatures.globalReturn\` is \`Skip:true\` with reason since rslint doesn't expose that framework option). Extras layer adds 46 valid + 30 invalid lock-in cases covering Dimension 4 universal edge shapes (paren-wrapped / element-access / async / generator / private members, class-in-class, static blocks, empty bodies, abstract / overload signatures, computed-key timing for methods vs fields, decorator timing for methods vs fields, TS expression wrapper opacity matching ESLint's no-case behavior), upstream branch lock-ins (\`&&\` / \`??\` operators, BindingElement / ShorthandPropertyAssignment destructuring defaults, \`findLast\` / \`findLastIndex\` / \`flatMap\` / \`Array.fromAsync\`, \`.call\` / \`.bind\` / \`.apply\` via element access, comma operator default branch), and real-user shapes from the upstream GitHub issue tracker.

Smoke-tested by running the rule against \`web-infra-dev/rsbuild\` and \`web-infra-dev/rspack\`: 87 reports total, every one matching ESLint's expected output on the same code (loader functions / Jest matcher helpers / plugin factories where TS type annotations carry \`this\` but the function expression itself lacks the parameter).

## Related Links

- typescript-eslint rule: https://typescript-eslint.io/rules/no-invalid-this
- typescript-eslint source: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-invalid-this.ts
- ESLint base rule: https://eslint.org/docs/latest/rules/no-invalid-this
- ESLint base source: https://github.com/eslint/eslint/blob/main/lib/rules/no-invalid-this.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).