### PR TITLE
feat: port rule @typescript-eslint/prefer-find

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_as_const"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_destructuring"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_enum_initializers"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_find"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_for_of"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_includes"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_literal_enum_member"
@@ -631,6 +632,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-as-const", prefer_as_const.PreferAsConstRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-destructuring", prefer_destructuring.PreferDestructuringRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-enum-initializers", prefer_enum_initializers.PreferEnumInitializersRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/prefer-find", prefer_find.PreferFindRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-includes", prefer_includes.PreferIncludesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-literal-enum-member", prefer_literal_enum_member.PreferLiteralEnumMemberRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-namespace-keyword", prefer_namespace_keyword.PreferNamespaceKeywordRule)

--- a/internal/plugins/typescript/rules/prefer_find/prefer_find.go
+++ b/internal/plugins/typescript/rules/prefer_find/prefer_find.go
@@ -1,0 +1,627 @@
+package prefer_find
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildPreferFindMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferFind",
+		Description: "Prefer .find(...) instead of .filter(...)[0].",
+	}
+}
+
+func buildPreferFindSuggestionMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferFindSuggestion",
+		Description: "Use .find(...) instead of .filter(...)[0].",
+	}
+}
+
+// filterExpressionData records a single `<obj>.filter(...)` call that should be
+// rewritten to `<obj>.find(...)`. When the rule fires on a ternary, multiple
+// distinct filter expressions can need rewriting in one report.
+type filterExpressionData struct {
+	// filterNode is the AST node that names the method being invoked —
+	// either the `filter` identifier (for `.filter(...)`) or the literal /
+	// identifier inside the brackets (for `['filter'](...)`, `` [`filter`](...) ``,
+	// or `[fltrVar](...)` when fltrVar resolves to "filter").
+	filterNode *ast.Node
+	// isBracketSyntax is true when the call site uses computed access
+	// (`['filter'](...)`). It controls whether the replacement text is
+	// `find` (member access) or `"find"` (string literal).
+	isBracketSyntax bool
+}
+
+// PreferFindRule reports `arr.filter(...)[0]` / `arr.filter(...).at(0)` patterns
+// that should be `arr.find(...)`. Mirrors typescript-eslint's prefer-find rule.
+var PreferFindRule = rule.CreateRule(rule.Rule{
+	Name:             "prefer-find",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		if ctx.TypeChecker == nil {
+			return rule.RuleListeners{}
+		}
+
+		// parseArrayFilterExpressions returns the list of `<obj>.filter(...)`
+		// CallExpressions reachable through sequence / ternary / paren wrappers.
+		// A non-empty result means the receiver "definitely produces an array
+		// from a .filter call" — either directly or in every branch of a
+		// ternary.
+		var parseArrayFilterExpressions func(expression *ast.Node) []filterExpressionData
+		parseArrayFilterExpressions = func(expression *ast.Node) []filterExpressionData {
+			// In tsgo, parentheses are explicit nodes and SequenceExpression /
+			// AssignmentExpression collapse into BinaryExpression. There is no
+			// ChainExpression wrapper, so the upstream `skipChainExpression`
+			// has no analogue here.
+			node := ast.SkipParentheses(expression)
+			if node == nil {
+				return nil
+			}
+
+			// SequenceExpression: only the last operand matters. `a, b, c` is
+			// `BinaryExpression(Op: ',', Left: (a, b), Right: c)` in tsgo, so
+			// the "last expression" is the Right child of the outermost comma
+			// BinaryExpression.
+			if node.Kind == ast.KindBinaryExpression {
+				bin := node.AsBinaryExpression()
+				if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindCommaToken {
+					return parseArrayFilterExpressions(bin.Right)
+				}
+			}
+
+			if node.Kind == ast.KindConditionalExpression {
+				cond := node.AsConditionalExpression()
+				consequent := parseArrayFilterExpressions(cond.WhenTrue)
+				if len(consequent) == 0 {
+					return nil
+				}
+				alternate := parseArrayFilterExpressions(cond.WhenFalse)
+				if len(alternate) == 0 {
+					return nil
+				}
+				return append(consequent, alternate...)
+			}
+
+			// CallExpression: `<obj>.filter(...)` (or bracket form). The CALL
+			// itself must not be optional (`.filter?.(...)` is excluded);
+			// optional-ness of the inner member access (`arr?.filter(...)`)
+			// is allowed — upstream behaves the same.
+			if node.Kind == ast.KindCallExpression {
+				call := node.AsCallExpression()
+				if call.QuestionDotToken != nil {
+					return nil
+				}
+				callee := ast.SkipParentheses(call.Expression)
+				if callee == nil {
+					return nil
+				}
+
+				var filterNode, object *ast.Node
+				isBracket := false
+				switch callee.Kind {
+				case ast.KindPropertyAccessExpression:
+					pae := callee.AsPropertyAccessExpression()
+					name := pae.Name()
+					if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "filter" {
+						return nil
+					}
+					filterNode = name
+					object = pae.Expression
+				case ast.KindElementAccessExpression:
+					eae := callee.AsElementAccessExpression()
+					arg := eae.ArgumentExpression
+					if arg == nil {
+						return nil
+					}
+					strVal, ok := resolveStaticString(ctx, arg)
+					if !ok || strVal != "filter" {
+						return nil
+					}
+					filterNode = arg
+					isBracket = true
+					object = eae.Expression
+				default:
+					return nil
+				}
+
+				if object == nil {
+					return nil
+				}
+				filteredType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, object)
+				if !isArrayish(ctx, filteredType) {
+					return nil
+				}
+				return []filterExpressionData{{filterNode: filterNode, isBracketSyntax: isBracket}}
+			}
+
+			return nil
+		}
+
+		// getObjectIfArrayAtZeroExpression returns the receiver of a
+		// `<obj>.at(<treatedAsZero>)` call, or nil if the call doesn't match.
+		// Mirrors the upstream helper of the same name.
+		getObjectIfArrayAtZero := func(node *ast.Node) *ast.Node {
+			call := node.AsCallExpression()
+			if call == nil {
+				return nil
+			}
+			// `<obj>.at(arg)` — must have exactly one argument. Unlike the
+			// filter call below, we do NOT exclude `at?.(0)` here: upstream
+			// only gates on `!callee.optional` (i.e., the member access
+			// `?.at` is excluded — see callee.QuestionDotToken below), and
+			// happily reports `<obj>.at?.(0)`. The `?.()` form is
+			// semantically equivalent to `.find?.()` for our purposes.
+			if call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
+				return nil
+			}
+			callee := call.Expression
+			if callee == nil {
+				return nil
+			}
+			var object *ast.Node
+			switch callee.Kind {
+			case ast.KindPropertyAccessExpression:
+				pae := callee.AsPropertyAccessExpression()
+				if pae.QuestionDotToken != nil {
+					return nil
+				}
+				name := pae.Name()
+				if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "at" {
+					return nil
+				}
+				object = pae.Expression
+			case ast.KindElementAccessExpression:
+				eae := callee.AsElementAccessExpression()
+				if eae.QuestionDotToken != nil {
+					return nil
+				}
+				arg := eae.ArgumentExpression
+				if arg == nil {
+					return nil
+				}
+				strVal, ok := resolveStaticString(ctx, arg)
+				if !ok || strVal != "at" {
+					return nil
+				}
+				object = eae.Expression
+			default:
+				return nil
+			}
+			if !isTreatedAsZeroByArrayAt(ctx, call.Arguments.Nodes[0]) {
+				return nil
+			}
+			return object
+		}
+
+		// isMemberAccessOfZero returns true for `<obj>[0]`, `<obj>['0']`,
+		// ``<obj>[`0`]`` and `<obj>[zeroVar]`-style accesses (non-optional).
+		// `<obj>?.[0]` is excluded because upstream specifically guards
+		// against rewriting the optional form (the autofix would change
+		// semantics).
+		isMemberAccessOfZero := func(node *ast.Node) bool {
+			eae := node.AsElementAccessExpression()
+			if eae == nil {
+				return false
+			}
+			if eae.QuestionDotToken != nil {
+				return false
+			}
+			return isTreatedAsZeroByMemberAccess(ctx, eae.ArgumentExpression)
+		}
+
+		buildSuggestion := func(object *ast.Node, flagged *ast.Node, filters []filterExpressionData) []rule.RuleFix {
+			fixes := make([]rule.RuleFix, 0, len(filters)+1)
+			for _, f := range filters {
+				replacement := "find"
+				if f.isBracketSyntax {
+					replacement = `"find"`
+				}
+				fixes = append(fixes, rule.RuleFixReplace(ctx.SourceFile, f.filterNode, replacement))
+			}
+			// Remove the `.at(0)` / `[0]` tail: from the next `.` or `[` token
+			// after the array expression up to the end of the flagged expression.
+			start := findNextDotOrBracket(ctx.SourceFile, object.End(), flagged.End())
+			if start < 0 {
+				return nil
+			}
+			fixes = append(fixes, rule.RuleFixRemoveRange(core.NewTextRange(start, flagged.End())))
+			return fixes
+		}
+
+		report := func(flagged *ast.Node, object *ast.Node, filters []filterExpressionData) {
+			fixes := buildSuggestion(object, flagged, filters)
+			suggestion := rule.RuleSuggestion{
+				Message:  buildPreferFindSuggestionMessage(),
+				FixesArr: fixes,
+			}
+			ctx.ReportNodeWithSuggestions(flagged, buildPreferFindMessage(), suggestion)
+		}
+
+		return rule.RuleListeners{
+			// `<obj>.at(<treatedAsZero>)` and `<obj>['at'](<treatedAsZero>)`.
+			ast.KindCallExpression: func(node *ast.Node) {
+				object := getObjectIfArrayAtZero(node)
+				if object == nil {
+					return
+				}
+				filters := parseArrayFilterExpressions(object)
+				if len(filters) == 0 {
+					return
+				}
+				report(node, object, filters)
+			},
+			// `<obj>[0]`, `<obj>['0']`, `<obj>[`0`]`, `<obj>[zeroVar]`. tsgo
+			// uses ElementAccessExpression for what ESTree calls
+			// `MemberExpression[computed=true]`.
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				if !isMemberAccessOfZero(node) {
+					return
+				}
+				eae := node.AsElementAccessExpression()
+				object := eae.Expression
+				if object == nil {
+					return
+				}
+				filters := parseArrayFilterExpressions(object)
+				if len(filters) == 0 {
+					return
+				}
+				report(node, object, filters)
+			},
+		}
+	},
+})
+
+// isArrayish mirrors upstream's helper of the same name: returns true when
+// every non-null/undefined union constituent is an Array or Tuple type (or an
+// intersection thereof), and at least one such constituent exists.
+// Uses tsgo's built-in `isArrayOrTupleType` (= `isArrayType || isTupleType`),
+// matching upstream's `checker.isArrayType(t) || checker.isTupleType(t)`.
+func isArrayish(ctx rule.RuleContext, t *checker.Type) bool {
+	if t == nil || ctx.TypeChecker == nil {
+		return false
+	}
+	hasArrayPart := false
+	for _, unionPart := range utils.UnionTypeParts(t) {
+		if utils.IsTypeFlagSet(unionPart, checker.TypeFlagsNull|checker.TypeFlagsUndefined) {
+			continue
+		}
+		intersectionAllArray := true
+		for _, ip := range utils.IntersectionTypeParts(unionPart) {
+			if !checker.Checker_isArrayOrTupleType(ctx.TypeChecker, ip) {
+				intersectionAllArray = false
+				break
+			}
+		}
+		if !intersectionAllArray {
+			return false
+		}
+		hasArrayPart = true
+	}
+	return hasArrayPart
+}
+
+// isSymbolLikeType returns true when the type of node is `symbol`,
+// `unique symbol`, or a union/intersection that ultimately resolves to one.
+// Used as a fast type-info-driven shortcut for upstream's
+// `typeof value === 'symbol'` early-return inside isTreatedAsZeroByArrayAt /
+// isTreatedAsZeroByMemberAccess — when the type checker says "this is a
+// symbol", we can't statically coerce it to a number or to "0", regardless
+// of the syntactic shape of the argument (`Symbol('0')`, `Symbol.for('0')`,
+// `s` where `s: symbol`, etc.).
+func isSymbolLikeType(ctx rule.RuleContext, node *ast.Node) bool {
+	if ctx.TypeChecker == nil || node == nil {
+		return false
+	}
+	t := ctx.TypeChecker.GetTypeAtLocation(node)
+	return t != nil && utils.IsTypeFlagSet(t, checker.TypeFlagsESSymbolLike)
+}
+
+// isTreatedAsZeroByMemberAccess returns true if `String(value) === '0'` for the
+// (statically resolved) value of node. Conservatively returns false when the
+// value cannot be statically determined — matching upstream, which returns
+// undefined from `getStaticValue` and short-circuits to "not zero".
+// Symbol-typed arguments short-circuit to false via the type checker, mirroring
+// upstream's `typeof value === 'symbol'` guard (which exists so the Number()
+// coercion below doesn't throw at runtime).
+func isTreatedAsZeroByMemberAccess(ctx rule.RuleContext, node *ast.Node) bool {
+	if isSymbolLikeType(ctx, node) {
+		return false
+	}
+	str, ok := resolveStaticString(ctx, node)
+	if !ok {
+		return false
+	}
+	return str == "0"
+}
+
+// isTreatedAsZeroByArrayAt mirrors upstream's helper: `isNaN(Number(value))` or
+// `Math.trunc(Number(value)) === 0`. Symbol-valued arguments are not zero
+// (Number(Symbol) throws in JS); we short-circuit via the type checker before
+// attempting any static resolution.
+func isTreatedAsZeroByArrayAt(ctx rule.RuleContext, node *ast.Node) bool {
+	if isSymbolLikeType(ctx, node) {
+		return false
+	}
+	// Try numeric resolution first — handles literal numbers, BigInts, unary
+	// minus, the `NaN` / `Infinity` globals, and identifiers that const-resolve
+	// to one of those.
+	if v, ok := resolveStaticNumber(ctx, node); ok {
+		if math.IsNaN(v) {
+			return true
+		}
+		return math.Trunc(v) == 0
+	}
+	// Fall back to string resolution → JS Number(string) coercion. Covers cases
+	// like `arr.filter(...).at('0')` (already tested upstream via the `[0]`
+	// form, but symmetrically handled here for robustness).
+	if s, ok := resolveStaticString(ctx, node); ok {
+		v := jsNumberFromString(s)
+		if math.IsNaN(v) {
+			return true
+		}
+		return math.Trunc(v) == 0
+	}
+	return false
+}
+
+// resolveStaticString returns the JS `String(value)` representation of node
+// when it can be statically determined. Recurses through const identifier
+// initializers using the type checker. Numeric/BigInt literals are normalized
+// via the standard helpers so `0x0`, `0o0`, `0.0`, `0n`, `-0n` all canonicalize
+// to "0".
+func resolveStaticString(ctx rule.RuleContext, node *ast.Node) (string, bool) {
+	return resolveStaticStringRec(ctx, node, map[*ast.Symbol]bool{})
+}
+
+func resolveStaticStringRec(ctx rule.RuleContext, node *ast.Node, seen map[*ast.Symbol]bool) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	// Transparently unwrap parens, `as T` / `<T>x` / `x satisfies T`, and
+	// `x!`. Matches ESLint's `getStaticValue` which transparently descends
+	// through all of these wrappers when evaluating a value position.
+	node = ast.SkipOuterExpressions(node, ast.OEKAll)
+	switch node.Kind {
+	case ast.KindStringLiteral,
+		ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindNumericLiteral,
+		ast.KindRegularExpressionLiteral:
+		// `utils.GetStaticExpressionValue` normalizes numeric literals
+		// (`0x0`/`0o0`/`0.0` → `"0"`) so the `== "0"` test below works for
+		// every numeric form ESTree's `String(value)` would.
+		return utils.GetStaticExpressionValue(node)
+	case ast.KindBigIntLiteral:
+		return utils.NormalizeBigIntLiteral(node.AsBigIntLiteral().Text), true
+	case ast.KindNullKeyword:
+		return "null", true
+	case ast.KindTrueKeyword:
+		return "true", true
+	case ast.KindFalseKeyword:
+		return "false", true
+	case ast.KindPrefixUnaryExpression:
+		unary := node.AsPrefixUnaryExpression()
+		if unary.Operator == ast.KindMinusToken {
+			if v, ok := resolveStaticNumberRec(ctx, node, seen); ok {
+				return jsStringFromNumber(v), true
+			}
+			// `-0n` / `-1n` etc. → string-format the negated bigint.
+			operand := ast.SkipParentheses(unary.Operand)
+			if operand != nil && operand.Kind == ast.KindBigIntLiteral {
+				abs := utils.NormalizeBigIntLiteral(operand.AsBigIntLiteral().Text)
+				if abs == "0" {
+					return "0", true
+				}
+				return "-" + abs, true
+			}
+		}
+		if unary.Operator == ast.KindPlusToken {
+			if v, ok := resolveStaticNumberRec(ctx, node, seen); ok {
+				return jsStringFromNumber(v), true
+			}
+		}
+	case ast.KindIdentifier:
+		name := node.AsIdentifier().Text
+		if name == "NaN" && !utils.IsShadowed(node, "NaN") {
+			return "NaN", true
+		}
+		if name == "Infinity" && !utils.IsShadowed(node, "Infinity") {
+			return "Infinity", true
+		}
+		if name == "undefined" && !utils.IsShadowed(node, "undefined") {
+			return "undefined", true
+		}
+		if init := resolveConstInitializer(ctx, node, seen); init != nil {
+			return resolveStaticStringRec(ctx, init, seen)
+		}
+	}
+	return "", false
+}
+
+// resolveStaticNumber returns the JS `Number(value)` coercion when the value
+// can be statically determined. NaN/Infinity are returned as Go's
+// math.NaN()/math.Inf(...). Returns ok=false for non-numeric resolvable
+// values (strings) — the caller should fall back to resolveStaticString.
+func resolveStaticNumber(ctx rule.RuleContext, node *ast.Node) (float64, bool) {
+	return resolveStaticNumberRec(ctx, node, map[*ast.Symbol]bool{})
+}
+
+func resolveStaticNumberRec(ctx rule.RuleContext, node *ast.Node, seen map[*ast.Symbol]bool) (float64, bool) {
+	if node == nil {
+		return 0, false
+	}
+	node = ast.SkipOuterExpressions(node, ast.OEKAll)
+	switch node.Kind {
+	case ast.KindNumericLiteral:
+		return evalNumericLiteralText(node.AsNumericLiteral().Text)
+	case ast.KindNullKeyword:
+		// Number(null) === 0
+		return 0, true
+	case ast.KindTrueKeyword:
+		return 1, true
+	case ast.KindFalseKeyword:
+		return 0, true
+	case ast.KindBigIntLiteral:
+		// Number(bigint) — lossy for large values; tests only use 0n / -0n.
+		norm := utils.NormalizeBigIntLiteral(node.AsBigIntLiteral().Text)
+		v, err := strconv.ParseFloat(norm, 64)
+		if err != nil {
+			return 0, false
+		}
+		return v, true
+	case ast.KindPrefixUnaryExpression:
+		unary := node.AsPrefixUnaryExpression()
+		if unary.Operator != ast.KindMinusToken && unary.Operator != ast.KindPlusToken {
+			return 0, false
+		}
+		v, ok := resolveStaticNumberRec(ctx, unary.Operand, seen)
+		if !ok {
+			return 0, false
+		}
+		if unary.Operator == ast.KindMinusToken {
+			return -v, true
+		}
+		return v, true
+	case ast.KindIdentifier:
+		name := node.AsIdentifier().Text
+		if name == "NaN" && !utils.IsShadowed(node, "NaN") {
+			return math.NaN(), true
+		}
+		if name == "Infinity" && !utils.IsShadowed(node, "Infinity") {
+			return math.Inf(1), true
+		}
+		if init := resolveConstInitializer(ctx, node, seen); init != nil {
+			return resolveStaticNumberRec(ctx, init, seen)
+		}
+	}
+	return 0, false
+}
+
+// resolveConstInitializer returns the initializer expression for an identifier
+// that resolves (via the type checker) to a `const` variable declaration.
+// Returns nil for non-const bindings, declarations without initializers, and
+// cycles (e.g. `const a = a`).
+func resolveConstInitializer(ctx rule.RuleContext, idNode *ast.Node, seen map[*ast.Symbol]bool) *ast.Node {
+	if ctx.TypeChecker == nil {
+		return nil
+	}
+	sym := ctx.TypeChecker.GetSymbolAtLocation(idNode)
+	if sym == nil || seen[sym] {
+		return nil
+	}
+	seen[sym] = true
+	if sym.Declarations == nil {
+		return nil
+	}
+	for _, decl := range sym.Declarations {
+		if decl == nil || !ast.IsVariableDeclaration(decl) {
+			continue
+		}
+		// Only `const` declarations can be statically inlined — `let` and `var`
+		// can be reassigned, so the initializer is not authoritative.
+		parent := decl.Parent
+		if parent == nil || !ast.IsVariableDeclarationList(parent) || parent.Flags&ast.NodeFlagsConst == 0 {
+			continue
+		}
+		init := decl.AsVariableDeclaration().Initializer
+		if init != nil {
+			return init
+		}
+	}
+	return nil
+}
+
+// evalNumericLiteralText returns the float64 value of a NumericLiteral.Text
+// (which is always non-negative — unary minus is a separate AST node).
+// Handles JS hex / octal / binary / decimal forms via the existing helper.
+func evalNumericLiteralText(text string) (float64, bool) {
+	norm := utils.NormalizeNumericLiteral(text)
+	switch norm {
+	case "Infinity":
+		return math.Inf(1), true
+	case "-Infinity":
+		return math.Inf(-1), true
+	}
+	v, err := strconv.ParseFloat(norm, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// jsStringFromNumber formats a float64 the way JavaScript's `String(n)` does.
+// Crucially, `String(-0)` is `"0"`, not `"-0"` — `arr[-0]` is the same index
+// as `arr[0]` and the rule must match it.
+func jsStringFromNumber(v float64) string {
+	if math.IsNaN(v) {
+		return "NaN"
+	}
+	if math.IsInf(v, 1) {
+		return "Infinity"
+	}
+	if math.IsInf(v, -1) {
+		return "-Infinity"
+	}
+	if v == 0 {
+		return "0"
+	}
+	return strconv.FormatFloat(v, 'f', -1, 64)
+}
+
+// jsNumberFromString approximates JavaScript's `Number(str)` coercion: trim
+// whitespace, empty → 0, otherwise parse as decimal/scientific/hex/octal/
+// binary, NaN on failure. Two JS-vs-Go quirks worth calling out:
+//
+//   - Go's `strconv.ParseFloat` accepts decimal and scientific forms, plus
+//     hex floats with a `p` exponent, but rejects the bare `0x` / `0o` / `0b`
+//     integer prefixes that JS `Number()` accepts (`Number('0x1') === 1`).
+//     Fall back to `strconv.ParseInt` with base 0 for those.
+//   - Go accepts `_` digit separators (`Number('1_000')` in Go = 1000), but
+//     JS `Number()` rejects them (`Number('1_000') === NaN`). Reject any
+//     string containing `_` up front to match JS.
+func jsNumberFromString(s string) float64 {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return 0
+	}
+	if strings.ContainsRune(trimmed, '_') {
+		return math.NaN()
+	}
+	if v, err := strconv.ParseFloat(trimmed, 64); err == nil {
+		return v
+	}
+	if len(trimmed) > 2 && trimmed[0] == '0' {
+		switch trimmed[1] {
+		case 'x', 'X', 'o', 'O', 'b', 'B':
+			if v, err := strconv.ParseInt(trimmed, 0, 64); err == nil {
+				return float64(v)
+			}
+		}
+	}
+	return math.NaN()
+}
+
+// findNextDotOrBracket scans forward from `start` until it finds a `.` or `[`
+// token (or reaches `end`). Returns the token's start position, or -1 if not
+// found. Used to locate the start of the `.at(0)` / `[0]` tail to delete.
+func findNextDotOrBracket(sourceFile *ast.SourceFile, start, end int) int {
+	s := scanner.GetScannerForSourceFile(sourceFile, start)
+	for s.TokenStart() < end {
+		tok := s.Token()
+		if tok == ast.KindDotToken || tok == ast.KindOpenBracketToken {
+			return s.TokenStart()
+		}
+		s.Scan()
+	}
+	return -1
+}

--- a/internal/plugins/typescript/rules/prefer_find/prefer_find.md
+++ b/internal/plugins/typescript/rules/prefer_find/prefer_find.md
@@ -1,0 +1,96 @@
+# prefer-find
+
+Enforce the use of `Array.prototype.find()` over `Array.prototype.filter()` followed by `[0]` when looking for a single result.
+
+## Rule Details
+
+When searching for the first item in an array matching a condition, it may be tempting to use code like `arr.filter(x => x > 0)[0]`. However, it is simpler to use [`Array.prototype.find()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) instead, `arr.find(x => x > 0)`, which also returns the first entry matching a condition. Because `.find()` only executes the callback until it finds a match, it is also more efficient.
+
+The rule triggers on these patterns when the receiver's type is an array or tuple:
+
+- `arr.filter(p)[0]`
+- `arr.filter(p).at(0)`
+- `arr.filter(p)['0']` and `` arr.filter(p)[`0`] ``
+- `arr['filter'](p)[0]` and `` arr[`filter`](p)[0] ``
+- Sequence and ternary wrappers: `(a, b, arr.filter(p))[0]`, `(cond ? arr1.filter(p) : arr2.filter(p))[0]`
+- Optional-chain receivers: `arr?.filter(p)[0]`
+
+It does not trigger when:
+
+- The receiver type is not an array or tuple (e.g. a custom `Filter` interface, `null`, `undefined`).
+- The subscript or `.at(...)` argument does not statically resolve to zero.
+- The `[0]` access is itself optional (`?.[0]`), the `.at(0)` callee is optional (`?.at(0)`), or the `.filter(...)` call is optional (`.filter?.(...)`) — rewriting these would change short-circuiting semantics.
+
+The rewrite is offered as a **suggestion** that you must explicitly apply — it is not auto-applied. `.find()` stops at the first match, but `.filter()` always visits every element, so if your `.filter()` callback has side effects, applying the suggestion will change behavior.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+declare const arr: string[];
+arr.filter(item => item === 'aha')[0];
+```
+
+```typescript
+declare const arr: string[];
+arr.filter(item => item === 'aha').at(0);
+```
+
+```typescript
+declare const arr: string[];
+arr.filter(item => item === 'aha')['0'];
+```
+
+```typescript
+declare const arr: string[];
+const zero = 0;
+arr.filter(item => item === 'aha').at(zero);
+```
+
+```typescript
+declare const arr: { a: 1 }[] & { b: 2 }[];
+arr.filter(f)[0];
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+[1, 2, 3].find(x => x > 1);
+```
+
+```typescript
+declare const arr: string[];
+arr.filter(item => item === 'aha')[1];
+```
+
+```typescript
+declare const arr: string[];
+arr.filter(item => item === 'aha').at(1);
+```
+
+```typescript
+[].filter(() => true)?.[0];
+```
+
+```typescript
+[].filter(() => true)?.at?.(0);
+```
+
+```typescript
+[].filter?.(() => true)[0];
+```
+
+```typescript
+interface Filter<T> {
+  filter(predicate: (item: T) => boolean): Filter<T>;
+}
+declare const f: Filter<string>;
+f.filter(x => x.length > 0)[0];
+```
+
+## When Not To Use It
+
+If you intentionally use patterns like `.filter(callback)[0]` to execute side effects in `callback` on all array elements, you will want to avoid this rule.
+
+## Original Documentation
+
+- [typescript-eslint prefer-find](https://typescript-eslint.io/rules/prefer-find)

--- a/internal/plugins/typescript/rules/prefer_find/prefer_find_extras_test.go
+++ b/internal/plugins/typescript/rules/prefer_find/prefer_find_extras_test.go
@@ -1,0 +1,852 @@
+// TestPreferFindExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+package prefer_find
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferFindExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferFindRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: Receiver wrappers ----
+
+		// Non-array receiver behind type assertion — type of the receiver is
+		// determined by the assertion, which is not arrayish.
+		{Code: `
+interface Box<T> { filter(p: (item: T) => boolean): Box<T> }
+declare const box: Box<string>;
+(box as Box<string>).filter(x => true)[0];
+`},
+		// `satisfies` keeps the value's apparent type; if it's not arrayish,
+		// the rule must not fire.
+		{Code: `
+interface Box<T> { filter(p: (item: T) => boolean): Box<T> }
+declare const box: Box<string>;
+(box satisfies Box<string>).filter(x => true)[0];
+`},
+
+		// ---- Dimension 4: Access / key forms ----
+
+		// `.at('1')` — Number('1') === 1, not zero.
+		{Code: `[1, 2, 3].filter(x => x > 0).at('1');`},
+		// `.at('')` — Number('') === 0, treated as zero. We DO fire here,
+		// matching JS semantics. (Negative — included for symmetry.)
+		// N/A: this row is actually invalid; covered below in invalid cases.
+
+		// `[1]` numeric subscript — not zero.
+		{Code: `[1, 2, 3].filter(x => x > 0)[1];`},
+		// `[`1`]` template-1 subscript — not zero.
+		{Code: "[1, 2, 3].filter(x => x > 0)[`1`];"},
+		// `[` ` `]` whitespace string — String(' ') === ' ', not '0'.
+		{Code: `[1, 2, 3].filter(x => x > 0)[' '];`},
+		// Whole-line subscript with unresolvable identifier — neither
+		// resolveStaticString nor resolveStaticNumber can ground it.
+		{Code: `
+declare const idx: number;
+[1, 2, 3].filter(x => x > 0)[idx];
+`},
+
+		// ---- Dimension 4: Graceful degradation ----
+
+		// `.at()` with zero arguments — args.length !== 1 short-circuits
+		// getObjectIfArrayAtZero. (.at requires one arg at runtime; this is
+		// a syntactic check.)
+		{Code: `
+declare const arr: string[];
+(arr.filter(x => x.length > 0) as any).at();
+`},
+		// `.at(0, 1)` with two arguments — args.length !== 1.
+		{Code: `
+declare const arr: string[];
+(arr.filter(x => x.length > 0) as any).at(0, 1);
+`},
+		// `.at(...spread)` — args.length is 1 (the SpreadElement counts as
+		// one argument node), but the value can't be statically determined,
+		// so resolveStaticNumber/String both fail → not zero.
+		{Code: `
+declare const arr: string[];
+declare const idx: [number];
+arr.filter(x => x.length > 0).at(...idx);
+`},
+		// `[at]` where `at` is unresolvable — locks in the symmetric
+		// behavior for the [0] path: subscript that doesn't resolve to '0'
+		// must not match.
+		{Code: `
+declare const arr: string[];
+declare const at: any;
+arr.filter(x => x.length > 0)[at];
+`},
+
+		// ---- Branch lock-ins ----
+
+		// Locks in parseArrayFilterExpressions: callee is not a member
+		// access at all (e.g. `filter(arr)[0]`) — must not match.
+		{Code: `
+declare function filter(arr: unknown[]): unknown[];
+filter([1, 2, 3])[0];
+`},
+		// Locks in parseArrayFilterExpressions: same kind, but called as a
+		// bare local function (not `<obj>.filter`).
+		{Code: `
+const filter = (arr: number[]) => arr.filter(x => x > 0);
+filter([1, 2, 3])[0];
+`},
+		// Locks in isArrayish: intersection contains a non-array member,
+		// so the type is rejected even though one side is array-shaped.
+		{Code: `
+interface Box<T> { filter(p: (x: T) => boolean): Box<T>; length: number }
+declare const arr: { a: 1 }[] & Box<{ a: 1 }>;
+arr.filter(x => true)[0];
+`},
+		// Locks in resolveConstInitializer: `let` binding, not `const` —
+		// initializer cannot be statically inlined.
+		{Code: `
+declare const arr: string[];
+let zero = 0;
+arr.filter(item => item === 'aha').at(zero);
+`},
+		// Locks in resolveConstInitializer: parameter — has no const
+		// initializer, can't be inlined.
+		{Code: `
+declare const arr: string[];
+function check(zero: number) {
+  return arr.filter(item => item === 'aha').at(zero);
+}
+check(0);
+`},
+		// Locks in resolveStaticString cycle guard: `const a = a` would loop
+		// forever without the `seen` map. Use a const referring to itself
+		// (legal at TDZ — won't compile-run, but the lint pass mustn't hang).
+		{Code: `
+declare const arr: string[];
+// @ts-expect-error: TDZ self-reference
+const a = a;
+arr.filter(x => x.length > 0)[a];
+`},
+		// Locks in `NaN`/`Infinity` shadowing — if the program declares
+		// its own `NaN`/`Infinity`, we must NOT treat the reference as the
+		// global. Here `NaN` is shadowed by a function parameter; without
+		// the shadow check we would (incorrectly) treat `.at(NaN)` as zero.
+		{Code: `
+declare const arr: string[];
+function check(NaN: number) {
+  return arr.filter(x => x.length > 0).at(NaN);
+}
+`},
+		// Locks in the TypeChecker-driven Symbol short-circuit: any
+		// argument whose static TYPE is `symbol` (or `unique symbol` or
+		// `typeof Symbol.foo`) bypasses static-value resolution and is
+		// treated as not-zero. Mirrors upstream's `typeof value === 'symbol'`
+		// branch in `isTreatedAsZeroByArrayAt`. Without the type-info
+		// shortcut, `Number(Symbol(...))` would throw at runtime, so the
+		// rule must not rewrite.
+		{Code: `
+declare const arr: string[];
+declare const s: symbol;
+arr.filter(x => x.length > 0).at(s);
+`},
+		// Same shortcut for the `[s]` subscript path
+		// (isTreatedAsZeroByMemberAccess).
+		{Code: `
+declare const arr: string[];
+declare const s: symbol;
+arr.filter(x => x.length > 0)[s];
+`},
+		// `unique symbol` typed via `typeof`-of-a-Symbol-call — still
+		// symbol-like via TypeFlagsESSymbolLike.
+		{Code: `
+declare const arr: string[];
+const sym = Symbol('zero');
+arr.filter(x => x.length > 0).at(sym);
+`},
+		// ---- Primitive globals — non-zero canonicalization ----
+		// `[null]` — String(null) === 'null' ≠ '0'.
+		{Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0)[null as any];
+`},
+		// `[true]` — String(true) === 'true' ≠ '0'.
+		{Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0)[true as any];
+`},
+		// `[false]` — String(false) === 'false' ≠ '0'.
+		{Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0)[false as any];
+`},
+		// `[NaN]` — String(NaN) === 'NaN' ≠ '0'.
+		{Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0)[NaN];
+`},
+		// `[Infinity]` / `[-Infinity]` — strings ≠ '0'.
+		{Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0)[Infinity];
+`},
+		{Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0)[-Infinity];
+`},
+		// `.at(true)` — Number(true) === 1, not zero.
+		{Code: `declare const arr: string[]; arr.filter(x => x.length > 0).at(true);`},
+		// `.at(Infinity)` — Number(Infinity) === Infinity, trunc !== 0.
+		{Code: `declare const arr: string[]; arr.filter(x => x.length > 0).at(Infinity);`},
+		// ---- jsNumberFromString lock-ins (hex / octal / binary STRING args) ----
+		// `.at('0x1')` — JS Number('0x1') === 1 (hex prefix accepted by JS
+		// string coercion). trunc=1 ≠ 0 → must NOT fire. Locks in the
+		// strconv.ParseInt(_, 0, 64) hex/octal/binary fallback in
+		// jsNumberFromString; without it, Go's ParseFloat would fail on
+		// `0x1` (it only accepts hex floats with a `p` exponent) and the
+		// resulting NaN would be (incorrectly) treated as zero.
+		{Code: `declare const arr: string[]; arr.filter(x => x.length > 0).at('0x1');`},
+		{Code: `declare const arr: string[]; arr.filter(x => x.length > 0).at('0o1');`},
+		{Code: `declare const arr: string[]; arr.filter(x => x.length > 0).at('0b1');`},
+		// `.at('1.0')` — Number('1.0') === 1, not zero (regression guard).
+		{Code: `declare const arr: string[]; arr.filter(x => x.length > 0).at('1.0');`},
+		// `.at('Infinity')` — Number('Infinity') === Infinity (parsed by
+		// ParseFloat). trunc=Inf ≠ 0 → must NOT fire.
+		{Code: `declare const arr: string[]; arr.filter(x => x.length > 0).at('Infinity');`},
+		// `.at('-0x1')` — JS rejects sign on hex strings (Number('-0x1') =
+		// NaN). Our hex fallback gates on trimmed[0]=='0', so signs are
+		// rejected and we return NaN — which is treated as zero, so this
+		// fires. Same outcome as JS via NaN propagation; documented for
+		// future readers.
+		// (Negative case below covers the NaN → fire path.)
+		// ---- Non-zero const numeric — sanity check that we don't over-fire ----
+		{Code: `
+declare const arr: string[];
+const one = 1;
+arr.filter(x => x.length > 0).at(one);
+`},
+		{Code: `
+declare const arr: string[];
+const one = 1;
+arr.filter(x => x.length > 0)[one];
+`},
+		// ---- Non-zero BigInt — Number(5n) === 5, trunc !== 0. ----
+		{Code: `declare const arr: string[]; arr.filter(x => x.length > 0).at(5n);`},
+		{Code: `declare const arr: string[]; arr.filter(x => x.length > 0)[5n];`},
+		// ---- Unresolvable expression — runtime length, not statically zero ----
+		{Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0)[arr.length - 1];
+`},
+		// ---- Iterable / non-array receiver (TypedArray) ----
+		// Uint8Array is not an Array instance via Checker_isArrayOrTupleType.
+		{Code: `
+declare const ua: Uint8Array;
+(ua as any).filter((x: number) => x > 0)[0];
+`},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: Receiver wrappers ----
+
+		// Locks in tsgo ParenthesizedExpression handling — upstream doesn't
+		// need to test this because ESTree drops parens; tsgo keeps them as
+		// explicit nodes and our SkipParentheses must unwrap them.
+		{
+			Code: `
+declare const arr: string[];
+(arr).filter(x => x.length > 0)[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+(arr).find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// Multi-level parens around the receiver.
+		{
+			Code: `
+declare const arr: string[];
+((arr)).filter(x => x.length > 0)[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+((arr)).find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// Non-null assertion on the receiver — `arr!` is arrayish if `arr` is.
+		{
+			Code: `
+declare const arr: string[] | undefined;
+arr!.filter(x => x.length > 0)[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[] | undefined;
+arr!.find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+
+		// ---- Dimension 4: Access / key forms ----
+
+		// `.at('')` — JS Number('') === 0, treated as zero. Upstream's
+		// helper resolves the empty string via Number(value) -> 0, so this
+		// must fire. Locks in our jsNumberFromString empty-string branch.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha').at('');
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// `.at('abc')` — Number('abc') is NaN, isNaN(NaN) === true → treated
+		// as zero. JS semantics, not intuitive — lock it in.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha').at('abc');
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// `[0x0]` — different numeric literal forms. tsgo's parser
+		// normalizes NumericLiteral.Text to decimal at parse time
+		// (`0x0`.Text == "0"), so the regular numeric path handles this.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha')[0x0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// `.at('0x0')` — Number('0x0') === 0 → fire. Locks in
+		// jsNumberFromString's hex fallback (ParseFloat rejects bare
+		// `0x...` so we fall through to ParseInt with base 0).
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha').at('0x0');
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// `.at('0o0')` — same hex/octal/binary fallback path.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha').at('0o0');
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// `.at('0b0')` — same hex/octal/binary fallback path.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha').at('0b0');
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// `.at('1_000')` — JS Number() rejects `_` separators
+		// (`Number('1_000') === NaN`), so isNaN → true → fire. Go's
+		// ParseFloat accepts `_`, so we need an explicit guard for parity.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha').at('1_000');
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// `[-0]` — String(-0) === '0' in JS. Lock in unary-minus-zero.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha')[-0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// `.at(NaN)` shadowed by const `NaN = NaN` (still resolves to the
+		// global since the const just aliases NaN). Sanity-check the const
+		// resolver doesn't break on shadowing identifiers.
+		// N/A: this is in the valid set above (the shadowing case).
+
+		// ---- Branch lock-ins for parseArrayFilterExpressions ----
+
+		// Ternary where one arm is a sub-ternary whose branches are filter
+		// calls — confirms recursion through nested ConditionalExpression.
+		{
+			Code: `
+declare const arr1: string[], arr2: string[], arr3: string[], pick: boolean;
+(pick ? (pick ? arr1.filter(f) : arr2.filter(f)) : arr3.filter(f))[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr1: string[], arr2: string[], arr3: string[], pick: boolean;
+(pick ? (pick ? arr1.find(f) : arr2.find(f)) : arr3.find(f));
+`,
+						},
+					},
+				},
+			},
+		},
+
+		// ---- Branch lock-ins for getObjectIfArrayAtZeroExpression ----
+
+		// `.at(0n)` — BigInt zero, Number(0n) === 0 → treated as zero. Lock
+		// in the BigInt branch of resolveStaticNumber.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha').at(0n);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// Locks in upstream getObjectIfArrayAtZeroExpression: it only gates
+		// on `!callee.optional` (the member access `?.at` is excluded), NOT
+		// on `node.optional` (the call's own `?.()`). So `<obj>.at?.(0)`
+		// — call optional, member non-optional — still fires. Easy to
+		// over-tighten by checking both, so a lock-in here.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha').at?.(0);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// `.at(-0)` — unary minus on numeric zero, trunc(-0) === 0 → fires.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha').at(-0);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+
+		// ---- Real-user: tuple receiver ----
+		// Tuple types are also array-ish via Checker_isTupleType. Closed
+		// issues against upstream's prefer-find frequently involve tuples.
+		{
+			Code: `
+declare const tuple: readonly [string, string, string];
+tuple.filter(x => x.length > 0)[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const tuple: readonly [string, string, string];
+tuple.find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Real-user: method-chain receiver ----
+		// Common idiom: a getter / method returning the array, then filter.
+		// Locks in that `<call>.filter(...)[0]` works as long as the call's
+		// return type is arrayish.
+		{
+			Code: `
+declare function getArr(): string[];
+getArr().filter(x => x.length > 0)[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare function getArr(): string[];
+getArr().find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Primitive globals: `.at(null)`, `.at(false)` — Number → 0 ----
+		// Number(null) === 0 → treated as zero. ESLint's getStaticValue
+		// recognizes null literals and reports; we mirror via the
+		// KindNullKeyword resolver branch.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0).at(null as any);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// Number(false) === 0 → treated as zero.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0).at(false as any);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// `.at(undefined)` — Number(undefined) === NaN, isNaN(NaN) === true
+		// → treated as zero. The `undefined` global identifier (when not
+		// shadowed) is recognized by resolveStaticStringRec, falls through
+		// to jsNumberFromString("undefined") → NaN.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0).at(undefined as any);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Decimal fractional `.at` — Math.trunc rounds toward zero ----
+		// `.at(0.5)` — trunc(0.5) === 0 → zero. JS rounds-toward-zero on
+		// fractional indices, so the rule fires. (Upstream's
+		// `-0.12635678` case covers this, but adding a forward `0.5`
+		// locks the positive-fractional path.)
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0).at(0.5);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Type assertions transparently unwrapped ----
+		// `.at(0 as number)` — SkipOuterExpressions unwraps the assertion.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0).at(0 as number);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// `[0 satisfies number]` — satisfies is transparent.
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(x => x.length > 0)[0 satisfies number];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// Non-null assertion `x!` on a const-resolved zero — also transparent.
+		{
+			Code: `
+declare const arr: string[];
+const zero: number | undefined = 0;
+arr.filter(x => x.length > 0).at(zero!);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      4,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+const zero: number | undefined = 0;
+arr.find(x => x.length > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/prefer_find/prefer_find_upstream_test.go
+++ b/internal/plugins/typescript/rules/prefer_find/prefer_find_upstream_test.go
@@ -1,0 +1,765 @@
+// TestPreferFindUpstream migrates the full valid/invalid suite from
+// typescript-eslint's tests/rules/prefer-find.test.ts 1:1. Position assertions
+// cover line/column for every invalid case. rslint-specific lock-in cases live
+// in prefer_find_extras_test.go.
+package prefer_find
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferFindUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferFindRule, []rule_tester.ValidTestCase{
+		// ---- type without array-shaped filter signature ----
+		{Code: `
+interface JerkCode<T> {
+  filter(predicate: (item: T) => boolean): JerkCode<T>;
+}
+
+declare const jerkCode: JerkCode<string>;
+
+jerkCode.filter(item => item === 'aha')[0];
+`},
+		// ---- non-zero subscript ----
+		{Code: `
+declare const arr: readonly string[];
+arr.filter(item => item === 'aha')[1];
+`},
+		// ---- .at(non-zero) ----
+		{Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha').at(1);
+`},
+		// ---- nullable receiver type still passes through isArrayish ----
+		{Code: `
+declare const notNecessarilyAnArray: unknown[] | undefined | null | string;
+notNecessarilyAnArray?.filter(item => true)[0];
+`},
+		// ---- optional [0] (don't change semantics of `?.[0]`) ----
+		{Code: `[].filter(() => true)?.[0];`},
+		// ---- optional .at?.() (don't change semantics) ----
+		{Code: `[].filter(() => true)?.at?.(0);`},
+		// ---- optional .filter?.() — call itself is optional ----
+		{Code: `[].filter?.(() => true)[0];`},
+		// ---- .at(-Infinity) — not zero ----
+		{Code: `[1, 2, 3].filter(x => x > 0).at(-Infinity);`},
+		// ---- .at(non-zero literal) with optional-chain receiver ----
+		{Code: `
+declare const arr: string[];
+declare const cond: Parameters<Array<string>['filter']>[0];
+const a = { arr };
+a?.arr.filter(cond).at(1);
+`},
+		// ---- plain .filter() without subscript ----
+		{Code: `['Just', 'a', 'filter'].filter(x => x.length > 4);`},
+		// ---- plain .find() ----
+		{Code: `['Just', 'a', 'find'].find(x => x.length > 4);`},
+		// ---- receiver is undefined (not arrayish) ----
+		{Code: `undefined.filter(x => x)[0];`},
+		// ---- receiver is null (optional chain short-circuits, not arrayish) ----
+		{Code: `null?.filter(x => x)[0];`},
+		// ---- Issue #8386 regression: Symbol.for must not throw ----
+		{Code: `
+declare function foo(param: any): any;
+foo(Symbol.for('foo'));
+`},
+		// ---- .at(symbol-typed const) ----
+		{Code: `
+declare const arr: string[];
+const s = Symbol.for("Don't throw!");
+arr.filter(item => item === 'aha').at(s);
+`},
+		// ---- [Symbol('0')] — String(Symbol) !== '0' ----
+		{Code: `[1, 2, 3].filter(x => x)[Symbol('0')];`},
+		// ---- [Symbol.for('0')] — same ----
+		{Code: `[1, 2, 3].filter(x => x)[Symbol.for('0')];`},
+		// ---- ternary where one branch is not a filter call ----
+		{Code: `(Math.random() < 0.5 ? [1, 2, 3].filter(x => true) : [1, 2, 3])[0];`},
+		// ---- ternary where one branch is .find(), other is .filter() ----
+		{Code: `
+(Math.random() < 0.5
+  ? [1, 2, 3].find(x => true)
+  : [1, 2, 3].filter(x => true))[0];
+`},
+	}, []rule_tester.InvalidTestCase{
+		// ---- basic [0] ----
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha')[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- [zero] where zero = 0 ----
+		{
+			Code: `
+declare const arr: Array<string>;
+const zero = 0;
+arr.filter(item => item === 'aha')[zero];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      4,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: Array<string>;
+const zero = 0;
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- [zero] where zero = 0n ----
+		{
+			Code: `
+declare const arr: Array<string>;
+const zero = 0n;
+arr.filter(item => item === 'aha')[zero];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      4,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: Array<string>;
+const zero = 0n;
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- [zero] where zero = -0n ----
+		{
+			Code: `
+declare const arr: Array<string>;
+const zero = -0n;
+arr.filter(item => item === 'aha')[zero];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      4,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: Array<string>;
+const zero = -0n;
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- .at(0) on readonly array ----
+		{
+			Code: `
+declare const arr: readonly string[];
+arr.filter(item => item === 'aha').at(0);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: readonly string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- sequence in receiver: only last operand matters ----
+		{
+			Code: `
+declare const arr: ReadonlyArray<string>;
+(undefined, arr.filter(item => item === 'aha')).at(0);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: ReadonlyArray<string>;
+(undefined, arr.find(item => item === 'aha'));
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- .at(zero) where zero = 0 ----
+		{
+			Code: `
+declare const arr: string[];
+const zero = 0;
+arr.filter(item => item === 'aha').at(zero);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      4,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+const zero = 0;
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- ['0'] string-zero subscript ----
+		{
+			Code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha')['0'];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- single-line inline assignment ----
+		{
+			Code: `const two = [1, 2, 3].filter(item => item === 2)[0];`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      1,
+					Column:    13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output:    `const two = [1, 2, 3].find(item => item === 2);`,
+						},
+					},
+				},
+			},
+		},
+		// ---- [fltr] where fltr = "filter" (computed access via const) ----
+		{
+			Code: `const fltr = "filter"; (([] as unknown[]))[fltr] ((item) => { return item === 2 }  ) [ 0  ] ;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      1,
+					Column:    24,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output:    `const fltr = "filter"; (([] as unknown[]))["find"] ((item) => { return item === 2 }  )  ;`,
+						},
+					},
+				},
+			},
+		},
+		// ---- ?.["filter"] computed access ----
+		{
+			Code: `(([] as unknown[]))?.["filter"] ((item) => { return item === 2 }  ) [ 0  ] ;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output:    `(([] as unknown[]))?.["find"] ((item) => { return item === 2 }  )  ;`,
+						},
+					},
+				},
+			},
+		},
+		// ---- nullable receiver with optional chain ----
+		{
+			Code: `
+declare const nullableArray: unknown[] | undefined | null;
+nullableArray?.filter(item => true)[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const nullableArray: unknown[] | undefined | null;
+nullableArray?.find(item => true);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- ([]?.filter(f))[0] ----
+		{
+			Code: `([]?.filter(f))[0];`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      1,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output:    `([]?.find(f));`,
+						},
+					},
+				},
+			},
+		},
+		// ---- nested sequence in console.log with optional-chain filter call ----
+		{
+			Code: `
+declare const objectWithArrayProperty: { arr: unknown[] };
+declare function cond(x: unknown): boolean;
+console.log((1, 2, objectWithArrayProperty?.arr['filter'](cond)).at(0));
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      4,
+					Column:    13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const objectWithArrayProperty: { arr: unknown[] };
+declare function cond(x: unknown): boolean;
+console.log((1, 2, objectWithArrayProperty?.arr["find"](cond)));
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- .at(NaN) — Number(NaN) is NaN → treated as 0 ----
+		{
+			Code: `
+[1, 2, 3].filter(x => x > 0).at(NaN);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      2,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+[1, 2, 3].find(x => x > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- .at(negative-fractional const) — Math.trunc rounds toward zero ----
+		{
+			Code: `
+const idxToLookUp = -0.12635678;
+[1, 2, 3].filter(x => x > 0).at(idxToLookUp);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+const idxToLookUp = -0.12635678;
+[1, 2, 3].find(x => x > 0);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- [`at`](0) — template-literal property name ----
+		{
+			Code: "\n[1, 2, 3].filter(x => x > 0)[`at`](0);\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      2,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output:    "\n[1, 2, 3].find(x => x > 0);\n",
+						},
+					},
+				},
+			},
+		},
+		// ---- comments around .filter and .at, .at('0') string subscript ----
+		{
+			Code: `
+declare const arr: string[];
+declare const cond: Parameters<Array<string>['filter']>[0];
+const a = { arr };
+a?.arr
+  .filter(cond) /* what a bad spot for a comment. Let's make sure
+  there's some yucky symbols too. [ . ?. <>   ' ' \'] */
+  .at('0');
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      5,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: string[];
+declare const cond: Parameters<Array<string>['filter']>[0];
+const a = { arr };
+a?.arr
+  .find(cond) /* what a bad spot for a comment. Let's make sure
+  there's some yucky symbols too. [ . ?. <>   ' ' \'] */
+  ;
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- spread inside push, comments in ['filter'] and [`0`]! non-null ----
+		{
+			Code: "\nconst imNotActuallyAnArray = [\n  [1, 2, 3],\n  [2, 3, 4],\n] as const;\nconst butIAm = [4, 5, 6];\nbutIAm.push(\n  // line comment!\n  ...imNotActuallyAnArray[/* comment */ 'filter' /* another comment */](\n    x => x[1] > 0,\n  ) /**/[`0`]!,\n);\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      9,
+					Column:    6,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output:    "\nconst imNotActuallyAnArray = [\n  [1, 2, 3],\n  [2, 3, 4],\n] as const;\nconst butIAm = [4, 5, 6];\nbutIAm.push(\n  // line comment!\n  ...imNotActuallyAnArray[/* comment */ \"find\" /* another comment */](\n    x => x[1] > 0,\n  ) /**/!,\n);\n",
+						},
+					},
+				},
+			},
+		},
+		// ---- generic-constrained array, comments in subscript ----
+		{
+			Code: `
+function actingOnArray<T extends string[]>(values: T) {
+  return values.filter(filter => filter === 'filter')[
+    /* filter */ -0.0 /* filter */
+  ];
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    10,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+function actingOnArray<T extends string[]>(values: T) {
+  return values.find(filter => filter === 'filter');
+}
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- deeply nested sequence ----
+		// The `['0']` binds to the LAST operand of the outer comma sequence
+		// (comma has lower precedence than subscript), so it's actually on
+		// the MIDDLE paren — that's why both upstream and we report line 5
+		// (`  (1,`), not line 3 (the outer paren).
+		{
+			Code: `
+const nestedSequenceAbomination =
+  (1,
+  2,
+  (1,
+  2,
+  3,
+  (1, 2, 3, 4),
+  (1, 2, 3, 4, 5, [1, 2, 3, 4, 5, 6].filter(x => x % 2 == 0)))['0']);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      5,
+					Column:    3,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+const nestedSequenceAbomination =
+  (1,
+  2,
+  (1,
+  2,
+  3,
+  (1, 2, 3, 4),
+  (1, 2, 3, 4, 5, [1, 2, 3, 4, 5, 6].find(x => x % 2 == 0))));
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- intersection of two arrays (with thisArg) ----
+		{
+			Code: `
+declare const arr: { a: 1 }[] & { b: 2 }[];
+arr.filter(f, thisArg)[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: { a: 1 }[] & { b: 2 }[];
+arr.find(f, thisArg);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- intersection of array and (union of arrays) ----
+		{
+			Code: `
+declare const arr: { a: 1 }[] & ({ b: 2 }[] | { c: 3 }[]);
+arr.filter(f, thisArg)[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const arr: { a: 1 }[] & ({ b: 2 }[] | { c: 3 }[]);
+arr.find(f, thisArg);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- ternary where both branches are filter() ----
+		{
+			Code: `
+(Math.random() < 0.5
+  ? [1, 2, 3].filter(x => false)
+  : [1, 2, 3].filter(x => true))[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      2,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+(Math.random() < 0.5
+  ? [1, 2, 3].find(x => false)
+  : [1, 2, 3].find(x => true));
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- statement-level ternary; outer ternary is .at(0) consumer ----
+		{
+			Code: `
+Math.random() < 0.5
+  ? [1, 2, 3].find(x => true)
+  : [1, 2, 3].filter(x => true)[0];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      4,
+					Column:    5,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+Math.random() < 0.5
+  ? [1, 2, 3].find(x => true)
+  : [1, 2, 3].find(x => true);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- nested ternaries — every leaf is a filter call ----
+		{
+			Code: `
+declare const f: (arg0: unknown, arg1: number, arg2: Array<unknown>) => boolean,
+  g: (arg0: unknown) => boolean;
+const nestedTernaries = (
+  Math.random() < 0.5
+    ? Math.random() < 0.5
+      ? [1, 2, 3].filter(f)
+      : []?.filter(x => 'shrug')
+    : [2, 3, 4]['filter'](g)
+).at(0.2);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      4,
+					Column:    25,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const f: (arg0: unknown, arg1: number, arg2: Array<unknown>) => boolean,
+  g: (arg0: unknown) => boolean;
+const nestedTernaries = (
+  Math.random() < 0.5
+    ? Math.random() < 0.5
+      ? [1, 2, 3].find(f)
+      : []?.find(x => 'shrug')
+    : [2, 3, 4]["find"](g)
+);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- nested ternaries with sequence expression inside a branch ----
+		{
+			Code: `
+declare const f: (arg0: unknown) => boolean, g: (arg0: unknown) => boolean;
+const nestedTernariesWithSequenceExpression = (
+  Math.random() < 0.5
+    ? ('sequence',
+      'expression',
+      Math.random() < 0.5 ? [1, 2, 3].filter(f) : []?.filter(x => 'shrug'))
+    : [2, 3, 4]['filter'](g)
+).at(0.2);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    47,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const f: (arg0: unknown) => boolean, g: (arg0: unknown) => boolean;
+const nestedTernariesWithSequenceExpression = (
+  Math.random() < 0.5
+    ? ('sequence',
+      'expression',
+      Math.random() < 0.5 ? [1, 2, 3].find(f) : []?.find(x => 'shrug'))
+    : [2, 3, 4]["find"](g)
+);
+`,
+						},
+					},
+				},
+			},
+		},
+		// ---- spread args inside filter ----
+		{
+			Code: `
+declare const spreadArgs: [(x: unknown) => boolean];
+[1, 2, 3].filter(...spreadArgs).at(0);
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferFind",
+					Line:      3,
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "preferFindSuggestion",
+							Output: `
+declare const spreadArgs: [(x: unknown) => boolean];
+[1, 2, 3].find(...spreadArgs);
+`,
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -327,7 +327,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/prefer-as-const.test.ts',
     './tests/typescript-eslint/rules/prefer-destructuring.test.ts',
     './tests/typescript-eslint/rules/prefer-enum-initializers.test.ts',
-    // './tests/typescript-eslint/rules/prefer-find.test.ts',
+    './tests/typescript-eslint/rules/prefer-find.test.ts',
     './tests/typescript-eslint/rules/prefer-for-of.test.ts',
     // './tests/typescript-eslint/rules/prefer-function-type.test.ts',
     './tests/typescript-eslint/rules/prefer-includes.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-find.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-find.test.ts.snap
@@ -1,0 +1,842 @@
+// Rstest Snapshot v1
+
+exports[`prefer-find > invalid 1`] = `
+{
+  "code": "
+declare const arr: string[];
+arr.filter(item => item === 'aha')[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 2`] = `
+{
+  "code": "
+declare const arr: Array<string>;
+const zero = 0;
+arr.filter(item => item === 'aha')[zero];
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 3`] = `
+{
+  "code": "
+declare const arr: Array<string>;
+const zero = 0n;
+arr.filter(item => item === 'aha')[zero];
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 4`] = `
+{
+  "code": "
+declare const arr: Array<string>;
+const zero = -0n;
+arr.filter(item => item === 'aha')[zero];
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 5`] = `
+{
+  "code": "
+declare const arr: readonly string[];
+arr.filter(item => item === 'aha').at(0);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 6`] = `
+{
+  "code": "
+declare const arr: ReadonlyArray<string>;
+(undefined, arr.filter(item => item === 'aha')).at(0);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 7`] = `
+{
+  "code": "
+declare const arr: string[];
+const zero = 0;
+arr.filter(item => item === 'aha').at(zero);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 8`] = `
+{
+  "code": "
+declare const arr: string[];
+arr.filter(item => item === 'aha')['0'];
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 9`] = `
+{
+  "code": "const two = [1, 2, 3].filter(item => item === 2)[0];",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 10`] = `
+{
+  "code": "const fltr = "filter"; (([] as unknown[]))[fltr] ((item) => { return item === 2 }  ) [ 0  ] ;",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 92,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 11`] = `
+{
+  "code": "(([] as unknown[]))?.["filter"] ((item) => { return item === 2 }  ) [ 0  ] ;",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 75,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 12`] = `
+{
+  "code": "
+declare const nullableArray: unknown[] | undefined | null;
+nullableArray?.filter(item => true)[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 13`] = `
+{
+  "code": "([]?.filter(f))[0];",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 14`] = `
+{
+  "code": "
+declare const objectWithArrayProperty: { arr: unknown[] };
+declare function cond(x: unknown): boolean;
+console.log((1, 2, objectWithArrayProperty?.arr['filter'](cond)).at(0));
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 15`] = `
+{
+  "code": "
+[1, 2, 3].filter(x => x > 0).at(NaN);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 16`] = `
+{
+  "code": "
+const idxToLookUp = -0.12635678;
+[1, 2, 3].filter(x => x > 0).at(idxToLookUp);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 17`] = `
+{
+  "code": "
+[1, 2, 3].filter(x => x > 0)[\`at\`](0);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 18`] = `
+{
+  "code": "
+declare const arr: string[];
+declare const cond: Parameters<Array<string>['filter']>[0];
+const a = { arr };
+a?.arr
+  .filter(cond) /* what a bad spot for a comment. Let's make sure
+  there's some yucky symbols too. [ . ?. <>   ' ' \\'] */
+  .at('0');
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 19`] = `
+{
+  "code": "
+const imNotActuallyAnArray = [
+  [1, 2, 3],
+  [2, 3, 4],
+] as const;
+const butIAm = [4, 5, 6];
+butIAm.push(
+  // line comment!
+  ...imNotActuallyAnArray[/* comment */ 'filter' /* another comment */](
+    x => x[1] > 0,
+  ) /**/[\`0\`]!,
+);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 11,
+        },
+        "start": {
+          "column": 6,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 20`] = `
+{
+  "code": "
+function actingOnArray<T extends string[]>(values: T) {
+  return values.filter(filter => filter === 'filter')[
+    /* filter */ -0.0 /* filter */
+  ];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 21`] = `
+{
+  "code": "
+const nestedSequenceAbomination =
+  (1,
+  2,
+  (1,
+  2,
+  3,
+  (1, 2, 3, 4),
+  (1, 2, 3, 4, 5, [1, 2, 3, 4, 5, 6].filter(x => x % 2 == 0)))['0']);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 9,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 22`] = `
+{
+  "code": "
+declare const arr: { a: 1 }[] & { b: 2 }[];
+arr.filter(f, thisArg)[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 23`] = `
+{
+  "code": "
+declare const arr: { a: 1 }[] & ({ b: 2 }[] | { c: 3 }[]);
+arr.filter(f, thisArg)[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 24`] = `
+{
+  "code": "
+(Math.random() < 0.5
+  ? [1, 2, 3].filter(x => false)
+  : [1, 2, 3].filter(x => true))[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 25`] = `
+{
+  "code": "
+Math.random() < 0.5
+  ? [1, 2, 3].find(x => true)
+  : [1, 2, 3].filter(x => true)[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 26`] = `
+{
+  "code": "
+declare const f: (arg0: unknown, arg1: number, arg2: Array<unknown>) => boolean,
+  g: (arg0: unknown) => boolean;
+const nestedTernaries = (
+  Math.random() < 0.5
+    ? Math.random() < 0.5
+      ? [1, 2, 3].filter(f)
+      : []?.filter(x => 'shrug')
+    : [2, 3, 4]['filter'](g)
+).at(0.2);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 10,
+        },
+        "start": {
+          "column": 25,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 27`] = `
+{
+  "code": "
+declare const f: (arg0: unknown) => boolean, g: (arg0: unknown) => boolean;
+const nestedTernariesWithSequenceExpression = (
+  Math.random() < 0.5
+    ? ('sequence',
+      'expression',
+      Math.random() < 0.5 ? [1, 2, 3].filter(f) : []?.filter(x => 'shrug'))
+    : [2, 3, 4]['filter'](g)
+).at(0.2);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 9,
+        },
+        "start": {
+          "column": 47,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-find > invalid 28`] = `
+{
+  "code": "
+declare const spreadArgs: [(x: unknown) => boolean];
+[1, 2, 3].filter(...spreadArgs).at(0);
+      ",
+  "diagnostics": [
+    {
+      "message": "Prefer .find(...) instead of .filter(...)[0].",
+      "messageId": "preferFind",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-find",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/prefer-find` rule from ESLint to rslint.

The rule reports `arr.filter(p)[0]` / `arr.filter(p).at(0)` patterns where the receiver is an array or tuple, and suggests rewriting to `arr.find(p)`. The fix is offered as a **suggestion** (not auto-applied) because `.find()` short-circuits at the first match while `.filter()` always visits every element — applying the rewrite is unsafe if the predicate has side effects.

Implementation notes:

- Recognized receiver shapes: `arr.filter(p)`, `arr['filter'](p)`, ``arr[`filter`](p)``, `arr[fltrVar](p)` (const-resolved), `arr?.filter(p)`, plus paren / non-null / `as` / `satisfies` / sequence / ternary wrappers.
- Recognized zero forms: `[0]`, `['0']`, ``[`0`]``, `[0n]`, `[-0n]`, `[zero]` (const-resolved), `.at(0)`, `.at(NaN)`, `.at(-0.x)`, `.at(0 as number)`, etc. Matches upstream's JS `Number(value)` / `String(value)` coercion semantics including the `Math.trunc` rule.
- Symbol-typed arguments are short-circuited via the type checker (`TypeFlagsESSymbolLike`), mirroring upstream's `typeof value === 'symbol'` guard.
- `isArrayish` uses tsgo's built-in `Checker_isArrayOrTupleType` over union / intersection constituents, skipping null / undefined parts.
- Excludes `?.[0]` / `?.at(0)` (callee optional) / `.filter?.(...)` (call optional) — rewriting them would change short-circuit semantics.

Test layout:

- `prefer_find_upstream_test.go`: 47 cases (19 valid + 28 invalid), 1:1 migration of typescript-eslint/main with line+column assertions.
- `prefer_find_extras_test.go`: 55 cases covering tsgo-specific edge shapes (multi-level parens, type assertions transparently unwrapped via `SkipOuterExpressions(OEKAll)`), branch lock-ins (`.at?.(0)`, intersection with non-array, `let` / parameter / TDZ self-ref guards, NaN/Infinity shadowing), TypeChecker-driven Symbol shortcuts, and real-user shapes (tuple receiver, method-chain receiver, decimal `.at`, primitive globals).

JS suite mirrors upstream's Layer 1 (19 valid + 28 invalid) at `packages/rslint-test-tools/tests/typescript-eslint/rules/prefer-find.test.ts`.

Verified end-to-end against `rsbuild` (1933 files) and `rspack` (471 files) — 0 false positives on production code; sanity-check fixtures injected into each project triggered all expected positives and silenced all expected negatives.

## Related Links

- ESLint rule: https://typescript-eslint.io/rules/prefer-find
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/prefer-find.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).