### PR TITLE
feat(eslint-plugin-jest): add `no-standalone-expect` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_hooks"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_identical_title"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_mocks_import"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_standalone_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_test_prefixes"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_strict_equal"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_be"
@@ -31,6 +32,7 @@ func GetAllRules() []rule.Rule {
 		no_hooks.NoHooksRule,
 		no_identical_title.NoIdenticalTitleRule,
 		no_mocks_import.NoMocksImportRule,
+		no_standalone_expect.NoStandaloneExpectRule,
 		no_test_prefixes.NoTestPrefixesRule,
 		prefer_strict_equal.PreferStrictEqualRule,
 		prefer_to_be.PreferToBeRule,

--- a/internal/plugins/jest/rules/no_done_callback/no_done_callback.go
+++ b/internal/plugins/jest/rules/no_done_callback/no_done_callback.go
@@ -57,12 +57,6 @@ func findCallbackArgument(callExpr *ast.CallExpression, jestFnCall *utils.Parsed
 	return nil
 }
 
-func isFunction(node *ast.Node) bool {
-	return node.Kind == ast.KindFunctionDeclaration ||
-		node.Kind == ast.KindFunctionExpression ||
-		node.Kind == ast.KindArrowFunction
-}
-
 var NoDoneCallbackRule = rule.Rule{
 	Name: "jest/no-done-callback",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
@@ -91,7 +85,7 @@ var NoDoneCallbackRule = rule.Rule{
 				callback := findCallbackArgument(callExpr, jestFnCall, isJestEach)
 				callbackArgIndex := boolToInt(isJestEach)
 				if callback == nil ||
-					!isFunction(callback) ||
+					!utils.IsFunction(callback) ||
 					len(callback.Parameters()) == 0 ||
 					len(callback.Parameters()) != 1+callbackArgIndex {
 					return

--- a/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.go
+++ b/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.go
@@ -1,0 +1,187 @@
+package no_standalone_expect
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type blockType string
+
+const (
+	blockTypeTest     blockType = "test"
+	blockTypeFunction blockType = "function"
+	blockTypeDescribe blockType = "describe"
+	blockTypeArrow    blockType = "arrow"
+	blockTypeTemplate blockType = "template"
+)
+
+type options struct {
+	additionalTestBlockFunctions map[string]struct{}
+}
+
+// Message Builder
+
+func buildUnexpectedExpectMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpectedExpect",
+		Description: "Expect must be inside of a test block",
+	}
+}
+
+func parseOptions(raw any) options {
+	opts := options{additionalTestBlockFunctions: map[string]struct{}{}}
+	if raw == nil {
+		return opts
+	}
+
+	optArray, ok := raw.([]interface{})
+	if !ok || len(optArray) == 0 {
+		return opts
+	}
+
+	optsMap, ok := optArray[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+
+	rawFns, ok := optsMap["additionalTestBlockFunctions"]
+	if !ok || rawFns == nil {
+		return opts
+	}
+
+	list, ok := rawFns.([]interface{})
+	if !ok {
+		return opts
+	}
+
+	for _, item := range list {
+		if name, ok := item.(string); ok {
+			opts.additionalTestBlockFunctions[name] = struct{}{}
+		}
+	}
+
+	return opts
+}
+
+func getBlockType(block *ast.Node, ctx rule.RuleContext) blockType {
+	fn := block.Parent
+	if !utils.IsFunction(fn) {
+		return ""
+	}
+
+	if ast.IsFunctionDeclaration(fn) {
+		return blockTypeFunction
+	}
+
+	if ast.FindAncestorKind(fn, ast.KindVariableDeclaration) != nil {
+		return blockTypeFunction
+	}
+
+	parent := fn.Parent
+	if parent != nil && parent.Kind == ast.KindCallExpression &&
+		utils.IsTypeOfJestFnCall(parent, ctx, utils.JestFnTypeDescribe) {
+		return blockTypeDescribe
+	}
+
+	return ""
+}
+
+func isStaticExpectPropertyCall(jestFnCall *utils.ParsedJestFnCall) bool {
+	return jestFnCall != nil &&
+		jestFnCall.Kind == utils.JestFnTypeExpect &&
+		utils.IsStaticExpectMatcher(jestFnCall.Matcher, jestFnCall.Head.Local.Node)
+}
+
+func shouldReportExpectCall(jestFnCall *utils.ParsedJestFnCall) bool {
+	return !isStaticExpectPropertyCall(jestFnCall)
+}
+
+func calleeIsTaggedTemplateExpression(node *ast.Node) bool {
+	callExpr := node.AsCallExpression()
+	return callExpr != nil &&
+		callExpr.Expression != nil &&
+		callExpr.Expression.Kind == ast.KindTaggedTemplateExpression
+}
+
+var NoStandaloneExpectRule = rule.Rule{
+	Name: "jest/no-standalone-expect",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		callStack := make([]blockType, 0, 8)
+
+		isCustomTestBlockFunction := func(node *ast.Node) bool {
+			name := utils.GetNodeName(node)
+			if name == "" {
+				return false
+			}
+			_, ok := opts.additionalTestBlockFunctions[name]
+			return ok
+		}
+
+		currentBlock := func() blockType {
+			if len(callStack) == 0 {
+				return ""
+			}
+			return callStack[len(callStack)-1]
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				jestFnCall := utils.ParseJestFnCall(node, ctx)
+				if jestFnCall != nil && jestFnCall.Kind == utils.JestFnTypeExpect {
+					if !shouldReportExpectCall(jestFnCall) {
+						return
+					}
+
+					parent := currentBlock()
+					if parent == "" || parent == blockTypeDescribe {
+						ctx.ReportNode(node, buildUnexpectedExpectMessage())
+					}
+					return
+				}
+
+				if (jestFnCall != nil && jestFnCall.Kind == utils.JestFnTypeTest) || isCustomTestBlockFunction(node) {
+					callStack = append(callStack, blockTypeTest)
+				}
+
+				if calleeIsTaggedTemplateExpression(node) {
+					callStack = append(callStack, blockTypeTemplate)
+				}
+			},
+			rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
+				top := currentBlock()
+				if top == blockTypeTest &&
+					(utils.IsTypeOfJestFnCall(node, ctx, utils.JestFnTypeTest) || isCustomTestBlockFunction(node)) {
+					callStack = callStack[:len(callStack)-1]
+					return
+				}
+
+				if top == blockTypeTemplate && calleeIsTaggedTemplateExpression(node) {
+					callStack = callStack[:len(callStack)-1]
+				}
+			},
+			ast.KindBlock: func(node *ast.Node) {
+				if blockType := getBlockType(node, ctx); blockType != "" {
+					callStack = append(callStack, blockType)
+				}
+			},
+			rule.ListenerOnExit(ast.KindBlock): func(node *ast.Node) {
+				blockType := getBlockType(node, ctx)
+				if blockType != "" && currentBlock() == blockType {
+					callStack = callStack[:len(callStack)-1]
+				}
+			},
+			ast.KindArrowFunction: func(node *ast.Node) {
+				if node.Parent != nil && node.Parent.Kind != ast.KindCallExpression {
+					callStack = append(callStack, blockTypeArrow)
+				}
+			},
+			rule.ListenerOnExit(ast.KindArrowFunction): func(node *ast.Node) {
+				if currentBlock() == blockTypeArrow {
+					callStack = callStack[:len(callStack)-1]
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.go
+++ b/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.go
@@ -20,6 +20,12 @@ type options struct {
 	additionalTestBlockFunctions map[string]struct{}
 }
 
+type scopeEntry struct {
+	kind  blockType
+	start int
+	end   int
+}
+
 // Message Builder
 
 func buildUnexpectedExpectMessage() rule.RuleMessage {
@@ -74,7 +80,12 @@ func getBlockType(block *ast.Node, ctx rule.RuleContext) blockType {
 		return blockTypeFunction
 	}
 
-	if ast.FindAncestorKind(fn, ast.KindVariableDeclaration) != nil {
+	if fn.Parent != nil && fn.Parent.Kind == ast.KindVariableDeclaration {
+		return blockTypeFunction
+	}
+
+	switch fn.Kind {
+	case ast.KindMethodDeclaration, ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
 		return blockTypeFunction
 	}
 
@@ -104,11 +115,49 @@ func calleeIsTaggedTemplateExpression(node *ast.Node) bool {
 		callExpr.Expression.Kind == ast.KindTaggedTemplateExpression
 }
 
+func getFunctionBodyRange(fn *ast.Node) (int, int, bool) {
+	if fn == nil {
+		return 0, 0, false
+	}
+
+	body := fn.Body()
+	if body == nil {
+		return 0, 0, false
+	}
+
+	return body.Pos(), body.End(), true
+}
+
+func getTestScopeRange(node *ast.Node) (int, int, bool) {
+	callExpr := node.AsCallExpression()
+	if callExpr == nil || callExpr.Arguments == nil {
+		return 0, 0, false
+	}
+
+	for i := len(callExpr.Arguments.Nodes) - 1; i >= 0; i-- {
+		arg := callExpr.Arguments.Nodes[i]
+		if start, end, ok := getFunctionBodyRange(arg); ok {
+			return start, end, true
+		}
+	}
+
+	return 0, 0, false
+}
+
+func getTemplateScopeRange(node *ast.Node) (int, int, bool) {
+	callExpr := node.AsCallExpression()
+	if callExpr == nil || callExpr.Expression == nil || callExpr.Expression.Kind != ast.KindTaggedTemplateExpression {
+		return 0, 0, false
+	}
+
+	return callExpr.Expression.Pos(), callExpr.Expression.End(), true
+}
+
 var NoStandaloneExpectRule = rule.Rule{
 	Name: "jest/no-standalone-expect",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		opts := parseOptions(options)
-		callStack := make([]blockType, 0, 8)
+		scopeStack := make([]scopeEntry, 0, 8)
 
 		isCustomTestBlockFunction := func(node *ast.Node) bool {
 			name := utils.GetNodeName(node)
@@ -119,11 +168,35 @@ var NoStandaloneExpectRule = rule.Rule{
 			return ok
 		}
 
-		currentBlock := func() blockType {
-			if len(callStack) == 0 {
+		currentScopeKind := func() blockType {
+			if len(scopeStack) == 0 {
 				return ""
 			}
-			return callStack[len(callStack)-1]
+			return scopeStack[len(scopeStack)-1].kind
+		}
+
+		pushScope := func(kind blockType, start, end int) {
+			scopeStack = append(scopeStack, scopeEntry{kind: kind, start: start, end: end})
+		}
+
+		popScope := func(kind blockType) {
+			if len(scopeStack) == 0 || scopeStack[len(scopeStack)-1].kind != kind {
+				return
+			}
+
+			scopeStack = scopeStack[:len(scopeStack)-1]
+		}
+
+		getContainingBlock := func(node *ast.Node) blockType {
+			pos := node.Pos()
+			for i := len(scopeStack) - 1; i >= 0; i-- {
+				scope := scopeStack[i]
+				if scope.start <= pos && pos < scope.end {
+					return scope.kind
+				}
+			}
+
+			return ""
 		}
 
 		return rule.RuleListeners{
@@ -134,7 +207,7 @@ var NoStandaloneExpectRule = rule.Rule{
 						return
 					}
 
-					parent := currentBlock()
+					parent := getContainingBlock(node)
 					if parent == "" || parent == blockTypeDescribe {
 						ctx.ReportNode(node, buildUnexpectedExpectMessage())
 					}
@@ -142,44 +215,48 @@ var NoStandaloneExpectRule = rule.Rule{
 				}
 
 				if (jestFnCall != nil && jestFnCall.Kind == utils.JestFnTypeTest) || isCustomTestBlockFunction(node) {
-					callStack = append(callStack, blockTypeTest)
+					if start, end, ok := getTestScopeRange(node); ok {
+						pushScope(blockTypeTest, start, end)
+					}
 				}
 
 				if calleeIsTaggedTemplateExpression(node) {
-					callStack = append(callStack, blockTypeTemplate)
+					if start, end, ok := getTemplateScopeRange(node); ok {
+						pushScope(blockTypeTemplate, start, end)
+					}
 				}
 			},
 			rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
-				top := currentBlock()
-				if top == blockTypeTest &&
-					(utils.IsTypeOfJestFnCall(node, ctx, utils.JestFnTypeTest) || isCustomTestBlockFunction(node)) {
-					callStack = callStack[:len(callStack)-1]
-					return
+				if calleeIsTaggedTemplateExpression(node) {
+					popScope(blockTypeTemplate)
 				}
 
-				if top == blockTypeTemplate && calleeIsTaggedTemplateExpression(node) {
-					callStack = callStack[:len(callStack)-1]
+				if (utils.IsTypeOfJestFnCall(node, ctx, utils.JestFnTypeTest) || isCustomTestBlockFunction(node)) &&
+					currentScopeKind() == blockTypeTest {
+					popScope(blockTypeTest)
 				}
 			},
 			ast.KindBlock: func(node *ast.Node) {
 				if blockType := getBlockType(node, ctx); blockType != "" {
-					callStack = append(callStack, blockType)
+					pushScope(blockType, node.Pos(), node.End())
 				}
 			},
 			rule.ListenerOnExit(ast.KindBlock): func(node *ast.Node) {
 				blockType := getBlockType(node, ctx)
-				if blockType != "" && currentBlock() == blockType {
-					callStack = callStack[:len(callStack)-1]
+				if blockType != "" && currentScopeKind() == blockType {
+					popScope(blockType)
 				}
 			},
 			ast.KindArrowFunction: func(node *ast.Node) {
 				if node.Parent != nil && node.Parent.Kind != ast.KindCallExpression {
-					callStack = append(callStack, blockTypeArrow)
+					if start, end, ok := getFunctionBodyRange(node); ok {
+						pushScope(blockTypeArrow, start, end)
+					}
 				}
 			},
 			rule.ListenerOnExit(ast.KindArrowFunction): func(node *ast.Node) {
-				if currentBlock() == blockTypeArrow {
-					callStack = callStack[:len(callStack)-1]
+				if currentScopeKind() == blockTypeArrow {
+					popScope(blockTypeArrow)
 				}
 			},
 		}

--- a/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.md
+++ b/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.md
@@ -1,0 +1,59 @@
+# no-standalone-expect
+
+## Rule Details
+
+Disallow using `expect` outside of `it` or `test` blocks. This rule reports `expect` calls that sit directly in a `describe` block, at module scope, or in other places where Jest will not run them as part of a test case. That helps catch assertions that look meaningful but never execute.
+
+`expect` inside a helper function is allowed, even when the helper is defined outside the `it`/`test` callback, because the assertion still runs when the helper is invoked from a test. Static `expect` APIs such as `expect.any()` and `expect.extend()` at module scope are also allowed.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+describe('a test', () => {
+  expect(1).toBe(1);
+});
+
+describe('a test', () => {
+  it('an it', () => {
+    expect(1).toBe(1);
+  });
+
+  expect(1).toBe(1);
+});
+
+expect(1).toBe(1);
+
+expect.hasAssertions();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+describe('a test', () => {
+  it('an it', () => {
+    expect(1).toBe(1);
+  });
+});
+
+describe('a test', () => {
+  const helper = () => {
+    expect(1).toBe(1);
+  };
+
+  it('an it', () => {
+    helper();
+  });
+});
+
+expect.any(String);
+expect.extend({});
+```
+
+## Options
+
+- First argument (optional): object with `additionalTestBlockFunctions`
+  - `additionalTestBlockFunctions`: array of function names that should also be treated as test blocks (for example `each.test`).
+
+## Original Documentation
+
+- [jest/no-standalone-expect](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md)

--- a/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect_test.go
+++ b/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect_test.go
@@ -40,6 +40,8 @@ func TestNoStandaloneExpectRule(t *testing.T) {
 			{Code: `it.only("an only", value => { expect(value).toBe(true); });`},
 			{Code: `it.concurrent("an concurrent", value => { expect(value).toBe(true); });`},
 			{Code: `describe.each([1, true])("trues", value => { it("an it", () => expect(value).toBe(true) ); });`},
+			{Code: `const helpers = { assert() { expect(1).toBe(1); } };`},
+			{Code: `class Helper { assert() { expect(1).toBe(1); } get value() { expect(1).toBe(1); return 1; } }`},
 			{
 				Code: `
         describe('scenario', () => {
@@ -210,6 +212,34 @@ func TestNoStandaloneExpectRule(t *testing.T) {
 				Code: `describe.each([1, true])("trues", value => { expect(value).toBe(true); });`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpectedExpect", Line: 1, Column: 46, EndColumn: 70},
+				},
+			},
+			{
+				Code: `
+        describe.each` + "`" + `
+          num   | value
+          ${1} | ${true}
+        ` + "`" + `('trues', ({ value }) => {
+          expect(value).toBe(true);
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 6, Column: 11, EndColumn: 35},
+				},
+			},
+			{
+				Code: `
+        it.each` + "`" + `
+          num   | value
+          ${1} | ${true}
+        ` + "`" + `('trues', ({ value }) => {
+          expect(value).toBe(true);
+        });
+
+        expect(1).toBe(1);
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 9, Column: 9, EndColumn: 26},
 				},
 			},
 			{

--- a/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect_test.go
+++ b/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect_test.go
@@ -1,0 +1,237 @@
+package no_standalone_expect_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_standalone_expect"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoStandaloneExpectRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_standalone_expect.NoStandaloneExpectRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect.any(String)`},
+			{Code: `expect.extend({})`},
+			{Code: `expect.not.stringContaining("value")`},
+			{Code: `describe("a test", () => { it("an it", () => {expect(1).toBe(1); }); });`},
+			{Code: `describe("a test", () => { it("an it", () => { const func = () => { expect(1).toBe(1); }; }); });`},
+			{Code: `describe("a test", () => { const func = () => { expect(1).toBe(1); }; });`},
+			{Code: `describe("a test", () => { function func() { expect(1).toBe(1); }; });`},
+			{Code: `describe("a test", () => { const func = function(){ expect(1).toBe(1); }; });`},
+			{Code: `it("an it", () => expect(1).toBe(1))`},
+			{Code: `const func = function(){ expect(1).toBe(1); };`},
+			{Code: `const func = () => expect(1).toBe(1);`},
+			{Code: `{}`},
+			{Code: `it.each([1, true])("trues", value => { expect(value).toBe(true); });`},
+			{Code: `it.each([1, true])("trues", value => { expect(value).toBe(true); }); it("an it", () => { expect(1).toBe(1) });`},
+			{Code: `
+      it.each` + "`" + `
+        num   | value
+        ${1} | ${true}
+      ` + "`" + `('trues', ({ value }) => {
+        expect(value).toBe(true);
+      });
+    `},
+			{Code: `it.only("an only", value => { expect(value).toBe(true); });`},
+			{Code: `it.concurrent("an concurrent", value => { expect(value).toBe(true); });`},
+			{Code: `describe.each([1, true])("trues", value => { it("an it", () => expect(value).toBe(true) ); });`},
+			{
+				Code: `
+        describe('scenario', () => {
+          const t = Math.random() ? it.only : it;
+          t('testing', () => expect(true));
+        });
+      `,
+				Options: []interface{}{
+					map[string]interface{}{"additionalTestBlockFunctions": []interface{}{"t"}},
+				},
+			},
+			{
+				Code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+				Options: []interface{}{
+					map[string]interface{}{"additionalTestBlockFunctions": []interface{}{"each.test"}},
+				},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: "(() => {})('testing', () => expect(true).toBe(false))",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 29, EndColumn: 53},
+				},
+			},
+			{
+				Code: `expect.hasAssertions()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code: `expect().hasAssertions()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code: `
+        describe('scenario', () => {
+          const t = Math.random() ? it.only : it;
+          t('testing', () => expect(true).toBe(false));
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 4, Column: 30, EndColumn: 54},
+				},
+			},
+			{
+				Code: `
+        describe('scenario', () => {
+          const t = Math.random() ? it.only : it;
+          t('testing', () => expect(true).toBe(false));
+        });
+      `,
+				Options: []interface{}{
+					map[string]interface{}{"additionalTestBlockFunctions": nil},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 4, Column: 30, EndColumn: 54},
+				},
+			},
+			{
+				Code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 7, Column: 11, EndColumn: 39},
+				},
+			},
+			{
+				Code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+				Options: []interface{}{
+					map[string]interface{}{"additionalTestBlockFunctions": []interface{}{"each"}},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 7, Column: 11, EndColumn: 39},
+				},
+			},
+			{
+				Code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+				Options: []interface{}{
+					map[string]interface{}{"additionalTestBlockFunctions": []interface{}{"test"}},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 7, Column: 11, EndColumn: 39},
+				},
+			},
+			{
+				Code: `describe("a test", () => { expect(1).toBe(1); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 28, EndColumn: 45},
+				},
+			},
+			{
+				Code: `describe("a test", () => expect(1).toBe(1));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 26, EndColumn: 43},
+				},
+			},
+			{
+				Code: `describe("a test", () => { const func = () => { expect(1).toBe(1); }; expect(1).toBe(1); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 71, EndColumn: 88},
+				},
+			},
+			{
+				Code: `describe("a test", () => {  it(() => { expect(1).toBe(1); }); expect(1).toBe(1); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 63, EndColumn: 80},
+				},
+			},
+			{
+				Code: `expect(1).toBe(1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code: `{expect(1).toBe(1)}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 2, EndColumn: 19},
+				},
+			},
+			{
+				Code: `it.each([1, true])("trues", value => { expect(value).toBe(true); }); expect(1).toBe(1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 70, EndColumn: 87},
+				},
+			},
+			{
+				Code: `it.only("an only", () => { expect(1).toBe(1); }); expect(2).toBe(2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 51, EndColumn: 68},
+				},
+			},
+			{
+				Code: `describe.each([1, true])("trues", value => { expect(value).toBe(true); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 1, Column: 46, EndColumn: 70},
+				},
+			},
+			{
+				Code: `
+        import { expect as pleaseExpect } from '@jest/globals';
+
+        describe("a test", () => { pleaseExpect(1).toBe(1); });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 4, Column: 36, EndColumn: 59},
+				},
+			},
+			{
+				Code: `
+        import { expect as pleaseExpect } from '@jest/globals';
+
+        beforeEach(() => pleaseExpect.hasAssertions());
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExpect", Line: 4, Column: 26, EndColumn: 54},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/jest/utils/jest.go
+++ b/internal/plugins/jest/utils/jest.go
@@ -441,7 +441,12 @@ func GetJestVersion(ctx rule.RuleContext) string {
 }
 
 func IsFunction(node *ast.Node) bool {
-	return ast.IsFunctionDeclaration(node) || ast.IsFunctionExpressionOrArrowFunction(node)
+	return ast.IsFunctionDeclaration(node) ||
+		ast.IsFunctionExpressionOrArrowFunction(node) ||
+		node.Kind == ast.KindMethodDeclaration ||
+		node.Kind == ast.KindConstructor ||
+		node.Kind == ast.KindGetAccessor ||
+		node.Kind == ast.KindSetAccessor
 }
 
 func IsMemberAccessNode(node *ast.Node) bool {

--- a/internal/plugins/jest/utils/jest.go
+++ b/internal/plugins/jest/utils/jest.go
@@ -126,6 +126,22 @@ type ParsedJestFnMemberEntry struct {
 	Node *ast.Node
 }
 
+// GetNodeName returns the dotted name of a call or tagged-template callee chain
+// (for example "each.test" or "t"). This matches eslint-plugin-jest's getNodeName.
+func GetNodeName(node *ast.Node) string {
+	entries := GetJestFnMemberEntries(node)
+	if len(entries) == 0 {
+		return ""
+	}
+
+	names := make([]string, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name
+	}
+
+	return strings.Join(names, ".")
+}
+
 func getPropertyName(node *ast.Node) string {
 	switch node.Kind {
 	case ast.KindIdentifier:
@@ -422,4 +438,36 @@ func GetJestVersion(ctx rule.RuleContext) string {
 	}
 
 	return DefaultJestVersion
+}
+
+func IsFunction(node *ast.Node) bool {
+	return ast.IsFunctionDeclaration(node) || ast.IsFunctionExpressionOrArrowFunction(node)
+}
+
+func IsMemberAccessNode(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsStaticExpectMatcher reports static expect APIs such as expect.any(...) or
+// expect.not.stringContaining(...), but not assertion matchers like toBe.
+func IsStaticExpectMatcher(matcher string, headNode *ast.Node) bool {
+	if matcher == "" || headNode == nil || !IsMemberAccessNode(headNode.Parent) {
+		return false
+	}
+
+	switch matcher {
+	case "assertions", "hasAssertions":
+		return false
+	default:
+		return true
+	}
 }

--- a/internal/plugins/jest/utils/parse_jest_fn.go
+++ b/internal/plugins/jest/utils/parse_jest_fn.go
@@ -16,6 +16,8 @@ type ParsedJestFnCall struct {
 	MemberEntries   []ParsedJestFnMemberEntry
 	Modifiers       []string
 	ModifierEntries []ParsedJestFnMemberEntry
+	Matcher         string
+	MatcherEntry    *ParsedJestFnMemberEntry
 	Head            ParsedJestFnCallHead
 }
 
@@ -56,10 +58,7 @@ func ParseJestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedJestFnCall {
 	}
 
 	callExpr := node.AsCallExpression()
-	if isEachFactoryCall(callExpr, members) {
-		return nil
-	}
-	if isInvalidTaggedTemplateCall(callExpr, members) {
+	if isEachFactoryCall(callExpr, members) || isInvalidTaggedTemplateCall(callExpr, members) || isInnerExpectCall(node, localName, members, ctx.Settings) {
 		return nil
 	}
 
@@ -82,14 +81,11 @@ func ParseJestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedJestFnCall {
 	}
 
 	parsed := &ParsedJestFnCall{
-		Name:      name,
-		LocalName: localName,
-		Kind:      kind,
-		Members:   members,
-		MemberEntries: append(
-			[]ParsedJestFnMemberEntry(nil),
-			memberEntries[1:]...,
-		),
+		Name:          name,
+		LocalName:     localName,
+		Kind:          kind,
+		Members:       members,
+		MemberEntries: memberEntries[1:],
 		Head: ParsedJestFnCallHead{
 			Type: headType,
 			Local: ParsedJestFnCallHeadEntry{
@@ -104,12 +100,124 @@ func ParseJestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedJestFnCall {
 	}
 
 	if kind == JestFnTypeExpect {
-		modifiers, modifierEntries := pickExpectModifiersAndEntries(parsed.MemberEntries)
-		parsed.Modifiers = modifiers
-		parsed.ModifierEntries = modifierEntries
+		if !applyParsedExpectCall(parsed) {
+			return nil
+		}
 	}
 
 	return parsed
+}
+
+// FindTopMostCallExpression walks up member/call chains to the outermost CallExpression,
+// matching eslint-plugin-jest's findTopMostCallExpression.
+func FindTopMostCallExpression(node *ast.Node) *ast.Node {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return node
+	}
+
+	top := node
+	parent := node.Parent
+	for parent != nil {
+		if parent.Kind == ast.KindCallExpression {
+			top = parent
+			parent = parent.Parent
+			continue
+		}
+		if parent.Kind != ast.KindPropertyAccessExpression &&
+			parent.Kind != ast.KindElementAccessExpression {
+			break
+		}
+		parent = parent.Parent
+	}
+
+	return top
+}
+
+func FindImportDeclaration(node *ast.Node) *ast.ImportDeclaration {
+	current := node
+	for current != nil {
+		switch current.Kind {
+		case ast.KindImportDeclaration, ast.KindJSImportDeclaration:
+			return current.AsImportDeclaration()
+		}
+		current = current.Parent
+	}
+	return nil
+}
+
+func applyParsedExpectCall(parsed *ParsedJestFnCall) bool {
+	modifierEntries, matcher, err := findModifiersAndMatcher(parsed.MemberEntries)
+	if err != "" {
+		return false
+	}
+
+	parsed.ModifierEntries = modifierEntries
+	parsed.Matcher = matcher.Name
+	parsed.MatcherEntry = matcher
+	if len(modifierEntries) > 0 {
+		parsed.Modifiers = make([]string, len(modifierEntries))
+		for i, entry := range modifierEntries {
+			parsed.Modifiers[i] = entry.Name
+		}
+	}
+	return true
+}
+
+// isInnerExpectCall detects expect() calls embedded in a matcher chain
+// (e.g. expect(1) in expect(1).toBe(2)) before running type-checker resolution.
+func isInnerExpectCall(node *ast.Node, localName string, members []string, settings map[string]interface{}) bool {
+	if len(members) > 0 || !IsMemberAccessNode(node.Parent) {
+		return false
+	}
+	if FindTopMostCallExpression(node) == node {
+		return false
+	}
+	name := ApplyGlobalJestAlias(localName, settings)
+	return GetJestKind(name) == JestFnTypeExpect
+}
+
+func findModifiersAndMatcher(entries []ParsedJestFnMemberEntry) (
+	[]ParsedJestFnMemberEntry,
+	*ParsedJestFnMemberEntry,
+	string,
+) {
+	if len(entries) == 0 {
+		return nil, nil, "matcher-not-found"
+	}
+
+	modifiers := make([]ParsedJestFnMemberEntry, 0, len(entries))
+	for _, member := range entries {
+		parent := member.Node.Parent
+		if parent == nil {
+			return nil, nil, "modifier-unknown"
+		}
+
+		grandparent := parent.Parent
+		if grandparent != nil && grandparent.Kind == ast.KindCallExpression {
+			return modifiers, &member, ""
+		}
+
+		switch len(modifiers) {
+		case 0:
+			if !EXPECT_MODIFIER_NAMES[member.Name] {
+				return nil, nil, "modifier-unknown"
+			}
+		case 1:
+			if member.Name != "not" {
+				return nil, nil, "modifier-unknown"
+			}
+			first := modifiers[0].Name
+			if first != "rejects" && first != "resolves" {
+				return nil, nil, "modifier-unknown"
+			}
+		default:
+			return nil, nil, "modifier-unknown"
+		}
+
+		modifiers = append(modifiers, member)
+	}
+
+	return nil, nil, "matcher-not-found"
 }
 
 func resolveOriginalName(node *ast.Node, localName string, localNode *ast.Node, ctx rule.RuleContext) (string, *ast.Node, JestImportMode) {
@@ -198,18 +306,6 @@ func resolveFirstIdentifier(node *ast.Node) *ast.Node {
 	return nil
 }
 
-func FindImportDeclaration(node *ast.Node) *ast.ImportDeclaration {
-	current := node
-	for current != nil {
-		switch current.Kind {
-		case ast.KindImportDeclaration, ast.KindJSImportDeclaration:
-			return current.AsImportDeclaration()
-		}
-		current = current.Parent
-	}
-	return nil
-}
-
 func isEachFactoryCall(callExpr *ast.CallExpression, members []string) bool {
 	if callExpr == nil || len(members) == 0 || members[len(members)-1] != "each" {
 		return false
@@ -246,29 +342,4 @@ func isValidJestCall(name string, members []string) bool {
 
 	_, ok := VALID_JEST_FN_CALL_CHAINS[chain]
 	return ok
-}
-
-func pickExpectModifiersAndEntries(entries []ParsedJestFnMemberEntry) ([]string, []ParsedJestFnMemberEntry) {
-	if len(entries) == 0 {
-		return nil, nil
-	}
-
-	modifierEntries := make([]ParsedJestFnMemberEntry, 0, len(entries))
-	for _, entry := range entries {
-		if !EXPECT_MODIFIER_NAMES[entry.Name] {
-			break
-		}
-		modifierEntries = append(modifierEntries, entry)
-	}
-
-	if len(modifierEntries) == 0 {
-		return nil, nil
-	}
-
-	modifiers := make([]string, 0, len(modifierEntries))
-	for _, entry := range modifierEntries {
-		modifiers = append(modifiers, entry.Name)
-	}
-
-	return modifiers, modifierEntries
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -433,6 +433,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/no-hooks.test.ts',
     './tests/eslint-plugin-jest/rules/no-identical-title.test.ts',
     './tests/eslint-plugin-jest/rules/no-mocks-import.test.ts',
+    './tests/eslint-plugin-jest/rules/no-standalone-expect.test.ts',
     './tests/eslint-plugin-jest/rules/no-test-prefixes.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-strict-equal.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-be.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-standalone-expect.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-standalone-expect.test.ts
@@ -52,6 +52,12 @@ ruleTester.run('no-standalone-expect', {} as never, {
       code: 'describe.each([1, true])("trues", value => { it("an it", () => expect(value).toBe(true) ); });',
     },
     {
+      code: 'const helpers = { assert() { expect(1).toBe(1); } };',
+    },
+    {
+      code: 'class Helper { assert() { expect(1).toBe(1); } get value() { expect(1).toBe(1); return 1; } }',
+    },
+    {
       code: `
         describe('scenario', () => {
           const t = Math.random() ? it.only : it;
@@ -174,6 +180,30 @@ ruleTester.run('no-standalone-expect', {} as never, {
     {
       code: 'describe.each([1, true])("trues", value => { expect(value).toBe(true); });',
       errors: [{ endColumn: 70, column: 46, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        describe.each\`
+          num   | value
+          \${1} | \${true}
+        \`('trues', ({ value }) => {
+          expect(value).toBe(true);
+        });
+      `,
+      errors: [{ endColumn: 27, column: 3, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        it.each\`
+          num   | value
+          \${1} | \${true}
+        \`('trues', ({ value }) => {
+          expect(value).toBe(true);
+        });
+
+        expect(1).toBe(1);
+      `,
+      errors: [{ endColumn: 17, column: 1, messageId: 'unexpectedExpect' }],
     },
     {
       code: `

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-standalone-expect.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-standalone-expect.test.ts
@@ -1,0 +1,195 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-standalone-expect', {} as never, {
+  valid: [
+    { code: 'expect.any(String)' },
+    { code: 'expect.extend({})' },
+    {
+      code: 'describe("a test", () => { it("an it", () => {expect(1).toBe(1); }); });',
+    },
+    {
+      code: 'describe("a test", () => { it("an it", () => { const func = () => { expect(1).toBe(1); }; }); });',
+    },
+    {
+      code: 'describe("a test", () => { const func = () => { expect(1).toBe(1); }; });',
+    },
+    {
+      code: 'describe("a test", () => { function func() { expect(1).toBe(1); }; });',
+    },
+    {
+      code: 'describe("a test", () => { const func = function(){ expect(1).toBe(1); }; });',
+    },
+    { code: 'it("an it", () => expect(1).toBe(1))' },
+    { code: 'const func = function(){ expect(1).toBe(1); };' },
+    { code: 'const func = () => expect(1).toBe(1);' },
+    { code: '{}' },
+    {
+      code: 'it.each([1, true])("trues", value => { expect(value).toBe(true); });',
+    },
+    {
+      code: 'it.each([1, true])("trues", value => { expect(value).toBe(true); }); it("an it", () => { expect(1).toBe(1) });',
+    },
+    {
+      code: `
+      it.each\`
+        num   | value
+        \${1} | \${true}
+      \`('trues', ({ value }) => {
+        expect(value).toBe(true);
+      });
+    `,
+    },
+    { code: 'it.only("an only", value => { expect(value).toBe(true); });' },
+    {
+      code: 'it.concurrent("an concurrent", value => { expect(value).toBe(true); });',
+    },
+    {
+      code: 'describe.each([1, true])("trues", value => { it("an it", () => expect(value).toBe(true) ); });',
+    },
+    {
+      code: 'describe.each([1, true])("trues", value => { it("an it", () => expect(value).toBe(true) ); });',
+    },
+    {
+      code: `
+        describe('scenario', () => {
+          const t = Math.random() ? it.only : it;
+          t('testing', () => expect(true));
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: ['t'] }],
+    },
+    {
+      code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: ['each.test'] }],
+    },
+  ],
+  invalid: [
+    {
+      code: "(() => {})('testing', () => expect(true).toBe(false))",
+      errors: [{ endColumn: 53, column: 29, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: 'expect.hasAssertions()',
+      errors: [{ endColumn: 23, column: 1, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: 'expect().hasAssertions()',
+      errors: [{ endColumn: 25, column: 1, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        describe('scenario', () => {
+          const t = Math.random() ? it.only : it;
+          t('testing', () => expect(true).toBe(false));
+        });
+      `,
+      errors: [{ endColumn: 46, column: 22, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        describe('scenario', () => {
+          const t = Math.random() ? it.only : it;
+          t('testing', () => expect(true).toBe(false));
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: undefined }],
+      errors: [{ endColumn: 46, column: 22, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+      errors: [{ endColumn: 31, column: 3, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: ['each'] }],
+      errors: [{ endColumn: 31, column: 3, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: ['test'] }],
+      errors: [{ endColumn: 31, column: 3, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: 'describe("a test", () => { expect(1).toBe(1); });',
+      errors: [{ endColumn: 45, column: 28, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: 'describe("a test", () => expect(1).toBe(1));',
+      errors: [{ endColumn: 43, column: 26, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: 'describe("a test", () => { const func = () => { expect(1).toBe(1); }; expect(1).toBe(1); });',
+      errors: [{ endColumn: 88, column: 71, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: 'describe("a test", () => {  it(() => { expect(1).toBe(1); }); expect(1).toBe(1); });',
+      errors: [{ endColumn: 80, column: 63, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: 'expect(1).toBe(1);',
+      errors: [{ endColumn: 18, column: 1, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: '{expect(1).toBe(1)}',
+      errors: [{ endColumn: 19, column: 2, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: 'it.each([1, true])("trues", value => { expect(value).toBe(true); }); expect(1).toBe(1);',
+      errors: [{ endColumn: 87, column: 70, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: 'describe.each([1, true])("trues", value => { expect(value).toBe(true); });',
+      errors: [{ endColumn: 70, column: 46, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        import { expect as pleaseExpect } from '@jest/globals';
+
+        describe("a test", () => { pleaseExpect(1).toBe(1); });
+      `,
+      errors: [{ endColumn: 51, column: 28, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        import { expect as pleaseExpect } from '@jest/globals';
+
+        beforeEach(() => pleaseExpect.hasAssertions());
+      `,
+      errors: [{ endColumn: 46, column: 18, messageId: 'unexpectedExpect' }],
+    },
+  ],
+});

--- a/packages/rslint/src/configs/jest.ts
+++ b/packages/rslint/src/configs/jest.ts
@@ -18,7 +18,7 @@ const recommended: RslintConfigEntry = {
     // 'jest/no-interpolation-in-snapshots': 'error', // not implemented
     // 'jest/no-jasmine-globals': 'error', // not implemented
     'jest/no-mocks-import': 'error',
-    // 'jest/no-standalone-expect': 'error', // not implemented
+    'jest/no-standalone-expect': 'error',
     'jest/no-test-prefixes': 'error',
     'jest/valid-describe-callback': 'error',
     // 'jest/valid-expect': 'error', // not implemented


### PR DESCRIPTION
## Summary

* Port `no-standalone-expect` from eslint-plugin-jest to rslint.
* Update `ParseJestFn` to align `eslint-plugin-jest`

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/no-standalone-expect [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/no-standalone-expect.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
