### PR TITLE
feat: port rule @stylistic/array-bracket-spacing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	promisePlugin "github.com/web-infra-dev/rslint/internal/plugins/promise"
 	reactPlugin "github.com/web-infra-dev/rslint/internal/plugins/react"
 	reactHooksPlugin "github.com/web-infra-dev/rslint/internal/plugins/react_hooks"
+	stylisticPlugin "github.com/web-infra-dev/rslint/internal/plugins/stylistic"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/adjacent_overload_signatures"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/array_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/await_thenable"
@@ -419,6 +420,11 @@ var KnownPlugins = []PluginInfo{
 		getAllRules: func() []rule.Rule { return reactHooksPlugin.GetAllRules() },
 	},
 	{
+		RulePrefix:  "@stylistic",
+		DeclNames:   []string{"@stylistic", "@stylistic/eslint-plugin"},
+		getAllRules: func() []rule.Rule { return stylisticPlugin.GetAllRules() },
+	},
+	{
 		RulePrefix:  "unicorn",
 		DeclNames:   []string{"eslint-plugin-unicorn", "unicorn"},
 		getAllRules: func() []rule.Rule { return unicornPlugin.GetAllRules() },
@@ -494,6 +500,7 @@ func RegisterAllRules() {
 		registerAllJestPluginRules()
 		registerAllJsxA11yPluginRules()
 		registerAllPromisePluginRules()
+		registerAllStylisticPluginRules()
 		registerAllUnicornPluginRules()
 		registerAllCoreEslintRules()
 	})
@@ -525,6 +532,12 @@ func registerAllJsxA11yPluginRules() {
 
 func registerAllPromisePluginRules() {
 	for _, rule := range promisePlugin.GetAllRules() {
+		GlobalRuleRegistry.Register(rule.Name, rule)
+	}
+}
+
+func registerAllStylisticPluginRules() {
+	for _, rule := range stylisticPlugin.GetAllRules() {
 		GlobalRuleRegistry.Register(rule.Name, rule)
 	}
 }

--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -1,0 +1,12 @@
+package stylistic_plugin
+
+import (
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/array_bracket_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func GetAllRules() []rule.Rule {
+	return []rule.Rule{
+		array_bracket_spacing.ArrayBracketSpacingRule,
+	}
+}

--- a/internal/plugins/stylistic/fixtures/fixtures.go
+++ b/internal/plugins/stylistic/fixtures/fixtures.go
@@ -1,0 +1,11 @@
+package fixtures
+
+import (
+	"path"
+	"runtime"
+)
+
+func GetRootDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return path.Dir(filename)
+}

--- a/internal/plugins/stylistic/fixtures/tsconfig.json
+++ b/internal/plugins/stylistic/fixtures/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2020"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/internal/plugins/stylistic/plugin.go
+++ b/internal/plugins/stylistic/plugin.go
@@ -1,0 +1,3 @@
+package stylistic_plugin
+
+const PLUGIN_NAME = "@stylistic/eslint-plugin"

--- a/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing.go
+++ b/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing.go
@@ -1,0 +1,412 @@
+package array_bracket_spacing
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	spacingNever  = "never"
+	spacingAlways = "always"
+)
+
+type options struct {
+	spaced                   bool
+	singleElementException   bool
+	objectsInArraysException bool
+	arraysInArraysException  bool
+}
+
+// parseOptions mirrors upstream's option-shape juggling.
+//
+//	rule: ['array-bracket-spacing']                        → defaults (spaced=false)
+//	rule: ['array-bracket-spacing', 'always']              → spaced=true, no exceptions
+//	rule: ['array-bracket-spacing', 'never', { ... }]      → spaced=false + exceptions
+//
+// rslint's config loader collapses a single trailing option element into the
+// option directly, so we accept several shapes for the secondary object as
+// well — see utils.GetOptionsMap for the canonical extraction. The string
+// element ('always'/'never') still travels as the first array slot.
+//
+// An option key is an "exception" iff its boolean value equals !spaced
+// (upstream `context.options[1][option] === !spaced`). E.g. with spacing
+// 'never', `singleValue: true` flips singleElement to spaced behavior; with
+// 'always', `singleValue: false` flips it to never-spaced.
+func parseOptions(raw any) options {
+	opts := options{spaced: false}
+
+	var arr []interface{}
+	switch v := raw.(type) {
+	case []interface{}:
+		arr = v
+	case string:
+		arr = []interface{}{v}
+	case map[string]interface{}:
+		// Defensive: spacing-mode string is required as the first element by
+		// the upstream schema; if a caller passes just an option object, the
+		// spacing mode defaults to 'never' and we still honor the exceptions.
+		arr = []interface{}{spacingNever, v}
+	}
+
+	if len(arr) > 0 {
+		if s, ok := arr[0].(string); ok && s == spacingAlways {
+			opts.spaced = true
+		}
+	}
+
+	flipTo := !opts.spaced
+	if len(arr) > 1 {
+		if m, ok := arr[1].(map[string]interface{}); ok {
+			if b, ok := m["singleValue"].(bool); ok && b == flipTo {
+				opts.singleElementException = true
+			}
+			if b, ok := m["objectsInArrays"].(bool); ok && b == flipTo {
+				opts.objectsInArraysException = true
+			}
+			if b, ok := m["arraysInArrays"].(bool); ok && b == flipTo {
+				opts.arraysInArraysException = true
+			}
+		}
+	}
+	return opts
+}
+
+func isObjectType(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return node.Kind == ast.KindObjectLiteralExpression || node.Kind == ast.KindObjectBindingPattern
+}
+
+func isArrayType(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return node.Kind == ast.KindArrayLiteralExpression || node.Kind == ast.KindArrayBindingPattern
+}
+
+func isWhitespaceByte(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\f', '\v':
+		return true
+	}
+	return false
+}
+
+// nextRealStart returns the position of the first non-trivia character at or
+// after `low`. Delegates to tsgo's scanner.SkipTrivia so we get UTF-8-safe
+// handling of every trivia form the parser itself recognizes (whitespace,
+// line comments, block comments, conflict markers, shebang). `high` exists
+// only as a safety clamp — `]` is not trivia, so scanner.SkipTrivia naturally
+// stops before crossing it.
+func nextRealStart(text string, low, high int) int {
+	p := scanner.SkipTrivia(text, low)
+	if p > high {
+		return high
+	}
+	return p
+}
+
+// prevRealEnd is the reverse-direction counterpart that tsgo doesn't expose:
+// from `high` (exclusive) it walks back past trailing whitespace and
+// trailing-edge block comments, returning the position one past the last
+// real-token character (or `low` if none).
+//
+// **`low` MUST be the byte position immediately after the last array
+// element's end.** That guarantees the bytes in `[low, high)` are pure
+// trivia (whitespace, comments, and the optional trailing `,`) — there is
+// no string or regex literal content to misinterpret. The reverse scan is
+// not token-aware (no string / regex state machine), so without that
+// invariant a regex like `[/abc*/]` would have its closing `*/` byte
+// sequence falsely classified as a block-comment terminator and the scan
+// would over-run into the regex body.
+//
+// We deliberately don't reverse-scan `//` line comments — that would require
+// locating the line start and verifying no string literal straddles it. In
+// practice the only effect is that with a trailing `// … \n ]` shape we
+// stop at the comment's body text rather than at the token before the
+// comment; the caller's `containsNewline` check then sees the intervening
+// newline and skips the closing report, matching upstream's
+// `isTokenOnSameLine` short-circuit for this shape. See
+// jsx-curly-spacing.scanBraceBody for the analogous rationale.
+func prevRealEnd(text string, low, high int) int {
+	p := high
+	for p > low {
+		if isWhitespaceByte(text[p-1]) {
+			p--
+			continue
+		}
+		if p-2 >= low && text[p-2] == '*' && text[p-1] == '/' {
+			p -= 2
+			for p-2 >= low && (text[p-2] != '/' || text[p-1] != '*') {
+				p--
+			}
+			if p-2 >= low {
+				p -= 2
+			} else {
+				p = low
+			}
+			continue
+		}
+		break
+	}
+	return p
+}
+
+func containsNewline(text string, from, to int) bool {
+	if from < 0 {
+		from = 0
+	}
+	if to > len(text) {
+		to = len(text)
+	}
+	return strings.ContainsAny(text[from:to], "\n\r")
+}
+
+func elementsOf(node *ast.Node) []*ast.Node {
+	switch node.Kind {
+	case ast.KindArrayLiteralExpression:
+		if arr := node.AsArrayLiteralExpression(); arr != nil && arr.Elements != nil {
+			return arr.Elements.Nodes
+		}
+	case ast.KindArrayBindingPattern:
+		if bp := node.AsBindingPattern(); bp != nil && bp.Elements != nil {
+			return bp.Elements.Nodes
+		}
+	}
+	return nil
+}
+
+// bindingElementBound returns the kind that should be tested against the
+// objectsInArrays / arraysInArrays exceptions for one element of the array.
+// In addition to BindingElement→name unwrapping (for ArrayBindingPattern
+// children), it also calls ast.SkipParentheses for ArrayLiteralExpression
+// elements: tsgo preserves `( ... )` as ParenthesizedExpression while
+// ESLint's TS parser flattens them, so `[({foo: 1})]` reads as
+// `ObjectExpression` upstream but as `ParenthesizedExpression` here. Without
+// the unwrap, the objectsInArrays / arraysInArrays exceptions would silently
+// miss every paren-wrapped first/last element.
+func bindingElementBound(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == ast.KindBindingElement {
+		be := node.AsBindingElement()
+		if be == nil {
+			return node
+		}
+		if be.DotDotDotToken != nil {
+			// `[ ...x ]` — upstream's RestElement isn't ArrayPattern /
+			// ObjectPattern even when the rest target is one, so don't
+			// unwrap.
+			return node
+		}
+		name := be.Name()
+		if name == nil {
+			return node
+		}
+		return name
+	}
+	return ast.SkipParentheses(node)
+}
+
+// resolveBrackets returns the byte positions of `[` and `]` for `node` and the
+// list of its element/binding nodes. Returns ok=false when the trimmed source
+// range doesn't actually start/end with brackets (e.g. parser recovery on
+// malformed input — defensive, should not happen for valid programs).
+func resolveBrackets(text string, sf *ast.SourceFile, node *ast.Node) (openPos, closePos int, elements []*ast.Node, ok bool) {
+	trimmed := utils.TrimNodeTextRange(sf, node)
+	start := trimmed.Pos()
+	end := trimmed.End()
+	if start >= end || end > len(text) {
+		return 0, 0, nil, false
+	}
+	if text[start] != '[' || text[end-1] != ']' {
+		return 0, 0, nil, false
+	}
+	return start, end - 1, elementsOf(node), true
+}
+
+// exceptionFor returns whether the bracket on `side` (firstElement or
+// lastElement) should flip the spaced default. Mirrors upstream's
+// `openingBracketMustBeSpaced` / `closingBracketMustBeSpaced` derivation.
+func exceptionFor(opts options, element *ast.Node, length int) bool {
+	if opts.singleElementException && length == 1 {
+		return true
+	}
+	if element == nil {
+		return false
+	}
+	if opts.objectsInArraysException && isObjectType(element) {
+		return true
+	}
+	if opts.arraysInArraysException && isArrayType(element) {
+		return true
+	}
+	return false
+}
+
+// ArrayBracketSpacingRule enforces consistent spacing inside array brackets,
+// covering both array literals and array destructuring patterns. Ported from
+// @stylistic/eslint-plugin's array-bracket-spacing.
+//
+// The opening-bracket check runs on the listener's enter call and the
+// closing-bracket check runs on exit. For nested arrays this interleaves
+// enter/exit calls into source order
+// (outer-open → inner-open → inner-close → outer-close), matching how
+// ESLint sorts its reports by location.
+var ArrayBracketSpacingRule = rule.Rule{
+	Name: "@stylistic/array-bracket-spacing",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		text := ctx.SourceFile.Text()
+
+		enter := func(node *ast.Node) {
+			openPos, closePos, elements, ok := resolveBrackets(text, ctx.SourceFile, node)
+			if !ok {
+				return
+			}
+			if opts.spaced && len(elements) == 0 {
+				return
+			}
+
+			var firstElement *ast.Node
+			if len(elements) > 0 {
+				firstElement = bindingElementBound(elements[0])
+			}
+			openingException := exceptionFor(opts, firstElement, len(elements))
+			openingBracketMustBeSpaced := opts.spaced
+			if openingException {
+				openingBracketMustBeSpaced = !opts.spaced
+			}
+
+			innerLow := openPos + 1
+			innerHigh := closePos
+
+			var secondStart int
+			if len(elements) == 0 {
+				secondStart = innerHigh
+			} else {
+				secondStart = nextRealStart(text, innerLow, innerHigh)
+			}
+			hasSpaceAfterOpen := secondStart > innerLow
+			if containsNewline(text, innerLow, secondStart) {
+				return
+			}
+
+			if openingBracketMustBeSpaced && !hasSpaceAfterOpen {
+				ctx.ReportRangeWithFixes(
+					core.NewTextRange(openPos, openPos+1),
+					rule.RuleMessage{
+						Id:          "missingSpaceAfter",
+						Description: "A space is required after '['.",
+						Data:        map[string]string{"tokenValue": "["},
+					},
+					rule.RuleFix{
+						Text:  " ",
+						Range: core.NewTextRange(openPos+1, openPos+1),
+					},
+				)
+				return
+			}
+			if !openingBracketMustBeSpaced && hasSpaceAfterOpen {
+				ctx.ReportRangeWithFixes(
+					core.NewTextRange(innerLow, secondStart),
+					rule.RuleMessage{
+						Id:          "unexpectedSpaceAfter",
+						Description: "There should be no space after '['.",
+						Data:        map[string]string{"tokenValue": "["},
+					},
+					rule.RuleFix{
+						Text:  "",
+						Range: core.NewTextRange(innerLow, secondStart),
+					},
+				)
+			}
+		}
+
+		exit := func(node *ast.Node) {
+			openPos, closePos, elements, ok := resolveBrackets(text, ctx.SourceFile, node)
+			if !ok {
+				return
+			}
+			// Empty arrays: upstream's `first === penultimate` short-circuit
+			// skips the closing check entirely. (This subsumes the
+			// `opts.spaced && len(elements) == 0` early-return in `enter` —
+			// closing checks never fire for empty arrays regardless of mode.)
+			if len(elements) == 0 {
+				return
+			}
+
+			rawLast := elements[len(elements)-1]
+			lastElement := bindingElementBound(rawLast)
+			closingException := exceptionFor(opts, lastElement, len(elements))
+			closingBracketMustBeSpaced := opts.spaced
+			if closingException {
+				closingBracketMustBeSpaced = !opts.spaced
+			}
+
+			innerHigh := closePos
+			// Lower-bound the reverse trivia scan at the last element's end
+			// position. Everything in `[rawLast.End(), closePos)` is pure
+			// trivia (optionally with a trailing `,`), so the non-token-aware
+			// reverse byte scan can't be tricked by regex / string literal
+			// suffixes like `*/`. Use `rawLast` (not `lastElement`) — the
+			// latter is the post-`SkipParentheses` / `BindingElement.Name()`
+			// unwrap used purely for the Array/Object classification, and
+			// its End() would be earlier than the actual element's End().
+			scanLow := rawLast.End()
+			if scanLow < openPos+1 {
+				scanLow = openPos + 1
+			}
+
+			penultimateEnd := prevRealEnd(text, scanLow, innerHigh)
+			hasSpaceBeforeClose := penultimateEnd < innerHigh
+			if containsNewline(text, penultimateEnd, innerHigh) {
+				return
+			}
+
+			if closingBracketMustBeSpaced && !hasSpaceBeforeClose {
+				ctx.ReportRangeWithFixes(
+					core.NewTextRange(closePos, closePos+1),
+					rule.RuleMessage{
+						Id:          "missingSpaceBefore",
+						Description: "A space is required before ']'.",
+						Data:        map[string]string{"tokenValue": "]"},
+					},
+					rule.RuleFix{
+						Text:  " ",
+						Range: core.NewTextRange(closePos, closePos),
+					},
+				)
+				return
+			}
+			if !closingBracketMustBeSpaced && hasSpaceBeforeClose {
+				ctx.ReportRangeWithFixes(
+					core.NewTextRange(penultimateEnd, closePos),
+					rule.RuleMessage{
+						Id:          "unexpectedSpaceBefore",
+						Description: "There should be no space before ']'.",
+						Data:        map[string]string{"tokenValue": "]"},
+					},
+					rule.RuleFix{
+						Text:  "",
+						Range: core.NewTextRange(penultimateEnd, closePos),
+					},
+				)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindArrayLiteralExpression:                      enter,
+			ast.KindArrayBindingPattern:                         enter,
+			rule.ListenerOnExit(ast.KindArrayLiteralExpression): exit,
+			rule.ListenerOnExit(ast.KindArrayBindingPattern):    exit,
+		}
+	},
+}

--- a/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing.md
+++ b/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing.md
@@ -1,0 +1,157 @@
+# array-bracket-spacing
+
+Enforce consistent spacing inside array brackets.
+
+## Rule Details
+
+This rule applies to both array literals (`[1, 2]`) and array destructuring patterns (`var [a, b] = arr`).
+
+Multi-line arrays are always allowed regardless of the option — the rule only fires when the opening and closing bracket sit on the same line as their adjacent token.
+
+## Options
+
+This rule has a string option:
+
+- `"never"` (default) disallows spaces inside array brackets.
+- `"always"` requires one or more spaces or newlines inside array brackets.
+
+This rule has an object option with three boolean exception keys. Each exception flips the spacing requirement for the matching shape — setting it to the opposite of the primary mode (e.g. `"singleValue": true` with `"never"`, or `"singleValue": false` with `"always"`) turns the exception on.
+
+Empty array literals (`[]`) do not require spaces under the `"always"` option.
+
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
+
+```javascript
+var arr = [ 'foo', 'bar' ];
+var arr = ['foo', 'bar' ];
+var arr = [ ['foo'], 'bar'];
+var [ x, y ] = z;
+var arr = [ ];
+```
+
+Examples of **correct** code for this rule with the default `"never"` option:
+
+```javascript
+var arr = [];
+var arr = ['foo', 'bar', 'baz'];
+var arr = [['foo'], 'bar', 'baz'];
+var [x, y] = z;
+var [x, ...y] = z;
+var arr = [
+  'foo',
+  'bar',
+];
+```
+
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/array-bracket-spacing": ["error", "always"] }
+```
+
+```javascript
+var arr = ['foo', 'bar'];
+var arr = ['foo', 'bar' ];
+var arr = [ ['foo'], 'bar'];
+var [x, y] = z;
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/array-bracket-spacing": ["error", "always"] }
+```
+
+```javascript
+var arr = [];
+var arr = [ 'foo', 'bar', 'baz' ];
+var arr = [ [ 'foo' ], 'bar', 'baz' ];
+var [ x, y ] = z;
+var [ x, ...y ] = z;
+```
+
+### singleValue
+
+Examples of **correct** code for this rule with `"never", { "singleValue": true }`:
+
+```json
+{ "@stylistic/array-bracket-spacing": ["error", "never", { "singleValue": true }] }
+```
+
+```javascript
+var foo = [ 'bar' ];
+var foo = [ 2 ];
+var foo = [ {'foo': 'bar'} ];
+```
+
+Examples of **correct** code for this rule with `"always", { "singleValue": false }`:
+
+```json
+{ "@stylistic/array-bracket-spacing": ["error", "always", { "singleValue": false }] }
+```
+
+```javascript
+var foo = ['bar'];
+var foo = [2];
+var foo = [{ 'foo': 'bar' }];
+```
+
+### objectsInArrays
+
+Examples of **correct** code for this rule with `"never", { "objectsInArrays": true }`:
+
+```json
+{ "@stylistic/array-bracket-spacing": ["error", "never", { "objectsInArrays": true }] }
+```
+
+```javascript
+var arr = [ {'foo': 'bar'} ];
+var arr = [ {'foo': 'bar'}, 1, 5];
+var arr = [1, 5, {'foo': 'bar'} ];
+```
+
+Examples of **correct** code for this rule with `"always", { "objectsInArrays": false }`:
+
+```json
+{ "@stylistic/array-bracket-spacing": ["error", "always", { "objectsInArrays": false }] }
+```
+
+```javascript
+var arr = [{ 'foo': 'bar' }];
+var arr = [{ 'foo': 'bar' }, 1, 5 ];
+var arr = [ 1, 5, { 'foo': 'bar' }];
+```
+
+### arraysInArrays
+
+Examples of **correct** code for this rule with `"never", { "arraysInArrays": true }`:
+
+```json
+{ "@stylistic/array-bracket-spacing": ["error", "never", { "arraysInArrays": true }] }
+```
+
+```javascript
+var arr = [ [1, 2] ];
+var arr = [ [1, 2], 2, 3, 4];
+var arr = [1, 2, 3, [4] ];
+```
+
+Examples of **correct** code for this rule with `"always", { "arraysInArrays": false }`:
+
+```json
+{ "@stylistic/array-bracket-spacing": ["error", "always", { "arraysInArrays": false }] }
+```
+
+```javascript
+var arr = [[ 1, 2 ]];
+var arr = [[ 1, 2 ], 2, 3, 4 ];
+var arr = [ 1, 2, 3, [ 4 ]];
+```
+
+## Original Documentation
+
+- [@stylistic/array-bracket-spacing](https://eslint.style/rules/array-bracket-spacing)

--- a/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing_extras_test.go
+++ b/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing_extras_test.go
@@ -1,0 +1,674 @@
+// TestArrayBracketSpacingExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking
+// a named lock-in.
+//
+// Dimension 4 walk for @stylistic/array-bracket-spacing:
+//
+//   - Receiver / expression wrappers (outside the array) — N/A. The rule
+//     fires on the array literal / array binding pattern itself; outer
+//     receiver wrappers (`(arr).x`, `arr!.x`, `arr?.x`) sit outside the
+//     listener. Wrappers in ELEMENT position are highly relevant — see
+//     "paren-wrapped element" + "TS type wrappers must NOT match" lock-ins.
+//   - Access / key forms — N/A. The rule doesn't inspect property accesses
+//     or computed keys; it only looks at the array brackets and a slice of
+//     trivia on either side.
+//   - Declaration / container forms — covered: array literal in variable
+//     init, function param default, JSX prop, decorator argument, hook
+//     deps, template substitution, `as const` wrapper, ObjectLit property
+//     value, callback param, for-of binding, arrow param.
+//   - Nesting / traversal boundaries — covered: same-kind nesting up to
+//     three levels (`[[[1]]]`), nested empty (`[[]]`), nested + rest
+//     (`[[a, ...b], c]`), and the inner-array-bracket exception
+//     interleaving (see the enter/exit emit order discussion in the
+//     rule's package comment).
+//   - Graceful degradation — covered: empty arrays in both modes, single-
+//     element arrays, sparse arrays with omitted first / last elements,
+//     trailing comma in destructuring, comments between brackets and
+//     tokens, comments WITH `]` / `[` inside their payload, string /
+//     template literals containing `]` or `[`, multi-byte (UTF-8)
+//     element content.
+//
+// Options-resilience subgroup covers: empty options array, unknown keys
+// in the second arg, non-bool exception values — all silently ignored
+// (rslint does not run JSON-schema validation that upstream's loader does).
+package array_bracket_spacing_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/array_bracket_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestArrayBracketSpacingExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&array_bracket_spacing.ArrayBracketSpacingRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: paren-wrapped element triggers objectsInArrays ----
+			// tsgo preserves the ParenthesizedExpression that ESLint's TS
+			// parser flattens; without SkipParentheses on the first/last
+			// element this would silently miss the exception. With the
+			// exception firing, opening + closing must be spaced even
+			// though the rule's primary mode is "never".
+			{Code: `var foo = [ ({ 'bar': 'baz' }), 1, 5];`, Options: []interface{}{"never", map[string]interface{}{"objectsInArrays": true}}},
+			{Code: `var foo = [1, 5, ({ 'bar': 'baz' }) ];`, Options: []interface{}{"never", map[string]interface{}{"objectsInArrays": true}}},
+			// ---- Dimension 4: paren-wrapped element triggers arraysInArrays ----
+			{Code: `var arr = [ ([1, 2]), 2, 3, 4];`, Options: []interface{}{"never", map[string]interface{}{"arraysInArrays": true}}},
+
+			// ---- Dimension 4: same-kind nesting, three levels deep ----
+			// Verifies the rule visits every layer (enter+exit) and emits in
+			// document order, not in visit (parent-first) order.
+			{Code: `var arr = [ [ [ 1 ] ] ];`, Options: []interface{}{"always"}},
+			{Code: `var arr = [[[1]]];`, Options: []interface{}{"never"}},
+
+			// ---- Dimension 4: TS type wrappers must NOT match the exception ----
+			// Upstream's rule reads `node.type === 'ObjectExpression'` and
+			// returns false for TSAsExpression / TSSatisfiesExpression /
+			// TSNonNullExpression — even when the wrapped value is an
+			// object. Our skipping is paren-only, so these should fall
+			// through to the default spaced behavior. With "never" and
+			// objectsInArrays:true the FIRST element check sees AsExpression
+			// (not ObjectLiteralExpression), so the default 'never' wins
+			// and no leading space is required.
+			{Code: `var foo = [{a: 1} as any, 2];`, Options: []interface{}{"never", map[string]interface{}{"objectsInArrays": true}}},
+			{Code: `var foo = [{a: 1} satisfies object, 2];`, Options: []interface{}{"never", map[string]interface{}{"objectsInArrays": true}}},
+			{Code: `var foo = [{a: 1}!, 2];`, Options: []interface{}{"never", map[string]interface{}{"objectsInArrays": true}}},
+
+			// ---- Dimension 4: TS array binding with type annotation on parent ----
+			// In tsgo the type annotation lives on VariableDeclaration, not
+			// on the binding pattern itself, so node.End() of the binding
+			// pattern stops at `]` without us needing to consult any
+			// type-annotation field. Upstream covers this via babel/flow;
+			// we lock the simpler tsgo path. The type annotation
+			// `[number, number]` is a TupleType node and not visited by
+			// this rule, so it can stay tight regardless of mode.
+			{Code: `var [ a, b ]: [number, number] = [ 1, 2 ];`, Options: []interface{}{"always"}},
+			{Code: `var [a, b]: [number, number] = [1, 2];`, Options: []interface{}{"never"}},
+			{Code: `function f([ a, b ]: [number, number]) {}`, Options: []interface{}{"always"}},
+			{Code: `function f([a, b]: [number, number]) {}`, Options: []interface{}{"never"}},
+
+			// ---- Dimension 4: arrow param destructuring with type annotation ----
+			{Code: `const f = ([a, b]: [number, number]) => a + b;`, Options: []interface{}{"never"}},
+			{Code: `const f = ([ a, b ]: [number, number]) => a + b;`, Options: []interface{}{"always"}},
+
+			// ---- Dimension 4: for-of destructuring ----
+			{Code: `for (const [a, b] of arr) {}`, Options: []interface{}{"never"}},
+			{Code: `for (const [ a, b ] of arr) {}`, Options: []interface{}{"always"}},
+
+			// ---- Dimension 4: nested binding with object pattern ----
+			// BindingElement.Name() is ObjectBindingPattern → matches the
+			// objectsInArrays exception under our bindingElementBound
+			// unwrap. Without the unwrap this would fall through to
+			// `KindBindingElement` and silently miss the exception.
+			{Code: `var [ { x, y }, z] = arr;`, Options: []interface{}{"never", map[string]interface{}{"objectsInArrays": true}}},
+			{Code: `var [z, { x, y } ] = arr;`, Options: []interface{}{"never", map[string]interface{}{"objectsInArrays": true}}},
+
+			// ---- Dimension 4: rest element (BindingRest) does NOT match exceptions ----
+			// `bindingElementBound` keeps DotDotDotToken-bearing
+			// BindingElements as-is so the rest target doesn't accidentally
+			// be classified as the inner array/object kind.
+			{Code: `var [...rest] = arr;`, Options: []interface{}{"never", map[string]interface{}{"arraysInArrays": true}}},
+			{Code: `var [ ...rest ] = arr;`, Options: []interface{}{"always", map[string]interface{}{"arraysInArrays": false}}},
+
+			// ---- Dimension 4: line comment near closing bracket ----
+			// A `//` line comment forces a newline before `]`, which the
+			// `isTokenOnSameLine` (newline) check uses to skip the closing
+			// report. Mirrors upstream's behavior under
+			// getTokenBefore({includeComments:false}).
+			{Code: "var arr = [\n  1,\n  2 // comment\n];", Options: []interface{}{"never"}},
+
+			// ---- Dimension 4: trailing block comment with newline ----
+			{Code: "var arr = [\n  1,\n  2 /* comment */\n];", Options: []interface{}{"never"}},
+
+			// ---- Real-user: array in function argument with always-spacing ----
+			// Common shape that previously triggered false reports when the
+			// nested array exception was applied to the wrong layer.
+			{Code: `fn([ a, b ], { c });`, Options: []interface{}{"always", map[string]interface{}{"objectsInArrays": false}}},
+
+			// ---- Real-user: array literal in object property value ----
+			{Code: `const obj = { items: [1, 2, 3] };`, Options: []interface{}{"never"}},
+			{Code: `const obj = { items: [ 1, 2, 3 ] };`, Options: []interface{}{"always"}},
+
+			// ---- Locks in upstream validateArraySpacing() arm: empty array under 'always' early-return ----
+			// `if (options.spaced && node.elements.length === 0) return` —
+			// upstream doesn't iterate further, so the input `[ ]` is
+			// valid under 'always' even though there IS a space between
+			// the brackets.
+			{Code: `var foo = [ ];`, Options: []interface{}{"always"}},
+
+			// ---- Locks in upstream validateArraySpacing() arm: 'never' empty array with no closing report ----
+			// `first !== penultimate` short-circuits closing — for `[]`
+			// the closing report is silently dropped even though the
+			// closing check would otherwise emit nothing. Verify the
+			// empty array under 'never' is clean.
+			{Code: `var foo = [];`, Options: []interface{}{"never"}},
+
+			// ---- Dimension 4: nested empty arrays ----
+			// Outer's first element is itself an ArrayLit (the inner `[]`),
+			// but without an arraysInArrays:true exception the outer keeps
+			// its default 'never' behavior. The inner's `spaced && len===0`
+			// (here: spaced=false, so no early-return) still produces no
+			// reports because there's nothing between the inner brackets.
+			{Code: `var arr = [[]];`, Options: []interface{}{"never"}},
+			{Code: `var arr = [[], []];`, Options: []interface{}{"never"}},
+
+			// ---- Dimension 4: SpreadElement / RestElement never match
+			//      Array/Object exceptions ----
+			// SpreadElement is not ArrayLit/ObjectLit even when its operand
+			// is, so `objectsInArrays` / `arraysInArrays` exceptions never
+			// fire. Mirrors upstream's `isArrayType(spreadElement) === false`.
+			{Code: `var arr = [...other];`, Options: []interface{}{"never"}},
+			{Code: `var arr = [ ...other ];`, Options: []interface{}{"always"}},
+			{Code: `var arr = [...arr1, ...arr2];`, Options: []interface{}{"never", map[string]interface{}{"arraysInArrays": true}}},
+
+			// ---- Dimension 4: BindingElement with default initializer ----
+			// `bindingElementBound` unwraps to the BindingElement's name
+			// (an Identifier), not to the Initializer expression — so a
+			// default of `1` or `[]` doesn't accidentally match the
+			// arraysInArrays exception via the wrong slot.
+			{Code: `var [a = 1, b = 2] = arr;`, Options: []interface{}{"never"}},
+			{Code: `var [ a = 1, b = 2 ] = arr;`, Options: []interface{}{"always"}},
+			// Parameter default initializer is itself an ArrayLit, but
+			// it's visited as a sibling listener call (not as a child of
+			// the binding pattern), so the two arrays are scored
+			// independently. Under 'always' the empty `[]` initializer
+			// hits the `spaced && len===0` early-return path.
+			{Code: `function f([a, b] = []) {}`, Options: []interface{}{"never"}},
+			{Code: `function f([ a, b ] = []) {}`, Options: []interface{}{"always"}},
+
+			// ---- Dimension 4: non-Array/non-Object element kinds (no exception) ----
+			// new / typeof / unary / optional chain / await — none of
+			// these are ArrayLit or ObjectLit, so even with both
+			// exceptions enabled the rule falls through to its default
+			// spaced setting.
+			{Code: `var arr = [new X(), -1, !flag, typeof x, void y];`, Options: []interface{}{"never", map[string]interface{}{"objectsInArrays": true, "arraysInArrays": true}}},
+			{Code: `var arr = [a?.b, c?.d()];`, Options: []interface{}{"never"}},
+			{Code: `async function f() { return [await one, await two]; }`, Options: []interface{}{"never"}},
+			{Code: `function * g() { yield [1, 2]; }`, Options: []interface{}{"never"}},
+
+			// ---- Dimension 4: parser robustness — bracket-like chars
+			//      inside string / template / comment payloads ----
+			// The parser correctly closes the outer ArrayLit at its own
+			// `]`. Our `text[end-1] == ']'` invariant holds because we
+			// query `node.End()` from the AST, not via byte heuristics.
+			{Code: `var arr = ["a]b", "c[d", "e]f[g"];`, Options: []interface{}{"never"}},
+			{Code: "var arr = [`a]b`, `c[d`];", Options: []interface{}{"never"}},
+			{Code: `var arr = [1 /* ] [ */, 2];`, Options: []interface{}{"never"}},
+
+			// ---- Adversarial: token suffixes that collide with `*/` ----
+			// Reverse byte scan is not token-aware. Without bounding it at
+			// `rawLast.End()` it would mistake the trailing bytes of these
+			// last elements for a block-comment terminator and over-run
+			// into the token body, generating spurious reports + a
+			// destructive autofix that deletes the element. Locked in by
+			// the `scanLow = rawLast.End()` bound — see PR #983 review.
+			//
+			// Regex literal forms with various `*/`-adjacent endings:
+			{Code: `var arr = [/abc*/];`, Options: []interface{}{"never"}},   // pattern ends in `*/`
+			{Code: `var arr = [/\*/];`, Options: []interface{}{"never"}},     // body is escaped star + closing `/`
+			{Code: `var arr = [/foo*\//];`, Options: []interface{}{"never"}}, // escaped slash in body
+			{Code: `var arr = [a, /xy*/];`, Options: []interface{}{"never"}}, // regex as LAST of multi-element
+			{Code: `var arr = [ /abc*/ ];`, Options: []interface{}{"always"}}, // 'always' mode + regex
+			// String literal ending with `*/`:
+			{Code: `var arr = ["x*/"];`, Options: []interface{}{"never"}},
+			{Code: `var arr = [1, "trailing*/"];`, Options: []interface{}{"never"}},
+			// Template literal ending with `*/`:
+			{Code: "var arr = [`hello*/`];", Options: []interface{}{"never"}},
+			{Code: "var arr = [1, `tail*/`];", Options: []interface{}{"never"}},
+
+			// ---- Dimension 4: ArrayLit inside template substitution ----
+			// Nested visit through a TemplateExpression. Confirms the
+			// listener fires on the inner array even though the byte
+			// scan never crosses `}` boundaries.
+			{Code: "var t = `pre ${[1, 2]} post`;", Options: []interface{}{"never"}},
+			{Code: "var t = `pre ${[ 1, 2 ]} post`;", Options: []interface{}{"always"}},
+
+			// ---- Dimension 4: multi-byte / non-ASCII content in elements ----
+			// Unicode strings / identifiers in element position don't
+			// shift the bracket positions returned by node.End(). Our
+			// byte-level scan only inspects ASCII characters
+			// immediately adjacent to `[` and `]`, so multi-byte
+			// payloads pass through transparently.
+			{Code: `var arr = ["✓", "✗", "中文"];`, Options: []interface{}{"never"}},
+			{Code: `var arr = [ "✓", "✗", "中文" ];`, Options: []interface{}{"always"}},
+			{Code: `var arr = [π, ε, μ];`, Options: []interface{}{"never"}},
+
+			// ---- Real-user: React hook dependency array ----
+			// `useEffect(() => {}, [a, b])` is the single most common
+			// shape this rule fires on in real React codebases. Lock
+			// both modes.
+			{Code: `useEffect(() => {}, [a, b]);`, Options: []interface{}{"never"}},
+			{Code: `useEffect(() => {}, [ a, b ]);`, Options: []interface{}{"always"}},
+			{Code: `useEffect(() => {}, []);`, Options: []interface{}{"never"}},
+
+			// ---- Real-user: JSX prop value containing an array ----
+			// Verifies the rule runs in .tsx files and inside JsxExpression
+			// containers. The array lives inside `{...}` so the listener
+			// must traverse through JsxAttribute → JsxExpression.
+			{Code: `const el = <List items={[1, 2, 3]} />;`, Options: []interface{}{"never"}, Tsx: true},
+			{Code: `const el = <Grid rows={[[1, 2], [3, 4]]} />;`, Options: []interface{}{"never"}, Tsx: true},
+
+			// ---- Real-user: array literal as call argument with `as const` ----
+			// `[1, 2, 3] as const` is an AsExpression wrapping the
+			// ArrayLit; our rule visits the inner ArrayLit only.
+			{Code: `var arr = [1, 2, 3] as const;`, Options: []interface{}{"never"}},
+			{Code: `var arr = [ 1, 2, 3 ] as const;`, Options: []interface{}{"always"}},
+
+			// ---- Real-user: nested destructuring with rest tail ----
+			// Lock the recursive descent into BindingPattern children.
+			{Code: `var [[a, ...b], c] = arr;`, Options: []interface{}{"never"}},
+			{Code: `var [ [ a, ...b ], c ] = arr;`, Options: []interface{}{"always"}},
+
+			// ---- Real-user: array destructuring in callback parameter ----
+			// `.reduce((acc, [k, v]) => …)` is one of the most common
+			// destructuring shapes outside variable declarations.
+			{Code: `arr.reduce((acc, [k, v]) => acc + v, 0);`, Options: []interface{}{"never"}},
+			{Code: `arr.reduce((acc, [ k, v ]) => acc + v, 0);`, Options: []interface{}{"always"}},
+			{Code: `arr.forEach(([k, v]) => { console.log(k, v); });`, Options: []interface{}{"never"}},
+
+			// ---- Real-user: ArrayLit inside an ObjectLit property value ----
+			// The classic "config object" shape. Verifies the listener
+			// reaches arrays nested in PropertyAssignment.Initializer.
+			{Code: `const cfg = { items: [1, 2], modes: ["a", "b"] };`, Options: []interface{}{"never"}},
+
+			// ---- Real-user: trailing comma in destructuring + 'never' ----
+			// Sparse-trailing form. `[a, b, ,]` is the upstream `[ ,x, ]`
+			// variant flipped to the trailing edge.
+			{Code: `var [a, b, ,] = arr;`, Options: []interface{}{"never"}},
+
+			// ---- Real-user: TS decorator with array argument ----
+			// `@Decorator([1, 2])` — array literal in a decorator's
+			// argument list. Confirms the rule runs inside Decorator
+			// nodes.
+			{Code: `@Decorator([1, 2]) class X {}`, Options: []interface{}{"never"}},
+			{Code: `@Decorator([ 1, 2 ]) class X {}`, Options: []interface{}{"always"}},
+
+			// ---- Options resilience: empty options array → 'never' defaults ----
+			// rslint's CLI can dispatch options as `[]` (level only); we
+			// fall through to spaced=false with no exceptions.
+			{Code: `var arr = [1, 2];`, Options: []interface{}{}},
+
+			// ---- Options resilience: unknown keys in the second arg are ignored ----
+			// Defensive: rslint does not perform JSON-schema validation, so
+			// we must silently ignore keys upstream's schema would reject.
+			{Code: `var arr = [1, 2];`, Options: []interface{}{"never", map[string]interface{}{"unknownKey": true}}},
+
+			// ---- Options resilience: non-bool exception values are ignored ----
+			// `singleValue: "true"` (string) must NOT flip the exception
+			// — only literal `true` / `false` matter (mirrors upstream's
+			// `=== !spaced` reference-equality check).
+			{Code: `var arr = [1];`, Options: []interface{}{"never", map[string]interface{}{"singleValue": "true"}}},
+			{Code: `var arr = [1];`, Options: []interface{}{"never", map[string]interface{}{"singleValue": 1}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Locks in upstream validateArraySpacing() arm:
+			// objectsInArrays + paren-wrapped element ----
+			// Without SkipParentheses on elements[0] the leading-bracket
+			// check would NOT flip the spaced default, and this would be
+			// reported as a regular 'never' violation. With SkipParentheses
+			// the exception fires and the opening space becomes required
+			// (closing space becomes required too because elements[len-1]
+			// is also paren-wrapped). Fix output and positions verify the
+			// exception is applied symmetrically.
+			{
+				Code:    `var foo = [({a: 1}), 2, ({b: 2})];`,
+				Output:  []string{`var foo = [ ({a: 1}), 2, ({b: 2}) ];`},
+				Options: []interface{}{"never", map[string]interface{}{"objectsInArrays": true}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 33, EndLine: 1, EndColumn: 34},
+				},
+			},
+
+			// ---- Locks in upstream validateArraySpacing() arm:
+			// arraysInArrays + paren-wrapped first element ----
+			{
+				Code:    `var arr = [([1, 2]), 2];`,
+				Output:  []string{`var arr = [ ([1, 2]), 2];`},
+				Options: []interface{}{"never", map[string]interface{}{"arraysInArrays": true}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+
+			// ---- Dimension 4: nested ArrayLiteral in 'always' — verifies
+			// enter/exit emit order matches source order across the layer
+			// boundary. Without the enter-on-open / exit-on-close split,
+			// the outer closing report would emit before the inner reports
+			// (parent-first traversal). The expected column sequence
+			// 11 → 18 → 23 → 24 exercises this.
+			{
+				Code:    `var arr = [1, 2, [3, 4]];`,
+				Output:  []string{`var arr = [ 1, 2, [ 3, 4 ] ];`},
+				Options: []interface{}{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+				},
+			},
+
+			// ---- Locks in upstream validateArraySpacing() arm:
+			// singleElementException with 'never' ----
+			// length === 1 triggers the exception arm that flips the
+			// opening-must-be-spaced AND closing-must-be-spaced from false
+			// to true, regardless of which other exceptions match. Verify
+			// both reports fire on a paren-wrapped single-element value
+			// (so neither object- nor array-in-arrays exceptions apply).
+			{
+				Code:    `var arr = [(x)];`,
+				Output:  []string{`var arr = [ (x) ];`},
+				Options: []interface{}{"never", map[string]interface{}{"singleValue": true}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+				},
+			},
+
+			// ---- Dimension 4: TS array binding pattern with type annotation, 'always' ----
+			// Confirms node.End() of the binding pattern stops at `]` and
+			// the type annotation `: [number, number]` on the parent
+			// declaration doesn't trip up our open/close position
+			// resolution. The annotation itself is a TupleType node and
+			// is not visited by this rule (no second-pass fix).
+			{
+				Code:    `var [a, b]: [number, number] = [1, 2];`,
+				Output:  []string{`var [ a, b ]: [number, number] = [ 1, 2 ];`},
+				Options: []interface{}{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 32, EndLine: 1, EndColumn: 33},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 37, EndLine: 1, EndColumn: 38},
+				},
+			},
+
+			// ---- Real-user: deeply nested array literal flagged at every layer ----
+			// Triple-level nesting in 'never' mode with arraysInArrays:true
+			// — every layer whose first/last element is itself an array
+			// has the exception fired independently. Confirms the
+			// per-node exception derivation doesn't bleed across nesting
+			// levels (e.g. the innermost `[2]` keeps default 'never'
+			// because its element `2` isn't an array, while its parent
+			// `[[2]]` flips to spaced). Also exercises the enter/exit
+			// emit ordering across three layers: 11 → 17 → 21 → 22.
+			{
+				Code:    `var arr = [[1], [[2]]];`,
+				Output:  []string{`var arr = [ [1], [ [2] ] ];`},
+				Options: []interface{}{"never", map[string]interface{}{"arraysInArrays": true}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 21, EndLine: 1, EndColumn: 22},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+
+			// ---- Locks in upstream babel block: arrow param destructuring
+			// with TS type annotation, 'never' ----
+			// Mirrors upstream's babel/Flow test `([ a, b ]: Array<any>) => {}`
+			// rewritten in tsgo-friendly TS syntax. Verifies node.End() of
+			// the ArrayBindingPattern stops at `]` even when the parent
+			// parameter carries a type annotation, so the closing report's
+			// reported range stays on `]` and the trailing `:` doesn't
+			// leak into the fix.
+			{
+				Code:    `([ a, b ]: Array<any>) => {}`,
+				Output:  []string{`([a, b]: Array<any>) => {}`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 3, EndLine: 1, EndColumn: 4},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+			{
+				Code:    `([a, b]: Array<any>) => {}`,
+				Output:  []string{`([ a, b ]: Array<any>) => {}`},
+				Options: []interface{}{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+				},
+			},
+
+			// ---- Real-user: array as call argument, multiple spaces ----
+			// Mirrors the 'multiple spaces' upstream cases but inside a
+			// function call rather than a variable initializer. Confirms
+			// that the rule's text-based scan locates the array's own
+			// brackets even when the surrounding context has its own
+			// whitespace.
+			{
+				Code:    `fn([   1, 2   ]);`,
+				Output:  []string{`fn([1, 2]);`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 8},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 12, EndLine: 1, EndColumn: 15},
+				},
+			},
+
+			// ---- Dimension 4: nested empty array under 'always' ----
+			// `[[]]` — outer needs spaces (default 'always'), inner empty
+			// hits early-return. Confirms the two layers don't interfere.
+			{
+				Code:    `var arr = [[]];`,
+				Output:  []string{`var arr = [ [] ];`},
+				Options: []interface{}{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+
+			// ---- Dimension 4: SpreadElement does NOT match
+			//      arraysInArrays — only the outer 'never' rule fires ----
+			{
+				Code:    `var arr = [ ...other ];`,
+				Output:  []string{`var arr = [...other];`},
+				Options: []interface{}{"never", map[string]interface{}{"arraysInArrays": true}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 21, EndLine: 1, EndColumn: 22},
+				},
+			},
+
+			// ---- Dimension 4: paren-wrapped array element triggers
+			//      arraysInArrays on both ends ----
+			// Symmetric companion to the [({a:1}), ...] objectsInArrays
+			// invalid case. Confirms SkipParentheses → ArrayLit
+			// classification works for first AND last positions.
+			{
+				Code:    `var arr = [([1]), ([2])];`,
+				Output:  []string{`var arr = [ ([1]), ([2]) ];`},
+				Options: []interface{}{"never", map[string]interface{}{"arraysInArrays": true}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+				},
+			},
+
+			// ---- Dimension 4: BindingElement with default initializer
+			//      under 'always' ----
+			// The defaults (`= 1`, `= 2`) are part of BindingElement, not
+			// elements at array level — they don't affect bracket
+			// classification.
+			{
+				Code:    `var [a = 1, b = 2] = arr;`,
+				Output:  []string{`var [ a = 1, b = 2 ] = arr;`},
+				Options: []interface{}{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+				},
+			},
+
+			// ---- Dimension 4: parameter default array initializer is
+			//      visited as a sibling, not a child ----
+			// Verifies the rule fires on the outer destructuring AND the
+			// initializer's empty array independently — the empty `[]`
+			// initializer hits early-return so only the destructuring
+			// brackets get reported.
+			{
+				Code:    `function f([a, b] = []) {}`,
+				Output:  []string{`function f([ a, b ] = []) {}`},
+				Options: []interface{}{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+
+			// ---- Branch lock-in: three-level always — single-pass fix
+			//      across six independent insert points ----
+			// Verifies all six fixes (3 opening + 3 closing, each at a
+			// distinct byte position) compose in one ApplyRuleFixes call
+			// without overlap. Also exercises the enter/exit emit order
+			// across three layers in a row.
+			{
+				Code:    `var arr = [[[1]]];`,
+				Output:  []string{`var arr = [ [ [ 1 ] ] ];`},
+				Options: []interface{}{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+
+			// ---- Locks in upstream destructive-fix behavior:
+			//      trailing block comment removed with the offending
+			//      space ----
+			// Upstream's `removeRange([penultimate.range[1], last.range[0]])`
+			// removes the comment between the last token and `]`. Our
+			// reverse-scan delivers the same byte range, so the fix
+			// matches upstream byte-for-byte.
+			{
+				Code:    `var arr = [1, 2 /* trailing */ ];`,
+				Output:  []string{`var arr = [1, 2];`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 16, EndLine: 1, EndColumn: 32},
+				},
+			},
+
+			// ---- Locks in upstream destructive-fix behavior:
+			//      leading block comment removed too ----
+			// Symmetric lock for the leading edge — `scanner.SkipTrivia`
+			// crosses the block comment, the fix removes everything
+			// between `[` and the first real token.
+			{
+				Code:    `var arr = [ /* leading */ 1, 2];`,
+				Output:  []string{`var arr = [1, 2];`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 27},
+				},
+			},
+
+			// ---- Real-user: React hook deps with 'always' ----
+			{
+				Code:    `useEffect(() => {}, [a, b]);`,
+				Output:  []string{`useEffect(() => {}, [ a, b ]);`},
+				Options: []interface{}{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 21, EndLine: 1, EndColumn: 22},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 26, EndLine: 1, EndColumn: 27},
+				},
+			},
+
+			// ---- Real-user: JSX prop array under 'always' ----
+			// Confirms the rule visits ArrayLit inside JsxExpression and
+			// the .tsx file path is exercised.
+			{
+				Code:    `const el = <List items={[1, 2, 3]} />;`,
+				Output:  []string{`const el = <List items={[ 1, 2, 3 ]} />;`},
+				Options: []interface{}{"always"},
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 33, EndLine: 1, EndColumn: 34},
+				},
+			},
+
+			// ---- Real-user: TS decorator argument needs spaces under
+			//      'always' ----
+			{
+				Code:    `@Decorator([1, 2]) class X {}`,
+				Output:  []string{`@Decorator([ 1, 2 ]) class X {}`},
+				Options: []interface{}{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+
+			// ---- Real-user: callback destructuring with default
+			//      'never' violation ----
+			// `.reduce((acc, [ k, v ]) => …)` is a common shape that
+			// gets accidentally formatted with spaces — verify the
+			// rule normalizes it.
+			{
+				Code:    `arr.reduce((acc, [ k, v ]) => acc + v, 0);`,
+				Output:  []string{`arr.reduce((acc, [k, v]) => acc + v, 0);`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+				},
+			},
+
+			// ---- Real-user: array literal in template substitution ----
+			{
+				Code:    "var t = `${[ 1, 2 ]}`;",
+				Output:  []string{"var t = `${[1, 2]}`;"},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+				},
+			},
+
+			// ---- Multi-byte safety: UTF-8 string content + 'never' violation ----
+			// The byte-level scan reads ASCII at the bracket boundary;
+			// the multi-byte payload between is opaque. Position
+			// reporting must use UTF-16 char offsets (via
+			// scanner.GetECMALineAndUTF16CharacterOfPosition).
+			{
+				Code:    `var arr = [ "中" ];`,
+				Output:  []string{`var arr = ["中"];`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+				},
+			},
+
+			// ---- Real-user: deeply nested config-style array ----
+			// `[{ items: [1, 2] }, { items: [3, 4] }]` — common
+			// fixture-style data shape. Lock with 'always' +
+			// objectsInArrays:false so only the inner ArrayLits get
+			// spaced, not the wrapper objects.
+			{
+				Code:    `var data = [{ items: [1, 2] }, { items: [3, 4] }];`,
+				Output:  []string{`var data = [{ items: [ 1, 2 ] }, { items: [ 3, 4 ] }];`},
+				Options: []interface{}{"always", map[string]interface{}{"objectsInArrays": false}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 27, EndLine: 1, EndColumn: 28},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 41, EndLine: 1, EndColumn: 42},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 46, EndLine: 1, EndColumn: 47},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing_upstream_test.go
+++ b/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing_upstream_test.go
@@ -1,0 +1,496 @@
+// TestArrayBracketSpacingUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/rules/array-bracket-spacing/array-bracket-spacing.test.ts
+// 1:1. Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in
+// array_bracket_spacing_extras_test.go.
+package array_bracket_spacing_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/array_bracket_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func optsAlways() []interface{}                    { return []interface{}{"always"} }
+func optsNever() []interface{}                     { return []interface{}{"never"} }
+func optsAlwaysObj(o map[string]interface{}) []any { return []interface{}{"always", o} }
+func optsNeverObj(o map[string]interface{}) []any  { return []interface{}{"never", o} }
+
+func TestArrayBracketSpacingUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&array_bracket_spacing.ArrayBracketSpacingRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Member access in always (upstream tests these for ArrayExpression visitor independence) ----
+			{Code: `var foo = obj[ 1 ]`, Options: optsAlways()},
+			{Code: `var foo = obj[ 'foo' ];`, Options: optsAlways()},
+			{Code: `var foo = obj[ [ 1, 1 ] ];`, Options: optsAlways()},
+
+			// ---- always - singleValue ----
+			{Code: `var foo = ['foo']`, Options: optsAlwaysObj(map[string]interface{}{"singleValue": false})},
+			{Code: `var foo = [2]`, Options: optsAlwaysObj(map[string]interface{}{"singleValue": false})},
+			{Code: `var foo = [[ 1, 1 ]]`, Options: optsAlwaysObj(map[string]interface{}{"singleValue": false})},
+			{Code: `var foo = [{ 'foo': 'bar' }]`, Options: optsAlwaysObj(map[string]interface{}{"singleValue": false})},
+			{Code: `var foo = [bar]`, Options: optsAlwaysObj(map[string]interface{}{"singleValue": false})},
+
+			// ---- always - objectsInArrays ----
+			{Code: `var foo = [{ 'bar': 'baz' }, 1,  5 ];`, Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false})},
+			{Code: `var foo = [ 1, 5, { 'bar': 'baz' }];`, Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false})},
+			{Code: "var foo = [{\n'bar': 'baz', \n'qux': [{ 'bar': 'baz' }], \n'quxx': 1 \n}]", Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false})},
+			{Code: `var foo = [{ 'bar': 'baz' }]`, Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false})},
+			{Code: `var foo = [{ 'bar': 'baz' }, 1, { 'bar': 'baz' }];`, Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false})},
+			{Code: `var foo = [ 1, { 'bar': 'baz' }, 5 ];`, Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false})},
+			{Code: `var foo = [ 1, { 'bar': 'baz' }, [{ 'bar': 'baz' }] ];`, Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false})},
+			{Code: `var foo = [ function(){} ];`, Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false})},
+
+			// ---- always - arraysInArrays ----
+			{Code: `var arr = [[ 1, 2 ], 2, 3, 4 ];`, Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false})},
+			{Code: `var arr = [[ 1, 2 ], [[[ 1 ]]], 3, 4 ];`, Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false})},
+			{Code: `var foo = [ arr[i], arr[j] ];`, Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false})},
+
+			// ---- always - arraysInArrays, objectsInArrays ----
+			{Code: `var arr = [[ 1, 2 ], 2, 3, { 'foo': 'bar' }];`, Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false, "objectsInArrays": false})},
+
+			// ---- always - arraysInArrays, objectsInArrays, singleValue ----
+			{Code: `var arr = [[ 1, 2 ], [2], 3, { 'foo': 'bar' }];`, Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false, "objectsInArrays": false, "singleValue": false})},
+
+			// ---- always ----
+			{Code: `obj[ foo ]`, Options: optsAlways()},
+			{Code: "obj[\nfoo\n]", Options: optsAlways()},
+			{Code: `obj[ 'foo' ]`, Options: optsAlways()},
+			{Code: `obj[ 'foo' + 'bar' ]`, Options: optsAlways()},
+			{Code: `obj[ obj2[ foo ] ]`, Options: optsAlways()},
+			{Code: "obj.map(function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsAlways()},
+			{Code: "obj[ 'map' ](function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsAlways()},
+			{Code: "obj[ 'for' + 'Each' ](function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsAlways()},
+
+			{Code: `var arr = [ 1, 2, 3, 4 ];`, Options: optsAlways()},
+			{Code: `var arr = [ [ 1, 2 ], 2, 3, 4 ];`, Options: optsAlways()},
+			{Code: "var arr = [\n1, 2, 3, 4\n];", Options: optsAlways()},
+			{Code: `var foo = [];`, Options: optsAlways()},
+
+			// ---- singleValue: false, objectsInArrays: true, arraysInArrays ----
+			{Code: "this.db.mappings.insert([\n { alias: 'a', url: 'http://www.amazon.de' },\n { alias: 'g', url: 'http://www.google.de' }\n], function() {});", Options: optsAlwaysObj(map[string]interface{}{"singleValue": false, "objectsInArrays": true, "arraysInArrays": true})},
+
+			// ---- always - destructuring assignment ----
+			{Code: `var [ x, y ] = z`, Options: optsAlways()},
+			{Code: `var [ x,y ] = z`, Options: optsAlways()},
+			{Code: "var [ x, y\n] = z", Options: optsAlways()},
+			{Code: "var [\nx, y ] = z", Options: optsAlways()},
+			{Code: "var [\nx, y\n] = z", Options: optsAlways()},
+			{Code: "var [\nx,,,\n] = z", Options: optsAlways()},
+			{Code: `var [ ,x, ] = z`, Options: optsAlways()},
+			{Code: "var [\nx, ...y\n] = z", Options: optsAlways()},
+			{Code: "var [\nx, ...y ] = z", Options: optsAlways()},
+			{Code: `var [[ x, y ], z ] = arr;`, Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false})},
+			{Code: `var [ x, [ y, z ]] = arr;`, Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false})},
+			{Code: `[{ x, y }, z ] = arr;`, Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false})},
+			{Code: `[ x, { y, z }] = arr;`, Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false})},
+
+			// ---- never ----
+			{Code: `obj[foo]`, Options: optsNever()},
+			{Code: `obj['foo']`, Options: optsNever()},
+			{Code: `obj['foo' + 'bar']`, Options: optsNever()},
+			{Code: `obj['foo'+'bar']`, Options: optsNever()},
+			{Code: `obj[obj2[foo]]`, Options: optsNever()},
+			{Code: "obj.map(function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsNever()},
+			{Code: "obj['map'](function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsNever()},
+			{Code: "obj['for' + 'Each'](function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsNever()},
+			{Code: `var arr = [1, 2, 3, 4];`, Options: optsNever()},
+			{Code: `var arr = [[1, 2], 2, 3, 4];`, Options: optsNever()},
+			{Code: "var arr = [\n1, 2, 3, 4\n];", Options: optsNever()},
+			{Code: "obj[\nfoo]", Options: optsNever()},
+			{Code: "obj[foo\n]", Options: optsNever()},
+			{Code: "var arr = [1,\n2,\n3,\n4\n];", Options: optsNever()},
+			{Code: "var arr = [\n1,\n2,\n3,\n4];", Options: optsNever()},
+
+			// ---- never - destructuring assignment ----
+			{Code: `var [x, y] = z`, Options: optsNever()},
+			{Code: `var [x,y] = z`, Options: optsNever()},
+			{Code: "var [x, y\n] = z", Options: optsNever()},
+			{Code: "var [\nx, y] = z", Options: optsNever()},
+			{Code: "var [\nx, y\n] = z", Options: optsNever()},
+			{Code: "var [\nx,,,\n] = z", Options: optsNever()},
+			{Code: `var [,x,] = z`, Options: optsNever()},
+			{Code: "var [\nx, ...y\n] = z", Options: optsNever()},
+			{Code: "var [\nx, ...y] = z", Options: optsNever()},
+			{Code: `var [ [x, y], z] = arr;`, Options: optsNeverObj(map[string]interface{}{"arraysInArrays": true})},
+			{Code: `var [x, [y, z] ] = arr;`, Options: optsNeverObj(map[string]interface{}{"arraysInArrays": true})},
+			{Code: `[ { x, y }, z] = arr;`, Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+			{Code: `[x, { y, z } ] = arr;`, Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+
+			// ---- never - singleValue ----
+			{Code: `var foo = [ 'foo' ]`, Options: optsNeverObj(map[string]interface{}{"singleValue": true})},
+			{Code: `var foo = [ 2 ]`, Options: optsNeverObj(map[string]interface{}{"singleValue": true})},
+			{Code: `var foo = [ [1, 1] ]`, Options: optsNeverObj(map[string]interface{}{"singleValue": true})},
+			{Code: `var foo = [ {'foo': 'bar'} ]`, Options: optsNeverObj(map[string]interface{}{"singleValue": true})},
+			{Code: `var foo = [ bar ]`, Options: optsNeverObj(map[string]interface{}{"singleValue": true})},
+
+			// ---- never - objectsInArrays ----
+			{Code: `var foo = [ {'bar': 'baz'}, 1, 5];`, Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+			{Code: `var foo = [1, 5, {'bar': 'baz'} ];`, Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+			{Code: "var foo = [ {\n'bar': 'baz', \n'qux': [ {'bar': 'baz'} ], \n'quxx': 1 \n} ]", Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+			{Code: `var foo = [ {'bar': 'baz'} ]`, Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+			{Code: `var foo = [ {'bar': 'baz'}, 1, {'bar': 'baz'} ];`, Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+			{Code: `var foo = [1, {'bar': 'baz'} , 5];`, Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+			{Code: `var foo = [1, {'bar': 'baz'}, [ {'bar': 'baz'} ]];`, Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+			{Code: `var foo = [function(){}];`, Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+			{Code: `var foo = [];`, Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true})},
+
+			// ---- never - arraysInArrays ----
+			{Code: `var arr = [ [1, 2], 2, 3, 4];`, Options: optsNeverObj(map[string]interface{}{"arraysInArrays": true})},
+			{Code: `var foo = [arr[i], arr[j]];`, Options: optsNeverObj(map[string]interface{}{"arraysInArrays": true})},
+			{Code: `var foo = [];`, Options: optsNeverObj(map[string]interface{}{"arraysInArrays": true})},
+
+			// ---- never - arraysInArrays, singleValue ----
+			{Code: `var arr = [ [1, 2], [ [ [ 1 ] ] ], 3, 4];`, Options: optsNeverObj(map[string]interface{}{"arraysInArrays": true, "singleValue": true})},
+
+			// ---- never - arraysInArrays, objectsInArrays ----
+			{Code: `var arr = [ [1, 2], 2, 3, {'foo': 'bar'} ];`, Options: optsNeverObj(map[string]interface{}{"arraysInArrays": true, "objectsInArrays": true})},
+
+			// ---- should not warn ----
+			{Code: `var foo = {};`, Options: optsNever()},
+			{Code: `var foo = [];`, Options: optsNever()},
+
+			{Code: `var foo = [{'bar':'baz'}, 1, {'bar': 'baz'}];`, Options: optsNever()},
+			{Code: `var foo = [{'bar': 'baz'}];`, Options: optsNever()},
+			{Code: "var foo = [{\n'bar': 'baz', \n'qux': [{'bar': 'baz'}], \n'quxx': 1 \n}]", Options: optsNever()},
+			{Code: `var foo = [1, {'bar': 'baz'}, 5];`, Options: optsNever()},
+			{Code: `var foo = [{'bar': 'baz'}, 1,  5];`, Options: optsNever()},
+			{Code: `var foo = [1, 5, {'bar': 'baz'}];`, Options: optsNever()},
+			{Code: `var obj = {'foo': [1, 2]}`, Options: optsNever()},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:    `var foo = [ ]`,
+				Output:  []string{`var foo = []`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+
+			// ---- objectsInArrays ----
+			{
+				Code:    `var foo = [ { 'bar': 'baz' }, 1,  5];`,
+				Output:  []string{`var foo = [{ 'bar': 'baz' }, 1,  5 ];`},
+				Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 36, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				Code:    `var foo = [1, 5, { 'bar': 'baz' } ];`,
+				Output:  []string{`var foo = [ 1, 5, { 'bar': 'baz' }];`},
+				Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 34, EndLine: 1, EndColumn: 35},
+				},
+			},
+			{
+				Code:    `var foo = [ { 'bar':'baz' }, 1, { 'bar': 'baz' } ];`,
+				Output:  []string{`var foo = [{ 'bar':'baz' }, 1, { 'bar': 'baz' }];`},
+				Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 49, EndLine: 1, EndColumn: 50},
+				},
+			},
+
+			// ---- singleValue ----
+			{
+				Code:    `var obj = [ 'foo' ];`,
+				Output:  []string{`var obj = ['foo'];`},
+				Options: optsAlwaysObj(map[string]interface{}{"singleValue": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code:    `var obj = ['foo' ];`,
+				Output:  []string{`var obj = ['foo'];`},
+				Options: optsAlwaysObj(map[string]interface{}{"singleValue": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:    `var obj = ['foo'];`,
+				Output:  []string{`var obj = [ 'foo' ];`},
+				Options: optsNeverObj(map[string]interface{}{"singleValue": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+
+			// ---- always - arraysInArrays ----
+			{
+				Code:    `var arr = [ [ 1, 2 ], 2, 3, 4 ];`,
+				Output:  []string{`var arr = [[ 1, 2 ], 2, 3, 4 ];`},
+				Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:    `var arr = [ 1, 2, 2, [ 3, 4 ] ];`,
+				Output:  []string{`var arr = [ 1, 2, 2, [ 3, 4 ]];`},
+				Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 30, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code:    `var arr = [[ 1, 2 ], 2, [ 3, 4 ] ];`,
+				Output:  []string{`var arr = [[ 1, 2 ], 2, [ 3, 4 ]];`},
+				Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 33, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code:    `var arr = [ [ 1, 2 ], 2, [ 3, 4 ]];`,
+				Output:  []string{`var arr = [[ 1, 2 ], 2, [ 3, 4 ]];`},
+				Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:    `var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];`,
+				Output:  []string{`var arr = [[ 1, 2 ], 2, [ 3, 4 ]];`},
+				Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 34, EndLine: 1, EndColumn: 35},
+				},
+			},
+
+			// ---- always - destructuring ----
+			{
+				Code:    `var [x,y] = y`,
+				Output:  []string{`var [ x,y ] = y`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code:    `var [x,y ] = y`,
+				Output:  []string{`var [ x,y ] = y`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+				},
+			},
+			{
+				Code:    `var [,,,x,,] = y`,
+				Output:  []string{`var [ ,,,x,, ] = y`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:    `var [ ,,,x,,] = y`,
+				Output:  []string{`var [ ,,,x,, ] = y`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code:    `var [...horse] = y`,
+				Output:  []string{`var [ ...horse ] = y`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:    `var [...horse ] = y`,
+				Output:  []string{`var [ ...horse ] = y`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+				},
+			},
+			{
+				Code:    `var [ [ x, y ], z ] = arr;`,
+				Output:  []string{`var [[ x, y ], z ] = arr;`},
+				Options: optsAlwaysObj(map[string]interface{}{"arraysInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				},
+			},
+			{
+				Code:    `[ { x, y }, z ] = arr;`,
+				Output:  []string{`[{ x, y }, z ] = arr;`},
+				Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+			{
+				Code:    `[ x, { y, z } ] = arr;`,
+				Output:  []string{`[ x, { y, z }] = arr;`},
+				Options: optsAlwaysObj(map[string]interface{}{"objectsInArrays": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+
+			// ---- never - arraysInArrays ----
+			{
+				Code:    `var arr = [[1, 2], 2, [3, 4]];`,
+				Output:  []string{`var arr = [ [1, 2], 2, [3, 4] ];`},
+				Options: optsNeverObj(map[string]interface{}{"arraysInArrays": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 29, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code:    `var arr = [ ];`,
+				Output:  []string{`var arr = [];`},
+				Options: optsNeverObj(map[string]interface{}{"arraysInArrays": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+
+			// ---- never - objectsInArrays ----
+			{
+				Code:    `var arr = [ ];`,
+				Output:  []string{`var arr = [];`},
+				Options: optsNeverObj(map[string]interface{}{"objectsInArrays": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+
+			// ---- always ----
+			{
+				Code:    `var arr = [1, 2, 3, 4];`,
+				Output:  []string{`var arr = [ 1, 2, 3, 4 ];`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code:    `var arr = [1, 2, 3, 4 ];`,
+				Output:  []string{`var arr = [ 1, 2, 3, 4 ];`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code:    `var arr = [ 1, 2, 3, 4];`,
+				Output:  []string{`var arr = [ 1, 2, 3, 4 ];`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+				},
+			},
+
+			// ---- never ----
+			{
+				Code:    `var arr = [ 1, 2, 3, 4 ];`,
+				Output:  []string{`var arr = [1, 2, 3, 4];`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code:    `var arr = [1, 2, 3, 4 ];`,
+				Output:  []string{`var arr = [1, 2, 3, 4];`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code:    `var arr = [ 1, 2, 3, 4];`,
+				Output:  []string{`var arr = [1, 2, 3, 4];`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:    `var arr = [ [ 1], 2, 3, 4];`,
+				Output:  []string{`var arr = [[1], 2, 3, 4];`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:    `var arr = [[1 ], 2, 3, 4 ];`,
+				Output:  []string{`var arr = [[1], 2, 3, 4];`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+				},
+			},
+
+			// ---- multiple spaces ----
+			{
+				Code:    `var arr = [  1, 2   ];`,
+				Output:  []string{`var arr = [1, 2];`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 14},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 18, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code:    `function f( [   a, b  ] ) {}`,
+				Output:  []string{`function f( [a, b] ) {}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 14, EndLine: 1, EndColumn: 17},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 21, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code:    "var arr = [ 1,\n   2   ];",
+				Output:  []string{"var arr = [1,\n   2];"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 2, Column: 5, EndLine: 2, EndColumn: 8},
+				},
+			},
+			{
+				Code:    `var arr = [  1, [ 2, 3  ] ];`,
+				Output:  []string{`var arr = [1, [2, 3]];`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 14},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 23, EndLine: 1, EndColumn: 25},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 26, EndLine: 1, EndColumn: 27},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -445,6 +445,9 @@ export default defineConfig({
     // eslint-plugin-promise
     './tests/eslint-plugin-promise/rules/param-names.test.ts',
 
+    // eslint-plugin-stylistic
+    './tests/eslint-plugin-stylistic/rules/array-bracket-spacing.test.ts',
+
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rslint.config.mjs
@@ -1,0 +1,13 @@
+export default [
+  {
+    files: [],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: ['./tsconfig.files.json', './tsconfig.virtual.json'],
+      },
+    },
+    rules: {},
+    plugins: ['@stylistic'],
+  },
+];

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rule-tester.ts
@@ -1,0 +1,237 @@
+import path from 'node:path';
+import util from 'node:util';
+
+import { lint } from '@rslint/core';
+
+import { buildConfigForSettings } from '../src/util/load-test-config';
+
+interface SuggestionOutput {
+  messageId?: string;
+  desc?: string;
+  data?: Record<string, unknown> | undefined;
+  output: string;
+}
+
+interface TestCaseError {
+  message?: string | RegExp;
+  messageId?: string;
+  /**
+   * @deprecated `type` is deprecated and will be removed in the next major version.
+   */
+  type?: string | undefined;
+  data?: any;
+  line?: number | undefined;
+  column?: number | undefined;
+  endLine?: number | undefined;
+  endColumn?: number | undefined;
+  suggestions?: SuggestionOutput[] | undefined;
+}
+
+// Port from 'eslint'
+export interface ValidTestCase {
+  name?: string;
+  code: string;
+  options?: any;
+  filename?: string | undefined;
+  only?: boolean;
+  settings?: Record<string, any> | undefined;
+}
+
+export interface InvalidTestCase extends ValidTestCase {
+  errors: number | (TestCaseError | string)[];
+  output?: string | null | undefined;
+}
+
+export class RuleTester {
+  run(
+    ruleName: string,
+    rule: never,
+    cases: {
+      valid: ValidTestCase[];
+      invalid: InvalidTestCase[];
+    },
+  ) {
+    ruleName = '@stylistic/' + ruleName;
+    describe(ruleName, () => {
+      const cwd = process.cwd();
+      const config = path.resolve(import.meta.dirname, './rslint.config.mjs');
+
+      // test whether case has only
+      let hasOnly =
+        cases.valid.some((x) => {
+          if (typeof x === 'object' && x.only) {
+            return true;
+          } else {
+            return false;
+          }
+        }) || cases.invalid.some((x) => x.only);
+
+      test('valid', async () => {
+        for (const validCase of cases.valid) {
+          if (hasOnly) {
+            if (typeof validCase === 'string') {
+              continue;
+            }
+            if (!validCase.only) {
+              continue;
+            }
+          }
+          const code =
+            typeof validCase === 'string' ? validCase : validCase.code;
+
+          const options =
+            typeof validCase === 'string' ? [] : validCase.options || [];
+          const settings =
+            typeof validCase === 'string' ? undefined : validCase.settings;
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof validCase === 'string'
+              ? defaultFilename
+              : (validCase.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+
+          const { configPath, cleanup } = await buildConfigForSettings(
+            config,
+            settings,
+          );
+          let diags;
+          try {
+            diags = await lint({
+              config: configPath,
+              workingDirectory: cwd,
+              fileContents: {
+                [absoluteFilename]: code,
+              },
+              ruleOptions: {
+                [ruleName]: options,
+              },
+            });
+          } finally {
+            cleanup();
+          }
+
+          assert(
+            diags.diagnostics?.length === 0,
+            `Expected no diagnostics for valid case, but got: ${JSON.stringify(diags)}\nCode: ${code}`,
+          );
+        }
+      });
+      test('invalid', async (t) => {
+        for (const item of cases.invalid) {
+          assert.ok(
+            item.errors || item.errors === 0,
+            `Did not specify errors for an invalid test of ${ruleName}`,
+          );
+          if (Array.isArray(item.errors) && item.errors.length === 0) {
+            assert.fail('Invalid cases must have at least one error');
+          }
+
+          const { code, only = false, options = [], settings } = item;
+          if (hasOnly && !only) {
+            continue;
+          }
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof item === 'string'
+              ? defaultFilename
+              : (item.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+          const { configPath, cleanup } = await buildConfigForSettings(
+            config,
+            settings,
+          );
+          let diags;
+          try {
+            diags = await lint({
+              config: configPath,
+              workingDirectory: cwd,
+              fileContents: {
+                [absoluteFilename]: code,
+              },
+              ruleOptions: {
+                [ruleName]: options,
+              },
+            });
+          } finally {
+            cleanup();
+          }
+
+          if (typeof item.errors === 'number') {
+            if (item.errors === 0) {
+              assert.fail(
+                "Invalid cases must have 'error' value greater than 0",
+              );
+            }
+
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors,
+                item.errors === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+          } else {
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors.length,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors.length,
+                item.errors.length === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+
+            const hasMessageOfThisRule = diags.diagnostics.some(
+              (d) => d.ruleName === ruleName,
+            );
+
+            for (let i = 0, l = item.errors.length; i < l; i++) {
+              const error = item.errors[i];
+              const message = diags.diagnostics[i];
+
+              assert(
+                hasMessageOfThisRule,
+                'Error rule name should be the same as the name of the rule being tested',
+              );
+              if (typeof error === 'string' || error instanceof RegExp) {
+                // Just an error message.
+                assertMessageMatches(message.message, error);
+                assert.ok(
+                  message.suggestions === void 0,
+                  `Error at index ${i} has suggestions. Please convert the test error into an object and specify 'suggestions' property on it to test suggestions.`,
+                );
+              } else if (typeof error === 'object' && error !== null) {
+                if (typeof error.message === 'string') {
+                  assertMessageMatches(message.message, error.message);
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  }
+}
+
+/**
+ * Asserts that the message matches its expected value. If the expected
+ * value is a regular expression, it is checked against the actual
+ * value.
+ */
+function assertMessageMatches(actual: string, expected: string | RegExp): void {
+  if (expected instanceof RegExp) {
+    // assert.js doesn't have a built-in RegExp match function
+    assert.ok(
+      expected.test(actual),
+      `Expected '${actual}' to match ${expected}`,
+    );
+  } else {
+    assert.strictEqual(actual, expected);
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/array-bracket-spacing.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/array-bracket-spacing.test.ts
@@ -1,0 +1,370 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('array-bracket-spacing', null as never, {
+  valid: [
+    { code: 'var foo = obj[ 1 ]', options: ['always'] },
+    { code: "var foo = obj[ 'foo' ];", options: ['always'] },
+    { code: 'var foo = obj[ [ 1, 1 ] ];', options: ['always'] },
+
+    // always - singleValue
+    { code: "var foo = ['foo']", options: ['always', { singleValue: false }] },
+    { code: 'var foo = [2]', options: ['always', { singleValue: false }] },
+    {
+      code: 'var foo = [[ 1, 1 ]]',
+      options: ['always', { singleValue: false }],
+    },
+    {
+      code: "var foo = [{ 'foo': 'bar' }]",
+      options: ['always', { singleValue: false }],
+    },
+    { code: 'var foo = [bar]', options: ['always', { singleValue: false }] },
+
+    // always - objectsInArrays
+    {
+      code: "var foo = [{ 'bar': 'baz' }, 1,  5 ];",
+      options: ['always', { objectsInArrays: false }],
+    },
+    {
+      code: "var foo = [ 1, 5, { 'bar': 'baz' }];",
+      options: ['always', { objectsInArrays: false }],
+    },
+    {
+      code: "var foo = [{ 'bar': 'baz' }]",
+      options: ['always', { objectsInArrays: false }],
+    },
+    {
+      code: 'var foo = [ function(){} ];',
+      options: ['always', { objectsInArrays: false }],
+    },
+
+    // always - arraysInArrays
+    {
+      code: 'var arr = [[ 1, 2 ], 2, 3, 4 ];',
+      options: ['always', { arraysInArrays: false }],
+    },
+    {
+      code: 'var foo = [ arr[i], arr[j] ];',
+      options: ['always', { arraysInArrays: false }],
+    },
+
+    // always
+    { code: 'obj[ foo ]', options: ['always'] },
+    { code: "obj[ 'foo' ]", options: ['always'] },
+    { code: 'var arr = [ 1, 2, 3, 4 ];', options: ['always'] },
+    { code: 'var foo = [];', options: ['always'] },
+
+    // always - destructuring assignment
+    { code: 'var [ x, y ] = z', options: ['always'] },
+    { code: 'var [ ,x, ] = z', options: ['always'] },
+    {
+      code: 'var [[ x, y ], z ] = arr;',
+      options: ['always', { arraysInArrays: false }],
+    },
+
+    // never
+    { code: 'obj[foo]', options: ['never'] },
+    { code: "obj['foo']", options: ['never'] },
+    { code: 'var arr = [1, 2, 3, 4];', options: ['never'] },
+    { code: 'var arr = [[1, 2], 2, 3, 4];', options: ['never'] },
+
+    // never - destructuring assignment
+    { code: 'var [x, y] = z', options: ['never'] },
+    { code: 'var [,x,] = z', options: ['never'] },
+    {
+      code: 'var [ [x, y], z] = arr;',
+      options: ['never', { arraysInArrays: true }],
+    },
+
+    // never - singleValue
+    { code: "var foo = [ 'foo' ]", options: ['never', { singleValue: true }] },
+    { code: 'var foo = [ 2 ]', options: ['never', { singleValue: true }] },
+    { code: 'var foo = [ bar ]', options: ['never', { singleValue: true }] },
+
+    // never - objectsInArrays
+    {
+      code: "var foo = [ {'bar': 'baz'}, 1, 5];",
+      options: ['never', { objectsInArrays: true }],
+    },
+    {
+      code: "var foo = [1, 5, {'bar': 'baz'} ];",
+      options: ['never', { objectsInArrays: true }],
+    },
+    { code: 'var foo = [];', options: ['never', { objectsInArrays: true }] },
+
+    // never - arraysInArrays
+    {
+      code: 'var arr = [ [1, 2], 2, 3, 4];',
+      options: ['never', { arraysInArrays: true }],
+    },
+    { code: 'var foo = [];', options: ['never', { arraysInArrays: true }] },
+
+    // should not warn
+    { code: 'var foo = {};', options: ['never'] },
+    { code: 'var foo = [];', options: ['never'] },
+    {
+      code: "var foo = [{'bar':'baz'}, 1, {'bar': 'baz'}];",
+      options: ['never'],
+    },
+    { code: "var obj = {'foo': [1, 2]}", options: ['never'] },
+  ],
+  invalid: [
+    {
+      code: 'var foo = [ ]',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+
+    // objectsInArrays
+    {
+      code: "var foo = [ { 'bar': 'baz' }, 1,  5];",
+      options: ['always', { objectsInArrays: false }],
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+        {
+          messageId: 'missingSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 36,
+          endLine: 1,
+          endColumn: 37,
+        },
+      ],
+    },
+
+    // singleValue
+    {
+      code: "var obj = [ 'foo' ];",
+      options: ['always', { singleValue: false }],
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 19,
+        },
+      ],
+    },
+    {
+      code: "var obj = ['foo'];",
+      options: ['never', { singleValue: true }],
+      errors: [
+        {
+          messageId: 'missingSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 12,
+        },
+        {
+          messageId: 'missingSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 17,
+          endLine: 1,
+          endColumn: 18,
+        },
+      ],
+    },
+
+    // always - arraysInArrays
+    {
+      code: 'var arr = [ [ 1, 2 ], 2, 3, 4 ];',
+      options: ['always', { arraysInArrays: false }],
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+
+    // always - destructuring
+    {
+      code: 'var [x,y] = y',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 6,
+        },
+        {
+          messageId: 'missingSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 10,
+        },
+      ],
+    },
+    {
+      code: 'var [...horse] = y',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 6,
+        },
+        {
+          messageId: 'missingSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 15,
+        },
+      ],
+    },
+
+    // never -  arraysInArrays
+    {
+      code: 'var arr = [[1, 2], 2, [3, 4]];',
+      options: ['never', { arraysInArrays: true }],
+      errors: [
+        {
+          messageId: 'missingSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 12,
+        },
+        {
+          messageId: 'missingSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 29,
+          endLine: 1,
+          endColumn: 30,
+        },
+      ],
+    },
+    {
+      code: 'var arr = [ ];',
+      options: ['never', { arraysInArrays: true }],
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+
+    // always
+    {
+      code: 'var arr = [1, 2, 3, 4];',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 12,
+        },
+        {
+          messageId: 'missingSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 23,
+        },
+      ],
+    },
+
+    // never
+    {
+      code: 'var arr = [ 1, 2, 3, 4 ];',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 24,
+        },
+      ],
+    },
+
+    // multiple spaces
+    {
+      code: 'var arr = [  1, 2   ];',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 14,
+        },
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 21,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/tsconfig.files.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/tsconfig.files.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "allowJs": true
+  },
+  "include": ["files/**/*"]
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/tsconfig.virtual.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/tsconfig.virtual.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"]
+  },
+  "include": ["src/virtual.tsx", "src/virtual.ts"]
+}

--- a/packages/rslint/src/configs/index.ts
+++ b/packages/rslint/src/configs/index.ts
@@ -7,6 +7,7 @@ import { recommended as promiseRecommended } from './promise.js';
 import { recommended as jestRecommended } from './jest.js';
 import { recommended as unicornRecommended } from './unicorn.js';
 import { recommended as jsxA11yRecommended } from './jsx-a11y.js';
+import { recommended as stylisticRecommended } from './stylistic.js';
 
 export const ts = {
   configs: { base: tsBase, recommended: tsRecommended },
@@ -42,4 +43,8 @@ export const unicornPlugin = {
 
 export const jsxA11yPlugin = {
   configs: { recommended: jsxA11yRecommended },
+};
+
+export const stylisticPlugin = {
+  configs: { recommended: stylisticRecommended },
 };

--- a/packages/rslint/src/configs/stylistic.ts
+++ b/packages/rslint/src/configs/stylistic.ts
@@ -1,0 +1,80 @@
+import type { RslintConfigEntry } from '../define-config.js';
+
+// Aligned with official @stylistic/eslint-plugin@5.x recommended.
+// Upstream exposes `recommended` as `customize()` invoked with default
+// options. Option values for not-yet-implemented rules are omitted —
+// see upstream's customize.ts for the full configuration each rule receives.
+// Rules commented out with "not implemented" are in the official preset but
+// not yet available.
+const recommended: RslintConfigEntry = {
+  plugins: ['@stylistic'],
+  rules: {
+    '@stylistic/array-bracket-spacing': ['error', 'never'],
+    // '@stylistic/arrow-parens': 'error', // not implemented
+    // '@stylistic/arrow-spacing': 'error', // not implemented
+    // '@stylistic/block-spacing': 'error', // not implemented
+    // '@stylistic/brace-style': 'error', // not implemented
+    // '@stylistic/comma-dangle': 'error', // not implemented
+    // '@stylistic/comma-spacing': 'error', // not implemented
+    // '@stylistic/comma-style': 'error', // not implemented
+    // '@stylistic/computed-property-spacing': 'error', // not implemented
+    // '@stylistic/dot-location': 'error', // not implemented
+    // '@stylistic/eol-last': 'error', // not implemented
+    // '@stylistic/generator-star-spacing': 'error', // not implemented
+    // '@stylistic/indent': 'error', // not implemented
+    // '@stylistic/indent-binary-ops': 'error', // not implemented
+    // '@stylistic/jsx-closing-bracket-location': 'error', // not implemented
+    // '@stylistic/jsx-closing-tag-location': 'error', // not implemented
+    // '@stylistic/jsx-curly-brace-presence': 'error', // not implemented
+    // '@stylistic/jsx-curly-newline': 'error', // not implemented
+    // '@stylistic/jsx-curly-spacing': 'error', // not implemented
+    // '@stylistic/jsx-equals-spacing': 'error', // not implemented
+    // '@stylistic/jsx-first-prop-new-line': 'error', // not implemented
+    // '@stylistic/jsx-function-call-newline': 'error', // not implemented
+    // '@stylistic/jsx-indent-props': 'error', // not implemented
+    // '@stylistic/jsx-max-props-per-line': 'error', // not implemented
+    // '@stylistic/jsx-one-expression-per-line': 'error', // not implemented
+    // '@stylistic/jsx-quotes': 'error', // not implemented
+    // '@stylistic/jsx-tag-spacing': 'error', // not implemented
+    // '@stylistic/jsx-wrap-multilines': 'error', // not implemented
+    // '@stylistic/key-spacing': 'error', // not implemented
+    // '@stylistic/keyword-spacing': 'error', // not implemented
+    // '@stylistic/lines-between-class-members': 'error', // not implemented
+    // '@stylistic/max-statements-per-line': 'error', // not implemented
+    // '@stylistic/member-delimiter-style': 'error', // not implemented
+    // '@stylistic/multiline-ternary': 'error', // not implemented
+    // '@stylistic/new-parens': 'error', // not implemented
+    // '@stylistic/no-extra-parens': 'error', // not implemented
+    // '@stylistic/no-floating-decimal': 'error', // not implemented
+    // '@stylistic/no-mixed-operators': 'error', // not implemented
+    // '@stylistic/no-mixed-spaces-and-tabs': 'error', // not implemented
+    // '@stylistic/no-multi-spaces': 'error', // not implemented
+    // '@stylistic/no-multiple-empty-lines': 'error', // not implemented
+    // '@stylistic/no-tabs': 'error', // not implemented
+    // '@stylistic/no-trailing-spaces': 'error', // not implemented
+    // '@stylistic/no-whitespace-before-property': 'error', // not implemented
+    // '@stylistic/object-curly-spacing': 'error', // not implemented
+    // '@stylistic/operator-linebreak': 'error', // not implemented
+    // '@stylistic/padded-blocks': 'error', // not implemented
+    // '@stylistic/quote-props': 'error', // not implemented
+    // '@stylistic/quotes': 'error', // not implemented
+    // '@stylistic/rest-spread-spacing': 'error', // not implemented
+    // '@stylistic/semi': 'error', // not implemented
+    // '@stylistic/semi-spacing': 'error', // not implemented
+    // '@stylistic/space-before-blocks': 'error', // not implemented
+    // '@stylistic/space-before-function-paren': 'error', // not implemented
+    // '@stylistic/space-in-parens': 'error', // not implemented
+    // '@stylistic/space-infix-ops': 'error', // not implemented
+    // '@stylistic/space-unary-ops': 'error', // not implemented
+    // '@stylistic/spaced-comment': 'error', // not implemented
+    // '@stylistic/template-curly-spacing': 'error', // not implemented
+    // '@stylistic/template-tag-spacing': 'error', // not implemented
+    // '@stylistic/type-annotation-spacing': 'error', // not implemented
+    // '@stylistic/type-generic-spacing': 'error', // not implemented
+    // '@stylistic/type-named-tuple-spacing': 'error', // not implemented
+    // '@stylistic/wrap-iife': 'error', // not implemented
+    // '@stylistic/yield-star-spacing': 'error', // not implemented
+  },
+};
+
+export { recommended };

--- a/packages/rslint/src/define-config.ts
+++ b/packages/rslint/src/define-config.ts
@@ -8,6 +8,7 @@ export type RuleSeverity = 'off' | 'warn' | 'error';
  * Plugin declaration names recognized by rslint's loader.
  */
 export type KnownPlugin =
+  | '@stylistic'
   | '@typescript-eslint'
   | 'import'
   | 'jest'
@@ -101,6 +102,7 @@ export interface RslintConfigEntry {
    *
    * Each built-in value maps to the original ESLint plugin it ports rules from:
    *
+   * - `'@stylistic'`         → `@stylistic/eslint-plugin`
    * - `'@typescript-eslint'` → `@typescript-eslint/eslint-plugin`
    * - `'import'`             → `eslint-plugin-import`
    * - `'jest'`               → `eslint-plugin-jest`

--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -21,6 +21,7 @@ export {
   jestPlugin,
   unicornPlugin,
   jsxA11yPlugin,
+  stylisticPlugin,
 } from './configs/index.js';
 
 // Export the main RSLintService class for direct usage

--- a/website/theme/plugin-registry.ts
+++ b/website/theme/plugin-registry.ts
@@ -101,6 +101,13 @@ export const PLUGIN_REGISTRY: PluginMeta[] = [
     presetName: 'jsxA11yPlugin.configs.recommended',
     description: 'JSX a11y rules',
   },
+  {
+    prefix: '@stylistic',
+    group: '@stylistic/eslint-plugin',
+    importName: 'stylisticPlugin',
+    presetName: 'stylisticPlugin.configs.recommended',
+    description: 'Stylistic / formatting rules',
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Port the `@stylistic/array-bracket-spacing` rule from [`@stylistic/eslint-plugin`](https://github.com/eslint-stylistic/eslint-stylistic) to rslint. The rule enforces consistent spacing inside array brackets, covering both array literals (`[1, 2]`) and array destructuring patterns (`var [a, b] = arr`).

This is the first rule under a new `@stylistic` plugin scaffold (`internal/plugins/stylistic/` and `packages/rslint-test-tools/tests/eslint-plugin-stylistic/`). The plugin is registered in `KnownPlugins` with declaration names `@stylistic` and `@stylistic/eslint-plugin`.

The rule supports the upstream schema 1:1: a string mode (`"never"` (default) / `"always"`) plus an exception object (`singleValue`, `objectsInArrays`, `arraysInArrays`). All four messageIds (`unexpectedSpaceAfter`, `unexpectedSpaceBefore`, `missingSpaceAfter`, `missingSpaceBefore`) and their fix ranges match upstream byte-for-byte.

### Verification

Differential validation against ESLint with the same rule + config on rsbuild (957 files) and rspack (real-world TypeScript codebases):

| Scenario | rslint warnings | rslint-scope files | Strict divergence vs ESLint |
|---|---|---|---|
| rsbuild + `'always'` | 1020 | 319 | 0 |
| rsbuild + `'never', { singleValue, objectsInArrays, arraysInArrays }` | 713 | 245 | 0 |
| rspack + `'never', { singleValue, objectsInArrays, arraysInArrays }` | 390 | 64 | 0 |
| rspack + `'never', { objectsInArrays: true }` | 2 | 1 | 0 |
| **Total** | **2125** | **629** | **0** |

Every single rslint report matches an ESLint report at byte-exact `file:line:col-endLine:endCol`. Files only ESLint scanned (e.g. `compiled/`, `dist/`, `*.d.ts`) are file-set differences caused by rslint's tsconfig-driven file discovery — running rslint explicitly on them returns `was not found in the project, skipping`.

### Notable tsgo-specific implementation choices

- Element-position paren wrappers are unwrapped via `ast.SkipParentheses` so the `objectsInArrays` / `arraysInArrays` exceptions trigger on `[({a:1})]` — matches upstream (TS parser flattens parens).
- TypeScript wrappers (`as` / `satisfies` / `!`) are intentionally NOT unwrapped, mirroring upstream's `node.type === 'ObjectExpression'` strict-kind check.
- Opening bracket check runs on the listener's enter call, closing bracket check on exit — this interleaves nested arrays' reports into source order, matching ESLint's final-sorted output.
- `BindingElement` is unwrapped to its name so `var [{a, b}, z]` correctly fires `objectsInArrays`.
- Forward trivia scan uses tsgo's `scanner.SkipTrivia` (UTF-8 safe; handles whitespace + comments + conflict markers + shebang).

## Related Links

- ESLint rule docs: https://eslint.style/rules/array-bracket-spacing
- Upstream source: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/array-bracket-spacing/array-bracket-spacing.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).