### PR TITLE
ci: drop per-batch GOCACHE cleanup in Windows Go test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,22 +82,14 @@ jobs:
           $packages = go list ./internal/... | Where-Object { $_ -ne "" }
           $batchSize = 100
           $batch = @()
-          $cacheDir = go env GOCACHE
 
           foreach ($pkg in $packages) {
             $batch += $pkg
 
             if ($batch.Count -ge $batchSize) {
               Write-Host "Running batch of $($batch.Count) packages..."
-              $marker = New-TemporaryFile
               go test -parallel 4 $batch
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-              # Remove only test-generated cache files, keeping build cache warm
-              Get-ChildItem -Path $cacheDir -Recurse -File |
-                Where-Object { $_.LastWriteTime -gt $marker.LastWriteTime } |
-                Remove-Item -Force -ErrorAction SilentlyContinue
-              Remove-Item $marker -Force
               $batch = @()
             }
           }


### PR DESCRIPTION
## Summary
- Drop the per-batch `Get-ChildItem -Recurse | Remove-Item` GOCACHE cleanup in `test-go-windows`. Keep the batched `go test` loop and `-parallel 4`.

## Why
The cleanup dates back to when `GOCACHE` lived on the small system drive and tests filled it up mid-run. `setup-go` now relocates `GOCACHE` (and `TEMP`/`GOTMPDIR`) to `_work\go\ci-go-windows` on the work disk.

Disk-usage diagnostics on the runner (a separate probe run):

| Metric | Before tests | After tests |
| --- | --- | --- |
| C: used / free | 0.91 / 18.97 GB | 1.59 / 18.28 GB |
| `_work\go\ci-go-windows` (GOCACHE) | 0 GB | **17.91 GB / 5,218 files** |
| `_work` total | 1.01 GB | 18.92 GB |

`_work` is mounted off C: (system drive only moves by ~0.7 GB across a full run), so the work disk comfortably holds GOCACHE; the cleanup is no longer needed and the recursive scan it triggers each batch is itself non-trivial overhead.

## Measured impact
On this PR's CI run, `Unit Test` finished in **31m28s**, within the recent main baseline (20-39 min on the same runner pool — performance varies significantly by runner instance). Batch 1 went from 14-21 min historically down to ~7.5 min after removing the scan; later batches also reuse test binaries that were previously being deleted.

We don't expect this to dramatically cut wall-clock time on its own — the per-package Go link cost dominates — but it removes a meaningless workaround and a measurable per-batch overhead. Further speedups (matrix sharding, single-pass) can be evaluated separately; an earlier attempt at single-pass `-parallel 8` on this branch OOM'd the runner, so this change is intentionally conservative.

If the Windows runner ever regresses to disk-full, revert this PR.

## Test plan
- [x] `Test Go (rspack-windows-2022-large) (1.26.0)` job passes on this PR.
- [x] Compare its `Unit Test` step duration against the recent main baseline.