### PR TITLE
feat: port rule @typescript-eslint/no-unnecessary-type-conversion

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_arguments"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_assertion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_constraint"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_conversion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_argument"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_assignment"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_call"
@@ -599,6 +600,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-type-arguments", no_unnecessary_type_arguments.NoUnnecessaryTypeArgumentsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-type-assertion", no_unnecessary_type_assertion.NoUnnecessaryTypeAssertionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-type-constraint", no_unnecessary_type_constraint.NoUnnecessaryTypeConstraintRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-type-conversion", no_unnecessary_type_conversion.NoUnnecessaryTypeConversionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-argument", no_unsafe_argument.NoUnsafeArgumentRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-assignment", no_unsafe_assignment.NoUnsafeAssignmentRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-call", no_unsafe_call.NoUnsafeCallRule)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.go
@@ -1,0 +1,640 @@
+package no_unnecessary_type_conversion
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/typescriptutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildUnnecessaryTypeConversionMessage(violation, typeName string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unnecessaryTypeConversion",
+		Description: fmt.Sprintf("%s does not change the type or value of the %s.", violation, typeName),
+		Data: map[string]string{
+			"type":      typeName,
+			"violation": violation,
+		},
+	}
+}
+
+func buildSuggestRemoveMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "suggestRemove",
+		Description: "Remove the type conversion.",
+	}
+}
+
+func buildSuggestSatisfiesMessage(typeName string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "suggestSatisfies",
+		Description: fmt.Sprintf("Instead, assert that the value satisfies the %s type.", typeName),
+		Data: map[string]string{
+			"type": typeName,
+		},
+	}
+}
+
+// doesUnderlyingTypeMatchFlag mirrors upstream's
+// `unionConstituents(type).every(t => isTypeFlagSet(t, flag))` — only true when
+// every union constituent already has the target type flag, so the conversion
+// is provably a no-op.
+func doesUnderlyingTypeMatchFlag(t *checker.Type, flag checker.TypeFlags) bool {
+	if t == nil {
+		return false
+	}
+	for _, part := range utils.UnionTypeParts(t) {
+		if !utils.IsTypeFlagSet(part, flag) {
+			return false
+		}
+	}
+	return true
+}
+
+// wrappedInnerText returns innerNode's source text, parenthesized when the
+// inner node does not have strong precedence (so inlining into a tighter
+// context would silently rebind operators). Reuses the shared
+// utils.IsStrongPrecedenceNode helper used by prefer_regexp_exec etc.
+func wrappedInnerText(sourceFile *ast.SourceFile, innerNode *ast.Node) string {
+	text := utils.TrimmedNodeText(sourceFile, innerNode)
+	if !utils.IsStrongPrecedenceNode(innerNode) {
+		return "(" + text + ")"
+	}
+	return text
+}
+
+// buildWrappingFix produces the replacement text for `outerNode` constructed
+// from `innerNode`'s text. When `wrap` is nil the inner text replaces the
+// outer node directly; when `wrap` is provided the result is additionally
+// wrapped in parens if the surrounding context could rebind precedence.
+func buildWrappingFix(sourceFile *ast.SourceFile, outerNode *ast.Node, innerNode *ast.Node, wrap func(string) string) rule.RuleFix {
+	innerCode := wrappedInnerText(sourceFile, innerNode)
+	var code string
+	if wrap == nil {
+		code = innerCode
+	} else {
+		code = wrap(innerCode)
+		if typescriptutil.IsWeakPrecedenceParent(outerNode) {
+			code = "(" + code + ")"
+		}
+	}
+	return rule.RuleFixReplace(sourceFile, outerNode, code)
+}
+
+// argumentSkippingParens unwraps any ParenthesizedExpression chain so that the
+// remaining node mirrors what ESLint's AST would expose as `.argument` /
+// `.arguments[0]` / `.left` etc. tsgo keeps parens as explicit nodes; the
+// upstream rule never sees them.
+func argumentSkippingParens(node *ast.Node) *ast.Node {
+	return ast.SkipParentheses(node)
+}
+
+// isEmptyStringLiteral mirrors upstream's `node.type === Literal && value === ''`.
+// In ESTree a TemplateLiteral is NOT a Literal — even `` `` ``. tsgo keeps
+// NoSubstitutionTemplateLiteral as a literal-kind, but to stay aligned we
+// match the upstream contract and only treat StringLiteral as empty here.
+//
+// SkipParentheses lets `('')` and `((''))` qualify, matching upstream which
+// never sees ParenthesizedExpression — ESTree treats parens transparently.
+func isEmptyStringLiteral(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	stripped := ast.SkipParentheses(node)
+	if stripped.Kind == ast.KindStringLiteral {
+		return stripped.AsStringLiteral().Text == ""
+	}
+	return false
+}
+
+// isLocallyShadowed mirrors upstream's `scope.set.get(name).defs.length > 0`
+// check: it asks only the IMMEDIATELY enclosing scope (the nearest block,
+// module body, function-like, or source file) whether it declares a binding
+// with the given name. Unlike rslint's `utils.IsShadowed` it does NOT walk up
+// the scope chain — upstream's ESLint scope.set is local-only, and matching
+// that quirk is required for parity (verified via differential validation
+// against typescript-eslint 8.x on nested function/block/arrow cases).
+//
+// Both value bindings (function/class/enum/var/import/namespace) and type
+// bindings (type alias/interface) shadow, since ESLint's scope manager folds
+// type bindings into the same scope.set.
+func isLocallyShadowed(node *ast.Node, name string) bool {
+	for current := node.Parent; current != nil; current = current.Parent {
+		switch current.Kind {
+		case ast.KindSourceFile:
+			sf := current.AsSourceFile()
+			if sf != nil && sf.Statements != nil {
+				return statementsDeclare(sf.Statements.Nodes, name)
+			}
+			return false
+		case ast.KindModuleBlock:
+			mb := current.AsModuleBlock()
+			if mb != nil && mb.Statements != nil {
+				return statementsDeclare(mb.Statements.Nodes, name)
+			}
+			return false
+		case ast.KindBlock:
+			block := current.AsBlock()
+			if block != nil && block.Statements != nil {
+				if statementsDeclare(block.Statements.Nodes, name) {
+					return true
+				}
+			}
+			// A Block that is a function-like body shares scope with the
+			// function's name + parameters per ESLint's scope manager.
+			parent := current.Parent
+			if parent != nil && ast.IsFunctionLikeDeclaration(parent) {
+				if functionHasOwnNameOrParam(parent, name) {
+					return true
+				}
+			}
+			return false
+		}
+		// Arrow function with expression body (no Block to land on), method
+		// declarations without a separate visit-able body, etc.
+		if ast.IsFunctionLikeDeclaration(current) {
+			return functionHasOwnNameOrParam(current, name)
+		}
+	}
+	return false
+}
+
+func functionHasOwnNameOrParam(fn *ast.Node, name string) bool {
+	if fn.Kind == ast.KindFunctionDeclaration || fn.Kind == ast.KindFunctionExpression {
+		n := fn.Name()
+		if n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+			return true
+		}
+	}
+	return utils.HasShadowingParameter(fn, name)
+}
+
+// statementsDeclare reports whether any of the given top-level/block-level
+// statements introduces a binding (value or type) with `name`.
+func statementsDeclare(stmts []*ast.Node, name string) bool {
+	for _, stmt := range stmts {
+		if stmt == nil {
+			continue
+		}
+		switch stmt.Kind {
+		case ast.KindFunctionDeclaration,
+			ast.KindClassDeclaration,
+			ast.KindEnumDeclaration,
+			ast.KindTypeAliasDeclaration,
+			ast.KindInterfaceDeclaration:
+			n := stmt.Name()
+			if n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+				return true
+			}
+		case ast.KindModuleDeclaration:
+			md := stmt.AsModuleDeclaration()
+			if md != nil && md.Name() != nil &&
+				md.Name().Kind == ast.KindIdentifier && md.Name().Text() == name {
+				return true
+			}
+		case ast.KindVariableStatement:
+			vs := stmt.AsVariableStatement()
+			if vs == nil || vs.DeclarationList == nil {
+				continue
+			}
+			dl := vs.DeclarationList.AsVariableDeclarationList()
+			if dl == nil || dl.Declarations == nil {
+				continue
+			}
+			for _, decl := range dl.Declarations.Nodes {
+				if decl == nil || decl.Kind != ast.KindVariableDeclaration {
+					continue
+				}
+				vd := decl.AsVariableDeclaration()
+				if vd != nil && vd.Name() != nil && utils.HasNameInBindingPattern(vd.Name(), name) {
+					return true
+				}
+			}
+		case ast.KindImportEqualsDeclaration:
+			ie := stmt.AsImportEqualsDeclaration()
+			if ie != nil && ie.Name() != nil && ie.Name().Text() == name {
+				return true
+			}
+		case ast.KindImportDeclaration:
+			id := stmt.AsImportDeclaration()
+			if id == nil || id.ImportClause == nil {
+				continue
+			}
+			ic := id.ImportClause.AsImportClause()
+			if ic == nil {
+				continue
+			}
+			if ic.Name() != nil && ic.Name().Text() == name {
+				return true
+			}
+			if ic.NamedBindings != nil {
+				switch ic.NamedBindings.Kind {
+				case ast.KindNamespaceImport:
+					ni := ic.NamedBindings.AsNamespaceImport()
+					if ni != nil && ni.Name() != nil && ni.Name().Text() == name {
+						return true
+					}
+				case ast.KindNamedImports:
+					nis := ic.NamedBindings.AsNamedImports()
+					if nis != nil && nis.Elements != nil {
+						for _, elem := range nis.Elements.Nodes {
+							if elem == nil {
+								continue
+							}
+							is := elem.AsImportSpecifier()
+							if is != nil && is.Name() != nil && is.Name().Text() == name {
+								return true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// callExprTypeFlags maps a built-in conversion function name to the TypeFlags
+// its argument must already satisfy for the call to be a no-op.
+var callExprTypeFlags = map[string]checker.TypeFlags{
+	"BigInt":  checker.TypeFlagsBigIntLike,
+	"Boolean": checker.TypeFlagsBooleanLike,
+	"Number":  checker.TypeFlagsNumberLike,
+	"String":  checker.TypeFlagsStringLike,
+}
+
+// isEnumOrEnumMemberType mirrors upstream's `isEnumType || isEnumMemberType`
+// short-circuit on `.toString()` — calling `EnumMember.toString()` is a way
+// to read the enum's underlying string/number, not a no-op type conversion.
+func isEnumOrEnumMemberType(t *checker.Type) bool {
+	if t == nil {
+		return false
+	}
+	if utils.IsTypeFlagSet(t, checker.TypeFlagsEnumLike) {
+		return true
+	}
+	sym := checker.Type_symbol(t)
+	if sym != nil && utils.IsSymbolFlagSet(sym, ast.SymbolFlagsEnumMember) {
+		return true
+	}
+	return false
+}
+
+// isInteger mirrors upstream's `Number.isInteger((t as NumberLiteralType).value)`.
+// tsgo stores NumberLiteral values as `jsnum.Number` (float64). Calling
+// `checker.ValueToString` is unsafe for integrality checks because Go's
+// `json.Marshal(float64)` emits scientific notation past ~1e21 (`1e+21`),
+// matching JS but breaking a string-pattern integer test. Parse the resulting
+// text back to a float and ask `math.Trunc(f) == f` to match
+// `Number.isInteger` semantics exactly.
+func isInteger(val interface{}) bool {
+	if val == nil {
+		return false
+	}
+	s := checker.ValueToString(val)
+	if s == "" {
+		return false
+	}
+	f, err := strconv.ParseFloat(strings.TrimSuffix(s, "n"), 64)
+	if err != nil {
+		return false
+	}
+	return !math.IsNaN(f) && !math.IsInf(f, 0) && f == math.Trunc(f)
+}
+
+// allUnionPartsAreIntegerNumberLiteral mirrors upstream's `~~` integer check:
+// every union constituent must be a NumberLiteral whose value is an integer.
+func allUnionPartsAreIntegerNumberLiteral(t *checker.Type) bool {
+	if t == nil {
+		return false
+	}
+	parts := utils.UnionTypeParts(t)
+	if len(parts) == 0 {
+		return false
+	}
+	for _, part := range parts {
+		if !utils.IsTypeFlagSet(part, checker.TypeFlagsNumberLiteral) {
+			return false
+		}
+		if !isInteger(part.AsLiteralType().Value()) {
+			return false
+		}
+	}
+	return true
+}
+
+var NoUnnecessaryTypeConversionRule = rule.CreateRule(rule.Rule{
+	Name:             "no-unnecessary-type-conversion",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		sourceFile := ctx.SourceFile
+
+		// reportUnaryConversion reports unary-operator-style conversions (`+x`,
+		// `!!x`, `~~x`). `outerNode` is the report anchor (the full `!!` /
+		// `~~` for double-operator variants, the single operator otherwise),
+		// `innerArgument` is the operand whose source text replaces it.
+		reportUnaryConversion := func(outerNode, opStartNode, innerArgument *ast.Node, typeName, violation string) {
+			outerRange := utils.TrimNodeTextRange(sourceFile, outerNode)
+			opStart := utils.TrimNodeTextRange(sourceFile, opStartNode).Pos()
+			reportRange := core.NewTextRange(outerRange.Pos(), opStart+1)
+			ctx.ReportRangeWithSuggestions(reportRange,
+				buildUnnecessaryTypeConversionMessage(violation, typeName),
+				rule.RuleSuggestion{
+					Message:  buildSuggestRemoveMessage(),
+					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, outerNode, innerArgument, nil)},
+				},
+				rule.RuleSuggestion{
+					Message: buildSuggestSatisfiesMessage(typeName),
+					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, outerNode, innerArgument, func(code string) string {
+						return code + " satisfies " + typeName
+					})},
+				},
+			)
+		}
+
+		reportCallConversion := func(callNode, calleeIdentifier, innerArg *ast.Node, fnName string) {
+			typeName := strings.ToLower(fnName)
+			violation := "Passing a " + typeName + " to " + fnName + "()"
+			calleeRange := utils.TrimNodeTextRange(sourceFile, calleeIdentifier)
+			ctx.ReportRangeWithSuggestions(calleeRange,
+				buildUnnecessaryTypeConversionMessage(violation, typeName),
+				rule.RuleSuggestion{
+					Message:  buildSuggestRemoveMessage(),
+					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, callNode, innerArg, nil)},
+				},
+				rule.RuleSuggestion{
+					Message: buildSuggestSatisfiesMessage(typeName),
+					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, callNode, innerArg, func(code string) string {
+						return code + " satisfies " + typeName
+					})},
+				},
+			)
+		}
+
+		reportToString := func(callNode, propertyIdent, innerObject *ast.Node) {
+			propertyRange := utils.TrimNodeTextRange(sourceFile, propertyIdent)
+			callRange := utils.TrimNodeTextRange(sourceFile, callNode)
+			reportRange := core.NewTextRange(propertyRange.Pos(), callRange.End())
+			ctx.ReportRangeWithSuggestions(reportRange,
+				buildUnnecessaryTypeConversionMessage("Calling a string's .toString() method", "string"),
+				rule.RuleSuggestion{
+					Message:  buildSuggestRemoveMessage(),
+					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, callNode, innerObject, nil)},
+				},
+				rule.RuleSuggestion{
+					Message: buildSuggestSatisfiesMessage("string"),
+					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, callNode, innerObject, func(code string) string {
+						return code + " satisfies string"
+					})},
+				},
+			)
+		}
+
+		// handleBinaryPlus handles both `+` and `+=` BinaryExpressions, branching
+		// on operator kind. tsgo collapses ESLint's separate AssignmentExpression
+		// listener into BinaryExpression too, so a single visitor covers both.
+		handleBinaryPlus := func(node *ast.Node) {
+			bin := node.AsBinaryExpression()
+			if bin == nil || bin.OperatorToken == nil {
+				return
+			}
+			operator := bin.OperatorToken.Kind
+			left := bin.Left
+			right := bin.Right
+			if left == nil || right == nil {
+				return
+			}
+
+			switch operator {
+			case ast.KindPlusEqualsToken:
+				if !isEmptyStringLiteral(right) {
+					return
+				}
+				leftType := ctx.TypeChecker.GetTypeAtLocation(left)
+				if !doesUnderlyingTypeMatchFlag(leftType, checker.TypeFlagsStringLike) {
+					return
+				}
+
+				inner := argumentSkippingParens(left)
+				removeFix := buildWrappingFix(sourceFile, node, inner, nil)
+				if node.Parent != nil && node.Parent.Kind == ast.KindExpressionStatement {
+					removeFix = rule.RuleFixRemoveRange(utils.TrimNodeTextRange(sourceFile, node.Parent))
+				}
+
+				ctx.ReportNodeWithSuggestions(node,
+					buildUnnecessaryTypeConversionMessage("Concatenating a string with ''", "string"),
+					rule.RuleSuggestion{
+						Message:  buildSuggestRemoveMessage(),
+						FixesArr: []rule.RuleFix{removeFix},
+					},
+					rule.RuleSuggestion{
+						Message: buildSuggestSatisfiesMessage("string"),
+						FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, node, inner, func(code string) string {
+							return code + " satisfies string"
+						})},
+					},
+				)
+
+			case ast.KindPlusToken:
+				// case: <string-like> + ''
+				if isEmptyStringLiteral(right) {
+					leftType := ctx.TypeChecker.GetTypeAtLocation(left)
+					if !doesUnderlyingTypeMatchFlag(leftType, checker.TypeFlagsStringLike) {
+						return
+					}
+					inner := argumentSkippingParens(left)
+					// Use the unwrapped inner's end for the start of the report,
+					// mirroring upstream's ESTree view (which never sees parens).
+					// `((('x'))) + ''` reports starting at the end of `'x'`, not
+					// the end of the outermost paren.
+					innerRange := utils.TrimNodeTextRange(sourceFile, inner)
+					nodeRange := utils.TrimNodeTextRange(sourceFile, node)
+					reportRange := core.NewTextRange(innerRange.End(), nodeRange.End())
+
+					ctx.ReportRangeWithSuggestions(reportRange,
+						buildUnnecessaryTypeConversionMessage("Concatenating a string with ''", "string"),
+						rule.RuleSuggestion{
+							Message:  buildSuggestRemoveMessage(),
+							FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, node, inner, nil)},
+						},
+						rule.RuleSuggestion{
+							Message: buildSuggestSatisfiesMessage("string"),
+							FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, node, inner, func(code string) string {
+								return code + " satisfies string"
+							})},
+						},
+					)
+					return
+				}
+				// case: '' + <string-like>
+				if isEmptyStringLiteral(left) {
+					rightType := ctx.TypeChecker.GetTypeAtLocation(right)
+					if !doesUnderlyingTypeMatchFlag(rightType, checker.TypeFlagsStringLike) {
+						return
+					}
+					inner := argumentSkippingParens(right)
+					// Same paren-transparent rule as the right-empty branch: end
+					// the report at the unwrapped inner's start, so `'' + ((s))`
+					// matches upstream's columns instead of including parens.
+					nodeRange := utils.TrimNodeTextRange(sourceFile, node)
+					innerRange := utils.TrimNodeTextRange(sourceFile, inner)
+					reportRange := core.NewTextRange(nodeRange.Pos(), innerRange.Pos())
+
+					ctx.ReportRangeWithSuggestions(reportRange,
+						buildUnnecessaryTypeConversionMessage("Concatenating '' with a string", "string"),
+						rule.RuleSuggestion{
+							Message:  buildSuggestRemoveMessage(),
+							FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, node, inner, nil)},
+						},
+						rule.RuleSuggestion{
+							Message: buildSuggestSatisfiesMessage("string"),
+							FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, node, inner, func(code string) string {
+								return code + " satisfies string"
+							})},
+						},
+					)
+				}
+			}
+		}
+
+		handleCallExpression := func(node *ast.Node) {
+			call := node.AsCallExpression()
+			if call == nil || call.Expression == nil {
+				return
+			}
+
+			// (1) String(arg) / Number(arg) / Boolean(arg) / BigInt(arg) —
+			// tsgo keeps `(String)('x')` parens explicit as a
+			// ParenthesizedExpression wrapping the Identifier; ESTree has
+			// no paren node. Unwrap before matching the callee name and
+			// report on the bare identifier so the location matches upstream.
+			calleeExpr := ast.SkipParentheses(call.Expression)
+			if calleeExpr.Kind == ast.KindIdentifier {
+				name := calleeExpr.AsIdentifier().Text
+				if flag, ok := callExprTypeFlags[name]; ok {
+					if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+						return
+					}
+					if isLocallyShadowed(node, name) {
+						return
+					}
+					arg0 := call.Arguments.Nodes[0]
+					// `String(...arr)` is never a no-op: spread iterates the
+					// rhs and forwards only the first element (or `undefined`
+					// when the iterator is empty). tsgo unwraps SpreadElement
+					// to its element type, which would otherwise let the rule
+					// over-fire for `string[]` etc. — upstream stays silent
+					// because TypeScript treats SpreadElement as the spreadable
+					// (an array/iterable) type. Short-circuit explicitly.
+					if arg0.Kind == ast.KindSpreadElement {
+						return
+					}
+					argType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, arg0)
+					if !doesUnderlyingTypeMatchFlag(argType, flag) {
+						return
+					}
+					inner := argumentSkippingParens(arg0)
+					reportCallConversion(node, calleeExpr, inner, name)
+					return
+				}
+			}
+
+			// (2) <string-like>.toString()
+			if call.Expression.Kind == ast.KindPropertyAccessExpression {
+				member := call.Expression.AsPropertyAccessExpression()
+				if member == nil || member.Name() == nil || member.Expression == nil {
+					return
+				}
+				nameNode := member.Name()
+				if nameNode.Kind != ast.KindIdentifier || nameNode.AsIdentifier().Text != "toString" {
+					return
+				}
+				objectType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, member.Expression)
+				if isEnumOrEnumMemberType(objectType) {
+					return
+				}
+				// Treat each union part individually for the enum-member short-circuit;
+				// upstream uses `isEnumType(type) || isEnumMemberType(type)` against
+				// the constrained type as a whole, so a union containing a non-enum
+				// constituent falls through to the StringLike-only check below.
+				if !doesUnderlyingTypeMatchFlag(objectType, checker.TypeFlagsStringLike) {
+					return
+				}
+				inner := argumentSkippingParens(member.Expression)
+				reportToString(node, nameNode, inner)
+			}
+		}
+
+		handlePrefixUnary := func(node *ast.Node) {
+			pu := node.AsPrefixUnaryExpression()
+			if pu == nil || pu.Operand == nil {
+				return
+			}
+
+			switch pu.Operator {
+			case ast.KindPlusToken:
+				// `+x` where x is number-like.
+				operand := pu.Operand
+				argType := ctx.TypeChecker.GetTypeAtLocation(operand)
+				if !doesUnderlyingTypeMatchFlag(argType, checker.TypeFlagsNumberLike) {
+					return
+				}
+				inner := argumentSkippingParens(operand)
+				reportUnaryConversion(node, node, inner, "number", "Using the unary + operator on a number")
+
+			case ast.KindExclamationToken:
+				// `!!x` — fire on the OUTER `!` whose operand (after stripping
+				// any ParenthesizedExpression layers) is another `!`. Detecting
+				// from the outer side lets `!(!x)` qualify too; ESTree has no
+				// paren node so upstream sees both as identical.
+				innerNode := ast.SkipParentheses(pu.Operand)
+				if innerNode == nil || innerNode.Kind != ast.KindPrefixUnaryExpression {
+					return
+				}
+				innerPu := innerNode.AsPrefixUnaryExpression()
+				if innerPu == nil || innerPu.Operator != ast.KindExclamationToken || innerPu.Operand == nil {
+					return
+				}
+				argType := ctx.TypeChecker.GetTypeAtLocation(innerPu.Operand)
+				if !doesUnderlyingTypeMatchFlag(argType, checker.TypeFlagsBooleanLike) {
+					return
+				}
+				inner := argumentSkippingParens(innerPu.Operand)
+				reportUnaryConversion(node, innerNode, inner, "boolean", "Using !! on a boolean")
+
+			case ast.KindTildeToken:
+				// `~~x` — same outer-side detection so `~(~x)` qualifies.
+				// The operand of the inner `~` must be an integer NumberLiteral
+				// union; non-integers are rounded by `~~` and so the operator
+				// is meaningful.
+				innerNode := ast.SkipParentheses(pu.Operand)
+				if innerNode == nil || innerNode.Kind != ast.KindPrefixUnaryExpression {
+					return
+				}
+				innerPu := innerNode.AsPrefixUnaryExpression()
+				if innerPu == nil || innerPu.Operator != ast.KindTildeToken || innerPu.Operand == nil {
+					return
+				}
+				argType := ctx.TypeChecker.GetTypeAtLocation(innerPu.Operand)
+				if !allUnionPartsAreIntegerNumberLiteral(argType) {
+					return
+				}
+				inner := argumentSkippingParens(innerPu.Operand)
+				reportUnaryConversion(node, innerNode, inner, "number", "Using ~~ on an integer")
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindBinaryExpression:      handleBinaryPlus,
+			ast.KindCallExpression:        handleCallExpression,
+			ast.KindPrefixUnaryExpression: handlePrefixUnary,
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.md
@@ -1,0 +1,58 @@
+# no-unnecessary-type-conversion
+
+## Rule Details
+
+Disallow conversion idioms when they do not change the type or value of the expression. TypeScript already tracks the type of every expression, so calling `String(x)`, `Number(x)`, `Boolean(x)`, `BigInt(x)`, `.toString()`, `+x`, `!!x`, `~~x`, or concatenating with `''` when the source expression already has the target type is a no-op — it adds noise without changing the value or the type.
+
+The rule never reports on `new String(...)`, `new Number(...)`, `new Boolean(...)`, or `new BigInt(...)`; those construct wrapper objects whose runtime type is `object`, not the primitive, so the call is not a no-op. It also opts out of the `.toString()` check when the receiver is an enum or enum member, since `.toString()` there is the documented way to read the enum's underlying string or number. A locally declared `String` / `Number` / `Boolean` / `BigInt` shadows the global and suppresses the call-form report.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+String('asdf');
+'asdf'.toString();
+'asdf' + '';
+'' + 'asdf';
+let str = 'asdf';
+str += '';
+
+Number(123);
++123;
+~~123;
+
+Boolean(true);
+!!true;
+
+BigInt(3n);
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+String(1);
+(1).toString();
+`${1}`;
+'' + 1;
+1 + '';
+let str = 1;
+str += '';
+
+Number('2');
++'2';
+~~'2';
+~~1.1;
+~~(1 / 3);
+
+Boolean(0);
+!!0;
+
+BigInt(3);
+
+new String('asdf');
+new Number(2);
+new Boolean(true);
+```
+
+## Original Documentation
+
+- [typescript-eslint no-unnecessary-type-conversion](https://typescript-eslint.io/rules/no-unnecessary-type-conversion)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion_extras_test.go
@@ -1,0 +1,1139 @@
+// TestNoUnnecessaryTypeConversionExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// Every assertion in this file was differential-validated against
+// typescript-eslint 8.x's `no-unnecessary-type-conversion` running under
+// ESLint + @typescript-eslint/parser on the same input snippets. Cases noted
+// `// upstream: fires` / `// upstream: no fire` were each confirmed by the
+// reference run; deviations are called out where the rule's surface diverges
+// for documented reasons (and there are none in this file).
+package no_unnecessary_type_conversion
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnnecessaryTypeConversionExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryTypeConversionRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: receiver wrappers — TS non-null assertion routing to a non-string-like type ----
+			// `foo!.toString()` where foo!'s type is `number` — number→toString stays valid.
+			{Code: `
+declare const x: number | null;
+x!.toString();
+`},
+			// ---- Dimension 4: optional chain on .toString receiver ----
+			// `s?.toString()` on possibly-undefined receiver: union with undefined is NOT all string-like.
+			{Code: `
+declare const s: string | undefined;
+s?.toString();
+`},
+			// ---- Dimension 4: union with non-string constituent — should NOT trigger ----
+			// `String(x)` where x is `string | number` — only every-constituent string-like fires.
+			{Code: `
+declare const x: string | number;
+String(x);
+`},
+			// ---- Dimension 4: element-access key form for the conversion call ----
+			// `globalThis['String']('asdf')` does not match an Identifier callee → not reported.
+			{Code: `globalThis['String']('asdf');`},
+			// ---- Dimension 4: nested-scope shadow (block-scoped function) ----
+			{Code: `
+{
+  function String(value: unknown) {
+    return value;
+  }
+  String('asdf');
+}
+export {};
+`},
+			// ---- Dimension 4: type alias declared in SAME scope shadows (matches upstream scope.set) ----
+			// Differential-validated: upstream does NOT fire — type aliases enter ESLint's
+			// scope.set even though they erase at runtime.
+			{Code: `
+type String = string;
+String('asdf');
+export {};
+`},
+			// ---- Dimension 4: interface declared in same scope shadows ----
+			// Differential-validated: upstream does NOT fire.
+			{Code: `
+interface String {
+  foo(): void;
+}
+String('asdf');
+export {};
+`},
+			// ---- Dimension 4: class declared in same scope shadows ----
+			{Code: `
+class String {}
+new String();
+export {};
+`},
+			// ---- Dimension 4: NoSubstitutionTemplateLiteral is NOT a Literal upstream ----
+			// `'asdf' + ``;` differential-validated: upstream does NOT fire because the
+			// `'' === node.right.value` check requires the right operand to be a Literal
+			// node, not a TemplateLiteral. tsgo treats backtick template as a literal kind;
+			// we explicitly opt out to stay aligned with upstream.
+			{Code: `
+declare const s: string;
+const r = s + ` + "``" + `;
+`},
+			{Code: `
+declare const s: string;
+const r = ` + "``" + ` + s;
+`},
+			{Code: `
+let m: string = '';
+m += ` + "``" + `;
+`},
+			// ---- Locks in enum-member short-circuit: a single enum member access ----
+			{Code: `
+enum E {
+  A = 'a',
+}
+E.A.toString();
+`},
+			// ---- Locks in upstream handleUnaryOperator integer branch: float NumberLiteral must not fire ----
+			{Code: `
+const x = 1.5;
+~~x;
+`},
+			// ---- Locks in upstream integer branch: NumberLiteralType union including a non-integer ----
+			{Code: `
+declare const x: 1 | 1.5;
+~~x;
+`},
+			// ---- Locks in upstream integer branch: `number` (general) is not a NumberLiteral, so ~~ stays valid ----
+			{Code: `
+declare const x: number;
+~~x;
+`},
+			// ---- Locks in `Boolean()` requiring booleanLike: any-type argument is not booleanLike ----
+			{Code: `
+declare const x: any;
+Boolean(x);
+`},
+			// ---- Locks in `+x` numberLike check: bigint is NOT numberLike, so +x stays valid ----
+			{Code: `
+declare const x: bigint;
++x;
+`},
+			// ---- Locks in `'' + x` rightTypeMatches branch: x must be all string-like ----
+			{Code: `
+declare const x: string | number;
+'' + x;
+`},
+			// ---- Locks in `x + ''` leftTypeMatches branch ----
+			{Code: `
+declare const x: string | number;
+x + '';
+`},
+			// ---- Locks in `+=` listener: left non-string forbids reporting ----
+			{Code: `
+let n = 1;
+n += '';
+`},
+			// ---- Real-user: `obj?.x.toString()` where `obj?.x` resolves to nullable ----
+			{Code: `
+declare const obj: { x: number } | undefined;
+obj?.x.toString();
+`},
+
+			// ---- `String(...arr)` SpreadElement — never a no-op so the rule
+			// must stay silent. tsgo's `getConstrainedTypeAtLocation` for a
+			// SpreadElement unwraps to the element type (`string`), which
+			// without an explicit short-circuit would let the rule over-fire
+			// against upstream. ----
+			{Code: `
+declare const arr: string[];
+String(...arr);
+`},
+			{Code: `
+declare const ns: number[];
+Number(...ns);
+`},
+
+			// =================================================================
+			// Sanity non-trigger forms — rule MUST stay silent (no false-fires)
+			// All differential-validated against typescript-eslint 8.x.
+			// =================================================================
+
+			// ---- Tagged template `String\`abc\`` is NOT a CallExpression ----
+			{Code: "const x = String`abc`;"},
+			// ---- `String.call(null, 'x')` — callee is MemberExpression, not Identifier ----
+			{Code: `const x = String.call(null, 'asdf');`},
+			// ---- `Symbol('x')` — name not in the 4 watched conversion fns ----
+			{Code: `const x = Symbol('asdf');`},
+			// ---- `parseInt('123')` — name not watched ----
+			{Code: `const x = parseInt('123');`},
+
+			// =================================================================
+			// Type-system edges (differential-validated upstream stays silent)
+			// =================================================================
+
+			// ---- `String(undefined)` — undefined is not StringLike ----
+			{Code: `String(undefined);`},
+			// ---- `String(null)` — null is not StringLike ----
+			{Code: `String(null);`},
+			// ---- `String(0)` — number is not StringLike ----
+			{Code: `String(0);`},
+			// ---- `Number(prompt)` — string is not NumberLike ----
+			{Code: `
+declare const ps: string;
+Number(ps);
+`},
+			// ---- Branded string `string & {__brand}` is Intersection, not String ----
+			// Verified: upstream does NOT fire. UnionTypeParts only splits unions,
+			// so an Intersection's flags are checked as-is (no StringLike).
+			{Code: `
+type Brand = string & { __brand: 'x' };
+declare const b: Brand;
+String(b);
+`},
+			// ---- `'asdf' + 'b'` — neither operand is the empty literal ----
+			{Code: `const x = 'asdf' + 'b';`},
+
+			// =================================================================
+			// Shadow edges — differential-validated against upstream's
+			// LOCAL-scope-only check (see isLocallyShadowed docstring).
+			// =================================================================
+
+			// ---- Destructure shadow in same block ----
+			{Code: `
+declare const obj: { String: (v: unknown) => unknown };
+{
+  const { String } = obj;
+  String('asdf');
+}
+`},
+			// ---- Function parameter shadow ----
+			{Code: `
+function outer(String: (v: unknown) => unknown) {
+  String('asdf');
+}
+export {};
+`},
+			// ---- Arrow parameter shadow ----
+			{Code: `
+const fn = (String: (v: unknown) => unknown) => String('asdf');
+export {};
+`},
+			// ---- Function expression's own name shadow ----
+			{Code: `
+const fn = function String(v: unknown) {
+  return String('asdf');
+};
+export {};
+`},
+			// ---- Same-scope const variable shadow ----
+			{Code: `
+const String = (v: unknown) => v;
+String('asdf');
+export {};
+`},
+			// ---- Same-scope namespace declaration shadow (creates value binding) ----
+			{Code: `
+namespace String {
+  export const x = 1;
+}
+String;
+export {};
+`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized argument of String() ----
+			// tsgo wraps argument in ParenthesizedExpression; rslint follows upstream
+			// (ESTree has no paren nodes) and inlines the unwrapped inner text.
+			{
+				Code: `String(('asdf'));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `'asdf';`},
+							{MessageId: "suggestSatisfies", Output: `'asdf' satisfies string;`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: parenthesized CALLEE — `(String)('asdf')` ----
+			// Differential-validated: upstream fires (its ESTree parser implicitly
+			// strips parens around the callee). rslint must SkipParentheses on the
+			// callee to match — verified.
+			{
+				Code: `(String)('asdf');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    2,
+						EndColumn: 8,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `'asdf';`},
+							{MessageId: "suggestSatisfies", Output: `'asdf' satisfies string;`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: optional call form `String?.('asdf')` ----
+			// Differential-validated: upstream fires.
+			{
+				Code: `String?.('asdf');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `'asdf';`},
+							{MessageId: "suggestSatisfies", Output: `'asdf' satisfies string;`},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: template literal with substitution receiver of .toString() ----
+			// Differential-validated: upstream fires.
+			{
+				Code: "`pre${0}`.toString();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    11,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							// TemplateExpression is not strong-precedence per utils.IsStrongPrecedenceNode,
+							// so the wrapping fixer adds parens around the bare receiver — matches upstream.
+							{MessageId: "suggestRemove", Output: "(`pre${0}`);"},
+							{MessageId: "suggestSatisfies", Output: "(`pre${0}`) satisfies string;"},
+						},
+					},
+				},
+			},
+			// ---- Dimension 4: NoSubstitutionTemplateLiteral receiver of .toString() ----
+			// Differential-validated: upstream fires (receiver type is stringLike).
+			{
+				Code: "`asdf`.toString();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    8,
+						EndColumn: 18,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: "`asdf`;"},
+							{MessageId: "suggestSatisfies", Output: "`asdf` satisfies string;"},
+						},
+					},
+				},
+			},
+			// ---- Locks in: top-level function declaration does NOT propagate as shadow into nested function ----
+			// Differential-validated: upstream's scope.set check is LOCAL — outer
+			// declarations do not shadow inside nested function/arrow/block scopes,
+			// even though TS semantics would resolve the bare name to the outer.
+			{
+				Code: `
+function String(v: unknown) {
+  return v;
+}
+function inner() {
+  String('asdf');
+}
+export {};
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      6,
+						Column:    3,
+						EndColumn: 9,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+function String(v: unknown) {
+  return v;
+}
+function inner() {
+  'asdf';
+}
+export {};
+`},
+							{MessageId: "suggestSatisfies", Output: `
+function String(v: unknown) {
+  return v;
+}
+function inner() {
+  'asdf' satisfies string;
+}
+export {};
+`},
+						},
+					},
+				},
+			},
+			// ---- Locks in: top-level type alias does NOT propagate as shadow into nested block ----
+			{
+				Code: `
+type String = string;
+if (1) {
+  String('asdf');
+}
+export {};
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      4,
+						Column:    3,
+						EndColumn: 9,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+type String = string;
+if (1) {
+  'asdf';
+}
+export {};
+`},
+							{MessageId: "suggestSatisfies", Output: `
+type String = string;
+if (1) {
+  'asdf' satisfies string;
+}
+export {};
+`},
+						},
+					},
+				},
+			},
+			// ---- Locks in handleUnaryOperator BooleanLike branch on a literal-union (true | false) ----
+			{
+				Code: `
+declare const b: true | false;
+!!b;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    1,
+						EndColumn: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const b: true | false;
+b;
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const b: true | false;
+b satisfies boolean;
+`},
+						},
+					},
+				},
+			},
+			// ---- Locks in `Boolean()` reporting on a boolean variable (no shadow) ----
+			{
+				Code: `
+declare const b: boolean;
+Boolean(b);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    1,
+						EndColumn: 8,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const b: boolean;
+b;
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const b: boolean;
+b satisfies boolean;
+`},
+						},
+					},
+				},
+			},
+			// ---- Locks in upstream "node.right === ''" branch when the LHS is a property access ----
+			{
+				Code: `
+declare const obj: { s: string };
+obj.s + '';
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    6,
+						EndLine:   3,
+						EndColumn: 11,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const obj: { s: string };
+obj.s;
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const obj: { s: string };
+obj.s satisfies string;
+`},
+						},
+					},
+				},
+			},
+			// ---- Locks in `node.left === ''` branch with an Identifier RHS ----
+			{
+				Code: `
+declare const s: string;
+'' + s;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    1,
+						EndLine:   3,
+						EndColumn: 6,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const s: string;
+s;
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const s: string;
+s satisfies string;
+`},
+						},
+					},
+				},
+			},
+			// ---- `!(!b)` with paren between the two `!` operators — upstream
+			// sees no paren node and fires; rslint must SkipParentheses on the
+			// outer operand to match. ----
+			{
+				Code: `
+declare const b: boolean;
+!(!b);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    1,
+						EndColumn: 4,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const b: boolean;
+b;
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const b: boolean;
+b satisfies boolean;
+`},
+						},
+					},
+				},
+			},
+			// ---- `~(~1)` — same paren-between fix. ----
+			{
+				Code: `~(~1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 4,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `1;`},
+							{MessageId: "suggestSatisfies", Output: `1 satisfies number;`},
+						},
+					},
+				},
+			},
+			// ---- `s += ('')` — empty literal wrapped in parens still counts.
+			// upstream's ESTree drops parens around the literal, so the rule
+			// sees `s += ''` and fires. ----
+			{
+				Code: `
+let m = '';
+m += ('');
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    1,
+						EndLine:   3,
+						EndColumn: 10,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+let m = '';
+
+`},
+							{MessageId: "suggestSatisfies", Output: `
+let m = '';
+m satisfies string;
+`},
+						},
+					},
+				},
+			},
+			// ---- `((('asdf'))) + ''` — outer paren chain on the left operand
+			// must not shift the report's start column off the inner literal.
+			// upstream column 10 (right after the `'asdf'` literal); rslint
+			// uses SkipParentheses to find the same position. ----
+			{
+				Code: `((('asdf'))) + '';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    10,
+						EndColumn: 18,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `'asdf';`},
+							{MessageId: "suggestSatisfies", Output: `'asdf' satisfies string;`},
+						},
+					},
+				},
+			},
+			// ---- `String(...arr)` with spread argument — never a no-op
+			// (spread iterates and forwards only the first element). upstream
+			// stays silent because TypeScript reports the spread's type as the
+			// iterable, not its element type; rslint must short-circuit on
+			// SpreadElement to avoid an over-fire on `string[]`. ----
+			// This is a NEGATIVE test — the entry below sits in the VALID set
+			// already (search for `SpreadElement`), so we don't need another
+			// invalid one here.
+
+			// ---- Locks in upstream's `Number.isInteger((t as NumberLiteralType).value)`
+			// check: large integers tsgo stringifies as scientific notation (e.g.
+			// `1e+21`) MUST still be treated as integers — earlier string-pattern
+			// implementations false-negatived these. ----
+			{
+				Code: `~~1e21;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `1e21;`},
+							{MessageId: "suggestSatisfies", Output: `1e21 satisfies number;`},
+						},
+					},
+				},
+			},
+			// ---- Locks in `~~` branch when operand is a negative literal preserved via unary minus ----
+			{
+				Code: `~~-42;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `(-42);`},
+							{MessageId: "suggestSatisfies", Output: `(-42) satisfies number;`},
+						},
+					},
+				},
+			},
+			// ---- Locks in triple-bang `!!!x`: 2 adjacent `!!` pairs → 2 reports ----
+			// Differential-validated: upstream fires twice on `!!!b`.
+			{
+				Code: `
+declare const b: boolean;
+!!!b;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    1,
+						EndColumn: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							// Outer report fixes !!! → (!b) because the inner `!b` is a
+							// PrefixUnaryExpression (not strong-precedence).
+							{MessageId: "suggestRemove", Output: `
+declare const b: boolean;
+(!b);
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const b: boolean;
+(!b) satisfies boolean;
+`},
+						},
+					},
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    2,
+						EndColumn: 4,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const b: boolean;
+!b;
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const b: boolean;
+!(b satisfies boolean);
+`},
+						},
+					},
+				},
+			},
+			// ---- Real-user: nested unnecessary conversions in the same expression must each report ----
+			{
+				Code: `String(String('asdf'));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `String('asdf');`},
+							{MessageId: "suggestSatisfies", Output: `String('asdf') satisfies string;`},
+						},
+					},
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    8,
+						EndColumn: 14,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `String('asdf');`},
+							{MessageId: "suggestSatisfies", Output: `String('asdf' satisfies string);`},
+						},
+					},
+				},
+			},
+
+			// =================================================================
+			// Chained binary `+`: each `+` operator is its own potential match
+			// (one report per matching pair). Differential-validated.
+			// =================================================================
+
+			// ---- `'' + s + ''` — parses `('' + s) + ''`. Both inner (left-empty)
+			// and outer (right-empty) fire. rslint emits outer first, inner
+			// second (top-down visit); upstream sorts by position so its
+			// display order is opposite — the diagnostic SET is identical. ----
+			{
+				Code: `
+declare const s: string;
+const c = '' + s + '';
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						// Outer (right-empty branch): ` + ''` covers cols 17-21.
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    17,
+						EndLine:   3,
+						EndColumn: 22,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const s: string;
+const c = ('' + s);
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const s: string;
+const c = ('' + s) satisfies string;
+`},
+						},
+					},
+					{
+						// Inner (left-empty branch): `'' + ` covers cols 11-15.
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    11,
+						EndLine:   3,
+						EndColumn: 16,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const s: string;
+const c = s + '';
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const s: string;
+const c = (s satisfies string) + '';
+`},
+						},
+					},
+				},
+			},
+			// ---- `'a' + '' + 'b'` — only the inner `'' + 'b'` middle? Actually
+			// parses as `('a' + '') + 'b'`. Outer: right is 'b' (not empty) → no
+			// fire. Inner: right is '' → fires.
+			{
+				Code: `const c = 'a' + '' + 'b';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    14,
+						EndColumn: 19,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `const c = 'a' + 'b';`},
+							{MessageId: "suggestSatisfies", Output: `const c = ('a' satisfies string) + 'b';`},
+						},
+					},
+				},
+			},
+			// ---- `'' + ''` — right-empty branch fires first, only 1 report ----
+			{
+				Code: `const c = '' + '';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    13,
+						EndColumn: 18,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `const c = '';`},
+							{MessageId: "suggestSatisfies", Output: `const c = '' satisfies string;`},
+						},
+					},
+				},
+			},
+
+			// =================================================================
+			// Nested type-conversion calls
+			// =================================================================
+
+			// ---- `String(Number(n))` — only inner Number() fires (outer's arg
+			// type is `number`, not StringLike). ----
+			{
+				Code: `
+declare const n: number;
+const c = String(Number(n));
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    18,
+						EndLine:   3,
+						EndColumn: 24,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const n: number;
+const c = String(n);
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const n: number;
+const c = String(n satisfies number);
+`},
+						},
+					},
+				},
+			},
+
+			// ---- `String(typeof 1)` — `typeof X` returns a string-literal-typed
+			// expression which IS StringLike → fires. TypeOfExpression is not
+			// strong-precedence per utils.IsStrongPrecedenceNode, so the
+			// wrapping fixer adds parens (matches upstream output). ----
+			{
+				Code: `const c = String(typeof 1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    11,
+						EndColumn: 17,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `const c = (typeof 1);`},
+							{MessageId: "suggestSatisfies", Output: `const c = (typeof 1) satisfies string;`},
+						},
+					},
+				},
+			},
+
+			// =================================================================
+			// Container forms — type-conversion call appearing in various
+			// container shapes. Each is differential-validated and produces
+			// the same diagnostic location as a bare call.
+			// =================================================================
+
+			// ---- Multi-line String call: trim collapses inner newlines ----
+			{
+				Code: `const c = String(
+  'long string'
+);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    11,
+						EndColumn: 17,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `const c = 'long string';`},
+							{MessageId: "suggestSatisfies", Output: `const c = 'long string' satisfies string;`},
+						},
+					},
+				},
+			},
+			// ---- Class field initializer ----
+			{
+				Code: `
+class K {
+  x = String('asdf');
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    7,
+						EndColumn: 13,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+class K {
+  x = 'asdf';
+}
+`},
+							{MessageId: "suggestSatisfies", Output: `
+class K {
+  x = 'asdf' satisfies string;
+}
+`},
+						},
+					},
+				},
+			},
+			// ---- Class static field ----
+			{
+				Code: `
+class K {
+  static s = String('asdf');
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    14,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+class K {
+  static s = 'asdf';
+}
+`},
+							{MessageId: "suggestSatisfies", Output: `
+class K {
+  static s = 'asdf' satisfies string;
+}
+`},
+						},
+					},
+				},
+			},
+			// ---- Default parameter ----
+			{
+				Code: `function f(x: string = String('asdf')) { return x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    24,
+						EndColumn: 30,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `function f(x: string = 'asdf') { return x; }`},
+							{MessageId: "suggestSatisfies", Output: `function f(x: string = 'asdf' satisfies string) { return x; }`},
+						},
+					},
+				},
+			},
+			// ---- Object literal value ----
+			{
+				Code: `
+declare const s: string;
+const c = { key: String(s) };
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    18,
+						EndLine:   3,
+						EndColumn: 24,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const s: string;
+const c = { key: s };
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const s: string;
+const c = { key: s satisfies string };
+`},
+						},
+					},
+				},
+			},
+			// ---- Array literal element ----
+			{
+				Code: `
+declare const s: string;
+const c = [String(s)];
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    12,
+						EndLine:   3,
+						EndColumn: 18,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const s: string;
+const c = [s];
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const s: string;
+const c = [s satisfies string];
+`},
+						},
+					},
+				},
+			},
+			// ---- Template-string interpolation ----
+			{
+				Code: "declare const s: string;\nconst c = `pre${String(s)}`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      2,
+						Column:    17,
+						EndColumn: 23,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: "declare const s: string;\nconst c = `pre${s}`;"},
+							{MessageId: "suggestSatisfies", Output: "declare const s: string;\nconst c = `pre${s satisfies string}`;"},
+						},
+					},
+				},
+			},
+			// ---- Deeply nested parens on callee `(((String)))('x')` ----
+			{
+				Code: `const c = (((String)))('asdf');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    14,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `const c = 'asdf';`},
+							{MessageId: "suggestSatisfies", Output: `const c = 'asdf' satisfies string;`},
+						},
+					},
+				},
+			},
+			// ---- catch-clause shadow does NOT enter body's local scope.set
+			// (upstream local-only scope quirk — fires) ----
+			{
+				Code: `
+try {} catch (String) {
+  String('asdf');
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    3,
+						EndColumn: 9,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+try {} catch (String) {
+  'asdf';
+}
+`},
+							{MessageId: "suggestSatisfies", Output: `
+try {} catch (String) {
+  'asdf' satisfies string;
+}
+`},
+						},
+					},
+				},
+			},
+			// ---- for-of binding does NOT enter body's local scope.set
+			// (upstream local-only scope quirk — fires) ----
+			{
+				Code: `
+declare const arr: any[];
+for (const String of arr) {
+  String('asdf');
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      4,
+						Column:    3,
+						EndColumn: 9,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const arr: any[];
+for (const String of arr) {
+  'asdf';
+}
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const arr: any[];
+for (const String of arr) {
+  'asdf' satisfies string;
+}
+`},
+						},
+					},
+				},
+			},
+
+			// =================================================================
+			// Type-system edges that DO fire
+			// =================================================================
+
+			// ---- Template literal type as argument — constrained type widens
+			// to string → fires. ----
+			{
+				Code: `
+declare const t: ` + "`pre${string}`" + `;
+String(t);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    1,
+						EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const t: ` + "`pre${string}`" + `;
+t;
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const t: ` + "`pre${string}`" + `;
+t satisfies string;
+`},
+						},
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion_upstream_test.go
@@ -1,0 +1,639 @@
+// TestNoUnnecessaryTypeConversionUpstream migrates the full valid/invalid
+// suite from upstream
+// packages/eslint-plugin/tests/rules/no-unnecessary-type-conversion.test.ts
+// 1:1. Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in
+// no_unnecessary_type_conversion_extras_test.go.
+package no_unnecessary_type_conversion
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnnecessaryTypeConversionUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryTypeConversionRule,
+		[]rule_tester.ValidTestCase{
+			// ---- standard type conversions are valid ----
+			{Code: `String(1);`},
+			{Code: `(1).toString();`},
+			{Code: "`${1}`;"},
+			{Code: `'' + 1;`},
+			{Code: `1 + '';`},
+			{Code: `
+let str = 1;
+str += '';
+`},
+			{Code: `Number('2');`},
+			{Code: `+'2';`},
+			{Code: `~~'2';`},
+			{Code: `~~1.1;`},
+			{Code: `~~-1.1;`},
+			{Code: `~~(1.5 + 2.3);`},
+			{Code: `~~(1 / 3);`},
+			{Code: `Boolean(0);`},
+			{Code: `!!0;`},
+			{Code: `BigInt(3);`},
+
+			// ---- things that look similar but are not type-conversion idioms ----
+			{Code: `new String('asdf');`},
+			{Code: `new Number(2);`},
+			{Code: `new Boolean(true);`},
+			{Code: `!false;`},
+			{Code: `~2;`},
+			{Code: `
+function String(value: unknown) {
+  return value;
+}
+String('asdf');
+export {};
+`},
+			{Code: `
+function Number(value: unknown) {
+  return value;
+}
+Number(2);
+export {};
+`},
+			{Code: `
+function Boolean(value: unknown) {
+  return value;
+}
+Boolean(true);
+export {};
+`},
+			{Code: `
+function BigInt(value: unknown) {
+  return value;
+}
+BigInt(3n);
+export {};
+`},
+			{Code: `
+function toString(value: unknown) {
+  return value;
+}
+toString('asdf');
+`},
+			{Code: `
+export {};
+declare const toString: string;
+toString.toUpperCase();
+`},
+
+			// ---- using conversion idioms to unbox boxed primitives is valid ----
+			{Code: `String(new String());`},
+			{Code: `new String().toString();`},
+			{Code: `'' + new String();`},
+			{Code: `new String() + '';`},
+			{Code: `
+let str = new String();
+str += '';
+`},
+			{Code: `Number(new Number());`},
+			{Code: `+new Number();`},
+			{Code: `~~new Number();`},
+			{Code: `Boolean(new Boolean());`},
+			{Code: `!!new Boolean();`},
+			{Code: `
+enum CustomIds {
+  Id1 = 'id1',
+  Id2 = 'id2',
+}
+const customId = 'id1';
+const compareWithToString = customId === CustomIds.Id1.toString();
+`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `String('asdf');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `'asdf';`},
+							{MessageId: "suggestSatisfies", Output: `'asdf' satisfies string;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `'asdf'.toString();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    8,
+						EndColumn: 18,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `'asdf';`},
+							{MessageId: "suggestSatisfies", Output: `'asdf' satisfies string;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `'' + 'asdf';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 6,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `'asdf';`},
+							{MessageId: "suggestSatisfies", Output: `'asdf' satisfies string;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `'asdf' + '';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    7,
+						EndColumn: 12,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `'asdf';`},
+							{MessageId: "suggestSatisfies", Output: `'asdf' satisfies string;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+let str = 'asdf';
+str += '';
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    1,
+						EndLine:   3,
+						EndColumn: 10,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+let str = 'asdf';
+
+`},
+							{MessageId: "suggestSatisfies", Output: `
+let str = 'asdf';
+str satisfies string;
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+let str = 'asdf';
+'asdf' + (str += '');
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    11,
+						EndLine:   3,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+let str = 'asdf';
+'asdf' + (str);
+`},
+							{MessageId: "suggestSatisfies", Output: `
+let str = 'asdf';
+'asdf' + (str satisfies string);
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `Number(123);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `123;`},
+							{MessageId: "suggestSatisfies", Output: `123 satisfies number;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `+123;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 2,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `123;`},
+							{MessageId: "suggestSatisfies", Output: `123 satisfies number;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `~~123;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `123;`},
+							{MessageId: "suggestSatisfies", Output: `123 satisfies number;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `Boolean(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 8,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `true;`},
+							{MessageId: "suggestSatisfies", Output: `true satisfies boolean;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `!!true;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `true;`},
+							{MessageId: "suggestSatisfies", Output: `true satisfies boolean;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `BigInt(3n);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `3n;`},
+							{MessageId: "suggestSatisfies", Output: `3n satisfies bigint;`},
+						},
+					},
+				},
+			},
+
+			// ---- generics that extend a primitive ----
+			{
+				Code: `
+function f<T extends string>(x: T) {
+  return String(x);
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    10,
+						EndLine:   3,
+						EndColumn: 16,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+function f<T extends string>(x: T) {
+  return x;
+}
+`},
+							{MessageId: "suggestSatisfies", Output: `
+function f<T extends string>(x: T) {
+  return x satisfies string;
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+function f<T extends number>(x: T) {
+  return Number(x);
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    10,
+						EndLine:   3,
+						EndColumn: 16,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+function f<T extends number>(x: T) {
+  return x;
+}
+`},
+							{MessageId: "suggestSatisfies", Output: `
+function f<T extends number>(x: T) {
+  return x satisfies number;
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+function f<T extends boolean>(x: T) {
+  return Boolean(x);
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    10,
+						EndLine:   3,
+						EndColumn: 17,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+function f<T extends boolean>(x: T) {
+  return x;
+}
+`},
+							{MessageId: "suggestSatisfies", Output: `
+function f<T extends boolean>(x: T) {
+  return x satisfies boolean;
+}
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+function f<T extends bigint>(x: T) {
+  return BigInt(x);
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    10,
+						EndLine:   3,
+						EndColumn: 16,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+function f<T extends bigint>(x: T) {
+  return x;
+}
+`},
+							{MessageId: "suggestSatisfies", Output: `
+function f<T extends bigint>(x: T) {
+  return x satisfies bigint;
+}
+`},
+						},
+					},
+				},
+			},
+
+			// ---- fixes preserve parentheses where precedence requires it ----
+			{
+				Code: `String('a' + 'b').length;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `('a' + 'b').length;`},
+							{MessageId: "suggestSatisfies", Output: `(('a' + 'b') satisfies string).length;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `('a' + 'b').toString().length;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    13,
+						EndColumn: 23,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `('a' + 'b').length;`},
+							{MessageId: "suggestSatisfies", Output: `(('a' + 'b') satisfies string).length;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `2 * +(2 + 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    5,
+						EndColumn: 6,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `2 * (2 + 2);`},
+							{MessageId: "suggestSatisfies", Output: `2 * ((2 + 2) satisfies number);`},
+						},
+					},
+				},
+			},
+			{
+				Code: `2 * Number(2 + 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    5,
+						EndColumn: 11,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `2 * (2 + 2);`},
+							{MessageId: "suggestSatisfies", Output: `2 * ((2 + 2) satisfies number);`},
+						},
+					},
+				},
+			},
+			{
+				Code: `false && !!(false || true);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    10,
+						EndColumn: 12,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `false && (false || true);`},
+							{MessageId: "suggestSatisfies", Output: `false && ((false || true) satisfies boolean);`},
+						},
+					},
+				},
+			},
+			{
+				Code: `false && Boolean(false || true);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    10,
+						EndColumn: 17,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `false && (false || true);`},
+							{MessageId: "suggestSatisfies", Output: `false && ((false || true) satisfies boolean);`},
+						},
+					},
+				},
+			},
+			{
+				Code: `2n * BigInt(2n + 2n);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    6,
+						EndColumn: 12,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `2n * (2n + 2n);`},
+							{MessageId: "suggestSatisfies", Output: `2n * ((2n + 2n) satisfies bigint);`},
+						},
+					},
+				},
+			},
+
+			// ---- suggestions add parens around the satisfies expression where syntax requires it ----
+			{
+				Code: `
+let str = 'asdf';
+String(str).length;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    1,
+						EndLine:   3,
+						EndColumn: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+let str = 'asdf';
+str.length;
+`},
+							{MessageId: "suggestSatisfies", Output: `
+let str = 'asdf';
+(str satisfies string).length;
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+let str = 'asdf';
+str.toString().length;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    5,
+						EndLine:   3,
+						EndColumn: 15,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+let str = 'asdf';
+str.length;
+`},
+							{MessageId: "suggestSatisfies", Output: `
+let str = 'asdf';
+(str satisfies string).length;
+`},
+						},
+					},
+				},
+			},
+			{
+				Code: `~~1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `1;`},
+							{MessageId: "suggestSatisfies", Output: `1 satisfies number;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `~~-1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      1,
+						Column:    1,
+						EndColumn: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `(-1);`},
+							{MessageId: "suggestSatisfies", Output: `(-1) satisfies number;`},
+						},
+					},
+				},
+			},
+			{
+				Code: `
+declare const threeOrFour: 3 | 4;
+~~threeOrFour;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryTypeConversion",
+						Line:      3,
+						Column:    1,
+						EndColumn: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestRemove", Output: `
+declare const threeOrFour: 3 | 4;
+threeOrFour;
+`},
+							{MessageId: "suggestSatisfies", Output: `
+declare const threeOrFour: 3 | 4;
+threeOrFour satisfies number;
+`},
+						},
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/prefer_regexp_exec/prefer_regexp_exec.go
+++ b/internal/plugins/typescript/rules/prefer_regexp_exec/prefer_regexp_exec.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/typescriptutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -66,36 +67,6 @@ func isNodeParenthesized(node *ast.Node) bool {
 	return parent != nil && parent.Expression == node
 }
 
-func isWeakPrecedenceParent(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	parent := node.Parent
-	if parent == nil {
-		return false
-	}
-	switch parent.Kind {
-	case ast.KindPostfixUnaryExpression,
-		ast.KindPrefixUnaryExpression,
-		ast.KindBinaryExpression,
-		ast.KindConditionalExpression,
-		ast.KindAwaitExpression:
-		return true
-	}
-	if ast.IsPropertyAccessExpression(parent) {
-		return parent.AsPropertyAccessExpression().Expression == node
-	}
-	if ast.IsElementAccessExpression(parent) {
-		return parent.AsElementAccessExpression().Expression == node
-	}
-	if ast.IsCallExpression(parent) || ast.IsNewExpression(parent) {
-		return parent.Expression() == node
-	}
-	if ast.IsTaggedTemplateExpression(parent) {
-		return parent.AsTaggedTemplateExpression().Tag == node
-	}
-	return false
-}
 
 func getWrappedNodeText(sourceFile *ast.SourceFile, node *ast.Node) string {
 	if sourceFile == nil || node == nil {
@@ -378,7 +349,7 @@ func buildPreferRegExpExecReplacement(ctx rule.RuleContext, callNode *ast.Node, 
 			return "", false
 		}
 	}
-	if isWeakPrecedenceParent(callNode) && !isNodeParenthesized(callNode) {
+	if typescriptutil.IsWeakPrecedenceParent(callNode) && !isNodeParenthesized(callNode) {
 		replacement = "(" + replacement + ")"
 	}
 	return replacement, true

--- a/internal/plugins/typescript/typescriptutil/typescriptutil.go
+++ b/internal/plugins/typescript/typescriptutil/typescriptutil.go
@@ -155,3 +155,51 @@ func IsClassImplementsOrInterfaceExtends(node *ast.Node) bool {
 	}
 	return false
 }
+
+// IsWeakPrecedenceParent mirrors typescript-eslint's `isWeakPrecedenceParent`
+// inside `getWrappingFixer`: it asks whether `node`'s parent might silently
+// rebind operator precedence after `node` is rewrapped, so the caller can
+// decide whether to wrap the replacement in parens. The list is kept in sync
+// with upstream's set:
+//
+//   - any unary/binary/conditional/await/typeof/void/delete parent
+//   - a property access whose object IS `node`
+//   - an element access whose expression IS `node`
+//   - a call/new whose callee IS `node`
+//   - a tagged template whose tag IS `node`
+//
+// Pairs with utils.IsStrongPrecedenceNode (which decides the inverse: whether
+// the INNER expression already binds tight enough to skip its inner paren).
+func IsWeakPrecedenceParent(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindPrefixUnaryExpression,
+		ast.KindPostfixUnaryExpression,
+		ast.KindBinaryExpression,
+		ast.KindConditionalExpression,
+		ast.KindAwaitExpression,
+		ast.KindTypeOfExpression,
+		ast.KindVoidExpression,
+		ast.KindDeleteExpression:
+		return true
+	}
+	if ast.IsPropertyAccessExpression(parent) {
+		return parent.AsPropertyAccessExpression().Expression == node
+	}
+	if ast.IsElementAccessExpression(parent) {
+		return parent.AsElementAccessExpression().Expression == node
+	}
+	if ast.IsCallExpression(parent) || ast.IsNewExpression(parent) {
+		return parent.Expression() == node
+	}
+	if ast.IsTaggedTemplateExpression(parent) {
+		return parent.AsTaggedTemplateExpression().Tag == node
+	}
+	return false
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -295,7 +295,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/no-unnecessary-type-arguments.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-type-assertion.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-type-constraint.test.ts',
-    // './tests/typescript-eslint/rules/no-unnecessary-type-conversion.test.ts',
+    './tests/typescript-eslint/rules/no-unnecessary-type-conversion.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-type-parameters.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-argument.test.ts',
     // './tests/typescript-eslint/rules/no-unsafe-assignment.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-type-conversion.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-type-conversion.test.ts.snap
@@ -1,0 +1,760 @@
+// Rstest Snapshot v1
+
+exports[`no-unnecessary-type-conversion > invalid 1`] = `
+{
+  "code": "String('asdf');",
+  "diagnostics": [
+    {
+      "message": "Passing a string to String() does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 2`] = `
+{
+  "code": "'asdf'.toString();",
+  "diagnostics": [
+    {
+      "message": "Calling a string's .toString() method does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 3`] = `
+{
+  "code": "'' + 'asdf';",
+  "diagnostics": [
+    {
+      "message": "Concatenating '' with a string does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 4`] = `
+{
+  "code": "'asdf' + '';",
+  "diagnostics": [
+    {
+      "message": "Concatenating a string with '' does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 5`] = `
+{
+  "code": "
+let str = 'asdf';
+str += '';
+      ",
+  "diagnostics": [
+    {
+      "message": "Concatenating a string with '' does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 6`] = `
+{
+  "code": "
+let str = 'asdf';
+'asdf' + (str += '');
+      ",
+  "diagnostics": [
+    {
+      "message": "Concatenating a string with '' does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 7`] = `
+{
+  "code": "Number(123);",
+  "diagnostics": [
+    {
+      "message": "Passing a number to Number() does not change the type or value of the number.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 8`] = `
+{
+  "code": "+123;",
+  "diagnostics": [
+    {
+      "message": "Using the unary + operator on a number does not change the type or value of the number.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 9`] = `
+{
+  "code": "~~123;",
+  "diagnostics": [
+    {
+      "message": "Using ~~ on an integer does not change the type or value of the number.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 10`] = `
+{
+  "code": "Boolean(true);",
+  "diagnostics": [
+    {
+      "message": "Passing a boolean to Boolean() does not change the type or value of the boolean.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 11`] = `
+{
+  "code": "!!true;",
+  "diagnostics": [
+    {
+      "message": "Using !! on a boolean does not change the type or value of the boolean.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 12`] = `
+{
+  "code": "BigInt(3n);",
+  "diagnostics": [
+    {
+      "message": "Passing a bigint to BigInt() does not change the type or value of the bigint.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 13`] = `
+{
+  "code": "
+function f<T extends string>(x: T) {
+  return String(x);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Passing a string to String() does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 14`] = `
+{
+  "code": "
+function f<T extends number>(x: T) {
+  return Number(x);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Passing a number to Number() does not change the type or value of the number.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 15`] = `
+{
+  "code": "
+function f<T extends boolean>(x: T) {
+  return Boolean(x);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Passing a boolean to Boolean() does not change the type or value of the boolean.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 16`] = `
+{
+  "code": "
+function f<T extends bigint>(x: T) {
+  return BigInt(x);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Passing a bigint to BigInt() does not change the type or value of the bigint.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 17`] = `
+{
+  "code": "String('a' + 'b').length;",
+  "diagnostics": [
+    {
+      "message": "Passing a string to String() does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 18`] = `
+{
+  "code": "('a' + 'b').toString().length;",
+  "diagnostics": [
+    {
+      "message": "Calling a string's .toString() method does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 19`] = `
+{
+  "code": "2 * +(2 + 2);",
+  "diagnostics": [
+    {
+      "message": "Using the unary + operator on a number does not change the type or value of the number.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 20`] = `
+{
+  "code": "2 * Number(2 + 2);",
+  "diagnostics": [
+    {
+      "message": "Passing a number to Number() does not change the type or value of the number.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 21`] = `
+{
+  "code": "false && !!(false || true);",
+  "diagnostics": [
+    {
+      "message": "Using !! on a boolean does not change the type or value of the boolean.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 22`] = `
+{
+  "code": "false && Boolean(false || true);",
+  "diagnostics": [
+    {
+      "message": "Passing a boolean to Boolean() does not change the type or value of the boolean.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 23`] = `
+{
+  "code": "2n * BigInt(2n + 2n);",
+  "diagnostics": [
+    {
+      "message": "Passing a bigint to BigInt() does not change the type or value of the bigint.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 24`] = `
+{
+  "code": "
+let str = 'asdf';
+String(str).length;
+      ",
+  "diagnostics": [
+    {
+      "message": "Passing a string to String() does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 25`] = `
+{
+  "code": "
+let str = 'asdf';
+str.toString().length;
+      ",
+  "diagnostics": [
+    {
+      "message": "Calling a string's .toString() method does not change the type or value of the string.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 26`] = `
+{
+  "code": "~~1;",
+  "diagnostics": [
+    {
+      "message": "Using ~~ on an integer does not change the type or value of the number.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 27`] = `
+{
+  "code": "~~-1;",
+  "diagnostics": [
+    {
+      "message": "Using ~~ on an integer does not change the type or value of the number.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-conversion > invalid 28`] = `
+{
+  "code": "
+declare const threeOrFour: 3 | 4;
+~~threeOrFour;
+      ",
+  "diagnostics": [
+    {
+      "message": "Using ~~ on an integer does not change the type or value of the number.",
+      "messageId": "unnecessaryTypeConversion",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-conversion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unnecessary-type-conversion.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unnecessary-type-conversion.test.ts
@@ -1,6 +1,5 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 
-
 import { getFixturesRootDir } from '../RuleTester';
 
 const rootDir = getFixturesRootDir();
@@ -23,12 +22,16 @@ ruleTester.run('no-unnecessary-type-conversion', {
     "'' + 1;",
     "1 + '';",
     `
-      let str = 1;
-      str += '';
+let str = 1;
+str += '';
     `,
     "Number('2');",
     "+'2';",
     "~~'2';",
+    '~~1.1;',
+    '~~-1.1;',
+    '~~(1.5 + 2.3);',
+    '~~(1 / 3);',
     'Boolean(0);',
     '!!0;',
     'BigInt(3);',
@@ -40,43 +43,43 @@ ruleTester.run('no-unnecessary-type-conversion', {
     '!false;',
     '~2;',
     `
-      function String(value: unknown) {
-        return value;
-      }
-      String('asdf');
-      export {};
+function String(value: unknown) {
+  return value;
+}
+String('asdf');
+export {};
     `,
     `
-      function Number(value: unknown) {
-        return value;
-      }
-      Number(2);
-      export {};
+function Number(value: unknown) {
+  return value;
+}
+Number(2);
+export {};
     `,
     `
-      function Boolean(value: unknown) {
-        return value;
-      }
-      Boolean(true);
-      export {};
+function Boolean(value: unknown) {
+  return value;
+}
+Boolean(true);
+export {};
     `,
     `
-      function BigInt(value: unknown) {
-        return value;
-      }
-      BigInt(3n);
-      export {};
+function BigInt(value: unknown) {
+  return value;
+}
+BigInt(3n);
+export {};
     `,
     `
-      function toString(value: unknown) {
-        return value;
-      }
-      toString('asdf');
+function toString(value: unknown) {
+  return value;
+}
+toString('asdf');
     `,
     `
-      export {};
-      declare const toString: string;
-      toString.toUpperCase();
+export {};
+declare const toString: string;
+toString.toUpperCase();
     `,
 
     // using type conversion idioms to unbox boxed primitives is valid
@@ -85,14 +88,22 @@ ruleTester.run('no-unnecessary-type-conversion', {
     "'' + new String();",
     "new String() + '';",
     `
-      let str = new String();
-      str += '';
+let str = new String();
+str += '';
     `,
     'Number(new Number());',
     '+new Number();',
     '~~new Number();',
     'Boolean(new Boolean());',
     '!!new Boolean();',
+    `
+enum CustomIds {
+  Id1 = 'id1',
+  Id2 = 'id2',
+}
+const customId = 'id1';
+const compareWithToString = customId === CustomIds.Id1.toString();
+    `,
   ],
 
   invalid: [
@@ -104,10 +115,7 @@ ruleTester.run('no-unnecessary-type-conversion', {
           endColumn: 7,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: "'asdf';",
-            },
+            { messageId: 'suggestRemove', output: "'asdf';" },
             {
               messageId: 'suggestSatisfies',
               output: "'asdf' satisfies string;",
@@ -124,10 +132,7 @@ ruleTester.run('no-unnecessary-type-conversion', {
           endColumn: 18,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: "'asdf';",
-            },
+            { messageId: 'suggestRemove', output: "'asdf';" },
             {
               messageId: 'suggestSatisfies',
               output: "'asdf' satisfies string;",
@@ -144,10 +149,7 @@ ruleTester.run('no-unnecessary-type-conversion', {
           endColumn: 6,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: "'asdf';",
-            },
+            { messageId: 'suggestRemove', output: "'asdf';" },
             {
               messageId: 'suggestSatisfies',
               output: "'asdf' satisfies string;",
@@ -164,10 +166,7 @@ ruleTester.run('no-unnecessary-type-conversion', {
           endColumn: 12,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: "'asdf';",
-            },
+            { messageId: 'suggestRemove', output: "'asdf';" },
             {
               messageId: 'suggestSatisfies',
               output: "'asdf' satisfies string;",
@@ -246,14 +245,8 @@ let str = 'asdf';
           endColumn: 7,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: '123;',
-            },
-            {
-              messageId: 'suggestSatisfies',
-              output: '123 satisfies number;',
-            },
+            { messageId: 'suggestRemove', output: '123;' },
+            { messageId: 'suggestSatisfies', output: '123 satisfies number;' },
           ],
         },
       ],
@@ -266,14 +259,8 @@ let str = 'asdf';
           endColumn: 2,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: '123;',
-            },
-            {
-              messageId: 'suggestSatisfies',
-              output: '123 satisfies number;',
-            },
+            { messageId: 'suggestRemove', output: '123;' },
+            { messageId: 'suggestSatisfies', output: '123 satisfies number;' },
           ],
         },
       ],
@@ -286,14 +273,8 @@ let str = 'asdf';
           endColumn: 3,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: '123;',
-            },
-            {
-              messageId: 'suggestSatisfies',
-              output: '123 satisfies number;',
-            },
+            { messageId: 'suggestRemove', output: '123;' },
+            { messageId: 'suggestSatisfies', output: '123 satisfies number;' },
           ],
         },
       ],
@@ -306,10 +287,7 @@ let str = 'asdf';
           endColumn: 8,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: 'true;',
-            },
+            { messageId: 'suggestRemove', output: 'true;' },
             {
               messageId: 'suggestSatisfies',
               output: 'true satisfies boolean;',
@@ -326,10 +304,7 @@ let str = 'asdf';
           endColumn: 3,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: 'true;',
-            },
+            { messageId: 'suggestRemove', output: 'true;' },
             {
               messageId: 'suggestSatisfies',
               output: 'true satisfies boolean;',
@@ -346,14 +321,8 @@ let str = 'asdf';
           endColumn: 7,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: '3n;',
-            },
-            {
-              messageId: 'suggestSatisfies',
-              output: '3n satisfies bigint;',
-            },
+            { messageId: 'suggestRemove', output: '3n;' },
+            { messageId: 'suggestSatisfies', output: '3n satisfies bigint;' },
           ],
         },
       ],
@@ -362,14 +331,14 @@ let str = 'asdf';
     // using type conversion idioms on generics that extend primitives is invalid
     {
       code: `
-        function f<T extends string>(x: T) {
-          return String(x);
-        }
+function f<T extends string>(x: T) {
+  return String(x);
+}
       `,
       errors: [
         {
-          column: 18,
-          endColumn: 24,
+          column: 10,
+          endColumn: 16,
           endLine: 3,
           line: 3,
           messageId: 'unnecessaryTypeConversion',
@@ -377,17 +346,17 @@ let str = 'asdf';
             {
               messageId: 'suggestRemove',
               output: `
-        function f<T extends string>(x: T) {
-          return x;
-        }
+function f<T extends string>(x: T) {
+  return x;
+}
       `,
             },
             {
               messageId: 'suggestSatisfies',
               output: `
-        function f<T extends string>(x: T) {
-          return x satisfies string;
-        }
+function f<T extends string>(x: T) {
+  return x satisfies string;
+}
       `,
             },
           ],
@@ -396,14 +365,14 @@ let str = 'asdf';
     },
     {
       code: `
-        function f<T extends number>(x: T) {
-          return Number(x);
-        }
+function f<T extends number>(x: T) {
+  return Number(x);
+}
       `,
       errors: [
         {
-          column: 18,
-          endColumn: 24,
+          column: 10,
+          endColumn: 16,
           endLine: 3,
           line: 3,
           messageId: 'unnecessaryTypeConversion',
@@ -411,17 +380,17 @@ let str = 'asdf';
             {
               messageId: 'suggestRemove',
               output: `
-        function f<T extends number>(x: T) {
-          return x;
-        }
+function f<T extends number>(x: T) {
+  return x;
+}
       `,
             },
             {
               messageId: 'suggestSatisfies',
               output: `
-        function f<T extends number>(x: T) {
-          return x satisfies number;
-        }
+function f<T extends number>(x: T) {
+  return x satisfies number;
+}
       `,
             },
           ],
@@ -430,14 +399,14 @@ let str = 'asdf';
     },
     {
       code: `
-        function f<T extends boolean>(x: T) {
-          return Boolean(x);
-        }
+function f<T extends boolean>(x: T) {
+  return Boolean(x);
+}
       `,
       errors: [
         {
-          column: 18,
-          endColumn: 25,
+          column: 10,
+          endColumn: 17,
           endLine: 3,
           line: 3,
           messageId: 'unnecessaryTypeConversion',
@@ -445,17 +414,17 @@ let str = 'asdf';
             {
               messageId: 'suggestRemove',
               output: `
-        function f<T extends boolean>(x: T) {
-          return x;
-        }
+function f<T extends boolean>(x: T) {
+  return x;
+}
       `,
             },
             {
               messageId: 'suggestSatisfies',
               output: `
-        function f<T extends boolean>(x: T) {
-          return x satisfies boolean;
-        }
+function f<T extends boolean>(x: T) {
+  return x satisfies boolean;
+}
       `,
             },
           ],
@@ -464,14 +433,14 @@ let str = 'asdf';
     },
     {
       code: `
-        function f<T extends bigint>(x: T) {
-          return BigInt(x);
-        }
+function f<T extends bigint>(x: T) {
+  return BigInt(x);
+}
       `,
       errors: [
         {
-          column: 18,
-          endColumn: 24,
+          column: 10,
+          endColumn: 16,
           endLine: 3,
           line: 3,
           messageId: 'unnecessaryTypeConversion',
@@ -479,17 +448,17 @@ let str = 'asdf';
             {
               messageId: 'suggestRemove',
               output: `
-        function f<T extends bigint>(x: T) {
-          return x;
-        }
+function f<T extends bigint>(x: T) {
+  return x;
+}
       `,
             },
             {
               messageId: 'suggestSatisfies',
               output: `
-        function f<T extends bigint>(x: T) {
-          return x satisfies bigint;
-        }
+function f<T extends bigint>(x: T) {
+  return x satisfies bigint;
+}
       `,
             },
           ],
@@ -506,10 +475,7 @@ let str = 'asdf';
           endColumn: 7,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: "('a' + 'b').length;",
-            },
+            { messageId: 'suggestRemove', output: "('a' + 'b').length;" },
             {
               messageId: 'suggestSatisfies',
               output: "(('a' + 'b') satisfies string).length;",
@@ -526,10 +492,7 @@ let str = 'asdf';
           endColumn: 23,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: "('a' + 'b').length;",
-            },
+            { messageId: 'suggestRemove', output: "('a' + 'b').length;" },
             {
               messageId: 'suggestSatisfies',
               output: "(('a' + 'b') satisfies string).length;",
@@ -546,10 +509,7 @@ let str = 'asdf';
           endColumn: 6,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: '2 * (2 + 2);',
-            },
+            { messageId: 'suggestRemove', output: '2 * (2 + 2);' },
             {
               messageId: 'suggestSatisfies',
               output: '2 * ((2 + 2) satisfies number);',
@@ -566,30 +526,7 @@ let str = 'asdf';
           endColumn: 11,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: '2 * (2 + 2);',
-            },
-            {
-              messageId: 'suggestSatisfies',
-              output: '2 * ((2 + 2) satisfies number);',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: '2 * ~~(2 + 2);',
-      errors: [
-        {
-          column: 5,
-          endColumn: 7,
-          messageId: 'unnecessaryTypeConversion',
-          suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: '2 * (2 + 2);',
-            },
+            { messageId: 'suggestRemove', output: '2 * (2 + 2);' },
             {
               messageId: 'suggestSatisfies',
               output: '2 * ((2 + 2) satisfies number);',
@@ -606,10 +543,7 @@ let str = 'asdf';
           endColumn: 12,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: 'false && (false || true);',
-            },
+            { messageId: 'suggestRemove', output: 'false && (false || true);' },
             {
               messageId: 'suggestSatisfies',
               output: 'false && ((false || true) satisfies boolean);',
@@ -626,10 +560,7 @@ let str = 'asdf';
           endColumn: 17,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: 'false && (false || true);',
-            },
+            { messageId: 'suggestRemove', output: 'false && (false || true);' },
             {
               messageId: 'suggestSatisfies',
               output: 'false && ((false || true) satisfies boolean);',
@@ -646,10 +577,7 @@ let str = 'asdf';
           endColumn: 12,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
-            {
-              messageId: 'suggestRemove',
-              output: '2n * (2n + 2n);',
-            },
+            { messageId: 'suggestRemove', output: '2n * (2n + 2n);' },
             {
               messageId: 'suggestSatisfies',
               output: '2n * ((2n + 2n) satisfies bigint);',
@@ -662,13 +590,13 @@ let str = 'asdf';
     // make sure suggestions add parentheses in cases where syntax would otherwise break
     {
       code: `
-        let str = 'asdf';
-        String(str).length;
+let str = 'asdf';
+String(str).length;
       `,
       errors: [
         {
-          column: 9,
-          endColumn: 15,
+          column: 1,
+          endColumn: 7,
           endLine: 3,
           line: 3,
           messageId: 'unnecessaryTypeConversion',
@@ -676,15 +604,15 @@ let str = 'asdf';
             {
               messageId: 'suggestRemove',
               output: `
-        let str = 'asdf';
-        str.length;
+let str = 'asdf';
+str.length;
       `,
             },
             {
               messageId: 'suggestSatisfies',
               output: `
-        let str = 'asdf';
-        (str satisfies string).length;
+let str = 'asdf';
+(str satisfies string).length;
       `,
             },
           ],
@@ -693,27 +621,87 @@ let str = 'asdf';
     },
     {
       code: `
-        let str = 'asdf';
-        str.toString().length;
+let str = 'asdf';
+str.toString().length;
       `,
       errors: [
         {
-          column: 13,
-          endColumn: 23,
+          column: 5,
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
           messageId: 'unnecessaryTypeConversion',
           suggestions: [
             {
               messageId: 'suggestRemove',
               output: `
-        let str = 'asdf';
-        str.length;
+let str = 'asdf';
+str.length;
       `,
             },
             {
               messageId: 'suggestSatisfies',
               output: `
-        let str = 'asdf';
-        (str satisfies string).length;
+let str = 'asdf';
+(str satisfies string).length;
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: '~~1;',
+      errors: [
+        {
+          column: 1,
+          endColumn: 3,
+          messageId: 'unnecessaryTypeConversion',
+          suggestions: [
+            { messageId: 'suggestRemove', output: '1;' },
+            { messageId: 'suggestSatisfies', output: '1 satisfies number;' },
+          ],
+        },
+      ],
+    },
+    {
+      code: '~~-1;',
+      errors: [
+        {
+          column: 1,
+          endColumn: 3,
+          messageId: 'unnecessaryTypeConversion',
+          suggestions: [
+            { messageId: 'suggestRemove', output: '(-1);' },
+            { messageId: 'suggestSatisfies', output: '(-1) satisfies number;' },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const threeOrFour: 3 | 4;
+~~threeOrFour;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 3,
+          line: 3,
+          messageId: 'unnecessaryTypeConversion',
+          suggestions: [
+            {
+              messageId: 'suggestRemove',
+              output: `
+declare const threeOrFour: 3 | 4;
+threeOrFour;
+      `,
+            },
+            {
+              messageId: 'suggestSatisfies',
+              output: `
+declare const threeOrFour: 3 | 4;
+threeOrFour satisfies number;
       `,
             },
           ],


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-unnecessary-type-conversion` rule from typescript-eslint to rslint.

The rule disallows conversion idioms (`String(x)`, `Number(x)`, `Boolean(x)`, `BigInt(x)`, `.toString()`, `+x`, `!!x`, `~~x`, `'' + x` / `x + ''` / `x += ''`) when the source expression already has the target type, since these are no-ops at runtime and add noise without changing the value or the type.

## Related Links

- typescript-eslint rule: https://typescript-eslint.io/rules/no-unnecessary-type-conversion
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unnecessary-type-conversion.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).