### PR TITLE
ci: probe Windows runner disk usage (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,28 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-name: ci-go-windows
 
+      - name: Disk usage (before tests)
+        shell: pwsh
+        run: |
+          Write-Host "=== PSDrive ==="
+          Get-PSDrive -PSProvider FileSystem | Format-Table -AutoSize
+
+          $paths = @(
+            $env:GOCACHE,
+            'C:\Users\ContainerAdministrator\runner\_work\temp\ci-go-windows',
+            'C:\Users\ContainerAdministrator\runner\_work\rslint\rslint',
+            'C:\Users\ContainerAdministrator\runner\_work'
+          )
+          foreach ($p in $paths) {
+            if ($p -and (Test-Path $p)) {
+              $items = Get-ChildItem $p -Recurse -File -Force -ErrorAction SilentlyContinue
+              $size = ($items | Measure-Object -Sum Length).Sum
+              "{0,-70} {1,10:N2} GB  {2,8:N0} files" -f $p, ($size / 1GB), $items.Count
+            } else {
+              "{0,-70} (missing)" -f $p
+            }
+          }
+
       - name: Unit Test
         shell: pwsh
         run: |
@@ -107,6 +129,29 @@ jobs:
             Write-Host "Running final batch of $($batch.Count) packages..."
             go test -parallel 4 $batch
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+
+      - name: Disk usage (after tests)
+        if: always()
+        shell: pwsh
+        run: |
+          Write-Host "=== PSDrive ==="
+          Get-PSDrive -PSProvider FileSystem | Format-Table -AutoSize
+
+          $paths = @(
+            $env:GOCACHE,
+            'C:\Users\ContainerAdministrator\runner\_work\temp\ci-go-windows',
+            'C:\Users\ContainerAdministrator\runner\_work\rslint\rslint',
+            'C:\Users\ContainerAdministrator\runner\_work'
+          )
+          foreach ($p in $paths) {
+            if ($p -and (Test-Path $p)) {
+              $items = Get-ChildItem $p -Recurse -File -Force -ErrorAction SilentlyContinue
+              $size = ($items | Measure-Object -Sum Length).Sum
+              "{0,-70} {1,10:N2} GB  {2,8:N0} files" -f $p, ($size / 1GB), $items.Count
+            } else {
+              "{0,-70} (missing)" -f $p
+            }
           }
 
   build-rslint-windows:


### PR DESCRIPTION
## Summary
- Temporary diagnostic PR. Adds two PowerShell steps to the `test-go-windows` job that print `Get-PSDrive` and the on-disk size of `GOCACHE`, the relocated `TEMP`, the checkout, and the entire `_work` root, both before and after the Unit Test step.
- Goal: decide whether the batched "delete test-generated cache files" workaround in `test-go-windows` (added in #696/#922 era to avoid disk-full) is still required now that `GOCACHE` is relocated to the work disk via `setup-go`.

## Why
Current Windows Test Go takes 20-39 minutes vs ~7 min on Ubuntu. Most of it is spent in batch 1 (~21 min) link/compile. We want to either:
- persist `GOCACHE` across runs via `lynx-infra/cache`, or
- drop the per-batch GOCACHE cleanup and run a single `go test ./internal/...`,

both of which raise peak disk usage. Need real numbers from the runner before deciding.

## Test plan
- [ ] CI runs the Windows Go job and the two `Disk usage` steps print PSDrive + folder sizes.
- [ ] Capture numbers from the run, then close/revert this PR — not for merge.