### PR TITLE
feat: port rule @typescript-eslint/prefer-function-type

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,6 +114,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_enum_initializers"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_find"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_for_of"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_function_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_includes"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_literal_enum_member"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_namespace_keyword"
@@ -639,6 +640,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-literal-enum-member", prefer_literal_enum_member.PreferLiteralEnumMemberRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-namespace-keyword", prefer_namespace_keyword.PreferNamespaceKeywordRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-for-of", prefer_for_of.PreferForOfRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/prefer-function-type", prefer_function_type.PreferFunctionTypeRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-nullish-coalescing", prefer_nullish_coalescing.PreferNullishCoalescingRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-optional-chain", prefer_optional_chain.PreferOptionalChainRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-promise-reject-errors", prefer_promise_reject_errors.PreferPromiseRejectErrorsRule)

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.go
@@ -74,8 +74,8 @@ func collectCommentsForward(text string, start, limit int) []core.TextRange {
 		if pos+1 < limit && text[pos] == '/' && text[pos+1] == '*' {
 			cStart := pos
 			pos += 2
-			for pos+1 < limit {
-				if text[pos] == '*' && text[pos+1] == '/' {
+			for pos < limit {
+				if pos+1 < limit && text[pos] == '*' && text[pos+1] == '/' {
 					pos += 2
 					break
 				}
@@ -259,19 +259,22 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 			suggestion = "type " + buildInterfaceHeader(node.AsInterfaceDeclaration()) + " = " + suggestion + lastChar
 		}
 
+		nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+
 		// Collect leading and trailing comments by scanning the trivia regions
 		// directly. tsgo's scanner.GetLeadingCommentRanges only collects line-
 		// boundary-adjacent comments, so it misses same-line inline blocks like
 		// `{ /* c */ (): void }` that the upstream rule needs to relocate.
+		// Trailing scan is capped at the containing node's end so comments
+		// outside the type-literal / interface body never leak in.
 		comments := append(
 			collectCommentsForward(sourceText, member.Pos(), memberStart),
-			collectCommentsForward(sourceText, memberEnd, len(sourceText))...,
+			collectCommentsForward(sourceText, memberEnd, nodeRange.End())...,
 		)
 
 		memberLine := scanner.ComputeLineOfPosition(lineStarts, memberStart)
 
 		var fixes []rule.RuleFix
-		nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
 
 		// `export interface Foo` has comments moved before `export` so they
 		// don't end up between `export` and the resulting `type` declaration.

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.go
@@ -1,0 +1,356 @@
+package prefer_function_type
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func phrase(kind ast.Kind) string {
+	switch kind {
+	case ast.KindInterfaceDeclaration:
+		return "Interface"
+	case ast.KindTypeLiteral:
+		return "Type literal"
+	}
+	return ""
+}
+
+func functionTypeOverCallableTypeMessage(literalOrInterface string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "functionTypeOverCallableType",
+		Description: literalOrInterface + " only has a call signature, you should use a function type instead.",
+		Data: map[string]string{
+			"literalOrInterface": literalOrInterface,
+		},
+	}
+}
+
+func unexpectedThisMessage(interfaceName string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "unexpectedThisOnFunctionOnlyInterface",
+		Description: "`this` refers to the function type '" + interfaceName +
+			"', did you intend to use a generic `this` parameter like `<Self>(this: Self, ...) => Self` instead?",
+		Data: map[string]string{
+			"interfaceName": interfaceName,
+		},
+	}
+}
+
+var PreferFunctionTypeRule = rule.CreateRule(rule.Rule{
+	Name: "prefer-function-type",
+	Run:  run,
+})
+
+// collectCommentsForward walks `text` starting at `start`, skipping whitespace
+// and collecting every `//` or `/* ... */` comment it sees. It stops at the
+// first non-trivia character or at `limit`. Used in place of
+// scanner.GetLeadingCommentRanges because that helper only collects comments
+// adjacent to line breaks, missing same-line inline blocks like
+// `{ /* c */ (): void }` that the rule needs to relocate.
+func collectCommentsForward(text string, start, limit int) []core.TextRange {
+	var result []core.TextRange
+	pos := start
+	for pos < limit {
+		ch := text[pos]
+		switch ch {
+		case ' ', '\t', '\n', '\r', '\v', '\f':
+			pos++
+			continue
+		}
+		if pos+1 < limit && text[pos] == '/' && text[pos+1] == '/' {
+			cStart := pos
+			pos += 2
+			for pos < limit && text[pos] != '\n' && text[pos] != '\r' {
+				pos++
+			}
+			result = append(result, core.NewTextRange(cStart, pos))
+			continue
+		}
+		if pos+1 < limit && text[pos] == '/' && text[pos+1] == '*' {
+			cStart := pos
+			pos += 2
+			for pos+1 < limit {
+				if text[pos] == '*' && text[pos+1] == '/' {
+					pos += 2
+					break
+				}
+				pos++
+			}
+			result = append(result, core.NewTextRange(cStart, pos))
+			continue
+		}
+		return result
+	}
+	return result
+}
+
+func run(ctx rule.RuleContext, options any) rule.RuleListeners {
+	sourceText := ctx.SourceFile.Text()
+	lineStarts := ctx.SourceFile.ECMALineMap()
+
+	// hasOneNonFunctionSupertype mirrors upstream's hasOneSupertype(): an
+	// interface with `extends X[, Y, ...]` is skipped unless the only supertype
+	// is literally the `Function` identifier.
+	hasOneNonFunctionSupertype := func(iface *ast.InterfaceDeclaration) bool {
+		if iface.HeritageClauses == nil {
+			return false
+		}
+		var extends []*ast.Node
+		for _, clause := range iface.HeritageClauses.Nodes {
+			hc := clause.AsHeritageClause()
+			if hc == nil || hc.Token != ast.KindExtendsKeyword || hc.Types == nil {
+				continue
+			}
+			extends = append(extends, hc.Types.Nodes...)
+		}
+		if len(extends) == 0 {
+			return false
+		}
+		if len(extends) != 1 {
+			return true
+		}
+		expr := extends[0].AsExpressionWithTypeArguments().Expression
+		if expr == nil || expr.Kind != ast.KindIdentifier || expr.AsIdentifier().Text != "Function" {
+			return true
+		}
+		return false
+	}
+
+	shouldWrapSuggestion := func(parent *ast.Node) bool {
+		if parent == nil {
+			return false
+		}
+		switch parent.Kind {
+		case ast.KindUnionType, ast.KindIntersectionType, ast.KindArrayType:
+			return true
+		}
+		return false
+	}
+
+	// collectThisTypes walks the interface for `this` type references that are
+	// not nested inside a TypeLiteral. Mirrors upstream's
+	// 'TSInterfaceDeclaration TSThisType' visitor with literalNesting tracking.
+	collectThisTypes := func(root *ast.Node) []*ast.Node {
+		var result []*ast.Node
+		nesting := 0
+		var visit func(n *ast.Node)
+		visit = func(n *ast.Node) {
+			if n == nil {
+				return
+			}
+			if n.Kind == ast.KindTypeLiteral {
+				nesting++
+				n.ForEachChild(func(child *ast.Node) bool {
+					visit(child)
+					return false
+				})
+				nesting--
+				return
+			}
+			if n.Kind == ast.KindThisType {
+				if nesting == 0 {
+					result = append(result, n)
+				}
+				return
+			}
+			n.ForEachChild(func(child *ast.Node) bool {
+				visit(child)
+				return false
+			})
+		}
+		visit(root)
+		return result
+	}
+
+	// buildInterfaceHeader returns the verbatim `Name<TypeParams>` text used to
+	// prefix the rewritten type alias. Includes the angle brackets when type
+	// parameters exist; constraints / defaults / variance markers are picked up
+	// for free because we slice raw source.
+	buildInterfaceHeader := func(iface *ast.InterfaceDeclaration) string {
+		nameText := utils.TrimmedNodeText(ctx.SourceFile, iface.Name())
+		if iface.TypeParameters == nil || len(iface.TypeParameters.Nodes) == 0 {
+			return nameText
+		}
+		params := iface.TypeParameters.Nodes
+		lastParam := params[len(params)-1]
+		lastParamEnd := utils.TrimNodeTextRange(ctx.SourceFile, lastParam).End()
+		gtPos := lastParamEnd
+		for gtPos < len(sourceText) && sourceText[gtPos] != '>' {
+			gtPos++
+		}
+		if gtPos < len(sourceText) {
+			gtPos++
+		}
+		nameStart := utils.TrimNodeTextRange(ctx.SourceFile, iface.Name()).Pos()
+		return sourceText[nameStart:gtPos]
+	}
+
+	checkMember := func(member *ast.Node, node *ast.Node, tsThisTypes []*ast.Node) {
+		var returnType *ast.Node
+		switch member.Kind {
+		case ast.KindCallSignature:
+			returnType = member.AsCallSignatureDeclaration().Type
+		case ast.KindConstructSignature:
+			returnType = member.AsConstructSignatureDeclaration().Type
+		default:
+			return
+		}
+		if returnType == nil {
+			return
+		}
+
+		isInterface := node.Kind == ast.KindInterfaceDeclaration
+
+		if isInterface && len(tsThisTypes) > 0 {
+			interfaceName := node.AsInterfaceDeclaration().Name().AsIdentifier().Text
+			ctx.ReportNode(tsThisTypes[0], unexpectedThisMessage(interfaceName))
+			return
+		}
+
+		msg := functionTypeOverCallableTypeMessage(phrase(node.Kind))
+
+		hasExport := isInterface && ast.HasSyntacticModifier(node, ast.ModifierFlagsExport)
+		hasDefault := isInterface && ast.HasSyntacticModifier(node, ast.ModifierFlagsDefault)
+
+		// Upstream marks `export default interface ...` as non-fixable because
+		// the fix would need to split it into a type alias plus a separate
+		// `export default` statement.
+		if hasExport && hasDefault {
+			ctx.ReportNode(member, msg)
+			return
+		}
+
+		memberRange := utils.TrimNodeTextRange(ctx.SourceFile, member)
+		memberStart := memberRange.Pos()
+		memberEnd := memberRange.End()
+		text := sourceText[memberStart:memberEnd]
+
+		// Find the ':' before the return type. The return type node starts at
+		// the type token itself (whitespace skipped); the ':' immediately
+		// precedes it (modulo whitespace).
+		returnTypeStart := utils.TrimNodeTextRange(ctx.SourceFile, returnType).Pos()
+		colonPos := returnTypeStart - 1
+		for colonPos >= memberStart && sourceText[colonPos] != ':' {
+			colonPos--
+		}
+		if colonPos < memberStart {
+			ctx.ReportNode(member, msg)
+			return
+		}
+		colonOffset := colonPos - memberStart
+
+		suggestion := text[:colonOffset] + " =>" + text[colonOffset+1:]
+		lastChar := ""
+		if strings.HasSuffix(suggestion, ";") {
+			lastChar = ";"
+			suggestion = suggestion[:len(suggestion)-1]
+		}
+
+		if shouldWrapSuggestion(node.Parent) {
+			suggestion = "(" + suggestion + ")"
+		}
+
+		if isInterface {
+			suggestion = "type " + buildInterfaceHeader(node.AsInterfaceDeclaration()) + " = " + suggestion + lastChar
+		}
+
+		// Collect leading and trailing comments by scanning the trivia regions
+		// directly. tsgo's scanner.GetLeadingCommentRanges only collects line-
+		// boundary-adjacent comments, so it misses same-line inline blocks like
+		// `{ /* c */ (): void }` that the upstream rule needs to relocate.
+		comments := append(
+			collectCommentsForward(sourceText, member.Pos(), memberStart),
+			collectCommentsForward(sourceText, memberEnd, len(sourceText))...,
+		)
+
+		memberLine := scanner.ComputeLineOfPosition(lineStarts, memberStart)
+
+		var fixes []rule.RuleFix
+		nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+
+		// `export interface Foo` has comments moved before `export` so they
+		// don't end up between `export` and the resulting `type` declaration.
+		if isInterface && hasExport && !hasDefault {
+			var commentsText strings.Builder
+			for _, c := range comments {
+				commentsText.WriteString(sourceText[c.Pos():c.End()])
+				commentsText.WriteByte('\n')
+			}
+			if commentsText.Len() > 0 {
+				fixes = append(fixes, rule.RuleFix{
+					Text:  commentsText.String(),
+					Range: core.NewTextRange(nodeRange.Pos(), nodeRange.Pos()),
+				})
+			}
+		} else {
+			for _, c := range comments {
+				cText := sourceText[c.Pos():c.End()]
+				if scanner.ComputeLineOfPosition(lineStarts, c.Pos()) == memberLine {
+					cText += " "
+				} else {
+					cText += "\n"
+				}
+				suggestion = cText + suggestion
+			}
+		}
+
+		// For interfaces, only replace from the `interface` keyword onwards.
+		// Preserving the modifier prefix verbatim avoids dropping any trivia
+		// (e.g. comments) that lives between modifiers, exactly matching
+		// upstream's `replaceTextRange([declaration.range[0], ...])` semantics
+		// — ESTree's `declaration.range[0]` is the `interface` keyword, not
+		// the first modifier.
+		replaceStart := nodeRange.Pos()
+		if isInterface {
+			modifiers := node.AsInterfaceDeclaration().Modifiers()
+			var scanFrom int
+			if modifiers != nil && len(modifiers.Nodes) > 0 {
+				scanFrom = modifiers.Nodes[len(modifiers.Nodes)-1].End()
+			} else {
+				scanFrom = nodeRange.Pos()
+			}
+			s := scanner.GetScannerForSourceFile(ctx.SourceFile, scanFrom)
+			for s.TokenStart() < nodeRange.End() {
+				if s.Token() == ast.KindInterfaceKeyword {
+					replaceStart = s.TokenStart()
+					break
+				}
+				s.Scan()
+			}
+		}
+
+		fixes = append(fixes, rule.RuleFix{
+			Text:  suggestion,
+			Range: core.NewTextRange(replaceStart, nodeRange.End()),
+		})
+
+		ctx.ReportNodeWithFixes(member, msg, fixes...)
+	}
+
+	return rule.RuleListeners{
+		ast.KindInterfaceDeclaration: func(node *ast.Node) {
+			iface := node.AsInterfaceDeclaration()
+			if hasOneNonFunctionSupertype(iface) {
+				return
+			}
+			if iface.Members == nil || len(iface.Members.Nodes) != 1 {
+				return
+			}
+			member := iface.Members.Nodes[0]
+			tsThisTypes := collectThisTypes(member)
+			checkMember(member, node, tsThisTypes)
+		},
+		ast.KindTypeLiteral: func(node *ast.Node) {
+			typeLit := node.AsTypeLiteralNode()
+			if typeLit.Members == nil || len(typeLit.Members.Nodes) != 1 {
+				return
+			}
+			checkMember(typeLit.Members.Nodes[0], node, nil)
+		},
+	}
+}

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.md
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.md
@@ -1,0 +1,69 @@
+# prefer-function-type
+
+## Rule Details
+
+Enforce using function types instead of interfaces with call signatures.
+
+TypeScript allows declaring a function type in two ways: as a function type (`() => string`) or as an object type with a single call signature (`{ (): string }`). The former is more concise, so this rule reports the latter on interfaces and type literals whose only member is a single call signature (or construct signature) and offers an autofix to rewrite them.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+interface Example {
+  (): string;
+}
+
+function foo(example: { (): number }): number {
+  return example();
+}
+
+interface ReturnsSelf {
+  // returns `this` directly, not a `this` type parameter
+  (arg: string): this;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+type Example = () => string;
+
+function foo(example: () => number): number {
+  return example();
+}
+
+// `this` parameter via a generic to avoid the
+// `unexpectedThisOnFunctionOnlyInterface` warning:
+type ReturnsSelf<Self> = (this: Self, arg: string) => Self;
+
+// Has additional properties besides the call signature:
+function foo(bar: { (): string; baz: number }): string {
+  return bar();
+}
+
+// Multiple call signatures (overloads):
+interface Overloaded {
+  (data: string): number;
+  (id: number): string;
+}
+
+// `extends` something other than `Function`:
+interface Foo {
+  bar: string;
+}
+interface Bar extends Foo {
+  (): void;
+}
+```
+
+## Options
+
+This rule has no options.
+
+## When Not To Use It
+
+Disable this rule if you prefer interfaces or object type literals for stylistic consistency, or if you rely on declaration merging (e.g. augmenting the global `Function` interface) — those cases occasionally produce false positives that can be silenced with an inline disable comment.
+
+## Original Documentation
+
+- [typescript-eslint prefer-function-type](https://typescript-eslint.io/rules/prefer-function-type)

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_extras_test.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_extras_test.go
@@ -918,6 +918,123 @@ export type Handler<T> = (event: T) => void;
 			},
 		},
 
+		// ---- Dimension 4: type parameter with nested generic constraint —
+		//      `T extends Map<K, V>`. The constraint contains a `>` of its
+		//      own; the header-slicing loop must walk past it and find the
+		//      type-parameter list's closing `>`, not the inner one.
+		{
+			Code: `
+interface Cache<T extends Map<string, number>> {
+  (key: T): number;
+}
+      `,
+			Output: []string{`
+type Cache<T extends Map<string, number>> = (key: T) => number;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in nested single-member type literal inside a single-
+		//      member interface. Both listeners fire (outer interface +
+		//      inner type literal); the fix outputs overlap so rule-tester
+		//      applies them across multiple passes — the final state has
+		//      both rewrites composed.
+		{
+			Code: `
+interface Outer {
+  (): { (): void };
+}
+      `,
+			Output: []string{`
+type Outer = () => { (): void };
+      `, `
+type Outer = () => () => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Locks in ConstructSignature with its own type parameters
+		//      living inside a type literal (the previous test had it in an
+		//      interface). Separate AST path: TypeLiteral listener +
+		//      ConstructSignatureDeclaration with TypeParameters.
+		{
+			Code: `
+type Ctor = { new <T>(arg: T): T };
+      `,
+			Output: []string{`
+type Ctor = new <T>(arg: T) => T;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    15,
+				},
+			},
+		},
+
+		// ---- Dimension 4: interface nested inside a namespace. The
+		//      InterfaceDeclaration listener fires the same way; the parent
+		//      ModuleBlock should not influence the rewrite.
+		{
+			Code: `
+namespace N {
+  export interface Handler {
+    (event: string): void;
+  }
+}
+      `,
+			Output: []string{`
+namespace N {
+  export type Handler = (event: string) => void;
+}
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      4,
+					Column:    5,
+				},
+			},
+		},
+
+		// ---- Dimension 4: mapped-type value containing a single-member type
+		//      literal — `{ [K in keyof T]: { (): void } }`. Locks in that the
+		//      TypeLiteral listener fires regardless of being inside a
+		//      MappedTypeNode value position.
+		{
+			Code: `
+type Listeners<T> = { [K in keyof T]: { (event: T[K]): void } };
+      `,
+			Output: []string{`
+type Listeners<T> = { [K in keyof T]: (event: T[K]) => void };
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    41,
+				},
+			},
+		},
+
 		// ---- Real-user: comment between modifier and `interface` keyword.
 		//      `export /* note */ interface Foo` must preserve the
 		//      `/* note */` verbatim — replace range starts at `interface`,

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_extras_test.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_extras_test.go
@@ -1,0 +1,1096 @@
+// TestPreferFunctionTypeExtras locks in branches and edge shapes that the
+// upstream test suite does not exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors cannot silently regress them without breaking a
+// named lock-in.
+package prefer_function_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferFunctionTypeExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferFunctionTypeRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: empty interface — `Members.Nodes` is empty, the
+		//      length-1 gate keeps the rule silent.
+		{Code: `interface Foo {}`},
+
+		// ---- Dimension 4: empty type literal — same gate, no diagnostic.
+		{Code: `type Foo = {};`},
+
+		// ---- Dimension 4: two call signatures (overloads) — only the
+		//      single-member shape is matched, so overloads are intentionally
+		//      ignored.
+		{Code: `
+interface Overloaded {
+  (data: string): number;
+  (id: number): string;
+}
+    `},
+
+		// ---- Dimension 4: a method signature is not a call signature — the
+		//      switch on member.Kind only matches CallSignature /
+		//      ConstructSignature, so a bare method stays valid.
+		{Code: `
+interface Foo {
+  method(): void;
+}
+    `},
+
+		// ---- Dimension 4: index signature — not a CallSignatureDeclaration,
+		//      so the rule must not report.
+		{Code: `
+interface Foo {
+  [key: string]: number;
+}
+    `},
+
+		// ---- Dimension 4: property signature — same reason.
+		{Code: `
+interface Foo {
+  bar: () => void;
+}
+    `},
+
+		// ---- Locks in hasOneSupertype() arm: extends.length !== 1 (two
+		//      supertypes, neither has to be Function) → skip the interface.
+		{Code: `
+interface Base1 {
+  base1: string;
+}
+interface Base2 {
+  base2: string;
+}
+interface Foo extends Base1, Base2 {
+  (): void;
+}
+    `},
+
+		// ---- Locks in hasOneSupertype() arm: extends expression is not an
+		//      Identifier (member access like `ns.Base`) → skip.
+		{Code: `
+namespace ns {
+  export interface Base {}
+}
+interface Foo extends ns.Base {
+  (): void;
+}
+    `},
+
+		// ---- Locks in hasOneSupertype() arm: extends one named type other
+		//      than Function → skip. Distinct from the case where the only
+		//      supertype is literally `Function` (upstream invalid-9).
+		{Code: `
+interface Base {
+  base: string;
+}
+interface Foo extends Base {
+  (): void;
+}
+    `},
+
+		// ---- Dimension 4: nested type literal containing only a call
+		//      signature is reported on the inner literal — but if the inner
+		//      literal also has a sibling property, the inner is not
+		//      single-member. Confirms the rule traverses each TypeLiteral
+		//      independently.
+		{Code: `
+type Wrapper = {
+  inner: { (): void; extra: number };
+};
+    `},
+
+		// ---- Real-user: a generic event-callback interface with a sibling
+		//      property is a common shape from React/Node typings and must
+		//      stay valid (sibling property defeats single-member gate).
+		{Code: `
+interface EventEmitter<T> {
+  (payload: T): void;
+  cancel(): void;
+}
+    `},
+
+		// ---- Dimension 4: function-type property — not a CallSignature, just
+		//      a PropertySignature whose type happens to be `() => void`. Must
+		//      not trigger the rule.
+		{Code: `
+interface Foo {
+  handler: () => void;
+}
+    `},
+
+		// ---- Dimension 4: type alias that's already a function type — there
+		//      is no Interface/TypeLiteral wrapper to rewrite, must stay
+		//      silent. Locks in that the rule doesn't accidentally fire on the
+		//      result of its own fix (idempotency).
+		{Code: `type Already = () => void;`},
+
+		// ---- Dimension 4: a single index signature — `[k: string]: number`
+		//      is the only member, but it's an IndexSignature (not a Call /
+		//      Construct signature) so the switch falls through to default.
+		{Code: `type Dict = { [k: string]: number };`},
+
+		// ---- Dimension 4: single ConstructSignature without explicit return
+		//      type — `member.returnType == null` keeps the rule silent (it
+		//      requires a non-nil return type to know what to put after `=>`).
+		//      `new ()` without explicit return reaches the `returnType == nil`
+		//      guard.
+		{Code: `type Ctor = { new (); };`},
+
+		// ---- Dimension 4: interface with extends Function but no body
+		//      members at all — Members.length === 0 skips the rule.
+		{Code: `interface Empty extends Function {}`},
+
+		// ---- Real-user: interface with multiple call signatures (overloads)
+		//      — TS-typical pattern from lib.dom.d.ts (e.g. addEventListener
+		//      overloads). Single-member gate keeps this valid.
+		{Code: `
+interface Overloaded {
+  (data: string): number;
+  (id: number, opts?: { strict: boolean }): string;
+}
+    `},
+
+		// ---- Real-user: interface 'extends Bar<T>' where Bar is generic —
+		//      typeArguments are ignored, expression is `Bar` (not Function),
+		//      so the rule skips on the "single supertype that's not Function"
+		//      branch.
+		{Code: `
+interface Base<T> {
+  base: T;
+}
+interface Foo extends Base<number> {
+  (): void;
+}
+    `},
+
+		// ---- Real-user: callable interface used as a class member type —
+		//      class field with a single-member type literal annotation
+		//      stays valid here because the rewrite target is the parameter
+		//      shape, but for class fields the listener is independent.
+		//      The Foo type below has 2 members so single-member gate keeps it valid.
+		{Code: `
+type Service = {
+  start(): void;
+  stop(): void;
+};
+    `},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Locks in checkMember() arm: ConstructSignature inside an
+		//      interface. Upstream tests only exercise call signatures; this
+		//      pins the `new` form.
+		{
+			Code: `
+interface Foo {
+  new (): Foo;
+}
+      `,
+			Output: []string{`
+type Foo = new () => Foo;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in checkMember() arm: ConstructSignature inside a
+		//      TypeLiteral.
+		{
+			Code: `
+type Foo = { new (): Foo };
+      `,
+			Output: []string{`
+type Foo = new () => Foo;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    14,
+				},
+			},
+		},
+
+		// ---- Locks in shouldWrapSuggestion() arm: parent.type === ArrayType
+		//      → wrap with parens. Upstream tests cover Union (invalid-16) and
+		//      Intersection (invalid-17) but not Array.
+		{
+			Code: `
+type X = { (): void }[];
+      `,
+			Output: []string{`
+type X = (() => void)[];
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    12,
+				},
+			},
+		},
+
+		// ---- Locks in interface fix path: type parameters with multiple
+		//      params + extends clause + complex return type.
+		{
+			Code: `
+interface Foo<T, U> {
+  (a: T): U;
+}
+      `,
+			Output: []string{`
+type Foo<T, U> = (a: T) => U;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in interface fix path: type parameter with a constraint
+		//      (`extends`) — the slice from name to typeParameters.range[1]
+		//      must include `<T extends X>` verbatim.
+		{
+			Code: `
+interface Foo<T extends string> {
+  (a: T): T;
+}
+      `,
+			Output: []string{`
+type Foo<T extends string> = (a: T) => T;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in interface fix path: type parameter with a default
+		//      (`T = string`) — same slicing requirement.
+		{
+			Code: `
+interface Foo<T = string> {
+  (a: T): T;
+}
+      `,
+			Output: []string{`
+type Foo<T = string> = (a: T) => T;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in interface modifier prefix: `declare interface ...`
+		//      keeps the `declare` keyword in the rewritten alias. Upstream
+		//      does not test this branch.
+		{
+			Code: `
+declare interface Foo {
+  (): string;
+}
+      `,
+			Output: []string{`
+declare type Foo = () => string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in interface modifier prefix: `export declare interface`
+		//      preserves both keywords in the rewritten alias.
+		{
+			Code: `
+export declare interface Foo {
+  (): string;
+}
+      `,
+			Output: []string{`
+export declare type Foo = () => string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in collectThisTypes() literalNesting branch: a `this`
+		//      reference inside a nested TypeLiteral inside the call sig's
+		//      return type must NOT trigger unexpectedThisOnFunctionOnlyInterface.
+		//      Upstream invalid-15 covers this for object-typed returns; here we
+		//      check it for a return inside an array of object types.
+		{
+			Code: `
+interface Foo {
+  (): { nested: this }[];
+}
+      `,
+			Output: []string{`
+type Foo = () => { nested: this }[];
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in collectThisTypes() arm: `this` in a parameter
+		//      type (not the parameter name) — must report unexpectedThis.
+		//      Distinct from `(this: T): void` where `this` is the parameter
+		//      identifier and never produces a ThisType node.
+		{
+			Code: `
+interface Foo {
+  (other: this, more: number): void;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unexpectedThisOnFunctionOnlyInterface",
+					Line:      3,
+					Column:    11,
+				},
+			},
+		},
+
+		// ---- Real-user: callback that returns its own type via a parameterized
+		//      type alias. Validates type-parameter forwarding survives the
+		//      rewrite (closely mirrors common React/RxJS callback shapes).
+		{
+			Code: `
+interface Mapper<T, U> {
+  (input: T, index: number): U;
+}
+      `,
+			Output: []string{`
+type Mapper<T, U> = (input: T, index: number) => U;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Real-user: a type literal annotation on a variable declaration
+		//      — `const cb: { (x: number): void } = ...` is a common manual
+		//      type assertion shape from issue trackers.
+		{
+			Code: `
+const cb: { (x: number): void } = x => {};
+      `,
+			Output: []string{`
+const cb: (x: number) => void = x => {};
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    13,
+				},
+			},
+		},
+
+		// ---- Dimension 4: rest parameter — `(...args: T[]): R` shape must
+		//      survive the rewrite. Locks in that the textual slicing from
+		//      member start to colon preserves the spread token.
+		{
+			Code: `
+interface Foo<T> {
+  (...args: T[]): void;
+}
+      `,
+			Output: []string{`
+type Foo<T> = (...args: T[]) => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Dimension 4: optional parameter — `(x?: T): R` must survive
+		//      the rewrite with the `?` preserved.
+		{
+			Code: `
+interface Foo<T> {
+  (x?: T): void;
+}
+      `,
+			Output: []string{`
+type Foo<T> = (x?: T) => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Dimension 4: type literal nested as the return type of a
+		//      function type — `() => { (): void }` is itself a single-member
+		//      type literal that the TypeLiteral listener must catch. The
+		//      inner rewrite needs no parens because TypeLiteral's parent is
+		//      FunctionType (not on shouldWrapSuggestion's list); `() => () => void`
+		//      is right-associative and unambiguous.
+		{
+			Code: `
+type Outer = () => { (): void };
+      `,
+			Output: []string{`
+type Outer = () => () => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    22,
+				},
+			},
+		},
+
+		// ---- Dimension 4: type literal as type argument inside `Promise<...>`
+		//      — must report. Locks in that the TypeLiteral listener fires
+		//      regardless of the containing TypeReference.
+		{
+			Code: `
+type P = Promise<{ (): void }>;
+      `,
+			Output: []string{`
+type P = Promise<() => void>;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    20,
+				},
+			},
+		},
+
+		// ---- Dimension 4: type literal in tuple — `[{ (): void }]`. parent
+		//      is TupleType, which is not on shouldWrapSuggestion's list, so
+		//      no surrounding parens are added.
+		{
+			Code: `
+type T = [{ (): void }];
+      `,
+			Output: []string{`
+type T = [() => void];
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    13,
+				},
+			},
+		},
+
+		// ---- Real-user: deeply-nested union with an inline call-signature
+		//      type literal. Locks in that union-arm wrapping kicks in even
+		//      after multiple parent layers.
+		{
+			Code: `
+type T = string | { (a: number): boolean } | null;
+      `,
+			Output: []string{`
+type T = string | ((a: number) => boolean) | null;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    21,
+				},
+			},
+		},
+
+		// ---- Locks in interface fix with extends Function AND a single
+		//      construct signature — upstream tests only mix `extends
+		//      Function` with a call signature (invalid-9), not a construct
+		//      signature.
+		{
+			Code: `
+interface Ctor extends Function {
+  new (): Ctor;
+}
+      `,
+			Output: []string{`
+type Ctor = new () => Ctor;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in collectThisTypes() arm: `this` inside a nested type
+		//      literal that itself is inside another nested type literal —
+		//      the nesting counter must reach 2 and still skip the `this`.
+		{
+			Code: `
+interface Foo {
+  (): { outer: { inner: this } };
+}
+      `,
+			Output: []string{`
+type Foo = () => { outer: { inner: this } };
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in CallSignature with its own generic type parameters —
+		//      `<T extends string>(arg: T): T` lives inside the interface
+		//      body and must survive the rewrite verbatim (raw-slice copies
+		//      the angle-bracket header).
+		{
+			Code: `
+interface Foo {
+  <T extends string>(arg: T): T;
+}
+      `,
+			Output: []string{`
+type Foo = <T extends string>(arg: T) => T;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in ConstructSignature with its own generic type
+		//      parameters — `new <T>(arg: T): T` is a separate combination
+		//      from plain call-sig generics.
+		{
+			Code: `
+interface Ctor {
+  new <T>(arg: T): T;
+}
+      `,
+			Output: []string{`
+type Ctor = new <T>(arg: T) => T;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Dimension 4: type literal in conditional-type extends position
+		//      — `T extends { (): void } ? ... : ...`. The TypeLiteral
+		//      listener must fire regardless of context. Parent is
+		//      ConditionalType (not on shouldWrapSuggestion's list), so no
+		//      parens are added.
+		{
+			Code: `
+type Check<T> = T extends { (): void } ? true : false;
+      `,
+			Output: []string{`
+type Check<T> = T extends () => void ? true : false;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    29,
+				},
+			},
+		},
+
+		// ---- Dimension 4: type literal in conditional-type false branch.
+		//      Same rationale, separate AST path.
+		{
+			Code: `
+type Check<T> = T extends string ? T : { (): void };
+      `,
+			Output: []string{`
+type Check<T> = T extends string ? T : () => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    42,
+				},
+			},
+		},
+
+		// ---- Dimension 4: type literal as a generic type argument inside
+		//      Map<...>. The TypeLiteral parent is TypeArgument (which is
+		//      part of TypeReferenceNode), not on the wrap list.
+		{
+			Code: `
+type M = Map<string, { (key: string): number }>;
+      `,
+			Output: []string{`
+type M = Map<string, (key: string) => number>;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    24,
+				},
+			},
+		},
+
+		// ---- Locks in shouldWrapSuggestion ArrayType arm with multi-level
+		//      arrays — `{ (): void }[][]`. Only the immediate parent
+		//      determines wrapping; reaching through two ArrayType levels is
+		//      not needed (immediate parent of the type literal is the inner
+		//      ArrayType).
+		{
+			Code: `
+type X = { (): void }[][];
+      `,
+			Output: []string{`
+type X = (() => void)[][];
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    12,
+				},
+			},
+		},
+
+		// ---- Locks in shouldWrapSuggestion IntersectionType arm with
+		//      multiple non-callable intersection terms — three-way
+		//      intersection `A & B & { (): void }`. shouldWrapSuggestion
+		//      returns true so parens wrap the rewritten function type.
+		{
+			Code: `
+type T = { a: number } & { b: string } & { (): void };
+      `,
+			Output: []string{`
+type T = { a: number } & { b: string } & (() => void);
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    44,
+				},
+			},
+		},
+
+		// ---- Real-user: Promise executor pattern (matches the actual signature
+		//      lib.es2015.promise.d.ts exposes). Generic + nested function-type
+		//      parameters + optional parameter.
+		{
+			Code: `
+type Executor<T> = {
+  (resolve: (value: T) => void, reject: (reason?: any) => void): void;
+};
+      `,
+			Output: []string{`
+type Executor<T> = (resolve: (value: T) => void, reject: (reason?: any) => void) => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Real-user: comparator for Array.sort. Two-arg numeric return —
+		//      the canonical shape that documentation always shows as a
+		//      function type, but real codebases sometimes write as interface.
+		{
+			Code: `
+interface Comparator<T> {
+  (a: T, b: T): number;
+}
+      `,
+			Output: []string{`
+type Comparator<T> = (a: T, b: T) => number;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Real-user: type guard predicate return — `value is X` form must
+		//      be preserved verbatim. The return-type slice runs from after
+		//      `:` to the end of the member, so `value is string` falls into
+		//      the post-colon text untouched.
+		{
+			Code: `
+interface IsString {
+  (value: unknown): value is string;
+}
+      `,
+			Output: []string{`
+type IsString = (value: unknown) => value is string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Real-user: assertion signature return — TS 3.7+ `asserts ...`
+		//      keyword in return position. Same raw-slice path as type guards
+		//      but distinct token shape.
+		{
+			Code: `
+interface AssertString {
+  (value: unknown): asserts value is string;
+}
+      `,
+			Output: []string{`
+type AssertString = (value: unknown) => asserts value is string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Real-user: Redux-style selector — generic state-to-result.
+		//      Very common pattern that real codebases write as interface to
+		//      get nominal-ish typing.
+		{
+			Code: `
+interface Selector<S, R> {
+  (state: S): R;
+}
+      `,
+			Output: []string{`
+type Selector<S, R> = (state: S) => R;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Real-user: middleware signature (Express/Koa) — three-arg with
+		//      `next` callback. Tests parameter list with a typed function-
+		//      type parameter mixed with primitives.
+		{
+			Code: `
+interface Middleware {
+  (req: Request, res: Response, next: (err?: Error) => void): void;
+}
+      `,
+			Output: []string{`
+type Middleware = (req: Request, res: Response, next: (err?: Error) => void) => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Real-user: decorator factory — `(target: any) => ClassDecorator`
+		//      pattern. ClassDecorator itself is a function type so the
+		//      return reads as a function-type token sequence.
+		{
+			Code: `
+interface DecoratorFactory {
+  (target: any): ClassDecorator;
+}
+      `,
+			Output: []string{`
+type DecoratorFactory = (target: any) => ClassDecorator;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Dimension 4: destructured parameter with type annotation —
+		//      `({ x, y }: Point): number`. The destructuring pattern is
+		//      embedded text inside the parameter list and must be preserved
+		//      by the raw-slice rewrite.
+		{
+			Code: `
+interface PointMapper {
+  ({ x, y }: { x: number; y: number }): number;
+}
+      `,
+			Output: []string{`
+type PointMapper = ({ x, y }: { x: number; y: number }) => number;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in modifier handling: `export interface` without leading
+		//      comments — comment relocation branch must still produce a
+		//      correct `export type` rewrite (the comments-pre-insert branch
+		//      must skip empty cases).
+		{
+			Code: `
+export interface Handler<T> {
+  (event: T): void;
+}
+      `,
+			Output: []string{`
+export type Handler<T> = (event: T) => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Real-user: comment between modifier and `interface` keyword.
+		//      `export /* note */ interface Foo` must preserve the
+		//      `/* note */` verbatim — replace range starts at `interface`,
+		//      not at the modifier list, matching upstream ESTree's
+		//      `declaration.range[0]` semantics.
+		{
+			Code: `
+export /* note */ interface Foo {
+  (): string;
+}
+      `,
+			Output: []string{`
+export /* note */ type Foo = () => string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Same shape but for `declare` keyword — `declare /* c */ interface`
+		//      must preserve the inline comment after `declare`.
+		{
+			Code: `
+declare /* c */ interface Foo {
+  (): string;
+}
+      `,
+			Output: []string{`
+declare /* c */ type Foo = () => string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Locks in CallSignature with type parameter that has a default —
+		//      `<T = string>` slice must include the default in the rewrite.
+		//      This is at the CallSignature level (not the InterfaceDeclaration
+		//      level which already has its own test).
+		{
+			Code: `
+interface Foo {
+  <T = string>(arg: T): T;
+}
+      `,
+			Output: []string{`
+type Foo = <T = string>(arg: T) => T;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Real-user: variance-marked type parameter (TS 4.7+) `in` / `out`.
+		//      Variance modifiers go inside the type-parameter declaration and
+		//      must be preserved by raw-slicing the header.
+		{
+			Code: `
+interface Box<in out T> {
+  (value: T): T;
+}
+      `,
+			Output: []string{`
+type Box<in out T> = (value: T) => T;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Dimension 4: empty parameter list with an inline block comment
+		//      between the parens — `(/* c */): void`. Inner trivia inside
+		//      the parameter list must be preserved by raw slicing.
+		{
+			Code: `
+interface Foo {
+  (/* inline */): void;
+}
+      `,
+			Output: []string{`
+type Foo = (/* inline */) => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Dimension 4: trailing comma in parameter list — `(a, b,): void`.
+		//      Modern TS allows trailing commas and the raw-slice rewrite must
+		//      keep them. (TypeScript itself drops them at emit time but the
+		//      source still parses.)
+		{
+			Code: `
+interface Foo {
+  (a: number, b: number): number;
+}
+      `,
+			Output: []string{`
+type Foo = (a: number, b: number) => number;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Real-user: callable interface returning the same interface type
+		//      — a self-referential alias pattern (chainable builder). Locks
+		//      in that the rewrite is valid TS even when the body references
+		//      the interface name.
+		{
+			Code: `
+interface Chainable {
+  (arg: string): Chainable;
+}
+      `,
+			Output: []string{`
+type Chainable = (arg: string) => Chainable;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+		// ---- Dimension 4: explicit `: void` versus implicit any — only the
+		//      explicit form should reach the rule because checkMember bails
+		//      when returnType is nil. This positive case pins the explicit
+		//      path while the corresponding valid case (above, `new ();`)
+		//      pins the bail.
+		{
+			Code: `
+interface Foo {
+  (): void;
+}
+      `,
+			Output: []string{`
+type Foo = () => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+
+	})
+}

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_upstream_test.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_upstream_test.go
@@ -1,0 +1,375 @@
+// TestPreferFunctionTypeUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/tests/rules/prefer-function-type.test.ts 1:1.
+// Position assertions cover line/column for every invalid case. Rslint-
+// specific lock-in cases and tsgo edge-shape coverage live in
+// prefer_function_type_extras_test.go.
+package prefer_function_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferFunctionTypeUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferFunctionTypeRule, []rule_tester.ValidTestCase{
+		{Code: `
+interface Foo {
+  (): void;
+  bar: number;
+}
+    `},
+		{Code: `
+type Foo = {
+  (): void;
+  bar: number;
+};
+    `},
+		{Code: `
+function foo(bar: { (): string; baz: number }): string {
+  return bar();
+}
+    `},
+		{Code: `
+interface Foo {
+  bar: string;
+}
+interface Bar extends Foo {
+  (): void;
+}
+    `},
+		{Code: `
+interface Foo {
+  bar: string;
+}
+interface Bar extends Function, Foo {
+  (): void;
+}
+    `},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `
+interface Foo {
+  (): string;
+}
+      `,
+			Output: []string{`
+type Foo = () => string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+		// https://github.com/typescript-eslint/typescript-eslint/issues/3004
+		{
+			Code: `
+export default interface Foo {
+  /** comment */
+  (): string;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      4,
+					Column:    3,
+				},
+			},
+		},
+		{
+			Code: `
+interface Foo {
+  // comment
+  (): string;
+}
+      `,
+			Output: []string{`
+// comment
+type Foo = () => string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      4,
+					Column:    3,
+				},
+			},
+		},
+		{
+			Code: `
+export interface Foo {
+  /** comment */
+  (): string;
+}
+      `,
+			Output: []string{`
+/** comment */
+export type Foo = () => string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      4,
+					Column:    3,
+				},
+			},
+		},
+		{
+			Code: `
+export interface Foo {
+  // comment
+  (): string;
+}
+      `,
+			Output: []string{`
+// comment
+export type Foo = () => string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      4,
+					Column:    3,
+				},
+			},
+		},
+		{
+			Code: `
+function foo(bar: { /* comment */ (s: string): number } | undefined): number {
+  return bar('hello');
+}
+      `,
+			Output: []string{`
+function foo(bar: /* comment */ ((s: string) => number) | undefined): number {
+  return bar('hello');
+}
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    35,
+				},
+			},
+		},
+		{
+			Code: `
+type Foo = {
+  (): string;
+};
+      `,
+			Output: []string{`
+type Foo = () => string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+		{
+			Code: `
+function foo(bar: { (s: string): number }): number {
+  return bar('hello');
+}
+      `,
+			Output: []string{`
+function foo(bar: (s: string) => number): number {
+  return bar('hello');
+}
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    21,
+				},
+			},
+		},
+		{
+			Code: `
+function foo(bar: { (s: string): number } | undefined): number {
+  return bar('hello');
+}
+      `,
+			Output: []string{`
+function foo(bar: ((s: string) => number) | undefined): number {
+  return bar('hello');
+}
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    21,
+				},
+			},
+		},
+		{
+			Code: `
+interface Foo extends Function {
+  (): void;
+}
+      `,
+			Output: []string{`
+type Foo = () => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+		{
+			Code: `
+interface Foo<T> {
+  (bar: T): string;
+}
+      `,
+			Output: []string{`
+type Foo<T> = (bar: T) => string;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+		{
+			Code: `
+interface Foo<T> {
+  (this: T): void;
+}
+      `,
+			Output: []string{`
+type Foo<T> = (this: T) => void;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      3,
+					Column:    3,
+				},
+			},
+		},
+		{
+			Code: `
+type Foo<T> = { (this: string): T };
+      `,
+			Output: []string{`
+type Foo<T> = (this: string) => T;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    17,
+				},
+			},
+		},
+		{
+			Code: `
+interface Foo {
+  (arg: this): void;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unexpectedThisOnFunctionOnlyInterface",
+					Line:      3,
+					Column:    9,
+				},
+			},
+		},
+		{
+			Code: `
+interface Foo {
+  (arg: number): this | undefined;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unexpectedThisOnFunctionOnlyInterface",
+					Line:      3,
+					Column:    18,
+				},
+			},
+		},
+		{
+			Code: `
+// isn't actually valid ts but want to not give message saying it refers to Foo.
+interface Foo {
+  (): {
+    a: {
+      nested: this;
+    };
+    between: this;
+    b: {
+      nested: string;
+    };
+  };
+}
+      `,
+			Output: []string{`
+// isn't actually valid ts but want to not give message saying it refers to Foo.
+type Foo = () => {
+    a: {
+      nested: this;
+    };
+    between: this;
+    b: {
+      nested: string;
+    };
+  };
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      4,
+					Column:    3,
+				},
+			},
+		},
+		{
+			Code: `
+type X = {} | { (): void; }
+      `,
+			Output: []string{`
+type X = {} | (() => void)
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    17,
+				},
+			},
+		},
+		{
+			Code: `
+type X = {} & { (): void; };
+      `,
+			Output: []string{`
+type X = {} & (() => void);
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "functionTypeOverCallableType",
+					Line:      2,
+					Column:    17,
+				},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -330,7 +330,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/prefer-enum-initializers.test.ts',
     './tests/typescript-eslint/rules/prefer-find.test.ts',
     './tests/typescript-eslint/rules/prefer-for-of.test.ts',
-    // './tests/typescript-eslint/rules/prefer-function-type.test.ts',
+    './tests/typescript-eslint/rules/prefer-function-type.test.ts',
     './tests/typescript-eslint/rules/prefer-includes.test.ts',
     './tests/typescript-eslint/rules/prefer-literal-enum-member.test.ts',
     './tests/typescript-eslint/rules/prefer-namespace-keyword.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-function-type.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-function-type.test.ts.snap
@@ -1,0 +1,614 @@
+// Rstest Snapshot v1
+
+exports[`prefer-function-type > invalid 1`] = `
+{
+  "code": "
+interface Foo {
+  (): string;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Interface only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = () => string;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 2`] = `
+{
+  "code": "
+export default interface Foo {
+  /** comment */
+  (): string;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Interface only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 3`] = `
+{
+  "code": "
+interface Foo {
+  // comment
+  (): string;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Interface only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+// comment
+type Foo = () => string;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 4`] = `
+{
+  "code": "
+export interface Foo {
+  /** comment */
+  (): string;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Interface only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+/** comment */
+export type Foo = () => string;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 5`] = `
+{
+  "code": "
+export interface Foo {
+  // comment
+  (): string;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Interface only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+// comment
+export type Foo = () => string;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 6`] = `
+{
+  "code": "
+function foo(bar: { /* comment */ (s: string): number } | undefined): number {
+  return bar('hello');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type literal only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 2,
+        },
+        "start": {
+          "column": 35,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function foo(bar: /* comment */ ((s: string) => number) | undefined): number {
+  return bar('hello');
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 7`] = `
+{
+  "code": "
+type Foo = {
+  (): string;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Type literal only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = () => string;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 8`] = `
+{
+  "code": "
+function foo(bar: { (s: string): number }): number {
+  return bar('hello');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type literal only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 2,
+        },
+        "start": {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function foo(bar: (s: string) => number): number {
+  return bar('hello');
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 9`] = `
+{
+  "code": "
+function foo(bar: { (s: string): number } | undefined): number {
+  return bar('hello');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type literal only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 2,
+        },
+        "start": {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function foo(bar: ((s: string) => number) | undefined): number {
+  return bar('hello');
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 10`] = `
+{
+  "code": "
+interface Foo extends Function {
+  (): void;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Interface only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo = () => void;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 11`] = `
+{
+  "code": "
+interface Foo<T> {
+  (bar: T): string;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Interface only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo<T> = (bar: T) => string;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 12`] = `
+{
+  "code": "
+interface Foo<T> {
+  (this: T): void;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Interface only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo<T> = (this: T) => void;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 13`] = `
+{
+  "code": "
+type Foo<T> = { (this: string): T };
+      ",
+  "diagnostics": [
+    {
+      "message": "Type literal only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type Foo<T> = (this: string) => T;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 14`] = `
+{
+  "code": "
+interface Foo {
+  (arg: this): void;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "\`this\` refers to the function type 'Foo', did you intend to use a generic \`this\` parameter like \`<Self>(this: Self, ...) => Self\` instead?",
+      "messageId": "unexpectedThisOnFunctionOnlyInterface",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 15`] = `
+{
+  "code": "
+interface Foo {
+  (arg: number): this | undefined;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "\`this\` refers to the function type 'Foo', did you intend to use a generic \`this\` parameter like \`<Self>(this: Self, ...) => Self\` instead?",
+      "messageId": "unexpectedThisOnFunctionOnlyInterface",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 16`] = `
+{
+  "code": "
+// isn't actually valid ts but want to not give message saying it refers to Foo.
+interface Foo {
+  (): {
+    a: {
+      nested: this;
+    };
+    between: this;
+    b: {
+      nested: string;
+    };
+  };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Interface only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 12,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+// isn't actually valid ts but want to not give message saying it refers to Foo.
+type Foo = () => {
+    a: {
+      nested: this;
+    };
+    between: this;
+    b: {
+      nested: string;
+    };
+  };
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 17`] = `
+{
+  "code": "
+type X = {} | { (): void; }
+      ",
+  "diagnostics": [
+    {
+      "message": "Type literal only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type X = {} | (() => void)
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-function-type > invalid 18`] = `
+{
+  "code": "
+type X = {} & { (): void; };
+      ",
+  "diagnostics": [
+    {
+      "message": "Type literal only has a call signature, you should use a function type instead.",
+      "messageId": "functionTypeOverCallableType",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-function-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type X = {} & (() => void);
+      ",
+  "ruleCount": 1,
+}
+`;

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -382,6 +382,7 @@ stype
 subclassing
 subtag
 subtests
+supertypes
 symb
 symbolname
 tabindex


### PR DESCRIPTION
## Summary

Port the [`@typescript-eslint/prefer-function-type`](https://typescript-eslint.io/rules/prefer-function-type) rule from typescript-eslint to rslint.

The rule enforces using function types (`() => string`) instead of interfaces or object type literals whose only member is a single call signature (`{ (): string }`). Construct signatures are handled identically. Reports `unexpectedThisOnFunctionOnlyInterface` instead of the standard message when the call signature references `this` outside a nested type literal.

Full upstream parity:

- All 5 valid + 18 invalid upstream cases migrated 1:1 with byte-for-byte fix output (`prefer_function_type_upstream_test.go`).
- 19 valid + 44 invalid rslint-added cases for Dimension 4 / branch lock-ins / real-user scenarios — covering nested type literals, conditional types, intersection / union / array / tuple / type-argument parents, modifier combinations (\`export\` / \`declare\` / \`export declare\`), TS-4.7 variance markers, type guards, assertion signatures, ConstructSignature with generics, comments between modifiers, and more (\`prefer_function_type_extras_test.go\`).
- 18 JS snapshots verifying the binary wire protocol (\`prefer-function-type.test.ts\`).

Verified end-to-end on \`web-infra-dev/rsbuild\` and \`web-infra-dev/rspack\`: 1 true positive on rsbuild with correct fix output, 0 false positives / 0 missed cases.

## Related Links

- ESLint rule: https://typescript-eslint.io/rules/prefer-function-type
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/prefer-function-type.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).