### PR TITLE
feat: port rule @typescript-eslint/no-unnecessary-parameter-property-assignment

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_this_alias"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_condition"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_qualifier"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_template_expression"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_arguments"
@@ -594,6 +595,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-shadow", ts_no_shadow.NoShadowRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-boolean-literal-compare", no_unnecessary_boolean_literal_compare.NoUnnecessaryBooleanLiteralCompareRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-condition", no_unnecessary_condition.NoUnnecessaryConditionRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-parameter-property-assignment", no_unnecessary_parameter_property_assignment.NoUnnecessaryParameterPropertyAssignmentRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-qualifier", no_unnecessary_qualifier.NoUnnecessaryQualifierRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-template-expression", no_unnecessary_template_expression.NoUnnecessaryTemplateExpressionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-type-arguments", no_unnecessary_type_arguments.NoUnnecessaryTypeArgumentsRule)

--- a/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment.go
@@ -138,6 +138,7 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 			}
 
 			funcNode := findParentFunction(node)
+			info := top()
 
 			// Constructor listener — mirrors upstream's
 			// `MethodDefinition[kind='constructor'] > FunctionExpression
@@ -150,7 +151,7 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 				}
 			}
 			if ctorFunc != nil && ctorFunc.Kind == ast.KindConstructor {
-				handleConstructor(ctx, top(), bin, leftName, op, ctorFunc)
+				handleConstructor(ctx, info, bin, leftName, op, ctorFunc)
 			}
 
 			// PropertyDefinition listener — mirrors upstream's
@@ -158,7 +159,7 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 			// fire independently in upstream and may both apply to the same
 			// assignment (e.g. a nested class field initializer inside an
 			// outer constructor); we mirror that by running both arms here.
-			handlePropertyDef(top(), funcNode, node, leftName)
+			handlePropertyDef(info, funcNode, node, leftName)
 		},
 	}
 }
@@ -288,8 +289,8 @@ func getPropertyName(left *ast.Node) (string, bool) {
 		// Mirror ESTree's paren-elision: `(this).foo` is identical to
 		// `this.foo` in upstream's AST, so we strip the receiver's parens
 		// before the ThisKeyword check.
-		if ast.SkipParentheses(pa.Expression) == nil ||
-			ast.SkipParentheses(pa.Expression).Kind != ast.KindThisKeyword {
+		receiver := ast.SkipParentheses(pa.Expression)
+		if receiver == nil || receiver.Kind != ast.KindThisKeyword {
 			return "", false
 		}
 		name := pa.Name()
@@ -299,8 +300,8 @@ func getPropertyName(left *ast.Node) (string, bool) {
 		return name.AsIdentifier().Text, true
 	case ast.KindElementAccessExpression:
 		ea := left.AsElementAccessExpression()
-		if ast.SkipParentheses(ea.Expression) == nil ||
-			ast.SkipParentheses(ea.Expression).Kind != ast.KindThisKeyword {
+		receiver := ast.SkipParentheses(ea.Expression)
+		if receiver == nil || receiver.Kind != ast.KindThisKeyword {
 			return "", false
 		}
 		// Index argument is also paren-elided in ESTree, so unwrap before
@@ -353,10 +354,15 @@ func iifeCallOfArrow(arrow *ast.Node) *ast.Node {
 }
 
 // getIdentifier unwraps the right-hand side through `as` / `!` (TSAsExpression
-// / TSNonNullExpression in upstream) to find a bare Identifier. Parentheses
-// and `satisfies` are intentionally NOT unwrapped — upstream's recursion only
-// peels those two specific wrapper kinds, and we mirror the set exactly so
-// `this.foo = (foo)` doesn't report despite the lexically-identical name.
+// / TSNonNullExpression in upstream) to find a bare Identifier. Parens ARE
+// stripped via ast.SkipParentheses so the function tracks upstream's behavior
+// on the ESTree AST (which elides ParenthesizedExpression entirely) — e.g.
+// `this.foo = (foo)` is reported by upstream because in ESTree the right-hand
+// side IS the Identifier; tsgo preserves the wrapping ParenthesizedExpression,
+// so we must skip it explicitly to align. SatisfiesExpression and other
+// wrappers are intentionally left alone — upstream's switch lists only
+// TSAsExpression and TSNonNullExpression, so anything else falls through to
+// the default `return null` arm.
 func getIdentifier(node *ast.Node) *ast.Node {
 	node = ast.SkipParentheses(node)
 	if node == nil {

--- a/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment.go
@@ -1,0 +1,417 @@
+package no_unnecessary_parameter_property_assignment
+
+import (
+	"sort"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// NoUnnecessaryParameterPropertyAssignmentRule mirrors
+// @typescript-eslint/no-unnecessary-parameter-property-assignment.
+//
+// It flags `this.X = X` (and the `||= && ??= && &&=` variants) inside a
+// constructor body whenever the constructor itself declares a parameter
+// property named X — the parameter-property syntax already performs the
+// assignment, so the explicit one is redundant.
+//
+// https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment
+// Upstream source: packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts
+var NoUnnecessaryParameterPropertyAssignmentRule = rule.CreateRule(rule.Rule{
+	Name:             "no-unnecessary-parameter-property-assignment",
+	RequiresTypeInfo: true,
+	Run:              run,
+})
+
+// reportInfo mirrors upstream's per-ClassBody stack frame.
+//
+//   - assignedBeforeConstructor: property names that are assigned in a class
+//     field initializer (directly, or via an arrow IIFE whose CallExpression
+//     is the PropertyDeclaration.Initializer). If a name shows up here, any
+//     `this.X = X` candidate that already landed in unnecessaryAssignments is
+//     suppressed on ClassBody:exit.
+//   - assignedBeforeUnnecessary: property names that received a non-unnecessary
+//     assignment operator (`+=`, `-=`, …) earlier in the SAME constructor —
+//     a later `this.X = X` is then treated as a re-assignment, not a redundant
+//     one, and won't be pushed.
+//   - unnecessaryAssignments: candidate `this.X = X` (or `||= && ??= && &&=`)
+//     assignments that survived the assignedBeforeUnnecessary gate; reported on
+//     ClassBody:exit unless suppressed by assignedBeforeConstructor.
+type reportInfo struct {
+	assignedBeforeConstructor map[string]bool
+	assignedBeforeUnnecessary map[string]bool
+	unnecessaryAssignments    []unnecessaryAssignment
+}
+
+type unnecessaryAssignment struct {
+	name string
+	node *ast.Node
+}
+
+func run(ctx rule.RuleContext, options any) rule.RuleListeners {
+	var stack []*reportInfo
+	// fileBuffer accumulates unsuppressed unnecessary assignments across all
+	// classes visited so far. The linter doesn't sort diagnostics, and visit
+	// order (inner class exit before outer class exit) doesn't match the
+	// expected source-position order — so we hold reports until the
+	// OUTERMOST class exit, sort by Pos, then emit. Reset after each flush
+	// so multiple sibling top-level classes don't bleed into each other.
+	var fileBuffer []unnecessaryAssignment
+
+	push := func() {
+		stack = append(stack, &reportInfo{
+			assignedBeforeConstructor: map[string]bool{},
+			assignedBeforeUnnecessary: map[string]bool{},
+		})
+	}
+
+	pop := func() *reportInfo {
+		if len(stack) == 0 {
+			return nil
+		}
+		top := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		return top
+	}
+
+	top := func() *reportInfo {
+		if len(stack) == 0 {
+			return nil
+		}
+		return stack[len(stack)-1]
+	}
+
+	msg := rule.RuleMessage{
+		Id:          "unnecessaryAssign",
+		Description: "This assignment is unnecessary since it is already assigned by a parameter property.",
+	}
+
+	enterClass := func(*ast.Node) { push() }
+	exitClass := func(*ast.Node) {
+		info := pop()
+		if info == nil {
+			return
+		}
+		for _, ua := range info.unnecessaryAssignments {
+			if info.assignedBeforeConstructor[ua.name] {
+				continue
+			}
+			fileBuffer = append(fileBuffer, ua)
+		}
+		// Outermost class just exited — flush in source-position order.
+		// Sibling top-level classes flush independently, so reports for
+		// earlier classes are emitted before later ones (matching how
+		// ESLint sorts its diagnostics).
+		if len(stack) == 0 && len(fileBuffer) > 0 {
+			sort.SliceStable(fileBuffer, func(i, j int) bool {
+				return fileBuffer[i].node.Pos() < fileBuffer[j].node.Pos()
+			})
+			for _, ua := range fileBuffer {
+				ctx.ReportNode(ua.node, msg)
+			}
+			fileBuffer = fileBuffer[:0]
+		}
+	}
+
+	return rule.RuleListeners{
+		// tsgo doesn't have a separate ClassBody node — the class declaration /
+		// expression IS the body. Push/pop on the class node itself.
+		ast.KindClassDeclaration:                      enterClass,
+		rule.ListenerOnExit(ast.KindClassDeclaration): exitClass,
+		ast.KindClassExpression:                       enterClass,
+		rule.ListenerOnExit(ast.KindClassExpression):  exitClass,
+
+		ast.KindBinaryExpression: func(node *ast.Node) {
+			bin := node.AsBinaryExpression()
+			op := bin.OperatorToken.Kind
+			if !ast.IsAssignmentOperator(op) {
+				return
+			}
+			if len(stack) == 0 {
+				return
+			}
+
+			leftName, ok := getPropertyName(bin.Left)
+			if !ok {
+				return
+			}
+
+			funcNode := findParentFunction(node)
+
+			// Constructor listener — mirrors upstream's
+			// `MethodDefinition[kind='constructor'] > FunctionExpression
+			// AssignmentExpression`. Arrow IIFE wrappers between the
+			// assignment and the constructor are transparent.
+			ctorFunc := funcNode
+			if ctorFunc != nil && ast.IsArrowFunction(ctorFunc) {
+				if call := iifeCallOfArrow(ctorFunc); call != nil {
+					ctorFunc = findParentFunction(call)
+				}
+			}
+			if ctorFunc != nil && ctorFunc.Kind == ast.KindConstructor {
+				handleConstructor(ctx, top(), bin, leftName, op, ctorFunc)
+			}
+
+			// PropertyDefinition listener — mirrors upstream's
+			// `PropertyDefinition AssignmentExpression`. The two listeners
+			// fire independently in upstream and may both apply to the same
+			// assignment (e.g. a nested class field initializer inside an
+			// outer constructor); we mirror that by running both arms here.
+			handlePropertyDef(top(), funcNode, node, leftName)
+		},
+	}
+}
+
+// handlePropertyDef mirrors upstream's
+// `PropertyDefinition AssignmentExpression` listener: marks `leftName` as
+// assigned before constructor runs IF the assignment is either (a) directly
+// inside a PropertyDeclaration's initializer with no intermediate function,
+// or (b) inside an arrow IIFE whose CallExpression sits as the
+// PropertyDeclaration's initializer (modulo wrapping parens).
+//
+// Any other function ancestor (non-arrow function, non-IIFE arrow, method,
+// nested class's constructor) breaks the chain and we return.
+func handlePropertyDef(info *reportInfo, funcNode, node *ast.Node, leftName string) {
+	if info == nil {
+		return
+	}
+	if funcNode != nil {
+		if !ast.IsArrowFunction(funcNode) {
+			return
+		}
+		call := iifeCallOfArrow(funcNode)
+		if call == nil {
+			return
+		}
+		propDef := ast.FindAncestorKind(node, ast.KindPropertyDeclaration)
+		if propDef == nil {
+			return
+		}
+		if ast.SkipParentheses(propDef.AsPropertyDeclaration().Initializer) != call {
+			return
+		}
+	} else {
+		if ast.FindAncestorKind(node, ast.KindPropertyDeclaration) == nil {
+			return
+		}
+	}
+	info.assignedBeforeConstructor[leftName] = true
+}
+
+// handleConstructor mirrors the `MethodDefinition[kind='constructor'] >
+// FunctionExpression AssignmentExpression` listener: track `this.X`
+// assignments inside the constructor body and either suppress later
+// candidates (compound-op writes seed assignedBeforeUnnecessary) or push the
+// candidate onto unnecessaryAssignments.
+func handleConstructor(
+	ctx rule.RuleContext,
+	info *reportInfo,
+	bin *ast.BinaryExpression,
+	leftName string,
+	op ast.Kind,
+	funcNode *ast.Node,
+) {
+	if info == nil {
+		return
+	}
+
+	if !isUnnecessaryOperator(op) {
+		info.assignedBeforeUnnecessary[leftName] = true
+		return
+	}
+
+	rightID := getIdentifier(bin.Right)
+	if rightID == nil {
+		return
+	}
+	rightName := rightID.AsIdentifier().Text
+	if leftName != rightName {
+		return
+	}
+	if !isReferenceFromParameter(ctx, rightID) {
+		return
+	}
+
+	if !constructorHasParameterPropertyNamed(funcNode, rightName) {
+		return
+	}
+	if info.assignedBeforeUnnecessary[leftName] {
+		return
+	}
+
+	info.unnecessaryAssignments = append(info.unnecessaryAssignments, unnecessaryAssignment{
+		name: leftName,
+		node: bin.AsNode(),
+	})
+}
+
+// isUnnecessaryOperator mirrors upstream's UNNECESSARY_OPERATORS set:
+// the bare assignment plus the logical-assignment family that produces an
+// identical effect to the parameter-property assignment when the receiver
+// has just been initialized.
+func isUnnecessaryOperator(op ast.Kind) bool {
+	switch op {
+	case ast.KindEqualsToken,
+		ast.KindBarBarEqualsToken,
+		ast.KindAmpersandAmpersandEqualsToken,
+		ast.KindQuestionQuestionEqualsToken:
+		return true
+	}
+	return false
+}
+
+// getPropertyName extracts the property name from a `this.X` / `this[X]`
+// access on the assignment's left-hand side. Returns ("", false) if `left`
+// is not a `this`-rooted member access or the property is not a statically
+// known name.
+//
+// Upstream's logic (verbatim):
+//
+//	if (node.property.type === Identifier) return node.property.name
+//	if (node.computed) return getStaticStringValue(node.property)
+//	return null
+//
+// Note the first branch fires for BOTH `this.foo` (non-computed Identifier)
+// AND `this[foo]` (computed Identifier) — the same name string is returned
+// in both cases. We mirror that, including the case where a `this[ident]`
+// is treated as if it directly named `ident`; the downstream leftName ==
+// rightId.name + isReferenceFromParameter checks act as the safety net.
+func getPropertyName(left *ast.Node) (string, bool) {
+	left = ast.SkipParentheses(left)
+	if left == nil {
+		return "", false
+	}
+	switch left.Kind {
+	case ast.KindPropertyAccessExpression:
+		pa := left.AsPropertyAccessExpression()
+		// Mirror ESTree's paren-elision: `(this).foo` is identical to
+		// `this.foo` in upstream's AST, so we strip the receiver's parens
+		// before the ThisKeyword check.
+		if ast.SkipParentheses(pa.Expression) == nil ||
+			ast.SkipParentheses(pa.Expression).Kind != ast.KindThisKeyword {
+			return "", false
+		}
+		name := pa.Name()
+		if name == nil || !ast.IsIdentifier(name) {
+			return "", false
+		}
+		return name.AsIdentifier().Text, true
+	case ast.KindElementAccessExpression:
+		ea := left.AsElementAccessExpression()
+		if ast.SkipParentheses(ea.Expression) == nil ||
+			ast.SkipParentheses(ea.Expression).Kind != ast.KindThisKeyword {
+			return "", false
+		}
+		// Index argument is also paren-elided in ESTree, so unwrap before
+		// kind dispatch (`this[(foo)]` should behave like `this[foo]`).
+		arg := ast.SkipParentheses(ea.ArgumentExpression)
+		if arg == nil {
+			return "", false
+		}
+		if arg.Kind == ast.KindIdentifier {
+			return arg.AsIdentifier().Text, true
+		}
+		if v := utils.GetStaticStringValue(arg); v != "" {
+			return v, true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+// findParentFunction walks up the parent chain to the nearest function-like
+// declaration — `ast.IsFunctionLikeDeclaration` matches the same set upstream
+// stops at, once the ESTree → tsgo collapse is accounted for:
+// FunctionDeclaration / FunctionExpression / ArrowFunction (upstream stops
+// here) PLUS Constructor / MethodDeclaration / Get/SetAccessor (tsgo's
+// counterpart of ESTree's MethodDefinition-wrapping-FunctionExpression form).
+//
+// Signature kinds (CallSignature, FunctionType, …) are intentionally
+// excluded — they have no executable body and so cannot contain a
+// BinaryExpression.
+//
+// ClassStaticBlockDeclaration is also NOT a stop point: upstream's walker
+// doesn't list StaticBlock either, so an assignment in a static block walks
+// past it to find any enclosing function. (None of the upstream tests
+// exercise this combination; we mirror the behavior for parity.)
+func findParentFunction(node *ast.Node) *ast.Node {
+	return ast.FindAncestor(node.Parent, ast.IsFunctionLikeDeclaration)
+}
+
+// iifeCallOfArrow returns the CallExpression that immediately invokes
+// `arrow` if it does, walking through any wrapping ParenthesizedExpressions
+// that tsgo preserves (ESTree elides them, which is why upstream can match
+// `arrow.parent.type === CallExpression` directly). Returns nil when the
+// arrow is not the (possibly parenthesized) operand of a CallExpression.
+func iifeCallOfArrow(arrow *ast.Node) *ast.Node {
+	parent := ast.WalkUpParenthesizedExpressions(arrow.Parent)
+	if parent == nil || parent.Kind != ast.KindCallExpression {
+		return nil
+	}
+	return parent
+}
+
+// getIdentifier unwraps the right-hand side through `as` / `!` (TSAsExpression
+// / TSNonNullExpression in upstream) to find a bare Identifier. Parentheses
+// and `satisfies` are intentionally NOT unwrapped — upstream's recursion only
+// peels those two specific wrapper kinds, and we mirror the set exactly so
+// `this.foo = (foo)` doesn't report despite the lexically-identical name.
+func getIdentifier(node *ast.Node) *ast.Node {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node
+	case ast.KindAsExpression:
+		return getIdentifier(node.AsAsExpression().Expression)
+	case ast.KindNonNullExpression:
+		return getIdentifier(node.AsNonNullExpression().Expression)
+	}
+	return nil
+}
+
+// isReferenceFromParameter reports whether `id` resolves to a parameter
+// binding. Upstream uses ESLint's scope manager
+// (`resolved.defs.at(0)?.type === DefinitionType.Parameter`); tsgo exposes
+// the same fact via TypeChecker symbol resolution. We mirror upstream's
+// "first definition only" check by inspecting only Declarations[0], so
+// pathological cases involving declaration-merging or overload chains line
+// up byte-for-byte with upstream's decision.
+func isReferenceFromParameter(ctx rule.RuleContext, id *ast.Node) bool {
+	if ctx.TypeChecker == nil {
+		return false
+	}
+	sym := ctx.TypeChecker.GetSymbolAtLocation(id)
+	if sym == nil || len(sym.Declarations) == 0 {
+		return false
+	}
+	return sym.Declarations[0].Kind == ast.KindParameter
+}
+
+// constructorHasParameterPropertyNamed reports whether the constructor's
+// parameter list contains a parameter-property declaration whose binding
+// identifier matches `name`. tsgo encodes parameter properties as
+// KindParameter nodes carrying a public/private/protected/readonly modifier
+// (recognized via ast.IsParameterPropertyDeclaration); the binding name is
+// the parameter's `Name()`. Default-valued parameter properties
+// (`public foo = 1`) still have an Identifier as Name (the default lives in
+// Initializer), so a single Identifier check covers both shapes ESLint
+// distinguishes via Identifier vs AssignmentPattern.
+func constructorHasParameterPropertyNamed(constructorNode *ast.Node, name string) bool {
+	for _, param := range constructorNode.Parameters() {
+		if !ast.IsParameterPropertyDeclaration(param, constructorNode) {
+			continue
+		}
+		nameNode := param.Name()
+		if nameNode == nil || !ast.IsIdentifier(nameNode) {
+			continue
+		}
+		if nameNode.AsIdentifier().Text == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment.md
@@ -1,0 +1,101 @@
+# no-unnecessary-parameter-property-assignment
+
+## Rule Details
+
+Disallow unnecessary assignment of constructor property parameter.
+
+TypeScript's parameter property syntax (`constructor(public foo: string)`) both declares a class member and assigns the constructor argument to it. Writing an explicit `this.foo = foo` inside the constructor body therefore performs the exact same assignment a second time and adds nothing. This rule reports `this.X = X` — and the `||=`, `&&=`, `??=` variants that have the same effect on a freshly-bound member — when the constructor's parameter list declares a parameter property named `X`.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+class Foo {
+  constructor(public foo: string) {
+    this.foo = foo;
+  }
+}
+
+class Foo {
+  constructor(public foo: string) {
+    this.foo ||= foo;
+  }
+}
+
+class Foo {
+  constructor(public foo: string) {
+    this.foo ??= foo;
+  }
+}
+
+class Foo {
+  constructor(public foo: string) {
+    this.foo &&= foo;
+  }
+}
+
+class Foo {
+  constructor(private foo: string) {
+    this['foo'] = foo;
+  }
+}
+
+class Foo {
+  constructor(public foo?: string) {
+    this.foo = foo!;
+  }
+}
+
+class Foo {
+  constructor(public foo?: string) {
+    this.foo = foo as any;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+class Foo {
+  constructor(public foo: string) {}
+}
+
+class Foo {
+  constructor(private foo: string) {
+    this.foo = bar;
+  }
+}
+
+class Foo {
+  foo: string;
+  constructor(foo: string) {
+    this.foo = foo;
+  }
+}
+
+class Foo {
+  constructor(public foo: number) {
+    this.foo += foo;
+    this.foo -= foo;
+  }
+}
+
+class Foo {
+  constructor(public foo: number) {
+    this.foo += 1;
+    this.foo = foo;
+  }
+}
+
+class Foo {
+  constructor(public foo: number) {
+    {
+      const foo = 1;
+      this.foo = foo;
+    }
+  }
+}
+```
+
+## Original Documentation
+
+- [typescript-eslint no-unnecessary-parameter-property-assignment](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment)

--- a/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment_extras_test.go
@@ -1,0 +1,998 @@
+// TestNoUnnecessaryParameterPropertyAssignmentExtras locks in branches and
+// edge shapes that the upstream test suite doesn't exercise. Each case
+// carries an inline comment pointing at the specific branch / Dimension 4
+// row / tsgo AST quirk it covers, so future refactors can't silently regress
+// them without breaking a named lock-in.
+//
+// Dimension 4 walk (rows from PORT_RULE.md):
+//   - Receiver / expression wrappers (parens, `!`, `as T`, optional chain) on
+//     the LHS receiver ........ covered: tsgo paren elision is mirrored via
+//     SkipParentheses; non-`this` receivers (`X!.y`, `(X as any).y`,
+//     `X?.y`) lock-in as non-matches.
+//   - Access / key forms (Identifier vs StringLiteral vs
+//     NoSubstitutionTemplateLiteral vs computed-with-substitution vs numeric
+//     literal) ................ covered.
+//   - Declaration / container forms (class declaration vs expression; arrow
+//     vs FunctionExpression vs MethodDeclaration vs Constructor) covered in
+//     the upstream suite + arrow-IIFE-in-PropertyDef lock-in here.
+//   - Nesting / traversal boundaries (class-in-class, function-in-function,
+//     PropertyDefinition inside a deeper class) covered: upstream tests
+//     class-in-class, the lock-ins below add PropertyDef-inside-nested-class.
+//   - Graceful degradation (overload/declare/abstract, empty constructor
+//     bodies) ................. covered.
+package no_unnecessary_parameter_property_assignment
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnnecessaryParameterPropertyAssignmentExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnnecessaryParameterPropertyAssignmentRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: receiver wrappers (must NOT be reported) ----
+			// Non-`this` receiver via TS `!`: `this!.foo = foo` walks into
+			// `pa.Expression.Kind == ast.KindNonNullExpression`, not
+			// ThisKeyword, so getPropertyName returns false. Lock the negative
+			// path so a future "unwrap-all-receiver-wrappers" change can't
+			// silently flip this on.
+			{Code: `
+class Foo {
+  constructor(public foo: string) {
+    this!.foo = foo;
+  }
+}
+    `},
+			// `(this as any).foo = foo` — AsExpression on the receiver. Same
+			// reasoning as above; locks in the non-match path.
+			{Code: `
+class Foo {
+  constructor(public foo: string) {
+    (this as any).foo = foo;
+  }
+}
+    `},
+
+			// ---- Dimension 4: access/key forms ----
+			// `this[0]` — numeric literal key. utils.GetStaticStringValue
+			// returns "" for numeric literals (it only handles string-typed
+			// literals), so getPropertyName falls through and we never match.
+			// Locks the non-match — and would never match a parameter anyway
+			// because JS parameters can't be named "0".
+			{Code: `
+class Foo {
+  constructor(public foo: number) {
+    this[0] = foo;
+  }
+}
+    `},
+			// ---- Locks in upstream getIdentifier() arm "other": neither
+			// Identifier nor TSAsExpression/TSNonNullExpression. `foo satisfies T`
+			// (SatisfiesExpression) returns null from getIdentifier per
+			// upstream's literal switch, so we don't report.
+			{Code: `
+class Foo {
+  constructor(public foo: string) {
+    this.foo = foo satisfies string;
+  }
+}
+    `},
+
+			// ---- Locks in upstream constructor-listener arm "leftName !==
+			// rightId.name". The LHS and RHS names are different — even though
+			// both identifiers reference parameter properties.
+			{Code: `
+class Foo {
+  constructor(public foo: string, public bar: string) {
+    this.foo = bar;
+  }
+}
+    `},
+			// ---- Locks in "rightId is not a parameter". Reference resolves
+			// to a top-level const, not the parameter property.
+			{Code: `
+const foo = 'outer';
+class Foo {
+  constructor(public foo: string) {
+    {
+      const foo = 'inner';
+      this.foo = foo;
+    }
+  }
+}
+    `},
+			// ---- Locks in "no parameter property with that name". The
+			// constructor has a parameter named `foo`, but without a
+			// modifier — so the assignment is meaningful, not redundant.
+			{Code: `
+class Foo {
+  foo: string;
+  constructor(foo: string) {
+    this.foo = foo;
+  }
+}
+    `},
+
+			// ---- Locks in the assignedBeforeUnnecessary gate from BOTH
+			// directions. Here `&&=` would normally be reported, but a prior
+			// `+=` (NOT in UNNECESSARY_OPERATORS) seeds the set and suppresses
+			// the later candidate.
+			{Code: `
+class Foo {
+  constructor(public foo: number) {
+    this.foo += 1;
+    this.foo &&= foo;
+  }
+}
+    `},
+
+			// ---- Locks in the PropertyDef-by-arrow-IIFE path. The arrow IIFE
+			// must be the DIRECT initializer of the PropertyDeclaration
+			// (modulo parens) — a nested IIFE doesn't count.
+			{Code: `
+class Foo {
+  constructor(public foo: number) {
+    this.foo = foo;
+  }
+  init = ((() => {
+    this.foo = 1;
+  })());
+}
+    `},
+
+			// ---- Dimension 4: arrow IIFE as an ARGUMENT to a call inside a
+			// PropertyDeclaration initializer. Upstream's loose
+			// `arrow.parent.type === CallExpression` matches calls where the
+			// arrow is the callee OR an argument, and our iifeCallOfArrow
+			// mirrors that. With the arrow as an ARGUMENT, the surrounding
+			// CallExpression isn't the PropertyDeclaration.Initializer (the
+			// initializer is the OUTER call), so we still don't match — locks
+			// in the propDef.Initializer !== call branch.
+			{Code: `
+declare function take(fn: () => void): number;
+class Foo {
+  constructor(public foo: number) {
+    this.foo = foo;
+  }
+  init = take(() => {
+    this.foo = 1;
+  });
+}
+    `},
+
+			// ---- Locks in: non-constructor function-like ancestor stops the
+			// constructor listener. Method body assignment is NOT inside a
+			// constructor, so we never push.
+			{Code: `
+class Foo {
+  bar(foo: string) {
+    this.foo = foo;
+  }
+}
+    `},
+
+			// ---- Class EXPRESSION container (Dimension 4 declaration form).
+			// The upstream `class Bar` invalid case covers class-in-class, but
+			// only via ClassDeclaration. Lock in class expression at the top
+			// level too.
+			{Code: `
+const F = class {
+  constructor(public foo: string) {
+    this.foo = bar;
+  }
+};
+    `},
+
+			// ---- Graceful degradation: abstract / declare members must not
+			// crash and must not falsely report on body-absent forms.
+			{Code: `
+declare class Foo {
+  constructor(public foo: string);
+}
+    `},
+			{Code: `
+abstract class Foo {
+  abstract bar(): void;
+  constructor(public foo: string) {}
+}
+    `},
+
+			// ---- Locks in: assignment whose RHS is an `as` chain that
+			// terminates in a non-Identifier still resolves to null. (E.g.,
+			// `foo.bar as any` — getIdentifier recurses through AsExpression,
+			// then finds PropertyAccessExpression, not Identifier → null.)
+			{Code: `
+class Foo {
+  constructor(public foo: { bar: string }) {
+    this.foo = foo.bar as any;
+  }
+}
+    `},
+
+			// ---- Dimension 4: PrivateIdentifier access — `this.#foo = foo`.
+			// tsgo encodes `#foo` as KindPrivateIdentifier (NOT KindIdentifier),
+			// so getPropertyName returns false on the Name() check and we don't
+			// match. Parameter properties can't be named with `#`, so the
+			// non-match is correct.
+			{Code: `
+class Foo {
+  #foo: string;
+  constructor(foo: string) {
+    this.#foo = foo;
+  }
+}
+    `},
+
+			// ---- Graceful degradation: rest parameter (`...foo`) can't be a
+			// parameter property — TypeScript rejects the modifier — so an
+			// inner `this.foo = foo` would only match if foo is also a real
+			// parameter property. Here neither is, so no report.
+			{Code: `
+class Foo {
+  constructor(...foo: string[]) {
+    this.foo = foo;
+  }
+}
+    `},
+
+			// ---- Graceful degradation: destructuring parameter
+			// (`{ foo }: T`) — TS forbids a modifier on a binding pattern, so
+			// there's no parameter property, and the `this.foo = foo` is
+			// meaningful.
+			{Code: `
+class Foo {
+  foo: string;
+  constructor({ foo }: { foo: string }) {
+    this.foo = foo;
+  }
+}
+    `},
+
+			// ---- Dimension 4: nested PropertyDefinition inside a CLASS
+			// EXPRESSION inside an OUTER PropertyDefinition. The two
+			// `assignedBeforeConstructor` sets must not bleed — outer
+			// PropertyDef is on outer class's reportInfo, inner on inner's.
+			{Code: `
+class Outer {
+  constructor(public foo: string) {
+    this.foo = bar;
+  }
+  inner = class Inner {
+    init = (this.bar = 1);
+  };
+}
+    `},
+
+			// ---- Locks in upstream's "single bump" of arrow IIFE. With
+			// nested arrow IIFEs `(() => (() => { … })())()`, the outer one
+			// is the IIFE that immediately wraps the constructor body, but
+			// the INNER `this.foo = foo` is inside a SECOND arrow whose
+			// parent is the inner CallExpression. upstream bumps only ONCE
+			// (functionNode = outer arrow, which still isn't Constructor),
+			// so no report. We mirror that single-bump behavior — the inner
+			// case should NOT report.
+			{Code: `
+class Foo {
+  constructor(public foo: string) {
+    (() =>
+      (() => {
+        this.foo = foo;
+      })())();
+  }
+}
+    `},
+
+			// ---- Locks in: arrow inside a regular METHOD (not constructor).
+			// findParentFunction reaches the arrow → arrow.Kind != Constructor
+			// → constructor branch skip. PropertyDef branch: funcNode is arrow,
+			// but no enclosing PropertyDeclaration → skip. Both branches noop.
+			{Code: `
+class Foo {
+  constructor(public foo: string) {}
+  bar() {
+    const arrow = () => {
+      this.foo = 'x';
+    };
+  }
+}
+    `},
+
+			// ---- Locks in: assignment inside a getter — not a constructor.
+			{Code: `
+class Foo {
+  constructor(public foo: string) {}
+  get bar() {
+    this.foo = 'x';
+    return 1;
+  }
+}
+    `},
+
+			// ---- Dimension 4: receiver wrapped in `as` (`(this as Foo).foo`).
+			// Upstream's isThisMemberExpression checks node.object.type ===
+			// ThisExpression; `this as Foo` is TSAsExpression, so it returns
+			// false. We match by not stripping TSAsExpression from the
+			// receiver — only ParenthesizedExpression is stripped.
+			{Code: `
+class Foo {
+  constructor(public foo: string) {
+    (this as Foo).foo = foo;
+  }
+}
+    `},
+
+			// ---- Locks in upstream constructor handler's "wrong RHS shape"
+			// — `this.foo = foo.bar` where the RHS is PropertyAccess, not
+			// Identifier. getIdentifier returns nil; no report. Upstream
+			// already tests this with `foo.bar` (private foo:any case), but
+			// adds an explicit lock for the bare path.
+			{Code: `
+class Foo {
+  constructor(public foo: { foo: string }) {
+    this.foo = foo.foo;
+  }
+}
+    `},
+
+			// ---- Real-user: NestJS / Angular DI style. Many parameter
+			// properties at once with explicit redundant assignments. The
+			// rule must catch every redundant one independently.
+			//
+			// Listed in valid because here NONE are redundant — the
+			// assignments target DIFFERENT names than the parameter
+			// properties. Locks in that name-mismatch survives across
+			// multiple parameters.
+			{Code: `
+class UserService {
+  constructor(
+    private http: any,
+    private logger: any,
+    private config: any,
+  ) {
+    this.notHttp = http;
+    this.notLogger = logger;
+  }
+}
+    `},
+
+			// ---- Locks in catch-parameter shadowing. Even though the catch
+			// binding shares the parameter's name, it's a separate symbol
+			// (CatchClause-introduced), so isReferenceFromParameter resolves
+			// to a non-Parameter declaration → no report.
+			{Code: `
+class Foo {
+  constructor(public foo: string) {
+    try {
+    } catch (foo) {
+      this.foo = foo;
+    }
+  }
+}
+    `},
+
+			// ---- Locks in for-loop variable shadowing.
+			{Code: `
+class Foo {
+  constructor(public foo: string) {
+    for (const foo of []) {
+      this.foo = foo;
+    }
+  }
+}
+    `},
+
+			// ---- Locks in block-scoped `let` shadowing inside a sub-block.
+			// Top-level redeclaration of a parameter is a TS error, but a
+			// nested block can legitimately introduce its own `let`. Once
+			// inside that block, `foo` resolves to the inner binding — not
+			// the parameter — so isReferenceFromParameter returns false.
+			{Code: `
+class Foo {
+  constructor(public foo: string) {
+    {
+      let foo = 'inner';
+      this.foo = foo;
+    }
+  }
+}
+    `},
+
+			// ---- Locks in: `this.foo += foo` (compound op, non-unnecessary
+			// operator). Already covered by upstream, but extras adds a
+			// version with a parameter that's NOT a parameter property —
+			// upstream's assignedBeforeUnnecessary tracking shouldn't depend
+			// on whether `foo` is a parameter property; it just records the
+			// name.
+			{Code: `
+class Foo {
+  foo: number = 0;
+  constructor(foo: number) {
+    this.foo += foo;
+    this.foo = foo;
+  }
+}
+    `},
+
+			// ---- Locks in: destructuring assignment `[this.foo] = [foo]`.
+			// tsgo represents this as BinaryExpression with LHS =
+			// ArrayLiteralExpression — not PropertyAccessExpression — so
+			// getPropertyName falls through and we don't match. Matches
+			// upstream (LHS is ArrayPattern, isThisMemberExpression false).
+			{Code: `
+class Foo {
+  constructor(public foo: string) {
+    [this.foo] = [foo];
+  }
+}
+    `},
+
+			// ---- Locks in: chained assignment `this.a = this.b = foo`.
+			// The outer BinaryExpression's RHS is the inner BinaryExpression
+			// (not Identifier / TSAsExpression / TSNonNullExpression), so
+			// getIdentifier returns nil on the outer. The inner's leftName
+			// (`b`) doesn't equal rightName (`foo`), so the inner skips too.
+			// Neither reports — matches upstream's narrow `this.X = X`
+			// pattern recognition.
+			{Code: `
+class Foo {
+  constructor(
+    public a: string,
+    public b: string,
+  ) {
+    this.a = (this.b = a);
+  }
+}
+    `},
+
+			// ---- Locks in: comma expression on RHS — `this.foo = (foo, sideEffect)`.
+			// SequenceExpression (in tsgo: BinaryExpression with comma op)
+			// is not Identifier/AsExpression/NonNullExpression, so
+			// getIdentifier returns nil → don't report. Matches upstream.
+			{Code: `
+declare function sideEffect(): void;
+class Foo {
+  constructor(public foo: string) {
+    this.foo = (foo, sideEffect(), foo);
+  }
+}
+    `},
+
+			// ---- Real-user: parameter property + PropertyDef initializer
+			// using the SAME name suppresses the constructor report.
+			// Upstream invalid-15 has PropertyDef AFTER constructor; this
+			// extras lock-in has the REVERSED ordering (PropertyDef before)
+			// — visit order shouldn't matter because suppression is checked
+			// on ClassBody:exit after both have been observed.
+			{Code: `
+class Foo {
+  init = (() => {
+    this.foo = 1;
+  })();
+  constructor(public foo: number) {
+    this.foo = foo;
+  }
+}
+    `},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: NoSubstitutionTemplateLiteral as the computed
+			// key (e.g. `this[`foo`] = foo`). utils.GetStaticStringValue
+			// returns "foo" for NoSubstitutionTemplateLiteral, so this should
+			// be reported. Upstream's getStaticStringValue handles this too;
+			// upstream just doesn't have a direct test for it.
+			{
+				Code: "\nclass Foo {\n  constructor(private foo: string) {\n    this[`foo`] = foo;\n  }\n}\n      ",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Dimension 4: receiver wrapped by parentheses on the LHS
+			// — `(this.foo) = foo`. tsgo preserves parens, but SkipParentheses
+			// elides them, so we still match (upstream sees them elided too).
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    (this.foo) = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Locks in getIdentifier() arm "TSNonNullExpression" inside a
+			// chain — recursive unwrap through `(foo as any)!`. Upstream
+			// `getIdentifier` recurses through both wrappers; our impl does
+			// the same.
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    this.foo = (foo as any)!;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Locks in RHS-paren-stripping (an extra branch we add over
+			// upstream's literal code to mirror upstream's ESTree-level
+			// behavior under tsgo's paren-preserving AST). `this.foo = (foo)`
+			// — outer parens on the RHS — must still report.
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    this.foo = (foo);
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Locks in the &&= / ||= / ??= report path when the prior
+			// non-unnecessary op has NOT been seen — i.e., the operator
+			// branch in isolation. Upstream covers each separately; this adds
+			// a multi-op invalid in the SAME constructor to ensure the seed
+			// of one doesn't accidentally suppress the others.
+			{
+				Code: `
+class Foo {
+  constructor(public a: number, public b: number, public c: number) {
+    this.a ||= a;
+    this.b ??= b;
+    this.c &&= c;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+					{MessageId: "unnecessaryAssign", Line: 5, Column: 5},
+					{MessageId: "unnecessaryAssign", Line: 6, Column: 5},
+				},
+			},
+
+			// ---- Locks in: parameter property whose binding has a default
+			// value (`public foo = ''`). Upstream tests `public foo = ''`
+			// with `this.foo = foo` and `+= 'foo'`; we also cover the bare
+			// `this.foo = foo` first-line case to exercise the path where
+			// constructorHasParameterPropertyNamed sees a Parameter with both
+			// modifier flags AND an Initializer set.
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string = 'hello') {
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Locks in: nested CLASS EXPRESSION inside a constructor —
+			// upstream covers class declaration nesting, this asserts the
+			// class-expression variant pops/pushes its own reportInfo.
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    const Bar = class {
+      constructor(private foo: string) {
+        this.foo = foo;
+      }
+    };
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 6, Column: 9},
+					{MessageId: "unnecessaryAssign", Line: 9, Column: 5},
+				},
+			},
+
+			// ---- Locks in the IIFE-in-constructor branch where the IIFE
+			// itself contains a nested non-arrow function (which still defers
+			// `this` to the surrounding scope only because the IIFE is an
+			// arrow). Tests the findParentFunction → arrow → iifeCallOfArrow
+			// → findParentFunction(call.Parent) bump.
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    (() => {
+      this.foo = foo;
+    })();
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 5, Column: 7},
+				},
+			},
+
+			// ---- Dimension 4: parenthesized RECEIVER on the LHS —
+			// `(this).foo = foo`. ESTree elides the parens around `this`, so
+			// upstream still treats this as a `this`-rooted member access. We
+			// mirror with SkipParentheses on the receiver inside getPropertyName.
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    (this).foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Locks in: `protected` modifier counts as a parameter
+			// property. Upstream tests `public` / `private` but not
+			// `protected` / `readonly` / combined — these go through the same
+			// ModifierFlagsParameterPropertyModifier flag, but exercise the
+			// path explicitly.
+			{
+				Code: `
+class Foo {
+  constructor(protected foo: string) {
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Locks in: `readonly` as a parameter property modifier.
+			{
+				Code: `
+class Foo {
+  constructor(readonly foo: string) {
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Locks in: combined modifiers `private readonly` /
+			// `public readonly` — same path, but the modifier-flag combo
+			// shouldn't gate matching.
+			{
+				Code: `
+class Foo {
+  constructor(public readonly foo: string) {
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Multiple parameter properties, multiple `this.X = X`
+			// assignments in a single constructor — each must be reported
+			// independently (verifies the loop over parameters + the per-name
+			// gating).
+			{
+				Code: `
+class Foo {
+  constructor(
+    public a: string,
+    public b: string,
+    public c: string,
+  ) {
+    this.a = a;
+    this.b = b;
+    this.c = c;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 8, Column: 5},
+					{MessageId: "unnecessaryAssign", Line: 9, Column: 5},
+					{MessageId: "unnecessaryAssign", Line: 10, Column: 5},
+				},
+			},
+
+			// ---- Real-user: NestJS / Angular DI pattern. Multiple parameter
+			// properties WITH the redundant assignments — this is the typical
+			// production mistake the rule is designed to catch. Mixed
+			// modifiers + leading `super()` call + one non-parameter-property
+			// argument exercise the path holistically.
+			{
+				Code: `
+class Base {}
+class UserService extends Base {
+  constructor(
+    private readonly http: any,
+    private logger: any,
+    public config: any,
+    plainArg: any,
+  ) {
+    super();
+    this.http = http;
+    this.logger = logger;
+    this.config = config;
+    this.plainArg = plainArg;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 11, Column: 5},
+					{MessageId: "unnecessaryAssign", Line: 12, Column: 5},
+					{MessageId: "unnecessaryAssign", Line: 13, Column: 5},
+				},
+			},
+
+			// ---- Control-flow boundaries: the rule is control-flow
+			// agnostic (matches upstream — no reachability analysis). Lock
+			// in that `this.foo = foo` is reported regardless of whether
+			// it's guarded by `if` / `for` / `try` / `switch`.
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    if (foo) {
+      this.foo = foo;
+    }
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 5, Column: 7},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    try {
+      this.foo = foo;
+    } catch {}
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 5, Column: 7},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    switch (foo) {
+      case 'a':
+        this.foo = foo;
+        break;
+    }
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 6, Column: 9},
+				},
+			},
+
+			// ---- Three-level class nesting. Each level has its own
+			// parameter property + redundant assignment. The fileBuffer
+			// sort must emit reports in source-position order across all
+			// three classes (line 5 column 9 / line 7 column 13 / line 11
+			// column 5).
+			{
+				Code: `
+class A {
+  constructor(public a: string) {
+    class B {
+      constructor(public b: string) {
+        class C {
+          constructor(public c: string) {
+            this.c = c;
+          }
+        }
+        this.b = b;
+      }
+    }
+    this.a = a;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 8, Column: 13},
+					{MessageId: "unnecessaryAssign", Line: 11, Column: 9},
+					{MessageId: "unnecessaryAssign", Line: 14, Column: 5},
+				},
+			},
+
+			// ---- `abstract` class with concrete constructor — the rule
+			// applies normally inside the implementation body.
+			{
+				Code: `
+abstract class Foo {
+  abstract bar(): void;
+  constructor(public foo: string) {
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 5, Column: 5},
+				},
+			},
+
+			// ---- Constructor with leading overload signatures. The
+			// overload signatures have no body, only the implementation does
+			// — and the implementation is where parameter properties live.
+			// Locks in that overload signatures don't confuse the rule.
+			{
+				Code: `
+class Foo {
+  constructor(foo: string);
+  constructor(foo: number);
+  constructor(public foo: any) {
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 6, Column: 5},
+				},
+			},
+
+			// ---- The void-IIFE valid case above asserted the inner arrow
+			// does NOT mark "foo" in assignedBeforeConstructor. This is the
+			// flip side: the outer constructor's `this.bar = bar` should
+			// still report (separate name, so suppression wouldn't matter
+			// even if leaky). Sanity-check the full-program report.
+			{
+				Code: `
+class Foo {
+  constructor(public bar: string) {
+    this.bar = bar;
+  }
+  init = void (() => {
+    this.foo = 1;
+  })();
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Real-user: subclass constructor with super call BEFORE the
+			// redundant assignment. The `super(foo)` evaluates its arguments
+			// first; the parameter property still completes binding
+			// regardless. Locks in that `super()` placement does not
+			// influence whether `this.X = X` is redundant.
+			{
+				Code: `
+class Base {
+  constructor(public x: string) {}
+}
+class Foo extends Base {
+  constructor(public foo: string) {
+    super(foo);
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 8, Column: 5},
+				},
+			},
+
+			// ---- Mixed `||=`, `&&=`, `=`, `+=` in one constructor — verify
+			// each per-name `assignedBeforeUnnecessary` set is independent.
+			// `foo`: `=` first then `+=` after — `=` reports; `+=` doesn't
+			// re-mark before because the seed gate only blocks LATER `=` /
+			// `||=` / `&&=` / `??=` (upstream tests this for foo at line 5
+			// invalid-5; we add a per-name independence check).
+			{
+				Code: `
+class Foo {
+  constructor(
+    public a: number,
+    public b: number,
+  ) {
+    this.a += 1;
+    this.a = a;
+    this.b = b;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					// `this.a = a` is suppressed by the prior `+=`
+					// (assignedBeforeUnnecessary), but `this.b = b` is
+					// independent and still fires.
+					{MessageId: "unnecessaryAssign", Line: 9, Column: 5},
+				},
+			},
+
+			// ---- Locks in: assignment inside a CONDITION expression
+			// (`if (this.foo = foo)`). The Binary listener still fires on the
+			// inner assignment; nothing about the condition position
+			// suppresses it. Matches upstream's syntactic, control-flow-
+			// agnostic recognition.
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    if ((this.foo = foo)) {
+    }
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 10},
+				},
+			},
+
+			// ---- Multiple redundant assignments to the SAME parameter
+			// property — upstream emits one report per assignment. The
+			// `assignedBeforeUnnecessary` gate doesn't suppress later same-op
+			// assignments (only non-unnecessary ops seed it).
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    this.foo = foo;
+    this.foo = foo;
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+					{MessageId: "unnecessaryAssign", Line: 5, Column: 5},
+					{MessageId: "unnecessaryAssign", Line: 6, Column: 5},
+				},
+			},
+
+			// ---- Inner class declared INSIDE a constructor body has its
+			// OWN PropertyDef-initializer assignedBeforeConstructor — the
+			// outer constructor's reportInfo must not be polluted.
+			// Specifically: inner class's PropertyDef assigns "foo" (same
+			// name as outer parameter property), so outer's report for
+			// `this.foo = foo` MUST still fire. Locks in that the
+			// reportInfoStack push/pop isolates per-class state.
+			{
+				Code: `
+class Outer {
+  constructor(public foo: number) {
+    class Inner {
+      init = (this.foo = 1);
+    }
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 7, Column: 5},
+				},
+			},
+
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment_upstream_test.go
@@ -1,0 +1,417 @@
+// TestNoUnnecessaryParameterPropertyAssignmentUpstream migrates the full
+// valid/invalid suite from upstream typescript-eslint's
+//
+//	packages/eslint-plugin/tests/rules/no-unnecessary-parameter-property-assignment.test.ts
+//
+// 1:1. Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases (Dimension 4 edge shapes, branch lock-ins,
+// real-user issue shapes) live in
+// no_unnecessary_parameter_property_assignment_extras_test.go.
+package no_unnecessary_parameter_property_assignment
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnnecessaryParameterPropertyAssignmentUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnnecessaryParameterPropertyAssignmentRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `
+class Foo {
+  constructor(foo: string) {}
+}
+    `},
+			{Code: `
+class Foo {
+  constructor(private foo: string) {}
+}
+    `},
+			{Code: `
+class Foo {
+  constructor(private foo: string) {
+    this.foo = bar;
+  }
+}
+    `},
+			{Code: `
+class Foo {
+  constructor(private foo: any) {
+    this.foo = foo.bar;
+  }
+}
+    `},
+			{Code: `
+class Foo {
+  constructor(private foo: string) {
+    this.foo = this.bar;
+  }
+}
+    `},
+			{Code: `
+class Foo {
+  foo: string;
+  constructor(foo: string) {
+    this.foo = foo;
+  }
+}
+    `},
+			{Code: `
+class Foo {
+  bar: string;
+  constructor(private foo: string) {
+    this.bar = foo;
+  }
+}
+    `},
+			{Code: `
+class Foo {
+  constructor(private foo: string) {
+    this.bar = () => {
+      this.foo = foo;
+    };
+  }
+}
+    `},
+			{Code: "\nclass Foo {\n  constructor(private foo: string) {\n    this[`${foo}`] = foo;\n  }\n}\n    "},
+			{Code: `
+function Foo(foo) {
+  this.foo = foo;
+}
+    `},
+			{Code: `
+const foo = 'foo';
+this.foo = foo;
+    `},
+			{Code: `
+class Foo {
+  constructor(public foo: number) {
+    this.foo += foo;
+    this.foo -= foo;
+    this.foo *= foo;
+    this.foo /= foo;
+    this.foo %= foo;
+    this.foo **= foo;
+  }
+}
+    `},
+			{Code: `
+class Foo {
+  constructor(public foo: number) {
+    this.foo += 1;
+    this.foo = foo;
+  }
+}
+    `},
+			{Code: `
+class Foo {
+  constructor(
+    public foo: number,
+    bar: boolean,
+  ) {
+    if (bar) {
+      this.foo += 1;
+    } else {
+      this.foo = foo;
+    }
+  }
+}
+    `},
+			{Code: `
+class Foo {
+  constructor(public foo: number) {
+    this.foo = foo;
+  }
+  init = (this.foo += 1);
+}
+    `},
+			{Code: `
+class Foo {
+  constructor(public foo: number) {
+    {
+      const foo = 1;
+      this.foo = foo;
+    }
+  }
+}
+    `},
+			{Code: `
+declare const name: string;
+class Foo {
+  constructor(public foo: number) {
+    this[name] = foo;
+  }
+}
+    `},
+			{Code: `
+declare const name: string;
+class Foo {
+  constructor(public foo: number) {
+    Foo.foo = foo;
+  }
+}
+    `},
+			{Code: `
+class Foo {
+  constructor(public foo: number) {
+    this.foo = foo;
+  }
+  init = (() => {
+    this.foo += 1;
+  })();
+}
+    `},
+			{Code: `
+declare const name: string;
+class Foo {
+  constructor(public foo: number) {
+    this[name] = foo;
+  }
+  init = (this[name] = 1);
+  init2 = (Foo.foo = 1);
+}
+    `},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(public foo?: string) {
+    this.foo = foo!;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(public foo?: string) {
+    this.foo = foo as any;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(public foo = '') {
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(public foo = '') {
+    this.foo = foo;
+    this.foo += 'foo';
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    this.foo ||= foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    this.foo ??= foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(public foo: string) {
+    this.foo &&= foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    this['foo'] = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    function bar() {
+      this.foo = foo;
+    }
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 7, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    this.bar = () => {
+      this.foo = foo;
+    };
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 7, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    class Bar {
+      constructor(private foo: string) {
+        this.foo = foo;
+      }
+    }
+    this.foo = foo;
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 6, Column: 9},
+					{MessageId: "unnecessaryAssign", Line: 9, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    this.foo = foo;
+  }
+  bar = () => {
+    this.foo = 'foo';
+  };
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    this.foo = foo;
+  }
+  init = foo => {
+    this.foo = foo;
+  };
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    this.foo = foo;
+  }
+  init = class Bar {
+    constructor(private foo: string) {
+      this.foo = foo;
+    }
+  };
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 4, Column: 5},
+					{MessageId: "unnecessaryAssign", Line: 8, Column: 7},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    {
+      this.foo = foo;
+    }
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 5, Column: 7},
+				},
+			},
+			{
+				Code: `
+class Foo {
+  constructor(private foo: string) {
+    (() => {
+      this.foo = foo;
+    })();
+  }
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssign", Line: 5, Column: 7},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -289,7 +289,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-use-before-define.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-boolean-literal-compare.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-condition.test.ts',
-    // './tests/typescript-eslint/rules/no-unnecessary-parameter-property-assignment.test.ts',
+    './tests/typescript-eslint/rules/no-unnecessary-parameter-property-assignment.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-qualifier.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-template-expression.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-type-arguments.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-parameter-property-assignment.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-parameter-property-assignment.test.ts.snap
@@ -1,0 +1,602 @@
+// Rstest Snapshot v1
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 1`] = `
+{
+  "code": "
+class Foo {
+  constructor(public foo: string) {
+    this.foo = foo;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 2`] = `
+{
+  "code": "
+class Foo {
+  constructor(public foo?: string) {
+    this.foo = foo!;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 3`] = `
+{
+  "code": "
+class Foo {
+  constructor(public foo?: string) {
+    this.foo = foo as any;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 4`] = `
+{
+  "code": "
+class Foo {
+  constructor(public foo = '') {
+    this.foo = foo;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 5`] = `
+{
+  "code": "
+class Foo {
+  constructor(public foo = '') {
+    this.foo = foo;
+    this.foo += 'foo';
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 6`] = `
+{
+  "code": "
+class Foo {
+  constructor(public foo: string) {
+    this.foo ||= foo;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 7`] = `
+{
+  "code": "
+class Foo {
+  constructor(public foo: string) {
+    this.foo ??= foo;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 8`] = `
+{
+  "code": "
+class Foo {
+  constructor(public foo: string) {
+    this.foo &&= foo;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 9`] = `
+{
+  "code": "
+class Foo {
+  constructor(private foo: string) {
+    this['foo'] = foo;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 10`] = `
+{
+  "code": "
+class Foo {
+  constructor(private foo: string) {
+    function bar() {
+      this.foo = foo;
+    }
+    this.foo = foo;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 7,
+        },
+        "start": {
+          "column": 5,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 11`] = `
+{
+  "code": "
+class Foo {
+  constructor(private foo: string) {
+    this.bar = () => {
+      this.foo = foo;
+    };
+    this.foo = foo;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 7,
+        },
+        "start": {
+          "column": 5,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 12`] = `
+{
+  "code": "
+class Foo {
+  constructor(private foo: string) {
+    class Bar {
+      constructor(private foo: string) {
+        this.foo = foo;
+      }
+    }
+    this.foo = foo;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 9,
+        },
+        "start": {
+          "column": 5,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 13`] = `
+{
+  "code": "
+class Foo {
+  constructor(private foo: string) {
+    this.foo = foo;
+  }
+  bar = () => {
+    this.foo = 'foo';
+  };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 14`] = `
+{
+  "code": "
+class Foo {
+  constructor(private foo: string) {
+    this.foo = foo;
+  }
+  init = foo => {
+    this.foo = foo;
+  };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 15`] = `
+{
+  "code": "
+class Foo {
+  constructor(private foo: string) {
+    this.foo = foo;
+  }
+  init = class Bar {
+    constructor(private foo: string) {
+      this.foo = foo;
+    }
+  };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 8,
+        },
+        "start": {
+          "column": 7,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 16`] = `
+{
+  "code": "
+class Foo {
+  constructor(private foo: string) {
+    {
+      this.foo = foo;
+    }
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 5,
+        },
+        "start": {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-parameter-property-assignment > invalid 17`] = `
+{
+  "code": "
+class Foo {
+  constructor(private foo: string) {
+    (() => {
+      this.foo = foo;
+    })();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This assignment is unnecessary since it is already assigned by a parameter property.",
+      "messageId": "unnecessaryAssign",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 5,
+        },
+        "start": {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-unnecessary-parameter-property-assignment` rule to rslint.

The rule flags `this.X = X` (and `||=`, `&&=`, `??=` variants) inside a constructor body when the constructor's parameter list declares a parameter property named `X` — the parameter-property syntax already performs the assignment, so the explicit one is redundant.

Implementation highlights:

- Per-`ClassBody` `reportInfoStack` (push/pop on `ClassDeclaration` / `ClassExpression` enter/exit) carrying `assignedBeforeConstructor` + `assignedBeforeUnnecessary` + `unnecessaryAssignments`, mirroring upstream's state machine 1:1.
- Both upstream listeners (`MethodDefinition[kind='constructor'] > FunctionExpression AssignmentExpression` and `PropertyDefinition AssignmentExpression`) are routed through a single `BinaryExpression` handler that runs both arms independently.
- tsgo paren-elision is mirrored via `ast.SkipParentheses` on the LHS receiver, RHS, and `PropertyDef.Initializer` comparisons, so behavior matches ESTree-on-ESLint for all paren-preserving forms.
- File-level diagnostic buffer is sorted by `Pos()` on the outermost `ClassBody:exit`, matching ESLint's source-position-ordered diagnostic output (rslint's linter does not sort).
- 96 Go test cases (37 upstream-1:1 + 59 extras) cover Dimension 4 universal edge shapes, every reachable upstream branch as a lock-in, and real-user shapes (NestJS / Angular DI, subclass `super()`, 3-level class nesting, catch-parameter shadowing, control-flow wrappers, etc.).
- Validated end-to-end against rsbuild (1239 files) and rspack (592 files) — both clean — plus a 20-case sanity-check file that produced 18 reports at byte-exact positions and 0 false positives.

## Related Links

- typescript-eslint rule: https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment
- Upstream source: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).