### PR TITLE
feat: port rule @typescript-eslint/strict-void-return

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,6 +136,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/restrict_plus_operands"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/restrict_template_expressions"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/return_await"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/strict_void_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/switch_exhaustiveness_check"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/triple_slash_reference"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/unbound_method"
@@ -659,6 +660,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/restrict-plus-operands", restrict_plus_operands.RestrictPlusOperandsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/restrict-template-expressions", restrict_template_expressions.RestrictTemplateExpressionsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/return-await", return_await.ReturnAwaitRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/strict-void-return", strict_void_return.StrictVoidReturnRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/switch-exhaustiveness-check", switch_exhaustiveness_check.SwitchExhaustivenessCheckRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/triple-slash-reference", triple_slash_reference.TripleSlashReferenceRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/unbound-method", unbound_method.UnboundMethodRule)

--- a/internal/plugins/typescript/rules/strict_void_return/strict_void_return.go
+++ b/internal/plugins/typescript/rules/strict_void_return/strict_void_return.go
@@ -1,0 +1,518 @@
+package strict_void_return
+
+import (
+	"encoding/json"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildAsyncFuncMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "asyncFunc",
+		Description: "Async function used in a context where a void function is expected.",
+	}
+}
+
+func buildNonVoidFuncMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "nonVoidFunc",
+		Description: "Value-returning function used in a context where a void function is expected.",
+	}
+}
+
+func buildNonVoidReturnMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "nonVoidReturn",
+		Description: "Value returned in a context where a void return is expected.",
+	}
+}
+
+type StrictVoidReturnOptions struct {
+	AllowReturnAny *bool `json:"allowReturnAny,omitempty"`
+}
+
+var StrictVoidReturnRule = rule.CreateRule(rule.Rule{
+	Name:             "strict-void-return",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts, ok := options.(StrictVoidReturnOptions)
+		if !ok {
+			opts = StrictVoidReturnOptions{}
+			if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+				if optsJSON, err := json.Marshal(optsMap); err == nil {
+					_ = json.Unmarshal(optsJSON, &opts)
+				}
+			}
+		}
+		if opts.AllowReturnAny == nil {
+			opts.AllowReturnAny = utils.Ref(false)
+		}
+
+		allowedReturnTypeFlags := checker.TypeFlagsVoid | checker.TypeFlagsNever | checker.TypeFlagsUndefined
+		if *opts.AllowReturnAny {
+			allowedReturnTypeFlags |= checker.TypeFlagsAny
+		}
+
+		isVoid := func(t *checker.Type) bool {
+			return utils.IsTypeFlagSet(t, checker.TypeFlagsVoid)
+		}
+
+		// nullishOrAny: VoidLike | Undefined | Null | Any | Never (mirrors upstream).
+		isNullishOrAny := func(t *checker.Type) bool {
+			return utils.IsTypeFlagSet(t, checker.TypeFlagsVoidLike|checker.TypeFlagsUndefined|checker.TypeFlagsNull|checker.TypeFlagsAny|checker.TypeFlagsNever)
+		}
+
+		isVoidReturningFunctionType := func(t *checker.Type) bool {
+			var returnTypes []*checker.Type
+			for _, sig := range utils.CollectAllCallSignatures(ctx.TypeChecker, t) {
+				ret := checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, sig)
+				returnTypes = append(returnTypes, utils.UnionTypeParts(ret)...)
+			}
+			if len(returnTypes) == 0 {
+				return false
+			}
+			for _, rt := range returnTypes {
+				if !isVoid(rt) {
+					return false
+				}
+			}
+			return true
+		}
+
+		// walkStatements yields every non-block, non-control-flow statement in a
+		// function body, descending into nested blocks / switch cases / loops /
+		// try-catch-finally. Mirrors upstream walkStatements.ts so we visit every
+		// `return` reachable from the function head.
+		var walkStatements func(stmts []*ast.Node, out *[]*ast.Node)
+		walkStatements = func(stmts []*ast.Node, out *[]*ast.Node) {
+			for _, s := range stmts {
+				switch s.Kind {
+				case ast.KindBlock:
+					walkStatements(s.AsBlock().Statements.Nodes, out)
+				case ast.KindSwitchStatement:
+					for _, clause := range s.AsSwitchStatement().CaseBlock.AsCaseBlock().Clauses.Nodes {
+						walkStatements(clause.AsCaseOrDefaultClause().Statements.Nodes, out)
+					}
+				case ast.KindIfStatement:
+					ifs := s.AsIfStatement()
+					walkStatements([]*ast.Node{ifs.ThenStatement}, out)
+					if ifs.ElseStatement != nil {
+						walkStatements([]*ast.Node{ifs.ElseStatement}, out)
+					}
+				case ast.KindWhileStatement, ast.KindDoStatement,
+					ast.KindForStatement, ast.KindForInStatement,
+					ast.KindForOfStatement, ast.KindWithStatement,
+					ast.KindLabeledStatement:
+					if body := s.Statement(); body != nil {
+						walkStatements([]*ast.Node{body}, out)
+					}
+				case ast.KindTryStatement:
+					try := s.AsTryStatement()
+					walkStatements([]*ast.Node{try.TryBlock}, out)
+					if try.CatchClause != nil {
+						walkStatements([]*ast.Node{try.CatchClause.AsCatchClause().Block}, out)
+					}
+					if try.FinallyBlock != nil {
+						walkStatements([]*ast.Node{try.FinallyBlock}, out)
+					}
+				default:
+					*out = append(*out, s)
+				}
+			}
+		}
+
+		// reportIfNonVoidFunction reports the appropriate diagnostic on funcNode
+		// when its actual return type isn't void/never/undefined (or any, when
+		// allowReturnAny is on). Mirrors upstream's switch but extends "function
+		// literal" to cover tsgo's MethodDeclaration / GetAccessor / SetAccessor
+		// / Constructor — upstream maps these onto a synthetic FunctionExpression
+		// via MethodDefinition.value, while tsgo represents the method as the
+		// function-like itself.
+		reportIfNonVoidFunction := func(funcNode *ast.Node) {
+			// tsgo preserves ParenthesizedExpression nodes that ESTree flattens.
+			// Strip parens so the IsArrowFunction / IsFunctionExpression branch
+			// detection (and downstream report-on-body / -head logic) sees the
+			// real function-like node — e.g. `((() => 1))` must report at `1`,
+			// not at the outer `(`.
+			funcNode = ast.SkipParentheses(funcNode)
+			actualType := checker.Checker_getApparentType(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(funcNode))
+
+			sigs := utils.CollectAllCallSignatures(ctx.TypeChecker, actualType)
+			if len(sigs) == 0 {
+				return
+			}
+			allReturnsAllowed := true
+			for _, sig := range sigs {
+				ret := checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, sig)
+				for _, part := range utils.UnionTypeParts(ret) {
+					if !utils.IsTypeFlagSet(part, allowedReturnTypeFlags) {
+						allReturnsAllowed = false
+						break
+					}
+				}
+				if !allReturnsAllowed {
+					break
+				}
+			}
+			if allReturnsAllowed {
+				return
+			}
+
+			isArrow := ast.IsArrowFunction(funcNode)
+			isFuncExpr := ast.IsFunctionExpression(funcNode)
+			isMethodLike := funcNode.Kind == ast.KindMethodDeclaration ||
+				funcNode.Kind == ast.KindGetAccessor ||
+				funcNode.Kind == ast.KindSetAccessor ||
+				funcNode.Kind == ast.KindConstructor
+			if !isArrow && !isFuncExpr && !isMethodLike {
+				ctx.ReportNode(funcNode, buildNonVoidFuncMessage())
+				return
+			}
+
+			flags := ast.GetFunctionFlags(funcNode)
+			if flags&ast.FunctionFlagsGenerator != 0 {
+				ctx.ReportRange(utils.GetFunctionHeadLoc(ctx.SourceFile, funcNode), buildNonVoidFuncMessage())
+				return
+			}
+			if flags&ast.FunctionFlagsAsync != 0 {
+				ctx.ReportRange(utils.GetFunctionHeadLoc(ctx.SourceFile, funcNode), buildAsyncFuncMessage())
+				return
+			}
+
+			body := funcNode.Body()
+			if isArrow && body != nil && body.Kind != ast.KindBlock {
+				// Concise arrow body: strip parens (tsgo preserves; ESTree flattens).
+				ctx.ReportNode(ast.SkipParentheses(body), buildNonVoidReturnMessage())
+				return
+			}
+
+			// Explicit non-void return-type annotation short-circuits the walk.
+			if typeAnnotation := funcNode.Type(); typeAnnotation != nil && typeAnnotation.Kind != ast.KindVoidKeyword {
+				ctx.ReportNode(typeAnnotation, buildNonVoidFuncMessage())
+				return
+			}
+
+			if body == nil || body.Kind != ast.KindBlock {
+				return
+			}
+
+			var stmts []*ast.Node
+			walkStatements(body.AsBlock().Statements.Nodes, &stmts)
+			for _, stmt := range stmts {
+				if stmt.Kind != ast.KindReturnStatement {
+					continue
+				}
+				ret := stmt.AsReturnStatement()
+				if ret.Expression == nil {
+					continue
+				}
+				retType := ctx.TypeChecker.GetTypeAtLocation(ret.Expression)
+				if utils.IsTypeFlagSet(retType, allowedReturnTypeFlags) {
+					continue
+				}
+				returnKeyword := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, stmt.Pos())
+				ctx.ReportRange(returnKeyword, buildNonVoidReturnMessage())
+			}
+		}
+
+		// checkExpressionNode is the generic entrypoint used by every non-call
+		// context. Returns true if the contextual type was a void-returning
+		// function (so callers can suppress fallback checks).
+		checkExpressionNode := func(node *ast.Node) bool {
+			expected := checker.Checker_getContextualType(ctx.TypeChecker, node, checker.ContextFlagsNone)
+			if expected != nil && isVoidReturningFunctionType(expected) {
+				reportIfNonVoidFunction(node)
+				return true
+			}
+			return false
+		}
+
+		// checkFunctionCallNode mirrors upstream's overload-aware argument check.
+		// We iterate every call/construct signature on the callee, build the union
+		// of expected return types per argument index, then decide per-argument
+		// whether the slot is void-only (after collapsing nullish/any/type-params
+		// down to void).
+		checkFunctionCallNode := func(callNode *ast.Node) {
+			calleeExpr := callNode.Expression()
+			funcType := ctx.TypeChecker.GetTypeAtLocation(calleeExpr)
+
+			isCall := ast.IsCallExpression(callNode)
+			var allSignatures []*checker.Signature
+			for _, t := range utils.UnionTypeParts(funcType) {
+				if isCall {
+					allSignatures = append(allSignatures, utils.GetCallSignatures(ctx.TypeChecker, t)...)
+				} else {
+					allSignatures = append(allSignatures, utils.GetConstructSignatures(ctx.TypeChecker, t)...)
+				}
+			}
+
+			args := callNode.Arguments()
+			hasSingleSignature := len(allSignatures) == 1
+
+			for argIdx, argNode := range args {
+				if argNode.Kind == ast.KindSpreadElement {
+					continue
+				}
+
+				// Collect every signature's argIdx-th param call-signature return
+				// type so we can detect `(() => void) | (() => any)`-style overloads
+				// where contextual type alone would mislead us. Upstream notes that
+				// `checker.getResolvedSignature` can't be used here because it
+				// prefers an early `() => void` over a later `() => Promise<void>`.
+				var argExpectedReturnTypes []*checker.Type
+				for _, sig := range allSignatures {
+					params := checker.Signature_parameters(sig)
+					if argIdx >= len(params) {
+						continue
+					}
+					paramType := ctx.TypeChecker.GetTypeOfSymbolAtLocation(params[argIdx], calleeExpr)
+					for _, ps := range utils.CollectAllCallSignatures(ctx.TypeChecker, paramType) {
+						argExpectedReturnTypes = append(argExpectedReturnTypes, checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, ps))
+					}
+				}
+
+				allSignaturesReturnVoid := true
+				for _, t := range argExpectedReturnTypes {
+					if isVoid(t) || isNullishOrAny(t) || utils.IsTypeFlagSet(t, checker.TypeFlagsTypeParameter) {
+						continue
+					}
+					allSignaturesReturnVoid = false
+					break
+				}
+
+				// Only trust contextual type when there is one signature, or every
+				// signature returns void for this slot — `getContextualType` picks
+				// the first overload's return type even if a later overload matches.
+				if hasSingleSignature || allSignaturesReturnVoid {
+					if checkExpressionNode(argNode) {
+						continue
+					}
+				}
+
+				// Fallback: treat the slot as void if at least one signature
+				// returns void and every other signature returns nullish/any.
+				hasVoid := false
+				allRestNullishOrAny := true
+				for _, t := range argExpectedReturnTypes {
+					if isVoid(t) {
+						hasVoid = true
+					}
+					if !isNullishOrAny(t) {
+						allRestNullishOrAny = false
+					}
+				}
+				if hasVoid && allRestNullishOrAny {
+					reportIfNonVoidFunction(argNode)
+				}
+			}
+		}
+
+		// checkObjectPropertyNode handles each property of an object literal.
+		// Method shorthand (`{ cb() {} }`) requires looking up the property
+		// symbol on the object's contextual type, since the method itself has
+		// no contextual type wired through. Getters/setters in object literals
+		// fall through to the same lookup path so a `get cb() { return () => 1 }`
+		// inside `{ cb: () => void }` is reported just like in upstream.
+		checkObjectPropertyNode := func(propNode *ast.Node) {
+			switch propNode.Kind {
+			case ast.KindPropertyAssignment:
+				if init := propNode.AsPropertyAssignment().Initializer; init != nil {
+					checkExpressionNode(init)
+				}
+			case ast.KindShorthandPropertyAssignment:
+				// `{ cb }` — check the identifier against the contextual prop type.
+				checkExpressionNode(propNode.Name())
+			case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+				name := propNode.Name()
+				if name == nil || name.Kind == ast.KindComputedPropertyName {
+					return
+				}
+				objType := checker.Checker_getContextualType(ctx.TypeChecker, propNode.Parent, checker.ContextFlagsNone)
+				if objType == nil {
+					return
+				}
+				propSymbol := checker.Checker_getPropertyOfType(ctx.TypeChecker, objType, name.Text())
+				if propSymbol == nil {
+					return
+				}
+				propExpectedType := ctx.TypeChecker.GetTypeOfSymbolAtLocation(propSymbol, propNode)
+				if isVoidReturningFunctionType(propExpectedType) {
+					reportIfNonVoidFunction(propNode)
+				}
+			}
+		}
+
+		// forEachBaseMemberType mirrors upstream's getBaseTypesOfClassMember:
+		// for a class member, yield each (base class / implemented interface)'s
+		// corresponding member type. Walks heritage clauses (both extends and
+		// implements) so behaviour matches upstream regardless of whether the
+		// override comes through extension or interface implementation.
+		forEachBaseMemberType := func(memberNode *ast.Node, fn func(baseMemberType *checker.Type) bool) {
+			name := memberNode.Name()
+			if name == nil {
+				return
+			}
+			memberSymbol := ctx.TypeChecker.GetSymbolAtLocation(name)
+			if memberSymbol == nil {
+				return
+			}
+			parent := memberNode.Parent
+			if parent == nil {
+				return
+			}
+			heritageClauses := utils.GetHeritageClauses(parent)
+			if heritageClauses == nil {
+				return
+			}
+			memberName := memberSymbol.Name
+			for _, clause := range heritageClauses.Nodes {
+				for _, baseTypeNode := range clause.AsHeritageClause().Types.Nodes {
+					baseType := ctx.TypeChecker.GetTypeAtLocation(baseTypeNode)
+					baseMemberSymbol := checker.Checker_getPropertyOfType(ctx.TypeChecker, baseType, memberName)
+					if baseMemberSymbol == nil {
+						continue
+					}
+					baseMemberType := ctx.TypeChecker.GetTypeOfSymbolAtLocation(baseMemberSymbol, memberNode)
+					if fn(baseMemberType) {
+						return
+					}
+				}
+			}
+		}
+
+		// checkClassMember handles methods, getters, setters: only reports when
+		// the member overrides a void-returning member of an extended class or
+		// implemented interface. The standalone contextual-type case is handled
+		// by checkClassPropertyNode for fields.
+		checkClassMember := func(memberNode *ast.Node) {
+			if memberNode.Body() == nil {
+				return
+			}
+			forEachBaseMemberType(memberNode, func(baseMemberType *checker.Type) bool {
+				if isVoidReturningFunctionType(baseMemberType) {
+					reportIfNonVoidFunction(memberNode)
+					return true // at most one error
+				}
+				return false
+			})
+		}
+
+		// classMemberListener wraps a class-member callback with a parent-kind
+		// gate so that method shorthand / accessors in object literals get
+		// routed through checkObjectPropertyNode instead.
+		classMemberListener := func(fn func(*ast.Node)) func(*ast.Node) {
+			return func(node *ast.Node) {
+				if parent := node.Parent; parent == nil || (!ast.IsClassDeclaration(parent) && !ast.IsClassExpression(parent)) {
+					return
+				}
+				fn(node)
+			}
+		}
+
+		// checkClassPropertyNode handles class fields: compare both against the
+		// base class/interface member and the field's contextual type.
+		checkClassPropertyNode := func(propNode *ast.Node) {
+			prop := propNode.AsPropertyDeclaration()
+			if prop.Initializer == nil {
+				return
+			}
+			reported := false
+			forEachBaseMemberType(propNode, func(baseMemberType *checker.Type) bool {
+				if isVoidReturningFunctionType(baseMemberType) {
+					reportIfNonVoidFunction(prop.Initializer)
+					reported = true
+					return true
+				}
+				return false
+			})
+			if reported {
+				return
+			}
+			checkExpressionNode(prop.Initializer)
+		}
+
+		return rule.RuleListeners{
+			ast.KindArrayLiteralExpression: func(node *ast.Node) {
+				for _, el := range node.AsArrayLiteralExpression().Elements.Nodes {
+					if el == nil || el.Kind == ast.KindOmittedExpression || el.Kind == ast.KindSpreadElement {
+						continue
+					}
+					checkExpressionNode(el)
+				}
+			},
+			ast.KindArrowFunction: func(node *ast.Node) {
+				body := node.Body()
+				if body != nil && body.Kind != ast.KindBlock {
+					checkExpressionNode(body)
+				}
+			},
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				bin := node.AsBinaryExpression()
+				if !ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
+					return
+				}
+				// Mirrors upstream's AssignmentExpression listener: defer the
+				// expected-type lookup to TypeChecker.getContextualType on the
+				// RHS. For `+=` / `-=` etc. the contextual type is numeric (not
+				// a function), so isVoidReturningFunctionType naturally bails.
+				checkExpressionNode(bin.Right)
+			},
+			ast.KindCallExpression: checkFunctionCallNode,
+			ast.KindNewExpression:  checkFunctionCallNode,
+			ast.KindJsxAttribute: func(node *ast.Node) {
+				init := node.AsJsxAttribute().Initializer
+				if init == nil || init.Kind != ast.KindJsxExpression {
+					return
+				}
+				expr := init.AsJsxExpression().Expression
+				if expr == nil {
+					return
+				}
+				// Query the JsxExpression wrapper for its contextual type, then
+				// dispatch reportIfNonVoidFunction on the inner expression —
+				// tsgo's getContextualType on the inner expression doesn't always
+				// resolve through the JSX attribute slot.
+				expected := checker.Checker_getContextualType(ctx.TypeChecker, init, checker.ContextFlagsNone)
+				if expected != nil && isVoidReturningFunctionType(expected) {
+					reportIfNonVoidFunction(expr)
+				}
+			},
+			// Class methods / getters / setters / constructor — same handler,
+			// the wrapper gates on parent kind so object-literal members are
+			// routed through checkObjectPropertyNode instead. Upstream's
+			// MethodDefinition listener covers constructor too; in practice
+			// it's always a no-op because a base type's constructor is not
+			// exposed via getPropertyOfType, but we register it for matrix
+			// parity so future heritage-walk changes can't silently drift.
+			ast.KindMethodDeclaration: classMemberListener(checkClassMember),
+			ast.KindGetAccessor:       classMemberListener(checkClassMember),
+			ast.KindSetAccessor:       classMemberListener(checkClassMember),
+			ast.KindConstructor:       classMemberListener(checkClassMember),
+			ast.KindObjectLiteralExpression: func(node *ast.Node) {
+				for _, prop := range node.AsObjectLiteralExpression().Properties.Nodes {
+					if prop.Kind == ast.KindSpreadAssignment {
+						continue
+					}
+					checkObjectPropertyNode(prop)
+				}
+			},
+			ast.KindPropertyDeclaration: func(node *ast.Node) {
+				checkClassPropertyNode(node)
+			},
+			ast.KindReturnStatement: func(node *ast.Node) {
+				if expr := node.AsReturnStatement().Expression; expr != nil {
+					checkExpressionNode(expr)
+				}
+			},
+			ast.KindVariableDeclaration: func(node *ast.Node) {
+				if init := node.AsVariableDeclaration().Initializer; init != nil {
+					checkExpressionNode(init)
+				}
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/strict_void_return/strict_void_return.md
+++ b/internal/plugins/typescript/rules/strict_void_return/strict_void_return.md
@@ -1,0 +1,124 @@
+# strict-void-return
+
+## Rule Details
+
+Disallow passing a value-returning function in a position accepting a void
+function. TypeScript permits a function returning a value to be used where a
+`void`-returning function is expected — callbacks can return any value and it
+is silently discarded — but it hides several common mistakes: forgotten
+`await`s on promise-returning callbacks, generators or async functions misused
+as fire-and-forget event handlers, and accidental dead values from arrow
+shorthands. This rule reports any value-returning function used in a context
+that expects a function whose return type is `void`. It checks function
+arguments, JSX attribute values, array elements, assignments, variable
+initializers, object properties, class members (against extended base classes
+and implemented interfaces), and `return` statements.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+const getNothing: () => void = () => 2137;
+
+declare function takesCallback(cb: () => void): void;
+takesCallback(async () => {
+  const response = await fetch('https://api.example.com/');
+});
+
+takesCallback(function* () {
+  yield 'Hello';
+});
+
+['Alice', 'Bob'].forEach(name => `Hello, ${name}!`);
+
+class Foo {
+  cb() {
+    console.log('foo');
+  }
+}
+class Bar extends Foo {
+  cb() {
+    return 'bar';
+  }
+}
+
+interface Foo {
+  cb(): void;
+}
+class Bar implements Foo {
+  cb() {
+    return 'cb';
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+const getNothing: () => void = () => {};
+
+declare function takesCallback(cb: () => void): void;
+takesCallback(() => {
+  void (async () => {
+    const response = await fetch('https://api.example.com/');
+  })();
+});
+
+takesCallback(() => {
+  function* gen() {
+    yield 'Hello';
+  }
+  for (const _ of gen());
+});
+
+['Alice', 'Bob'].forEach(name => console.log(`Hello, ${name}!`));
+
+class Foo {
+  cb() {
+    console.log('foo');
+  }
+}
+class Bar extends Foo {
+  cb() {
+    super.cb();
+    console.log('bar');
+  }
+}
+
+interface Foo {
+  cb(): void;
+}
+class Bar implements Foo {
+  cb() {
+    console.log('cb');
+  }
+}
+```
+
+## Options
+
+### `allowReturnAny`
+
+**Type:** `boolean` — **Default:** `false`
+
+When `false` (default), a function returning `any` is treated the same as any
+other non-void return — for example, `fn(() => JSON.parse('{}'))` is reported.
+When `true`, functions returning `any` are accepted in void positions. Useful
+for codebases where untyped values flow through callbacks intentionally.
+
+Examples of **correct** code with `{ "allowReturnAny": true }`:
+
+```json
+{ "@typescript-eslint/strict-void-return": ["error", { "allowReturnAny": true }] }
+```
+
+```typescript
+declare function fn(cb: () => void): void;
+fn(() => JSON.parse('{}'));
+fn(() => {
+  return someUntypedApi();
+});
+```
+
+## Original Documentation
+
+- [typescript-eslint strict-void-return](https://typescript-eslint.io/rules/strict-void-return)

--- a/internal/plugins/typescript/rules/strict_void_return/strict_void_return_extras_test.go
+++ b/internal/plugins/typescript/rules/strict_void_return/strict_void_return_extras_test.go
@@ -1,0 +1,664 @@
+// TestStrictVoidReturnExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in. Upstream parity cases live in strict_void_return_upstream_test.go.
+package strict_void_return
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestStrictVoidReturnExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &StrictVoidReturnRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: receiver wrappers — parenthesized callee ----
+		// tsgo preserves ParenthesizedExpression nodes that ESTree flattens; the
+		// callee here is `(foo)` and must still resolve through to the call sig.
+		{Code: `
+declare function foo(cb: () => void): void;
+(foo)(() => {});
+`},
+		// ---- Dimension 4: receiver wrappers — multi-level parenthesized callee ----
+		{Code: `
+declare function foo(cb: () => void): void;
+((foo))(() => {});
+`},
+		// ---- Dimension 4: receiver wrappers — non-null on callee ----
+		// `foo!(cb)` exercises NonNullExpression around the callee.
+		{Code: `
+declare function foo(cb: () => void): void | null;
+foo!(() => {});
+`},
+		// ---- Dimension 4: receiver wrappers — optional chain callee ----
+		// `foo?.(cb)` is a CallExpression with the optional-chain flag in tsgo;
+		// no ChainExpression wrapper, so the argument check still runs.
+		{Code: `
+declare const foo: ((cb: () => void) => void) | null;
+foo?.(() => {});
+`},
+		// ---- Dimension 4: element-access callee ----
+		// `obj['m'](cb)` — callee is ElementAccessExpression, not PropertyAccess.
+		{Code: `
+declare const obj: { m(cb: () => void): void };
+obj['m'](() => {});
+`},
+		// ---- N/A: SpreadElement in array literal expected to be skipped ----
+		// Spread cannot bind to a single void-fn slot, so the rule must not
+		// inspect spread elements.
+		{Code: `
+declare const cbs: Array<() => void>;
+const arr: Array<() => void> = [...cbs];
+`},
+		// ---- N/A: omitted (sparse) array element ----
+		// `[, () => {}]` includes an OmittedExpression for the missing slot.
+		{Code: `
+const arr: Array<() => void> = [, () => {}];
+`},
+		// ---- Dimension 4: as-assertion on function-typed value ----
+		// The value is a `() => number as () => void` — getApparentType strips
+		// the assertion, so the underlying number return triggers nonVoidFunc
+		// only when the type actually still reports a value. The assertion sets
+		// the type to `() => void`, so we expect this to pass.
+		{Code: `
+declare function cb(): number;
+const foo: () => void = cb as () => void;
+`},
+		// ---- Dimension 4: satisfies on function-typed value ----
+		// `satisfies` preserves the original (`() => void`) inferred type. A
+		// truly void function should remain valid through the wrapper.
+		{Code: `
+const foo: () => void = (() => {}) satisfies () => void;
+`},
+		// ---- Branch lock-in: empty arg list, allReturnsAllowed early return ----
+		// `new Foo` with no args must not crash the argument loop.
+		{Code: `
+declare class Foo { constructor(cb?: () => void); }
+new Foo();
+`},
+		// ---- Branch lock-in: compound assignment += (non-void-fn RHS context) ----
+		// Upstream's note: `+=` / `-=` are inherently safe because the RHS
+		// contextual type is numeric — our BinaryExpression listener should not
+		// flag these.
+		{Code: `
+let n = 0;
+n += 1;
+`},
+		// ---- Branch lock-in: object literal with no contextual type ----
+		// `let foo = { cb() { return 1; } }` — no contextual type, skipped.
+		{Code: `
+let foo = { cb() { return 1; } };
+`},
+		// ---- Branch lock-in: object literal where contextual type lacks the property ----
+		{Code: `
+interface Foo { fn(): void }
+let foo: Foo = { other() { return 1; } } as any;
+`},
+		// ---- Branch lock-in: shorthand-property pattern with object-assignment-initializer ----
+		// `{ cb = () => 1 }` inside an obj literal — upstream comment: "don't
+		// check this thing". The shorthand's name is checked against contextual
+		// type; the ObjectAssignmentInitializer is ignored.
+		{Code: `
+declare let foo: { cb: () => void };
+foo = {
+  cb = () => 1,
+};
+`},
+		// ---- Branch lock-in: class field with no initializer ----
+		// `propNode.value == null` early return.
+		{Code: `
+class Foo { cb: () => void; }
+`},
+		// ---- Branch lock-in: class member with no body (overload signature) ----
+		// `methodNode.value.type === TSEmptyBodyFunctionExpression` early return.
+		{Code: `
+class Bar { foo() {} }
+class Foo extends Bar {
+  foo();
+  foo() {}
+}
+`},
+		// ---- Branch lock-in: constructor in derived class is never reported ----
+		// Upstream's MethodDefinition listener covers constructor too, but
+		// the base's constructor isn't exposed via getPropertyOfType, so
+		// the heritage walk never matches. Negative lock-in for matrix parity.
+		{Code: `
+class Foo { constructor() {} }
+class Bar extends Foo {
+  constructor() {
+    super();
+  }
+}
+`},
+		// ---- Branch lock-in: object-literal getter returning a value-fn ----
+		// `{ get cb() { return () => 1 } }` inside `{ cb: () => void }` —
+		// upstream's checkObjectPropertyNode walks the getter's body, so
+		// rslint must too. Negative lock-in: getter returning `() => {}`
+		// (a true void function) is fine.
+		{Code: `
+const obj: { cb: () => void } = {
+  get cb() {
+    return () => {};
+  },
+};
+`},
+		// ---- Branch lock-in: return statement with no argument ----
+		// `return;` inside an arrow whose context expects void — no contextual
+		// type for empty return, skipped.
+		{Code: `
+declare function foo(cb: () => void): void;
+foo(() => {
+  return;
+});
+`},
+		// ---- Branch lock-in: VariableDeclaration with no initializer ----
+		// Pure declaration — `if (init != nil)` guard skips.
+		{Code: `
+let foo: () => void;
+`},
+		// ---- Branch lock-in: JSX attribute with no initializer ----
+		// `<Foo cb />` — `init == nil` guard skips.
+		{Code: `
+declare function Foo(props: { cb?: () => void }): unknown;
+const _ = <Foo />;
+`, Tsx: true},
+		// ---- Branch lock-in: JSX attribute string-literal value ----
+		// `<Foo cb="x" />` — Initializer kind is StringLiteral, not JsxExpression.
+		{Code: `
+declare function Foo(props: { cb?: string }): unknown;
+const _ = <Foo cb="x" />;
+`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: parenthesized callee with non-void-returning callback ----
+		// Confirms the argument check still fires when callee is wrapped in
+		// parens that tsgo preserves.
+		{Code: `
+declare function foo(cb: () => void): void;
+(foo)(() => 1);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 13},
+		}},
+		// ---- Dimension 4: non-null callee with non-void-returning callback ----
+		// Mirrors the upstream `foo!(cb)` case but with arrow + literal body.
+		{Code: `
+declare function foo(cb: () => void): void | null;
+foo!(() => 1);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 12},
+		}},
+		// ---- Dimension 4: optional-chain callee with bad callback ----
+		// Optional chain on the callee shouldn't bypass the void-function check.
+		{Code: `
+declare const foo: ((cb: () => void) => void) | null;
+foo?.(() => 1);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 13},
+		}},
+		// ---- Dimension 4: element-access callee with bad callback ----
+		{Code: `
+declare const obj: { m(cb: () => void): void };
+obj['m'](() => 1);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 16},
+		}},
+		// ---- Branch lock-in: spread is skipped, but other elements still checked ----
+		// Confirms the SpreadElement skip in the array listener doesn't mask
+		// adjacent siblings.
+		{Code: `
+declare function cb(): number;
+declare const cbs: Array<() => void>;
+const arr: Array<(() => void) | false> = [false, cb, ...cbs];
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 50},
+		}},
+		// ---- Branch lock-in: omitted array element is skipped, others still checked ----
+		{Code: `
+declare function cb(): number;
+const arr: Array<(() => void) | undefined> = [, cb];
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 3, Column: 49},
+		}},
+		// ---- Branch lock-in: object literal spread is skipped, props still checked ----
+		{Code: `
+declare function cb(): number;
+declare const rest: Record<string, () => void>;
+const foo: Record<string, () => void> = {
+  ...rest,
+  bad: cb,
+};
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 6, Column: 8},
+		}},
+		// ---- Branch lock-in: ReturnStatement with non-void contextual type ----
+		// Mirrors the inner-arrow `return cb;` reporting that upstream tests
+		// indirectly via larger fixtures; lock it down in a minimal shape.
+		{Code: `
+declare let foo: () => () => void;
+foo = () => {
+  return () => 1;
+};
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 4, Column: 16},
+		}},
+		// ---- Branch lock-in: nested arrow concise body returning non-void ----
+		{Code: `
+declare let foo: () => () => void;
+foo = () => () => 1;
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 19},
+		}},
+		// ---- Branch lock-in: generator class member overriding void base ----
+		// Generator branch in reportIfNonVoidFunction reports at function head.
+		{Code: `
+class Foo { cb() {} }
+class Bar extends Foo {
+  *cb() { yield 1; }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 3},
+		}},
+		// ---- Real-user: array forEach with sync callback returning a value ----
+		// The common dead-code shape (`arr.forEach(x => x * 2)`) — reported.
+		{Code: `
+[1, 2, 3].forEach(x => x * 2);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 2, Column: 24},
+		}},
+		// ---- Real-user: event handler returning a promise (async arrow) ----
+		// addEventListener('click', async () => {...}) is the canonical real
+		// case the rule is meant to catch.
+		{Code: `
+declare const el: { addEventListener(t: string, cb: (e: Event) => void): void };
+el.addEventListener('click', async e => {
+  await Promise.resolve();
+});
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 3, Column: 38},
+		}},
+		// ---- Dimension 4: paren-wrapped funcNode passed as callback ----
+		// Without SkipParentheses on funcNode entry, the outer paren would
+		// shadow the inner arrow's Kind and the rule would degrade to
+		// nonVoidFunc at the paren position.
+		{Code: `
+declare function foo(cb: () => void): void;
+foo(((() => 1)));
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 13},
+		}},
+		// ---- Dimension 4: multi-level paren-wrapped funcNode in assignment ----
+		{Code: `
+const cb: () => void = (((() => 1)));
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 2, Column: 33},
+		}},
+		// ---- Dimension 4: AsExpression-wrapped value (TS type-expression wrapper) ----
+		// `cb as () => number` — apparent type still has number return; the
+		// outer AsExpression isn't a function literal, so we report
+		// nonVoidFunc on the whole AsExpression node.
+		{Code: `
+declare function cb(): number;
+const foo: () => void = cb as () => string;
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 3, Column: 25},
+		}},
+		// ---- Dimension 4: multi-level class inheritance (3 levels) ----
+		// Verifies the heritage walk doesn't stop at the immediate parent —
+		// `getPropertyOfType` traverses the prototype chain transparently,
+		// so a `cb` declared on the grandparent still triggers reporting.
+		{Code: `
+class A { cb() {} }
+class B extends A {}
+class C extends B {
+  cb() { return 1; }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 10},
+		}},
+		// ---- Branch lock-in: NewExpression with no arguments ----
+		// `node.Arguments()` returns nil/empty — the for-range must not panic
+		// and the rule must produce no diagnostic.
+		// (Covered by sibling valid case above — listed here as negative.)
+		{Code: `
+declare const Foo: { new (cb: () => void): void };
+declare function cb(): string;
+new Foo(cb);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 9},
+		}},
+		// ---- Branch lock-in: nested ObjectExpression with method shorthand ----
+		// Nested object literal — outer's contextual prop must resolve the
+		// inner method's contextual type through two layers of context.
+		{Code: `
+declare let foo: { inner: { cb(): void } };
+foo = { inner: { cb() { return 1; } } };
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 25},
+		}},
+		// ---- Real-user: Promise constructor with async executor ----
+		// `new Promise(async (resolve) => ...)` is a canonical anti-pattern —
+		// the executor signature is `(resolve, reject) => void` so async
+		// executors are reported. Head loc is the `=>` token.
+		{Code: `
+new Promise<number>(async resolve => {
+  resolve(1);
+});
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 2, Column: 35},
+		}},
+		// ---- Real-user: lib.d.ts `setTimeout` accepts loose `Function` ----
+		// Negative lock-in: lib.d.ts types `setTimeout`'s handler as
+		// `TimerHandler = string | Function`, which has signatures returning
+		// `any` (not void-only). The rule must NOT fire on the global
+		// setTimeout — same as ESLint behaviour, since the type isn't a
+		// void-returning function type per the rule's definition.
+		{Code: `
+setTimeout(async () => {
+  await Promise.resolve();
+}, 100);
+`},
+		// ---- Real-user: strictly-typed timer-style API with async callback ----
+		// In contrast to global setTimeout, a project-local typed timer with
+		// a `() => void` callback should report — this is the pattern most
+		// application code hits.
+		{Code: `
+declare function scheduleTask(cb: () => void, ms: number): number;
+scheduleTask(async () => {
+  await Promise.resolve();
+}, 100);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 3, Column: 23},
+		}},
+		// ---- Real-user: Express-style request handler async ----
+		// Web frameworks like Express type handlers as `(req, res) => void`;
+		// async handlers leak unhandled rejections. Head loc is `=>`.
+		{Code: `
+interface Req {}
+interface Res { send(s: string): void; }
+type Handler = (req: Req, res: Res) => void;
+declare function get(path: string, handler: Handler): void;
+get('/', async (req, res) => {
+  res.send('ok');
+});
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 6, Column: 27},
+		}},
+		// ---- Dimension 4: AsExpression on callback identifier in call arg ----
+		// `foo(cb as () => number)` — outer AsExpression isn't a function
+		// literal, must report nonVoidFunc on the whole AsExpression.
+		{Code: `
+declare function foo(cb: () => void): void;
+declare function cb(): number;
+foo(cb as () => number);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 5},
+		}},
+		// ---- Dimension 4: SatisfiesExpression on callback ----
+		// `cb satisfies T` preserves cb's inferred type; the outer satisfies
+		// node isn't a function literal so we report on the whole expression.
+		{Code: `
+declare function foo(cb: () => void): void;
+declare function cb(): number;
+foo(cb satisfies () => number);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 5},
+		}},
+		// ---- Dimension 4: NonNullExpression on callback identifier in call arg ----
+		// `foo(cb!)` — outer NonNullExpression isn't a function literal,
+		// nonVoidFunc on the whole `cb!` expression.
+		{Code: `
+declare function foo(cb: () => void): void;
+declare const cb: (() => number) | null;
+foo(cb!);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 5},
+		}},
+		// ---- Dimension 4: ConditionalExpression giving void slot ----
+		// `foo(cond ? cbA : cbB)` — both branches return number; the cond
+		// expr is neither Arrow nor FunctionExpression, report on the
+		// whole conditional.
+		{Code: `
+declare function foo(cb: () => void): void;
+declare function cbA(): number;
+declare function cbB(): string;
+declare const cond: boolean;
+foo(cond ? cbA : cbB);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 6, Column: 5},
+		}},
+		// ---- Dimension 4: nullish coalescing fallback ----
+		// `foo(cb ?? defaultCb)` — both potentially non-void; nonVoidFunc
+		// on the whole binary expression.
+		{Code: `
+declare function foo(cb: () => void): void;
+declare const cb: (() => number) | null;
+declare function defaultCb(): boolean;
+foo(cb ?? defaultCb);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 5, Column: 5},
+		}},
+		// ---- Real-user: super.method() call inside override ----
+		// Common: subclass override calls super and then accidentally
+		// returns a value. Must still flag the explicit return.
+		{Code: `
+class Foo { cb() { console.log('foo'); } }
+class Bar extends Foo {
+  cb() {
+    super.cb();
+    return 'bar';
+  }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 5},
+		}},
+		// ---- Branch lock-in: generic constrained callback returning non-void ----
+		// `bar<Cb extends () => number>(cb: Cb): void { foo(cb); }` — cb's
+		// type is the constraint, which is non-void.
+		{Code: `
+declare function foo(cb: () => void): void;
+function bar<Cb extends () => number | string>(cb: Cb) {
+  foo(cb);
+}
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 7},
+		}},
+		// ---- Branch lock-in: type-alias indirection ----
+		// `type Cb = () => void;` — alias resolves to the underlying type.
+		{Code: `
+type Cb = () => void;
+const foo: Cb = () => 'never observed';
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 23},
+		}},
+		// ---- Branch lock-in: interface extends interface ----
+		// `Foo2 extends Foo1` — Foo2's cb override walks through Foo1.
+		{Code: `
+interface Foo1 { cb(): void; }
+interface Foo2 extends Foo1 {}
+class Bar implements Foo2 {
+  cb() { return 1; }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 10},
+		}},
+		// ---- Branch lock-in: deeply nested arrow in object property ----
+		// `{cb: () => () => () => 1}` in `{cb: () => () => () => void}` —
+		// only the innermost arrow should fire.
+		{Code: `
+const foo: { cb: () => () => () => void } = {
+  cb: () => () => () => 1,
+};
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 25},
+		}},
+		// ---- Real-user: Map/Set forEach with sync return value ----
+		// Map.forEach signature is `(value, key, map) => void`; sync return
+		// of a value is dead code in real call sites.
+		{Code: `
+declare const m: Map<string, number>;
+m.forEach(v => v * 2);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 16},
+		}},
+		// ---- Branch lock-in: void context inherited via union type alias ----
+		// `type Cb = (() => void) | (() => Promise<void>);` — the union is
+		// not a void-only function type, so async arrow IS allowed.
+		// Negative lock-in: must NOT report.
+		{Code: `
+type Cb = (() => void) | (() => Promise<void>);
+declare function foo(cb: Cb): void;
+foo(async () => {});
+`},
+		// ---- Real-user: NodeJS-style error-first callback ----
+		// Many Node APIs take (err, result) => void callbacks; async here
+		// is wrong because the runtime ignores the promise. Head loc is `=>`.
+		{Code: `
+declare function readFile(p: string, cb: (err: Error | null, data: string) => void): void;
+readFile('/etc/hosts', async (err, data) => {
+  await Promise.resolve();
+});
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 3, Column: 42},
+		}},
+		// ---- Branch lock-in: private identifier method (`#cb`) cannot be overridden ----
+		// Private identifiers are class-scoped; even if a subclass declares
+		// a `#cb` the symbol is distinct, so heritage walk never matches.
+		// Must NOT report (negative lock-in for the heritage path).
+		{Code: `
+class Foo {
+  #cb() {}
+}
+class Bar extends Foo {
+  #cb() { return 1; }
+}
+`},
+		// ---- Real-user: deeply nested callback chain (3 levels) ----
+		// `foo(() => bar(() => baz(() => 1)))` — only the innermost arrow
+		// where `() => void` slot is actually expected should fire.
+		{Code: `
+declare function foo(cb: () => void): void;
+declare function bar(): void;
+declare function baz(cb: () => void): void;
+foo(() => baz(() => 1));
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 21},
+		}},
+		// ---- Branch lock-in: function parameter default value typed as void fn ----
+		// `function foo(cb: () => void = () => 1) {}` — the default is in
+		// a Parameter binding (not via VariableDeclaration listener), so the
+		// rule shouldn't fire there. Upstream behaviour: not reported.
+		{Code: `
+function foo(cb: () => void = () => 1) {
+  cb();
+}
+`},
+		// ---- Branch lock-in: typed destructuring binding picking up wrong arrow ----
+		// `const { cb }: { cb: () => void } = { cb: () => 1 };` — the inner
+		// ObjectExpression's `cb: () => 1` is checked through the contextual
+		// type flowing from the destructuring type annotation.
+		{Code: `
+const { cb }: { cb: () => void } = { cb: () => 1 };
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 2, Column: 48},
+		}},
+		// ---- Branch lock-in: intersection callback type ----
+		// `(() => void) & {tag: 'x'}` — the intersection collapses sigs via
+		// CollectAllCallSignatures's intersection branch (only one callable
+		// part allowed); should still detect non-void cb.
+		{Code: `
+type TaggedCb = (() => void) & { tag: 'x' };
+declare function foo(cb: TaggedCb): void;
+declare const cb: ((() => number) & { tag: 'x' });
+foo(cb);
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 5, Column: 5},
+		}},
+		// ---- Branch lock-in: abstract method override with bad return ----
+		// Concrete `cb` returning a value should trigger via heritage walk
+		// through the abstract base.
+		{Code: `
+abstract class A {
+  abstract cb(): void;
+}
+class B extends A {
+  cb() { return 1; }
+}
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 10},
+		}},
+		// ---- Branch lock-in: anonymous class expression with named base ----
+		// Mixin / decorator-style anonymous subclass — heritage clauses
+		// still walked, so the explicit return is caught.
+		{Code: `
+class Foo { cb() {} }
+const cls = class extends Foo {
+  cb() { return 1; }
+};
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 4, Column: 10},
+		}},
+		// ---- Branch lock-in: variable declared then assigned later ----
+		// `let foo: () => void; foo = () => 1;` — both VariableDeclaration
+		// (no init) and BinaryExpression (=) listeners fire; only the
+		// assignment should report.
+		{Code: `
+let foo: () => void;
+foo = () => 1;
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 13},
+		}},
+		// ---- Real-user: callback in array .find() vs .filter() — should NOT fire ----
+		// .find/.filter expect predicates returning boolean (not void), so
+		// no contextual void type flows through. Negative lock-in.
+		{Code: `
+const arr: number[] = [];
+arr.find(x => x > 0);
+arr.filter(x => x % 2 === 0);
+`},
+		// ---- Real-user: void-position callback inside Promise.then's onfinally-style API ----
+		// .then's onfulfilled/onrejected take `(value) => TResult` (not void),
+		// so async/sync return is fine. Negative lock-in for promise APIs.
+		{Code: `
+declare const p: Promise<number>;
+p.then(async v => v + 1);
+p.then(v => v * 2);
+`},
+		// ---- Branch lock-in: union of function types where some have void return ----
+		// `(() => void) | (() => string)` — not a void-only union, so the
+		// rule must NOT fire on a value-returning callback.
+		{Code: `
+declare const cb: () => string;
+const f: (() => void) | (() => string) = cb;
+`},
+		// ---- Branch lock-in: multiple invalid returns in switch inside arrow ----
+		// Each non-void return statement should be reported independently.
+		{Code: `
+const foo: () => void = (arg: 1 | 2 | 3) => {
+  switch (arg) {
+    case 1: return 'a';
+    case 2: return 'b';
+    case 3: return;
+  }
+};
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 4, Column: 13},
+			{MessageId: "nonVoidReturn", Line: 5, Column: 13},
+		}},
+		// ---- Branch lock-in: object-literal getter returning a value-fn ----
+		// `{ get cb() { return () => 1 } }` in `{ cb: () => void }` context —
+		// upstream walks getter body via checkExpressionNode → contextual type
+		// is `() => void` → reportIfNonVoidFunction → body walk → flags the
+		// returned `() => 1`. The branch only fires if our object-literal
+		// switch case for getter/setter is registered.
+		{Code: `
+const obj: { cb: () => void } = {
+  get cb() {
+    return () => 1;
+  },
+};
+`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 4, Column: 5},
+		}},
+	})
+}

--- a/internal/plugins/typescript/rules/strict_void_return/strict_void_return_upstream_test.go
+++ b/internal/plugins/typescript/rules/strict_void_return/strict_void_return_upstream_test.go
@@ -1,0 +1,1814 @@
+// TestStrictVoidReturnUpstream migrates the full valid/invalid suite from
+// typescript-eslint's tests/rules/strict-void-return.test.ts 1:1. Position
+// assertions cover line/column for every invalid case. rslint-specific lock-in
+// cases (Dimension 4 universal edge shapes, upstream branch lock-ins, real-user
+// regressions) live in strict_void_return_extras_test.go.
+package strict_void_return
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestStrictVoidReturnUpstream(t *testing.T) {
+	allowReturnAny := map[string]interface{}{"allowReturnAny": true}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &StrictVoidReturnRule, []rule_tester.ValidTestCase{
+		{Code: `
+        declare function foo(cb: {}): void;
+        foo(() => () => []);
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        type Void = void;
+        foo((): Void => {
+          return;
+        });
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo((): ReturnType<typeof foo> => {
+          return;
+        });
+      `},
+		{Code: `
+        declare function foo(cb: any): void;
+        foo(() => () => []);
+      `},
+		{Code: `
+        declare class Foo {
+          constructor(cb: unknown): void;
+        }
+        new Foo(() => ({}));
+      `},
+		{Code: `
+        declare function foo(cb: () => {}): void;
+        foo(() => 1 as any);
+      `, Options: allowReturnAny},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(() => {
+          throw new Error('boom');
+        });
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        declare function boom(): never;
+        foo(() => boom());
+        foo(boom);
+      `},
+		{Code: `
+        declare const Foo: {
+          new (cb: () => any): void;
+        };
+        new Foo(function () {
+          return 1;
+        });
+      `},
+		{Code: `
+        declare const Foo: {
+          new (cb: () => unknown): void;
+        };
+        new Foo(function () {
+          return 1;
+        });
+      `},
+		{Code: `
+        declare const foo: {
+          bar(cb1: () => unknown, cb2: () => void): void;
+        };
+        foo.bar(
+          function () {
+            return 1;
+          },
+          function () {
+            return;
+          },
+        );
+      `},
+		{Code: `
+        declare const Foo: {
+          new (cb: () => string | void): void;
+        };
+        new Foo(() => {
+          if (maybe) {
+            return 'a';
+          } else {
+            return 'b';
+          }
+        });
+      `},
+		{Code: `
+        declare function foo<Cb extends (...args: any[]) => void>(cb: Cb): void;
+        foo(() => {
+          console.log('a');
+        });
+      `},
+		{Code: `
+        declare function foo(cb: (() => void) | (() => string)): void;
+        foo(() => {
+          label: while (maybe) {
+            for (let i = 0; i < 10; i++) {
+              switch (i) {
+                case 0:
+                  continue;
+                case 1:
+                  return 'a';
+              }
+            }
+          }
+        });
+      `},
+		{Code: `
+        declare function foo(cb: (() => void) | null): void;
+        foo(null);
+      `},
+		{Code: `
+        interface Cb {
+          (): void;
+          (): string;
+        }
+        declare const Foo: {
+          new (cb: Cb): void;
+        };
+        new Foo(() => {
+          do {
+            try {
+              throw 1;
+            } catch {
+              return 'a';
+            }
+          } while (maybe);
+        });
+      `},
+		{Code: `
+        declare const foo: ((cb: () => boolean) => void) | ((cb: () => void) => void);
+        foo(() => false);
+      `},
+		{Code: `
+        declare const foo: {
+          (cb: () => boolean): void;
+          (cb: () => void): void;
+        };
+        foo(function () {
+          with ({}) {
+            return false;
+          }
+        });
+      `},
+		{Code: `
+        declare const Foo: {
+          new (cb: () => void): void;
+          (cb: () => unknown): void;
+        };
+        Foo(() => false);
+      `},
+		{Code: `
+        declare const Foo: {
+          new (cb: () => any): void;
+          (cb: () => void): void;
+        };
+        new Foo(() => false);
+      `},
+		{Code: `
+        declare function foo(cb: () => boolean): void;
+        declare function foo(cb: () => void): void;
+        foo(() => false);
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        declare function foo(cb: () => boolean): void;
+        foo(() => false);
+      `},
+		{Code: `
+        declare function foo(cb: () => Promise<void>): void;
+        declare function foo(cb: () => void): void;
+        foo(async () => {});
+      `},
+		{Code: `
+        declare function foo(fn: () => void);
+        declare function foo(fn: () => Promise<void>);
+
+        foo(async () => {});
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(() => 1 as any);
+      `, Options: allowReturnAny},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(() => {});
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        const cb = () => {};
+        foo(cb);
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(function () {});
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(cb);
+        function cb() {}
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(() => undefined);
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(function () {
+          return;
+        });
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(function () {
+          return void 0;
+        });
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(() => {
+          return;
+        });
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        declare function cb(): never;
+        foo(cb);
+      `},
+		{Code: `
+        declare class Foo {
+          constructor(cb: () => void): any;
+        }
+        declare function cb(): void;
+        new Foo(cb);
+      `},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(cb);
+        function cb() {
+          throw new Error('boom');
+        }
+      `},
+		{Code: `
+        declare function foo(arg: string, cb: () => void): void;
+        declare function cb(): undefined;
+        foo('arg', cb);
+      `},
+		{Code: `
+        declare function foo(cb?: () => void): void;
+        foo();
+      `},
+		{Code: `
+        declare class Foo {
+          constructor(cb?: () => void): void;
+        }
+        declare function cb(): void;
+        new Foo(cb);
+      `},
+		{Code: `
+        declare function foo(...cbs: Array<() => void>): void;
+        foo(
+          () => {},
+          () => void null,
+          () => undefined,
+        );
+      `},
+		{Code: `
+        declare function foo(...cbs: Array<() => void>): void;
+        declare const cbs: Array<() => void>;
+        foo(...cbs);
+      `},
+		{Code: `
+        declare function foo(...cbs: [() => any, () => void, (() => void)?]): void;
+        foo(
+          async () => {},
+          () => void null,
+          () => undefined,
+        );
+      `},
+		{Code: `
+        let cb;
+        cb = async () => 10;
+      `},
+		{Code: `
+        const foo: () => void = () => {};
+      `},
+		{Code: `
+        declare function cb(): void;
+        const foo: () => void = cb;
+      `},
+		{Code: `
+        const foo: () => void = function () {
+          throw new Error('boom');
+        };
+      `},
+		{Code: `
+        const foo: { (): string; (): void } = () => {
+          return 'a';
+        };
+      `},
+		{Code: `
+        const foo: (() => void) | (() => number) = () => {
+          return 1;
+        };
+      `},
+		{Code: `
+        type Foo = () => void;
+        const foo: Foo = cb;
+        function cb() {
+          return void null;
+        }
+      `},
+		{Code: `
+        interface Foo {
+          (): void;
+        }
+        const foo: Foo = cb;
+        function cb() {
+          return undefined;
+        }
+      `},
+		{Code: `
+        declare function cb(): void;
+        declare let foo: () => void;
+        foo = cb;
+      `},
+		{Code: `
+        declare let foo: () => void;
+        foo += () => 1;
+      `},
+		{Code: `
+        declare function defaultCb(): object;
+        declare let foo: { cb?: () => void };
+        // default doesn't have to be void
+        const { cb = defaultCb } = foo;
+      `},
+		{Code: `
+        let foo: (() => void) | null = null;
+        foo &&= null;
+      `},
+		{Code: `
+        declare function cb(): void;
+        let foo: (() => void) | boolean = false;
+        foo ||= cb;
+      `},
+		{Code: `
+        declare function Foo(props: { cb: () => void }): unknown;
+        return <Foo cb={() => {}} />;
+      `, Tsx: true},
+		{Code: `
+        declare function Foo(props: { cb: () => void }): unknown;
+        return <Foo cb="() => {}" />;
+      `, Tsx: true},
+		{Code: `
+        declare function Foo(props: { cb: () => void }): unknown;
+        return <Foo cb={} />;
+      `, Tsx: true},
+		{Code: `
+        declare function Foo(props: { cb: () => void }): unknown;
+        return <Bar children=<Foo cb={() => {}} /> />;
+      `, Tsx: true},
+		{Code: `
+        type Cb = () => void;
+        declare function Foo(props: { cb: Cb; s: string }): unknown;
+        return <Foo cb={function () {}} s="asd" />;
+      `, Tsx: true},
+		{Code: `
+        type Cb = () => void;
+        declare function Foo(props: { x: number; cb?: Cb }): unknown;
+        return <Foo x={123} />;
+      `, Tsx: true},
+		{Code: `
+        type Cb = (() => void) | (() => number);
+        declare function Foo(props: { cb?: Cb }): unknown;
+        return (
+          <Foo
+            cb={function (arg) {
+              return 123;
+            }}
+          />
+        );
+      `, Tsx: true},
+		{Code: `
+        interface Props {
+          cb: ((arg: unknown) => void) | boolean;
+        }
+        declare function Foo(props: Props): unknown;
+        return <Foo cb />;
+      `, Tsx: true},
+		{Code: `
+        interface Props {
+          cb: (() => void) | (() => Promise<void>);
+        }
+        declare function Foo(props: Props): any;
+        const _ = <Foo cb={async () => {}} />;
+      `, Tsx: true},
+		{Code: `
+        interface Props {
+          children: (arg: unknown) => void;
+        }
+        declare function Foo(props: Props): unknown;
+        declare function cb(): void;
+        return <Foo>{cb}</Foo>;
+      `, Tsx: true},
+		{Code: `
+        declare function foo(cbs: { arg: number; cb: () => void }): void;
+        foo({ arg: 1, cb: () => undefined });
+      `},
+		{Code: `
+        declare let foo: { arg?: string; cb: () => void };
+        foo = {
+          cb: () => {
+            return something;
+          },
+        };
+      `, Options: allowReturnAny},
+		{Code: `
+        declare let foo: { cb: () => void };
+        foo = {
+          cb() {
+            return something;
+          },
+        };
+      `, Options: allowReturnAny},
+		{Code: `
+        declare let foo: { cb: () => void };
+        foo = {
+          // don't check this thing
+          cb = () => 1,
+        };
+      `},
+		{Code: `
+        declare let foo: { cb: (n: number) => void };
+        let method = 'cb';
+        foo = {
+          // don't check computed methods
+          [method](n) {
+            return n;
+          },
+        };
+      `},
+		{Code: `
+        // no contextual type for object
+        let foo = {
+          cb(n) {
+            return n;
+          },
+        };
+      `},
+		{Code: `
+        interface Foo {
+          fn(): void;
+        }
+        // no symbol for method cb
+        let foo: Foo = {
+          cb(n) {
+            return n;
+          },
+        };
+      `},
+		{Code: `
+        declare let foo: { cb: (() => void) | number };
+        foo = {
+          cb: 0,
+        };
+      `},
+		{Code: `
+        declare function cb(): void;
+        const foo: Record<string, () => void> = {
+          cb1: cb,
+          cb2: cb,
+        };
+      `},
+		{Code: `
+        declare function cb(): string;
+        const foo: Record<string, () => void> = {
+          ...cb,
+        };
+      `},
+		{Code: `
+        declare function cb(): string;
+        const foo: Record<string, () => void> = {
+          ...cb,
+          ...{},
+        };
+      `},
+		{Code: `
+        declare function cb(): void;
+        const foo: Array<(() => void) | false> = [false, cb, () => cb()];
+      `},
+		{Code: `
+        declare function cb(): void;
+        const foo: [string, () => void, (() => void)?] = ['asd', cb];
+      `},
+		{Code: `
+        const foo: { cbs: Array<() => void> | null } = {
+          cbs: [
+            function () {
+              return undefined;
+            },
+            () => {
+              return void 0;
+            },
+            null,
+          ],
+        };
+      `},
+		{Code: `
+        const foo: { cb: () => void } = class {
+          static cb = () => {};
+        };
+      `},
+		{Code: `
+        class Foo {
+          foo;
+        }
+      `},
+		{Code: `
+        class Bar {
+          foo() {}
+        }
+        class Foo extends Bar {
+          foo();
+        }
+      `},
+		{Code: `
+        interface Bar {
+          foo(): void;
+        }
+        class Foo implements Bar {
+          get foo() {
+            return new Date();
+          }
+          set foo() {
+            return new Date('wtf');
+          }
+        }
+      `},
+		{Code: `
+        class Foo {
+          foo: () => void = () => undefined;
+        }
+      `},
+		{Code: `
+        class Bar {}
+        class Foo extends Bar {
+          foo = () => 1;
+        }
+      `},
+		{Code: `
+        class Foo extends Wtf {
+          foo = () => 1;
+        }
+      `},
+		{Code: `
+        class Foo extends Wtf {
+          [unknown] = () => 1;
+        }
+      `},
+		{Code: `
+        class Foo {
+          cb = () => {
+            console.log('hello');
+          };
+        }
+        class Bar extends Foo {
+          cb = () => {
+            console.log('nara');
+          };
+        }
+      `},
+		{Code: `
+        class Foo {
+          cb1 = () => {};
+        }
+        class Bar extends Foo {
+          cb2() {}
+        }
+        class Baz extends Bar {
+          cb1 = () => {
+            console.log('hello');
+          };
+          cb2() {
+            console.log('nara');
+          }
+        }
+      `},
+		{Code: `
+        class Foo {
+          fn() {
+            return 'a';
+          }
+          cb() {}
+        }
+        void class extends Foo {
+          cb() {
+            if (maybe) {
+              console.log('hello');
+            } else {
+              console.log('nara');
+            }
+          }
+        };
+      `},
+		{Code: `
+        abstract class Foo {
+          abstract cb(): void;
+        }
+        class Bar extends Foo {
+          cb() {
+            console.log('a');
+          }
+        }
+      `},
+		{Code: `
+        class Bar implements Foo {
+          cb = () => 1;
+        }
+      `},
+		{Code: `
+        interface Foo {
+          cb: () => void;
+        }
+        class Bar implements Foo {
+          cb = () => {};
+        }
+      `},
+		{Code: `
+        interface Foo {
+          cb: () => void;
+        }
+        class Bar implements Foo {
+          get cb() {
+            return () => {};
+          }
+        }
+      `},
+		{Code: `
+        interface Foo {
+          cb(): void;
+        }
+        class Bar implements Foo {
+          cb() {
+            return undefined;
+          }
+        }
+      `},
+		{Code: `
+        interface Foo1 {
+          cb1(): void;
+        }
+        interface Foo2 {
+          cb2: () => void;
+        }
+        class Bar implements Foo1, Foo2 {
+          cb1() {}
+          cb2() {}
+        }
+      `},
+		{Code: `
+        interface Foo1 {
+          cb1(): void;
+        }
+        interface Foo2 extends Foo1 {
+          cb2: () => void;
+        }
+        class Bar implements Foo2 {
+          cb1() {}
+          cb2() {}
+        }
+      `},
+		{Code: `
+        declare let foo: () => () => void;
+        foo = () => () => {};
+      `},
+		{Code: `
+        declare let foo: { f(): () => void };
+        foo = {
+          f() {
+            return () => undefined;
+          },
+        };
+        function cb() {}
+      `},
+		{Code: `
+        declare let foo: { f(): () => void };
+        foo.f = function () {
+          return () => {};
+        };
+      `},
+		{Code: `
+        declare let foo: () => (() => void) | string;
+        foo = () => 'asd' + 'zxc';
+      `},
+		{Code: `
+        declare function foo(cb: () => () => void): void;
+        foo(function () {
+          return () => {};
+        });
+      `},
+		{Code: `
+        declare function foo(cb: (arg: string) => () => void): void;
+        declare function foo(cb: (arg: number) => () => boolean): void;
+        foo((arg: number) => {
+          return cb;
+        });
+        function cb() {
+          return true;
+        }
+      `},
+		{Code: `
+        declare function f<T extends void>(arg: T, cb: () => T): void;
+        declare function f<T extends string>(arg: T, cb: () => T): void;
+
+        f('test', () => 'test');
+        f(undefined, () => {});
+      `},
+		{Code: `
+        interface HookFunction<T extends void | Hook = void> {
+          (fn: () => void): T;
+          (fn: () => Promise<void>): T;
+        }
+
+        class Hook {}
+
+        declare var beforeEach: HookFunction<Hook>;
+
+        beforeEach(() => {});
+
+        beforeEach(async () => {});
+      `},
+	}, []rule_tester.InvalidTestCase{
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(() => null);
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 19},
+		}},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(() => (((true))));
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 22},
+		}},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(() => {
+          if (maybe) {
+            return (((1) + 1));
+          }
+        });
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 13},
+		}},
+		{Code: `
+        declare function foo(arg: number, cb: () => void): void;
+        foo(0, () => 0);
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 22},
+		}},
+		{Code: `
+        declare function foo(cb?: { (): void }): void;
+        foo(() => () => {});
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 19},
+		}},
+		{Code: `
+        declare const obj: { foo(cb: () => void) } | null;
+        obj?.foo(() => JSON.parse('{}'));
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 24},
+		}},
+		{Code: `
+        ((cb: () => void) => cb())!(() => 1);
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 2, Column: 43},
+		}},
+		{Code: `
+        declare function foo(cb: { (): void }): void;
+        declare function cb(): string;
+        foo(cb);
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 13},
+		}},
+		{Code: `
+        type AnyFunc = (...args: unknown[]) => unknown;
+        declare function foo<F extends AnyFunc>(cb: F): void;
+        foo(async () => ({}));
+        foo<() => void>(async () => ({}));
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 5, Column: 34},
+		}},
+		{Code: `
+        function foo<T extends {}>(arg: T, cb: () => T);
+        function foo(arg: null, cb: () => void);
+        function foo(arg: any, cb: () => any) {}
+
+        foo(null, () => Math.random());
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 25},
+		}},
+		{Code: `
+        declare function foo<T extends {}>(arg: T, cb: () => T): void;
+        declare function foo(arg: any, cb: () => void): void;
+
+        foo(null, async () => {});
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 5, Column: 28},
+		}},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        declare function foo(cb: () => any): void;
+        foo(async () => {
+          return Math.random();
+        });
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 4, Column: 22},
+		}},
+		{Code: `
+        declare function f<T extends void>(arg: T, cb: () => T): void;
+
+        f(undefined, () => 'test');
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 4, Column: 28},
+		}},
+		{Code: `
+        declare function foo(cb: { (): void }): void;
+        foo(cb);
+        async function cb() {}
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 3, Column: 13},
+		}},
+		{Code: `
+        declare function foo<Cb extends (...args: any[]) => void>(cb: Cb): void;
+        foo(() => {
+          console.log('a');
+          return 1;
+        });
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 11},
+		}},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        function bar<Cb extends () => number>(cb: Cb) {
+          foo(cb);
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 15},
+		}},
+		{Code: `
+        declare function foo(cb: { (): void }): void;
+        const cb = () => dunno;
+        foo!(cb);
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 14},
+		}},
+		{Code: `
+        declare const foo: {
+          (arg: boolean, cb: () => void): void;
+        };
+        foo(false, () => Promise.resolve(undefined));
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 26},
+		}},
+		{Code: `
+        declare const foo: {
+          bar(cb1: () => any, cb2: () => void): void;
+        };
+        foo.bar(
+          () => Promise.resolve(1),
+          () => Promise.resolve(1),
+        );
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 7, Column: 17},
+		}},
+		{Code: `
+        declare const Foo: {
+          new (cb: () => void): void;
+        };
+        new Foo(async () => {});
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 5, Column: 26},
+		}},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(() => {
+          label: while (maybe) {
+            for (const i of [1, 2, 3]) {
+              if (maybe) return null;
+              else return null;
+            }
+          }
+          return void 0;
+        });
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 26},
+			{MessageId: "nonVoidReturn", Line: 7, Column: 20},
+		}},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(() => {
+          do {
+            try {
+              throw 1;
+            } catch (e) {
+              return null;
+            } finally {
+              console.log('finally');
+            }
+          } while (maybe);
+        });
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 8, Column: 15},
+		}},
+		{Code: `
+        declare function foo(cb: () => void): void;
+        foo(async () => {
+          try {
+            await Promise.resolve();
+          } catch {
+            console.error('fail');
+          }
+        });
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 3, Column: 22},
+		}},
+		{Code: `
+        declare const Foo: {
+          new (cb: () => void): void;
+          (cb: () => unknown): void;
+        };
+        new Foo(() => false);
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 23},
+		}},
+		{Code: `
+        declare const Foo: {
+          new (cb: () => any): void;
+          (cb: () => void): void;
+        };
+        Foo(() => false);
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 19},
+		}},
+		{Code: `
+        interface Cb {
+          (arg: string): void;
+          (arg: number): void;
+        }
+        declare function foo(cb: Cb): void;
+        foo(cb);
+        function cb() {
+          return true;
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 7, Column: 13},
+		}},
+		{Code: `
+        declare function foo(
+          cb: ((arg: number) => void) | ((arg: string) => void),
+        ): void;
+        foo(cb);
+        function cb() {
+          return 1 + 1;
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 5, Column: 13},
+		}},
+		{Code: `
+        declare function foo(cb: (() => void) | null): void;
+        declare function cb(): boolean;
+        foo(cb);
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 13},
+		}},
+		{Code: `
+        declare function foo(...cbs: Array<() => void>): void;
+        foo(
+          () => {},
+          () => false,
+          () => 0,
+          () => '',
+        );
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 17},
+			{MessageId: "nonVoidReturn", Line: 6, Column: 17},
+			{MessageId: "nonVoidReturn", Line: 7, Column: 17},
+		}},
+		{Code: `
+        declare function foo(...cbs: [() => void, () => void, (() => void)?]): void;
+        foo(
+          () => {},
+          () => Math.random(),
+          () => (1).toString(),
+        );
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 17},
+			{MessageId: "nonVoidReturn", Line: 6, Column: 17},
+		}},
+		{Code: `
+        interface Ev {}
+        interface EvMap {
+          DOMContentLoaded: Ev;
+        }
+        type EvListOrEvListObj = EvList | EvListObj;
+        interface EvList {
+          (evt: Event): void;
+        }
+        interface EvListObj {
+          handleEvent(object: Ev): void;
+        }
+        interface Win {
+          addEventListener<K extends keyof EvMap>(
+            type: K,
+            listener: (ev: EvMap[K]) => any,
+          ): void;
+          addEventListener(type: string, listener: EvListOrEvListObj): void;
+        }
+        declare const win: Win;
+        win.addEventListener('DOMContentLoaded', ev => ev);
+        win.addEventListener('custom', ev => ev);
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 21, Column: 56},
+			{MessageId: "nonVoidReturn", Line: 22, Column: 46},
+		}},
+		{Code: `
+        declare function foo(x: null, cb: () => void): void;
+        declare function foo(x: unknown, cb: () => any): void;
+        foo({}, async () => {});
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 4, Column: 26},
+		}},
+		{Code: `
+        const arr = [1, 2];
+        arr.forEach(async x => {
+          console.log(x);
+        });
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 3, Column: 29},
+		}},
+		{Code: `
+        [1, 2].forEach(async x => console.log(x));
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 2, Column: 32},
+		}},
+		{Code: `
+        const foo: () => void = () => false;
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 2, Column: 39},
+		}},
+		{Code: `
+        const { name }: () => void = function foo() {
+          return false;
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 11},
+		}},
+		{Code: `
+        declare const foo: Record<string, () => void>;
+        foo['a' + 'b'] = () => true;
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 32},
+		}},
+		{Code: `
+        const foo: () => void = async () => Promise.resolve(true);
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 2, Column: 42},
+		}},
+		{Code: `const cb: () => void = (): Array<number> => [];`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 1, Column: 45},
+		}},
+		{Code: `
+        const cb: () => void = (): Array<number> => {
+          return [];
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 2, Column: 36},
+		}},
+		{Code: `const cb: () => void = function*foo() {}`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 1, Column: 24},
+		}},
+		{Code: `const cb: () => void = (): Promise<number> => Promise.resolve(1);`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 1, Column: 47},
+		}},
+		{Code: `
+        const cb: () => void = async (): Promise<number> => {
+          try {
+            return Promise.resolve(1);
+          } catch {}
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 2, Column: 58},
+		}},
+		{Code: `const cb: () => void = async (): Promise<number> => Promise.resolve(1);`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 1, Column: 50},
+		}},
+		{Code: `
+        const foo: () => void = async () => {
+          try {
+            return 1;
+          } catch {}
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 2, Column: 42},
+		}},
+		{Code: `
+        const foo: () => void = async (): Promise<void> => {
+          try {
+            await Promise.resolve();
+          } finally {
+          }
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 2, Column: 57},
+		}},
+		{Code: `
+        const foo: () => void = async () => {
+          try {
+            await Promise.resolve();
+          } catch (err) {
+            console.error(err);
+          }
+          console.log('ok');
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 2, Column: 42},
+		}},
+		{Code: `const foo: () => void = (): number => {};`, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 1, Column: 29},
+		}},
+		{Code: `
+        declare function cb(): boolean;
+        const foo: () => void = cb;
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 3, Column: 33},
+		}},
+		{Code: `
+        const foo: () => void = function () {
+          if (maybe) {
+            return null;
+          } else {
+            return null;
+          }
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 4, Column: 13},
+			{MessageId: "nonVoidReturn", Line: 6, Column: 13},
+		}},
+		{Code: `
+        const foo: () => void = function () {
+          if (maybe) {
+            console.log('elo');
+            return { [1]: Math.random() };
+          }
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 13},
+		}},
+		{Code: `
+        const foo: { (arg: number): void; (arg: string): void } = arg => {
+          console.log('foo');
+          switch (typeof arg) {
+            case 'number':
+              return 0;
+            case 'string':
+              return '';
+          }
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 15},
+			{MessageId: "nonVoidReturn", Line: 8, Column: 15},
+		}},
+		{Code: `
+        const foo: ((arg: number) => void) | ((arg: string) => void) = async () => {
+          return 1;
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 2, Column: 81},
+		}},
+		{Code: `
+        type Foo = () => void;
+        const foo: Foo = cb;
+        function cb() {
+          return [1, 2, 3];
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 3, Column: 26},
+		}},
+		{Code: `
+        interface Foo {
+          (): void;
+        }
+        const foo: Foo = cb;
+        function cb() {
+          return { a: 1 };
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 5, Column: 26},
+		}},
+		{Code: `
+        declare function cb(): unknown;
+        declare let foo: () => void;
+        foo = cb;
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 15},
+		}},
+		{Code: `
+        declare let foo: { arg?: string; cb?: () => void };
+        foo.cb = () => {
+          return 'hello';
+          console.log('hello');
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 4, Column: 11},
+		}},
+		{Code: `
+        declare function cb(): unknown;
+        let foo: (() => void) | null = null;
+        foo ??= cb;
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 17},
+		}},
+		{Code: `
+        declare function cb(): unknown;
+        let foo: (() => void) | boolean = false;
+        foo ||= cb;
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 17},
+		}},
+		{Code: `
+        declare function cb(): unknown;
+        let foo: (() => void) | boolean = false;
+        foo &&= cb;
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 17},
+		}},
+		{Code: `
+        declare function Foo(props: { cb: () => void }): unknown;
+        return <Foo cb={() => 1} />;
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 31},
+		}},
+		{Code: `
+        declare function Foo(props: { cb: () => void }): unknown;
+        declare function getNull(): null;
+        return (
+          <Foo
+            cb={() => {
+              if (maybe) return Math.random();
+              else return getNull();
+            }}
+          />
+        );
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 7, Column: 26},
+			{MessageId: "nonVoidReturn", Line: 8, Column: 20},
+		}},
+		{Code: `
+        type Cb = () => void;
+        declare function Foo(props: { cb: Cb; s: string }): unknown;
+        return <Foo cb={async function () {}} s="!@#jp2gmd" />;
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 4, Column: 25},
+		}},
+		{Code: `
+        type Cb = () => void;
+        declare function Foo(props: { n: number; cb?: Cb }): unknown;
+        return <Foo n={2137} cb={function* () {}} />;
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 34},
+		}},
+		{Code: `
+        type Cb = ((arg: string) => void) | ((arg: number) => void);
+        declare function Foo(props: { cb?: Cb }): unknown;
+        return (
+          <Foo
+            cb={async function* (arg) {
+              await arg;
+              yield arg;
+            }}
+          />
+        );
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 6, Column: 17},
+		}},
+		{Code: `
+        interface Props {
+          cb: ((arg: unknown) => void) | boolean;
+        }
+        declare function Foo(props: Props): unknown;
+        return <Foo cb={x => x} />;
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 30},
+		}},
+		{Code: `
+        type EventHandler<E> = { bivarianceHack(event: E): void }['bivarianceHack'];
+        interface ButtonProps {
+          onClick?: EventHandler<unknown> | undefined;
+        }
+        declare function Button(props: ButtonProps): unknown;
+        function App() {
+          return <Button onClick={x => x} />;
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 8, Column: 40},
+		}},
+		{Code: `
+        declare function foo(cbs: { arg: number; cb: () => void }): void;
+        foo({ arg: 1, cb: () => 1 });
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 33},
+		}},
+		{Code: `
+        declare let foo: { arg?: string; cb: () => void };
+        foo = {
+          cb: () => {
+            let x = 'hello';
+            return x;
+          },
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 13},
+		}},
+		{Code: `
+        declare let foo: { cb: (n: number) => void };
+        foo = {
+          cb(n) {
+            return n;
+          },
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 13},
+		}},
+		{Code: `
+        declare let foo: { 1234: (n: number) => void };
+        foo = {
+          1234(n) {
+            return n;
+          },
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 13},
+		}},
+		{Code: `
+        declare let foo: { '1e+21': () => void };
+        foo = {
+          1_000_000_000_000_000_000_000: () => 1,
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 4, Column: 48},
+		}},
+		{Code: `
+        declare let foo: { cb: (() => void) | number };
+        foo = {
+          cb: async () => {
+            if (maybe) {
+              return 'asd';
+            }
+          },
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 4, Column: 11},
+		}},
+		{Code: `
+        declare function cb(): number;
+        const foo: Record<string, () => void> = {
+          cb1: cb,
+          cb2: cb,
+          ...cb,
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 16},
+			{MessageId: "nonVoidFunc", Line: 5, Column: 16},
+		}},
+		{Code: `
+        declare function cb(): number;
+        const foo: Array<(() => void) | false> = [false, cb, () => cb()];
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 3, Column: 58},
+			{MessageId: "nonVoidReturn", Line: 3, Column: 68},
+		}},
+		{Code: `
+        declare function cb(): number;
+        const foo: [string, () => void, (() => void)?] = ['asd', cb];
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 3, Column: 66},
+		}},
+		{Code: `
+        const foo: { cbs: Array<() => void> | null } = {
+          cbs: [
+            function* () {
+              yield 1;
+            },
+            async () => {
+              await 1;
+            },
+            null,
+          ],
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 13},
+			{MessageId: "asyncFunc", Line: 7, Column: 22},
+		}},
+		{Code: `
+        const foo: { cb: () => void } = class {
+          static cb = () => ({});
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 30},
+		}},
+		{Code: `
+        class Foo {
+          foo: () => void = () => [];
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 35},
+		}},
+		{Code: `
+        class Foo {
+          static foo: () => void = Math.random;
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 3, Column: 36},
+		}},
+		{Code: `
+        class Foo {
+          cb = () => {};
+        }
+        class Bar extends Foo {
+          cb = Math.random;
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 6, Column: 16},
+		}},
+		{Code: `
+        const foo = () =>
+          class {
+            cb = () => {};
+          };
+        class Bar extends foo() {
+          cb = Math.random;
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 7, Column: 16},
+		}},
+		{Code: `
+        class Foo {
+          cb() {
+            console.log('hello');
+          }
+        }
+        const method = 'cb' as const;
+        class Bar extends Foo {
+          [method]() {
+            return 'nara';
+          }
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 10, Column: 13},
+		}},
+		{Code: `
+        class Bar {
+          foo() {}
+        }
+        class Foo extends Bar {
+          get foo() {
+            return () => 1;
+          }
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 7, Column: 13},
+		}},
+		{Code: `
+        class Foo {
+          cb() {}
+        }
+        void class extends Foo {
+          cb() {
+            return Math.random();
+          }
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 7, Column: 13},
+		}},
+		{Code: `
+        class Foo {
+          cb1 = () => {};
+        }
+        class Bar extends Foo {
+          cb2() {}
+        }
+        class Baz extends Bar {
+          cb1 = () => Math.random();
+          cb2() {
+            return Math.random();
+          }
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 9, Column: 23},
+			{MessageId: "nonVoidReturn", Line: 11, Column: 13},
+		}},
+		{Code: `
+        declare function f(): Promise<void>;
+        interface Foo {
+          cb: () => void;
+        }
+        class Bar {
+          cb = () => {};
+        }
+        class Baz extends Bar implements Foo {
+          cb: () => void = f;
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 10, Column: 28},
+		}},
+		{Code: `
+        class Foo {
+          fn() {
+            return 'a';
+          }
+          cb() {}
+        }
+        class Bar extends Foo {
+          cb() {
+            if (maybe) {
+              return Promise.resolve('hello');
+            } else {
+              return Promise.resolve('nara');
+            }
+          }
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 11, Column: 15},
+			{MessageId: "nonVoidReturn", Line: 13, Column: 15},
+		}},
+		{Code: `
+        abstract class Foo {
+          abstract cb(): void;
+        }
+        class Bar extends Foo {
+          async cb() {}
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 6, Column: 11},
+		}},
+		{Code: `
+        class Foo {
+          fn() {
+            return 'a';
+          }
+          cb() {}
+        }
+        class Bar extends Foo {
+          *cb() {}
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 9, Column: 11},
+		}},
+		{Code: `
+        interface Foo {
+          cb: () => void;
+        }
+        class Bar implements Foo {
+          cb = Math.random;
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 6, Column: 16},
+		}},
+		{Code: `
+        const o = { cb() {} };
+        type O = typeof o;
+        class Bar implements O {
+          cb = Math.random;
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 5, Column: 16},
+		}},
+		{Code: `
+        class Foo {
+          cb() {}
+        }
+        class Bar extends Foo {
+          async*cb() {}
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 6, Column: 11},
+		}},
+		{Code: `
+        interface Foo {
+          cb(): void;
+        }
+        class Bar implements Foo {
+          async cb(): Promise<string> {
+            return Promise.resolve('hello');
+          }
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 6, Column: 11},
+		}},
+		{Code: `
+        interface Foo {
+          cb(): void;
+        }
+        class Bar implements Foo {
+          async cb() {
+            try {
+              return { a: ['asdf', 1234] };
+            } catch {
+              console.error('error');
+            }
+          }
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 6, Column: 11},
+		}},
+		{Code: `
+        interface Foo {
+          cb(): void;
+        }
+        class Bar implements Foo {
+          cb() {
+            if (maybe) {
+              return Promise.resolve(1);
+            } else {
+              return;
+            }
+          }
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 8, Column: 15},
+		}},
+		{Code: `
+        interface Foo1 {
+          cb1(): void;
+        }
+        interface Foo2 {
+          cb2: () => void;
+        }
+        class Bar implements Foo1, Foo2 {
+          async cb1() {}
+          async *cb2() {}
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 9, Column: 11},
+			{MessageId: "nonVoidFunc", Line: 10, Column: 11},
+		}},
+		{Code: `
+        interface Foo1 {
+          cb1(): void;
+        }
+        interface Foo2 {
+          cb2: () => void;
+        }
+        class Baz {
+          cb3() {}
+        }
+        class Bar extends Baz implements Foo1, Foo2 {
+          async cb1() {}
+          async *cb2() {}
+          cb3() {
+            return Math.random();
+          }
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 12, Column: 11},
+			{MessageId: "nonVoidFunc", Line: 13, Column: 11},
+			{MessageId: "nonVoidReturn", Line: 15, Column: 13},
+		}},
+		{Code: `
+        class A extends class {
+          cb() {}
+        } {
+          cb() {
+            return Math.random();
+          }
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 13},
+		}},
+		{Code: `
+        class A extends class B {
+          cb() {}
+        } {
+          cb() {
+            return Math.random();
+          }
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 13},
+		}},
+		{Code: `
+        interface Foo1 {
+          cb1(): void;
+        }
+        interface Foo2 extends Foo1 {
+          cb2: () => void;
+        }
+        class Bar implements Foo2 {
+          async cb1() {}
+          async *cb2() {}
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 9, Column: 11},
+			{MessageId: "nonVoidFunc", Line: 10, Column: 11},
+		}},
+		{Code: `
+        declare let foo: () => () => void;
+        foo = () => () => 1 + 1;
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 27},
+		}},
+		{Code: `
+        declare let foo: () => () => void;
+        foo = () => () => Math.random();
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 3, Column: 27},
+		}},
+		{Code: `
+        declare let foo: () => () => void;
+        declare const cb: () => null | false;
+        foo = () => cb;
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 4, Column: 21},
+		}},
+		{Code: `
+        declare let foo: { f(): () => void };
+        foo = {
+          f() {
+            return () => cb;
+          },
+        };
+        function cb() {}
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 26},
+		}},
+		{Code: `
+        declare let foo: { f(): () => void };
+        foo.f = function () {
+          return () => {
+            return null;
+          };
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 5, Column: 13},
+		}},
+		{Code: `
+        declare let foo: () => (() => void) | string;
+        foo = () => () => {
+          return 'asd' + 'zxc';
+        };
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 4, Column: 11},
+		}},
+		{Code: `
+        declare function foo(cb: () => () => void): void;
+        foo(function () {
+          return async () => {};
+        });
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncFunc", Line: 4, Column: 27},
+		}},
+		{Code: `
+        declare function foo(cb: () => () => void): void;
+        foo(() => () => {
+          if (n == 1) {
+            console.log('asd')
+            return [1].map(x => x)
+          }
+          if (n == 2) {
+            console.log('asd')
+            return -Math.random()
+          }
+          if (n == 3) {
+            console.log('asd')
+            return ` + "`x`" + `.toUpperCase()
+          }
+          return <i>{Math.random()}</i>
+        });
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidReturn", Line: 6, Column: 13},
+			{MessageId: "nonVoidReturn", Line: 10, Column: 13},
+			{MessageId: "nonVoidReturn", Line: 14, Column: 13},
+			{MessageId: "nonVoidReturn", Line: 16, Column: 11},
+		}},
+		{Code: `
+        declare function foo(cb: (arg: string) => () => void): void;
+        declare function foo(cb: (arg: number) => () => boolean): void;
+        foo((arg: string) => {
+          return cb;
+        });
+        async function* cb() {
+          yield true;
+        }
+      `, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "nonVoidFunc", Line: 5, Column: 18},
+		}},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -353,6 +353,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/return-await.test.ts',
     // './tests/typescript-eslint/rules/sort-type-constituents.test.ts',
     // './tests/typescript-eslint/rules/strict-boolean-expressions.test.ts',
+    './tests/typescript-eslint/rules/strict-void-return.test.ts',
     // './tests/typescript-eslint/rules/switch-exhaustiveness-check.test.ts',
     // './tests/typescript-eslint/rules/triple-slash-reference.test.ts',
     // './tests/typescript-eslint/rules/typedef.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/strict-void-return.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/strict-void-return.test.ts.snap
@@ -1,0 +1,3875 @@
+// Rstest Snapshot v1
+
+exports[`strict-void-return > invalid 1`] = `
+{
+  "code": "
+declare function foo(cb: () => void): void;
+foo(() => null);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 2`] = `
+{
+  "code": "
+declare function foo(cb: () => void): void;
+foo(() => (((true))));
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 3`] = `
+{
+  "code": "
+declare function foo(cb: () => void): void;
+foo(() => {
+  if (maybe) {
+    return (((1) + 1));
+  }
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 4`] = `
+{
+  "code": "
+declare function foo(arg: number, cb: () => void): void;
+foo(0, () => 0);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 5`] = `
+{
+  "code": "
+declare function foo(cb?: { (): void }): void;
+foo(() => () => {});
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 6`] = `
+{
+  "code": "
+declare const obj: { foo(cb: () => void) } | null;
+obj?.foo(() => JSON.parse('{}'));
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 3,
+        },
+        "start": {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 7`] = `
+{
+  "code": "
+((cb: () => void) => cb())!(() => 1);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 2,
+        },
+        "start": {
+          "column": 35,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 8`] = `
+{
+  "code": "
+declare function foo(cb: { (): void }): void;
+declare function cb(): string;
+foo(cb);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 9`] = `
+{
+  "code": "
+type AnyFunc = (...args: unknown[]) => unknown;
+declare function foo<F extends AnyFunc>(cb: F): void;
+foo(async () => ({}));
+foo<() => void>(async () => ({}));
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 5,
+        },
+        "start": {
+          "column": 26,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 10`] = `
+{
+  "code": "
+function foo<T extends {}>(arg: T, cb: () => T);
+function foo(arg: null, cb: () => void);
+function foo(arg: any, cb: () => any) {}
+
+foo(null, () => Math.random());
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 6,
+        },
+        "start": {
+          "column": 17,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 11`] = `
+{
+  "code": "
+declare function foo<T extends {}>(arg: T, cb: () => T): void;
+declare function foo(arg: any, cb: () => void): void;
+
+foo(null, async () => {});
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 20,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 12`] = `
+{
+  "code": "
+declare function foo(cb: () => void): void;
+declare function foo(cb: () => any): void;
+foo(async () => {
+  return Math.random();
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 13`] = `
+{
+  "code": "
+declare function f<T extends void>(arg: T, cb: () => T): void;
+
+f(undefined, () => 'test');
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 4,
+        },
+        "start": {
+          "column": 20,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 14`] = `
+{
+  "code": "
+declare function foo(cb: { (): void }): void;
+foo(cb);
+async function cb() {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 15`] = `
+{
+  "code": "
+declare function foo<Cb extends (...args: any[]) => void>(cb: Cb): void;
+foo(() => {
+  console.log('a');
+  return 1;
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 16`] = `
+{
+  "code": "
+declare function foo(cb: () => void): void;
+function bar<Cb extends () => number>(cb: Cb) {
+  foo(cb);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 4,
+        },
+        "start": {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 17`] = `
+{
+  "code": "
+declare function foo(cb: { (): void }): void;
+const cb = () => dunno;
+foo!(cb);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 18`] = `
+{
+  "code": "
+declare const foo: {
+  (arg: boolean, cb: () => void): void;
+};
+foo(false, () => Promise.resolve(undefined));
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 5,
+        },
+        "start": {
+          "column": 18,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 19`] = `
+{
+  "code": "
+declare const foo: {
+  bar(cb1: () => any, cb2: () => void): void;
+};
+foo.bar(
+  () => Promise.resolve(1),
+  () => Promise.resolve(1),
+);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 7,
+        },
+        "start": {
+          "column": 9,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 20`] = `
+{
+  "code": "
+declare const Foo: {
+  new (cb: () => void): void;
+};
+new Foo(async () => {});
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 5,
+        },
+        "start": {
+          "column": 18,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 21`] = `
+{
+  "code": "
+declare function foo(cb: () => void): void;
+foo(() => {
+  label: while (maybe) {
+    for (const i of [1, 2, 3]) {
+      if (maybe) return null;
+      else return null;
+    }
+  }
+  return void 0;
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 6,
+        },
+        "start": {
+          "column": 18,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 7,
+        },
+        "start": {
+          "column": 12,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 22`] = `
+{
+  "code": "
+declare function foo(cb: () => void): void;
+foo(() => {
+  do {
+    try {
+      throw 1;
+    } catch (e) {
+      return null;
+    } finally {
+      console.log('finally');
+    }
+  } while (maybe);
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 8,
+        },
+        "start": {
+          "column": 7,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 23`] = `
+{
+  "code": "
+declare function foo(cb: () => void): void;
+foo(async () => {
+  try {
+    await Promise.resolve();
+  } catch {
+    console.error('fail');
+  }
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 24`] = `
+{
+  "code": "
+declare const Foo: {
+  new (cb: () => void): void;
+  (cb: () => unknown): void;
+};
+new Foo(() => false);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 6,
+        },
+        "start": {
+          "column": 15,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 25`] = `
+{
+  "code": "
+declare const Foo: {
+  new (cb: () => any): void;
+  (cb: () => void): void;
+};
+Foo(() => false);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 6,
+        },
+        "start": {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 26`] = `
+{
+  "code": "
+interface Cb {
+  (arg: string): void;
+  (arg: number): void;
+}
+declare function foo(cb: Cb): void;
+foo(cb);
+function cb() {
+  return true;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 7,
+        },
+        "start": {
+          "column": 5,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 27`] = `
+{
+  "code": "
+declare function foo(
+  cb: ((arg: number) => void) | ((arg: string) => void),
+): void;
+foo(cb);
+function cb() {
+  return 1 + 1;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 28`] = `
+{
+  "code": "
+declare function foo(cb: (() => void) | null): void;
+declare function cb(): boolean;
+foo(cb);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 29`] = `
+{
+  "code": "
+declare function foo(...cbs: Array<() => void>): void;
+foo(
+  () => {},
+  () => false,
+  () => 0,
+  () => '',
+);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 5,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 7,
+        },
+        "start": {
+          "column": 9,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 30`] = `
+{
+  "code": "
+declare function foo(...cbs: [() => void, () => void, (() => void)?]): void;
+foo(
+  () => {},
+  () => Math.random(),
+  () => (1).toString(),
+);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 31`] = `
+{
+  "code": "
+interface Ev {}
+interface EvMap {
+  DOMContentLoaded: Ev;
+}
+type EvListOrEvListObj = EvList | EvListObj;
+interface EvList {
+  (evt: Event): void;
+}
+interface EvListObj {
+  handleEvent(object: Ev): void;
+}
+interface Win {
+  addEventListener<K extends keyof EvMap>(
+    type: K,
+    listener: (ev: EvMap[K]) => any,
+  ): void;
+  addEventListener(type: string, listener: EvListOrEvListObj): void;
+}
+declare const win: Win;
+win.addEventListener('DOMContentLoaded', ev => ev);
+win.addEventListener('custom', ev => ev);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 21,
+        },
+        "start": {
+          "column": 48,
+          "line": 21,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 22,
+        },
+        "start": {
+          "column": 38,
+          "line": 22,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 32`] = `
+{
+  "code": "
+declare function foo(x: null, cb: () => void): void;
+declare function foo(x: unknown, cb: () => any): void;
+foo({}, async () => {});
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 4,
+        },
+        "start": {
+          "column": 18,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 33`] = `
+{
+  "code": "
+const arr = [1, 2];
+arr.forEach(async x => {
+  console.log(x);
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 21,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 34`] = `
+{
+  "code": "
+[1, 2].forEach(async x => console.log(x));
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 2,
+        },
+        "start": {
+          "column": 24,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 35`] = `
+{
+  "code": "
+const foo: () => void = () => false;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 2,
+        },
+        "start": {
+          "column": 31,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 36`] = `
+{
+  "code": "
+const { name }: () => void = function foo() {
+  return false;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 37`] = `
+{
+  "code": "
+declare const foo: Record<string, () => void>;
+foo['a' + 'b'] = () => true;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 38`] = `
+{
+  "code": "
+const foo: () => void = async () => Promise.resolve(true);
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 2,
+        },
+        "start": {
+          "column": 34,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 39`] = `
+{
+  "code": "const cb: () => void = (): Array<number> => [];",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 40`] = `
+{
+  "code": "
+const cb: () => void = (): Array<number> => {
+  return [];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 2,
+        },
+        "start": {
+          "column": 28,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 41`] = `
+{
+  "code": "const cb: () => void = function*foo() {}",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 42`] = `
+{
+  "code": "const cb: () => void = (): Promise<number> => Promise.resolve(1);",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 43`] = `
+{
+  "code": "
+const cb: () => void = async (): Promise<number> => {
+  try {
+    return Promise.resolve(1);
+  } catch {}
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 2,
+        },
+        "start": {
+          "column": 50,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 44`] = `
+{
+  "code": "const cb: () => void = async (): Promise<number> => Promise.resolve(1);",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 45`] = `
+{
+  "code": "
+const foo: () => void = async () => {
+  try {
+    return 1;
+  } catch {}
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 2,
+        },
+        "start": {
+          "column": 34,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 46`] = `
+{
+  "code": "
+const foo: () => void = async (): Promise<void> => {
+  try {
+    await Promise.resolve();
+  } finally {
+  }
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 2,
+        },
+        "start": {
+          "column": 49,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 47`] = `
+{
+  "code": "
+const foo: () => void = async () => {
+  try {
+    await Promise.resolve();
+  } catch (err) {
+    console.error(err);
+  }
+  console.log('ok');
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 2,
+        },
+        "start": {
+          "column": 34,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 48`] = `
+{
+  "code": "const foo: () => void = (): number => {};",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 49`] = `
+{
+  "code": "
+declare function cb(): boolean;
+const foo: () => void = cb;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 25,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 50`] = `
+{
+  "code": "
+const foo: () => void = function () {
+  if (maybe) {
+    return null;
+  } else {
+    return null;
+  }
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 51`] = `
+{
+  "code": "
+const foo: () => void = function () {
+  if (maybe) {
+    console.log('elo');
+    return { [1]: Math.random() };
+  }
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 52`] = `
+{
+  "code": "
+const foo: { (arg: number): void; (arg: string): void } = arg => {
+  console.log('foo');
+  switch (typeof arg) {
+    case 'number':
+      return 0;
+    case 'string':
+      return '';
+  }
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 6,
+        },
+        "start": {
+          "column": 7,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 8,
+        },
+        "start": {
+          "column": 7,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 53`] = `
+{
+  "code": "
+const foo: ((arg: number) => void) | ((arg: string) => void) = async () => {
+  return 1;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 75,
+          "line": 2,
+        },
+        "start": {
+          "column": 73,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 54`] = `
+{
+  "code": "
+type Foo = () => void;
+const foo: Foo = cb;
+function cb() {
+  return [1, 2, 3];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 55`] = `
+{
+  "code": "
+interface Foo {
+  (): void;
+}
+const foo: Foo = cb;
+function cb() {
+  return { a: 1 };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 5,
+        },
+        "start": {
+          "column": 18,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 56`] = `
+{
+  "code": "
+declare function cb(): unknown;
+declare let foo: () => void;
+foo = cb;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 4,
+        },
+        "start": {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 57`] = `
+{
+  "code": "
+declare let foo: { arg?: string; cb?: () => void };
+foo.cb = () => {
+  return 'siema';
+  console.log('siema');
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 58`] = `
+{
+  "code": "
+declare function cb(): unknown;
+let foo: (() => void) | null = null;
+foo ??= cb;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 59`] = `
+{
+  "code": "
+declare function cb(): unknown;
+let foo: (() => void) | boolean = false;
+foo ||= cb;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 60`] = `
+{
+  "code": "
+declare function cb(): unknown;
+let foo: (() => void) | boolean = false;
+foo &&= cb;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 61`] = `
+{
+  "code": "
+declare function Foo(props: { cb: () => void }): unknown;
+return <Foo cb={() => 1} />;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 23,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 62`] = `
+{
+  "code": "
+declare function Foo(props: { cb: () => void }): unknown;
+declare function getNull(): null;
+return (
+  <Foo
+    cb={() => {
+      if (maybe) return Math.random();
+      else return getNull();
+    }}
+  />
+);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 7,
+        },
+        "start": {
+          "column": 18,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 8,
+        },
+        "start": {
+          "column": 12,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 63`] = `
+{
+  "code": "
+type Cb = () => void;
+declare function Foo(props: { cb: Cb; s: string }): unknown;
+return <Foo cb={async function () {}} s="!@#jp2gmd" />;
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 64`] = `
+{
+  "code": "
+type Cb = () => void;
+declare function Foo(props: { n: number; cb?: Cb }): unknown;
+return <Foo n={2137} cb={function* () {}} />;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 4,
+        },
+        "start": {
+          "column": 26,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 65`] = `
+{
+  "code": "
+type Cb = ((arg: string) => void) | ((arg: number) => void);
+declare function Foo(props: { cb?: Cb }): unknown;
+return (
+  <Foo
+    cb={async function* (arg) {
+      await arg;
+      yield arg;
+    }}
+  />
+);
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 66`] = `
+{
+  "code": "
+interface Props {
+  cb: ((arg: unknown) => void) | boolean;
+}
+declare function Foo(props: Props): unknown;
+return <Foo cb={x => x} />;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 6,
+        },
+        "start": {
+          "column": 22,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 67`] = `
+{
+  "code": "
+type EventHandler<E> = { bivarianceHack(event: E): void }['bivarianceHack'];
+interface ButtonProps {
+  onClick?: EventHandler<unknown> | undefined;
+}
+declare function Button(props: ButtonProps): unknown;
+function App() {
+  return <Button onClick={x => x} />;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 8,
+        },
+        "start": {
+          "column": 32,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 68`] = `
+{
+  "code": "
+declare function foo(cbs: { arg: number; cb: () => void }): void;
+foo({ arg: 1, cb: () => 1 });
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 25,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 69`] = `
+{
+  "code": "
+declare let foo: { arg?: string; cb: () => void };
+foo = {
+  cb: () => {
+    let x = 'siema';
+    return x;
+  },
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 70`] = `
+{
+  "code": "
+declare let foo: { cb: (n: number) => void };
+foo = {
+  cb(n) {
+    return n;
+  },
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 71`] = `
+{
+  "code": "
+declare let foo: { 1234: (n: number) => void };
+foo = {
+  1234(n) {
+    return n;
+  },
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 72`] = `
+{
+  "code": "
+declare let foo: { '1e+21': () => void };
+foo = {
+  1_000_000_000_000_000_000_000: () => 1,
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 40,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 73`] = `
+{
+  "code": "
+declare let foo: { cb: (() => void) | number };
+foo = {
+  cb: async () => {
+    if (maybe) {
+      return 'asd';
+    }
+  },
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 74`] = `
+{
+  "code": "
+declare function cb(): number;
+const foo: Record<string, () => void> = {
+  cb1: cb,
+  cb2: cb,
+  ...cb,
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 5,
+        },
+        "start": {
+          "column": 8,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 75`] = `
+{
+  "code": "
+declare function cb(): number;
+const foo: Array<(() => void) | false> = [false, cb, () => cb()];
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 3,
+        },
+        "start": {
+          "column": 50,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 3,
+        },
+        "start": {
+          "column": 60,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 76`] = `
+{
+  "code": "
+declare function cb(): number;
+const foo: [string, () => void, (() => void)?] = ['asd', cb];
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 3,
+        },
+        "start": {
+          "column": 58,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 77`] = `
+{
+  "code": "
+const foo: { cbs: Array<() => void> | null } = {
+  cbs: [
+    function* () {
+      yield 1;
+    },
+    async () => {
+      await 1;
+    },
+    null,
+  ],
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 7,
+        },
+        "start": {
+          "column": 14,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 78`] = `
+{
+  "code": "
+const foo: { cb: () => void } = class {
+  static cb = () => ({});
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 22,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 79`] = `
+{
+  "code": "
+class Foo {
+  foo: () => void = () => [];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 80`] = `
+{
+  "code": "
+class Foo {
+  static foo: () => void = Math.random;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 28,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 81`] = `
+{
+  "code": "
+class Foo {
+  cb = () => {};
+}
+class Bar extends Foo {
+  cb = Math.random;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 82`] = `
+{
+  "code": "
+const foo = () =>
+  class {
+    cb = () => {};
+  };
+class Bar extends foo() {
+  cb = Math.random;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 7,
+        },
+        "start": {
+          "column": 8,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 83`] = `
+{
+  "code": "
+class Foo {
+  cb() {
+    console.log('siema');
+  }
+}
+const method = 'cb' as const;
+class Bar extends Foo {
+  [method]() {
+    return 'nara';
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 10,
+        },
+        "start": {
+          "column": 5,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 84`] = `
+{
+  "code": "
+class Bar {
+  foo() {}
+}
+class Foo extends Bar {
+  get foo() {
+    return () => 1;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 7,
+        },
+        "start": {
+          "column": 5,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 85`] = `
+{
+  "code": "
+class Foo {
+  cb() {}
+}
+void class extends Foo {
+  cb() {
+    return Math.random();
+  }
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 7,
+        },
+        "start": {
+          "column": 5,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 86`] = `
+{
+  "code": "
+class Foo {
+  cb1 = () => {};
+}
+class Bar extends Foo {
+  cb2() {}
+}
+class Baz extends Bar {
+  cb1 = () => Math.random();
+  cb2() {
+    return Math.random();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 9,
+        },
+        "start": {
+          "column": 15,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 11,
+        },
+        "start": {
+          "column": 5,
+          "line": 11,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 87`] = `
+{
+  "code": "
+declare function f(): Promise<void>;
+interface Foo {
+  cb: () => void;
+}
+class Bar {
+  cb = () => {};
+}
+class Baz extends Bar implements Foo {
+  cb: () => void = f;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 10,
+        },
+        "start": {
+          "column": 20,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 88`] = `
+{
+  "code": "
+class Foo {
+  fn() {
+    return 'a';
+  }
+  cb() {}
+}
+class Bar extends Foo {
+  cb() {
+    if (maybe) {
+      return Promise.resolve('siema');
+    } else {
+      return Promise.resolve('nara');
+    }
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 11,
+        },
+        "start": {
+          "column": 7,
+          "line": 11,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 13,
+        },
+        "start": {
+          "column": 7,
+          "line": 13,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 89`] = `
+{
+  "code": "
+abstract class Foo {
+  abstract cb(): void;
+}
+class Bar extends Foo {
+  async cb() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 90`] = `
+{
+  "code": "
+class Foo {
+  fn() {
+    return 'a';
+  }
+  cb() {}
+}
+class Bar extends Foo {
+  *cb() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 9,
+        },
+        "start": {
+          "column": 3,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 91`] = `
+{
+  "code": "
+interface Foo {
+  cb: () => void;
+}
+class Bar implements Foo {
+  cb = Math.random;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 92`] = `
+{
+  "code": "
+const o = { cb() {} };
+type O = typeof o;
+class Bar implements O {
+  cb = Math.random;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 5,
+        },
+        "start": {
+          "column": 8,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 93`] = `
+{
+  "code": "
+class Foo {
+  cb() {}
+}
+class Bar extends Foo {
+  async*cb() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 94`] = `
+{
+  "code": "
+interface Foo {
+  cb(): void;
+}
+class Bar implements Foo {
+  async cb(): Promise<string> {
+    return Promise.resolve('siema');
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 95`] = `
+{
+  "code": "
+interface Foo {
+  cb(): void;
+}
+class Bar implements Foo {
+  async cb() {
+    try {
+      return { a: ['asdf', 1234] };
+    } catch {
+      console.error('error');
+    }
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 96`] = `
+{
+  "code": "
+interface Foo {
+  cb(): void;
+}
+class Bar implements Foo {
+  cb() {
+    if (maybe) {
+      return Promise.resolve(1);
+    } else {
+      return;
+    }
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 8,
+        },
+        "start": {
+          "column": 7,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 97`] = `
+{
+  "code": "
+interface Foo1 {
+  cb1(): void;
+}
+interface Foo2 {
+  cb2: () => void;
+}
+class Bar implements Foo1, Foo2 {
+  async cb1() {}
+  async *cb2() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 9,
+        },
+        "start": {
+          "column": 3,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 10,
+        },
+        "start": {
+          "column": 3,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 98`] = `
+{
+  "code": "
+interface Foo1 {
+  cb1(): void;
+}
+interface Foo2 {
+  cb2: () => void;
+}
+class Baz {
+  cb3() {}
+}
+class Bar extends Baz implements Foo1, Foo2 {
+  async cb1() {}
+  async *cb2() {}
+  cb3() {
+    return Math.random();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 12,
+        },
+        "start": {
+          "column": 3,
+          "line": 12,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 13,
+        },
+        "start": {
+          "column": 3,
+          "line": 13,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 15,
+        },
+        "start": {
+          "column": 5,
+          "line": 15,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 99`] = `
+{
+  "code": "
+class A extends class {
+  cb() {}
+} {
+  cb() {
+    return Math.random();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 100`] = `
+{
+  "code": "
+class A extends class B {
+  cb() {}
+} {
+  cb() {
+    return Math.random();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 101`] = `
+{
+  "code": "
+interface Foo1 {
+  cb1(): void;
+}
+interface Foo2 extends Foo1 {
+  cb2: () => void;
+}
+class Bar implements Foo2 {
+  async cb1() {}
+  async *cb2() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 9,
+        },
+        "start": {
+          "column": 3,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 10,
+        },
+        "start": {
+          "column": 3,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 102`] = `
+{
+  "code": "
+declare let foo: () => () => void;
+foo = () => () => 1 + 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 19,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 103`] = `
+{
+  "code": "
+declare let foo: () => () => void;
+foo = () => () => Math.random();
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 3,
+        },
+        "start": {
+          "column": 19,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 104`] = `
+{
+  "code": "
+declare let foo: () => () => void;
+declare const cb: () => null | false;
+foo = () => cb;
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 105`] = `
+{
+  "code": "
+declare let foo: { f(): () => void };
+foo = {
+  f() {
+    return () => cb;
+  },
+};
+function cb() {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 5,
+        },
+        "start": {
+          "column": 18,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 106`] = `
+{
+  "code": "
+declare let foo: { f(): () => void };
+foo.f = function () {
+  return () => {
+    return null;
+  };
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 107`] = `
+{
+  "code": "
+declare let foo: () => (() => void) | string;
+foo = () => () => {
+  return 'asd' + 'zxc';
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 108`] = `
+{
+  "code": "
+declare function foo(cb: () => () => void): void;
+foo(function () {
+  return async () => {};
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Async function used in a context where a void function is expected.",
+      "messageId": "asyncFunc",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 19,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 109`] = `
+{
+  "code": "
+declare function foo(cb: () => () => void): void;
+foo(() => () => {
+  if (n == 1) {
+    console.log('asd')
+    return [1].map(x => x)
+  }
+  if (n == 2) {
+    console.log('asd')
+    return -Math.random()
+  }
+  if (n == 3) {
+    console.log('asd')
+    return \`x\`.toUpperCase()
+  }
+  return <i>{Math.random()}</i>
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 10,
+        },
+        "start": {
+          "column": 5,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 14,
+        },
+        "start": {
+          "column": 5,
+          "line": 14,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+    {
+      "message": "Value returned in a context where a void return is expected.",
+      "messageId": "nonVoidReturn",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 16,
+        },
+        "start": {
+          "column": 3,
+          "line": 16,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict-void-return > invalid 110`] = `
+{
+  "code": "
+declare function foo(cb: (arg: string) => () => void): void;
+declare function foo(cb: (arg: number) => () => boolean): void;
+foo((arg: string) => {
+  return cb;
+});
+async function* cb() {
+  yield true;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Value-returning function used in a context where a void function is expected.",
+      "messageId": "nonVoidFunc",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 5,
+        },
+        "start": {
+          "column": 10,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/strict-void-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/strict-void-return.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/strict-void-return.test.ts
@@ -1,0 +1,2077 @@
+import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
+
+import { getFixturesRootDir } from '../RuleTester';
+
+const rootPath = getFixturesRootDir();
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      project: './tsconfig.json',
+      tsconfigRootDir: rootPath,
+    },
+  },
+});
+
+ruleTester.run('strict-void-return', {
+  valid: [
+    `
+declare function foo(cb: {}): void;
+foo(() => () => []);
+    `,
+    `
+declare function foo(cb: () => void): void;
+type Void = void;
+foo((): Void => {
+  return;
+});
+    `,
+    `
+declare function foo(cb: () => void): void;
+foo((): ReturnType<typeof foo> => {
+  return;
+});
+    `,
+    `
+declare function foo(cb: any): void;
+foo(() => () => []);
+    `,
+    `
+declare class Foo {
+  constructor(cb: unknown): void;
+}
+new Foo(() => ({}));
+    `,
+    {
+      code: `
+declare function foo(cb: () => {}): void;
+foo(() => 1 as any);
+      `,
+      options: [{ allowReturnAny: true }],
+    },
+    `
+declare function foo(cb: () => void): void;
+foo(() => {
+  throw new Error('boom');
+});
+    `,
+    `
+declare function foo(cb: () => void): void;
+declare function boom(): never;
+foo(() => boom());
+foo(boom);
+    `,
+    `
+declare const Foo: {
+  new (cb: () => any): void;
+};
+new Foo(function () {
+  return 1;
+});
+    `,
+    `
+declare const Foo: {
+  new (cb: () => unknown): void;
+};
+new Foo(function () {
+  return 1;
+});
+    `,
+    `
+declare const foo: {
+  bar(cb1: () => unknown, cb2: () => void): void;
+};
+foo.bar(
+  function () {
+    return 1;
+  },
+  function () {
+    return;
+  },
+);
+    `,
+    `
+declare const Foo: {
+  new (cb: () => string | void): void;
+};
+new Foo(() => {
+  if (maybe) {
+    return 'a';
+  } else {
+    return 'b';
+  }
+});
+    `,
+    `
+declare function foo<Cb extends (...args: any[]) => void>(cb: Cb): void;
+foo(() => {
+  console.log('a');
+});
+    `,
+    `
+declare function foo(cb: (() => void) | (() => string)): void;
+foo(() => {
+  label: while (maybe) {
+    for (let i = 0; i < 10; i++) {
+      switch (i) {
+        case 0:
+          continue;
+        case 1:
+          return 'a';
+      }
+    }
+  }
+});
+    `,
+    `
+declare function foo(cb: (() => void) | null): void;
+foo(null);
+    `,
+    `
+interface Cb {
+  (): void;
+  (): string;
+}
+declare const Foo: {
+  new (cb: Cb): void;
+};
+new Foo(() => {
+  do {
+    try {
+      throw 1;
+    } catch {
+      return 'a';
+    }
+  } while (maybe);
+});
+    `,
+    `
+declare const foo: ((cb: () => boolean) => void) | ((cb: () => void) => void);
+foo(() => false);
+    `,
+    `
+declare const foo: {
+  (cb: () => boolean): void;
+  (cb: () => void): void;
+};
+foo(function () {
+  with ({}) {
+    return false;
+  }
+});
+    `,
+    `
+declare const Foo: {
+  new (cb: () => void): void;
+  (cb: () => unknown): void;
+};
+Foo(() => false);
+    `,
+    `
+declare const Foo: {
+  new (cb: () => any): void;
+  (cb: () => void): void;
+};
+new Foo(() => false);
+    `,
+    `
+declare function foo(cb: () => boolean): void;
+declare function foo(cb: () => void): void;
+foo(() => false);
+    `,
+    `
+declare function foo(cb: () => void): void;
+declare function foo(cb: () => boolean): void;
+foo(() => false);
+    `,
+    `
+declare function foo(cb: () => Promise<void>): void;
+declare function foo(cb: () => void): void;
+foo(async () => {});
+    `,
+    `
+declare function foo(fn: () => void);
+declare function foo(fn: () => Promise<void>);
+
+foo(async () => {});
+    `,
+    {
+      code: `
+declare function foo(cb: () => void): void;
+foo(() => 1 as any);
+      `,
+      options: [{ allowReturnAny: true }],
+    },
+    `
+declare function foo(cb: () => void): void;
+foo(() => {});
+    `,
+    `
+declare function foo(cb: () => void): void;
+const cb = () => {};
+foo(cb);
+    `,
+    `
+declare function foo(cb: () => void): void;
+foo(function () {});
+    `,
+    `
+declare function foo(cb: () => void): void;
+foo(cb);
+function cb() {}
+    `,
+    `
+declare function foo(cb: () => void): void;
+foo(() => undefined);
+    `,
+    `
+declare function foo(cb: () => void): void;
+foo(function () {
+  return;
+});
+    `,
+    `
+declare function foo(cb: () => void): void;
+foo(function () {
+  return void 0;
+});
+    `,
+    `
+declare function foo(cb: () => void): void;
+foo(() => {
+  return;
+});
+    `,
+    `
+declare function foo(cb: () => void): void;
+declare function cb(): never;
+foo(cb);
+    `,
+    `
+declare class Foo {
+  constructor(cb: () => void): any;
+}
+declare function cb(): void;
+new Foo(cb);
+    `,
+    `
+declare function foo(cb: () => void): void;
+foo(cb);
+function cb() {
+  throw new Error('boom');
+}
+    `,
+    `
+declare function foo(arg: string, cb: () => void): void;
+declare function cb(): undefined;
+foo('arg', cb);
+    `,
+    `
+declare function foo(cb?: () => void): void;
+foo();
+    `,
+    `
+declare class Foo {
+  constructor(cb?: () => void): void;
+}
+declare function cb(): void;
+new Foo(cb);
+    `,
+    `
+declare function foo(...cbs: Array<() => void>): void;
+foo(
+  () => {},
+  () => void null,
+  () => undefined,
+);
+    `,
+    `
+declare function foo(...cbs: Array<() => void>): void;
+declare const cbs: Array<() => void>;
+foo(...cbs);
+    `,
+    `
+declare function foo(...cbs: [() => any, () => void, (() => void)?]): void;
+foo(
+  async () => {},
+  () => void null,
+  () => undefined,
+);
+    `,
+    `
+let cb;
+cb = async () => 10;
+    `,
+    `
+const foo: () => void = () => {};
+    `,
+    `
+declare function cb(): void;
+const foo: () => void = cb;
+    `,
+    `
+const foo: () => void = function () {
+  throw new Error('boom');
+};
+    `,
+    `
+const foo: { (): string; (): void } = () => {
+  return 'a';
+};
+    `,
+    `
+const foo: (() => void) | (() => number) = () => {
+  return 1;
+};
+    `,
+    `
+type Foo = () => void;
+const foo: Foo = cb;
+function cb() {
+  return void null;
+}
+    `,
+    `
+interface Foo {
+  (): void;
+}
+const foo: Foo = cb;
+function cb() {
+  return undefined;
+}
+    `,
+    `
+declare function cb(): void;
+declare let foo: () => void;
+foo = cb;
+    `,
+    `
+declare let foo: () => void;
+foo += () => 1;
+    `,
+    `
+declare function defaultCb(): object;
+declare let foo: { cb?: () => void };
+// default doesn't have to be void
+const { cb = defaultCb } = foo;
+    `,
+    `
+let foo: (() => void) | null = null;
+foo &&= null;
+    `,
+    `
+declare function cb(): void;
+let foo: (() => void) | boolean = false;
+foo ||= cb;
+    `,
+    {
+      code: `
+declare function Foo(props: { cb: () => void }): unknown;
+return <Foo cb={() => {}} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+declare function Foo(props: { cb: () => void }): unknown;
+return <Foo cb="() => {}" />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+declare function Foo(props: { cb: () => void }): unknown;
+return <Foo cb={} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+declare function Foo(props: { cb: () => void }): unknown;
+return <Bar children=<Foo cb={() => {}} /> />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+type Cb = () => void;
+declare function Foo(props: { cb: Cb; s: string }): unknown;
+return <Foo cb={function () {}} s="asd" />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+type Cb = () => void;
+declare function Foo(props: { x: number; cb?: Cb }): unknown;
+return <Foo x={123} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+type Cb = (() => void) | (() => number);
+declare function Foo(props: { cb?: Cb }): unknown;
+return (
+  <Foo
+    cb={function (arg) {
+      return 123;
+    }}
+  />
+);
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+interface Props {
+  cb: ((arg: unknown) => void) | boolean;
+}
+declare function Foo(props: Props): unknown;
+return <Foo cb />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+interface Props {
+  cb: (() => void) | (() => Promise<void>);
+}
+declare function Foo(props: Props): any;
+const _ = <Foo cb={async () => {}} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+interface Props {
+  children: (arg: unknown) => void;
+}
+declare function Foo(props: Props): unknown;
+declare function cb(): void;
+return <Foo>{cb}</Foo>;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    `
+declare function foo(cbs: { arg: number; cb: () => void }): void;
+foo({ arg: 1, cb: () => undefined });
+    `,
+    {
+      code: `
+declare let foo: { arg?: string; cb: () => void };
+foo = {
+  cb: () => {
+    return something;
+  },
+};
+      `,
+      options: [{ allowReturnAny: true }],
+    },
+    {
+      code: `
+declare let foo: { cb: () => void };
+foo = {
+  cb() {
+    return something;
+  },
+};
+      `,
+      options: [{ allowReturnAny: true }],
+    },
+    `
+declare let foo: { cb: () => void };
+foo = {
+  // don't check this thing
+  cb = () => 1,
+};
+    `,
+    `
+declare let foo: { cb: (n: number) => void };
+let method = 'cb';
+foo = {
+  // don't check computed methods
+  [method](n) {
+    return n;
+  },
+};
+    `,
+    `
+// no contextual type for object
+let foo = {
+  cb(n) {
+    return n;
+  },
+};
+    `,
+    `
+interface Foo {
+  fn(): void;
+}
+// no symbol for method cb
+let foo: Foo = {
+  cb(n) {
+    return n;
+  },
+};
+    `,
+    `
+declare let foo: { cb: (() => void) | number };
+foo = {
+  cb: 0,
+};
+    `,
+    `
+declare function cb(): void;
+const foo: Record<string, () => void> = {
+  cb1: cb,
+  cb2: cb,
+};
+    `,
+    `
+declare function cb(): string;
+const foo: Record<string, () => void> = {
+  ...cb,
+};
+    `,
+    `
+declare function cb(): string;
+const foo: Record<string, () => void> = {
+  ...cb,
+  ...{},
+};
+    `,
+    `
+declare function cb(): void;
+const foo: Array<(() => void) | false> = [false, cb, () => cb()];
+    `,
+    `
+declare function cb(): void;
+const foo: [string, () => void, (() => void)?] = ['asd', cb];
+    `,
+    `
+const foo: { cbs: Array<() => void> | null } = {
+  cbs: [
+    function () {
+      return undefined;
+    },
+    () => {
+      return void 0;
+    },
+    null,
+  ],
+};
+    `,
+    `
+const foo: { cb: () => void } = class {
+  static cb = () => {};
+};
+    `,
+    `
+class Foo {
+  foo;
+}
+    `,
+    `
+class Bar {
+  foo() {}
+}
+class Foo extends Bar {
+  foo();
+}
+    `,
+    `
+interface Bar {
+  foo(): void;
+}
+class Foo implements Bar {
+  get foo() {
+    return new Date();
+  }
+  set foo() {
+    return new Date('wtf');
+  }
+}
+    `,
+    `
+class Foo {
+  foo: () => void = () => undefined;
+}
+    `,
+    `
+class Bar {}
+class Foo extends Bar {
+  foo = () => 1;
+}
+    `,
+    `
+class Foo extends Wtf {
+  foo = () => 1;
+}
+    `,
+    `
+class Foo extends Wtf {
+  [unknown] = () => 1;
+}
+    `,
+    `
+class Foo {
+  cb = () => {
+    console.log('siema');
+  };
+}
+class Bar extends Foo {
+  cb = () => {
+    console.log('nara');
+  };
+}
+    `,
+    `
+class Foo {
+  cb1 = () => {};
+}
+class Bar extends Foo {
+  cb2() {}
+}
+class Baz extends Bar {
+  cb1 = () => {
+    console.log('siema');
+  };
+  cb2() {
+    console.log('nara');
+  }
+}
+    `,
+    `
+class Foo {
+  fn() {
+    return 'a';
+  }
+  cb() {}
+}
+void class extends Foo {
+  cb() {
+    if (maybe) {
+      console.log('siema');
+    } else {
+      console.log('nara');
+    }
+  }
+};
+    `,
+    `
+abstract class Foo {
+  abstract cb(): void;
+}
+class Bar extends Foo {
+  cb() {
+    console.log('a');
+  }
+}
+    `,
+    `
+class Bar implements Foo {
+  cb = () => 1;
+}
+    `,
+    `
+interface Foo {
+  cb: () => void;
+}
+class Bar implements Foo {
+  cb = () => {};
+}
+    `,
+    `
+interface Foo {
+  cb: () => void;
+}
+class Bar implements Foo {
+  get cb() {
+    return () => {};
+  }
+}
+    `,
+    `
+interface Foo {
+  cb(): void;
+}
+class Bar implements Foo {
+  cb() {
+    return undefined;
+  }
+}
+    `,
+    `
+interface Foo1 {
+  cb1(): void;
+}
+interface Foo2 {
+  cb2: () => void;
+}
+class Bar implements Foo1, Foo2 {
+  cb1() {}
+  cb2() {}
+}
+    `,
+    `
+interface Foo1 {
+  cb1(): void;
+}
+interface Foo2 extends Foo1 {
+  cb2: () => void;
+}
+class Bar implements Foo2 {
+  cb1() {}
+  cb2() {}
+}
+    `,
+    `
+declare let foo: () => () => void;
+foo = () => () => {};
+    `,
+    `
+declare let foo: { f(): () => void };
+foo = {
+  f() {
+    return () => undefined;
+  },
+};
+function cb() {}
+    `,
+    `
+declare let foo: { f(): () => void };
+foo.f = function () {
+  return () => {};
+};
+    `,
+    `
+declare let foo: () => (() => void) | string;
+foo = () => 'asd' + 'zxc';
+    `,
+    `
+declare function foo(cb: () => () => void): void;
+foo(function () {
+  return () => {};
+});
+    `,
+    `
+declare function foo(cb: (arg: string) => () => void): void;
+declare function foo(cb: (arg: number) => () => boolean): void;
+foo((arg: number) => {
+  return cb;
+});
+function cb() {
+  return true;
+}
+    `,
+    `
+declare function f<T extends void>(arg: T, cb: () => T): void;
+declare function f<T extends string>(arg: T, cb: () => T): void;
+
+f('test', () => 'test');
+f(undefined, () => {});
+    `,
+    `
+interface HookFunction<T extends void | Hook = void> {
+  (fn: () => void): T;
+  (fn: () => Promise<void>): T;
+}
+
+class Hook {}
+
+declare var beforeEach: HookFunction<Hook>;
+
+beforeEach(() => {});
+
+beforeEach(async () => {});
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+declare function foo(cb: () => void): void;
+foo(() => null);
+      `,
+      errors: [{ column: 11, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: noFormat`
+declare function foo(cb: () => void): void;
+foo(() => (((true))));
+      `,
+      errors: [{ column: 14, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: noFormat`
+declare function foo(cb: () => void): void;
+foo(() => {
+  if (maybe) {
+    return (((1) + 1));
+  }
+});
+      `,
+      errors: [{ column: 5, line: 5, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare function foo(arg: number, cb: () => void): void;
+foo(0, () => 0);
+      `,
+      errors: [{ column: 14, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare function foo(cb?: { (): void }): void;
+foo(() => () => {});
+      `,
+      errors: [{ column: 11, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare const obj: { foo(cb: () => void) } | null;
+obj?.foo(() => JSON.parse('{}'));
+      `,
+      errors: [{ column: 16, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+((cb: () => void) => cb())!(() => 1);
+      `,
+      errors: [{ column: 35, line: 2, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare function foo(cb: { (): void }): void;
+declare function cb(): string;
+foo(cb);
+      `,
+      errors: [{ column: 5, line: 4, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+type AnyFunc = (...args: unknown[]) => unknown;
+declare function foo<F extends AnyFunc>(cb: F): void;
+foo(async () => ({}));
+foo<() => void>(async () => ({}));
+      `,
+      errors: [{ column: 26, line: 5, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+function foo<T extends {}>(arg: T, cb: () => T);
+function foo(arg: null, cb: () => void);
+function foo(arg: any, cb: () => any) {}
+
+foo(null, () => Math.random());
+      `,
+      errors: [{ column: 17, line: 6, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare function foo<T extends {}>(arg: T, cb: () => T): void;
+declare function foo(arg: any, cb: () => void): void;
+
+foo(null, async () => {});
+      `,
+      errors: [{ column: 20, line: 5, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+declare function foo(cb: () => void): void;
+declare function foo(cb: () => any): void;
+foo(async () => {
+  return Math.random();
+});
+      `,
+      errors: [{ column: 14, line: 4, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+declare function f<T extends void>(arg: T, cb: () => T): void;
+
+f(undefined, () => 'test');
+      `,
+      errors: [{ column: 20, line: 4, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare function foo(cb: { (): void }): void;
+foo(cb);
+async function cb() {}
+      `,
+      errors: [{ column: 5, line: 3, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare function foo<Cb extends (...args: any[]) => void>(cb: Cb): void;
+foo(() => {
+  console.log('a');
+  return 1;
+});
+      `,
+      errors: [{ column: 3, line: 5, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare function foo(cb: () => void): void;
+function bar<Cb extends () => number>(cb: Cb) {
+  foo(cb);
+}
+      `,
+      errors: [{ column: 7, line: 4, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare function foo(cb: { (): void }): void;
+const cb = () => dunno;
+foo!(cb);
+      `,
+      errors: [{ column: 6, line: 4, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare const foo: {
+  (arg: boolean, cb: () => void): void;
+};
+foo(false, () => Promise.resolve(undefined));
+      `,
+      errors: [{ column: 18, line: 5, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare const foo: {
+  bar(cb1: () => any, cb2: () => void): void;
+};
+foo.bar(
+  () => Promise.resolve(1),
+  () => Promise.resolve(1),
+);
+      `,
+      errors: [{ column: 9, line: 7, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare const Foo: {
+  new (cb: () => void): void;
+};
+new Foo(async () => {});
+      `,
+      errors: [{ column: 18, line: 5, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+declare function foo(cb: () => void): void;
+foo(() => {
+  label: while (maybe) {
+    for (const i of [1, 2, 3]) {
+      if (maybe) return null;
+      else return null;
+    }
+  }
+  return void 0;
+});
+      `,
+      errors: [
+        { column: 18, line: 6, messageId: 'nonVoidReturn' },
+        { column: 12, line: 7, messageId: 'nonVoidReturn' },
+      ],
+    },
+    {
+      code: `
+declare function foo(cb: () => void): void;
+foo(() => {
+  do {
+    try {
+      throw 1;
+    } catch (e) {
+      return null;
+    } finally {
+      console.log('finally');
+    }
+  } while (maybe);
+});
+      `,
+      errors: [{ column: 7, line: 8, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare function foo(cb: () => void): void;
+foo(async () => {
+  try {
+    await Promise.resolve();
+  } catch {
+    console.error('fail');
+  }
+});
+      `,
+      errors: [{ column: 14, line: 3, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+declare const Foo: {
+  new (cb: () => void): void;
+  (cb: () => unknown): void;
+};
+new Foo(() => false);
+      `,
+      errors: [{ column: 15, line: 6, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare const Foo: {
+  new (cb: () => any): void;
+  (cb: () => void): void;
+};
+Foo(() => false);
+      `,
+      errors: [{ column: 11, line: 6, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+interface Cb {
+  (arg: string): void;
+  (arg: number): void;
+}
+declare function foo(cb: Cb): void;
+foo(cb);
+function cb() {
+  return true;
+}
+      `,
+      errors: [{ column: 5, line: 7, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare function foo(
+  cb: ((arg: number) => void) | ((arg: string) => void),
+): void;
+foo(cb);
+function cb() {
+  return 1 + 1;
+}
+      `,
+      errors: [{ column: 5, line: 5, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare function foo(cb: (() => void) | null): void;
+declare function cb(): boolean;
+foo(cb);
+      `,
+      errors: [{ column: 5, line: 4, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare function foo(...cbs: Array<() => void>): void;
+foo(
+  () => {},
+  () => false,
+  () => 0,
+  () => '',
+);
+      `,
+      errors: [
+        { column: 9, line: 5, messageId: 'nonVoidReturn' },
+        { column: 9, line: 6, messageId: 'nonVoidReturn' },
+        { column: 9, line: 7, messageId: 'nonVoidReturn' },
+      ],
+    },
+    {
+      code: `
+declare function foo(...cbs: [() => void, () => void, (() => void)?]): void;
+foo(
+  () => {},
+  () => Math.random(),
+  () => (1).toString(),
+);
+      `,
+      errors: [
+        { column: 9, line: 5, messageId: 'nonVoidReturn' },
+        { column: 9, line: 6, messageId: 'nonVoidReturn' },
+      ],
+    },
+    {
+      code: `
+interface Ev {}
+interface EvMap {
+  DOMContentLoaded: Ev;
+}
+type EvListOrEvListObj = EvList | EvListObj;
+interface EvList {
+  (evt: Event): void;
+}
+interface EvListObj {
+  handleEvent(object: Ev): void;
+}
+interface Win {
+  addEventListener<K extends keyof EvMap>(
+    type: K,
+    listener: (ev: EvMap[K]) => any,
+  ): void;
+  addEventListener(type: string, listener: EvListOrEvListObj): void;
+}
+declare const win: Win;
+win.addEventListener('DOMContentLoaded', ev => ev);
+win.addEventListener('custom', ev => ev);
+      `,
+      errors: [
+        { column: 48, line: 21, messageId: 'nonVoidReturn' },
+        { column: 38, line: 22, messageId: 'nonVoidReturn' },
+      ],
+    },
+    {
+      code: `
+declare function foo(x: null, cb: () => void): void;
+declare function foo(x: unknown, cb: () => any): void;
+foo({}, async () => {});
+      `,
+      errors: [{ column: 18, line: 4, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+const arr = [1, 2];
+arr.forEach(async x => {
+  console.log(x);
+});
+      `,
+      errors: [{ column: 21, line: 3, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+[1, 2].forEach(async x => console.log(x));
+      `,
+      errors: [{ column: 24, line: 2, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+const foo: () => void = () => false;
+      `,
+      errors: [{ column: 31, line: 2, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+const { name }: () => void = function foo() {
+  return false;
+};
+      `,
+      errors: [{ column: 3, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare const foo: Record<string, () => void>;
+foo['a' + 'b'] = () => true;
+      `,
+      errors: [{ column: 24, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+const foo: () => void = async () => Promise.resolve(true);
+      `,
+      errors: [{ column: 34, line: 2, messageId: 'asyncFunc' }],
+    },
+    {
+      code: 'const cb: () => void = (): Array<number> => [];',
+      errors: [{ column: 45, line: 1, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+const cb: () => void = (): Array<number> => {
+  return [];
+};
+      `,
+      errors: [{ column: 28, line: 2, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: noFormat`const cb: () => void = function*foo() {}`,
+      errors: [{ column: 24, line: 1, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: 'const cb: () => void = (): Promise<number> => Promise.resolve(1);',
+      errors: [{ column: 47, line: 1, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+const cb: () => void = async (): Promise<number> => {
+  try {
+    return Promise.resolve(1);
+  } catch {}
+};
+      `,
+      errors: [{ column: 50, line: 2, messageId: 'asyncFunc' }],
+    },
+    {
+      code: 'const cb: () => void = async (): Promise<number> => Promise.resolve(1);',
+      errors: [{ column: 50, line: 1, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+const foo: () => void = async () => {
+  try {
+    return 1;
+  } catch {}
+};
+      `,
+      errors: [{ column: 34, line: 2, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+const foo: () => void = async (): Promise<void> => {
+  try {
+    await Promise.resolve();
+  } finally {
+  }
+};
+      `,
+      errors: [{ column: 49, line: 2, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+const foo: () => void = async () => {
+  try {
+    await Promise.resolve();
+  } catch (err) {
+    console.error(err);
+  }
+  console.log('ok');
+};
+      `,
+      errors: [{ column: 34, line: 2, messageId: 'asyncFunc' }],
+    },
+    {
+      code: 'const foo: () => void = (): number => {};',
+      errors: [{ column: 29, line: 1, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare function cb(): boolean;
+const foo: () => void = cb;
+      `,
+      errors: [{ column: 25, line: 3, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+const foo: () => void = function () {
+  if (maybe) {
+    return null;
+  } else {
+    return null;
+  }
+};
+      `,
+      errors: [
+        { column: 5, line: 4, messageId: 'nonVoidReturn' },
+        { column: 5, line: 6, messageId: 'nonVoidReturn' },
+      ],
+    },
+    {
+      code: `
+const foo: () => void = function () {
+  if (maybe) {
+    console.log('elo');
+    return { [1]: Math.random() };
+  }
+};
+      `,
+      errors: [{ column: 5, line: 5, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+const foo: { (arg: number): void; (arg: string): void } = arg => {
+  console.log('foo');
+  switch (typeof arg) {
+    case 'number':
+      return 0;
+    case 'string':
+      return '';
+  }
+};
+      `,
+      errors: [
+        { column: 7, line: 6, messageId: 'nonVoidReturn' },
+        { column: 7, line: 8, messageId: 'nonVoidReturn' },
+      ],
+    },
+    {
+      code: `
+const foo: ((arg: number) => void) | ((arg: string) => void) = async () => {
+  return 1;
+};
+      `,
+      errors: [{ column: 73, line: 2, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+type Foo = () => void;
+const foo: Foo = cb;
+function cb() {
+  return [1, 2, 3];
+}
+      `,
+      errors: [{ column: 18, line: 3, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+interface Foo {
+  (): void;
+}
+const foo: Foo = cb;
+function cb() {
+  return { a: 1 };
+}
+      `,
+      errors: [{ column: 18, line: 5, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare function cb(): unknown;
+declare let foo: () => void;
+foo = cb;
+      `,
+      errors: [{ column: 7, line: 4, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare let foo: { arg?: string; cb?: () => void };
+foo.cb = () => {
+  return 'siema';
+  console.log('siema');
+};
+      `,
+      errors: [{ column: 3, line: 4, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare function cb(): unknown;
+let foo: (() => void) | null = null;
+foo ??= cb;
+      `,
+      errors: [{ column: 9, line: 4, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare function cb(): unknown;
+let foo: (() => void) | boolean = false;
+foo ||= cb;
+      `,
+      errors: [{ column: 9, line: 4, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare function cb(): unknown;
+let foo: (() => void) | boolean = false;
+foo &&= cb;
+      `,
+      errors: [{ column: 9, line: 4, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare function Foo(props: { cb: () => void }): unknown;
+return <Foo cb={() => 1} />;
+      `,
+      errors: [{ column: 23, line: 3, messageId: 'nonVoidReturn' }],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+declare function Foo(props: { cb: () => void }): unknown;
+declare function getNull(): null;
+return (
+  <Foo
+    cb={() => {
+      if (maybe) return Math.random();
+      else return getNull();
+    }}
+  />
+);
+      `,
+      errors: [
+        { column: 18, line: 7, messageId: 'nonVoidReturn' },
+        { column: 12, line: 8, messageId: 'nonVoidReturn' },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+type Cb = () => void;
+declare function Foo(props: { cb: Cb; s: string }): unknown;
+return <Foo cb={async function () {}} s="!@#jp2gmd" />;
+      `,
+      errors: [{ column: 17, line: 4, messageId: 'asyncFunc' }],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+type Cb = () => void;
+declare function Foo(props: { n: number; cb?: Cb }): unknown;
+return <Foo n={2137} cb={function* () {}} />;
+      `,
+      errors: [{ column: 26, line: 4, messageId: 'nonVoidFunc' }],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+type Cb = ((arg: string) => void) | ((arg: number) => void);
+declare function Foo(props: { cb?: Cb }): unknown;
+return (
+  <Foo
+    cb={async function* (arg) {
+      await arg;
+      yield arg;
+    }}
+  />
+);
+      `,
+      errors: [{ column: 9, line: 6, messageId: 'nonVoidFunc' }],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+interface Props {
+  cb: ((arg: unknown) => void) | boolean;
+}
+declare function Foo(props: Props): unknown;
+return <Foo cb={x => x} />;
+      `,
+      errors: [{ column: 22, line: 6, messageId: 'nonVoidReturn' }],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+type EventHandler<E> = { bivarianceHack(event: E): void }['bivarianceHack'];
+interface ButtonProps {
+  onClick?: EventHandler<unknown> | undefined;
+}
+declare function Button(props: ButtonProps): unknown;
+function App() {
+  return <Button onClick={x => x} />;
+}
+      `,
+      errors: [{ column: 32, line: 8, messageId: 'nonVoidReturn' }],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+declare function foo(cbs: { arg: number; cb: () => void }): void;
+foo({ arg: 1, cb: () => 1 });
+      `,
+      errors: [{ column: 25, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare let foo: { arg?: string; cb: () => void };
+foo = {
+  cb: () => {
+    let x = 'siema';
+    return x;
+  },
+};
+      `,
+      errors: [{ column: 5, line: 6, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare let foo: { cb: (n: number) => void };
+foo = {
+  cb(n) {
+    return n;
+  },
+};
+      `,
+      errors: [{ column: 5, line: 5, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare let foo: { 1234: (n: number) => void };
+foo = {
+  1234(n) {
+    return n;
+  },
+};
+      `,
+      errors: [{ column: 5, line: 5, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare let foo: { '1e+21': () => void };
+foo = {
+  1_000_000_000_000_000_000_000: () => 1,
+};
+      `,
+      errors: [{ column: 40, line: 4, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare let foo: { cb: (() => void) | number };
+foo = {
+  cb: async () => {
+    if (maybe) {
+      return 'asd';
+    }
+  },
+};
+      `,
+      errors: [{ column: 3, line: 4, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+declare function cb(): number;
+const foo: Record<string, () => void> = {
+  cb1: cb,
+  cb2: cb,
+  ...cb,
+};
+      `,
+      errors: [
+        { column: 8, line: 4, messageId: 'nonVoidFunc' },
+        { column: 8, line: 5, messageId: 'nonVoidFunc' },
+      ],
+    },
+    {
+      code: `
+declare function cb(): number;
+const foo: Array<(() => void) | false> = [false, cb, () => cb()];
+      `,
+      errors: [
+        { column: 50, line: 3, messageId: 'nonVoidFunc' },
+        { column: 60, line: 3, messageId: 'nonVoidReturn' },
+      ],
+    },
+    {
+      code: `
+declare function cb(): number;
+const foo: [string, () => void, (() => void)?] = ['asd', cb];
+      `,
+      errors: [{ column: 58, line: 3, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+const foo: { cbs: Array<() => void> | null } = {
+  cbs: [
+    function* () {
+      yield 1;
+    },
+    async () => {
+      await 1;
+    },
+    null,
+  ],
+};
+      `,
+      errors: [
+        { column: 5, line: 4, messageId: 'nonVoidFunc' },
+        { column: 14, line: 7, messageId: 'asyncFunc' },
+      ],
+    },
+    {
+      code: `
+const foo: { cb: () => void } = class {
+  static cb = () => ({});
+};
+      `,
+      errors: [{ column: 22, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+class Foo {
+  foo: () => void = () => [];
+}
+      `,
+      errors: [{ column: 27, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+class Foo {
+  static foo: () => void = Math.random;
+}
+      `,
+      errors: [{ column: 28, line: 3, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+class Foo {
+  cb = () => {};
+}
+class Bar extends Foo {
+  cb = Math.random;
+}
+      `,
+      errors: [{ column: 8, line: 6, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+const foo = () =>
+  class {
+    cb = () => {};
+  };
+class Bar extends foo() {
+  cb = Math.random;
+}
+      `,
+      errors: [{ column: 8, line: 7, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+class Foo {
+  cb() {
+    console.log('siema');
+  }
+}
+const method = 'cb' as const;
+class Bar extends Foo {
+  [method]() {
+    return 'nara';
+  }
+}
+      `,
+      errors: [{ column: 5, line: 10, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+class Bar {
+  foo() {}
+}
+class Foo extends Bar {
+  get foo() {
+    return () => 1;
+  }
+}
+      `,
+      errors: [{ column: 5, line: 7, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+class Foo {
+  cb() {}
+}
+void class extends Foo {
+  cb() {
+    return Math.random();
+  }
+};
+      `,
+      errors: [{ column: 5, line: 7, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+class Foo {
+  cb1 = () => {};
+}
+class Bar extends Foo {
+  cb2() {}
+}
+class Baz extends Bar {
+  cb1 = () => Math.random();
+  cb2() {
+    return Math.random();
+  }
+}
+      `,
+      errors: [
+        { column: 15, line: 9, messageId: 'nonVoidReturn' },
+        { column: 5, line: 11, messageId: 'nonVoidReturn' },
+      ],
+    },
+    {
+      code: `
+declare function f(): Promise<void>;
+interface Foo {
+  cb: () => void;
+}
+class Bar {
+  cb = () => {};
+}
+class Baz extends Bar implements Foo {
+  cb: () => void = f;
+}
+      `,
+      errors: [{ column: 20, line: 10, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+class Foo {
+  fn() {
+    return 'a';
+  }
+  cb() {}
+}
+class Bar extends Foo {
+  cb() {
+    if (maybe) {
+      return Promise.resolve('siema');
+    } else {
+      return Promise.resolve('nara');
+    }
+  }
+}
+      `,
+      errors: [
+        { column: 7, line: 11, messageId: 'nonVoidReturn' },
+        { column: 7, line: 13, messageId: 'nonVoidReturn' },
+      ],
+    },
+    {
+      code: `
+abstract class Foo {
+  abstract cb(): void;
+}
+class Bar extends Foo {
+  async cb() {}
+}
+      `,
+      errors: [{ column: 3, line: 6, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+class Foo {
+  fn() {
+    return 'a';
+  }
+  cb() {}
+}
+class Bar extends Foo {
+  *cb() {}
+}
+      `,
+      errors: [{ column: 3, line: 9, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+interface Foo {
+  cb: () => void;
+}
+class Bar implements Foo {
+  cb = Math.random;
+}
+      `,
+      errors: [{ column: 8, line: 6, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+const o = { cb() {} };
+type O = typeof o;
+class Bar implements O {
+  cb = Math.random;
+}
+      `,
+      errors: [{ column: 8, line: 5, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: noFormat`
+class Foo {
+  cb() {}
+}
+class Bar extends Foo {
+  async*cb() {}
+}
+      `,
+      errors: [{ column: 3, line: 6, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+interface Foo {
+  cb(): void;
+}
+class Bar implements Foo {
+  async cb(): Promise<string> {
+    return Promise.resolve('siema');
+  }
+}
+      `,
+      errors: [{ column: 3, line: 6, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+interface Foo {
+  cb(): void;
+}
+class Bar implements Foo {
+  async cb() {
+    try {
+      return { a: ['asdf', 1234] };
+    } catch {
+      console.error('error');
+    }
+  }
+}
+      `,
+      errors: [{ column: 3, line: 6, messageId: 'asyncFunc' }],
+    },
+    {
+      code: `
+interface Foo {
+  cb(): void;
+}
+class Bar implements Foo {
+  cb() {
+    if (maybe) {
+      return Promise.resolve(1);
+    } else {
+      return;
+    }
+  }
+}
+      `,
+      errors: [{ column: 7, line: 8, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+interface Foo1 {
+  cb1(): void;
+}
+interface Foo2 {
+  cb2: () => void;
+}
+class Bar implements Foo1, Foo2 {
+  async cb1() {}
+  async *cb2() {}
+}
+      `,
+      errors: [
+        { column: 3, line: 9, messageId: 'asyncFunc' },
+        { column: 3, line: 10, messageId: 'nonVoidFunc' },
+      ],
+    },
+    {
+      code: `
+interface Foo1 {
+  cb1(): void;
+}
+interface Foo2 {
+  cb2: () => void;
+}
+class Baz {
+  cb3() {}
+}
+class Bar extends Baz implements Foo1, Foo2 {
+  async cb1() {}
+  async *cb2() {}
+  cb3() {
+    return Math.random();
+  }
+}
+      `,
+      errors: [
+        { column: 3, line: 12, messageId: 'asyncFunc' },
+        { column: 3, line: 13, messageId: 'nonVoidFunc' },
+        { column: 5, line: 15, messageId: 'nonVoidReturn' },
+      ],
+    },
+    {
+      code: `
+class A extends class {
+  cb() {}
+} {
+  cb() {
+    return Math.random();
+  }
+}
+      `,
+      errors: [{ column: 5, line: 6, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+class A extends class B {
+  cb() {}
+} {
+  cb() {
+    return Math.random();
+  }
+}
+      `,
+      errors: [{ column: 5, line: 6, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+interface Foo1 {
+  cb1(): void;
+}
+interface Foo2 extends Foo1 {
+  cb2: () => void;
+}
+class Bar implements Foo2 {
+  async cb1() {}
+  async *cb2() {}
+}
+      `,
+      errors: [
+        { column: 3, line: 9, messageId: 'asyncFunc' },
+        { column: 3, line: 10, messageId: 'nonVoidFunc' },
+      ],
+    },
+    {
+      code: `
+declare let foo: () => () => void;
+foo = () => () => 1 + 1;
+      `,
+      errors: [{ column: 19, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare let foo: () => () => void;
+foo = () => () => Math.random();
+      `,
+      errors: [{ column: 19, line: 3, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare let foo: () => () => void;
+declare const cb: () => null | false;
+foo = () => cb;
+      `,
+      errors: [{ column: 13, line: 4, messageId: 'nonVoidFunc' }],
+    },
+    {
+      code: `
+declare let foo: { f(): () => void };
+foo = {
+  f() {
+    return () => cb;
+  },
+};
+function cb() {}
+      `,
+      errors: [{ column: 18, line: 5, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare let foo: { f(): () => void };
+foo.f = function () {
+  return () => {
+    return null;
+  };
+};
+      `,
+      errors: [{ column: 5, line: 5, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare let foo: () => (() => void) | string;
+foo = () => () => {
+  return 'asd' + 'zxc';
+};
+      `,
+      errors: [{ column: 3, line: 4, messageId: 'nonVoidReturn' }],
+    },
+    {
+      code: `
+declare function foo(cb: () => () => void): void;
+foo(function () {
+  return async () => {};
+});
+      `,
+      errors: [{ column: 19, line: 4, messageId: 'asyncFunc' }],
+    },
+    {
+      code: noFormat`
+declare function foo(cb: () => () => void): void;
+foo(() => () => {
+  if (n == 1) {
+    console.log('asd')
+    return [1].map(x => x)
+  }
+  if (n == 2) {
+    console.log('asd')
+    return -Math.random()
+  }
+  if (n == 3) {
+    console.log('asd')
+    return \`x\`.toUpperCase()
+  }
+  return <i>{Math.random()}</i>
+});
+      `,
+      errors: [
+        { column: 5, line: 6, messageId: 'nonVoidReturn' },
+        { column: 5, line: 10, messageId: 'nonVoidReturn' },
+        { column: 5, line: 14, messageId: 'nonVoidReturn' },
+        { column: 3, line: 16, messageId: 'nonVoidReturn' },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+    },
+    {
+      code: `
+declare function foo(cb: (arg: string) => () => void): void;
+declare function foo(cb: (arg: number) => () => boolean): void;
+foo((arg: string) => {
+  return cb;
+});
+async function* cb() {
+  yield true;
+}
+      `,
+      errors: [{ column: 10, line: 5, messageId: 'nonVoidFunc' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -39,6 +39,7 @@ bigints
 Bild
 binaryexpression
 biske
+bivariance
 bizz
 bleh
 bmatcuk


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/strict-void-return` rule from ESLint to rslint. The rule disallows passing a value-returning function in a position accepting a void function. It checks function arguments, JSX attribute values, array elements, assignments, variable initializers, object properties, class members (against extended base classes and implemented interfaces), and `return` statements.

## Related Links

- ESLint rule: https://typescript-eslint.io/rules/strict-void-return
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/strict-void-return.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).