### PR TITLE
feat: port rule @typescript-eslint/no-unused-private-class-members

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_type_assertion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_unary_minus"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unused_expressions"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unused_private_class_members"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unused_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_use_before_define"
 	ts_no_useless_constructor "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_constructor"
@@ -616,6 +617,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-type-assertion", no_unsafe_type_assertion.NoUnsafeTypeAssertionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-unary-minus", no_unsafe_unary_minus.NoUnsafeUnaryMinusRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unused-expressions", no_unused_expressions.NoUnusedExpressionsRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-unused-private-class-members", no_unused_private_class_members.NoUnusedPrivateClassMembersRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unused-vars", no_unused_vars.NoUnusedVarsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-use-before-define", no_use_before_define.NoUseBeforeDefineRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-constructor", ts_no_useless_constructor.NoUselessConstructorRule)

--- a/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.go
+++ b/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.go
@@ -1,0 +1,1007 @@
+package no_unused_private_class_members
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// memberKey distinguishes #-private members from public / private-keyword
+// members. `#foo` carries the unique prefix so it never collides with a
+// public `foo` in the same lookup map.
+type memberKey string
+
+func privateKey(name string) memberKey { return memberKey("#private@@" + name) }
+func publicKey(name string) memberKey  { return memberKey(name) }
+
+type member struct {
+	declNode   *ast.Node // owning declaration (PropertyDeclaration / MethodDeclaration / Parameter / …)
+	nameNode   *ast.Node // identifier or private-identifier the diagnostic anchors on
+	name       string    // display name; hash-private members include the leading `#`
+	key        memberKey
+	isPrivate  bool // has the `private` keyword
+	isHash     bool // declared with `#name`
+	isAccessor bool // get/set accessor or auto-accessor field
+	isStatic   bool
+	readCount  int
+	writeCount int
+}
+
+func (m *member) isUsed() bool {
+	// Mirrors upstream: any access of an accessor counts (potential side effects);
+	// regular members only stay alive when actually read.
+	return m.readCount > 0 || (m.writeCount > 0 && m.isAccessor)
+}
+
+// classScope is the per-class collection of tracked members.
+type classScope struct {
+	node      *ast.Node
+	className string // "" for anonymous class expressions
+	instance  map[memberKey]*member
+	static    map[memberKey]*member
+}
+
+// thisScope tracks how `this` resolves at each level of the AST walk.
+type thisScope struct {
+	upper       *thisScope
+	owningClass *classScope // non-nil iff THIS scope was created by a Class node
+	thisContext *classScope // class the `this` keyword resolves to here, or nil
+	isStatic    bool        // when thisContext != nil, true ⇒ `this` is the class object
+}
+
+// findClassByName walks outwards looking for the nearest class scope whose
+// owning declaration is named `name` (used to resolve `Foo.staticMember`).
+func (s *thisScope) findClassByName(name string) *classScope {
+	for cur := s; cur != nil; cur = cur.upper {
+		if cur.owningClass != nil && cur.owningClass.className == name {
+			return cur.owningClass
+		}
+	}
+	return nil
+}
+
+type thisAlias struct {
+	class    *classScope
+	isStatic bool
+}
+
+var NoUnusedPrivateClassMembersRule = rule.CreateRule(rule.Rule{
+	Name: "no-unused-private-class-members",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// Root scope corresponds to upstream's IntermediateScope-for-Program:
+		// no `this` binding.
+		root := &thisScope{}
+		stack := []*thisScope{root}
+		var classes []*classScope
+
+		// aliasBySymbol keys `const X = this` style aliases by the variable's
+		// symbol identity. Symbol equality intrinsically handles shadowing
+		// and cross-scope visibility — no per-scope frames or name pushes
+		// needed. Populated by recordAlias when an init `= this` is seen
+		// during the walk.
+		aliasBySymbol := map[*ast.Symbol]*thisAlias{}
+
+		// writtenSymbols holds every variable symbol that appears in a
+		// non-initializer write position anywhere in the file (collected
+		// during the walk via utils.IsWriteReference). At EndOfFile we use
+		// this to retroactively invalidate alias-mediated accesses whose
+		// variable was reassigned — covers BOTH write-before-read and
+		// read-before-write orderings, mirroring upstream's
+		// `variable.references.some(ref => ref.isWrite() && !ref.init)`.
+		writtenSymbols := map[*ast.Symbol]bool{}
+
+		// pendingAliasAccess records each `member.readCount++` /
+		// `writeCount++` that was attributed via an alias, so we can roll
+		// it back at EndOfFile if the alias turns out to have been
+		// reassigned. Direct (`this.X` / `Foo.X`) and typed-binding
+		// (`thing: Foo`) accesses count immediately and are never deferred.
+		type pendingAliasAccess struct {
+			m       *member
+			aliasOf *ast.Symbol
+			isWrite bool
+		}
+		var pendingAliasAccesses []pendingAliasAccess
+
+		current := func() *thisScope { return stack[len(stack)-1] }
+
+		// lookupAliasFor returns the alias info for `node` (a receiver
+		// Identifier), plus the alias variable's symbol so the caller can
+		// register the access for deferred validation. Symbol-keyed
+		// resolution requires TypeChecker; if absent, no aliases resolve.
+		lookupAliasFor := func(node *ast.Node) (*thisAlias, *ast.Symbol) {
+			if ctx.TypeChecker == nil {
+				return nil, nil
+			}
+			sym := utils.GetReferenceSymbol(node, ctx.TypeChecker)
+			if sym == nil {
+				return nil, nil
+			}
+			if a, ok := aliasBySymbol[sym]; ok {
+				return a, sym
+			}
+			return nil, nil
+		}
+
+		// ---------- member collection ----------
+
+		memberFromDecl := func(decl *ast.Node) *member {
+			name := decl.Name()
+			if name == nil {
+				return nil
+			}
+			if name.Kind == ast.KindPrivateIdentifier {
+				priv := name.AsPrivateIdentifier()
+				// tsgo's PrivateIdentifier.Text already carries the leading
+				// `#`; keep it so the display name in reportUnused matches
+				// the source identifier verbatim.
+				return &member{
+					declNode: decl,
+					nameNode: name,
+					name:     priv.Text,
+					key:      privateKey(priv.Text),
+					isHash:   true,
+				}
+			}
+			if s, ok := utils.GetStaticPropertyName(name); ok {
+				return &member{
+					declNode: decl,
+					nameNode: name,
+					name:     s,
+					key:      publicKey(s),
+				}
+			}
+			return nil
+		}
+
+		memberFromParameter := func(param *ast.Node) *member {
+			n := param.Name()
+			if n == nil || n.Kind != ast.KindIdentifier {
+				return nil
+			}
+			id := n.AsIdentifier()
+			return &member{
+				declNode: param,
+				nameNode: n,
+				name:     id.Text,
+				key:      publicKey(id.Text),
+			}
+		}
+
+		collectMembers := func(cs *classScope, classNode *ast.Node) {
+			for _, m := range classNode.Members() {
+				switch m.Kind {
+				case ast.KindConstructor:
+					ctor := m.AsConstructorDeclaration()
+					if ctor == nil || ctor.Parameters == nil {
+						continue
+					}
+					for _, param := range ctor.Parameters.Nodes {
+						if param.Kind != ast.KindParameter {
+							continue
+						}
+						if !ast.IsParameterPropertyDeclaration(param, m) {
+							continue
+						}
+						mem := memberFromParameter(param)
+						if mem == nil {
+							continue
+						}
+						flags := ast.GetCombinedModifierFlags(param)
+						mem.isPrivate = flags&ast.ModifierFlagsPrivate != 0
+						cs.instance[mem.key] = mem
+					}
+				case ast.KindPropertyDeclaration,
+					ast.KindMethodDeclaration,
+					ast.KindGetAccessor,
+					ast.KindSetAccessor:
+					mem := memberFromDecl(m)
+					if mem == nil {
+						continue
+					}
+					flags := ast.GetCombinedModifierFlags(m)
+					mem.isPrivate = flags&ast.ModifierFlagsPrivate != 0
+					mem.isStatic = flags&ast.ModifierFlagsStatic != 0
+					switch m.Kind {
+					case ast.KindGetAccessor, ast.KindSetAccessor:
+						mem.isAccessor = true
+					case ast.KindPropertyDeclaration:
+						if flags&ast.ModifierFlagsAccessor != 0 {
+							mem.isAccessor = true
+						}
+					}
+					if mem.isStatic {
+						cs.static[mem.key] = mem
+					} else {
+						cs.instance[mem.key] = mem
+					}
+				}
+				// ClassStaticBlockDeclaration and IndexSignature declare no
+				// tracked members.
+			}
+		}
+
+		// ---------- read/write classification ----------
+
+		// classifyAccess returns true iff `memberExpr` is consumed purely as
+		// a write. Mirrors upstream's countReference / isWriteOnlyUsage.
+		classifyAccess := func(memberExpr *ast.Node) bool {
+			target := ast.GetAssignmentTarget(memberExpr)
+			if target == nil {
+				return false
+			}
+			switch target.Kind {
+			case ast.KindBinaryExpression:
+				op := target.AsBinaryExpression().OperatorToken.Kind
+				if op == ast.KindEqualsToken {
+					// Simple `=` assignment, destructuring-element default,
+					// and direct property-assignment destructuring all land
+					// here.
+					return true
+				}
+				return isStatementFormParent(target.Parent)
+			case ast.KindPrefixUnaryExpression, ast.KindPostfixUnaryExpression:
+				return isStatementFormParent(target.Parent)
+			case ast.KindForInStatement, ast.KindForOfStatement:
+				return true
+			}
+			return false
+		}
+
+		// count tags the access immediately, and — when it was mediated by a
+		// `const X = this` alias — also files a deferred pending entry so
+		// EndOfFile can roll the count back if the alias variable turns out
+		// to have been reassigned anywhere in the file.
+		count := func(memberExpr *ast.Node, m *member, aliasOf *ast.Symbol) {
+			isWrite := classifyAccess(memberExpr)
+			if isWrite {
+				m.writeCount++
+			} else {
+				m.readCount++
+			}
+			if aliasOf != nil {
+				pendingAliasAccesses = append(pendingAliasAccesses, pendingAliasAccess{
+					m: m, aliasOf: aliasOf, isWrite: isWrite,
+				})
+			}
+		}
+
+		// ---------- resolution of the access receiver ----------
+
+		// resolveByTypeAnnotation looks for `obj` declared with an explicit
+		// type annotation that points to a known class scope. Mirrors
+		// upstream's Identifier → variable-defs → typeAnnotation branch.
+		//
+		// Class resolution stays bound to the lexical upper chain of the
+		// access site (`current().findClassByName`) — same scope-visibility
+		// semantics as upstream's `currentScope.findClassScopeWithName`.
+		resolveByTypeAnnotation := func(obj *ast.Node) (*classScope, bool, bool) {
+			if obj.Kind != ast.KindIdentifier {
+				return nil, false, false
+			}
+			needle := obj.AsIdentifier().Text
+			find := current().findClassByName
+			// Prefer TypeChecker-backed symbol resolution when available:
+			// it correctly walks every binding scope (nested blocks, etc.)
+			// in one call. Fall back to a manual walk over enclosing
+			// function-like / program bodies when TypeChecker is absent.
+			if ctx.TypeChecker != nil {
+				if cs, st, ok := resolveBySymbol(ctx.TypeChecker, obj, find); ok {
+					return cs, st, true
+				}
+				return nil, false, false
+			}
+			scope := utils.FindEnclosingScope(obj)
+			for scope != nil {
+				if cs, st, ok := matchTypedBinding(scope, needle, find); ok {
+					return cs, st, true
+				}
+				if scope.Kind == ast.KindSourceFile {
+					break
+				}
+				scope = utils.FindEnclosingScope(scope)
+			}
+			return nil, false, false
+		}
+
+		// resolveAccessOwner returns the class scope that `obj` accesses,
+		// whether the access is static, and — when the receiver was a
+		// `const X = this` alias — the alias variable's symbol (so the
+		// caller can register a deferred entry for post-walk validation).
+		// Returns (nil, false, nil) if the receiver cannot be resolved.
+		resolveAccessOwner := func(obj *ast.Node) (*classScope, bool, *ast.Symbol) {
+			// Strip parens and TS type wrappers — `(x as T).foo`,
+			// `x satisfies T`, `x!.foo` all preserve the runtime value of
+			// `x`, so the access still targets the same class.
+			obj = ast.SkipOuterExpressions(obj, ast.OEKParentheses|ast.OEKAssertions)
+			scope := current()
+			switch obj.Kind {
+			case ast.KindThisKeyword:
+				if scope.thisContext == nil {
+					return nil, false, nil
+				}
+				return scope.thisContext, scope.isStatic, nil
+			case ast.KindIdentifier:
+				name := obj.AsIdentifier().Text
+				if cs := scope.findClassByName(name); cs != nil {
+					return cs, true, nil
+				}
+				if a, sym := lookupAliasFor(obj); a != nil {
+					return a.class, a.isStatic, sym
+				}
+				if cs, st, ok := resolveByTypeAnnotation(obj); ok {
+					return cs, st, nil
+				}
+			}
+			return nil, false, nil
+		}
+
+		// handleThisDestructuring counts a READ on each non-computed
+		// identifier key inside `pattern` against the current `this`
+		// context. Used for `const {a} = this`, `({a} = this)`, and
+		// `((({a} = this)) => …)` shapes.
+		handleThisDestructuring := func(pattern *ast.Node) {
+			scope := current()
+			if scope.thisContext == nil {
+				return
+			}
+			members := scope.thisContext.instance
+			if scope.isStatic {
+				members = scope.thisContext.static
+			}
+			eachDestructuredKey(pattern, func(name string) {
+				if m, ok := members[publicKey(name)]; ok {
+					m.readCount++
+				}
+			})
+		}
+
+		// ---------- scope handling ----------
+
+		pushClassScope := func(node *ast.Node) {
+			cs := &classScope{
+				node:     node,
+				instance: map[memberKey]*member{},
+				static:   map[memberKey]*member{},
+			}
+			if name := node.Name(); name != nil && name.Kind == ast.KindIdentifier {
+				cs.className = name.AsIdentifier().Text
+			}
+			collectMembers(cs, node)
+			ts := &thisScope{
+				upper:       current(),
+				owningClass: cs,
+				thisContext: cs,
+				isStatic:    false,
+			}
+			stack = append(stack, ts)
+			classes = append(classes, cs)
+		}
+
+		pushMemberScope := func(_ *ast.Node, isStatic bool) {
+			parent := current()
+			ts := &thisScope{upper: parent}
+			if parent != nil && parent.owningClass != nil {
+				ts.thisContext = parent.owningClass
+				ts.isStatic = isStatic
+			}
+			stack = append(stack, ts)
+		}
+
+		pushFunctionScope := func(node *ast.Node) {
+			parent := current()
+			ts := &thisScope{upper: parent}
+
+			// Detect `function (this: Foo)` — the type annotation rebinds
+			// `this` inside the function body to a known class scope.
+			// Resolution is rooted at the function's *enclosing* scope's
+			// upper chain (parent.findClassByName), matching upstream's
+			// `upper.findClassScopeWithName` lookup site.
+			if params := functionLikeParameters(node); len(params) > 0 {
+				first := params[0]
+				if first.Kind == ast.KindParameter {
+					name := first.Name()
+					if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "this" {
+						pd := first.AsParameterDeclaration()
+						if pd != nil && pd.Type != nil {
+							if cs, st, ok := classScopeFromTypeAnnotation(pd.Type, parent.findClassByName); ok {
+								ts.thisContext = cs
+								ts.isStatic = st
+							}
+						}
+					}
+				}
+			}
+			stack = append(stack, ts)
+		}
+
+		popScope := func(_ *ast.Node) {
+			stack = stack[:len(stack)-1]
+		}
+
+		// ---------- alias tracking ----------
+
+		recordAlias := func(name *ast.Node, init *ast.Node) {
+			if name == nil || init == nil || name.Kind != ast.KindIdentifier {
+				return
+			}
+			if ast.SkipParentheses(init).Kind != ast.KindThisKeyword {
+				return
+			}
+			scope := current()
+			if scope.thisContext == nil {
+				return
+			}
+			// Symbol-keyed so shadowing and cross-scope distinctions fall
+			// out for free. Requires TypeChecker; without it we can't
+			// register the alias (the rule's `private` / parameter-property
+			// surfaces are TS-only, so a TypeChecker is virtually always
+			// present in real use).
+			if ctx.TypeChecker == nil {
+				return
+			}
+			sym := utils.GetReferenceSymbol(name, ctx.TypeChecker)
+			if sym == nil {
+				return
+			}
+			aliasBySymbol[sym] = &thisAlias{
+				class:    scope.thisContext,
+				isStatic: scope.isStatic,
+			}
+		}
+
+		// handlePropAccess and handleElemAccess process a single
+		// PropertyAccessExpression / ElementAccessExpression as a reference
+		// to a tracked class member. Extracted so the BinaryExpression /
+		// PropertyAssignment workaround below can re-trigger them on
+		// computed-key subtrees that the linter's patternVisitor skips.
+		var handlePropAccess func(node *ast.Node)
+		var handleElemAccess func(node *ast.Node)
+		handlePropAccess = func(node *ast.Node) {
+			pa := node.AsPropertyAccessExpression()
+			if pa == nil {
+				return
+			}
+			keyNode := pa.Name()
+			if keyNode == nil {
+				return
+			}
+			if keyNode.Kind == ast.KindPrivateIdentifier {
+				handlePrivateRef(node, keyNode, current(), count)
+				return
+			}
+			if keyNode.Kind != ast.KindIdentifier {
+				return
+			}
+			cls, isStatic, aliasSym := resolveAccessOwner(pa.Expression)
+			if cls == nil {
+				return
+			}
+			members := cls.instance
+			if isStatic {
+				members = cls.static
+			}
+			if m, ok := members[publicKey(keyNode.AsIdentifier().Text)]; ok {
+				count(node, m, aliasSym)
+			}
+		}
+		handleElemAccess = func(node *ast.Node) {
+			ea := node.AsElementAccessExpression()
+			if ea == nil || ea.ArgumentExpression == nil {
+				return
+			}
+			name, ok := utils.GetStaticExpressionValue(ast.SkipParentheses(ea.ArgumentExpression))
+			if !ok {
+				return
+			}
+			cls, isStatic, aliasSym := resolveAccessOwner(ea.Expression)
+			if cls == nil {
+				return
+			}
+			members := cls.instance
+			if isStatic {
+				members = cls.static
+			}
+			if m, ok := members[publicKey(name)]; ok {
+				count(node, m, aliasSym)
+			}
+		}
+
+		// scanComputedKey walks `node` looking for member accesses the
+		// linter's patternVisitor would have skipped (it never descends
+		// into the *key* of a `[ expr ]: target` element when the parent
+		// OLE is an assignment target). Each PropertyAccess / ElementAccess
+		// encountered is replayed through the normal handlers.
+		var scanComputedKey func(*ast.Node)
+		scanComputedKey = func(n *ast.Node) {
+			if n == nil {
+				return
+			}
+			switch n.Kind {
+			case ast.KindPropertyAccessExpression:
+				handlePropAccess(n)
+			case ast.KindElementAccessExpression:
+				handleElemAccess(n)
+			}
+			n.ForEachChild(func(child *ast.Node) bool {
+				scanComputedKey(child)
+				return false
+			})
+		}
+
+		return rule.RuleListeners{
+			// Class scopes.
+			ast.KindClassDeclaration:                      pushClassScope,
+			rule.ListenerOnExit(ast.KindClassDeclaration): popScope,
+			ast.KindClassExpression:                       pushClassScope,
+			rule.ListenerOnExit(ast.KindClassExpression):  popScope,
+
+			// Class-member function-likes inherit `this` from the class.
+			ast.KindMethodDeclaration: func(node *ast.Node) {
+				pushMemberScope(node, ast.HasSyntacticModifier(node, ast.ModifierFlagsStatic))
+			},
+			rule.ListenerOnExit(ast.KindMethodDeclaration): popScope,
+			ast.KindConstructor: func(node *ast.Node) {
+				pushMemberScope(node, false)
+			},
+			rule.ListenerOnExit(ast.KindConstructor): popScope,
+			ast.KindGetAccessor: func(node *ast.Node) {
+				pushMemberScope(node, ast.HasSyntacticModifier(node, ast.ModifierFlagsStatic))
+			},
+			rule.ListenerOnExit(ast.KindGetAccessor): popScope,
+			ast.KindSetAccessor: func(node *ast.Node) {
+				pushMemberScope(node, ast.HasSyntacticModifier(node, ast.ModifierFlagsStatic))
+			},
+			rule.ListenerOnExit(ast.KindSetAccessor): popScope,
+			ast.KindClassStaticBlockDeclaration: func(node *ast.Node) {
+				pushMemberScope(node, true)
+			},
+			rule.ListenerOnExit(ast.KindClassStaticBlockDeclaration): popScope,
+
+			// Regular functions rebind `this` (unless they declare a typed
+			// `this` parameter referring to a known class).
+			ast.KindFunctionDeclaration:                      pushFunctionScope,
+			rule.ListenerOnExit(ast.KindFunctionDeclaration): popScope,
+			ast.KindFunctionExpression:                       pushFunctionScope,
+			rule.ListenerOnExit(ast.KindFunctionExpression):  popScope,
+
+			// Property / element access: count read or write on the matching
+			// tracked member.
+			ast.KindPropertyAccessExpression: handlePropAccess,
+			ast.KindElementAccessExpression:  handleElemAccess,
+
+			// Workaround for the linter's destructuring walker. patternVisitor
+			// on a PropertyAssignment visits only the *Initializer* (target);
+			// the *Name* (e.g. `[this.#x]:` ) is silently dropped. Without
+			// this listener, member accesses inside a computed destructuring
+			// key would never reach the standard PAE / EAE handlers above.
+			// We scan the name ONLY when the surrounding OLE is itself an
+			// assignment target — value-context property assignments
+			// continue to be walked by the linter as usual, so no
+			// double-counting occurs.
+			ast.KindPropertyAssignment: func(node *ast.Node) {
+				pa := node.AsPropertyAssignment()
+				if pa == nil {
+					return
+				}
+				name := pa.Name()
+				if name == nil || name.Kind != ast.KindComputedPropertyName {
+					return
+				}
+				parent := node.Parent
+				if parent == nil || parent.Kind != ast.KindObjectLiteralExpression {
+					return
+				}
+				if !ast.IsAssignmentTarget(parent) {
+					return
+				}
+				scanComputedKey(name)
+			},
+
+			ast.KindVariableDeclaration: func(node *ast.Node) {
+				vd := node.AsVariableDeclaration()
+				if vd == nil || vd.Initializer == nil {
+					return
+				}
+				name := vd.Name()
+				if name == nil {
+					return
+				}
+				switch name.Kind {
+				case ast.KindIdentifier:
+					recordAlias(name, vd.Initializer)
+				case ast.KindObjectBindingPattern:
+					if ast.SkipParentheses(vd.Initializer).Kind == ast.KindThisKeyword {
+						handleThisDestructuring(name)
+					}
+				}
+			},
+
+			ast.KindParameter: func(node *ast.Node) {
+				pd := node.AsParameterDeclaration()
+				if pd == nil || pd.Initializer == nil {
+					return
+				}
+				name := pd.Name()
+				if name == nil {
+					return
+				}
+				if name.Kind == ast.KindObjectBindingPattern &&
+					ast.SkipParentheses(pd.Initializer).Kind == ast.KindThisKeyword {
+					handleThisDestructuring(name)
+				}
+			},
+
+			// Universal write tracker. utils.IsWriteReference covers every
+			// assignment / compound-op / update / destructuring shape, so a
+			// single Identifier listener captures all non-init writes to a
+			// variable — exactly what upstream's
+			// `variable.references.some(ref => ref.isWrite() && !ref.init)`
+			// gives via the scope manager. The symbol is the one shared
+			// across all references; symbol identity disambiguates shadows.
+			ast.KindIdentifier: func(node *ast.Node) {
+				if ctx.TypeChecker == nil {
+					return
+				}
+				if !utils.IsWriteReference(node) {
+					return
+				}
+				if sym := utils.GetReferenceSymbol(node, ctx.TypeChecker); sym != nil {
+					writtenSymbols[sym] = true
+				}
+			},
+
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				be := node.AsBinaryExpression()
+				if be == nil || be.OperatorToken == nil {
+					return
+				}
+				if be.OperatorToken.Kind != ast.KindEqualsToken {
+					return
+				}
+				if ast.SkipParentheses(be.Right).Kind != ast.KindThisKeyword {
+					return
+				}
+				if left := ast.SkipParentheses(be.Left); left.Kind == ast.KindObjectLiteralExpression {
+					handleThisDestructuring(left)
+				}
+			},
+
+			// SourceFile.ForEachChild visits each statement followed by the
+			// EndOfFileToken — using its listener as the "Program:exit"
+			// equivalent guarantees every top-level reference has been
+			// counted before we report.
+			ast.KindEndOfFile: func(_ *ast.Node) {
+				// Roll back every alias-mediated count whose underlying
+				// variable was reassigned anywhere in the file. This is the
+				// single-pass equivalent of upstream's eager
+				// `variable.references.some(ref => ref.isWrite() && !ref.init)`
+				// bailout: by the time we hit EndOfFile both the deferred
+				// accesses and the writtenSymbols set are complete, so the
+				// reconciliation is order-independent — read-before-write
+				// and write-before-read collapse to the same outcome.
+				for _, p := range pendingAliasAccesses {
+					if !writtenSymbols[p.aliasOf] {
+						continue
+					}
+					if p.isWrite {
+						p.m.writeCount--
+					} else {
+						p.m.readCount--
+					}
+				}
+				for _, cs := range classes {
+					reportUnused(ctx, cs.instance)
+					reportUnused(ctx, cs.static)
+				}
+			},
+		}
+	},
+})
+
+// handlePrivateRef matches a `obj.#name` access against the nearest
+// enclosing class scope whose member map contains a matching key. Mirrors
+// upstream's `PrivateIdentifier` visitor: walk the `upper` chain skipping
+// scopes with a null thisContext (regular functions rebind `this`); the
+// first scope that has the member wins. Hash-private members live in their
+// own per-class namespace, so we don't need to distinguish instance vs
+// static at this layer. The access is never alias-mediated (hash-private
+// resolution is purely scope-based), so `count` is invoked with a nil
+// alias symbol.
+func handlePrivateRef(node *ast.Node, key *ast.Node, scope *thisScope, count func(*ast.Node, *member, *ast.Symbol)) {
+	k := privateKey(key.AsPrivateIdentifier().Text)
+	for cur := scope; cur != nil; cur = cur.upper {
+		if cur.thisContext == nil {
+			continue
+		}
+		if m, ok := cur.thisContext.instance[k]; ok {
+			count(node, m, nil)
+			return
+		}
+		if m, ok := cur.thisContext.static[k]; ok {
+			count(node, m, nil)
+			return
+		}
+	}
+}
+
+func reportUnused(ctx rule.RuleContext, members map[memberKey]*member) {
+	// Collect and sort by source position so diagnostics emerge in a
+	// stable, top-to-bottom order. Go's map iteration is randomized, which
+	// would otherwise flip the reported line ordering between runs.
+	pending := make([]*member, 0, len(members))
+	for _, m := range members {
+		if !m.isPrivate && !m.isHash {
+			continue
+		}
+		if m.isUsed() {
+			continue
+		}
+		pending = append(pending, m)
+	}
+	sort.Slice(pending, func(i, j int) bool {
+		return pending[i].nameNode.Pos() < pending[j].nameNode.Pos()
+	})
+	for _, m := range pending {
+		ctx.ReportNode(m.nameNode, rule.RuleMessage{
+			Id:          "unusedPrivateClassMember",
+			Description: fmt.Sprintf("Private class member '%s' is defined but never used.", m.name),
+			Data:        map[string]string{"classMemberName": m.name},
+		})
+	}
+}
+
+// isStatementFormParent returns true when `parent` (skipping parens) is an
+// ExpressionStatement. Mirrors upstream's `parent.parent === ExpressionStatement`
+// check on compound assignments and UpdateExpressions.
+func isStatementFormParent(parent *ast.Node) bool {
+	parent = ast.WalkUpParenthesizedExpressions(parent)
+	return parent != nil && parent.Kind == ast.KindExpressionStatement
+}
+
+// functionLikeParameters returns `node.Parameters()` when `node` is
+// function-like, and nil otherwise. Thin wrapper around the public tsgo
+// getter to make the IsFunctionLike guard explicit at every call site.
+func functionLikeParameters(node *ast.Node) []*ast.Node {
+	if node == nil || !ast.IsFunctionLike(node) {
+		return nil
+	}
+	return node.Parameters()
+}
+
+// eachDestructuredKey invokes `visit` for every non-computed identifier-keyed
+// element of a destructuring pattern. The pattern can be either an
+// ObjectBindingPattern (declaration context) or an ObjectLiteralExpression
+// being used as a target (assignment context). Computed keys, rest elements,
+// and non-identifier keys are intentionally skipped — same as upstream.
+func eachDestructuredKey(pattern *ast.Node, visit func(name string)) {
+	switch pattern.Kind {
+	case ast.KindObjectBindingPattern:
+		bp := pattern.AsBindingPattern()
+		if bp == nil || bp.Elements == nil {
+			return
+		}
+		for _, el := range bp.Elements.Nodes {
+			if el.Kind != ast.KindBindingElement {
+				continue
+			}
+			be := el.AsBindingElement()
+			if be == nil {
+				continue
+			}
+			// Rest element (`...rest`) gathers everything else; upstream's
+			// `prop.type !== Property` filter drops it. The gathered name
+			// is a *binding* target, not a class member key.
+			if be.DotDotDotToken != nil {
+				continue
+			}
+			var keyNode *ast.Node
+			if be.PropertyName != nil {
+				keyNode = be.PropertyName
+			} else {
+				keyNode = be.Name()
+			}
+			if keyNode == nil || keyNode.Kind != ast.KindIdentifier {
+				continue
+			}
+			visit(keyNode.AsIdentifier().Text)
+		}
+	case ast.KindObjectLiteralExpression:
+		ole := pattern.AsObjectLiteralExpression()
+		if ole == nil || ole.Properties == nil {
+			return
+		}
+		for _, prop := range ole.Properties.Nodes {
+			var keyNode *ast.Node
+			switch prop.Kind {
+			case ast.KindShorthandPropertyAssignment:
+				keyNode = prop.AsShorthandPropertyAssignment().Name()
+			case ast.KindPropertyAssignment:
+				keyNode = prop.AsPropertyAssignment().Name()
+			default:
+				continue
+			}
+			if keyNode == nil || keyNode.Kind != ast.KindIdentifier {
+				continue
+			}
+			visit(keyNode.AsIdentifier().Text)
+		}
+	}
+}
+
+// resolveBySymbol uses TypeChecker to find the first declaration of `ident`
+// and inspects its explicit type annotation. Mirrors upstream's
+// `firstDef.name.typeAnnotation` branch but leverages the type checker's
+// proper scope-aware symbol resolution (handles nested blocks, hoisting,
+// declaration merging) instead of the manual walk. Returns the resolved
+// class scope, isStatic, and ok flag.
+//
+// Only the FIRST declaration is consulted — same as upstream's
+// `variable.defs[0]` check. Const-asserted patterns and complex inferred
+// types are intentionally unsupported (mirroring upstream's known limit).
+func resolveBySymbol(tc *checker.Checker, ident *ast.Node, find func(string) *classScope) (*classScope, bool, bool) {
+	sym := tc.GetSymbolAtLocation(ident)
+	if sym == nil || len(sym.Declarations) == 0 {
+		return nil, false, false
+	}
+	decl := sym.Declarations[0]
+	var typeNode *ast.Node
+	switch decl.Kind {
+	case ast.KindParameter:
+		typeNode = decl.AsParameterDeclaration().Type
+	case ast.KindVariableDeclaration:
+		typeNode = decl.AsVariableDeclaration().Type
+	default:
+		// ClassDeclaration / FunctionDeclaration / etc. don't have a type
+		// annotation we can use here. Upstream's "default branch" returns
+		// null in the same way.
+		return nil, false, false
+	}
+	if typeNode == nil {
+		return nil, false, false
+	}
+	return classScopeFromTypeAnnotation(typeNode, find)
+}
+
+// classScopeFromTypeAnnotation maps a type annotation to a known class
+// scope, returning (cls, isStatic, ok). Supports:
+//   - `T` referencing a class: instance access.
+//   - `typeof T` referencing a class: static access.
+func classScopeFromTypeAnnotation(typ *ast.Node, find func(string) *classScope) (*classScope, bool, bool) {
+	if typ == nil {
+		return nil, false, false
+	}
+	switch typ.Kind {
+	case ast.KindTypeReference:
+		tr := typ.AsTypeReferenceNode()
+		if tr == nil || tr.TypeName == nil || tr.TypeName.Kind != ast.KindIdentifier {
+			return nil, false, false
+		}
+		if cs := find(tr.TypeName.AsIdentifier().Text); cs != nil {
+			return cs, false, true
+		}
+	case ast.KindTypeQuery:
+		tq := typ.AsTypeQueryNode()
+		if tq == nil || tq.ExprName == nil || tq.ExprName.Kind != ast.KindIdentifier {
+			return nil, false, false
+		}
+		if cs := find(tq.ExprName.AsIdentifier().Text); cs != nil {
+			return cs, true, true
+		}
+	}
+	return nil, false, false
+}
+
+// matchTypedBinding finds a binding for `needle` inside `scope` and, if it
+// has a type annotation pointing to a known class, returns the resolution.
+//
+// `scope` is a function-like or program node returned by FindEnclosingScope.
+// We inspect both parameters (most common case in the rule's test suite —
+// `method(thing: Foo)`) and direct child variable declarations.
+func matchTypedBinding(scope *ast.Node, needle string, find func(string) *classScope) (*classScope, bool, bool) {
+	// Parameters.
+	for _, p := range functionLikeParameters(scope) {
+		if p.Kind != ast.KindParameter {
+			continue
+		}
+		pn := p.Name()
+		if pn == nil || pn.Kind != ast.KindIdentifier || pn.AsIdentifier().Text != needle {
+			continue
+		}
+		pd := p.AsParameterDeclaration()
+		if pd == nil || pd.Type == nil {
+			return nil, false, false
+		}
+		return classScopeFromTypeAnnotation(pd.Type, find)
+	}
+	// Top-level variable declarations inside the scope's body / source file.
+	if cs, st, ok := scanForVariableType(scope, needle, find); ok {
+		return cs, st, ok
+	}
+	return nil, false, false
+}
+
+// scanForVariableType walks the immediate body of a function-like or the
+// statements of a SourceFile looking for `let|const|var needle: T` and, if
+// `T` resolves to a tracked class, returns the resolution.
+func scanForVariableType(scope *ast.Node, needle string, find func(string) *classScope) (*classScope, bool, bool) {
+	body := getBodyStatements(scope)
+	for _, stmt := range body {
+		if stmt.Kind != ast.KindVariableStatement {
+			continue
+		}
+		decls := stmt.AsVariableStatement().DeclarationList
+		if decls == nil {
+			continue
+		}
+		dl := decls.AsVariableDeclarationList()
+		if dl == nil || dl.Declarations == nil {
+			continue
+		}
+		for _, d := range dl.Declarations.Nodes {
+			if d.Kind != ast.KindVariableDeclaration {
+				continue
+			}
+			vd := d.AsVariableDeclaration()
+			if vd == nil {
+				continue
+			}
+			n := vd.Name()
+			if n == nil || n.Kind != ast.KindIdentifier || n.AsIdentifier().Text != needle {
+				continue
+			}
+			if vd.Type == nil {
+				return nil, false, false
+			}
+			return classScopeFromTypeAnnotation(vd.Type, find)
+		}
+	}
+	return nil, false, false
+}
+
+// getBodyStatements returns the direct child statements of a function-like
+// or SourceFile node.
+func getBodyStatements(node *ast.Node) []*ast.Node {
+	switch node.Kind {
+	case ast.KindSourceFile:
+		return node.AsSourceFile().Statements.Nodes
+	case ast.KindFunctionDeclaration:
+		if fd := node.AsFunctionDeclaration(); fd != nil && fd.Body != nil {
+			return fd.Body.AsBlock().Statements.Nodes
+		}
+	case ast.KindFunctionExpression:
+		if fe := node.AsFunctionExpression(); fe != nil && fe.Body != nil {
+			return fe.Body.AsBlock().Statements.Nodes
+		}
+	case ast.KindArrowFunction:
+		if af := node.AsArrowFunction(); af != nil && af.Body != nil && af.Body.Kind == ast.KindBlock {
+			return af.Body.AsBlock().Statements.Nodes
+		}
+	case ast.KindMethodDeclaration:
+		if md := node.AsMethodDeclaration(); md != nil && md.Body != nil {
+			return md.Body.AsBlock().Statements.Nodes
+		}
+	case ast.KindConstructor:
+		if ctor := node.AsConstructorDeclaration(); ctor != nil && ctor.Body != nil {
+			return ctor.Body.AsBlock().Statements.Nodes
+		}
+	case ast.KindGetAccessor:
+		if ga := node.AsGetAccessorDeclaration(); ga != nil && ga.Body != nil {
+			return ga.Body.AsBlock().Statements.Nodes
+		}
+	case ast.KindSetAccessor:
+		if sa := node.AsSetAccessorDeclaration(); sa != nil && sa.Body != nil {
+			return sa.Body.AsBlock().Statements.Nodes
+		}
+	case ast.KindClassStaticBlockDeclaration:
+		if csb := node.AsClassStaticBlockDeclaration(); csb != nil && csb.Body != nil {
+			return csb.Body.AsBlock().Statements.Nodes
+		}
+	case ast.KindModuleBlock:
+		return node.AsModuleBlock().Statements.Nodes
+	}
+	return nil
+}

--- a/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.md
+++ b/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.md
@@ -1,0 +1,95 @@
+# no-unused-private-class-members
+
+## Rule Details
+
+Disallow unused private class members.
+
+This rule extends the base ESLint [`no-unused-private-class-members`](https://eslint.org/docs/latest/rules/no-unused-private-class-members) rule by recognizing members declared with TypeScript's `private` accessibility modifier and parameter properties (`constructor(private x: T)`), in addition to JavaScript's `#`-prefixed private fields.
+
+A private class member is considered *used* when its value is read at least once. Pure writes do not count — a field that is only assigned but never read can be removed with no observable effect. Getter and setter accessors are the exception: any access keeps them alive, since they can have side effects.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+class A {
+  #foo = 123;
+}
+```
+
+```typescript
+class A {
+  private foo = 123;
+}
+```
+
+```typescript
+class A {
+  private foo = 123;
+  bar() {
+    this.foo = 1;
+    this.foo += 2;
+    this.foo++;
+  }
+}
+```
+
+```typescript
+class A {
+  constructor(private foo: number) {}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+class A {
+  #foo = 123;
+  bar() {
+    return this.#foo;
+  }
+}
+```
+
+```typescript
+class A {
+  private foo = 123;
+  constructor() {
+    console.log(this.foo);
+  }
+}
+```
+
+```typescript
+class A {
+  private foo: number = 0;
+  bar(other: A) {
+    return other.foo;
+  }
+}
+```
+
+```typescript
+class A {
+  private accessor foo = 123;
+  bar() {
+    this.foo = 0;
+  }
+}
+```
+
+## Options
+
+This rule has no options.
+
+## Known Limitations
+
+Detection is shape-based, so the rule cannot see uses that reach the member through these indirect patterns:
+
+- Access through a variable whose type annotation is more complex than a single `T` or `typeof T` (unions, intersections, generic constraints).
+- External access via bracket notation with a dynamic key (`instance[someVar]`).
+- Usages reached through multi-step `this`-aliasing (`let X = this; let Y = X; Y.foo`).
+
+## Original Documentation
+
+- [typescript-eslint no-unused-private-class-members](https://typescript-eslint.io/rules/no-unused-private-class-members)
+- [ESLint no-unused-private-class-members](https://eslint.org/docs/latest/rules/no-unused-private-class-members)

--- a/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members_extras_test.go
@@ -1,0 +1,1444 @@
+// TestNoUnusedPrivateClassMembersExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+package no_unused_private_class_members
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedPrivateClassMembersExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedPrivateClassMembersRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: parenthesized receiver (tsgo preserves the paren) ----
+		{Code: `
+class C {
+  private foo = 1;
+  bar() {
+    return (this).foo;
+  }
+}
+    `},
+		{Code: `
+class C {
+  #foo = 1;
+  bar() {
+    return ((this)).#foo;
+  }
+}
+    `},
+
+		// ---- Dimension 4: receiver wrapped in TS expression types ----
+		{Code: `
+class C {
+  private foo = 1;
+  bar() {
+    return (this as C).foo;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private foo = 1;
+  bar() {
+    return (this satisfies C).foo;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private foo = 1;
+  bar(self: C) {
+    return self!.foo;
+  }
+}
+    `},
+
+		// ---- Dimension 4: optional-chain access counts as a read ----
+		// (`obj?.#name` is rejected by TS18030 so the hash-private variant
+		// is not legal — only the modifier form has a meaningful test.)
+		{Code: `
+class C {
+  private foo = 1;
+  bar(self?: C) {
+    return self?.foo;
+  }
+}
+    `},
+
+		// ---- Dimension 4: bracket access with template literal key ----
+		{Code: "\nclass C {\n  private foo = 1;\n  bar() {\n    return this[`foo`];\n  }\n}\n    "},
+
+		// ---- Dimension 4: numeric / string literal member keys ----
+		{Code: `
+class C {
+  private 'foo' = 1;
+  bar() {
+    return this.foo;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private 0 = 1;
+  bar() {
+    return this[0];
+  }
+}
+    `},
+
+		// ---- Dimension 4: declaration / container forms (class expression) ----
+		{Code: `
+const C = class {
+  #x = 1;
+  method() {
+    return this.#x;
+  }
+};
+    `},
+
+		// ---- Dimension 4: async / generator method bodies ----
+		{Code: `
+class C {
+  #x = 1;
+  async method() {
+    return this.#x;
+  }
+}
+    `},
+		{Code: `
+class C {
+  #x = 1;
+  *method() {
+    yield this.#x;
+  }
+}
+    `},
+		{Code: `
+class C {
+  #x = 1;
+  async *method() {
+    yield this.#x;
+  }
+}
+    `},
+
+		// ---- Dimension 4: nesting boundaries — outer class only ----
+		{Code: `
+class Outer {
+  private foo = 1;
+  method() {
+    class Inner {
+      private bar = 2;
+      use() {
+        return this.bar;
+      }
+    }
+    return this.foo;
+  }
+}
+    `},
+
+		// ---- Dimension 4: arrow function inherits `this` from class ----
+		{Code: `
+class C {
+  #foo = 1;
+  bar = () => this.#foo;
+}
+    `},
+		{Code: `
+class C {
+  #foo = 1;
+  bar = () => {
+    const inner = () => this.#foo;
+    return inner();
+  };
+}
+    `},
+
+		// ---- Dimension 4: rest pattern with non-target sibling ----
+		{Code: `
+class C {
+  private foo = 1;
+  method() {
+    const { foo, ...rest } = this;
+    void rest;
+    return foo;
+  }
+}
+    `},
+
+		// ---- Dimension 4: static block reads the static member ----
+		{Code: `
+class C {
+  private static foo = 1;
+  static {
+    console.log(C.foo);
+  }
+}
+    `},
+
+		// ---- Locks in upstream PrivateIdentifier visitor walking outward ----
+		// (matches member on inner OR outer ClassScope thanks to private-key
+		// namespace uniqueness)
+		{Code: `
+class Outer {
+  #x = 1;
+  method() {
+    class Inner {
+      use(o: Outer) {
+        return o.#x;
+      }
+    }
+  }
+}
+    `},
+
+		// ---- Real-user: getter with computed key matching the alias ----
+		{Code: `
+class C {
+  private accessor data = 0;
+  bump() {
+    this.data += 1;
+  }
+}
+    `},
+
+		// ---- Real-user: parameter property with private read in constructor ----
+		{Code: `
+class C {
+  constructor(private value: number) {
+    console.log(this.value);
+  }
+}
+    `},
+
+		// ---- Locks in upstream getObjectClass `typeof` branch ----
+		{Code: `
+class C {
+  private static FOO = 1;
+  static log(cls: typeof C) {
+    console.log(cls.FOO);
+  }
+}
+    `},
+
+		// ---- Locks in upstream MemberExpression visitor for ElementAccess ----
+		{Code: `
+class C {
+  private foo = 1;
+  bar() {
+    return this['foo'];
+  }
+}
+    `},
+
+		// ---- Locks in upstream `set` accessor: writeCount alone keeps it alive ----
+		{Code: `
+class C {
+  private set name(value: string) {}
+  init() {
+    this.name = 'rslint';
+  }
+}
+    `},
+
+		// ---- Dimension 4: arrow inside non-arrow function — outer function
+		// rebinds `this`, but the arrow inherits the *function's* binding,
+		// which is null. Access still resolves through the class scope's
+		// PrivateIdentifier walk-up because hash-private namespace is global
+		// per identifier. ----
+		{Code: `
+class C {
+  #counter = 0;
+  bump() {
+    return function (this: C) {
+      const arrow = () => this.#counter + 1;
+      return arrow();
+    };
+  }
+}
+    `},
+
+		// ---- Locks in upstream this-aliasing through `let` (not just const) ----
+		{Code: `
+class C {
+  private prop = 1;
+  method() {
+    let self = this;
+    return self.prop;
+  }
+}
+    `},
+
+		// ---- Locks in upstream: a class field arrow can both read AND write
+		// (`this.x = ...; this.x` in arrow body) — neither alone makes the
+		// member used; the read does. ----
+		{Code: `
+class C {
+  #cache: number | null = null;
+  set = (v: number) => {
+    this.#cache = v;
+    return this.#cache;
+  };
+}
+    `},
+
+		// ---- Dimension 4: getter accessed via bracket notation with string literal ----
+		{Code: `
+class C {
+  private get name() {
+    return 'rslint';
+  }
+  log() {
+    return this['name'];
+  }
+}
+    `},
+
+		// ---- Dimension 4: TypeScript abstract method that is still called by
+		// a subclass via super. The base abstract method is the *member node*,
+		// the call resolves at runtime. ----
+		{Code: `
+abstract class Base {
+  protected abstract handle(): void;
+  #invoke() {
+    this.handle();
+  }
+  start() {
+    return this.#invoke();
+  }
+}
+    `},
+
+		// ---- Locks in upstream isWriteOnlyUsage compound-op + non-statement
+		// parent: `bar(this.#x += 1)` IS a read (return-value consumed). ----
+		{Code: `
+class C {
+  #total = 0;
+  bump(out: (n: number) => void) {
+    out((this.#total += 1));
+  }
+}
+    `},
+
+		// ---- Dimension 4: destructuring with renaming + default value ----
+		{Code: `
+class C {
+  private foo = 1;
+  method() {
+    const { foo: aliased = 99 } = this;
+    return aliased;
+  }
+}
+    `},
+
+		// ---- Dimension 4: chained TS wrappers on the receiver ----
+		{Code: `
+class C {
+  private foo = 1;
+  bar() {
+    return ((this as C) satisfies C).foo;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private foo = 1;
+  bar() {
+    return ((this!) as C)!.foo;
+  }
+}
+    `},
+
+		// ---- Dimension 4: optional-chain link in a longer chain ----
+		// (`self: C | null` would not resolve — upstream only matches the
+		// TSTypeReference branch, not unions — so we keep the parameter as
+		// non-nullable to actually exercise the access path.)
+		{Code: `
+class C {
+  private foo = { bar: 1 };
+  use(self: C) {
+    return self?.foo?.bar;
+  }
+}
+    `},
+
+		// ---- Dimension 4: read context — typeof / void / delete / await / yield ----
+		{Code: `
+class C {
+  private foo = 1;
+  bar() {
+    return typeof this.foo;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private foo = 1;
+  bar() {
+    return void this.foo;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private foo: number | undefined = 1;
+  bar() {
+    return delete this.foo;
+  }
+}
+    `},
+		{Code: `
+class C {
+  #promise = Promise.resolve(1);
+  async bar() {
+    return await this.#promise;
+  }
+}
+    `},
+		{Code: `
+class C {
+  #values = [1, 2, 3];
+  *gen() {
+    yield this.#values;
+  }
+}
+    `},
+
+		// ---- Dimension 4: spread access in value position (read) ----
+		{Code: `
+class C {
+  #arr = [1, 2, 3];
+  copy() {
+    return [...this.#arr];
+  }
+}
+    `},
+		{Code: `
+class C {
+  private data = { a: 1 };
+  copy() {
+    return { ...this.data };
+  }
+}
+    `},
+		{Code: `
+class C {
+  #args = [1, 2, 3];
+  call(fn: (...args: number[]) => void) {
+    fn(...this.#args);
+  }
+}
+    `},
+
+		// ---- Dimension 4: template literal interpolation is a read ----
+		{Code: "\nclass C {\n  #title = 'rslint';\n  greet() {\n    return `hello, ${this.#title}`;\n  }\n}\n    "},
+		{Code: "\nclass C {\n  private label = 'x';\n  format() {\n    return tagged`prefix-${this.label}-suffix`;\n  }\n}\nfunction tagged(parts: TemplateStringsArray, ...args: string[]) {\n  return parts.join(',') + args.join(',');\n}\n    "},
+
+		// ---- Dimension 4: nested destructuring — only top-level key counted ----
+		{Code: `
+class C {
+  private cfg = { nested: { x: 1 } };
+  method() {
+    const { cfg: { nested: { x } } } = this;
+    return x;
+  }
+}
+    `},
+
+		// ---- Dimension 4: array destructuring of a private member is a read ----
+		{Code: `
+class C {
+  #pair = [1, 2];
+  swap() {
+    const [a, b] = this.#pair;
+    return [b, a];
+  }
+}
+    `},
+		{Code: `
+class C {
+  #arr = [1, 2, 3];
+  first() {
+    const [, , third] = this.#arr;
+    return third;
+  }
+}
+    `},
+
+		// ---- Dimension 4: read followed by write in compound expression ----
+		{Code: `
+class C {
+  private counter = 0;
+  inc() {
+    return (this.counter = this.counter + 1);
+  }
+}
+    `},
+		{Code: `
+class C {
+  #val = 1;
+  combine() {
+    return this.#val ?? 0;
+  }
+}
+    `},
+		{Code: `
+class C {
+  #val = 1;
+  use() {
+    const result = (this.#val, 'sequence');
+    return result;
+  }
+}
+    `},
+
+		// ---- Dimension 4: deeply nested classes — outer member used by
+		// 3rd-level deep this access ----
+		{Code: `
+class L1 {
+  #shared = 1;
+  m1() {
+    return class L2 {
+      m2() {
+        return class L3 {
+          m3() {
+            // Inner-most class doesn't define #shared, so the walk-up
+            // finds L1's. (Hash-private resolution walks past intermediate
+            // class scopes whose member maps don't contain the key.)
+            const helper = (x: L1) => x.#shared;
+            return helper;
+          }
+        };
+      }
+    };
+  }
+}
+    `},
+
+		// ---- Dimension 4: class inside arrow inside method ----
+		{Code: `
+class Outer {
+  #seed = 1;
+  factory() {
+    return () => {
+      return class Inner {
+        method(o: Outer) {
+          return o.#seed;
+        }
+      };
+    };
+  }
+}
+    `},
+
+		// ---- Dimension 4: static block with `this` access (this = class object) ----
+		{Code: `
+class C {
+  private static items: number[] = [];
+  static {
+    this.items.push(1);
+  }
+}
+    `},
+
+		// ---- Dimension 4: computed name with literal — member key resolves
+		// to the literal value via GetStaticPropertyName ----
+		{Code: `
+class C {
+  private ['computedName'] = 1;
+  use() {
+    return this.computedName;
+  }
+}
+    `},
+		{Code: "\nclass C {\n  private [`templateKey`] = 1;\n  use() {\n    return this.templateKey;\n  }\n}\n    "},
+		{Code: `
+class C {
+  private [42] = 'forty-two';
+  use() {
+    return this[42];
+  }
+}
+    `},
+
+		// ---- Dimension 4: TS abstract get/set pair — only one half used,
+		// counts because the abstract member is a single accessor entry. ----
+		{Code: `
+abstract class C {
+  protected abstract get id(): string;
+  use() {
+    return this.id;
+  }
+}
+    `},
+
+		// ---- Dimension 4: generic class — the type parameter doesn't hide
+		// the class scope lookup. ----
+		{Code: `
+class Box<T> {
+  #value: T | null = null;
+  get() {
+    return this.#value;
+  }
+  set(v: T) {
+    this.#value = v;
+  }
+}
+    `},
+
+		// ---- Dimension 4: class implementing interface ----
+		{Code: `
+interface Greeter {
+  greet(): string;
+}
+class C implements Greeter {
+  private salutation = 'hi';
+  greet() {
+    return this.salutation;
+  }
+}
+    `},
+
+		// ---- Dimension 4: decorator on a private member doesn't affect
+		// tracking; the access on the next line is still counted. ----
+		{Code: `
+function dec(_target: any, _key: string) {}
+class C {
+  @dec
+  private decorated = 1;
+  use() {
+    return this.decorated;
+  }
+}
+    `},
+
+		// ---- Dimension 4: arrow function as static field accesses class via
+		// the static name (since `this` in field initializer is unreliable). ----
+		{Code: `
+class C {
+  private static count = 0;
+  private static incCount = () => C.count + 1;
+  static run() {
+    return C.incCount();
+  }
+}
+    `},
+
+		// ---- Real-user: singleton pattern (private static instance) ----
+		{Code: `
+class Singleton {
+  private static instance: Singleton | null = null;
+  static getInstance() {
+    if (!Singleton.instance) {
+      Singleton.instance = new Singleton();
+    }
+    return Singleton.instance;
+  }
+}
+    `},
+
+		// ---- Real-user: builder pattern with chained methods reading own state ----
+		{Code: `
+class Builder {
+  #parts: string[] = [];
+  add(part: string) {
+    this.#parts.push(part);
+    return this;
+  }
+  build() {
+    return this.#parts.join('');
+  }
+}
+    `},
+
+		// ---- Real-user: observer / event emitter pattern ----
+		{Code: `
+class Emitter {
+  #listeners: Array<() => void> = [];
+  on(fn: () => void) {
+    this.#listeners.push(fn);
+  }
+  emit() {
+    for (const fn of this.#listeners) {
+      fn();
+    }
+  }
+}
+    `},
+
+		// ---- Real-user: bound method handler (this.handle = this.handle.bind(this)) ----
+		{Code: `
+class Component {
+  #boundHandler: () => void;
+  constructor() {
+    this.#boundHandler = this.#handle.bind(this);
+  }
+  #handle() {}
+  attach(el: { addEventListener(e: string, fn: () => void): void }) {
+    el.addEventListener('click', this.#boundHandler);
+  }
+}
+    `},
+
+		// ---- Real-user: memoization with private cache ----
+		{Code: `
+class Memo {
+  #cache = new Map<string, number>();
+  compute(key: string) {
+    if (this.#cache.has(key)) {
+      return this.#cache.get(key);
+    }
+    const value = key.length;
+    this.#cache.set(key, value);
+    return value;
+  }
+}
+    `},
+
+		// ---- Real-user: iterator protocol ----
+		{Code: `
+class Range {
+  #from: number;
+  #to: number;
+  constructor(from: number, to: number) {
+    this.#from = from;
+    this.#to = to;
+  }
+  *[Symbol.iterator]() {
+    for (let i = this.#from; i < this.#to; i++) {
+      yield i;
+    }
+  }
+}
+    `},
+
+		// ---- Locks in member-collection: declare member (ambient) — the
+		// declaration is still a class member; access works as usual. ----
+		{Code: `
+class C {
+  private declare foo: number;
+  init(v: number) {
+    Object.assign(this, { foo: v });
+    return this.foo;
+  }
+}
+    `},
+
+		// ---- Locks in member-collection: `static get` / `static set` accessor
+		// pair where only the setter is used through `C.x = …`. ----
+		{Code: `
+class C {
+  private static get x() {
+    return 1;
+  }
+  private static set x(_v: number) {}
+  static init() {
+    C.x = 2;
+    return C.x;
+  }
+}
+    `},
+
+		// ---- Locks in handleThisDestructuring with rest sibling: rest gathers
+		// non-listed properties but doesn't count any specific member. The
+		// explicitly-named `foo` IS counted. ----
+		{Code: `
+class C {
+  private foo = 1;
+  use() {
+    const { foo, ...rest } = this;
+    return [foo, rest];
+  }
+}
+    `},
+
+	}, []rule_tester.InvalidTestCase{
+		// ---- Locks in member-collection: overloaded method signatures —
+		// only the implementation body matters, all overloads share one
+		// member key. Member is reported once (not per overload). The
+		// diagnostic anchors on the surviving (last-collected) member,
+		// which is the implementation. ----
+		{
+			Code: `
+class C {
+  private foo(a: string): void;
+  private foo(a: number): void;
+  private foo(a: any) {
+    return a;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 5, Column: 11},
+			},
+		},
+		// ---- Locks in upstream PrivateIdentifier visitor: nested classes shadow
+		// outer hash-private members per spec — outer member stays unused even if
+		// inner class uses a member with the same #name. ----
+		{
+			Code: `
+class Outer {
+  #shared = 1;
+  use() {
+    return class Inner {
+      #shared = 2;
+      consume() {
+        return this.#shared;
+      }
+    };
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+
+		// ---- Dimension 4: receiver-with-non-null-assertion that doesn't
+		// resolve to a tracked class still leaves the member unused. ----
+		{
+			Code: `
+class C {
+  private foo = 1;
+}
+
+declare const arr: C[];
+console.log(arr[0]!.foo);
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Dimension 4: shorthand destructuring at the class scope sees the
+		// inherited `this`; member is still unused because the destructured
+		// binding is consumed but `this.foo` itself is only read into a temp. ----
+		// (Verifies handleThisDestructuring counts the read AND that pure
+		// assignment without subsequent use is the only thing that flags.)
+		{
+			Code: `
+class C {
+  private foo = 1;
+  method() {
+    this.foo = 2;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks in classifyAccess UpdateExpression branch: ++ inside a
+		// non-statement context (`++this.#x` used as a value) counts as a
+		// READ because the produced value is consumed elsewhere. Upstream:
+		// `identifierGreatGrandparent !== ExpressionStatement` falls through
+		// to readCount++.
+		// Inverse case: when ++ IS a statement → write-only. ----
+		{
+			Code: `
+class C {
+  #counter = 0;
+  bump() {
+    ++this.#counter;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+
+		// ---- Locks in classifyAccess BinaryExpression compound-op branch:
+		// `+=` whose result is discarded (ExpressionStatement parent) ⇒ write.
+		// Pair with the upstream valid case `bar((this.#x += 1))`. ----
+		{
+			Code: `
+class C {
+  #total = 0;
+  bump(amount: number) {
+    this.#total += amount;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+
+		// ---- Locks in handleThisDestructuring computed-key skip: even when
+		// the computed key resolves at compile time to a tracked member name,
+		// upstream intentionally bails (`prop.computed` skip). ----
+		{
+			Code: `
+class C {
+  private foo = 1;
+  method() {
+    const key = 'foo';
+    const { [key]: alias } = this;
+    void alias;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Real-user: assignment inside an arrow inherits `this` from the
+		// enclosing method scope. `this.#cached = bar()` is a pure write ⇒ the
+		// member stays unused. ----
+		{
+			Code: `
+class Memo {
+  #cached: number | null = null;
+  compute(bar: () => number) {
+    const update = () => {
+      this.#cached = bar();
+    };
+    update();
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+
+		// ---- Locks in upstream getObjectClass: `Foo.helper` accessed from a
+		// sibling class is NOT counted (findClassScopeWithName only walks the
+		// upper chain, which from inside Bar reaches Bar then root, never Foo).
+		// Even though the access is syntactically present, upstream treats it
+		// as unresolved — the private member is reported. ----
+		{
+			Code: `
+class Foo {
+  private static helper = 1;
+}
+class Bar extends Foo {
+  static use() {
+    return Foo.helper;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 18},
+			},
+		},
+
+		// ---- Real-user: destructuring from `this` only reads matching keys.
+		// `private bar` is never destructured, so it stays unused. ----
+		{
+			Code: `
+class C {
+  private foo = 1;
+  private bar = 2;
+  method() {
+    const { foo } = this;
+    void foo;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 11},
+			},
+		},
+
+		// ---- Locks the rest-binding bug fix: `const { ...rest } = this`
+		// must NOT register `rest` as an access of a same-named class
+		// member. The rest target is a *binding name*, not a property key,
+		// so it should be filtered out. ----
+		{
+			Code: `
+class C {
+  private rest = 1;
+  method() {
+    const { ...rest } = this;
+    return rest;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks in upstream: external bracket access with a STATIC literal
+		// from outside the class is also treated as unresolved (the receiver
+		// `instance` doesn't resolve to a tracked class scope by name). ----
+		{
+			Code: `
+class C {
+  private static foo = 1;
+}
+console.log(C['foo']);
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 18},
+			},
+		},
+
+		// ---- Locks in upstream: union-typed parameter — only TSTypeReference
+		// is matched, unions / intersections fall through. ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  method(thing: C | null) {
+    return thing?.prop;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks in upstream: array-typed parameter — `Foo[]` is a
+		// TypeReference whose name resolves to `Array`, not `Foo`. So an
+		// access through an array element (without indexing) doesn't match. ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  process(arr: C[]) {
+    return arr.map(x => x.prop);
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks in upstream: `this`-aliasing must be direct (`X = this`).
+		// `let X = anything-else; X.foo` is not treated as an alias. ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  method(other: C) {
+    const self = other;
+    return self.prop;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks in pushFunctionScope: a regular (non-arrow) function
+		// nested inside a method rebinds `this`. Without a typed `this`
+		// parameter, the inner function's `this.#x` doesn't reach the
+		// outer class. ----
+		{
+			Code: `
+class C {
+  #data = 1;
+  method() {
+    function inner(this: void) {
+      return this; // void context, no #data access
+    }
+    inner.call(undefined);
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+
+		// ---- Locks in classifyAccess: for-in / for-of `this.#x` as the
+		// initializer is a write (`for (this.#x in obj)` /
+		// `for (this.#x of arr)`). No read. ----
+		{
+			Code: `
+class C {
+  #key = '';
+  scan(obj: object) {
+    for (this.#key in obj) {
+    }
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+
+		// ---- Locks in member-collection: TS abstract property without body
+		// is still a tracked member. Without any read it's reported. ----
+		{
+			Code: `
+abstract class C {
+  protected abstract count: number;
+  private internal = 0;
+  abstract describe(): string;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 11},
+			},
+		},
+
+		// ---- Locks in member-collection: `private static readonly` constants
+		// are tracked like any other member. ----
+		{
+			Code: `
+class Config {
+  private static readonly TIMEOUT = 5000;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 27},
+			},
+		},
+
+		// ---- Locks in handleThisDestructuring: rest-only destructuring with
+		// a same-named private member must NOT count the member as accessed
+		// (regression: the rest binding is a target, not a key). ----
+		{
+			Code: `
+class C {
+  private values = 1;
+  method() {
+    const { ...values } = this;
+    return values;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks in classifyAccess: ForInStatement initializer through
+		// a NESTED destructuring left side — `for (this.#k of arr)` is a
+		// write; the wrapping array spread doesn't escape it to a read. ----
+		{
+			Code: `
+class C {
+  #buffer: number[] = [];
+  fill(src: number[]) {
+    for (this.#buffer of [src]) {
+      // body intentionally empty
+    }
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+
+		// ---- Locks in classifyAccess: destructuring assignment writes to
+		// every nested target. `[this.#a, this.#b] = pair` → both writes. ----
+		{
+			Code: `
+class C {
+  #a = 0;
+  #b = 0;
+  fill(pair: [number, number]) {
+    [this.#a, this.#b] = pair;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 3},
+			},
+		},
+
+		// ---- Locks in resolveBySymbol: a variable with NO type annotation
+		// (just an `init`) and not `= this` is left unresolved — even when
+		// the runtime value happens to be a class instance. ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  static make() {
+    const inst = new C();
+    return inst.prop;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks pushFunctionScope `this:` typed param routing through
+		// upper.findClassByName: a function declared OUTSIDE the class
+		// can't see the class via lexical upper chain, so its typed `this`
+		// parameter doesn't resolve. ----
+		{
+			Code: `
+class C {
+  #prop = 1;
+}
+function freeFn(this: C) {
+  return this.#prop;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+
+		// ---- Locks in handleThisDestructuring: nested destructuring counts
+		// only the TOP-LEVEL key. The inner level doesn't count `nested` as
+		// an access of a `nested` member of `this`. ----
+		{
+			Code: `
+class C {
+  private cfg = { nested: { x: 1 } };
+  private nested = 'unrelated';
+  method() {
+    const { cfg: { nested: { x } } } = this;
+    return x;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 11},
+			},
+		},
+
+		// ---- Locks in classifyAccess: a member appearing both on LHS and RHS
+		// of `this.#x = this.#y` — left is a write, right is a read.
+		// Only the writer-only member is reported. ----
+		{
+			Code: `
+class C {
+  #target = 0;
+  #source = 0;
+  copy() {
+    this.#target = this.#source;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+
+		// ---- Locks in resolveBySymbol fall-through: a variable typed as the
+		// containing class's `T` generic parameter (not the class itself).
+		// The type name is `T`, which has no matching classScope. ----
+		{
+			Code: `
+class Box<T> {
+  private content: T | null = null;
+  static handle<U>(value: U) {
+    return value;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks in member-collection: getter and setter share the same
+		// member key (both isAccessor=true). When neither has any access,
+		// only ONE diagnostic is emitted (last-wins anchors on the setter). ----
+		{
+			Code: `
+class C {
+  private get count() {
+    return 0;
+  }
+  private set count(_v: number) {}
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 6, Column: 15},
+			},
+		},
+
+		// ---- Locks the alias-invalidation fix: once a `let X = this` is
+		// reassigned, subsequent `X.foo` no longer counts as a class member
+		// access. Matches upstream's `variable.references.some(isWrite)` bail. ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  method(other: { prop: number }) {
+    let self = this;
+    self = other;
+    return self.prop;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks alias invalidation through compound assignment: any write
+		// to the alias name (including +=) disowns the alias. ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  method(other: any) {
+    let self = this as any;
+    self ||= other;
+    return self.prop;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks ORDER-INDEPENDENT alias invalidation: even when the
+		// `X.foo` READ appears textually BEFORE the `X = other` write, the
+		// post-walk reconciliation rolls back the count. Matches upstream's
+		// scope-manager-based `references.some(isWrite)` bailout — which is
+		// also order-independent. ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  method(other: { prop: number }) {
+    let self = this;
+    const captured = self.prop;
+    self = other;
+    return captured;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks invalidation across nested function boundary: a write
+		// inside an arrow function still invalidates the outer-scope alias
+		// (symbol identity is shared across scopes). ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  method(other: { prop: number }) {
+    let self = this;
+    const useThenWrite = () => {
+      const r = self.prop;
+      self = other;
+      return r;
+    };
+    return useThenWrite();
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks invalidation via destructuring assignment to the alias
+		// name: `[self] = [other]` is a write to `self`. ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  method(other: { prop: number }) {
+    let self = this;
+    const r = self.prop;
+    [self] = [other];
+    return r;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks alias-invalidation triggered inside a control-flow loop:
+		// `self = other` happens conditionally on each iteration, the
+		// reads of `self.prop` appear both before AND inside the loop. ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  iterate(others: { prop: number }[]) {
+    let self = this;
+    const before = self.prop;
+    for (const o of others) {
+      if (o) {
+        self = o;
+      }
+      void self.prop;
+    }
+    return before;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks invalidation via for-of as a write target ----
+		{
+			Code: `
+class C {
+  private prop = 1;
+  method(arr: any[]) {
+    let self = this as any;
+    const r = self.prop;
+    for (self of arr) {
+      // body intentionally empty
+    }
+    return r;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Locks symbol-based aliasing through shadowing: an INNER `let X`
+		// that shadows the outer alias `X` does NOT invalidate the outer
+		// alias when written, because the symbols are distinct. ----
+		// (The outer X is never written → its alias survives. The inner X
+		// access doesn't resolve to the outer C class — it's `string`. So
+		// `prop` IS used (via the outer self.prop on line 6) and NOT
+		// reported.)
+		{
+			Code: `
+class C {
+  private prop = 1;
+  private inner = 'inner-only';
+  method() {
+    let self = this;
+    const r = self.prop;
+    {
+      let self = 'shadow';
+      self = 'rewritten';
+      void self;
+    }
+    return r;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Only `inner` should be reported — the outer self.prop
+				// access on `prop` survives the symbol-shadowing test, but
+				// `inner` was never accessed.
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 11},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members_upstream_test.go
@@ -1,0 +1,1110 @@
+// TestNoUnusedPrivateClassMembersUpstream migrates the full valid/invalid suite
+// from typescript-eslint's tests/rules/no-unused-private-class-members.test.ts
+// 1:1. Position assertions cover line/column for every invalid case. rslint-
+// specific lock-in cases live in no_unused_private_class_members_extras_test.go.
+package no_unused_private_class_members
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedPrivateClassMembersUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedPrivateClassMembersRule, []rule_tester.ValidTestCase{
+		{Code: `class Foo {}`},
+		{Code: `
+class Foo {
+  publicMember = 42;
+}
+    `},
+		{Code: `
+class Foo {
+  public publicMember = 42;
+}
+    `},
+		{Code: `
+class Foo {
+  protected publicMember = 42;
+}
+    `},
+		{Code: `
+class C {
+  #usedInInnerClass;
+
+  method(a) {
+    return class {
+      foo = a.#usedInInnerClass;
+    };
+  }
+}
+    `},
+		{Code: `
+class C {
+  private accessor accessorMember = 42;
+
+  method() {
+    return this.accessorMember;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private static staticMember = 42;
+
+  static method() {
+    return this.staticMember;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private static staticMember = 42;
+
+  method() {
+    return C.staticMember;
+  }
+}
+      `},
+		{Code: `
+class Test1 {
+  constructor(private parameterProperty: number) {}
+  method() {
+    return this.parameterProperty;
+  }
+}
+    `},
+		{Code: `
+class Test1 {
+  constructor(private readonly parameterProperty: number) {}
+  method() {
+    return this.parameterProperty;
+  }
+}
+    `},
+		{Code: `
+class Test1 {
+  constructor(private readonly parameterProperty: number = 1) {}
+  method() {
+    return this.parameterProperty;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private prop: number;
+
+  method(thing: Foo) {
+    return thing.prop;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private static staticProp: number;
+
+  method(thing: typeof Foo) {
+    return thing.staticProp;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private prop: number;
+
+  method() {
+    const self = this;
+    return self.prop;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  #privateMember = 42;
+  method() {
+    return this.#privateMember;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember = 42;
+  method() {
+    return this.privateMember;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  #privateMember = 42;
+  anotherMember = this.#privateMember;
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember = 42;
+  anotherMember = this.privateMember;
+}
+    `},
+		{Code: `
+class Foo {
+  #privateMember = 42;
+  foo() {
+    anotherMember = this.#privateMember;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember = 42;
+  foo() {
+    anotherMember = this.privateMember;
+  }
+}
+    `},
+		{Code: `
+class C {
+  #privateMember;
+
+  foo() {
+    bar((this.#privateMember += 1));
+  }
+}
+    `},
+		{Code: `
+class C {
+  private privateMember;
+
+  foo() {
+    bar((this.privateMember += 1));
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  #privateMember = 42;
+  method() {
+    return someGlobalMethod(this.#privateMember);
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember = 42;
+  method() {
+    return someGlobalMethod(this.privateMember);
+  }
+}
+    `},
+		{Code: `
+class C {
+  #privateMember;
+
+  foo() {
+    return class {};
+  }
+
+  bar() {
+    return this.#privateMember;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private privateMember;
+
+  foo() {
+    return class {};
+  }
+
+  bar() {
+    return this.privateMember;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  #privateMember;
+  method() {
+    for (const bar in this.#privateMember) {
+    }
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember;
+  method() {
+    for (const bar in this.privateMember) {
+    }
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  #privateMember;
+  method() {
+    for (const bar of this.#privateMember) {
+    }
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember;
+  method() {
+    for (const bar of this.privateMember) {
+    }
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  #privateMember;
+  method() {
+    [bar = 1] = this.#privateMember;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember;
+  method() {
+    [bar = 1] = this.privateMember;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  #privateMember;
+  method() {
+    [bar] = this.#privateMember;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember;
+  method() {
+    [bar] = this.privateMember;
+  }
+}
+    `},
+		{Code: `
+class C {
+  #privateMember;
+
+  method() {
+    ({ [this.#privateMember]: a } = foo);
+  }
+}
+    `},
+		{Code: `
+class C {
+  private privateMember;
+
+  method() {
+    ({ [this.privateMember]: a } = foo);
+  }
+}
+    `},
+		{Code: `
+class C {
+  set #privateMember(value) {
+    doSomething(value);
+  }
+  get #privateMember() {
+    return something();
+  }
+  method() {
+    this.#privateMember += 1;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private set privateMember(value) {
+    doSomething(value);
+  }
+  private get privateMember() {
+    return something();
+  }
+  method() {
+    this.privateMember += 1;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  set #privateMember(value) {}
+
+  method(a) {
+    [this.#privateMember] = a;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private set privateMember(value) {}
+
+  method(a) {
+    [this.privateMember] = a;
+  }
+}
+    `},
+		{Code: `
+class C {
+  get #privateMember() {
+    return something();
+  }
+  set #privateMember(value) {
+    doSomething(value);
+  }
+  method() {
+    this.#privateMember += 1;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private get privateMember() {
+    return something();
+  }
+  private set privateMember(value) {
+    doSomething(value);
+  }
+  method() {
+    this.privateMember += 1;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember;
+  private privateMember2;
+
+  method() {
+    const { privateMember, privateMember2 } = this;
+    console.log(privateMember, privateMember2);
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private static staticMember = 1;
+  static method() {
+    const { staticMember } = this;
+    console.log(staticMember);
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember = 1;
+  method() {
+    const { privateMember } = this;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember = 1;
+  method() {
+    const { privateMember: privateMember2 } = this;
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember = 1;
+
+  method() {
+    let privateMember;
+    ({ privateMember } = this);
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember = 1;
+
+  method() {
+    const foo = ({ privateMember } = this) => {};
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember;
+
+  method() {
+    const { privateMember: used } = this;
+  }
+}
+    `},
+
+		// ---- Method definitions (upstream group) ----
+		{Code: `
+class Foo {
+  #privateMember() {
+    return 42;
+  }
+  anotherMethod() {
+    return this.#privateMember();
+  }
+}
+    `},
+		{Code: `
+class Foo {
+  private privateMember() {
+    return 42;
+  }
+  anotherMethod() {
+    return this.privateMember();
+  }
+}
+    `},
+		{Code: `
+class C {
+  set #privateMember(value) {
+    doSomething(value);
+  }
+
+  foo() {
+    this.#privateMember = 1;
+  }
+}
+    `},
+		{Code: `
+class C {
+  private set privateMember(value) {
+    doSomething(value);
+  }
+
+  foo() {
+    this.privateMember = 1;
+  }
+}
+    `},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `
+class C {
+  #unusedInOuterClass;
+
+  foo() {
+    return class D {
+      #unusedInOuterClass;
+
+      bar() {
+        return this.#unusedInOuterClass;
+      }
+    };
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class C {
+  #unusedOnlyInSecondNestedClass;
+
+  foo() {
+    return class {
+      #unusedOnlyInSecondNestedClass;
+
+      bar() {
+        return this.#unusedOnlyInSecondNestedClass;
+      }
+    };
+  }
+
+  baz() {
+    return this.#unusedOnlyInSecondNestedClass;
+  }
+
+  bar() {
+    return class {
+      #unusedOnlyInSecondNestedClass;
+    };
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 21, Column: 7},
+			},
+		},
+		{
+			Code: `
+class C {
+  #usedOnlyInTheSecondInnerClass;
+
+  method(a) {
+    return class {
+      #usedOnlyInTheSecondInnerClass;
+
+      method2(b) {
+        foo = b.#usedOnlyInTheSecondInnerClass;
+      }
+
+      method3(b) {
+        foo = b.#usedOnlyInTheSecondInnerClass;
+      }
+    };
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class C {
+  private accessor accessorMember = 42;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 20},
+			},
+		},
+		{
+			Code: `
+class C {
+  private static staticMember = 42;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 18},
+			},
+		},
+		{
+			Code: `
+class Test1 {
+  constructor(private parameterProperty: number) {}
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 23},
+			},
+		},
+		{
+			Code: `
+class Test1 {
+  constructor(private readonly parameterProperty: number) {}
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 32},
+			},
+		},
+		{
+			Code: `
+class Test1 {
+  constructor(private readonly parameterProperty: number = 1) {}
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 32},
+			},
+		},
+		// Usage of a property outside the class — bracket and dot notation.
+		{
+			Code: `
+class C {
+  private usedOutsideClass;
+}
+
+const instance = new C();
+console.log(instance.usedOutsideClass);
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class C {
+  private usedOutsideClass;
+}
+
+const instance = new C();
+console.log(instance['usedOutsideClass']);
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		// Too much indirection (`const self1 = this; const self2 = self1;`) —
+		// the rule intentionally bails after one hop.
+		{
+			Code: `
+class Foo {
+  private prop: number;
+
+  method() {
+    const self1 = this;
+    const self2 = self1;
+    return self2.prop;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		{
+			Code: `
+class Foo {
+  #privateMember = 5;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember = 5;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class First {}
+class Second {
+  #privateMember = 5;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 3},
+			},
+		},
+		{
+			Code: `
+class First {}
+class Second {
+  private privateMember = 5;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 11},
+			},
+		},
+		{
+			Code: `
+class First {
+  #privateMember = 5;
+}
+class Second {}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class First {
+  private privateMember = 5;
+}
+class Second {}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class First {
+  #privateMember = 5;
+  #privateMember2 = 5;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 3},
+			},
+		},
+		{
+			Code: `
+class First {
+  private privateMember = 5;
+  private privateMember2 = 5;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 11},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  #privateMember = 5;
+  method() {
+    this.#privateMember = 42;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember = 5;
+  method() {
+    this.privateMember = 42;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  #privateMember = 5;
+  method() {
+    this.#privateMember += 42;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember = 5;
+  method() {
+    this.privateMember += 42;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class C {
+  #privateMember;
+
+  foo() {
+    this.#privateMember++;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class C {
+  private privateMember;
+
+  foo() {
+    this.privateMember++;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Unused method definitions (upstream group) ----
+		{
+			Code: `
+class Foo {
+  #privateMember() {}
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember() {}
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  #privateMember() {}
+  #privateMemberUsed() {
+    return 42;
+  }
+  publicMethod() {
+    return this.#privateMemberUsed();
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember() {}
+  private privateMemberUsed() {
+    return 42;
+  }
+  publicMethod() {
+    return this.privateMemberUsed();
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  set #privateMember(value) {}
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 7},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private set privateMember(value) {}
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 15},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  #privateMember;
+  method() {
+    for (this.#privateMember in bar) {
+    }
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember;
+  method() {
+    for (this.privateMember in bar) {
+    }
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  #privateMember;
+  method() {
+    for (this.#privateMember of bar) {
+    }
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember;
+  method() {
+    for (this.privateMember of bar) {
+    }
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  #privateMember;
+  method() {
+    ({ x: this.#privateMember } = bar);
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember;
+  method() {
+    ({ x: this.privateMember } = bar);
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  #privateMember;
+  method() {
+    [...this.#privateMember] = bar;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember;
+  method() {
+    [...this.privateMember] = bar;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  #privateMember;
+  method() {
+    [this.#privateMember = 1] = bar;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember;
+  method() {
+    [this.privateMember = 1] = bar;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  #privateMember;
+  method() {
+    [this.#privateMember] = bar;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember;
+  method() {
+    [this.privateMember] = bar;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  private privateMember;
+
+  method() {
+    const { unused: privateMember } = this;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+const foo = 'bar';
+class Foo {
+  private foo = 1;
+
+  method() {
+    const { [foo]: test } = this;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 11},
+			},
+		},
+		{
+			Code: `
+const foo = 'bar';
+class Foo {
+  private foo = 1;
+  private bar = 2;
+
+  method() {
+    const { [foo]: test } = this;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedPrivateClassMember", Line: 4, Column: 11},
+				{MessageId: "unusedPrivateClassMember", Line: 5, Column: 11},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -308,6 +308,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-unsafe-type-assertion.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-unary-minus.test.ts',
     './tests/typescript-eslint/rules/no-unused-expressions.test.ts',
+    './tests/typescript-eslint/rules/no-unused-private-class-members.test.ts',
     './tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-eslint-basic.test.ts',
     './tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-eslint-patterns.test.ts',
     './tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-eslint-catch-loops.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unused-private-class-members.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unused-private-class-members.test.ts.snap
@@ -1,0 +1,404 @@
+// Rstest Snapshot v1
+
+exports[`no-unused-private-class-members > invalid 1`] = `
+{
+  "code": "
+class C {
+  private accessor accessorMember = 42;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member 'accessorMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 2`] = `
+{
+  "code": "
+class C {
+  private static staticMember = 42;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member 'staticMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 3`] = `
+{
+  "code": "
+class Test1 {
+  constructor(private parameterProperty: number) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member 'parameterProperty' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 3,
+        },
+        "start": {
+          "column": 23,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 4`] = `
+{
+  "code": "
+class C {
+  private usedOutsideClass;
+}
+
+const instance = new C();
+console.log(instance.usedOutsideClass);
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member 'usedOutsideClass' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 5`] = `
+{
+  "code": "
+class Foo {
+  #privateMember = 5;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member '#privateMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 6`] = `
+{
+  "code": "
+class Foo {
+  private privateMember = 5;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member 'privateMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 7`] = `
+{
+  "code": "
+class Foo {
+  #privateMember = 5;
+  method() {
+    this.#privateMember = 42;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member '#privateMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 8`] = `
+{
+  "code": "
+class Foo {
+  private privateMember = 5;
+  method() {
+    this.privateMember = 42;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member 'privateMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 9`] = `
+{
+  "code": "
+class C {
+  #privateMember;
+
+  foo() {
+    this.#privateMember++;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member '#privateMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 10`] = `
+{
+  "code": "
+class Foo {
+  #privateMember() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member '#privateMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 11`] = `
+{
+  "code": "
+class Foo {
+  private privateMember() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member 'privateMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 12`] = `
+{
+  "code": "
+class Foo {
+  set #privateMember(value) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member '#privateMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 13`] = `
+{
+  "code": "
+class Foo {
+  private set privateMember(value) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Private class member 'privateMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-private-class-members.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-private-class-members.test.ts
@@ -1,0 +1,361 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unused-private-class-members', {
+  valid: [
+    'class Foo {}',
+    `
+class Foo {
+  publicMember = 42;
+}
+    `,
+    `
+class Foo {
+  public publicMember = 42;
+}
+    `,
+    `
+class Foo {
+  protected publicMember = 42;
+}
+    `,
+    `
+class C {
+  #usedInInnerClass;
+
+  method(a) {
+    return class {
+      foo = a.#usedInInnerClass;
+    };
+  }
+}
+    `,
+    `
+class C {
+  private accessor accessorMember = 42;
+
+  method() {
+    return this.accessorMember;
+  }
+}
+    `,
+    `
+class C {
+  private static staticMember = 42;
+
+  static method() {
+    return this.staticMember;
+  }
+}
+    `,
+    `
+class Test1 {
+  constructor(private parameterProperty: number) {}
+  method() {
+    return this.parameterProperty;
+  }
+}
+    `,
+    `
+class Foo {
+  private prop: number;
+
+  method(thing: Foo) {
+    return thing.prop;
+  }
+}
+    `,
+    `
+class Foo {
+  private static staticProp: number;
+
+  method(thing: typeof Foo) {
+    return thing.staticProp;
+  }
+}
+    `,
+    `
+class Foo {
+  private prop: number;
+
+  method() {
+    const self = this;
+    return self.prop;
+  }
+}
+    `,
+    `
+class Foo {
+  #privateMember = 42;
+  method() {
+    return this.#privateMember;
+  }
+}
+    `,
+    `
+class Foo {
+  private privateMember = 42;
+  method() {
+    return this.privateMember;
+  }
+}
+    `,
+    `
+class C {
+  set #privateMember(value) {
+    doSomething(value);
+  }
+  get #privateMember() {
+    return something();
+  }
+  method() {
+    this.#privateMember += 1;
+  }
+}
+    `,
+    `
+class C {
+  private set privateMember(value) {
+    doSomething(value);
+  }
+  private get privateMember() {
+    return something();
+  }
+  method() {
+    this.privateMember += 1;
+  }
+}
+    `,
+    `
+class Foo {
+  #privateMember() {
+    return 42;
+  }
+  anotherMethod() {
+    return this.#privateMember();
+  }
+}
+    `,
+    `
+class Foo {
+  private privateMember() {
+    return 42;
+  }
+  anotherMethod() {
+    return this.privateMember();
+  }
+}
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+class C {
+  private accessor accessorMember = 42;
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: 'accessorMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class C {
+  private static staticMember = 42;
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: 'staticMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class Test1 {
+  constructor(private parameterProperty: number) {}
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: 'parameterProperty',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class C {
+  private usedOutsideClass;
+}
+
+const instance = new C();
+console.log(instance.usedOutsideClass);
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: 'usedOutsideClass',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  #privateMember = 5;
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: '#privateMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  private privateMember = 5;
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: 'privateMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  #privateMember = 5;
+  method() {
+    this.#privateMember = 42;
+  }
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: '#privateMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  private privateMember = 5;
+  method() {
+    this.privateMember = 42;
+  }
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: 'privateMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class C {
+  #privateMember;
+
+  foo() {
+    this.#privateMember++;
+  }
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: '#privateMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  #privateMember() {}
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: '#privateMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  private privateMember() {}
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: 'privateMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  set #privateMember(value) {}
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: '#privateMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  private set privateMember(value) {}
+}
+      `,
+      errors: [
+        {
+          data: {
+            classMemberName: 'privateMember',
+          },
+          messageId: 'unusedPrivateClassMember',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-unused-private-class-members` rule from ESLint / typescript-eslint to rslint.

The rule flags private class members (declared with the `private` keyword or the `#name` prefix) that are never read inside their class. Writes alone don't keep a member alive; get/set accessors are the exception. TypeScript parameter properties (`constructor(private x: T)`) are tracked as instance members.

Implementation notes:

- Algorithm mirrors typescript-eslint's `analyzeClassMemberUsage`: a `this`-scope tree with class / function / static-block frames, each member tracked across instance / static maps keyed by `publicKey(name)` or `privateKey('#' + name)`.
- Read/write classification uses `ast.GetAssignmentTarget` (handles compound ops, destructuring, for-in/of) plus `ast.WalkUpParenthesizedExpressions` for the statement-form check on `+=` / `++`.
- Receiver resolution accepts `this`, `ClassName`, `const X = this` aliases, and typed-variable bindings (`thing: Foo` or `thing: typeof Foo`).
- `this`-aliases are tracked symbol-keyed (via `utils.GetReferenceSymbol` + TypeChecker), and any non-init write is collected file-wide via `utils.IsWriteReference`. At `Program:exit` (EndOfFile token) the pending alias-mediated counts are rolled back if their variable's symbol was reassigned — matches upstream's `variable.references.some(isWrite && !init)` bail-out for both read-before-write and write-before-read orderings.
- A `PropertyAssignment` listener re-scans computed keys in destructuring (`({ [this.#x]: a } = foo)`) that the linter's pattern walker would otherwise skip.

## Related Links

- typescript-eslint rule: <https://typescript-eslint.io/rules/no-unused-private-class-members>
- ESLint base rule: <https://eslint.org/docs/latest/rules/no-unused-private-class-members>
- typescript-eslint source: <https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unused-private-class-members.ts>

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).