### PR TITLE
feat: port rule @typescript-eslint/no-restricted-types

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_redundant_type_constituents"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_require_imports"
 	ts_no_restricted_imports "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_restricted_imports"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_restricted_types"
 	ts_no_shadow "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_shadow"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_this_alias"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare"
@@ -593,6 +594,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-this-alias", no_this_alias.NoThisAliasRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-require-imports", no_require_imports.NoRequireImportsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-restricted-imports", ts_no_restricted_imports.NoRestrictedImportsRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-restricted-types", no_restricted_types.NoRestrictedTypesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-shadow", ts_no_shadow.NoShadowRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-boolean-literal-compare", no_unnecessary_boolean_literal_compare.NoUnnecessaryBooleanLiteralCompareRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-condition", no_unnecessary_condition.NoUnnecessaryConditionRule)

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.go
@@ -1,0 +1,263 @@
+package no_restricted_types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/typescriptutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// keywordTypeNames maps the tsgo keyword `ast.Kind` for a primitive type
+// annotation to the lower-case name upstream uses as the bannedTypes map key
+// (see TYPE_KEYWORDS in upstream). Listeners for these kinds are only wired up
+// when the corresponding name is actually present in the user's `types`
+// option, matching upstream's `objectReduceKey` behavior.
+var keywordTypeNames = map[ast.Kind]string{
+	ast.KindBigIntKeyword:    "bigint",
+	ast.KindBooleanKeyword:   "boolean",
+	ast.KindNeverKeyword:     "never",
+	ast.KindNullKeyword:      "null",
+	ast.KindNumberKeyword:    "number",
+	ast.KindObjectKeyword:    "object",
+	ast.KindStringKeyword:    "string",
+	ast.KindSymbolKeyword:    "symbol",
+	ast.KindUndefinedKeyword: "undefined",
+	ast.KindUnknownKeyword:   "unknown",
+	ast.KindVoidKeyword:      "void",
+}
+
+// bannedTypeConfig holds the parsed per-type configuration. The four shapes
+// upstream supports (`true`, `false`, `null`, `string`, `object`) collapse
+// here into: `Disabled` (null/false → don't report), or a record with the
+// fields below. `kind` distinguishes the unset / string / object shapes so we
+// can mirror upstream's getCustomMessage branching exactly.
+type bannedTypeConfig struct {
+	Disabled bool
+	// "true" | "string" | "object"
+	Kind    string
+	Message string
+	FixWith string
+	HasFix  bool
+	Suggest []string
+}
+
+func parseBannedTypes(raw map[string]interface{}) map[string]bannedTypeConfig {
+	out := make(map[string]bannedTypeConfig, len(raw))
+	for key, value := range raw {
+		normalized := removeSpaces(key)
+		cfg := bannedTypeConfig{}
+		switch v := value.(type) {
+		case nil:
+			cfg.Disabled = true
+		case bool:
+			if !v {
+				cfg.Disabled = true
+			} else {
+				cfg.Kind = "true"
+			}
+		case string:
+			cfg.Kind = "string"
+			cfg.Message = v
+		case map[string]interface{}:
+			cfg.Kind = "object"
+			if msg, ok := v["message"].(string); ok {
+				cfg.Message = msg
+			}
+			if fix, ok := v["fixWith"].(string); ok {
+				cfg.FixWith = fix
+				cfg.HasFix = true
+			}
+			if suggest, ok := v["suggest"].([]interface{}); ok {
+				for _, s := range suggest {
+					if str, ok := s.(string); ok {
+						cfg.Suggest = append(cfg.Suggest, str)
+					}
+				}
+			}
+		default:
+			// Unknown shape — upstream would pass through to `getCustomMessage`
+			// and treat it as truthy; we treat it as a bare ban (no message).
+			cfg.Kind = "true"
+		}
+		out[normalized] = cfg
+	}
+	return out
+}
+
+func removeSpaces(s string) string {
+	// Match upstream's `replaceAll(/\s/g, '')` — strip every Unicode whitespace
+	// codepoint, not just ASCII space. tsgo's source text is the raw input, so
+	// tabs and newlines inside `Banned<\n  A\n>` must collapse the same way
+	// the option key `Banned<A>` does.
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isWhitespace(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func isWhitespace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n', '\r', '\f', '\v', 0x00A0, 0x1680, 0x2028, 0x2029, 0x202F, 0x205F, 0x3000, 0xFEFF:
+		return true
+	}
+	if r >= 0x2000 && r <= 0x200A {
+		return true
+	}
+	return false
+}
+
+// customMessageFor mirrors upstream's getCustomMessage. Upstream short-circuits
+// any falsy value (including the empty string ` Banned: '' `) at the
+// `!bannedType` check and returns ''. So the rule for every shape collapses to:
+// non-empty Message → " " + Message; otherwise "".
+func customMessageFor(cfg bannedTypeConfig) string {
+	if cfg.Message == "" {
+		return ""
+	}
+	return " " + cfg.Message
+}
+
+var NoRestrictedTypesRule = rule.CreateRule(rule.Rule{
+	Name: "no-restricted-types",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		bannedTypes := map[string]bannedTypeConfig{}
+		if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+			if types, ok := optsMap["types"].(map[string]interface{}); ok {
+				bannedTypes = parseBannedTypes(types)
+			}
+		}
+
+		nodeText := func(node *ast.Node) string {
+			r := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			return ctx.SourceFile.Text()[r.Pos():r.End()]
+		}
+
+		checkBannedTypes := func(typeNode *ast.Node, presetName string) {
+			if typeNode == nil {
+				return
+			}
+			name := presetName
+			if name == "" {
+				name = removeSpaces(nodeText(typeNode))
+			}
+			cfg, found := bannedTypes[name]
+			if !found || cfg.Disabled {
+				return
+			}
+
+			customMessage := customMessageFor(cfg)
+			msg := rule.RuleMessage{
+				Id:          "bannedTypeMessage",
+				Description: fmt.Sprintf("Don't use `%s` as a type.%s", name, customMessage),
+				Data: map[string]string{
+					"name":          name,
+					"customMessage": customMessage,
+				},
+			}
+
+			var fixes []rule.RuleFix
+			if cfg.Kind == "object" && cfg.HasFix {
+				fixes = []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, typeNode, cfg.FixWith)}
+			}
+
+			var suggestions []rule.RuleSuggestion
+			for _, replacement := range cfg.Suggest {
+				suggestions = append(suggestions, rule.RuleSuggestion{
+					Message: rule.RuleMessage{
+						Id:          "bannedTypeReplacement",
+						Description: fmt.Sprintf("Replace `%s` with `%s`.", name, replacement),
+						Data: map[string]string{
+							"name":        name,
+							"replacement": replacement,
+						},
+					},
+					FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, typeNode, replacement)},
+				})
+			}
+
+			switch {
+			case len(fixes) > 0 && len(suggestions) > 0:
+				ctx.ReportNodeWithFixesAndSuggestions(typeNode, msg, fixes, suggestions)
+			case len(fixes) > 0:
+				ctx.ReportNodeWithFixes(typeNode, msg, fixes...)
+			case len(suggestions) > 0:
+				ctx.ReportNodeWithSuggestions(typeNode, msg, suggestions...)
+			default:
+				ctx.ReportNode(typeNode, msg)
+			}
+		}
+
+		listeners := rule.RuleListeners{}
+
+		// Mirror upstream's `objectReduceKey(TYPE_KEYWORDS, ...)`: only
+		// register a keyword listener when the corresponding name is
+		// actually present in the user's banned-types map. This keeps the
+		// traversal cost proportional to the configured set rather than
+		// firing on every primitive annotation in the file.
+		for kind, name := range keywordTypeNames {
+			if _, banned := bannedTypes[name]; !banned {
+				continue
+			}
+			kw := name
+			kindCopy := kind
+			listeners[kindCopy] = func(node *ast.Node) {
+				checkBannedTypes(node, kw)
+			}
+		}
+
+		listeners[ast.KindTypeReference] = func(node *ast.Node) {
+			ref := node.AsTypeReferenceNode()
+			if ref == nil {
+				return
+			}
+			checkBannedTypes(ref.TypeName, "")
+			if ref.TypeArguments != nil {
+				checkBannedTypes(node, "")
+			}
+		}
+
+		listeners[ast.KindExpressionWithTypeArguments] = func(node *ast.Node) {
+			if !typescriptutil.IsClassImplementsOrInterfaceExtends(node) {
+				return
+			}
+			expr := node.AsExpressionWithTypeArguments()
+			if expr == nil {
+				return
+			}
+			checkBannedTypes(expr.Expression, "")
+			if expr.TypeArguments != nil {
+				checkBannedTypes(node, "")
+			}
+		}
+
+		listeners[ast.KindTupleType] = func(node *ast.Node) {
+			tuple := node.AsTupleTypeNode()
+			if tuple == nil {
+				return
+			}
+			if tuple.Elements == nil || len(tuple.Elements.Nodes) == 0 {
+				checkBannedTypes(node, "")
+			}
+		}
+
+		listeners[ast.KindTypeLiteral] = func(node *ast.Node) {
+			literal := node.AsTypeLiteralNode()
+			if literal == nil {
+				return
+			}
+			if literal.Members == nil || len(literal.Members.Nodes) == 0 {
+				checkBannedTypes(node, "")
+			}
+		}
+
+		return listeners
+	},
+})

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.md
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.md
@@ -1,0 +1,66 @@
+# no-restricted-types
+
+## Rule Details
+
+Disallow specified types. The rule reports any usage of a type whose name matches a key in the configured `types` map. Names are compared after stripping all whitespace, so a source-side `Banned<A, B>` matches a configured key of `Banned<A,B>` (and a configured key of `  NS.Banned  ` matches a source-side `NS.Banned`).
+
+The rule recognizes these type-syntax forms:
+
+- Primitive type keywords (`bigint`, `boolean`, `never`, `null`, `number`, `object`, `string`, `symbol`, `undefined`, `unknown`, `void`).
+- Type references — both bare (`Banned`, `NS.Banned`) and parameterized (`Banned<A>`, `NS.Banned<A>`).
+- The empty tuple type `[]`.
+- The empty type literal `{}`.
+- Heritage references — `class X implements Banned` and `interface X extends Banned`.
+
+Each entry in `types` pairs a type name with one of:
+
+- `true` — ban with the default message.
+- `false` or `null` — explicitly do not ban this name.
+- A `string` — ban with the string appended to the default message.
+- An object `{ message?: string, fixWith?: string, suggest?: string[] }` — ban with an extra message, an optional auto-fix replacement, and/or one or more editor suggestions.
+
+Examples of **incorrect** code for this rule with `{ "types": { "Banned": "Use Ok instead." } }`:
+
+```json
+{ "@typescript-eslint/no-restricted-types": ["error", { "types": { "Banned": "Use Ok instead." } }] }
+```
+
+```typescript
+let value: Banned;
+```
+
+Examples of **correct** code for this rule with `{ "types": { "Banned": "Use Ok instead." } }`:
+
+```json
+{ "@typescript-eslint/no-restricted-types": ["error", { "types": { "Banned": "Use Ok instead." } }] }
+```
+
+```typescript
+let value: Ok;
+```
+
+Examples of **incorrect** code for this rule with `{ "types": { "Banned": { "fixWith": "Ok", "message": "Use Ok instead." } } }`:
+
+```json
+{ "@typescript-eslint/no-restricted-types": ["error", { "types": { "Banned": { "fixWith": "Ok", "message": "Use Ok instead." } } }] }
+```
+
+```typescript
+let value: Banned;
+```
+
+The auto-fix rewrites the type reference to `Ok`.
+
+Examples of **incorrect** code for this rule with `{ "types": { "[]": "Use unknown[] instead." } }`:
+
+```json
+{ "@typescript-eslint/no-restricted-types": ["error", { "types": { "[]": "Use unknown[] instead." } }] }
+```
+
+```typescript
+let value: [];
+```
+
+## Original Documentation
+
+- [typescript-eslint no-restricted-types](https://typescript-eslint.io/rules/no-restricted-types)

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
@@ -653,29 +653,79 @@ func TestNoRestrictedTypesExtras(t *testing.T) {
 			},
 		},
 		// ---- Real-user: ban `React.FC` with a suggested replacement ----
-		// Frequently asked-for ban in React codebases. Important subtlety:
-		// the suggestion replaces only the *TypeName* (`React.FC`), not the
-		// outer TypeReference, so the original `<Props>` argument carries
-		// over into the suggested replacement. Locks in that fix/suggest
-		// scope is the same as the matched node (the typeName), not the
-		// whole parameterized form.
+		// Frequently asked-for ban in React codebases. The suggestion replaces
+		// only the *TypeName* (`React.FC`), not the outer TypeReference, so
+		// the original `<Props>` argument carries over into the suggested
+		// replacement. The replacement type `React.FunctionComponent` itself
+		// accepts type arguments, so the resulting `React.FunctionComponent<Props>`
+		// remains valid TypeScript — the test demonstrates the design intent
+		// while keeping output syntactically valid.
 		{
 			Code: `type Props = {}; const C: React.FC<Props> = () => null;`,
 			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
 				"React.FC": map[string]interface{}{
-					"message": "Prefer plain functions returning JSX.",
-					"suggest": []interface{}{"(props: Props) => JSX.Element"},
+					"message": "Use React.FunctionComponent instead.",
+					"suggest": []interface{}{"React.FunctionComponent"},
 				},
 			}}),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "bannedTypeMessage",
-					Message:   "Don't use `React.FC` as a type. Prefer plain functions returning JSX.",
+					Message:   "Don't use `React.FC` as a type. Use React.FunctionComponent instead.",
 					Line:      1, Column: 27,
 					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-						{MessageId: "bannedTypeReplacement", Output: `type Props = {}; const C: (props: Props) => JSX.Element<Props> = () => null;`},
+						{MessageId: "bannedTypeReplacement", Output: `type Props = {}; const C: React.FunctionComponent<Props> = () => null;`},
 					},
 				},
+			},
+		},
+		// ---- Design intent: fixWith on the TypeName preserves TypeArguments ----
+		// This is the *positive-output* counterpart to the upstream
+		// `Omit<Foo, 'a'>` → `Ok<Foo, 'a'>` migration test, written in this
+		// extras suite so the typeName-only-replacement design is locked in
+		// with a directly-named test, not just as a side effect of an upstream
+		// case. If a future refactor anchors fix/report on the outer
+		// TypeReference instead of the TypeName, both this and the upstream
+		// Omit case fail together.
+		{
+			Code: `let v: Banned<X>;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{"fixWith": "Ok", "message": "Use Ok."},
+			}}),
+			Output: []string{`let v: Ok<X>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok.", Line: 1, Column: 8},
+			},
+		},
+		// ---- Design intent: whole-node ban with fixWith replaces the whole TypeReference ----
+		// Mirror of the design-intent lock-in above, this time configuring the
+		// parameterized form `Banned<X>` directly. Here the fix DOES rewrite
+		// the entire `Banned<X>` to `Ok` because the bannedTypes key matches
+		// the whole-node text. Locks in that registering the parameterized
+		// key replaces the parameterized form end-to-end.
+		{
+			Code: `let v: Banned<X>;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned<X>": map[string]interface{}{"fixWith": "Ok", "message": "Replace whole Banned<X>."},
+			}}),
+			Output: []string{`let v: Ok;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned<X>` as a type. Replace whole Banned<X>.", Line: 1, Column: 8},
+			},
+		},
+		// ---- Branch lock-in: unknown JSON value shape collapses to bare ban ----
+		// Upstream getCustomMessage treats any truthy non-string non-object
+		// (e.g. a stray number `1` slipped past schema validation) as a bare
+		// ban — customMessage = ''. parseBannedTypes' default arm mirrors
+		// this: a number value goes through Kind="true", reporting with no
+		// custom-message suffix.
+		{
+			Code: `let v: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": 1,
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 8},
 			},
 		},
 		// ---- Real-user: same name banned and not-banned in same file ----

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
@@ -1,0 +1,871 @@
+// TestNoRestrictedTypesExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+package no_restricted_types
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoRestrictedTypesExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRestrictedTypesRule, []rule_tester.ValidTestCase{
+		// ---- Branch lock-in checkBannedTypes() arm 1: bannedType === null disables the ban ----
+		{
+			Code:    `let value: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": nil}}),
+		},
+		// ---- Branch lock-in checkBannedTypes() arm 1: bannedType === false disables the ban ----
+		{
+			Code:    `let value: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": false}}),
+		},
+		// ---- Branch lock-in: keyword listener is not wired when its name is absent ----
+		// bigint is NOT in the types map → the keyword listener is never
+		// registered, so an unconfigured primitive keyword stays valid.
+		{
+			Code:    `let value: bigint;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+		},
+		// ---- Branch lock-in TSTupleType arm 2: non-empty tuple does not match "[]" key ----
+		// Upstream gates the empty-tuple report on `node.elementTypes.length === 0`.
+		// `[number]` has one element, so even though `[]` is banned the rule must stay silent.
+		{
+			Code:    `let value: [number];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"[]": "Use unknown[] instead."}}),
+		},
+		// ---- Branch lock-in TSTypeLiteral arm 2: non-empty literal does not match "{}" key ----
+		{
+			Code:    `let value: { a: number };`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"{}": "Use object instead."}}),
+		},
+		// ---- Branch lock-in IsClassImplementsOrInterfaceExtends: `class X extends Y` is NOT a heritage match ----
+		// Upstream registers TSClassImplements + TSInterfaceHeritage but
+		// deliberately omits the class-extends listener. `Banned` here is
+		// an expression-position identifier, not a TypeReference, so neither
+		// listener fires.
+		{
+			Code:    `class Derived extends Banned {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+		},
+		// ---- Real-user: ban Object in expression-position usage stays silent ----
+		// Same as the upstream Object-call valid cases — we re-assert here on
+		// a value-position expression that *looks* like a type reference but
+		// is parsed as an Identifier expression. The rule must not bleed
+		// into value position.
+		{
+			Code:    `const foo = Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+		},
+		// ---- Real-user: shadowing a banned name with a local type alias should still report ----
+		// Upstream's rule is *name-string* matching, not symbol-aware — any
+		// `Banned` text in a type position reports, even when a local
+		// `type Banned = ...` alias would have resolved it.
+		// This valid case asserts the opposite: when the type-reference name
+		// is NOT in the banned set, the local alias is treated normally.
+		{
+			Code: `
+				type Allowed = string;
+				let v: Allowed;
+			`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+		},
+		// ---- Real-user / Branch lock-in: `any` is not in TYPE_KEYWORDS upstream ----
+		// Upstream's TYPE_KEYWORDS deliberately omits `any` (handled by
+		// `no-explicit-any` instead). Locking in that banning `any` here
+		// has no effect, so a future extension of keywordTypeNames doesn't
+		// silently start firing on `any`.
+		{
+			Code: `let value: any;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"any": map[string]interface{}{
+					"message": "Use unknown instead.",
+					"suggest": []interface{}{"unknown"},
+				},
+			}}),
+		},
+		// ---- Dimension 4 / Receiver wrappers: N/A ----
+		// N/A: TypeReference cannot itself be wrapped by `(...)` /
+		// non-null / `as` / optional-chain — those are value-expression
+		// wrappers. A `(Banned)` in type position is `ParenthesizedType`
+		// containing a TypeReference, and the TypeReference listener fires
+		// on the inner node — covered by the corresponding invalid case
+		// below rather than as a valid no-match case.
+	}, []rule_tester.InvalidTestCase{
+		// ---- Branch lock-in checkBannedTypes() arm: bannedType === true → empty customMessage ----
+		// Already covered for Banned in upstream; this locks in the same
+		// shape for an empty type literal.
+		{
+			Code:    `let value: {};`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"{}": true}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `{}` as a type.", Line: 1, Column: 12},
+			},
+		},
+		// ---- Branch lock-in getCustomMessage() arm: object without message → empty customMessage ----
+		{
+			Code: `let value: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{"fixWith": "Ok"},
+			}}),
+			Output: []string{`let value: Ok;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 12},
+			},
+		},
+		// ---- Branch lock-in getCustomMessage() arm: object with empty-string message → empty customMessage ----
+		// Upstream's `if (bannedType.message)` falsifies on '' so customMessage stays empty.
+		{
+			Code: `let value: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{"message": ""},
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 12},
+			},
+		},
+		// ---- Branch lock-in checkBannedTypes() arm: object with suggest → emit suggestion(s) ----
+		{
+			Code: `let value: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{
+					"message": "Use Ok instead.",
+					"suggest": []interface{}{"Ok"},
+				},
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bannedTypeMessage",
+					Message:   "Don't use `Banned` as a type. Use Ok instead.",
+					Line:      1, Column: 12,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "bannedTypeReplacement", Output: `let value: Ok;`},
+					},
+				},
+			},
+		},
+		// ---- Branch lock-in: multiple suggestions are emitted in order ----
+		{
+			Code: `let value: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{
+					"message": "Use a real type.",
+					"suggest": []interface{}{"OkOne", "OkTwo"},
+				},
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bannedTypeMessage",
+					Message:   "Don't use `Banned` as a type. Use a real type.",
+					Line:      1, Column: 12,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "bannedTypeReplacement", Output: `let value: OkOne;`},
+						{MessageId: "bannedTypeReplacement", Output: `let value: OkTwo;`},
+					},
+				},
+			},
+		},
+		// ---- Branch lock-in: object with BOTH fixWith and suggest emits fix + suggestions ----
+		// Upstream `context.report({...fix, suggest})` keeps both; we
+		// match by sending the diagnostic via
+		// ReportNodeWithFixesAndSuggestions.
+		{
+			Code: `let value: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{
+					"fixWith": "FixedOk",
+					"message": "Use Ok instead.",
+					"suggest": []interface{}{"SuggestedOk"},
+				},
+			}}),
+			Output: []string{`let value: FixedOk;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bannedTypeMessage",
+					Message:   "Don't use `Banned` as a type. Use Ok instead.",
+					Line:      1, Column: 12,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "bannedTypeReplacement", Output: `let value: SuggestedOk;`},
+					},
+				},
+			},
+		},
+		// ---- Branch lock-in TSTypeReference arm 2: typeArguments → also check whole-node text ----
+		// Same shape as `Banned<any>` upstream case, but this version
+		// also has `Banned` banned bare. Both reports fire: one on the
+		// TypeName, one on the whole node text.
+		{
+			Code: `let value: Banned<X>;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned":    true,
+				"Banned<X>": "Don't parameterize Banned with X.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 12},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned<X>` as a type. Don't parameterize Banned with X.", Line: 1, Column: 12},
+			},
+		},
+		// ---- Branch lock-in TSClassImplements typeArguments → check both expression and whole node ----
+		{
+			Code: `class C implements Banned<X> {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned":    true,
+				"Banned<X>": "Don't parameterize Banned.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 20},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned<X>` as a type. Don't parameterize Banned.", Line: 1, Column: 20},
+			},
+		},
+		// ---- Branch lock-in TSInterfaceHeritage typeArguments → check both expression and whole node ----
+		{
+			Code: `interface I extends Banned<X> {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned":    true,
+				"Banned<X>": "Don't parameterize Banned.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 21},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned<X>` as a type. Don't parameterize Banned.", Line: 1, Column: 21},
+			},
+		},
+		// ---- Dimension 4 / Receiver wrappers: ParenthesizedType wrapping TypeReference ----
+		// tsgo parses `(Banned)` in type position as ParenthesizedType containing
+		// a TypeReference. ESTree flattens parens, so upstream's listener still
+		// fires on the inner TSTypeReference. Lock in that the wrapper does not
+		// prevent the report (and that the column anchors at the inner
+		// TypeReference, not the opening paren).
+		{
+			Code:    `let value: (Banned);`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 13},
+			},
+		},
+		// ---- Dimension 4 / Receiver wrappers: nested ParenthesizedType ----
+		// `((Banned))` becomes ParenthesizedType(ParenthesizedType(TypeReference)).
+		// The TypeReference listener fires on the innermost node regardless of
+		// how many parens wrap it.
+		{
+			Code:    `let value: ((Banned));`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 14},
+			},
+		},
+		// ---- Dimension 4 / Nesting: TypeReference inside Array<...> still fires ----
+		// `Array<Banned>` is TypeReference(Array, [TypeReference(Banned)]). The
+		// outer TypeReference's TypeName is `Array` (no match) but the inner
+		// TypeReference fires on `Banned`.
+		{
+			Code:    `let value: Array<Banned>;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 18},
+			},
+		},
+		// ---- Dimension 4 / Nesting: empty TypeLiteral nested inside TypeLiteral ----
+		// Outer `{ a: {} }` has one member so the empty-literal check skips
+		// it; the inner `{}` is empty so the rule reports on it.
+		{
+			Code:    `let value: { a: {} };`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"{}": "Use object instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `{}` as a type. Use object instead.", Line: 1, Column: 17},
+			},
+		},
+		// ---- Dimension 4 / Nesting: same-kind nesting boundary on empty tuple ----
+		// `[Banned, []]` has two elements so empty-tuple check skips it; the
+		// inner `[]` is empty so it triggers.
+		{
+			Code: `let value: [Banned, []];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"[]":     "Use unknown[] instead.",
+				"Banned": true,
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 13},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `[]` as a type. Use unknown[] instead.", Line: 1, Column: 21},
+			},
+		},
+		// ---- Dimension 4 / Access forms: QualifiedName text comparison strips inner whitespace ----
+		// `NS . Banned` in source matches the bannedTypes key "NS.Banned"
+		// after whitespace normalization. Locks in that `removeSpaces`
+		// is applied to the *node text*, not just to user keys.
+		{
+			Code: `let value: NS . Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"NS.Banned": "Use NS.Ok instead.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `NS.Banned` as a type. Use NS.Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		// ---- Real-user: namespace + parameterized type ban ----
+		// Locks in that whole-node match works through QualifiedName with
+		// type arguments.
+		{
+			Code: `let value: NS.Banned<X>;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"NS.Banned<X>": "Avoid NS.Banned<X>.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `NS.Banned<X>` as a type. Avoid NS.Banned<X>.", Line: 1, Column: 12},
+			},
+		},
+		// ---- Dimension 4 / Type context: function-type parameter and return type ----
+		// FunctionType nests parameter TypeReferences and a return TypeReference.
+		// Each occurrence fires independently — locking that the listener walks
+		// into every TypeReference in a FunctionTypeNode, not just top-level.
+		{
+			Code:    `let f: (x: Banned) => Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 12},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 23},
+			},
+		},
+		// ---- Dimension 4 / Type context: generic type parameter constraint ----
+		// `<T extends Banned>` puts a TypeReference inside a TypeParameter's
+		// `constraint` slot. The listener must still fire there.
+		{
+			Code:    `function f<T extends Banned>() {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 22},
+			},
+		},
+		// ---- Dimension 4 / Type context: conditional type (extends + true + false branches) ----
+		// `T extends Banned ? Banned : never` puts TypeReferences in the
+		// extends/true/false slots of a ConditionalType. Locks in that the
+		// listener traverses all three.
+		{
+			Code:    `type T<X> = X extends Banned ? Banned : never;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 23},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 32},
+			},
+		},
+		// ---- Dimension 4 / Type context: mapped type value ----
+		// `{ [K in keyof T]: Banned }` puts a TypeReference inside a MappedType's
+		// `type` slot. The listener must reach it.
+		{
+			Code:    `type M<T> = { [K in keyof T]: Banned };`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 31},
+			},
+		},
+		// ---- Dimension 4 / Type context: keyof Banned (TypeOperator) ----
+		// `keyof Banned` wraps a TypeReference in a TypeOperator node. The
+		// listener fires on the inner TypeReference.
+		{
+			Code:    `type K = keyof Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 16},
+			},
+		},
+		// ---- Dimension 4 / Type context: indexed access type ----
+		// `Banned[K]` is IndexedAccessType(TypeReference, TypeReference). Both
+		// the object and the index can be TypeReferences; here only the object
+		// matches Banned.
+		{
+			Code:    `type I<K extends string> = Banned[K];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 28},
+			},
+		},
+		// ---- Dimension 4 / Type context: `satisfies` expression ----
+		// `x satisfies Banned` puts a TypeReference in a SatisfiesExpression's
+		// type slot. Locks in that the listener walks expression-position
+		// type annotations as well as declaration-position ones.
+		{
+			Code:    `1 satisfies Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 13},
+			},
+		},
+		// ---- Dimension 4 / Type context: `new` with type arguments ----
+		// `new Foo<Banned>()` puts the TypeReference inside the NewExpression's
+		// type-argument list — a TypeArguments-of-NewExpression slot that is
+		// distinct from the TypeArguments-of-TypeReference slot.
+		{
+			Code:    `const x = new Foo<Banned>();`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 19},
+			},
+		},
+		// ---- Dimension 4 / Same-kind nesting: TypeReference inside TypeReference ----
+		// `Banned<Banned>` is TypeReference(Banned, [TypeReference(Banned)]).
+		// With only `Banned` banned, three reports fire:
+		//   1. outer TypeName  → "Banned"
+		//   2. outer whole node (because TypeArguments != nil) → "Banned<Banned>"
+		//      (no match; not banned)
+		//   3. inner TypeName → "Banned"
+		// So we see exactly two `Banned` reports.
+		{
+			Code: `let value: Banned<Banned>;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": true,
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 12},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 19},
+			},
+		},
+		// ---- tsgo AST: KindNullKeyword fires inside union/array/tuple positions ----
+		// In tsgo, `null` in type position is `KindNullKeyword` directly (not
+		// wrapped in `KindLiteralType`). The keyword listener must fire on it
+		// regardless of how deeply nested it is, not just at the top of the
+		// type annotation. Three positions, three reports.
+		{
+			Code: `let a: string | null; let b: null[]; let c: [null];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"null": "Use `unknown` or be explicit.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `null` as a type. Use `unknown` or be explicit.", Line: 1, Column: 17},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `null` as a type. Use `unknown` or be explicit.", Line: 1, Column: 30},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `null` as a type. Use `unknown` or be explicit.", Line: 1, Column: 46},
+			},
+		},
+		// ---- tsgo AST: KindUndefinedKeyword fires inside union/array/type-arg positions ----
+		// Same shape lock-in for undefined as for null — both are top-level
+		// keyword kinds in tsgo (not literal-type wrapped), so the keyword
+		// listener should fire in any nested position.
+		{
+			Code: `let a: string | undefined; let b: Array<undefined>;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"undefined": "Prefer optional ?: instead.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `undefined` as a type. Prefer optional ?: instead.", Line: 1, Column: 17},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `undefined` as a type. Prefer optional ?: instead.", Line: 1, Column: 41},
+			},
+		},
+		// ---- tsgo AST: KindBigIntKeyword fires inside intersection / type-arg / nested arrays ----
+		// Locks in that primitive keyword listeners reach arbitrary nesting,
+		// not just declaration-direct positions.
+		{
+			Code: `type X = bigint & { x: 1 }; type Y = Set<bigint>; let z: bigint[][];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"bigint": "Use number.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `bigint` as a type. Use number.", Line: 1, Column: 10},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `bigint` as a type. Use number.", Line: 1, Column: 42},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `bigint` as a type. Use number.", Line: 1, Column: 58},
+			},
+		},
+		// ---- tsgo AST: PropertyAccess as heritage expression ----
+		// `class X implements ns.Banned` — in tsgo the expression slot of
+		// ExpressionWithTypeArguments can be a PropertyAccessExpression
+		// (lowercase namespace bound in expression scope) rather than a
+		// QualifiedName. Locks in that `stringifyNode` works on both shapes,
+		// and the helper still matches the heritage gate.
+		{
+			Code:    `const ns = { Banned: class {} }; class C implements ns.Banned {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"ns.Banned": "Use ns.Ok."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `ns.Banned` as a type. Use ns.Ok.", Line: 1, Column: 53},
+			},
+		},
+		// ---- tsgo AST: PropertyAccess heritage with type arguments ----
+		// Outer-node match on `ns.Banned<T>` after the expression-only match
+		// on `ns.Banned`. Locks in the typeArguments branch for the
+		// PropertyAccess-shaped heritage.
+		{
+			Code: `const ns = { Banned: class<T>{} }; class C implements ns.Banned<number> {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"ns.Banned":         "Don't use the bare class.",
+				"ns.Banned<number>": "Don't use the numeric specialization.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `ns.Banned` as a type. Don't use the bare class.", Line: 1, Column: 55},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `ns.Banned<number>` as a type. Don't use the numeric specialization.", Line: 1, Column: 55},
+			},
+		},
+		// ---- tsgo AST: NamedTupleMember keeps tuple non-empty ----
+		// `[name: Banned]` is a TupleType with one NamedTupleMember element.
+		// Two lock-ins in one shape:
+		//   1. The empty-tuple check skips (Elements has 1 node), so `[]` ban
+		//      does NOT fire on this construct (verified via the absence of a
+		//      `[]` error in Errors).
+		//   2. The inner TypeReference still fires for `Banned`.
+		{
+			Code: `let v: [name: Banned];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"[]":     "Use unknown[] instead.",
+				"Banned": "Use Ok instead.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 15},
+			},
+		},
+		// ---- tsgo AST: OptionalType in tuple keeps tuple non-empty ----
+		// `[Banned?]` is TupleType with one OptionalType element (wrapping a
+		// TypeReference). Same lock-in: empty-tuple ban must not fire, inner
+		// TypeReference must.
+		{
+			Code: `let v: [Banned?];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"[]":     "Use unknown[] instead.",
+				"Banned": "Use Ok instead.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 9},
+			},
+		},
+		// ---- tsgo AST: RestType in tuple keeps tuple non-empty ----
+		// `[...Banned[]]` — RestType wrapping ArrayType wrapping TypeReference.
+		// Inner TypeReference fires; empty-tuple ban must not.
+		{
+			Code: `let v: [...Banned[]];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"[]":     "Use unknown[] instead.",
+				"Banned": "Use Ok instead.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		// ---- tsgo AST: `readonly` TypeOperator over banned tuple/array ----
+		// `readonly Banned[]` and `readonly [Banned]` — TypeOperator(readonly, ...)
+		// must not block descent into its operand.
+		{
+			Code: `let a: readonly Banned[]; let b: readonly [Banned];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": true,
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 17},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 44},
+			},
+		},
+		// ---- tsgo AST: type predicate ----
+		// `function f(x): x is Banned` puts a TypeReference inside a
+		// TypePredicateNode. Locks in that the type-predicate type slot is
+		// walked by the listener.
+		{
+			Code:    `function check(x: unknown): x is Banned { return true; }`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok.", Line: 1, Column: 34},
+			},
+		},
+		// ---- tsgo AST: template literal type ----
+		// In tsgo, `${Banned}` inside a TemplateLiteralType holds a
+		// TypeReference. Locks in that the listener fires inside the
+		// template-substitution slot.
+		{
+			Code: `type T = ` + "`${Banned}`" + `;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": "Use a concrete type.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use a concrete type.", Line: 1, Column: 13},
+			},
+		},
+		// ---- tsgo AST: TypeAssertion (`<Banned>x` old-style) ----
+		// Locks in the angle-bracket assertion shape — different from `as`.
+		// The TypeReference inside the assertion is reachable.
+		{
+			Code:    `const x = <Banned>1;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok.", Line: 1, Column: 12},
+			},
+			TSConfig: "tsconfig.json",
+			Tsx:      false,
+		},
+		// ---- tsgo AST: `as` cast with ParenthesizedType ----
+		// `1 as (Banned)` — AsExpression with type=ParenthesizedType(TypeReference).
+		// Listener fires on the inner TypeReference regardless of the paren
+		// wrapper.
+		{
+			Code:    `1 as (Banned);`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok.", Line: 1, Column: 7},
+			},
+		},
+		// ---- tsgo AST: comment inside the type annotation ----
+		// A comment between the colon and the TypeReference is leading
+		// trivia; TrimNodeTextRange must skip it so the report still anchors
+		// on `Banned`, not on the comment.
+		{
+			Code:    `let v: /* legacy */ Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use Ok."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok.", Line: 1, Column: 21},
+			},
+		},
+		// ---- tsgo AST: multi-line type annotation with internal whitespace ----
+		// Whitespace + newline inside `Banned<\n  number\n>` must collapse to
+		// `Banned<number>` after removeSpaces — matching the same configured
+		// key.
+		{
+			Code: "let v: Banned<\n  number\n>;",
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned<number>": "Don't parameterize Banned with number.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned<number>` as a type. Don't parameterize Banned with number.", Line: 1, Column: 8},
+			},
+		},
+		// ---- tsgo AST: multi-level QualifiedName (A.B.C.Banned) ----
+		// Locks in that QualifiedName text extraction handles arbitrary
+		// nesting depth, not just two-level NS.X.
+		{
+			Code: `let v: A.B.C.Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"A.B.C.Banned": "Reach for a flatter type.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `A.B.C.Banned` as a type. Reach for a flatter type.", Line: 1, Column: 8},
+			},
+		},
+		// ---- Real-user: ban legacy `Function` keyword (no-unsafe-function-type style) ----
+		// Common deprecation-period config: ban a primitive-ish global with
+		// a fix suggestion. Locks in that `Function` is matched via
+		// TypeReference TypeName (it is *not* a TS keyword node in either
+		// ESTree or tsgo).
+		{
+			Code: `let f: Function;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Function": map[string]interface{}{
+					"message": "Use a specific function signature instead.",
+					"fixWith": "() => void",
+				},
+			}}),
+			Output: []string{`let f: () => void;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Function` as a type. Use a specific function signature instead.", Line: 1, Column: 8},
+			},
+		},
+		// ---- Real-user: ban `React.FC` with a suggested replacement ----
+		// Frequently asked-for ban in React codebases. Important subtlety:
+		// the suggestion replaces only the *TypeName* (`React.FC`), not the
+		// outer TypeReference, so the original `<Props>` argument carries
+		// over into the suggested replacement. Locks in that fix/suggest
+		// scope is the same as the matched node (the typeName), not the
+		// whole parameterized form.
+		{
+			Code: `type Props = {}; const C: React.FC<Props> = () => null;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"React.FC": map[string]interface{}{
+					"message": "Prefer plain functions returning JSX.",
+					"suggest": []interface{}{"(props: Props) => JSX.Element"},
+				},
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "bannedTypeMessage",
+					Message:   "Don't use `React.FC` as a type. Prefer plain functions returning JSX.",
+					Line:      1, Column: 27,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "bannedTypeReplacement", Output: `type Props = {}; const C: (props: Props) => JSX.Element<Props> = () => null;`},
+					},
+				},
+			},
+		},
+		// ---- Real-user: same name banned and not-banned in same file ----
+		// User configures `Banned` but a *different* identifier `Allowed`
+		// appears in the same scope — must not bleed into reports.
+		{
+			Code: `type Allowed = { ok: true }; let a: Allowed; let b: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": "Use Allowed instead.",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Allowed instead.", Line: 1, Column: 53},
+			},
+		},
+		// ---- Real-user: class field, method param/return, and static field ----
+		// Every type-annotation slot inside a class body is reachable.
+		{
+			Code: `
+				class C {
+					field: Banned = null as any;
+					static staticField: Banned;
+					method(x: Banned): Banned { return x; }
+					get acc(): Banned { return null as any; }
+					set acc(v: Banned) {}
+				}
+			`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": true,
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 3, Column: 13},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 4, Column: 26},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 5, Column: 16},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 5, Column: 25},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 6, Column: 17},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 7, Column: 17},
+			},
+		},
+		// ---- Real-user: interface body with property, method, index signature ----
+		{
+			Code: `
+				interface I {
+					p: Banned;
+					m(x: Banned): Banned;
+					[k: string]: Banned;
+				}
+			`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": true,
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 3, Column: 9},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 4, Column: 11},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 4, Column: 20},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 5, Column: 19},
+			},
+		},
+		// ---- Real-user: generic default ----
+		// `<T = Banned>` puts a TypeReference in the TypeParameter's
+		// `default` slot, separate from the `constraint` slot.
+		{
+			Code:    `function f<T = Banned>() {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 16},
+			},
+		},
+		// ---- Real-user: rest parameter & optional parameter ----
+		// `?:` makes the parameter optional but the type slot stays a regular
+		// TypeReference; `...` makes it rest, type slot is ArrayType.
+		{
+			Code:    `function f(a?: Banned, ...rest: Banned[]) {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 16},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 33},
+			},
+		},
+		// ---- Real-user: ban Object both bare and as global identifier ----
+		// `let f = Object();` (value position) — must NOT report; `let v: Object;`
+		// (type position) — must report. Lock in the two-position invariant.
+		{
+			Code: `let f = Object(); let v: Object;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Object": "Use object (lowercase).",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Object` as a type. Use object (lowercase).", Line: 1, Column: 26},
+			},
+		},
+	})
+}
+
+// TestNoRestrictedTypesNonFalsePositives is a second extras suite focused on
+// shapes that should NOT fire — defensive against future broadening of the
+// listener set. Each case is a real syntax form that *looks* close to one of
+// the banned shapes but, per upstream's listener wiring, must stay silent.
+func TestNoRestrictedTypesNonFalsePositives(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRestrictedTypesRule, []rule_tester.ValidTestCase{
+		// ---- Non-FP: `boolean` ban does NOT match `true` / `false` literal types ----
+		// Upstream's TYPE_KEYWORDS maps "boolean" only to TSBooleanKeyword.
+		// `true` / `false` are LiteralType(TrueKeyword/FalseKeyword), not
+		// BooleanKeyword. Banning "boolean" must not fire on them.
+		{
+			Code:    `let t: true; let f: false;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"boolean": true}}),
+		},
+		// ---- Non-FP: keyword ban does NOT match a same-named TypeReference ----
+		// `Bigint` (capital B) is a TypeReference, not the bigint keyword. We
+		// don't have an entry for capital-B Bigint, so it must stay valid.
+		{
+			Code:    `type Bigint = number; let v: Bigint;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"bigint": true}}),
+		},
+		// ---- Non-FP: `import('module').Banned` is not a TypeReference ----
+		// ImportType has its own AST kind; the qualifier "Banned" is not a
+		// TypeReference. Upstream doesn't fire on it either. Locks in that we
+		// don't accidentally bridge ImportType qualifiers to the TypeReference
+		// listener.
+		{
+			Code:    `let v: import('./mod').Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+		},
+		// ---- Non-FP: `typeof Banned` does NOT fire ----
+		// `typeof X` is TypeQuery containing an Identifier — not a
+		// TypeReference. Upstream doesn't fire either.
+		{
+			Code:    `const Banned = {}; type T = typeof Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+		},
+		// ---- Non-FP: `Banned` as a value identifier in expression position ----
+		// `Banned()` (value call), `new Banned()` (value new), `Banned.foo`
+		// (value access) — none are type positions. None must fire.
+		{
+			Code: `
+				class Banned {
+					static foo() {}
+				}
+				Banned();
+				new Banned();
+				Banned.foo();
+			`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+		},
+		// ---- Non-FP: object literal key named like a banned type ----
+		// `{ Banned: 1 }` — Banned is a PropertyName, not a TypeReference.
+		// Must stay silent.
+		{
+			Code:    `const x = { Banned: 1 };`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+		},
+		// ---- Non-FP: `enum` declaration with banned name ----
+		// The enum *declaration* names a type but it's not a TypeReference
+		// usage. References *to* the enum would fire; the declaration site
+		// shouldn't.
+		{
+			Code:    `enum Banned { A, B }`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+		},
+		// ---- Non-FP: empty interface body / empty class body ----
+		// Empty `interface I {}` body is *not* an empty TypeLiteral — it's an
+		// InterfaceDeclaration. Banning `{}` must not fire on it.
+		{
+			Code:    `interface I {} class C {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"{}": "Use object."}}),
+		},
+		// ---- Non-FP: `class extends` with banned identifier ----
+		// Lock-in alongside the in-positive-suite test: `class X extends Banned {}`
+		// must stay silent because upstream omits the class-extends listener.
+		// This second copy lives in the false-positive defense suite to
+		// catch any drift where a future listener-set widening starts firing.
+		{
+			Code:    `class X extends Banned {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+		},
+		// ---- Non-FP: empty bannedTypes (default options) means nothing fires ----
+		// Important real-user default: if the user does not supply `types`,
+		// the rule degrades to a no-op. Verifies that an empty map (and an
+		// entirely missing options) doesn't break the listener wiring.
+		{
+			Code: `let v: bigint | string; let w: {}; let x: []; class C implements Whatever {}`,
+		},
+		// ---- Non-FP: explicit `null` value disables an otherwise-active key ----
+		// Already covered in the positive-suite valid cases; repeating in the
+		// FP suite locks the disable-via-null branch into the FP audit.
+		{
+			Code: `let v: bigint;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"bigint": nil,
+			}}),
+		},
+	}, []rule_tester.InvalidTestCase{})
+}

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_upstream_test.go
@@ -1,0 +1,337 @@
+// TestNoRestrictedTypesUpstream migrates the full valid/invalid suite from
+// upstream
+// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-restricted-types.test.ts
+// 1:1. Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in no_restricted_types_extras_test.go.
+package no_restricted_types
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// optionsArr wraps a single options object the way upstream's
+// `options: [{...}]` ships it across the JS bridge — exercising the
+// `GetOptionsMap` JSON path rather than a typed-struct shortcut.
+func optionsArr(o map[string]interface{}) []interface{} {
+	return []interface{}{o}
+}
+
+func TestNoRestrictedTypesUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRestrictedTypesRule, []rule_tester.ValidTestCase{
+		{Code: `let f = Object();`},
+		{Code: `let f: { x: number; y: number } = { x: 1, y: 1 };`},
+		{
+			Code:    `let f = Object();`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Object": true}}),
+		},
+		{
+			Code:    `let f = Object(false);`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Object": true}}),
+		},
+		{
+			Code:    `let g = Object.create(null);`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Object": true}}),
+		},
+		{
+			Code:    `let e: namespace.Object;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Object": true}}),
+		},
+		{
+			Code:    `let value: _.NS.Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"NS.Banned": true}}),
+		},
+		{
+			Code:    `let value: NS.Banned._;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"NS.Banned": true}}),
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:    `let value: bigint;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"bigint": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `bigint` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: boolean;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"boolean": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `boolean` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: never;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"never": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `never` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: null;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"null": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `null` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: number;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"number": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `number` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: object;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"object": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `object` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: string;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"string": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `string` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: symbol;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"symbol": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `symbol` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: undefined;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"undefined": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `undefined` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: unknown;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"unknown": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `unknown` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: void;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"void": "Use Ok instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `void` as a type. Use Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: [];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"[]": "Use unknown[] instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `[]` as a type. Use unknown[] instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: [  ];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"[]": "Use unknown[] instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `[]` as a type. Use unknown[] instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: [[]];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"[]": "Use unknown[] instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `[]` as a type. Use unknown[] instead.", Line: 1, Column: 13},
+			},
+		},
+		{
+			Code:    `let value: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": true}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use '{}' instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use '{}' instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: Banned[];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use '{}' instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use '{}' instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code:    `let value: [Banned];`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": "Use '{}' instead."}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use '{}' instead.", Line: 1, Column: 13},
+			},
+		},
+		{
+			// Upstream's getCustomMessage short-circuits on !bannedType, so
+			// `Banned: ''` collapses to a bare ban with no trailing space.
+			Code:    `let value: Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": ""}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code: `let b: { c: Banned };`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{"fixWith": "Ok", "message": "Use Ok instead."},
+			}}),
+			Output: []string{`let b: { c: Ok };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 13},
+			},
+		},
+		{
+			Code: `1 as Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{"fixWith": "Ok", "message": "Use Ok instead."},
+			}}),
+			Output: []string{`1 as Ok;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `class Derived implements Banned {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{"fixWith": "Ok", "message": "Use Ok instead."},
+			}}),
+			Output: []string{`class Derived implements Ok {}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 26},
+			},
+		},
+		{
+			Code: `class Derived implements Banned1, Banned2 {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned1": map[string]interface{}{"fixWith": "Ok1", "message": "Use Ok1 instead."},
+				"Banned2": map[string]interface{}{"fixWith": "Ok2", "message": "Use Ok2 instead."},
+			}}),
+			Output: []string{`class Derived implements Ok1, Ok2 {}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned1` as a type. Use Ok1 instead.", Line: 1, Column: 26},
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned2` as a type. Use Ok2 instead.", Line: 1, Column: 35},
+			},
+		},
+		{
+			Code: `class Derived implements Omit<Foo, 'a'> {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Omit": map[string]interface{}{"fixWith": "Ok", "message": "Use Ok instead."},
+			}}),
+			Output: []string{`class Derived implements Ok<Foo, 'a'> {}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Omit` as a type. Use Ok instead.", Line: 1, Column: 26},
+			},
+		},
+		{
+			Code: `interface Derived extends Banned {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{"fixWith": "Ok", "message": "Use Ok instead."},
+			}}),
+			Output: []string{`interface Derived extends Ok {}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 27},
+			},
+		},
+		{
+			Code: `interface Derived extends Omit<Foo, 'a'> {}`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Omit": map[string]interface{}{"fixWith": "Ok", "message": "Use Ok instead."},
+			}}),
+			Output: []string{`interface Derived extends Ok<Foo, 'a'> {}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Omit` as a type. Use Ok instead.", Line: 1, Column: 27},
+			},
+		},
+		{
+			Code: `type Intersection = Banned & {};`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{"fixWith": "Ok", "message": "Use Ok instead."},
+			}}),
+			Output: []string{`type Intersection = Ok & {};`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 21},
+			},
+		},
+		{
+			Code: `type Union = Banned | {};`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned": map[string]interface{}{"fixWith": "Ok", "message": "Use Ok instead."},
+			}}),
+			Output: []string{`type Union = Ok | {};`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `let value: NS.Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"NS.Banned": map[string]interface{}{"fixWith": "NS.Ok", "message": "Use NS.Ok instead."},
+			}}),
+			Output: []string{`let value: NS.Ok;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `NS.Banned` as a type. Use NS.Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code: `let value: {} = {};`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"{}": map[string]interface{}{"fixWith": "object", "message": "Use object instead."},
+			}}),
+			Output: []string{`let value: object = {};`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `{}` as a type. Use object instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code: `let value: NS.Banned;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"  NS.Banned  ": map[string]interface{}{"fixWith": "NS.Ok", "message": "Use NS.Ok instead."},
+			}}),
+			Output: []string{`let value: NS.Ok;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `NS.Banned` as a type. Use NS.Ok instead.", Line: 1, Column: 12},
+			},
+		},
+		{
+			Code: `let value: Type<   Banned   >;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"       Banned      ": map[string]interface{}{"fixWith": "Ok", "message": "Use Ok instead."},
+			}}),
+			Output: []string{`let value: Type<   Ok   >;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type. Use Ok instead.", Line: 1, Column: 20},
+			},
+		},
+		{
+			Code: `type Intersection = Banned<any>;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned<any>": "Don't use `any` as a type parameter to `Banned`",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned<any>` as a type. Don't use `any` as a type parameter to `Banned`", Line: 1, Column: 21},
+			},
+		},
+		{
+			Code: `type Intersection = Banned<A,B>;`,
+			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
+				"Banned<A, B>": "Don't pass `A, B` as parameters to `Banned`",
+			}}),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned<A,B>` as a type. Don't pass `A, B` as parameters to `Banned`", Line: 1, Column: 21},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -281,7 +281,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-redundant-type-constituents.test.ts',
     './tests/typescript-eslint/rules/no-require-imports.test.ts',
     './tests/typescript-eslint/rules/no-restricted-imports.test.ts',
-    // './tests/typescript-eslint/rules/no-restricted-types.test.ts',
+    './tests/typescript-eslint/rules/no-restricted-types.test.ts',
     // './tests/typescript-eslint/rules/no-shadow/no-shadow-eslint.test.ts',
     './tests/typescript-eslint/rules/no-shadow/no-shadow.test.ts',
     './tests/typescript-eslint/rules/no-this-alias.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-restricted-types.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-restricted-types.test.ts.snap
@@ -1,0 +1,880 @@
+// Rstest Snapshot v1
+
+exports[`no-restricted-types > invalid 1`] = `
+{
+  "code": "let value: bigint;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`bigint\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 2`] = `
+{
+  "code": "let value: boolean;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`boolean\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 3`] = `
+{
+  "code": "let value: never;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`never\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 4`] = `
+{
+  "code": "let value: null;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`null\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 5`] = `
+{
+  "code": "let value: number;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`number\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 6`] = `
+{
+  "code": "let value: object;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`object\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 7`] = `
+{
+  "code": "let value: string;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`string\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 8`] = `
+{
+  "code": "let value: symbol;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`symbol\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 9`] = `
+{
+  "code": "let value: undefined;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`undefined\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 10`] = `
+{
+  "code": "let value: unknown;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`unknown\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 11`] = `
+{
+  "code": "let value: void;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`void\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 12`] = `
+{
+  "code": "let value: [];",
+  "diagnostics": [
+    {
+      "message": "Don't use \`[]\` as a type. Use unknown[] instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 13`] = `
+{
+  "code": "let value: [  ];",
+  "diagnostics": [
+    {
+      "message": "Don't use \`[]\` as a type. Use unknown[] instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 14`] = `
+{
+  "code": "let value: [[]];",
+  "diagnostics": [
+    {
+      "message": "Don't use \`[]\` as a type. Use unknown[] instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 15`] = `
+{
+  "code": "let value: Banned;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 16`] = `
+{
+  "code": "let value: Banned;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type. Use '{}' instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 17`] = `
+{
+  "code": "let value: Banned[];",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type. Use '{}' instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 18`] = `
+{
+  "code": "let value: [Banned];",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type. Use '{}' instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 19`] = `
+{
+  "code": "let value: Banned;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 20`] = `
+{
+  "code": "let b: { c: Banned };",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let b: { c: Ok };",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 21`] = `
+{
+  "code": "1 as Banned;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "1 as Ok;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 22`] = `
+{
+  "code": "class Derived implements Banned {}",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "class Derived implements Ok {}",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 23`] = `
+{
+  "code": "class Derived implements Banned1, Banned2 {}",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned1\` as a type. Use Ok1 instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+    {
+      "message": "Don't use \`Banned2\` as a type. Use Ok2 instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": "class Derived implements Ok1, Ok2 {}",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 24`] = `
+{
+  "code": "interface Derived extends Banned {}",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "interface Derived extends Ok {}",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 25`] = `
+{
+  "code": "type Intersection = Banned & {};",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Intersection = Ok & {};",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 26`] = `
+{
+  "code": "type Union = Banned | {};",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "type Union = Ok | {};",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 27`] = `
+{
+  "code": "let value: NS.Banned;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`NS.Banned\` as a type. Use NS.Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: NS.Ok;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 28`] = `
+{
+  "code": "let value: {} = {};",
+  "diagnostics": [
+    {
+      "message": "Don't use \`{}\` as a type. Use object instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: object = {};",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 29`] = `
+{
+  "code": "let value: NS.Banned;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`NS.Banned\` as a type. Use NS.Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: NS.Ok;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 30`] = `
+{
+  "code": "let value: Type<   Banned   >;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned\` as a type. Use Ok instead.",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "let value: Type<   Ok   >;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 31`] = `
+{
+  "code": "type Intersection = Banned<any>;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned<any>\` as a type. Don't use \`any\` as a type parameter to \`Banned\`",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-types > invalid 32`] = `
+{
+  "code": "type Intersection = Banned<A,B>;",
+  "diagnostics": [
+    {
+      "message": "Don't use \`Banned<A,B>\` as a type. Don't pass \`A, B\` as parameters to \`Banned\`",
+      "messageId": "bannedTypeMessage",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-restricted-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-restricted-types` rule from ESLint to rslint.

The rule reports any usage of a configured "banned" type name. It matches against primitive keyword types (`bigint`, `boolean`, `never`, `null`, `number`, `object`, `string`, `symbol`, `undefined`, `unknown`, `void`), type references (bare and parameterized: `Banned`, `NS.Banned`, `Banned<A>`), the empty tuple `[]`, the empty type literal `{}`, and heritage clauses (`class implements` / `interface extends`). Each `types` entry supports `true`, `false` / `null` (disable), a string (custom message), or an object with `message`, `fixWith`, and `suggest` for auto-fix and editor suggestions. Source-side names and configured keys are both whitespace-normalized before matching.

## Related Links

- ESLint rule: https://typescript-eslint.io/rules/no-restricted-types
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-restricted-types.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).