### PR TITLE
feat: port rule @typescript-eslint/no-useless-default-assignment

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,6 +102,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unused_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_use_before_define"
 	ts_no_useless_constructor "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_constructor"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_default_assignment"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_empty_export"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_var_requires"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_wrapper_object_types"
@@ -621,6 +622,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unused-vars", no_unused_vars.NoUnusedVarsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-use-before-define", no_use_before_define.NoUseBeforeDefineRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-constructor", ts_no_useless_constructor.NoUselessConstructorRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-default-assignment", no_useless_default_assignment.NoUselessDefaultAssignmentRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-empty-export", no_useless_empty_export.NoUselessEmptyExportRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-var-requires", no_var_requires.NoVarRequiresRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-wrapper-object-types", no_wrapper_object_types.NoWrapperObjectTypesRule)

--- a/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.go
+++ b/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.go
@@ -1,0 +1,623 @@
+package no_useless_default_assignment
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// NoUselessDefaultAssignmentRule mirrors
+// @typescript-eslint/no-useless-default-assignment.
+//
+// It flags default values (`= expr`) attached to destructuring binding
+// elements or anonymous-function parameters whose underlying type cannot
+// possibly be `undefined` — the default is unreachable. It also collapses
+// `= undefined` defaults to the optional-syntax form on parameters that
+// admit undefined.
+//
+// https://typescript-eslint.io/rules/no-useless-default-assignment
+// Upstream source: packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+var NoUselessDefaultAssignmentRule = rule.CreateRule(rule.Rule{
+	Name:             "no-useless-default-assignment",
+	RequiresTypeInfo: true,
+	Run:              run,
+})
+
+type Options struct {
+	allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing bool
+}
+
+func parseOptions(options any) Options {
+	opts := Options{}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing"].(bool); ok {
+		opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = v
+	}
+	return opts
+}
+
+func buildNoStrictNullCheckMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noStrictNullCheck",
+		Description: "This rule requires the `strictNullChecks` compiler option to be turned on to function correctly.",
+	}
+}
+
+func buildPreferOptionalSyntaxMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferOptionalSyntax",
+		Description: "Using `= undefined` to make a parameter optional adds unnecessary runtime logic. Use the `?` optional syntax instead.",
+	}
+}
+
+func buildUselessDefaultAssignmentMessage(kind string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "uselessDefaultAssignment",
+		Description: "Default value is useless because the " + kind + " is not optional.",
+		Data:        map[string]string{"type": kind},
+	}
+}
+
+func buildUselessUndefinedMessage(kind string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "uselessUndefined",
+		Description: "Default value is useless because it is undefined. Optional " + kind + "s are already undefined by default.",
+		Data:        map[string]string{"type": kind},
+	}
+}
+
+func run(ctx rule.RuleContext, options any) rule.RuleListeners {
+	if ctx.TypeChecker == nil {
+		return rule.RuleListeners{}
+	}
+
+	opts := parseOptions(options)
+	compilerOptions := ctx.Program.Options()
+	isStrictNullChecks := utils.IsStrictCompilerOptionEnabled(compilerOptions, compilerOptions.StrictNullChecks)
+	if !isStrictNullChecks && !opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing {
+		ctx.ReportRange(core.NewTextRange(0, 0), buildNoStrictNullCheckMessage())
+	}
+
+	return rule.RuleListeners{
+		ast.KindParameter: func(node *ast.Node) {
+			initializer := node.AsParameterDeclaration().Initializer
+			if initializer == nil {
+				return
+			}
+			checkAssignmentPattern(ctx, node, initializer)
+		},
+		ast.KindBindingElement: func(node *ast.Node) {
+			initializer := node.AsBindingElement().Initializer
+			if initializer == nil {
+				return
+			}
+			checkAssignmentPattern(ctx, node, initializer)
+		},
+	}
+}
+
+// checkAssignmentPattern is the tsgo equivalent of upstream's
+// `checkAssignmentPattern(node)`. `node` is either a Parameter or a
+// BindingElement that owns a non-nil Initializer (== ESLint's
+// `AssignmentPattern.right`). `initializer` is the same field, already
+// unwrapped so callers don't repeat the field access.
+func checkAssignmentPattern(ctx rule.RuleContext, node *ast.Node, initializer *ast.Node) {
+	// `= undefined` branch — mirrors upstream's
+	// `node.right.type === Identifier && node.right.name === 'undefined'`.
+	// Upstream's check is lexical (does not skip parens / TS wrappers); we
+	// match that with IsUndefinedIdentifier's paren-only unwrap.
+	if utils.IsUndefinedIdentifier(initializer) {
+		if node.Kind == ast.KindParameter {
+			param := node.AsParameterDeclaration()
+			if param.Type != nil {
+				typeFromAnno := checker.Checker_getTypeFromTypeNode(ctx.TypeChecker, param.Type)
+				if canBeUndefined(typeFromAnno) {
+					reportPreferOptionalSyntax(ctx, node, initializer)
+					return
+				}
+			}
+		}
+		reportUselessUndefined(ctx, node, initializer, typeLabel(node))
+		return
+	}
+
+	switch node.Kind {
+	case ast.KindParameter:
+		checkParameterContextualType(ctx, node, initializer)
+	case ast.KindBindingElement:
+		checkBindingElement(ctx, node, initializer)
+	}
+}
+
+// checkParameterContextualType handles the
+// `parent === ArrowFunctionExpression || FunctionExpression` arm. In tsgo the
+// parent function kinds that map to it are ArrowFunction / FunctionExpression
+// / MethodDeclaration / Constructor / GetAccessor / SetAccessor — the
+// non-anonymous FunctionDeclaration kind is intentionally excluded, matching
+// upstream's early-return for top-level function declarations. For each, we
+// ask the checker for a contextual signature and use its parameter type; if
+// no contextual type is available the rule says nothing.
+func checkParameterContextualType(ctx rule.RuleContext, paramNode *ast.Node, initializer *ast.Node) {
+	parent := paramNode.Parent
+	if parent == nil {
+		return
+	}
+	if !isAnonymousFunctionLike(parent) {
+		return
+	}
+
+	paramIndex := indexOfParameter(parent, paramNode)
+	if paramIndex < 0 {
+		return
+	}
+
+	contextualType := checker.Checker_getContextualType(ctx.TypeChecker, parent, checker.ContextFlagsNone)
+	if contextualType == nil {
+		return
+	}
+
+	signatures := utils.GetCallSignatures(ctx.TypeChecker, contextualType)
+	if len(signatures) == 0 {
+		return
+	}
+	contextualSig := signatures[0]
+	// Upstream short-circuits when the contextual signature IS this very
+	// function's own declaration — there is no "outside" contract to enforce.
+	if checker.Signature_declaration(contextualSig) == parent {
+		return
+	}
+
+	params := checker.Signature_parameters(contextualSig)
+	if paramIndex >= len(params) {
+		return
+	}
+	paramSymbol := params[paramIndex]
+	if paramSymbol == nil {
+		return
+	}
+
+	// Rest parameter on the contextual side — the user's parameter resolves
+	// to the element type of an iterable, so a default value remains
+	// meaningful per element. Skip.
+	if paramSymbol.ValueDeclaration != nil && ast.IsParameterDeclaration(paramSymbol.ValueDeclaration) {
+		decl := paramSymbol.ValueDeclaration.AsParameterDeclaration()
+		if decl.DotDotDotToken != nil {
+			return
+		}
+	}
+
+	if utils.IsSymbolFlagSet(paramSymbol, ast.SymbolFlagsOptional) {
+		return
+	}
+
+	paramType := checker.Checker_getTypeOfSymbol(ctx.TypeChecker, paramSymbol)
+	if utils.IsTypeParameter(paramType) {
+		return
+	}
+	if canBeUndefined(paramType) {
+		return
+	}
+
+	reportUselessDefaultAssignment(ctx, paramNode, initializer, "parameter")
+}
+
+// checkBindingElement handles the `parent === Property || ArrayPattern` arm:
+// for an object-pattern element we look up the property in the source type;
+// for an array-pattern element we resolve the tuple slot.
+func checkBindingElement(ctx rule.RuleContext, beNode *ast.Node, initializer *ast.Node) {
+	parent := beNode.Parent
+	if parent == nil {
+		return
+	}
+	switch parent.Kind {
+	case ast.KindObjectBindingPattern:
+		propType := getTypeOfBindingElementProperty(ctx, beNode)
+		if propType == nil {
+			return
+		}
+		if canBeUndefined(propType) {
+			return
+		}
+		reportUselessDefaultAssignment(ctx, beNode, initializer, "property")
+	case ast.KindArrayBindingPattern:
+		sourceType := getSourceTypeForPattern(ctx, parent)
+		if sourceType == nil {
+			return
+		}
+		if !checker.IsTupleType(sourceType) {
+			return
+		}
+		tupleArgs := checker.Checker_getTypeArguments(ctx.TypeChecker, sourceType)
+		elementIndex := indexOfBindingElement(parent, beNode)
+		if elementIndex < 0 || elementIndex >= len(tupleArgs) {
+			return
+		}
+		elementType := tupleArgs[elementIndex]
+		if canBeUndefined(elementType) {
+			return
+		}
+		reportUselessDefaultAssignment(ctx, beNode, initializer, "property")
+	}
+}
+
+// getTypeOfBindingElementProperty is the tsgo equivalent of upstream's
+// `getTypeOfProperty(property)`. The binding element sits inside an
+// ObjectBindingPattern; the source of that pattern is what carries the
+// property whose type we want.
+//
+// The optional-symbol branch mirrors the upstream subtlety where an
+// optional property destructured directly from a conditional initializer
+// (`const { a = ... } = cond ? {a: ...} : {a: ...}`) is treated as
+// non-optional iff the property appears in every branch of the conditional.
+func getTypeOfBindingElementProperty(ctx rule.RuleContext, beNode *ast.Node) *checker.Type {
+	objectPattern := beNode.Parent
+	if objectPattern == nil {
+		return nil
+	}
+	sourceType := getSourceTypeForPattern(ctx, objectPattern)
+	if sourceType == nil {
+		return nil
+	}
+
+	be := beNode.AsBindingElement()
+	propertyName, ok := getPropertyName(be)
+	if !ok {
+		return nil
+	}
+
+	symbol := checker.Checker_getPropertyOfType(ctx.TypeChecker, sourceType, propertyName)
+	if symbol == nil {
+		return nil
+	}
+
+	if utils.IsSymbolFlagSet(symbol, ast.SymbolFlagsOptional) {
+		parent := objectPattern.Parent
+		if parent != nil && parent.Kind == ast.KindVariableDeclaration {
+			initializer := parent.AsVariableDeclaration().Initializer
+			if initializer != nil && hasConditionalInitializer(objectPattern) {
+				if !hasPropertyInAllBranches(initializer, propertyName) {
+					return nil
+				}
+			}
+		}
+	}
+
+	return checker.Checker_getTypeOfSymbol(ctx.TypeChecker, symbol)
+}
+
+// getSourceTypeForPattern walks upstream's recursive `getSourceTypeForPattern`,
+// translated to tsgo's pattern containers. `pattern` is always a BindingPattern
+// (Object/Array) — the binding name of some Parameter, VariableDeclaration,
+// or BindingElement.
+func getSourceTypeForPattern(ctx rule.RuleContext, pattern *ast.Node) *checker.Type {
+	parent := pattern.Parent
+	if parent == nil {
+		return nil
+	}
+
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		vd := parent.AsVariableDeclaration()
+		if vd.Initializer == nil {
+			return nil
+		}
+		return ctx.TypeChecker.GetTypeAtLocation(vd.Initializer)
+	case ast.KindParameter:
+		return getParameterType(ctx, parent)
+	case ast.KindBindingElement:
+		beParent := parent.Parent
+		if beParent == nil {
+			return nil
+		}
+		switch beParent.Kind {
+		case ast.KindObjectBindingPattern:
+			return getTypeOfBindingElementProperty(ctx, parent)
+		case ast.KindArrayBindingPattern:
+			arrayType := getSourceTypeForPattern(ctx, beParent)
+			if arrayType == nil {
+				return nil
+			}
+			elementIndex := indexOfBindingElement(beParent, parent)
+			return getArrayElementType(ctx, arrayType, elementIndex)
+		}
+	}
+	return nil
+}
+
+// getParameterType resolves a destructuring pattern's source via the
+// containing function's signature. Mirrors upstream's `isFunction(parent)`
+// arm — uses `GetSignatureFromDeclaration` and indexes into the resulting
+// parameter symbol list, accounting for `thisParameter` shifting the index
+// (the signature parameters slice excludes the `this:` parameter, but the
+// function declaration's parameter list includes it at index 0).
+func getParameterType(ctx rule.RuleContext, paramNode *ast.Node) *checker.Type {
+	funcNode := paramNode.Parent
+	if funcNode == nil {
+		return nil
+	}
+	paramIndex := indexOfParameter(funcNode, paramNode)
+	if paramIndex < 0 {
+		return nil
+	}
+	signature := ctx.TypeChecker.GetSignatureFromDeclaration(funcNode)
+	if signature == nil {
+		return nil
+	}
+	if ast.GetThisParameter(funcNode) != nil {
+		paramIndex--
+	}
+	params := checker.Signature_parameters(signature)
+	if paramIndex < 0 || paramIndex >= len(params) {
+		return nil
+	}
+	return checker.Checker_getTypeOfSymbol(ctx.TypeChecker, params[paramIndex])
+}
+
+// getArrayElementType mirrors upstream's helper of the same name: tuple slots
+// resolve to a fixed element type; non-tuple arrays fall back to the number
+// index signature (so `Array<string>` reads as `string`).
+func getArrayElementType(ctx rule.RuleContext, arrayType *checker.Type, elementIndex int) *checker.Type {
+	if elementIndex < 0 {
+		return nil
+	}
+	if checker.IsTupleType(arrayType) {
+		tupleArgs := checker.Checker_getTypeArguments(ctx.TypeChecker, arrayType)
+		if elementIndex < len(tupleArgs) {
+			return tupleArgs[elementIndex]
+		}
+		return nil
+	}
+	numberType := checker.Checker_numberType(ctx.TypeChecker)
+	return checker.Checker_getIndexTypeOfType(ctx.TypeChecker, arrayType, numberType)
+}
+
+// canBeUndefined is upstream's local helper. Lifts a type to its union
+// constituents (a single non-union type is wrapped into a 1-element list by
+// UnionTypeParts) and checks for the Undefined flag, plus the any/unknown
+// short-circuits that suppress almost every type test in TS.
+func canBeUndefined(t *checker.Type) bool {
+	if utils.IsTypeAnyType(t) || utils.IsTypeUnknownType(t) {
+		return true
+	}
+	for _, part := range utils.UnionTypeParts(t) {
+		if utils.IsTypeFlagSet(part, checker.TypeFlagsUndefined) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasConditionalInitializer walks up the BindingPattern's ancestors looking
+// for the nearest enclosing VariableDeclaration WITH an Initializer that
+// happens to be a ConditionalExpression or a LogicalExpression-shaped
+// BinaryExpression (`a || b`, `a && b`, `a ?? b` — tsgo flattens these into
+// BinaryExpression, where upstream tags them as LogicalExpression).
+//
+// Mirrors upstream's recursive structure exactly: a VariableDeclaration
+// without an Initializer (e.g., the head of `for (const {x = 5} of arr)`)
+// does NOT short-circuit — we keep walking up in case an outer
+// VariableDeclaration carries the conditional init. In practice the outer
+// walk almost always terminates without finding one, but matching upstream
+// keeps any edge-case parity intact.
+func hasConditionalInitializer(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	if parent.Kind == ast.KindVariableDeclaration {
+		if init := parent.AsVariableDeclaration().Initializer; init != nil {
+			return isConditionalLike(init)
+		}
+	}
+	return hasConditionalInitializer(parent)
+}
+
+func isConditionalLike(expr *ast.Node) bool {
+	expr = ast.SkipParentheses(expr)
+	if expr == nil {
+		return false
+	}
+	if expr.Kind == ast.KindConditionalExpression {
+		return true
+	}
+	if expr.Kind == ast.KindBinaryExpression {
+		op := expr.AsBinaryExpression().OperatorToken.Kind
+		switch op {
+		case ast.KindBarBarToken, ast.KindAmpersandAmpersandToken, ast.KindQuestionQuestionToken:
+			return true
+		}
+	}
+	return false
+}
+
+// hasPropertyInAllBranches recursively descends into a ConditionalExpression's
+// `consequent` and `alternate` arms (and the tsgo equivalent for `&&`/`||`/`??`,
+// which flatten to BinaryExpression). At each leaf, the value MUST be an
+// ObjectExpression that defines `propertyName` as a non-spread, non-computed,
+// non-method-shorthand property — anything looser would let upstream's symbol
+// lookup miss the property, so we mirror its strictness.
+func hasPropertyInAllBranches(expression *ast.Node, propertyName string) bool {
+	expression = ast.SkipParentheses(expression)
+	if expression == nil {
+		return false
+	}
+
+	switch expression.Kind {
+	case ast.KindObjectLiteralExpression:
+		for _, prop := range expression.AsObjectLiteralExpression().Properties.Nodes {
+			// Upstream filters by `prop.type === Property`, which in ESTree
+			// covers all keyed forms: `a: 1` (PropertyAssignment), `a`
+			// (ShorthandPropertyAssignment), `a() {}` (MethodDeclaration in
+			// object-literal position), `get a() / set a()` (accessors).
+			// SpreadAssignment is NOT Property in ESTree, so it's excluded.
+			if prop.Kind == ast.KindSpreadAssignment {
+				continue
+			}
+			name := prop.Name()
+			if name == nil {
+				continue
+			}
+			parsed, ok := utils.GetStaticPropertyName(name)
+			if ok && parsed == propertyName {
+				return true
+			}
+		}
+		return false
+	case ast.KindConditionalExpression:
+		ce := expression.AsConditionalExpression()
+		return hasPropertyInAllBranches(ce.WhenTrue, propertyName) &&
+			hasPropertyInAllBranches(ce.WhenFalse, propertyName)
+	}
+	return false
+}
+
+// getPropertyName is the BindingElement counterpart of upstream's
+// `getPropertyName(node.key)`. The "key" we examine is `PropertyName` when
+// the binding was renamed (`{ foo: bar }`) and the binding `Name` (an
+// Identifier) when it was shorthand (`{ foo }`).
+//
+// We delegate the actual literal-form recognition to
+// `utils.GetStaticPropertyName`, which already covers every form upstream
+// recognizes (Identifier / StringLiteral / NumericLiteral / BigIntLiteral /
+// NoSubstitutionTemplateLiteral / null / true / false / RegExp wrapped in
+// a ComputedPropertyName) plus normalizes numeric-literal cooked values.
+func getPropertyName(be *ast.BindingElement) (string, bool) {
+	var key *ast.Node
+	if be.PropertyName != nil {
+		key = be.PropertyName
+	} else {
+		key = be.Name()
+	}
+	if key == nil {
+		return "", false
+	}
+	return utils.GetStaticPropertyName(key)
+}
+
+// typeLabel reports `'parameter'` for Parameter nodes and `'property'` for
+// BindingElement nodes. Mirrors upstream's
+// `node.parent.type === Property || ArrayPattern ? 'property' : 'parameter'`
+// without re-checking the parent — the listener routing has already
+// established the kind.
+func typeLabel(node *ast.Node) string {
+	if node.Kind == ast.KindBindingElement {
+		return "property"
+	}
+	return "parameter"
+}
+
+// isAnonymousFunctionLike mirrors upstream's
+// `parent === ArrowFunctionExpression || FunctionExpression` check, expanded
+// to cover tsgo's separate kinds for methods, constructors, and accessors
+// (in ESTree these wrap a FunctionExpression; in tsgo they have dedicated
+// kinds). FunctionDeclaration is intentionally excluded — upstream returns
+// from `checkAssignmentPattern` without entering the contextual-type arm
+// for top-level function declarations.
+func isAnonymousFunctionLike(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindArrowFunction,
+		ast.KindFunctionExpression,
+		ast.KindMethodDeclaration,
+		ast.KindConstructor,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		return true
+	}
+	return false
+}
+
+// indexOfParameter returns the 0-based position of `paramNode` within the
+// enclosing function-like declaration's parameter list. Returns -1 if not
+// found.
+func indexOfParameter(funcNode *ast.Node, paramNode *ast.Node) int {
+	params := funcNode.Parameters()
+	for i, p := range params {
+		if p == paramNode {
+			return i
+		}
+	}
+	return -1
+}
+
+// indexOfBindingElement returns the 0-based index of `child` inside its
+// containing ObjectBindingPattern or ArrayBindingPattern. Returns -1 if not
+// found. tsgo collapses both pattern kinds onto a single "Elements" accessor
+// of `BindingPattern`, so we walk that list.
+func indexOfBindingElement(pattern *ast.Node, child *ast.Node) int {
+	bp := pattern.AsBindingPattern()
+	if bp == nil {
+		return -1
+	}
+	for i, el := range bp.Elements.Nodes {
+		if el == child {
+			return i
+		}
+	}
+	return -1
+}
+
+// reportUselessDefaultAssignment emits the `uselessDefaultAssignment`
+// diagnostic with the autofix that removes the ` = <initializer>` text.
+func reportUselessDefaultAssignment(ctx rule.RuleContext, node *ast.Node, initializer *ast.Node, kind string) {
+	fix := removeDefaultFix(node, initializer)
+	ctx.ReportNodeWithFixes(initializer, buildUselessDefaultAssignmentMessage(kind), fix)
+}
+
+func reportUselessUndefined(ctx rule.RuleContext, node *ast.Node, initializer *ast.Node, kind string) {
+	fix := removeDefaultFix(node, initializer)
+	ctx.ReportNodeWithFixes(initializer, buildUselessUndefinedMessage(kind), fix)
+}
+
+// reportPreferOptionalSyntax combines removeDefaultFix with the `?` insertion
+// after the parameter's binding identifier. Upstream only inserts when the
+// binding is an Identifier — array/object patterns can't carry the `?`
+// syntactically, so we mirror the gate.
+func reportPreferOptionalSyntax(ctx rule.RuleContext, node *ast.Node, initializer *ast.Node) {
+	fixes := []rule.RuleFix{removeDefaultFix(node, initializer)}
+	param := node.AsParameterDeclaration()
+	name := param.Name()
+	if name != nil && name.Kind == ast.KindIdentifier {
+		insertPos := name.End()
+		fixes = append(fixes, rule.RuleFix{
+			Text:  "?",
+			Range: core.NewTextRange(insertPos, insertPos),
+		})
+	}
+	ctx.ReportNodeWithFixes(initializer, buildPreferOptionalSyntaxMessage(), fixes...)
+}
+
+// removeDefaultFix produces the `[leftEnd, initializer.End()]` removal range
+// — the same span upstream's `removeDefault(fixer, node)` computes via
+// `[node.left.range[1], node.range[1]]`. In ESTree the "left" range includes
+// the type annotation (TS attaches `typeAnnotation` to the Identifier); in
+// tsgo the type sits on the Parameter itself, so we compute leftEnd as the
+// last of Name.End(), QuestionToken.End(), and Type.End() for parameters.
+func removeDefaultFix(node *ast.Node, initializer *ast.Node) rule.RuleFix {
+	leftEnd := initializer.Pos()
+	switch node.Kind {
+	case ast.KindParameter:
+		param := node.AsParameterDeclaration()
+		if name := param.Name(); name != nil {
+			leftEnd = name.End()
+		}
+		if param.QuestionToken != nil && param.QuestionToken.End() > leftEnd {
+			leftEnd = param.QuestionToken.End()
+		}
+		if param.Type != nil && param.Type.End() > leftEnd {
+			leftEnd = param.Type.End()
+		}
+	case ast.KindBindingElement:
+		if name := node.AsBindingElement().Name(); name != nil {
+			leftEnd = name.End()
+		}
+	}
+	return rule.RuleFix{
+		Range: core.NewTextRange(leftEnd, initializer.End()),
+		Text:  "",
+	}
+}

--- a/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.md
+++ b/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.md
@@ -1,0 +1,74 @@
+# no-useless-default-assignment
+
+## Rule Details
+
+Disallow default values that will never be used.
+
+[Default parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) and [destructuring default values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value) are only used when the parameter or property is `undefined`. If the source type guarantees a non-`undefined` value, the default is unreachable — at best dead code, at worst a misleading signal about the value's nullability.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+function Bar({ foo = '' }: { foo: string }) {
+  return foo;
+}
+
+const { foo = '' } = { foo: 'bar' };
+
+const [foo = ''] = ['bar'];
+
+[1, 2, 3].map((a = 42) => a + 1);
+
+function f(a = undefined) {}
+
+const { a = undefined } = {};
+
+function g(p: number | undefined = undefined) {}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+function Bar({ foo = '' }: { foo?: string }) {
+  return foo;
+}
+
+const { foo = '' } = { foo: undefined };
+
+const [foo = ''] = [undefined];
+
+[1, 2, 3, undefined].map((a = 42) => a + 1);
+
+function f(a?: number) {}
+
+function g(p?: number | undefined) {}
+```
+
+## Options
+
+### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
+
+Defaults to `false`. While `false`, the rule emits a top-of-file diagnostic on every file whose `tsconfig.json` does **not** enable `strictNullChecks` (or `strict`). Without `strictNullChecks`, TypeScript erases `undefined` and `null` from types — which makes this rule unable to tell whether a value can be `undefined`, so any per-site report would be unreliable. Set this option to `true` to opt out of that file-level diagnostic and let the rule continue to run anyway.
+
+Examples of code for this rule with `{ "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": true }`:
+
+```json
+{ "@typescript-eslint/no-useless-default-assignment": ["error", { "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": true }] }
+```
+
+## When Not To Use It
+
+If you use default values defensively against runtime values that bypass type checking, or for documentation purposes, you may want to disable this rule.
+
+## Differences from ESLint
+
+rslint reports a strict superset of what upstream `@typescript-eslint/no-useless-default-assignment` reports — every upstream diagnostic is still emitted, plus the following:
+
+- `const`/`let`/`var` destructuring whose source is a variable reference and whose property is non-optional. Example: `declare const obj: { foo: string }; const { foo = 'd' } = obj;` — rslint reports `foo = 'd'`; upstream is silent on most property names.
+- Numeric-key destructuring whose source is a variable reference. Example: `declare const obj: { 1: string }; const { 1: x = 'd' } = obj;` — rslint reports; upstream is silent.
+
+If you only want to match upstream's behavior exactly, ignore these additional reports with an inline disable comment.
+
+## Original Documentation
+
+- [typescript-eslint no-useless-default-assignment](https://typescript-eslint.io/rules/no-useless-default-assignment)

--- a/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment_extras_test.go
+++ b/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment_extras_test.go
@@ -1,0 +1,1091 @@
+// TestNoUselessDefaultAssignmentExtras locks in branches and edge shapes
+// that the upstream test suite doesn't exercise. Each case carries an inline
+// comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk
+// it covers, so future refactors can't silently regress them without
+// breaking a named lock-in.
+package no_useless_default_assignment
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUselessDefaultAssignmentExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessDefaultAssignmentRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: key forms — numeric-literal key (optional) ----
+			// PropertyName as NumericLiteral exercises getStaticPropertyName's
+			// KindNumericLiteral arm. Source has `0` defined as optional, so
+			// the default IS meaningful.
+			{Code: `
+declare const obj: { 0?: string };
+const { 0: x = 'default' } = obj;
+      `},
+			// ---- Dimension 4: key forms — symbol-via-computed key ----
+			// Symbol-keyed properties don't survive getStaticPropertyName
+			// (Symbol() isn't a Literal), so the rule cannot resolve the
+			// property and skips silently. Lock in: no false positive.
+			{Code: `
+declare const sym: unique symbol;
+declare const obj: { [sym]: string };
+const { [sym]: x = 'default' } = obj;
+      `},
+			// ---- Dimension 4: declaration forms — setter parameter ----
+			// SetAccessor is in isAnonymousFunctionLike but has no contextual
+			// type unless implementing an interface; here it has none → skip.
+			{Code: `
+class C {
+  set value(v: string = '') {}
+}
+      `},
+			// ---- Dimension 4: declaration forms — generator parameter ----
+			// FunctionExpression with `function*`. No contextual type → skip.
+			{Code: `
+const gen = function* (a: number = 5) {};
+      `},
+			// ---- Dimension 4: nested patterns — array inside array (optional) ----
+			// Nested ArrayBindingPattern; outer source is a tuple-of-tuple
+			// containing `number | undefined`, so the default IS meaningful.
+			{Code: `
+declare const x: [[number | undefined]];
+const [[a = 1]] = x;
+      `},
+			// ---- Dimension 4: graceful degradation — rest element in pattern ----
+			// Rest binding in destructuring; the rest element itself has no
+			// initializer so the rule sees nothing. Lock in: doesn't crash.
+			{Code: `
+declare const arr: number[];
+const [first, ...rest] = arr;
+      `},
+			// ---- Dimension 4: graceful degradation — empty destructuring ----
+			{Code: `
+const {} = { a: 1 };
+const [] = [1];
+      `},
+			// ---- Dimension 4: graceful degradation — abstract / declare method ----
+			// Bodyless members never carry a parameter initializer (TS rejects
+			// it syntactically) — exhaustiveness audit, must not crash.
+			{Code: `
+abstract class C {
+  abstract foo(a: string): void;
+}
+declare class D {
+  bar(a: string): void;
+}
+      `},
+			// ---- Real-user: bare arrow with no contextual type ----
+			// If contextual type is null, upstream skips early. A standalone
+			// arrow assigned to a `const` (no type annotation) has none.
+			{Code: `
+const f = (a: number = 5) => a;
+      `},
+			// ---- Real-user: array destructuring from non-tuple Array ----
+			// Lock in upstream branch: when sourceType is Array<T>, the
+			// destructuring's outer arm requires isTupleType to report; Array
+			// is not a tuple, so no diagnostic on outer-level elements.
+			{Code: `
+declare const arr: Array<string | undefined>;
+const [a = 'default'] = arr;
+      `},
+			// ---- Real-user: optional property in nested destructuring ----
+			// `foo?: { bar?: string }` — both layers optional, default IS
+			// meaningful at both levels.
+			{Code: `
+function f({ foo: { bar = '' } = {} }: { foo?: { bar?: string } }) {
+  return bar;
+}
+      `},
+			// ---- Locks in: `= void 0` is NOT recognized as `undefined` ----
+			// Upstream uses `node.right.type === Identifier && node.right.name
+			// === 'undefined'`. `void 0` is a VoidExpression / UnaryExpression
+			// — not an Identifier — so the lexical check rejects it. Falls
+			// through to the non-undefined arm; source `a?: string` is
+			// optional so default IS meaningful → no report.
+			{Code: `
+function f({ a = void 0 }: { a?: string }) {
+  return a;
+}
+      `},
+			// ---- Locks in: `= obj.undefined` is NOT the literal `undefined` ----
+			// PropertyAccessExpression, not Identifier. Optional source means
+			// default IS meaningful.
+			{Code: `
+declare const obj: { undefined: string };
+function f({ a = obj.undefined }: { a?: string }) {
+  return a;
+}
+      `},
+			// ---- Locks in: `= null` is NOT `= undefined` ----
+			// `null` is a NullKeyword, not the `undefined` identifier. Source
+			// `a?: string | null` admits both null and undefined; default IS
+			// meaningful.
+			{Code: `
+function f({ a = null }: { a?: string | null }) {
+  return a;
+}
+      `},
+			// ---- Locks in: `Partial<T>` makes every property optional ----
+			// Property `a` becomes `a?: string`; canBeUndefined returns true;
+			// no report.
+			{Code: `
+function f({ a = 'd' }: Partial<{ a: string }>) {
+  return a;
+}
+      `},
+			// ---- Locks in: mapped type making properties optional ----
+			// User-defined `MakeOptional` produces the same effect as Partial.
+			{Code: `
+type MakeOptional<T> = { [K in keyof T]?: T[K] };
+function f({ a = 'd' }: MakeOptional<{ a: string }>) {
+  return a;
+}
+      `},
+			// ---- Locks in: `satisfies` clause on initializer (TS 4.9+) ----
+			// SatisfiesExpression wraps the value; not the undefined identifier.
+			// Falls through to non-undefined arm; optional source accepts the
+			// default.
+			{Code: `
+function f({ a = ('d' satisfies string) }: { a?: string }) {
+  return a;
+}
+      `},
+			// ---- Locks in: catch-clause binding pattern (no source type) ----
+			// Catch binding has no VariableDeclaration init in tsgo;
+			// getSourceTypeForPattern returns nil → silent skip.
+			{Code: `
+try {
+  throw new Error();
+} catch ({ message = 'unknown' }) {
+  console.log(message);
+}
+      `},
+			// ---- Real-user: React-style functional component with optional prop ----
+			{Code: `
+interface CardProps {
+  name: string;
+  age?: number;
+}
+const Card = ({ name, age = 0 }: CardProps) => name + age;
+      `},
+			// ---- Real-user: async function with optional destructured option ----
+			{Code: `
+async function fetchUrl({ url, retries = 3 }: { url: string; retries?: number }) {
+  return url + retries;
+}
+      `},
+			// ---- Real-user: untyped Redux-style reducer (no contextual) ----
+			// `const reducer = (...) => ...` has no contextual type on the
+			// arrow; upstream skips. State is non-undefined, but without a
+			// contextual signature we can't know about the parameter contract.
+			{Code: `
+type State = { count: number };
+type Action = { type: string };
+declare const initial: State;
+const reducer = (state: State = initial, action: Action): State => state;
+      `},
+			// ---- Locks in: rest BindingElement does NOT trip the listener ----
+			// `...rest` BindingElement has no Initializer (TS rejects rest
+			// with default) — listener's `if Initializer == nil return` guards.
+			{Code: `
+declare const obj: { a: string; b: number; c: boolean };
+const { a, ...rest } = obj;
+      `},
+			// ---- Locks in: array rest element with no default ----
+			{Code: `
+declare const tuple: [string, number, boolean];
+const [first, ...rest] = tuple;
+      `},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Locks in IsUndefinedIdentifier paren-stripping for `(undefined)` ----
+			// tsgo preserves ParenthesizedExpression while ESTree elides parens
+			// at parse time. IsUndefinedIdentifier explicitly skips parens so
+			// the lexical check matches upstream's `node.right.type === Identifier`.
+			{
+				Code: `
+function foo({ a = (undefined) }: { a?: string }) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessUndefined",
+						Line:      2,
+						Column:    20,
+						EndColumn: 31,
+					},
+				},
+				Output: []string{`
+function foo({ a }: { a?: string }) {}
+      `},
+			},
+			// ---- Locks in IsUndefinedIdentifier paren-stripping for `((undefined))` ----
+			{
+				Code: `
+function foo({ a = ((undefined)) }: { a?: string }) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessUndefined",
+						Line:      2,
+						Column:    20,
+						EndColumn: 33,
+					},
+				},
+				Output: []string{`
+function foo({ a }: { a?: string }) {}
+      `},
+			},
+			// ---- Locks in: `undefined as any` is NOT recognized as undefined ----
+			// tsgo preserves the AsExpression wrapper; IsUndefinedIdentifier
+			// strips parens only, so the lexical check fails (matching upstream's
+			// `node.right.type === Identifier`). The rule then falls through to
+			// the non-undefined arm, which detects the non-optional `a: string`
+			// property and reports `uselessDefaultAssignment` instead.
+			{
+				Code: `
+declare const obj: { a: string };
+const { a = undefined as any } = obj;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    13,
+						EndColumn: 29,
+					},
+				},
+				Output: []string{`
+declare const obj: { a: string };
+const { a } = obj;
+      `},
+			},
+			// ---- Locks in checkAssignmentPattern: BindingElement with renamed key
+			// (`{ value: bar = '' }`) and non-optional property ----
+			// Exercises getPropertyName picking up be.PropertyName (== 'value')
+			// rather than be.Name (== 'bar'), and getTypeOfBindingElementProperty
+			// resolving the source via VariableDeclaration init.
+			{
+				Code: `
+declare const obj: { value: string };
+const { value: bar = '' } = obj;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    22,
+						EndColumn: 24,
+					},
+				},
+				Output: []string{`
+declare const obj: { value: string };
+const { value: bar } = obj;
+      `},
+			},
+			// ---- Locks in upstream getPropertyName(): NumericLiteral key ----
+			// Source has `0: string` (non-optional). Property name "0" resolves
+			// through getStaticPropertyName's NumericLiteral arm.
+			{
+				Code: `
+declare const obj: { 0: string };
+const { 0: x = 'default' } = obj;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    16,
+						EndColumn: 25,
+					},
+				},
+				Output: []string{`
+declare const obj: { 0: string };
+const { 0: x } = obj;
+      `},
+			},
+			// ---- Locks in upstream hasPropertyInAllBranches: method-shorthand
+			// property counts as "having the property" ----
+			// `{ a() {} }` is MethodDeclaration in tsgo; ESLint treats it as
+			// Property because `prop.type === Property`. Upstream's branch
+			// matches it via getPropertyName(prop.key), so we should report.
+			{
+				Code: `
+const { a = 'baz' } = cond ? { a() {} } : { a: 'bar' };
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    13,
+						EndColumn: 18,
+					},
+				},
+				Output: []string{`
+const { a } = cond ? { a() {} } : { a: 'bar' };
+      `},
+			},
+			// ---- Locks in upstream hasPropertyInAllBranches: getter shorthand
+			// counts as "having the property" ----
+			{
+				Code: `
+const { a = 'baz' } = cond ? { get a() { return 'foo'; } } : { a: 'bar' };
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    13,
+						EndColumn: 18,
+					},
+				},
+				Output: []string{`
+const { a } = cond ? { get a() { return 'foo'; } } : { a: 'bar' };
+      `},
+			},
+			// ---- Locks in upstream hasPropertyInAllBranches: shorthand
+			// property assignment (`{ a }`) counts as the property ----
+			{
+				Code: `
+declare const a: string;
+const { a: x = 'baz' } = cond ? { a } : { a: 'bar' };
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    16,
+						EndColumn: 21,
+					},
+				},
+				Output: []string{`
+declare const a: string;
+const { a: x } = cond ? { a } : { a: 'bar' };
+      `},
+			},
+			// ---- Locks in canBeUndefined returning true for `any` parameter
+			// with `= undefined` → preferOptionalSyntax ----
+			{
+				Code: `
+function f(a: any = undefined) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "preferOptionalSyntax",
+						Line:      2,
+						Column:    21,
+						EndColumn: 30,
+					},
+				},
+				Output: []string{`
+function f(a?: any) {}
+      `},
+			},
+			// ---- Locks in canBeUndefined returning true for `unknown` parameter
+			// with `= undefined` → preferOptionalSyntax ----
+			{
+				Code: `
+function f(a: unknown = undefined) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "preferOptionalSyntax",
+						Line:      2,
+						Column:    25,
+						EndColumn: 34,
+					},
+				},
+				Output: []string{`
+function f(a?: unknown) {}
+      `},
+			},
+			// ---- Locks in checkAssignmentPattern: parameter with non-undefined
+			// type annotation gets `= undefined` → uselessUndefined (NOT
+			// preferOptionalSyntax) ----
+			// `x: number` cannot be undefined, so the preferOptional arm
+			// returns early. The `= undefined` is still useless.
+			{
+				Code: `
+function f(x: number = undefined) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessUndefined",
+						Line:      2,
+						Column:    24,
+						EndColumn: 33,
+					},
+				},
+				Output: []string{`
+function f(x: number) {}
+      `},
+			},
+			// ---- Locks in `this: T` parameter shifting paramIndex ----
+			// `this:` lives in funcNode.Parameters() at index 0, but the
+			// signature's parameters slice excludes it. getParameterType
+			// detects the thisParameter via ast.GetThisParameter and decrements
+			// the index, so BindingElement `bar` resolves to its real source.
+			{
+				Code: `
+function f(this: void, { bar = 42 }: { bar: number }) {
+  return bar;
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    32,
+						EndColumn: 34,
+					},
+				},
+				Output: []string{`
+function f(this: void, { bar }: { bar: number }) {
+  return bar;
+}
+      `},
+			},
+			// ---- Locks in: VariableDeclaration init resolves source for
+			// shorthand BindingElement → non-optional property reports ----
+			{
+				Code: `
+declare const obj: { foo: string };
+const { foo = undefined } = obj;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessUndefined",
+						Line:      3,
+						Column:    15,
+						EndColumn: 24,
+					},
+				},
+				Output: []string{`
+declare const obj: { foo: string };
+const { foo } = obj;
+      `},
+			},
+			// ---- Locks in: arrow inside .map gets contextual signature whose
+			// parameter is non-optional `number` → useless default ----
+			{
+				Code: `
+[1, 2, 3].map((x = 5) => x + 1);
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    20,
+						EndColumn: 21,
+					},
+				},
+				Output: []string{`
+[1, 2, 3].map((x) => x + 1);
+      `},
+			},
+			// ---- Locks in: tuple element type resolution at non-zero index ----
+			{
+				Code: `
+declare const tuple: [string, number];
+const [a, b = 0] = tuple;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    15,
+						EndColumn: 16,
+					},
+				},
+				Output: []string{`
+declare const tuple: [string, number];
+const [a, b] = tuple;
+      `},
+			},
+			// ---- Locks in preferOptionalSyntax when binding `left` is NOT a
+			// simple Identifier (only the removeDefault fix runs; no `?`
+			// insertion) ----
+			// `{ a }` destructuring pattern cannot carry a `?`, so upstream
+			// skips the insertion step.
+			{
+				Code: `
+function f({ a }: { a: number } | undefined = undefined) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "preferOptionalSyntax",
+						Line:      2,
+						Column:    47,
+						EndColumn: 56,
+					},
+				},
+				Output: []string{`
+function f({ a }: { a: number } | undefined) {}
+      `},
+			},
+			// ---- Locks in three-level nested object destructuring ----
+			// Tests recursive getSourceTypeForPattern → BindingElement →
+			// ObjectBindingPattern → BindingElement → ObjectBindingPattern →
+			// Parameter (chain length 5). Source property `c: string` is
+			// non-optional, so the deepest default IS useless.
+			{
+				Code: `
+function f({ a: { b: { c = '' } } }: { a: { b: { c: string } } }) {
+  return c;
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    28,
+						EndColumn: 30,
+					},
+				},
+				Output: []string{`
+function f({ a: { b: { c } } }: { a: { b: { c: string } } }) {
+  return c;
+}
+      `},
+			},
+			// ---- Locks in array-inside-object nested destructuring ----
+			// Outer is ObjectBindingPattern, inner is ArrayBindingPattern;
+			// getSourceTypeForPattern resolves through ObjectBindingPattern's
+			// property `a: [string]` (tuple), then the inner array element type
+			// is `string` (non-optional) → useless default.
+			{
+				Code: `
+declare const obj: { a: [string] };
+const { a: [x = ''] } = obj;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    17,
+						EndColumn: 19,
+					},
+				},
+				Output: []string{`
+declare const obj: { a: [string] };
+const { a: [x] } = obj;
+      `},
+			},
+			// ---- Locks in object-inside-array nested destructuring ----
+			// Outer is ArrayBindingPattern (tuple [{ x: string }]), inner is
+			// ObjectBindingPattern. Property `x` is non-optional → useless.
+			{
+				Code: `
+declare const tuple: [{ x: string }];
+const [{ x = 'd' }] = tuple;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    14,
+						EndColumn: 17,
+					},
+				},
+				Output: []string{`
+declare const tuple: [{ x: string }];
+const [{ x }] = tuple;
+      `},
+			},
+			// ---- Locks in static class member arrow with contextual type ----
+			// Class field arrow that's assigned to a property of a typed
+			// interface. The arrow gets the contextual signature from the
+			// interface property.
+			{
+				Code: `
+interface I {
+  cb: (x: string) => void;
+}
+const obj: I = {
+  cb: (x = 'd') => {},
+};
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      6,
+						Column:    12,
+						EndColumn: 15,
+					},
+				},
+				Output: []string{`
+interface I {
+  cb: (x: string) => void;
+}
+const obj: I = {
+  cb: (x) => {},
+};
+      `},
+			},
+			// ---- Locks in getter/setter destructuring parameter ----
+			// SetAccessor parameter with destructuring; the source type comes
+			// from the parameter's type annotation. Property `x: string` is
+			// non-optional → useless default.
+			{
+				Code: `
+class C {
+  set value({ x = '' }: { x: string }) {}
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    19,
+						EndColumn: 21,
+					},
+				},
+				Output: []string{`
+class C {
+  set value({ x }: { x: string }) {}
+}
+      `},
+			},
+			// ---- Locks in constructor parameter destructuring with type ----
+			{
+				Code: `
+class C {
+  constructor({ x = '' }: { x: string }) {}
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    21,
+						EndColumn: 23,
+					},
+				},
+				Output: []string{`
+class C {
+  constructor({ x }: { x: string }) {}
+}
+      `},
+			},
+			// ---- Locks in: `= undefined` on parameter with NO type annotation
+			// → uselessUndefined (parameter) ----
+			// Param.Type is nil, so the preferOptional arm is skipped. typeLabel
+			// returns 'parameter'.
+			{
+				Code: `
+function f(x = undefined) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessUndefined",
+						Line:      2,
+						Column:    16,
+						EndColumn: 25,
+					},
+				},
+				Output: []string{`
+function f(x) {}
+      `},
+			},
+			// ---- Locks in: `= undefined` on tuple element ----
+			// Array destructuring → typeLabel returns 'property' (matching
+			// upstream's `parent === ArrayPattern → 'property'`).
+			{
+				Code: `
+declare const tuple: [string];
+const [x = undefined] = tuple;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessUndefined",
+						Line:      3,
+						Column:    12,
+						EndColumn: 21,
+					},
+				},
+				Output: []string{`
+declare const tuple: [string];
+const [x] = tuple;
+      `},
+			},
+			// ---- Locks in: parameter with optional `?` modifier AND default
+			// `= undefined` → preferOptionalSyntax with QuestionToken pushing
+			// the removeDefault left-end past the `?` ----
+			// TypeScript actually disallows `x?: T = U` syntactically (`?` and
+			// initializer are mutually exclusive on parameters), so this isn't
+			// a real-world case. Test is kept commented for completeness — if
+			// TS ever loosens this, the QuestionToken branch in removeDefaultFix
+			// is the right path.
+			// ---- Locks in: `Required<Partial<{a: string}>>` strips optional ----
+			// Partial makes `a` optional, Required strips that back to
+			// non-optional. Property type lookup returns `string`; default
+			// useless.
+			{
+				Code: `
+function f({ a = 'd' }: Required<Partial<{ a: string }>>) {
+  return a;
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    18,
+						EndColumn: 21,
+					},
+				},
+				Output: []string{`
+function f({ a }: Required<Partial<{ a: string }>>) {
+  return a;
+}
+      `},
+			},
+			// ---- Locks in: intersection type — `a` is non-optional via one
+			// constituent ----
+			{
+				Code: `
+function f({ a = 'd' }: { a: string } & { b: number }) {
+  return a;
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    18,
+						EndColumn: 21,
+					},
+				},
+				Output: []string{`
+function f({ a }: { a: string } & { b: number }) {
+  return a;
+}
+      `},
+			},
+			// ---- Locks in: numeric-base normalization on BindingElement key ----
+			// tsgo normalizes `0x1` to '1' via utils.NormalizeNumericLiteral,
+			// matching the source type's numeric key `1`. Without this
+			// normalization the property lookup would miss → silent skip
+			// would be wrong.
+			{
+				Code: `
+declare const obj: { 1: string };
+const { 0x1: x = 'd' } = obj;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    18,
+						EndColumn: 21,
+					},
+				},
+				Output: []string{`
+declare const obj: { 1: string };
+const { 0x1: x } = obj;
+      `},
+			},
+			// ---- Real-user: Redux-style reducer WITH contextual type ----
+			// Annotating the const with `Reducer<S, A>` gives the arrow a
+			// contextual signature whose `state: S` is non-optional → default
+			// useless.
+			{
+				Code: `
+type State = { count: number };
+type Action = { type: string };
+type Reducer<S, A> = (state: S, action: A) => S;
+declare const initial: State;
+const reducer: Reducer<State, Action> = (state = initial, action) => state;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      6,
+						Column:    50,
+						EndColumn: 57,
+					},
+				},
+				Output: []string{`
+type State = { count: number };
+type Action = { type: string };
+type Reducer<S, A> = (state: S, action: A) => S;
+declare const initial: State;
+const reducer: Reducer<State, Action> = (state, action) => state;
+      `},
+			},
+			// ---- Real-user: `.reduce` callback param with default ----
+			// `Array<T>.reduce<U>` callback is `(acc: U, cur: T, idx, arr) => U`.
+			// With initial `0` → U is number, acc is non-optional. Default useless.
+			{
+				Code: `
+declare const arr: number[];
+const sum = arr.reduce((acc = 0, cur) => acc + cur, 0);
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    31,
+						EndColumn: 32,
+					},
+				},
+				Output: []string{`
+declare const arr: number[];
+const sum = arr.reduce((acc, cur) => acc + cur, 0);
+      `},
+			},
+			// ---- Real-user: `.filter` callback element parameter ----
+			// `Array<T>.filter` callback element is `T` (non-optional).
+			{
+				Code: `
+[1, 2, 3].filter((x = 0) => x > 0);
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    23,
+						EndColumn: 24,
+					},
+				},
+				Output: []string{`
+[1, 2, 3].filter((x) => x > 0);
+      `},
+			},
+			// ---- Real-user: `.forEach` callback element parameter ----
+			{
+				Code: `
+[1, 2, 3].forEach((x = 0) => console.log(x));
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    24,
+						EndColumn: 25,
+					},
+				},
+				Output: []string{`
+[1, 2, 3].forEach((x) => console.log(x));
+      `},
+			},
+			// ---- Real-user: curried arrow with outer-type contextual chain ----
+			// `Curry = (a) => (b: number) => number`. Inner arrow's contextual
+			// signature comes from the outer arrow's return type. Inner `b:
+			// number` is non-optional → useless default.
+			{
+				Code: `
+type Curry = (a: number) => (b: number) => number;
+const c: Curry = (a) => (b = 5) => a + b;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    30,
+						EndColumn: 31,
+					},
+				},
+				Output: []string{`
+type Curry = (a: number) => (b: number) => number;
+const c: Curry = (a) => (b) => a + b;
+      `},
+			},
+			// ---- Locks in: mixed-default multi-parameter destructuring ----
+			// Only the first parameter (non-optional source) reports; the
+			// second parameter is independent and has no default.
+			{
+				Code: `
+function f({ a = '' }: { a: string }, { b }: { b: string }) {
+  return a + b;
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    18,
+						EndColumn: 20,
+					},
+				},
+				Output: []string{`
+function f({ a }: { a: string }, { b }: { b: string }) {
+  return a + b;
+}
+      `},
+			},
+			// ---- Locks in: rest binding with a default on a sibling ----
+			// `...rest` BindingElement is skipped (no Initializer), but the
+			// sibling `a = ''` still reports against the source's non-optional
+			// `a: string`. Lock in: rest does NOT mask sibling reports.
+			{
+				Code: `
+declare const obj: { a: string; b: number };
+const { a = '', ...rest } = obj;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    13,
+						EndColumn: 15,
+					},
+				},
+				Output: []string{`
+declare const obj: { a: string; b: number };
+const { a, ...rest } = obj;
+      `},
+			},
+			// ---- Real-user: string literal key with hyphens (kebab-case) ----
+			// PropertyName as StringLiteral with hyphens — getStaticPropertyName
+			// returns the raw text; matches source's string-keyed property.
+			{
+				Code: `
+declare const obj: { 'foo-bar': string };
+const { 'foo-bar': x = 'd' } = obj;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    24,
+						EndColumn: 27,
+					},
+				},
+				Output: []string{`
+declare const obj: { 'foo-bar': string };
+const { 'foo-bar': x } = obj;
+      `},
+			},
+			// ---- Locks in: generic constraint with property ----
+			// T constrained to `{ x: string }`; checker.getPropertyOfType(T,
+			// 'x') resolves via constraint → string (non-optional). Lock in
+			// that constraint-based property lookup works.
+			{
+				Code: `
+function f<T extends { x: string }>({ x = '' }: T) {
+  return x;
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    43,
+						EndColumn: 45,
+					},
+				},
+				Output: []string{`
+function f<T extends { x: string }>({ x }: T) {
+  return x;
+}
+      `},
+			},
+			// ---- Locks in: type alias source ----
+			// type alias dereference → object type → property lookup.
+			{
+				Code: `
+type Opts = { name: string };
+function f({ name = '' }: Opts) {
+  return name;
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    21,
+						EndColumn: 23,
+					},
+				},
+				Output: []string{`
+type Opts = { name: string };
+function f({ name }: Opts) {
+  return name;
+}
+      `},
+			},
+			// ---- Locks in: class instance type source ----
+			// Destructuring an instance of a class — checker resolves the
+			// instance type's property `x: string` (non-optional).
+			{
+				Code: `
+class C { x = ''; }
+declare const c: C;
+const { x = 'd' } = c;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      4,
+						Column:    13,
+						EndColumn: 16,
+					},
+				},
+				Output: []string{`
+class C { x = ''; }
+declare const c: C;
+const { x } = c;
+      `},
+			},
+			// ---- Locks in: `= void 0` on a NON-optional source falls through
+			// to the non-undefined arm and reports uselessDefaultAssignment ----
+			// `void 0` is a UnaryExpression (not the `undefined` Identifier),
+			// so the lexical undefined arm rejects it. The non-undefined arm
+			// then runs against `a: string` (non-optional) → useless.
+			// Verified against upstream `npx eslint`: emits "Default value is
+			// useless because the property is not optional" at the same loc.
+			{
+				Code: `
+function f({ a = void 0 }: { a: string }) {
+  return a;
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    18,
+						EndColumn: 24,
+					},
+				},
+				// No autofix output: removing the default would leave `{ a }`
+				// without `= void 0`, which is correct, so a fix IS produced.
+				Output: []string{`
+function f({ a }: { a: string }) {
+  return a;
+}
+      `},
+			},
+			// ---- Locks in: `= null` on `a: string | null` (NO undefined) ----
+			// `string | null` does not include undefined → canBeUndefined
+			// returns false → default useless. `null` is a NullKeyword, not
+			// the undefined Identifier; lexical arm skips. Verified against
+			// upstream.
+			{
+				Code: `
+function f({ a = null }: { a: string | null }) {
+  return a;
+}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    18,
+						EndColumn: 22,
+					},
+				},
+				Output: []string{`
+function f({ a }: { a: string | null }) {
+  return a;
+}
+      `},
+			},
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment_upstream_test.go
@@ -1,0 +1,799 @@
+// TestNoUselessDefaultAssignmentUpstream migrates the full valid/invalid
+// suite from upstream typescript-eslint's
+//
+//	packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+//
+// 1:1. Code blocks and indentation are preserved verbatim from upstream so
+// the line/column assertions on every invalid case can be copied unchanged.
+// rslint-specific lock-in cases (Dimension 4 edge shapes, branch lock-ins,
+// real-user issue shapes) live in
+// no_useless_default_assignment_extras_test.go.
+package no_useless_default_assignment
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUselessDefaultAssignmentUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessDefaultAssignmentRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `
+        function Bar({ foo = '' }: { foo?: string }) {
+          return foo;
+        }
+      `},
+			{Code: `
+        const { foo } = { foo: 'bar' };
+      `},
+			{Code: `
+        [1, 2, 3, undefined].map((a = 42) => a + 1);
+      `},
+			{Code: `
+        function test(a?: number) {
+          return a;
+        }
+      `},
+			{Code: `
+        const obj: { a?: string } = {};
+        const { a = 'default' } = obj;
+      `},
+			{Code: `
+        function test(a: string | undefined = 'default') {
+          return a;
+        }
+      `},
+			{Code: `
+        (a: string = 'default') => a;
+      `},
+			{Code: `
+        function test(a: string = 'default') {
+          return a;
+        }
+      `},
+			{Code: `
+        class C {
+          public test(a: string = 'default') {
+            return a;
+          }
+        }
+      `},
+			{Code: `
+        const obj: { a: string | undefined } = { a: undefined };
+        const { a = 'default' } = obj;
+      `},
+			{Code: `
+        function test(arr: number[] | undefined = []) {
+          return arr;
+        }
+      `},
+			{Code: `
+        function Bar({ nested: { foo = '' } = {} }: { nested?: { foo?: string } }) {
+          return foo;
+        }
+      `},
+			{Code: `
+        function test(a: any = 'default') {
+          return a;
+        }
+      `},
+			{Code: `
+        function test(a: unknown = 'default') {
+          return a;
+        }
+      `},
+			{Code: `
+        function test(a = 5) {
+          return a;
+        }
+      `},
+			{Code: `
+        function createValidator(): () => void {
+          return (param = 5) => {};
+        }
+      `},
+			{Code: `
+        function Bar({ foo = '' }: { foo: any }) {
+          return foo;
+        }
+      `},
+			{Code: `
+        function Bar({ foo = '' }: { foo: unknown }) {
+          return foo;
+        }
+      `},
+			{Code: `
+        function getValue(): undefined;
+        function getValue(box: { value: string }): string;
+        function getValue({ value = '' }: { value?: string } = {}): string | undefined {
+          return value;
+        }
+      `},
+			{Code: `
+        function getValueObject({ value = '' }: Partial<{ value: string }>) {
+          return value;
+        }
+      `},
+			{Code: `
+        const { value = 'default' } = someUnknownFunction();
+      `},
+			{Code: `
+        const [value = 'default'] = someUnknownFunction();
+      `},
+			{Code: `
+        for (const { value = 'default' } of []) {
+        }
+      `},
+			{Code: `
+        for (const [value = 'default'] of []) {
+        }
+      `},
+			{Code: `
+        declare const x: [[number | undefined]];
+        const [[a = 1]] = x;
+      `},
+			{Code: `
+        function foo(x: string = '') {}
+      `},
+			{Code: `
+        class C {
+          method(x: string = '') {}
+        }
+      `},
+			{Code: `
+        const foo = (x: string = '') => {};
+      `},
+			{Code: `
+        const obj = { ab: { x: 1 } };
+        const {
+          ['a' + 'b']: { x = 1 },
+        } = obj;
+      `},
+			{Code: `
+        const obj = { ab: 1 };
+        const { ['a' + 'b']: x = 1 } = obj;
+      `},
+			{Code: `
+        for ([[a = 1]] of []) {
+        }
+      `},
+			{
+				Code: `
+        declare const g: Array<string>;
+        const [foo = ''] = g;
+      `,
+				TSConfig: "tsconfig.noUncheckedIndexedAccess.json",
+			},
+			{
+				Code: `
+        declare const g: Record<string, string>;
+        const { foo = '' } = g;
+      `,
+				TSConfig: "tsconfig.noUncheckedIndexedAccess.json",
+			},
+			{
+				Code: `
+        declare const h: { [key: string]: string };
+        const { bar = '' } = h;
+      `,
+				TSConfig: "tsconfig.noUncheckedIndexedAccess.json",
+			},
+			{Code: `
+        declare const g: Array<string>;
+        const [foo = ''] = g;
+      `},
+			{Code: `
+        declare const g: Record<string, string>;
+        const { foo = '' } = g;
+      `},
+			{Code: `
+        declare const h: { [key: string]: string };
+        const { bar = '' } = h;
+      `},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11849
+			{Code: `
+        type Merge = boolean | ((incoming: string[]) => void);
+
+        const policy: { merge: Merge } = {
+          merge: (incoming: string[] = []) => {
+            incoming;
+          },
+        };
+      `},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11846
+			{Code: `
+        const [a, b = ''] = 'hello.world'.split('.');
+      `},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11846
+			{Code: `
+        declare const params: string[];
+        const [c = '123'] = params;
+      `},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11846
+			{Code: `
+        declare function useCallback<T>(callback: T);
+        useCallback((value: number[] = []) => {});
+      `},
+			{Code: `
+        declare const tuple: [string];
+        const [a, b = 'default'] = tuple;
+      `},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11911
+			{Code: `
+        const run = (cb: (...args: unknown[]) => void) => cb();
+        const cb = (p: boolean = true) => null;
+        run(cb);
+        run((p: boolean = true) => null);
+      `},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11850
+			{Code: `
+        const { a = 'default' } = Math.random() > 0.5 ? { a: 'Hello' } : {};
+      `},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11850
+			{Code: `
+        const { a = 'default' } =
+          Math.random() > 0.5 ? (Math.random() > 0.5 ? { a: 'Hello' } : {}) : {};
+      `},
+			// Optional parameter with meaningful default value
+			{Code: `
+        function findPosts({
+          category,
+          maxResults = 100,
+        }: {
+          category: string;
+          maxResults?: number;
+        }): Promise<string[]> {
+          return Promise.resolve([category, String(maxResults)]);
+        }
+      `},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11980
+			{Code: `
+        const { a = 'baz' } = cond ? {} : { a: 'bar' };
+      `},
+			{Code: `
+        const { a = 'baz' } = cond ? foo : { a: 'bar' };
+      `},
+			{Code: `
+        const { a = 'baz' } = foo && { a: 'bar' };
+      `},
+			{Code: `
+        const { a = 'baz' } = cond ? { a: 'foo', ...extra } : { a: 'bar' };
+      `},
+			{Code: `
+        const { a = 'baz' } = cond ? { ...foo } : { a: 'bar' };
+      `},
+			{Code: `
+        const key = Math.random() > 0.5 ? 'a' : 'b';
+        const { a = 'baz' } = cond ? { [key]: 'foo' } : { [key]: 'bar' };
+      `},
+			{Code: `
+        const { a = 'baz' } = cond ? foo && { a: 'bar' } : { a: 'baz' };
+      `},
+			{Code: `
+        const obj: unknown = { a: 'bar' };
+        const { a = 'baz' } = cond ? obj : { a: 'bar' };
+      `},
+			{Code: `
+        const sym = Symbol('a');
+        const { a = 'baz' } = cond ? { [sym]: 'foo' } : { [sym]: 'bar' };
+      `},
+			{Code: "\n        const { a = 'baz' } = cond ? { [`a${1}`]: 'foo' } : { a: 'bar' };\n      "},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11948
+			{Code: `
+        class AbstractEntity {
+          public a: string | undefined;
+          public static fromJson<T extends { a: string }>(
+            this: new () => T,
+            { inner = { a: 'test' } }: { inner?: { a: string } },
+          ): T {
+            const entity = new this();
+            entity.a = inner?.a;
+            return entity;
+          }
+        }
+      `},
+			{Code: `
+        type FetchFn<TParams> =
+          Partial<TParams> extends TParams
+            ? (params?: TParams) => void
+            : (params: TParams) => void;
+
+        function createFetcher<TParams>() {
+          type Params = TParams;
+
+          const fn: FetchFn<TParams> = (
+            params: Partial<Params> = {} as Partial<Params>,
+          ) => {
+            console.log(params);
+          };
+
+          return fn;
+        }
+      `},
+			{Code: `
+        interface Foos {
+          bar?: number;
+        }
+        const foos: Foos[] = [];
+        foos.flatMap(({ bar = 42 }) => bar);
+      `},
+			{Code: `
+        function f(this: void, { bar = 42 }: { bar?: number }) {
+          return bar;
+        }
+      `},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `
+        function Bar({ foo = '' }: { foo: string }) {
+          return foo;
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    30,
+						EndColumn: 32,
+					},
+				},
+				Output: []string{`
+        function Bar({ foo }: { foo: string }) {
+          return foo;
+        }
+      `},
+			},
+			{
+				Code: `
+        class C {
+          public method({ foo = '' }: { foo: string }) {
+            return foo;
+          }
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      3,
+						Column:    33,
+						EndColumn: 35,
+					},
+				},
+				Output: []string{`
+        class C {
+          public method({ foo }: { foo: string }) {
+            return foo;
+          }
+        }
+      `},
+			},
+			{
+				Code: `
+        const { 'literal-key': literalKey = 'default' } = { 'literal-key': 'value' };
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    45,
+						EndColumn: 54,
+					},
+				},
+				Output: []string{`
+        const { 'literal-key': literalKey } = { 'literal-key': 'value' };
+      `},
+			},
+			{
+				Code: `
+        [1, 2, 3].map((a = 42) => a + 1);
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    28,
+						EndColumn: 30,
+					},
+				},
+				Output: []string{`
+        [1, 2, 3].map((a) => a + 1);
+      `},
+			},
+			{
+				Code: `
+        function getValue(): undefined;
+        function getValue(box: { value: string }): string;
+        function getValue({ value = '' }: { value: string } = {}): string | undefined {
+          return value;
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      4,
+						Column:    37,
+						EndColumn: 39,
+					},
+				},
+				Output: []string{`
+        function getValue(): undefined;
+        function getValue(box: { value: string }): string;
+        function getValue({ value }: { value: string } = {}): string | undefined {
+          return value;
+        }
+      `},
+			},
+			{
+				Code: `
+        function getValue([value = '']: [string]) {
+          return value;
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    36,
+						EndColumn: 38,
+					},
+				},
+				Output: []string{`
+        function getValue([value]: [string]) {
+          return value;
+        }
+      `},
+			},
+			{
+				Code: `
+        declare const x: { hello: { world: string } };
+
+        const {
+          hello: { world = '' },
+        } = x;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      5,
+						Column:    28,
+						EndColumn: 30,
+					},
+				},
+				Output: []string{`
+        declare const x: { hello: { world: string } };
+
+        const {
+          hello: { world },
+        } = x;
+      `},
+			},
+			{
+				Code: `
+        declare const x: { hello: Array<{ world: string }> };
+
+        const {
+          hello: [{ world = '' }],
+        } = x;
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      5,
+						Column:    29,
+						EndColumn: 31,
+					},
+				},
+				Output: []string{`
+        declare const x: { hello: Array<{ world: string }> };
+
+        const {
+          hello: [{ world }],
+        } = x;
+      `},
+			},
+			{
+				Code: `
+        interface B {
+          foo: (b: boolean | string) => void;
+        }
+
+        const h: B = {
+          foo: (b = false) => {},
+        };
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      7,
+						Column:    21,
+						EndColumn: 26,
+					},
+				},
+				Output: []string{`
+        interface B {
+          foo: (b: boolean | string) => void;
+        }
+
+        const h: B = {
+          foo: (b) => {},
+        };
+      `},
+			},
+			{
+				Code: `
+        function foo(a = undefined) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessUndefined",
+						Line:      2,
+						Column:    26,
+						EndColumn: 35,
+					},
+				},
+				Output: []string{`
+        function foo(a) {}
+      `},
+			},
+			{
+				Code: `
+        const { a = undefined } = {};
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessUndefined",
+						Line:      2,
+						Column:    21,
+						EndColumn: 30,
+					},
+				},
+				Output: []string{`
+        const { a } = {};
+      `},
+			},
+			{
+				Code: `
+        const [a = undefined] = [];
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessUndefined",
+						Line:      2,
+						Column:    20,
+						EndColumn: 29,
+					},
+				},
+				Output: []string{`
+        const [a] = [];
+      `},
+			},
+			{
+				Code: `
+        function foo({ a = undefined }) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessUndefined",
+						Line:      2,
+						Column:    28,
+						EndColumn: 37,
+					},
+				},
+				Output: []string{`
+        function foo({ a }) {}
+      `},
+			},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11847
+			{
+				Code: `
+        function myFunction(p1: string, p2: number | undefined = undefined) {
+          console.log(p1, p2);
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "preferOptionalSyntax",
+						Line:      2,
+						Column:    66,
+						EndColumn: 75,
+					},
+				},
+				Output: []string{`
+        function myFunction(p1: string, p2?: number | undefined) {
+          console.log(p1, p2);
+        }
+      `},
+			},
+			{
+				Code: `
+        type SomeType = number | undefined;
+        function f(
+          /* comment */ x /* comment 2 */ : /* comment 3 */ SomeType /* comment 4 */ = /* comment 5 */ undefined,
+        ) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "preferOptionalSyntax",
+						Line:      4,
+						Column:    104,
+						EndColumn: 113,
+					},
+				},
+				Output: []string{`
+        type SomeType = number | undefined;
+        function f(
+          /* comment */ x? /* comment 2 */ : /* comment 3 */ SomeType,
+        ) {}
+      `},
+			},
+			// noStrictNullCheck tests — upstream sets tsconfigRootDir to the 'unstrict'
+			// fixture dir, which we mirror via TSConfig: "tsconfig.unstrict.json".
+			{
+				Code: `
+        function Bar({ foo = '' }: { foo: string }) {
+          return foo;
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noStrictNullCheck",
+						Line:      0,
+						Column:    1,
+					},
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    30,
+						EndColumn: 32,
+					},
+				},
+				TSConfig: "tsconfig.unstrict.json",
+				Output: []string{`
+        function Bar({ foo }: { foo: string }) {
+          return foo;
+        }
+      `},
+			},
+			{
+				Code: `
+        function foo(a = undefined) {}
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noStrictNullCheck",
+						Line:      0,
+						Column:    1,
+					},
+					{
+						MessageId: "uselessUndefined",
+						Line:      2,
+						Column:    26,
+						EndColumn: 35,
+					},
+				},
+				TSConfig: "tsconfig.unstrict.json",
+				Output: []string{`
+        function foo(a) {}
+      `},
+			},
+			{
+				Code: `
+        function Bar({ foo = '' }: { foo: string }) {
+          return foo;
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    30,
+						EndColumn: 32,
+					},
+				},
+				TSConfig: "tsconfig.unstrict.json",
+				Options: map[string]interface{}{
+					"allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": true,
+				},
+				Output: []string{`
+        function Bar({ foo }: { foo: string }) {
+          return foo;
+        }
+      `},
+			},
+			// https://github.com/typescript-eslint/typescript-eslint/issues/11980
+			{
+				Code: `
+        const { a = 'baz' } = Math.random() < 0.5 ? { a: 'foo' } : { a: 'bar' };
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    21,
+						EndColumn: 26,
+					},
+				},
+				Output: []string{`
+        const { a } = Math.random() < 0.5 ? { a: 'foo' } : { a: 'bar' };
+      `},
+			},
+			{
+				Code: `
+        const { a = 'baz' } =
+          Math.random() < 0.5
+            ? { a: 'foo' }
+            : Math.random() > 0.2
+              ? { a: 'bar' }
+              : { a: 'qux' };
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    21,
+						EndColumn: 26,
+					},
+				},
+				Output: []string{`
+        const { a } =
+          Math.random() < 0.5
+            ? { a: 'foo' }
+            : Math.random() > 0.2
+              ? { a: 'bar' }
+              : { a: 'qux' };
+      `},
+			},
+			{
+				Code: `
+        const { a = 'baz' } = cond ? { ['a']: 'foo' } : { ['a']: 'bar' };
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    21,
+						EndColumn: 26,
+					},
+				},
+				Output: []string{`
+        const { a } = cond ? { ['a']: 'foo' } : { ['a']: 'bar' };
+      `},
+			},
+			{
+				Code: `
+        const { a = 'baz' } = cond ? { a() {} } : { a: 'bar' };
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    21,
+						EndColumn: 26,
+					},
+				},
+				Output: []string{`
+        const { a } = cond ? { a() {} } : { a: 'bar' };
+      `},
+			},
+			{
+				Code: "\n        const { a = 'b' } = Math.random() < 0.5 ? { [`a`]: 'a' } : { a: 'b' };\n      ",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "uselessDefaultAssignment",
+						Line:      2,
+						Column:    21,
+						EndColumn: 24,
+					},
+				},
+				Output: []string{"\n        const { a } = Math.random() < 0.5 ? { [`a`]: 'a' } : { a: 'b' };\n      "},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -318,6 +318,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-declare.test.ts',
     // './tests/typescript-eslint/rules/no-use-before-define.test.ts',
     './tests/typescript-eslint/rules/no-useless-constructor.test.ts',
+    './tests/typescript-eslint/rules/no-useless-default-assignment.test.ts',
     // './tests/typescript-eslint/rules/no-useless-empty-export.test.ts',
     // './tests/typescript-eslint/rules/no-var-requires.test.ts',
     './tests/typescript-eslint/rules/no-wrapper-object-types.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-useless-default-assignment.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-useless-default-assignment.test.ts.snap
@@ -1,0 +1,374 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-default-assignment > invalid 1`] = `
+{
+  "code": "
+function Bar({ foo = '' }: { foo: string }) {
+  return foo;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Default value is useless because the property is not optional.",
+      "messageId": "uselessDefaultAssignment",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 2,
+        },
+        "start": {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function Bar({ foo }: { foo: string }) {
+  return foo;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-default-assignment > invalid 2`] = `
+{
+  "code": "
+class C {
+  public method({ foo = '' }: { foo: string }) {
+    return foo;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Default value is useless because the property is not optional.",
+      "messageId": "uselessDefaultAssignment",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 25,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class C {
+  public method({ foo }: { foo: string }) {
+    return foo;
+  }
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-default-assignment > invalid 3`] = `
+{
+  "code": "
+const { 'literal-key': literalKey = 'default' } = { 'literal-key': 'value' };
+      ",
+  "diagnostics": [
+    {
+      "message": "Default value is useless because the property is not optional.",
+      "messageId": "uselessDefaultAssignment",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 2,
+        },
+        "start": {
+          "column": 37,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+const { 'literal-key': literalKey } = { 'literal-key': 'value' };
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-default-assignment > invalid 4`] = `
+{
+  "code": "
+[1, 2, 3].map((a = 42) => a + 1);
+      ",
+  "diagnostics": [
+    {
+      "message": "Default value is useless because the parameter is not optional.",
+      "messageId": "uselessDefaultAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 2,
+        },
+        "start": {
+          "column": 20,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+[1, 2, 3].map((a) => a + 1);
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-default-assignment > invalid 5`] = `
+{
+  "code": "
+function getValue([value = '']: [string]) {
+  return value;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Default value is useless because the property is not optional.",
+      "messageId": "uselessDefaultAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 2,
+        },
+        "start": {
+          "column": 28,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function getValue([value]: [string]) {
+  return value;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-default-assignment > invalid 6`] = `
+{
+  "code": "
+interface B {
+  foo: (b: boolean | string) => void;
+}
+
+const h: B = {
+  foo: (b = false) => {},
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Default value is useless because the parameter is not optional.",
+      "messageId": "uselessDefaultAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 7,
+        },
+        "start": {
+          "column": 13,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+interface B {
+  foo: (b: boolean | string) => void;
+}
+
+const h: B = {
+  foo: (b) => {},
+};
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-default-assignment > invalid 7`] = `
+{
+  "code": "
+function foo(a = undefined) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Default value is useless because it is undefined. Optional parameters are already undefined by default.",
+      "messageId": "uselessUndefined",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 2,
+        },
+        "start": {
+          "column": 18,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function foo(a) {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-default-assignment > invalid 8`] = `
+{
+  "code": "
+const { a = undefined } = {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Default value is useless because it is undefined. Optional propertys are already undefined by default.",
+      "messageId": "uselessUndefined",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 2,
+        },
+        "start": {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+const { a } = {};
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-default-assignment > invalid 9`] = `
+{
+  "code": "
+const [a = undefined] = [];
+      ",
+  "diagnostics": [
+    {
+      "message": "Default value is useless because it is undefined. Optional propertys are already undefined by default.",
+      "messageId": "uselessUndefined",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+const [a] = [];
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-default-assignment > invalid 10`] = `
+{
+  "code": "
+function foo({ a = undefined }) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Default value is useless because it is undefined. Optional propertys are already undefined by default.",
+      "messageId": "uselessUndefined",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 2,
+        },
+        "start": {
+          "column": 20,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function foo({ a }) {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-default-assignment > invalid 11`] = `
+{
+  "code": "
+function myFunction(p1: string, p2: number | undefined = undefined) {
+  console.log(p1, p2);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Using \`= undefined\` to make a parameter optional adds unnecessary runtime logic. Use the \`?\` optional syntax instead.",
+      "messageId": "preferOptionalSyntax",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 2,
+        },
+        "start": {
+          "column": 58,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-default-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function myFunction(p1: string, p2?: number | undefined) {
+  console.log(p1, p2);
+}
+      ",
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-useless-default-assignment.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-useless-default-assignment.test.ts
@@ -1,0 +1,400 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { getFixturesRootDir } from '../RuleTester';
+
+const rootDir = getFixturesRootDir();
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      project: './tsconfig.json',
+      projectService: false,
+      tsconfigRootDir: rootDir,
+    },
+  },
+});
+
+ruleTester.run('no-useless-default-assignment', {
+  valid: [
+    `
+function Bar({ foo = '' }: { foo?: string }) {
+  return foo;
+}
+    `,
+    `
+const { foo } = { foo: 'bar' };
+    `,
+    `
+[1, 2, 3, undefined].map((a = 42) => a + 1);
+    `,
+    `
+function test(a?: number) {
+  return a;
+}
+    `,
+    `
+const obj: { a?: string } = {};
+const { a = 'default' } = obj;
+    `,
+    `
+function test(a: string | undefined = 'default') {
+  return a;
+}
+    `,
+    `
+(a: string = 'default') => a;
+    `,
+    `
+function test(a: string = 'default') {
+  return a;
+}
+    `,
+    `
+class C {
+  public test(a: string = 'default') {
+    return a;
+  }
+}
+    `,
+    `
+const obj: { a: string | undefined } = { a: undefined };
+const { a = 'default' } = obj;
+    `,
+    `
+function test(arr: number[] | undefined = []) {
+  return arr;
+}
+    `,
+    `
+function Bar({ nested: { foo = '' } = {} }: { nested?: { foo?: string } }) {
+  return foo;
+}
+    `,
+    `
+function test(a: any = 'default') {
+  return a;
+}
+    `,
+    `
+function test(a: unknown = 'default') {
+  return a;
+}
+    `,
+    `
+function test(a = 5) {
+  return a;
+}
+    `,
+    `
+function createValidator(): () => void {
+  return (param = 5) => {};
+}
+    `,
+    `
+function getValue(): undefined;
+function getValue(box: { value: string }): string;
+function getValue({ value = '' }: { value?: string } = {}): string | undefined {
+  return value;
+}
+    `,
+    `
+function getValueObject({ value = '' }: Partial<{ value: string }>) {
+  return value;
+}
+    `,
+    `
+const { value = 'default' } = someUnknownFunction();
+    `,
+    `
+const [value = 'default'] = someUnknownFunction();
+    `,
+    `
+for (const { value = 'default' } of []) {
+}
+    `,
+    `
+for (const [value = 'default'] of []) {
+}
+    `,
+    `
+declare const x: [[number | undefined]];
+const [[a = 1]] = x;
+    `,
+    `
+function foo(x: string = '') {}
+    `,
+    `
+const foo = (x: string = '') => {};
+    `,
+    `
+declare const g: Array<string>;
+const [foo = ''] = g;
+    `,
+    `
+declare const g: Record<string, string>;
+const { foo = '' } = g;
+    `,
+    `
+declare const h: { [key: string]: string };
+const { bar = '' } = h;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11849
+    `
+type Merge = boolean | ((incoming: string[]) => void);
+
+const policy: { merge: Merge } = {
+  merge: (incoming: string[] = []) => {
+    incoming;
+  },
+};
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11846
+    `
+const [a, b = ''] = 'somestr'.split('.');
+    `,
+    `
+declare const params: string[];
+const [c = '123'] = params;
+    `,
+    `
+declare function useCallback<T>(callback: T);
+useCallback((value: number[] = []) => {});
+    `,
+    `
+declare const tuple: [string];
+const [a, b = 'default'] = tuple;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11850
+    `
+const { a = 'default' } = Math.random() > 0.5 ? { a: 'Hello' } : {};
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11980
+    `
+const { a = 'baz' } = cond ? {} : { a: 'bar' };
+    `,
+    `
+const { a = 'baz' } = foo && { a: 'bar' };
+    `,
+    `
+const { a = 'baz' } = cond ? { a: 'foo', ...extra } : { a: 'bar' };
+    `,
+    `
+const { a = 'baz' } = cond ? { ...foo } : { a: 'bar' };
+    `,
+    `
+function f(this: void, { bar = 42 }: { bar?: number }) {
+  return bar;
+}
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+function Bar({ foo = '' }: { foo: string }) {
+  return foo;
+}
+      `,
+      errors: [
+        {
+          column: 22,
+          endColumn: 24,
+          line: 2,
+          messageId: 'uselessDefaultAssignment',
+        },
+      ],
+      output: `
+function Bar({ foo }: { foo: string }) {
+  return foo;
+}
+      `,
+    },
+    {
+      code: `
+class C {
+  public method({ foo = '' }: { foo: string }) {
+    return foo;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 25,
+          endColumn: 27,
+          line: 3,
+          messageId: 'uselessDefaultAssignment',
+        },
+      ],
+      output: `
+class C {
+  public method({ foo }: { foo: string }) {
+    return foo;
+  }
+}
+      `,
+    },
+    {
+      code: `
+const { 'literal-key': literalKey = 'default' } = { 'literal-key': 'value' };
+      `,
+      errors: [
+        {
+          column: 37,
+          endColumn: 46,
+          line: 2,
+          messageId: 'uselessDefaultAssignment',
+        },
+      ],
+      output: `
+const { 'literal-key': literalKey } = { 'literal-key': 'value' };
+      `,
+    },
+    {
+      code: `
+[1, 2, 3].map((a = 42) => a + 1);
+      `,
+      errors: [
+        {
+          column: 20,
+          endColumn: 22,
+          line: 2,
+          messageId: 'uselessDefaultAssignment',
+        },
+      ],
+      output: `
+[1, 2, 3].map((a) => a + 1);
+      `,
+    },
+    {
+      code: `
+function getValue([value = '']: [string]) {
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 28,
+          endColumn: 30,
+          line: 2,
+          messageId: 'uselessDefaultAssignment',
+        },
+      ],
+      output: `
+function getValue([value]: [string]) {
+  return value;
+}
+      `,
+    },
+    {
+      code: `
+interface B {
+  foo: (b: boolean | string) => void;
+}
+
+const h: B = {
+  foo: (b = false) => {},
+};
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 18,
+          line: 7,
+          messageId: 'uselessDefaultAssignment',
+        },
+      ],
+      output: `
+interface B {
+  foo: (b: boolean | string) => void;
+}
+
+const h: B = {
+  foo: (b) => {},
+};
+      `,
+    },
+    {
+      code: `
+function foo(a = undefined) {}
+      `,
+      errors: [
+        {
+          column: 18,
+          endColumn: 27,
+          line: 2,
+          messageId: 'uselessUndefined',
+        },
+      ],
+      output: `
+function foo(a) {}
+      `,
+    },
+    {
+      code: `
+const { a = undefined } = {};
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 22,
+          line: 2,
+          messageId: 'uselessUndefined',
+        },
+      ],
+      output: `
+const { a } = {};
+      `,
+    },
+    {
+      code: `
+const [a = undefined] = [];
+      `,
+      errors: [
+        {
+          column: 12,
+          endColumn: 21,
+          line: 2,
+          messageId: 'uselessUndefined',
+        },
+      ],
+      output: `
+const [a] = [];
+      `,
+    },
+    {
+      code: `
+function foo({ a = undefined }) {}
+      `,
+      errors: [
+        {
+          column: 20,
+          endColumn: 29,
+          line: 2,
+          messageId: 'uselessUndefined',
+        },
+      ],
+      output: `
+function foo({ a }) {}
+      `,
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11847
+    {
+      code: `
+function myFunction(p1: string, p2: number | undefined = undefined) {
+  console.log(p1, p2);
+}
+      `,
+      errors: [
+        {
+          column: 58,
+          endColumn: 67,
+          line: 2,
+          messageId: 'preferOptionalSyntax',
+        },
+      ],
+      output: `
+function myFunction(p1: string, p2?: number | undefined) {
+  console.log(p1, p2);
+}
+      `,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-useless-default-assignment` rule to rslint. It flags default values (parameter defaults and destructuring `= D` defaults) that can never be reached because the source type guarantees a non-`undefined` value, and collapses `= undefined` parameter defaults whose annotation already admits undefined to the `?` optional-syntax form.

Verified against upstream `@typescript-eslint/eslint-plugin@8.59` by running both implementations on the real-world `rsbuild` and `rspack` codebases: all 6 real diagnostics produced are identical between rslint and upstream (same file/line/column, same `messageId`, same message text, same fix range).

## Related Links

- typescript-eslint rule: https://typescript-eslint.io/rules/no-useless-default-assignment
- Upstream source: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).