### PR TITLE
feat: port rule @stylistic/arrow-parens

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -2,11 +2,13 @@ package stylistic_plugin
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/array_bracket_spacing"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/arrow_parens"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		array_bracket_spacing.ArrayBracketSpacingRule,
+		arrow_parens.ArrowParensRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/arrow_parens/arrow_parens.go
+++ b/internal/plugins/stylistic/rules/arrow_parens/arrow_parens.go
@@ -1,0 +1,280 @@
+package arrow_parens
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	msgExpectedParens         = "expectedParens"
+	msgUnexpectedParens       = "unexpectedParens"
+	msgExpectedParensBlock    = "expectedParensBlock"
+	msgUnexpectedParensInline = "unexpectedParensInline"
+
+	descExpectedParens         = "Expected parentheses around arrow function argument."
+	descUnexpectedParens       = "Unexpected parentheses around single function argument."
+	descExpectedParensBlock    = "Expected parentheses around arrow function argument having a body with curly braces."
+	descUnexpectedParensInline = "Unexpected parentheses around single function argument having a body with no curly braces."
+)
+
+type options struct {
+	asNeeded            bool
+	requireForBlockBody bool
+}
+
+// parseOptions mirrors upstream's option layout.
+//
+//	rule: ['arrow-parens']                                            → asNeeded=false  (default 'always')
+//	rule: ['arrow-parens', 'always']                                  → asNeeded=false
+//	rule: ['arrow-parens', 'as-needed']                               → asNeeded=true
+//	rule: ['arrow-parens', 'as-needed', { requireForBlockBody: bool }] → as above + flag
+//
+// rslint's config loader collapses single-element options arrays; GetOptionsMap
+// is not used here because the rule's primary option is a string, not an
+// object, so the standard helper would discard the string.
+func parseOptions(raw any) options {
+	opts := options{}
+
+	var arr []interface{}
+	switch v := raw.(type) {
+	case []interface{}:
+		arr = v
+	case string:
+		arr = []interface{}{v}
+	}
+
+	if len(arr) > 0 {
+		if s, ok := arr[0].(string); ok && s == "as-needed" {
+			opts.asNeeded = true
+		}
+	}
+	if opts.asNeeded && len(arr) > 1 {
+		if m, ok := arr[1].(map[string]interface{}); ok {
+			if b, ok := m["requireForBlockBody"].(bool); ok {
+				opts.requireForBlockBody = b
+			}
+		}
+	}
+	return opts
+}
+
+func hasBlockBody(arrowFn *ast.ArrowFunction) bool {
+	return arrowFn.Body != nil && arrowFn.Body.Kind == ast.KindBlock
+}
+
+// findOpenParenPos returns the byte position of the opening `(` of the arrow
+// function's parameters, or -1 if the arrow function has no parens (single
+// identifier param like `a => a`).
+//
+// We rely on the parser's invariant that for parens-wrapped parameter lists,
+// the ParameterList's Pos starts immediately after `(`. For the simple-arrow
+// form (`a => b`, with or without `async`), the parser sets the list's Loc to
+// the parameter's own Loc, which never crosses an outer call's `(`. Comparing
+// `parameters.Pos() - 1 >= node.Pos()` rejects the outer-call false positive
+// (e.g. `foo(a => b)` — the `(` at `node.Pos() - 1` belongs to `foo`, not the
+// arrow).
+func findOpenParenPos(node *ast.Node, arrowFn *ast.ArrowFunction, text string) int {
+	if arrowFn == nil || arrowFn.Parameters == nil {
+		return -1
+	}
+	parenPos := arrowFn.Parameters.Pos() - 1
+	if parenPos < node.Pos() || parenPos < 0 || parenPos >= len(text) {
+		return -1
+	}
+	if text[parenPos] != '(' {
+		return -1
+	}
+	return parenPos
+}
+
+// findCloseParenPos returns the byte position of the closing `)` after the
+// single parameter, accounting for an optional trailing comma. Returns -1 on
+// a parser-recovery shape that doesn't actually contain a `)` (defensive).
+//
+// Uses the tsgo scanner instead of byte-walking so we get Unicode whitespace
+// handling and proper tokenization for free — the same recipe `no_array_delete`
+// uses to locate `]`/`[` siblings via `scanner.GetRangeOfTokenAtPosition`.
+func findCloseParenPos(sf *ast.SourceFile, paramEnd int) int {
+	tok := scanner.ScanTokenAtPosition(sf, paramEnd)
+	rng := scanner.GetRangeOfTokenAtPosition(sf, paramEnd)
+	if tok == ast.KindCommaToken {
+		tok = scanner.ScanTokenAtPosition(sf, rng.End())
+		rng = scanner.GetRangeOfTokenAtPosition(sf, rng.End())
+	}
+	if tok == ast.KindCloseParenToken {
+		return rng.Pos()
+	}
+	return -1
+}
+
+// hasCommentsBetween reports whether the byte range [low, high) contains any
+// `//` or `/*` sequence. Between an arrow function's parens the only legal
+// content is identifier/comma trivia plus the param itself — no strings or
+// regexes can appear, so a plain substring search is safe.
+func hasCommentsBetween(text string, low, high int) bool {
+	if low < 0 {
+		low = 0
+	}
+	if high > len(text) {
+		high = len(text)
+	}
+	if low >= high {
+		return false
+	}
+	s := text[low:high]
+	return strings.Contains(s, "//") || strings.Contains(s, "/*")
+}
+
+// needsSpaceBeforeOpenParen reports whether the rune immediately before
+// `openParenPos` is part of an identifier or keyword token — in which case
+// removing the `(` would fuse two adjacent tokens into a single identifier
+// (`async(a)=>a` → without a space would become an undefined identifier).
+// Equivalent to upstream's `canTokensBeAdjacent` guard for the realistic
+// keyword-prefix shapes, but Unicode-aware via tsgo's scanner.
+func needsSpaceBeforeOpenParen(text string, openParenPos int) bool {
+	if openParenPos <= 0 {
+		return false
+	}
+	r, size := utf8.DecodeLastRuneInString(text[:openParenPos])
+	if size == 0 || r == utf8.RuneError {
+		return false
+	}
+	return scanner.IsIdentifierPart(r)
+}
+
+// ArrowParensRule enforces consistent use of parentheses around arrow function
+// parameters. Ported from @stylistic/eslint-plugin's arrow-parens.
+//
+// The rule only fires when an arrow function has exactly one parameter — both
+// `() => {}` and `(a, b) => {}` are out of scope. For single-parameter
+// arrows, the rule either:
+//
+//   - in `'always'` mode (default), requires `(a) => ...`
+//   - in `'as-needed'` mode, drops parens for plain `Identifier` params with
+//     no annotation, default, optional marker, rest, generics, return type,
+//     or interior comments
+//   - with `requireForBlockBody: true`, restores the requirement when the
+//     arrow's body is a `{ ... }` block.
+var ArrowParensRule = rule.Rule{
+	Name: "@stylistic/arrow-parens",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		text := ctx.SourceFile.Text()
+
+		check := func(node *ast.Node) {
+			arrowFn := node.AsArrowFunction()
+			if arrowFn == nil || arrowFn.Parameters == nil {
+				return
+			}
+			params := arrowFn.Parameters.Nodes
+			if len(params) != 1 {
+				return
+			}
+			param := params[0]
+			if param == nil || param.Kind != ast.KindParameter {
+				return
+			}
+
+			shouldHaveParens := !opts.asNeeded || (opts.requireForBlockBody && hasBlockBody(arrowFn))
+			openParenPos := findOpenParenPos(node, arrowFn, text)
+			hasParens := openParenPos >= 0
+
+			paramRange := utils.TrimNodeTextRange(ctx.SourceFile, param)
+			paramStart := paramRange.Pos()
+			paramEnd := paramRange.End()
+
+			if shouldHaveParens && !hasParens {
+				msgId := msgExpectedParens
+				desc := descExpectedParens
+				if opts.requireForBlockBody {
+					msgId = msgExpectedParensBlock
+					desc = descExpectedParensBlock
+				}
+				ctx.ReportRangeWithFixes(
+					paramRange,
+					rule.RuleMessage{Id: msgId, Description: desc},
+					rule.RuleFix{Text: "(", Range: core.NewTextRange(paramStart, paramStart)},
+					rule.RuleFix{Text: ")", Range: core.NewTextRange(paramEnd, paramEnd)},
+				)
+				return
+			}
+
+			if shouldHaveParens || !hasParens {
+				return
+			}
+
+			// As-needed branch: parens exist but may be removable.
+			paramDecl := param.AsParameterDeclaration()
+			if paramDecl == nil {
+				return
+			}
+			name := paramDecl.Name()
+			if name == nil || name.Kind != ast.KindIdentifier {
+				return
+			}
+			if paramDecl.DotDotDotToken != nil ||
+				paramDecl.Initializer != nil ||
+				paramDecl.QuestionToken != nil ||
+				paramDecl.Type != nil {
+				return
+			}
+			if arrowFn.Type != nil {
+				return
+			}
+			// Generics force parens: `<T>(a) => b`. In tsgo TypeParameters are a
+			// dedicated field, so we don't need to walk tokens — the presence
+			// of the list is sufficient (upstream relies on `getFirstToken`
+			// after skipping `async`).
+			if arrowFn.TypeParameters != nil && len(arrowFn.TypeParameters.Nodes) > 0 {
+				return
+			}
+
+			closeParenPos := findCloseParenPos(ctx.SourceFile, paramEnd)
+			if closeParenPos < 0 {
+				return
+			}
+			if hasCommentsBetween(text, openParenPos+1, closeParenPos) {
+				return
+			}
+
+			fixes := []rule.RuleFix{}
+			// Guard against token fusion: if the rune immediately before `(`
+			// is part of an identifier / keyword (no whitespace separates them),
+			// removing the paren would glue the keyword to the param name —
+			// e.g. removing `async(a)=>a`'s parens without inserting a space
+			// would join the `async` and `a` tokens into a single identifier.
+			if needsSpaceBeforeOpenParen(text, openParenPos) {
+				fixes = append(fixes, rule.RuleFix{
+					Text:  " ",
+					Range: core.NewTextRange(openParenPos, openParenPos),
+				})
+			}
+			fixes = append(fixes,
+				rule.RuleFix{Text: "", Range: core.NewTextRange(openParenPos, paramStart)},
+				rule.RuleFix{Text: "", Range: core.NewTextRange(paramEnd, closeParenPos+1)},
+			)
+
+			msgId := msgUnexpectedParens
+			desc := descUnexpectedParens
+			if opts.requireForBlockBody {
+				msgId = msgUnexpectedParensInline
+				desc = descUnexpectedParensInline
+			}
+			ctx.ReportRangeWithFixes(
+				paramRange,
+				rule.RuleMessage{Id: msgId, Description: desc},
+				fixes...,
+			)
+		}
+
+		return rule.RuleListeners{
+			ast.KindArrowFunction: check,
+		}
+	},
+}

--- a/internal/plugins/stylistic/rules/arrow_parens/arrow_parens.go
+++ b/internal/plugins/stylistic/rules/arrow_parens/arrow_parens.go
@@ -41,12 +41,12 @@ type options struct {
 func parseOptions(raw any) options {
 	opts := options{}
 
-	var arr []interface{}
+	var arr []any
 	switch v := raw.(type) {
-	case []interface{}:
+	case []any:
 		arr = v
 	case string:
-		arr = []interface{}{v}
+		arr = []any{v}
 	}
 
 	if len(arr) > 0 {
@@ -55,7 +55,7 @@ func parseOptions(raw any) options {
 		}
 	}
 	if opts.asNeeded && len(arr) > 1 {
-		if m, ok := arr[1].(map[string]interface{}); ok {
+		if m, ok := arr[1].(map[string]any); ok {
 			if b, ok := m["requireForBlockBody"].(bool); ok {
 				opts.requireForBlockBody = b
 			}

--- a/internal/plugins/stylistic/rules/arrow_parens/arrow_parens.md
+++ b/internal/plugins/stylistic/rules/arrow_parens/arrow_parens.md
@@ -1,0 +1,108 @@
+# arrow-parens
+
+Require parentheses around arrow function arguments.
+
+## Rule Details
+
+This rule enforces parentheses around the parameter of arrow functions that take a single argument. Multi-parameter and zero-parameter arrows are never reported — JavaScript syntactically requires parentheses around them, so the rule has no decision to make.
+
+The default option is `"always"`, which requires parentheses around every single-parameter arrow.
+
+## Options
+
+This rule has a string option:
+
+- `"always"` (default) requires parentheses around every single-parameter arrow.
+- `"as-needed"` removes parentheses when the parameter is a plain identifier with no annotation, default, optional marker, rest, or comments.
+
+This rule has an object option, only meaningful with `"as-needed"`:
+
+- `"requireForBlockBody": true` reverses the requirement when the arrow's body is a block — `a => { ... }` becomes invalid, `(a) => { ... }` becomes correct.
+
+### always
+
+Examples of **incorrect** code for this rule with the default `"always"` option:
+
+```javascript
+a => {};
+a => a;
+a.then(foo => {});
+```
+
+Examples of **correct** code for this rule with the default `"always"` option:
+
+```javascript
+() => {};
+(a) => {};
+(a) => a;
+a.then((foo) => {});
+```
+
+### as-needed
+
+Examples of **incorrect** code for this rule with the `"as-needed"` option:
+
+```json
+{ "@stylistic/arrow-parens": ["error", "as-needed"] }
+```
+
+```javascript
+(a) => a;
+```
+
+Examples of **correct** code for this rule with the `"as-needed"` option:
+
+```json
+{ "@stylistic/arrow-parens": ["error", "as-needed"] }
+```
+
+```javascript
+() => {};
+a => {};
+a => a;
+([a, b]) => a;
+({ a, b }) => a;
+(a = 10) => a;
+(...a) => a[0];
+(a, b) => a + b;
+```
+
+The exceptions that keep parentheses under `"as-needed"`:
+
+- Destructured parameters (`([a]) => a`, `({a}) => a`).
+- A parameter with a default value (`(a = 1) => a`).
+- A rest parameter (`(...a) => a`).
+- A TypeScript optional parameter (`(a?: number) => a`).
+- A parameter with a type annotation (`(a: number) => a`).
+- An arrow with a return type annotation (`(a): number => a`).
+- An arrow with generic type parameters (`<T>(a) => a`).
+- A comment between the parentheses (`(/* doc */ a) => a`).
+
+### requireForBlockBody
+
+Examples of **incorrect** code for this rule with `"as-needed", { "requireForBlockBody": true }`:
+
+```json
+{ "@stylistic/arrow-parens": ["error", "as-needed", { "requireForBlockBody": true }] }
+```
+
+```javascript
+(a) => a;
+a => { return a; };
+```
+
+Examples of **correct** code for this rule with `"as-needed", { "requireForBlockBody": true }`:
+
+```json
+{ "@stylistic/arrow-parens": ["error", "as-needed", { "requireForBlockBody": true }] }
+```
+
+```javascript
+a => a;
+(a) => { return a; };
+a => ({});
+```
+
+## Original Documentation
+
+- [@stylistic/arrow-parens](https://eslint.style/rules/arrow-parens)

--- a/internal/plugins/stylistic/rules/arrow_parens/arrow_parens_extras_test.go
+++ b/internal/plugins/stylistic/rules/arrow_parens/arrow_parens_extras_test.go
@@ -131,9 +131,9 @@ func TestArrowParensExtras(t *testing.T) {
 			{Code: `([a, ...rest]) => rest.length;`, Options: optsAsNeeded()},
 			{Code: `({a}) => a;`, Options: optsAsNeeded()},
 			{Code: `({a, b}) => a + b;`, Options: optsAsNeeded()},
-			{Code: `({a: x, b: y}) => x + y;`, Options: optsAsNeeded()},     // aliasing
-			{Code: `({a = 1, b = 2}) => a + b;`, Options: optsAsNeeded()},   // pattern default
-			{Code: `({a, ...rest}) => rest;`, Options: optsAsNeeded()},      // pattern rest
+			{Code: `({a: x, b: y}) => x + y;`, Options: optsAsNeeded()},   // aliasing
+			{Code: `({a = 1, b = 2}) => a + b;`, Options: optsAsNeeded()}, // pattern default
+			{Code: `({a, ...rest}) => rest;`, Options: optsAsNeeded()},    // pattern rest
 
 			// ---- Rest param `...a` ----
 			// tsgo: paramDecl.DotDotDotToken != nil. ESTree: RestElement
@@ -155,7 +155,7 @@ func TestArrowParensExtras(t *testing.T) {
 			{Code: `(a: number) => a;`, Options: optsAsNeededBlock()},
 			{Code: `(a: string) => a.length;`, Options: optsAsNeeded()},
 			{Code: `(a: { x: number }) => a.x;`, Options: optsAsNeeded()},  // object type
-			{Code: `(a: number | string) => a;`, Options: optsAsNeeded()}, // union type
+			{Code: `(a: number | string) => a;`, Options: optsAsNeeded()},  // union type
 			{Code: `(a: Array<number>) => a[0];`, Options: optsAsNeeded()}, // generic type ref
 
 			// ---- TS optional `a?`: keep parens ----
@@ -202,8 +202,8 @@ func TestArrowParensExtras(t *testing.T) {
 			{Code: `const f = ( /* leading block */ a ) => a;`, Options: optsAsNeeded()},
 			{Code: "const f = ( a // line\n) => a;", Options: optsAsNeeded()},
 			{Code: "const f = (\n  // line comment alone\n  a\n) => a;", Options: optsAsNeeded()},
-			{Code: "const f = (a /* line1\nline2 */) => a;", Options: optsAsNeeded()},        // multi-line block comment
-			{Code: `const f = (/** JSDoc */ a) => a;`, Options: optsAsNeeded()},               // JSDoc block
+			{Code: "const f = (a /* line1\nline2 */) => a;", Options: optsAsNeeded()},     // multi-line block comment
+			{Code: `const f = (/** JSDoc */ a) => a;`, Options: optsAsNeeded()},           // JSDoc block
 			{Code: `const f = (a /* end */ , /* sep */ ) => a;`, Options: optsAsNeeded()}, // comment between param and trailing comma + after
 
 			// ---- Comments OUTSIDE parens — should NOT block paren removal ----
@@ -232,13 +232,13 @@ func TestArrowParensExtras(t *testing.T) {
 
 			// ---- async + various param shapes under as-needed ----
 			{Code: `async a => a;`, Options: optsAsNeeded()},
-			{Code: `async (a: number) => a;`, Options: optsAsNeeded()},                   // TS type → keep
-			{Code: `async (a?) => a;`, Options: optsAsNeeded()},                          // TS optional → keep
-			{Code: `async (a): Promise<number> => a;`, Options: optsAsNeeded()},          // return type → keep
-			{Code: `async (...args) => args.length;`, Options: optsAsNeeded()},           // rest → keep
-			{Code: `async ({a, b}) => a + b;`, Options: optsAsNeeded()},                  // destructuring → keep
-			{Code: `async <T>(a: T) => a;`, Options: optsAsNeeded()},                     // generic → keep
-			{Code: `async <T>(/* doc */a: T) => a;`, Options: optsAsNeeded()},            // generic + comment
+			{Code: `async (a: number) => a;`, Options: optsAsNeeded()},          // TS type → keep
+			{Code: `async (a?) => a;`, Options: optsAsNeeded()},                 // TS optional → keep
+			{Code: `async (a): Promise<number> => a;`, Options: optsAsNeeded()}, // return type → keep
+			{Code: `async (...args) => args.length;`, Options: optsAsNeeded()},  // rest → keep
+			{Code: `async ({a, b}) => a + b;`, Options: optsAsNeeded()},         // destructuring → keep
+			{Code: `async <T>(a: T) => a;`, Options: optsAsNeeded()},            // generic → keep
+			{Code: `async <T>(/* doc */a: T) => a;`, Options: optsAsNeeded()},   // generic + comment
 
 			// ---- async + requireForBlockBody ----
 			{Code: `async a => a`, Options: optsAsNeededBlock()},
@@ -343,7 +343,7 @@ func TestArrowParensExtras(t *testing.T) {
 			{Code: `[(a) => a, (b) => b].length;`, Options: optsAlways()},
 
 			// ---- Empty options array ----
-			{Code: `(a) => a`, Options: []interface{}{}},
+			{Code: `(a) => a`, Options: []any{}},
 
 			// ---- Bare-string options form ----
 			{Code: `a => a`, Options: "as-needed"},
@@ -351,10 +351,10 @@ func TestArrowParensExtras(t *testing.T) {
 
 			// ---- Options as nested array (rule_tester / config-loader path) ----
 			// `['as-needed']` is the canonical shape; verify nil inner option.
-			{Code: `a => a`, Options: []interface{}{"as-needed"}},
+			{Code: `a => a`, Options: []any{"as-needed"}},
 
 			// ---- Options shape with explicit requireForBlockBody=true and a body ----
-			{Code: `a => a`, Options: []interface{}{"as-needed", map[string]interface{}{"requireForBlockBody": true}}},
+			{Code: `a => a`, Options: []any{"as-needed", map[string]any{"requireForBlockBody": true}}},
 
 			// ---- requireForBlockBody set when mode is 'always' — flag IGNORED ----
 			// Upstream: `requireForBlockBody = asNeeded && options?.requireForBlockBody`.
@@ -363,7 +363,7 @@ func TestArrowParensExtras(t *testing.T) {
 			// 'always' (covered in invalid below). Here we lock that
 			// `(a) => {}` is VALID — it would be UNEXPECTED if the flag
 			// silently activated.
-			{Code: `(a) => {}`, Options: []interface{}{"always", map[string]interface{}{"requireForBlockBody": true}}},
+			{Code: `(a) => {}`, Options: []any{"always", map[string]any{"requireForBlockBody": true}}},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ============================================================
@@ -497,9 +497,9 @@ func TestArrowParensExtras(t *testing.T) {
 			// `expectedParens` (NOT `expectedParensBlock`) because upstream
 			// only sets requireForBlockBody internal flag when asNeeded.
 			{
-				Code:   `a => {}`,
-				Output: []string{`(a) => {}`},
-				Options: []interface{}{"always", map[string]interface{}{"requireForBlockBody": true}},
+				Code:    `a => {}`,
+				Output:  []string{`(a) => {}`},
+				Options: []any{"always", map[string]any{"requireForBlockBody": true}},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "expectedParens", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
 				},

--- a/internal/plugins/stylistic/rules/arrow_parens/arrow_parens_extras_test.go
+++ b/internal/plugins/stylistic/rules/arrow_parens/arrow_parens_extras_test.go
@@ -1,0 +1,690 @@
+// TestArrowParensExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing
+// at the specific branch / Dimension 4 row / tsgo AST quirk / GitHub issue
+// it covers, so future refactors can't silently regress them without breaking
+// a named lock-in.
+//
+// Dimension 4 walk for @stylistic/arrow-parens:
+//
+//   - Receiver / expression wrappers — N/A. The rule fires on the
+//     ArrowFunction node itself; surrounding wrappers (`(arrow).then(...)`,
+//     `arrow as any`) are out of scope.
+//   - Access / key forms — N/A. The rule doesn't inspect property or
+//     computed-key access.
+//   - Declaration / container forms — covered: arrow with single Identifier
+//     vs destructuring (Array/Object binding) vs rest vs default vs typed
+//     param; async-modified arrows; arrows used as object/class field
+//     initializers; arrows nested inside other arrows.
+//   - Nesting / traversal boundaries — covered: arrow-in-arrow where each
+//     instance is independently checked; ensures the listener doesn't bleed
+//     across boundaries.
+//   - Graceful degradation — covered: zero-param `()` (never reported),
+//     multi-param `(a, b)` (never reported), single TS optional `(a?)`
+//     (keep parens), trailing comma `(a,)`, multi-line inside parens.
+//
+// Branch walk for upstream's `arrow-parens.ts`:
+//
+//   - `params.length === 1` filter
+//   - `shouldHaveParens = !asNeeded || requireForBlockBody && hasBlockBody`
+//   - `findOpeningParenOfParams` (returns paren or null)
+//   - Each of the as-needed remove-paren guard clauses:
+//     `param.type === 'Identifier'`, `!param.optional`,
+//     `!param.typeAnnotation`, `!node.returnType`,
+//     `!hasCommentsInParensOfParams`, `!hasUnexpectedTokensBeforeOpeningParen`
+//   - Fix's `canTokensBeAdjacent` space-insertion branch
+//
+// Issue-tracker anchors (real-user shapes):
+//
+//   - eslint-stylistic#498 — `(opts?) =>` (TS optional, no type annotation)
+//   - eslint#12570 — complex nested generics with multiple constraints
+//   - eslint#8834 — trailing comma in multi-line arrow params
+//   - eslint#6311 / #8682 — async + as-needed interplay
+package arrow_parens_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/arrow_parens"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestArrowParensExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&arrow_parens.ArrowParensRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// Dimension 4: declaration / container forms
+			// ============================================================
+
+			// ---- Dimension 4: arrow inside object literal value ----
+			{Code: `const o = { f: (a) => a };`, Options: optsAlways()},
+			{Code: `const o = { f: a => a };`, Options: optsAsNeeded()},
+
+			// ---- Dimension 4: arrow as class field initializer ----
+			{Code: `class C { handler = (a) => a; }`, Options: optsAlways()},
+			{Code: `class C { handler = a => a; }`, Options: optsAsNeeded()},
+
+			// ---- Dimension 4: arrow as default param value of regular fn ----
+			// Locks in that the listener fires on the arrow nested inside a
+			// FunctionDeclaration's parameter initializer, not on the outer fn.
+			{Code: `function f(cb = (a) => a) { return cb; }`, Options: optsAlways()},
+			{Code: `function f(cb = a => a) { return cb; }`, Options: optsAsNeeded()},
+
+			// ---- Dimension 4: arrow returned from another arrow's body ----
+			{Code: `const curry = (x) => (y) => x + y;`, Options: optsAlways()},
+			{Code: `const curry = x => y => x + y;`, Options: optsAsNeeded()},
+
+			// ---- Dimension 4: three-level nested arrow ----
+			// Each level visited independently.
+			{Code: `const a = x => y => z => x + y + z;`, Options: optsAsNeeded()},
+			{Code: `const a = (x) => (y) => (z) => x + y + z;`, Options: optsAlways()},
+
+			// ============================================================
+			// Dimension 4: nesting boundaries
+			// ============================================================
+
+			// ---- Nesting boundaries: nested arrow that should NOT bleed ----
+			// The outer arrow's parens are evaluated independently of the
+			// inner arrow. With requireForBlockBody, outer block body needs
+			// parens; inner expression body without parens is fine.
+			{Code: `(a) => { return b => b + a; }`, Options: optsAsNeededBlock()},
+
+			// ---- Nesting boundaries: arrow inside body of regular function ----
+			{Code: `function f() { return a => a; }`, Options: optsAsNeeded()},
+
+			// ============================================================
+			// Dimension 4: graceful degradation
+			// ============================================================
+
+			// ---- Multi-param arrow under any mode — `params.length === 1` filter ----
+			{Code: `(a, b) => a + b`, Options: optsAlways()},
+			{Code: `(a, b) => a + b`, Options: optsAsNeeded()},
+			{Code: `(a, b) => { return a + b; }`, Options: optsAsNeededBlock()},
+			{Code: `(a, b, c) => a + b + c`, Options: optsAsNeeded()},
+
+			// ---- Zero-param arrow ----
+			{Code: `() => 42`, Options: optsAlways()},
+			{Code: `() => 42`, Options: optsAsNeeded()},
+			{Code: `() => { return 42; }`, Options: optsAsNeededBlock()},
+
+			// ---- Empty body / expression body / paren-wrapped body ----
+			{Code: `(a) => {}`, Options: optsAlways()},
+			{Code: `a => ({})`, Options: optsAsNeeded()},
+			{Code: `a => (a + 1)`, Options: optsAsNeeded()},
+			{Code: `a => (a)`, Options: optsAsNeededBlock()},
+
+			// ============================================================
+			// Branch lock-ins: `param.type === 'Identifier'` guard
+			// ============================================================
+
+			// ---- Destructuring patterns: parens stay under as-needed ----
+			// In tsgo: ArrayBindingPattern / ObjectBindingPattern under
+			// ParameterDeclaration.Name(). Equivalent to ESTree's
+			// `params[0].type` being `ArrayPattern` / `ObjectPattern`.
+			{Code: `([a]) => a;`, Options: optsAsNeeded()},
+			{Code: `([a, b]) => a + b;`, Options: optsAsNeeded()},
+			{Code: `([a, , c]) => a + c;`, Options: optsAsNeeded()}, // sparse / hole
+			{Code: `([a, ...rest]) => rest.length;`, Options: optsAsNeeded()},
+			{Code: `({a}) => a;`, Options: optsAsNeeded()},
+			{Code: `({a, b}) => a + b;`, Options: optsAsNeeded()},
+			{Code: `({a: x, b: y}) => x + y;`, Options: optsAsNeeded()},     // aliasing
+			{Code: `({a = 1, b = 2}) => a + b;`, Options: optsAsNeeded()},   // pattern default
+			{Code: `({a, ...rest}) => rest;`, Options: optsAsNeeded()},      // pattern rest
+
+			// ---- Rest param `...a` ----
+			// tsgo: paramDecl.DotDotDotToken != nil. ESTree: RestElement
+			// (not Identifier).
+			{Code: `(...rest) => rest;`, Options: optsAsNeeded()},
+
+			// ---- Default param `a = 10` ----
+			// tsgo: paramDecl.Initializer != nil. ESTree: AssignmentPattern
+			// (not Identifier).
+			{Code: `(a = 1) => a;`, Options: optsAsNeeded()},
+			{Code: `(a = () => 1) => a;`, Options: optsAsNeeded()}, // arrow as default value of arrow param
+
+			// ============================================================
+			// Branch lock-ins: TS-specific guards (!optional, !type, !returnType)
+			// ============================================================
+
+			// ---- TS type annotation on param: keep parens ----
+			{Code: `(a: number) => a;`, Options: optsAsNeeded()},
+			{Code: `(a: number) => a;`, Options: optsAsNeededBlock()},
+			{Code: `(a: string) => a.length;`, Options: optsAsNeeded()},
+			{Code: `(a: { x: number }) => a.x;`, Options: optsAsNeeded()},  // object type
+			{Code: `(a: number | string) => a;`, Options: optsAsNeeded()}, // union type
+			{Code: `(a: Array<number>) => a[0];`, Options: optsAsNeeded()}, // generic type ref
+
+			// ---- TS optional `a?`: keep parens ----
+			{Code: `(a?: number) => a;`, Options: optsAsNeeded()},
+			{Code: `(a?: number) => a;`, Options: optsAsNeededBlock()},
+			// Real-user: eslint-stylistic#498 — `(opts?) => doSomething(opts)`
+			// Locks: TS optional WITHOUT a type annotation. Upstream's
+			// guard `!param.optional` must fire even when no type follows.
+			{Code: `myObj.something = (opts?) => doSomething(opts);`, Options: optsAsNeeded()},
+			{Code: `myObj.something = (opts?) => doSomething(opts);`, Options: optsAsNeededBlock()},
+
+			// ---- TS arrow return-type `(a): T =>`: keep parens ----
+			{Code: `(a): number => a;`, Options: optsAsNeeded()},
+			{Code: `(a): number => a;`, Options: optsAsNeededBlock()},
+			{Code: `async (a): Promise<number> => a;`, Options: optsAsNeeded()},
+			// Real-user: TS type-guard return type `(x): x is string => ...`
+			// — type predicates also use the return-type slot, so parens stay.
+			{Code: `(x): x is string => typeof x === 'string';`, Options: optsAsNeeded()},
+			{Code: `(x): asserts x is number => { if (typeof x !== 'number') throw new Error(); };`, Options: optsAsNeeded()},
+
+			// ============================================================
+			// Branch lock-ins: `!hasUnexpectedTokensBeforeOpeningParen`
+			// ============================================================
+
+			// ---- Generics: parens forced by `<T>` ----
+			{Code: `<T,>(a) => a;`, Options: optsAsNeeded()},
+			{Code: `<T, U>(a: T, b: U) => a;`, Options: optsAsNeeded()},
+			{Code: `<const T>(a) => a;`, Options: optsAsNeeded()},
+			{Code: `<T extends keyof U, U>(a: T) => a;`, Options: optsAsNeeded()},
+			// Real-user: eslint#12570 — nested generic constraint with
+			// complex keyof / Extract usage. Body is block, but params is
+			// empty so the rule should NOT fire.
+			{Code: `const useABTests = <T extends ABTests, TName extends Extract<keyof T, string | number>>() => { return null; };`, Options: optsAsNeeded()},
+			// Same shape with single param + complex generic — locks the
+			// "generics present means keep parens" path under heavy nesting.
+			{Code: `const useABTests = <T extends ABTests, TName extends Extract<keyof T, string | number>>(name: TName) => name;`, Options: optsAsNeeded()},
+
+			// ============================================================
+			// Branch lock-ins: `!hasCommentsInParensOfParams`
+			// ============================================================
+
+			// ---- Comment position variants inside parens ----
+			{Code: `const f = ( a /* trailing block */ ) => a;`, Options: optsAsNeeded()},
+			{Code: `const f = ( /* leading block */ a ) => a;`, Options: optsAsNeeded()},
+			{Code: "const f = ( a // line\n) => a;", Options: optsAsNeeded()},
+			{Code: "const f = (\n  // line comment alone\n  a\n) => a;", Options: optsAsNeeded()},
+			{Code: "const f = (a /* line1\nline2 */) => a;", Options: optsAsNeeded()},        // multi-line block comment
+			{Code: `const f = (/** JSDoc */ a) => a;`, Options: optsAsNeeded()},               // JSDoc block
+			{Code: `const f = (a /* end */ , /* sep */ ) => a;`, Options: optsAsNeeded()}, // comment between param and trailing comma + after
+
+			// ---- Comments OUTSIDE parens — should NOT block paren removal ----
+			// Locks the as-needed comment scan window: only the [openParen+1,
+			// closeParen) range matters, not surrounding source.
+			{Code: `a => a;`, Options: optsAsNeeded()},
+
+			// ============================================================
+			// requireForBlockBody flag variations
+			// ============================================================
+
+			// ---- requireForBlockBody=false → plain as-needed ----
+			{Code: `a => a`, Options: optsAsNeededFlag(false)},
+			{Code: `a => ({})`, Options: optsAsNeededFlag(false)},
+			{Code: `a => { return a; }`, Options: optsAsNeededFlag(false)}, // block body, parens NOT required
+
+			// ---- requireForBlockBody with arrow-body-is-arrow-with-block ----
+			// The outer arrow has an expression body (an inner arrow), the
+			// inner arrow has a block body — requireForBlockBody affects each
+			// individually.
+			{Code: `a => (b) => { return a + b; }`, Options: optsAsNeededBlock()},
+
+			// ============================================================
+			// Async modifier combinations
+			// ============================================================
+
+			// ---- async + various param shapes under as-needed ----
+			{Code: `async a => a;`, Options: optsAsNeeded()},
+			{Code: `async (a: number) => a;`, Options: optsAsNeeded()},                   // TS type → keep
+			{Code: `async (a?) => a;`, Options: optsAsNeeded()},                          // TS optional → keep
+			{Code: `async (a): Promise<number> => a;`, Options: optsAsNeeded()},          // return type → keep
+			{Code: `async (...args) => args.length;`, Options: optsAsNeeded()},           // rest → keep
+			{Code: `async ({a, b}) => a + b;`, Options: optsAsNeeded()},                  // destructuring → keep
+			{Code: `async <T>(a: T) => a;`, Options: optsAsNeeded()},                     // generic → keep
+			{Code: `async <T>(/* doc */a: T) => a;`, Options: optsAsNeeded()},            // generic + comment
+
+			// ---- async + requireForBlockBody ----
+			{Code: `async a => a`, Options: optsAsNeededBlock()},
+			{Code: `async (a) => { return a; }`, Options: optsAsNeededBlock()},
+			{Code: `async a => ({a})`, Options: optsAsNeededBlock()}, // body is paren-wrapped expression, not block
+
+			// ============================================================
+			// Real-user code patterns (without issue refs)
+			// ============================================================
+
+			// ---- Real-user: Promise.then chain ----
+			{Code: `fetch('/api').then((res) => res.json()).then((data) => data);`, Options: optsAlways()},
+			{Code: `fetch('/api').then(res => res.json()).then(data => data);`, Options: optsAsNeeded()},
+
+			// ---- Real-user: Array.prototype methods ----
+			{Code: `items.map(item => item.id);`, Options: optsAsNeeded()},
+			{Code: `items.filter(item => item.active);`, Options: optsAsNeeded()},
+			{Code: `items.reduce((acc, x) => acc + x, 0);`, Options: optsAsNeeded()}, // multi-param skipped
+			{Code: `items.find(item => item.id === target);`, Options: optsAsNeeded()},
+			{Code: `items.some(item => item.flag);`, Options: optsAsNeeded()},
+
+			// ---- Real-user: React useState updater pattern ----
+			{Code: `setCount(prev => prev + 1);`, Options: optsAsNeeded()},
+			{Code: `setItems(prev => [...prev, newItem]);`, Options: optsAsNeeded()},
+
+			// ---- Real-user: useEffect / dependency-array hook ----
+			// Zero-param arrow — never reported.
+			{Code: `useEffect(() => { document.title = title; }, [title]);`, Options: optsAsNeededBlock()},
+			{Code: `useMemo(() => computeValue(), [a]);`, Options: optsAsNeeded()},
+
+			// ---- Real-user: IIFE ----
+			{Code: `((x) => x)(1);`, Options: optsAlways()},
+			{Code: `(x => x)(1);`, Options: optsAsNeeded()},
+
+			// ---- Real-user: arrow + TS `as` in body ----
+			{Code: `(x) => (x as number) + 1;`, Options: optsAlways()},
+			{Code: `x => (x as number) + 1;`, Options: optsAsNeeded()},
+
+			// ---- Real-user: arrow + TS `satisfies` in body ----
+			{Code: `(x) => x satisfies object;`, Options: optsAlways()},
+			{Code: `x => x satisfies object;`, Options: optsAsNeeded()},
+
+			// ---- Real-user: arrow body uses non-null + optional chain ----
+			{Code: `x => x!.y;`, Options: optsAsNeeded()},
+			{Code: `x => x?.y;`, Options: optsAsNeeded()},
+
+			// ============================================================
+			// Operator precedence / placement (where arrow can appear)
+			// ============================================================
+
+			// ---- Conditional expression branches ----
+			{Code: `flag ? (a) => a : (b) => b;`, Options: optsAlways()},
+			{Code: `flag ? a => a : b => b;`, Options: optsAsNeeded()},
+
+			// ---- Sequence expression — multiple arrows ----
+			{Code: `(a => a, b => b);`, Options: optsAsNeeded()},
+
+			// ---- Spread argument in call ----
+			{Code: `Promise.all([(a) => a, (b) => b]);`, Options: optsAlways()},
+			{Code: `Promise.all([a => a, b => b]);`, Options: optsAsNeeded()},
+
+			// ---- Arrow as JSX prop / inside JSX expression container ----
+			{Code: `const C = () => <button onClick={(e) => e.preventDefault()}>x</button>;`, Options: optsAlways(), Tsx: true},
+			{Code: `const C = () => <button onClick={e => e.preventDefault()}>x</button>;`, Options: optsAsNeeded(), Tsx: true},
+
+			// ---- Arrow inside template substitution ----
+			{Code: "const s = `${((a) => a)(1)}`;", Options: optsAlways()},
+			{Code: "const s = `${(a => a)(1)}`;", Options: optsAsNeeded()},
+
+			// ---- Arrow in tagged template substitution ----
+			{Code: "tag`prefix ${(a) => a} suffix`;", Options: optsAlways()},
+
+			// ============================================================
+			// Unicode / encoding boundaries
+			// ============================================================
+
+			// ---- Unicode identifier as param name ----
+			// `λ` is a valid ES identifier-start character per the Unicode ID
+			// spec. Our needsSpaceBeforeOpenParen uses scanner.IsIdentifierPart
+			// which handles this correctly.
+			{Code: `λ => λ * 2;`, Options: optsAsNeeded()},
+			{Code: `(λ) => λ * 2;`, Options: optsAlways()},
+
+			// ---- Param name with leading Unicode (Greek letter) ----
+			{Code: `const f = (αβγ) => αβγ;`, Options: optsAlways()},
+			{Code: `const f = αβγ => αβγ;`, Options: optsAsNeeded()},
+
+			// ---- Comment containing multi-byte chars ----
+			// Tests that the byte-level substring search in hasCommentsBetween
+			// (looking for `//` and `/*`) isn't fooled by Unicode in the
+			// payload. The presence of multi-byte chars between the comment
+			// markers shouldn't matter.
+			{Code: `const f = (/* 中文 注释 */ a) => a;`, Options: optsAsNeeded()},
+			{Code: "const f = (a /* 中文 */ ) => a;", Options: optsAsNeeded()},
+
+			// ============================================================
+			// Robustness boundaries
+			// ============================================================
+
+			// ---- Same line, multiple arrows ----
+			// Independent reports per arrow; order matches source.
+			{Code: `[(a) => a, (b) => b].length;`, Options: optsAlways()},
+
+			// ---- Empty options array ----
+			{Code: `(a) => a`, Options: []interface{}{}},
+
+			// ---- Bare-string options form ----
+			{Code: `a => a`, Options: "as-needed"},
+			{Code: `(a) => a`, Options: "always"},
+
+			// ---- Options as nested array (rule_tester / config-loader path) ----
+			// `['as-needed']` is the canonical shape; verify nil inner option.
+			{Code: `a => a`, Options: []interface{}{"as-needed"}},
+
+			// ---- Options shape with explicit requireForBlockBody=true and a body ----
+			{Code: `a => a`, Options: []interface{}{"as-needed", map[string]interface{}{"requireForBlockBody": true}}},
+
+			// ---- requireForBlockBody set when mode is 'always' — flag IGNORED ----
+			// Upstream: `requireForBlockBody = asNeeded && options?.requireForBlockBody`.
+			// With 'always' mode, the second-arg flag must be ignored;
+			// `a => {}` (no parens, block body) should still report under
+			// 'always' (covered in invalid below). Here we lock that
+			// `(a) => {}` is VALID — it would be UNEXPECTED if the flag
+			// silently activated.
+			{Code: `(a) => {}`, Options: []interface{}{"always", map[string]interface{}{"requireForBlockBody": true}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Token-fusion fix branch
+			// ============================================================
+
+			// ---- Non-identifier prefix → no space inserted ----
+			// `=` is not part of an identifier; safe to be adjacent.
+			{
+				Code:    `var x =(a) => a;`,
+				Output:  []string{`var x =a => a;`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			// `,` is not part of an identifier; safe.
+			{
+				Code:    `[1,(a) => a];`,
+				Output:  []string{`[1,a => a];`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+				},
+			},
+			// `?` (ternary) is not part of an identifier; safe.
+			{
+				Code:    `cond?(a) => a:b;`,
+				Output:  []string{`cond?a => a:b;`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+				},
+			},
+			// ---- Identifier-char prefix on a Unicode keyword-like identifier ----
+			// `myFunc` ends in identifier char. Because this is a CallExpression
+			// (`myFunc(arg)`) at parse time and `(a) => a` would be the
+			// single argument, the inner arrow's parens removal needs no
+			// space — the outer `(` belongs to `myFunc`. Locks the
+			// `parenPos >= node.Pos()` exclusion path.
+			{
+				Code:    `myFunc((a) => a);`,
+				Output:  []string{`myFunc(a => a);`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+
+			// ============================================================
+			// Multi-line / trailing comma fix
+			// ============================================================
+
+			// ---- Multi-line param with trailing comma ----
+			{
+				Code:    "(\n  a,\n) => a",
+				Output:  []string{`a => a`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 2, Column: 3, EndLine: 2, EndColumn: 4},
+				},
+			},
+			// ---- Real-user: eslint#8834 — multi-line trailing comma + paren body ----
+			{
+				Code:    "const foo = (\n  bar,\n) => ({});",
+				Output:  []string{"const foo = bar => ({});"},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 2, Column: 3, EndLine: 2, EndColumn: 6},
+				},
+			},
+
+			// ============================================================
+			// Nesting — independent reports per arrow
+			// ============================================================
+
+			// ---- Two-level nested arrow, both fire (always mode) ----
+			{
+				Code:   `a => b => a + b`,
+				Output: []string{`(a) => (b) => a + b`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+					{MessageId: "expectedParens", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				},
+			},
+			// ---- Two-level nested arrow, both fire (as-needed mode) ----
+			{
+				Code:    `(a) => (b) => a + b`,
+				Output:  []string{`a => b => a + b`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+					{MessageId: "unexpectedParens", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			// ---- Three-level nesting ----
+			{
+				Code:   `a => b => c => a + b + c`,
+				Output: []string{`(a) => (b) => (c) => a + b + c`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+					{MessageId: "expectedParens", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+					{MessageId: "expectedParens", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+
+			// ============================================================
+			// requireForBlockBody messageId selection
+			// ============================================================
+
+			// ---- requireForBlockBody, expression body — unexpectedParensInline ----
+			{
+				Code:    `(a) => a + 1`,
+				Output:  []string{`a => a + 1`},
+				Options: optsAsNeededBlock(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParensInline", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+			// ---- requireForBlockBody, block body — expectedParensBlock ----
+			{
+				Code:    `a => { return a; }`,
+				Output:  []string{`(a) => { return a; }`},
+				Options: optsAsNeededBlock(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParensBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- requireForBlockBody falsy on 'always' mode — flag ignored ----
+			// 'always' with requireForBlockBody:true should still emit plain
+			// `expectedParens` (NOT `expectedParensBlock`) because upstream
+			// only sets requireForBlockBody internal flag when asNeeded.
+			{
+				Code:   `a => {}`,
+				Output: []string{`(a) => {}`},
+				Options: []interface{}{"always", map[string]interface{}{"requireForBlockBody": true}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+
+			// ============================================================
+			// Trailing-comma / paren-position fixes
+			// ============================================================
+
+			// ---- Trailing comma without comment — parens removed ----
+			{
+				Code:    `var foo = (a,) => b;`,
+				Output:  []string{`var foo = a => b;`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+
+			// ---- Arrow inside argument list — outer `(` ignored ----
+			{
+				Code:    `foo((a) => a)`,
+				Output:  []string{`foo(a => a)`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				},
+			},
+			// ---- Arrow wrapped in ParenthesizedExpression ----
+			{
+				Code:    `((a) => a)`,
+				Output:  []string{`(a => a)`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 3, EndLine: 1, EndColumn: 4},
+				},
+			},
+			// ---- Double-wrapped ParenthesizedExpression ----
+			// Locks the case where multiple layers of ParenthesizedExpression
+			// wrap the arrow but don't interfere with inner-paren detection.
+			{
+				Code:    `(((a) => a))`,
+				Output:  []string{`((a => a))`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 4, EndLine: 1, EndColumn: 5},
+				},
+			},
+
+			// ============================================================
+			// Default mode (no options)
+			// ============================================================
+
+			// ---- No options → defaults to 'always' ----
+			{
+				Code:   `a => a`,
+				Output: []string{`(a) => a`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- String-only options form ----
+			{
+				Code:    `(a) => a`,
+				Output:  []string{`a => a`},
+				Options: "as-needed",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+
+			// ============================================================
+			// Real-user / operator-placement fixes
+			// ============================================================
+
+			// ---- Real-user: arrow in conditional branches ----
+			{
+				Code:    `const fn = flag ? (a) => a : (b) => b;`,
+				Output:  []string{`const fn = flag ? a => a : b => b;`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+					{MessageId: "unexpectedParens", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+				},
+			},
+			// ---- Real-user: chained .then with single-arg callback ----
+			{
+				Code:    `fetch('/').then((res) => res.json()).then((data) => data);`,
+				Output:  []string{`fetch('/').then(res => res.json()).then(data => data);`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 18, EndLine: 1, EndColumn: 21},
+					{MessageId: "unexpectedParens", Line: 1, Column: 44, EndLine: 1, EndColumn: 48},
+				},
+			},
+			// ---- Real-user: Array.prototype.map under as-needed ----
+			{
+				Code:    `items.map((item) => item.id);`,
+				Output:  []string{`items.map(item => item.id);`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 12, EndLine: 1, EndColumn: 16},
+				},
+			},
+			// ---- Real-user: React setState updater ----
+			{
+				Code:    `setCount((prev) => prev + 1);`,
+				Output:  []string{`setCount(prev => prev + 1);`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 11, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// ---- Real-user: IIFE ----
+			{
+				Code:    `((x) => x)(1);`,
+				Output:  []string{`(x => x)(1);`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 3, EndLine: 1, EndColumn: 4},
+				},
+			},
+			// ---- Real-user: arrow as JSX prop value ----
+			{
+				Code:    `const C = () => <button onClick={(e) => e.preventDefault()}>x</button>;`,
+				Output:  []string{`const C = () => <button onClick={e => e.preventDefault()}>x</button>;`},
+				Options: optsAsNeeded(),
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 35, EndLine: 1, EndColumn: 36},
+				},
+			},
+
+			// ============================================================
+			// Token-fusion guard: all keyword-prefix shapes that can legally
+			// precede an arrow's `(` without intervening whitespace
+			// ============================================================
+			//
+			// `async(a) => a` and `yield(a) => a` are in upstream's invalid
+			// suite. The keyword set that can legally prefix an arrow
+			// without space is small — these locks complete the coverage.
+
+			// ---- `throw(a) => a;` — throw statement + arrow ----
+			// `throw` followed by an arrow expression. Removing parens
+			// requires a space between `throw` and `a` to avoid fusing the
+			// keyword and the parameter into a single identifier token.
+			{
+				Code:    `function f() { throw(a) => a; }`,
+				Output:  []string{`function f() { throw a => a; }`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- `return(a) => a;` — return statement + arrow ----
+			{
+				Code:    `function g() { return(a) => a; }`,
+				Output:  []string{`function g() { return a => a; }`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+				},
+			},
+
+			// ============================================================
+			// FullSignature (JSDoc @type) — must NOT block paren removal
+			// ============================================================
+			//
+			// tsgo's reparser sets `arrowFn.FullSignature` from a JSDoc
+			// `@type` tag (see typescript-go/internal/parser/reparser.go).
+			// Upstream's `node.returnType` (ESTree) is unaffected by JSDoc,
+			// so ESLint also wouldn't block removal here. The rule must
+			// follow upstream — only the SYNTACTIC return type
+			// (`arrowFn.Type` / `(x): T =>`) blocks removal; FullSignature
+			// (JSDoc-inferred) does not.
+
+			// ---- JSDoc @type before arrow, as-needed — parens removed ----
+			{
+				Code:    "/** @type {(x: number) => string} */\nconst h = (x) => x;",
+				Output:  []string{"/** @type {(x: number) => string} */\nconst h = x => x;"},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 2, Column: 12, EndLine: 2, EndColumn: 13},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/arrow_parens/arrow_parens_upstream_test.go
+++ b/internal/plugins/stylistic/rules/arrow_parens/arrow_parens_upstream_test.go
@@ -1,0 +1,315 @@
+// TestArrowParensUpstream migrates the full valid/invalid suite from upstream
+// packages/eslint-plugin/rules/arrow-parens/arrow-parens.test.ts 1:1. Position
+// assertions cover line/column for every invalid case. rslint-specific
+// lock-in cases live in arrow_parens_extras_test.go.
+package arrow_parens_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/arrow_parens"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func optsAlways() []interface{}                      { return []interface{}{"always"} }
+func optsAsNeeded() []interface{}                    { return []interface{}{"as-needed"} }
+func optsAsNeededBlock() []interface{}               { return []interface{}{"as-needed", map[string]interface{}{"requireForBlockBody": true}} }
+func optsAsNeededFlag(b bool) []interface{}          { return []interface{}{"as-needed", map[string]interface{}{"requireForBlockBody": b}} }
+
+func TestArrowParensUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&arrow_parens.ArrowParensRule,
+		[]rule_tester.ValidTestCase{
+			// ---- "always" (by default) ----
+			{Code: `() => {}`},
+			{Code: `(a) => {}`},
+			{Code: `(a) => a`},
+			{Code: "(a) => {\n}"},
+			{Code: `a.then((foo) => {});`},
+			{Code: `a.then((foo) => { if (true) {}; });`},
+			{Code: `const f = (/* */a) => a + a;`},
+			{Code: `const f = (a/** */) => a + a;`},
+			{Code: "const f = (a//\n) => a + a;"},
+			{Code: "const f = (//\na) => a + a;"},
+			{Code: "const f = (/*\n */a//\n) => a + a;"},
+			{Code: `const f = (/** @type {number} */a/**hello*/) => a + a;`},
+			{Code: `a.then(async (foo) => { if (true) {}; });`},
+
+			// ---- "always" (explicit) ----
+			{Code: `() => {}`, Options: optsAlways()},
+			{Code: `(a) => {}`, Options: optsAlways()},
+			{Code: `(a) => a`, Options: optsAlways()},
+			{Code: "(a) => {\n}", Options: optsAlways()},
+			{Code: `a.then((foo) => {});`, Options: optsAlways()},
+			{Code: `a.then((foo) => { if (true) {}; });`, Options: optsAlways()},
+			{Code: `a.then(async (foo) => { if (true) {}; });`, Options: optsAlways()},
+
+			// ---- "as-needed" ----
+			{Code: `() => {}`, Options: optsAsNeeded()},
+			{Code: `a => {}`, Options: optsAsNeeded()},
+			{Code: `a => a`, Options: optsAsNeeded()},
+			{Code: `a => (a)`, Options: optsAsNeeded()},
+			{Code: `(a => a)`, Options: optsAsNeeded()},
+			{Code: `((a => a))`, Options: optsAsNeeded()},
+			{Code: `([a, b]) => {}`, Options: optsAsNeeded()},
+			{Code: `({ a, b }) => {}`, Options: optsAsNeeded()},
+			{Code: `(a = 10) => {}`, Options: optsAsNeeded()},
+			{Code: `(...a) => a[0]`, Options: optsAsNeeded()},
+			{Code: `(a, b) => {}`, Options: optsAsNeeded()},
+			{Code: `async a => a`, Options: optsAsNeeded()},
+			{Code: `async ([a, b]) => {}`, Options: optsAsNeeded()},
+			{Code: `async (a, b) => {}`, Options: optsAsNeeded()},
+
+			// ---- "as-needed", { requireForBlockBody: true } ----
+			{Code: `() => {}`, Options: optsAsNeededBlock()},
+			{Code: `a => a`, Options: optsAsNeededBlock()},
+			{Code: `a => (a)`, Options: optsAsNeededBlock()},
+			{Code: `(a => a)`, Options: optsAsNeededBlock()},
+			{Code: `((a => a))`, Options: optsAsNeededBlock()},
+			{Code: `([a, b]) => {}`, Options: optsAsNeededBlock()},
+			{Code: `([a, b]) => a`, Options: optsAsNeededBlock()},
+			{Code: `({ a, b }) => {}`, Options: optsAsNeededBlock()},
+			{Code: `({ a, b }) => a + b`, Options: optsAsNeededBlock()},
+			{Code: `(a = 10) => {}`, Options: optsAsNeededBlock()},
+			{Code: `(...a) => a[0]`, Options: optsAsNeededBlock()},
+			{Code: `(a, b) => {}`, Options: optsAsNeededBlock()},
+			{Code: `a => ({})`, Options: optsAsNeededBlock()},
+			{Code: `async a => ({})`, Options: optsAsNeededBlock()},
+			{Code: `async a => a`, Options: optsAsNeededBlock()},
+
+			// ---- "as-needed" — comments inside parens keep them ----
+			{Code: `const f = (/** @type {number} */a/**hello*/) => a + a;`, Options: optsAsNeeded()},
+			{Code: `const f = (/* */a) => a + a;`, Options: optsAsNeeded()},
+			{Code: `const f = (a/** */) => a + a;`, Options: optsAsNeeded()},
+			{Code: "const f = (a//\n) => a + a;", Options: optsAsNeeded()},
+			{Code: "const f = (//\na) => a + a;", Options: optsAsNeeded()},
+			{Code: "const f = (/*\n */a//\n) => a + a;", Options: optsAsNeeded()},
+			{Code: `var foo = (a,/**/) => b;`, Options: optsAsNeeded()},
+			{Code: `var foo = (a , /**/) => b;`, Options: optsAsNeeded()},
+			{Code: "var foo = (a\n,\n/**/) => b;", Options: optsAsNeeded()},
+			{Code: "var foo = (a,//\n) => b;", Options: optsAsNeeded()},
+			{Code: `const i = (a/**/,) => a + a;`, Options: optsAsNeeded()},
+			{Code: "const i = (a \n /**/,) => a + a;", Options: optsAsNeeded()},
+			{Code: `var bar = ({/*comment here*/a}) => a`, Options: optsAsNeeded()},
+			{Code: `var bar = (/*comment here*/{a}) => a`, Options: optsAsNeeded()},
+
+			// ---- generics — parens are forced by the `<T>` prefix ----
+			{Code: `<T>(a) => b`, Options: optsAlways(), Tsx: false},
+			{Code: `<T>(a) => b`, Options: optsAsNeeded(), Tsx: false},
+			{Code: `<T>(a) => b`, Options: optsAsNeededBlock(), Tsx: false},
+			{Code: `async <T>(a) => b`, Options: optsAlways(), Tsx: false},
+			{Code: `async <T>(a) => b`, Options: optsAsNeeded(), Tsx: false},
+			{Code: `async <T>(a) => b`, Options: optsAsNeededBlock(), Tsx: false},
+			{Code: `<T>() => b`, Options: optsAlways(), Tsx: false},
+			{Code: `<T>() => b`, Options: optsAsNeeded(), Tsx: false},
+			{Code: `<T>() => b`, Options: optsAsNeededBlock(), Tsx: false},
+			{Code: `<T extends A>(a) => b`, Options: optsAlways(), Tsx: false},
+			{Code: `<T extends A>(a) => b`, Options: optsAsNeeded(), Tsx: false},
+			{Code: `<T extends A>(a) => b`, Options: optsAsNeededBlock(), Tsx: false},
+			{Code: `<T extends (A | B) & C>(a) => b`, Options: optsAlways(), Tsx: false},
+			{Code: `<T extends (A | B) & C>(a) => b`, Options: optsAsNeeded(), Tsx: false},
+			{Code: `<T extends (A | B) & C>(a) => b`, Options: optsAsNeededBlock(), Tsx: false},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- "always" (by default) ----
+			{
+				Code:   `a => {}`,
+				Output: []string{`(a) => {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `a => a`,
+				Output: []string{`(a) => a`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   "a => {\n}",
+				Output: []string{"(a) => {\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `a.then(foo => {});`,
+				Output: []string{`a.then((foo) => {});`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 8, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
+				Code:   `a.then(foo => a);`,
+				Output: []string{`a.then((foo) => a);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 8, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
+				Code:   `a(foo => { if (true) {}; });`,
+				Output: []string{`a((foo) => { if (true) {}; });`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 3, EndLine: 1, EndColumn: 6},
+				},
+			},
+			{
+				Code:   `a(async foo => { if (true) {}; });`,
+				Output: []string{`a(async (foo) => { if (true) {}; });`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 9, EndLine: 1, EndColumn: 12},
+				},
+			},
+
+			// ---- "as-needed" ----
+			{
+				Code:    `(a) => a`,
+				Output:  []string{`a => a`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+			{
+				Code:    `(  a  ) => b`,
+				Output:  []string{`a => b`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 4, EndLine: 1, EndColumn: 5},
+				},
+			},
+			{
+				Code:    "(\na\n) => b",
+				Output:  []string{`a => b`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+				},
+			},
+			{
+				Code:    `(a,) => a`,
+				Output:  []string{`a => a`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+			{
+				Code:    `async (a) => a`,
+				Output:  []string{`async a => a`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+			{
+				Code:    `async(a) => a`,
+				Output:  []string{`async a => a`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+				},
+			},
+			{
+				Code:    `typeof((a) => {})`,
+				Output:  []string{`typeof(a => {})`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code:    `function *f() { yield(a) => a; }`,
+				Output:  []string{`function *f() { yield a => a; }`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+				},
+			},
+
+			// ---- "as-needed", { requireForBlockBody: true } ----
+			{
+				Code:    `a => {}`,
+				Output:  []string{`(a) => {}`},
+				Options: optsAsNeededBlock(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParensBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:    `(a) => a`,
+				Output:  []string{`a => a`},
+				Options: optsAsNeededBlock(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParensInline", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+			{
+				Code:    `async a => {}`,
+				Output:  []string{`async (a) => {}`},
+				Options: optsAsNeededBlock(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParensBlock", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+				},
+			},
+			{
+				Code:    `async (a) => a`,
+				Output:  []string{`async a => a`},
+				Options: optsAsNeededBlock(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParensInline", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+			{
+				Code:    `async(a) => a`,
+				Output:  []string{`async a => a`},
+				Options: optsAsNeededBlock(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParensInline", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+				},
+			},
+			{
+				Code:    `const f = /** @type {number} */(a)/**hello*/ => a + a;`,
+				Output:  []string{`const f = /** @type {number} */a/**hello*/ => a + a;`},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 1, Column: 33, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code:    "const f = //\n(a) => a + a;",
+				Output:  []string{"const f = //\na => a + a;"},
+				Options: optsAsNeeded(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedParens", Line: 2, Column: 2, EndLine: 2, EndColumn: 3},
+				},
+			},
+			{
+				Code:   `var foo = /**/ a => b;`,
+				Output: []string{`var foo = /**/ (a) => b;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:   `var bar = a /**/ =>  b;`,
+				Output: []string{`var bar = (a) /**/ =>  b;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code:   "const foo = a => {};\n\n// comment between 'a' and an unrelated closing paren\n\nbar();",
+				Output: []string{"const foo = (a) => {};\n\n// comment between 'a' and an unrelated closing paren\n\nbar();"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedParens", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/arrow_parens/arrow_parens_upstream_test.go
+++ b/internal/plugins/stylistic/rules/arrow_parens/arrow_parens_upstream_test.go
@@ -12,10 +12,14 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-func optsAlways() []interface{}                      { return []interface{}{"always"} }
-func optsAsNeeded() []interface{}                    { return []interface{}{"as-needed"} }
-func optsAsNeededBlock() []interface{}               { return []interface{}{"as-needed", map[string]interface{}{"requireForBlockBody": true}} }
-func optsAsNeededFlag(b bool) []interface{}          { return []interface{}{"as-needed", map[string]interface{}{"requireForBlockBody": b}} }
+func optsAlways() []any   { return []any{"always"} }
+func optsAsNeeded() []any { return []any{"as-needed"} }
+func optsAsNeededBlock() []any {
+	return []any{"as-needed", map[string]any{"requireForBlockBody": true}}
+}
+func optsAsNeededFlag(b bool) []any {
+	return []any{"as-needed", map[string]any{"requireForBlockBody": b}}
+}
 
 func TestArrowParensUpstream(t *testing.T) {
 	rule_tester.RunRuleTester(

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -449,6 +449,7 @@ export default defineConfig({
 
     // eslint-plugin-stylistic
     './tests/eslint-plugin-stylistic/rules/array-bracket-spacing.test.ts',
+    './tests/eslint-plugin-stylistic/rules/arrow-parens.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/arrow-parens.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/arrow-parens.test.ts
@@ -1,0 +1,374 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('arrow-parens', null as never, {
+  valid: [
+    // "always" (by default)
+    { code: '() => {}' },
+    { code: '(a) => {}' },
+    { code: '(a) => a' },
+    { code: '(a) => {\n}' },
+    { code: 'a.then((foo) => {});' },
+    { code: 'a.then((foo) => { if (true) {}; });' },
+    { code: 'const f = (/* */a) => a + a;' },
+    { code: 'const f = (a/** */) => a + a;' },
+    { code: 'const f = (a//\n) => a + a;' },
+    { code: 'const f = (//\na) => a + a;' },
+    { code: 'const f = (/*\n */a//\n) => a + a;' },
+    { code: 'const f = (/** @type {number} */a/**hello*/) => a + a;' },
+    { code: 'a.then(async (foo) => { if (true) {}; });' },
+
+    // "always" (explicit)
+    { code: '() => {}', options: ['always'] },
+    { code: '(a) => {}', options: ['always'] },
+    { code: '(a) => a', options: ['always'] },
+    { code: 'a.then((foo) => {});', options: ['always'] },
+    { code: 'a.then((foo) => { if (true) {}; });', options: ['always'] },
+    { code: 'a.then(async (foo) => { if (true) {}; });', options: ['always'] },
+
+    // "as-needed"
+    { code: '() => {}', options: ['as-needed'] },
+    { code: 'a => {}', options: ['as-needed'] },
+    { code: 'a => a', options: ['as-needed'] },
+    { code: 'a => (a)', options: ['as-needed'] },
+    { code: '(a => a)', options: ['as-needed'] },
+    { code: '((a => a))', options: ['as-needed'] },
+    { code: '([a, b]) => {}', options: ['as-needed'] },
+    { code: '({ a, b }) => {}', options: ['as-needed'] },
+    { code: '(a = 10) => {}', options: ['as-needed'] },
+    { code: '(...a) => a[0]', options: ['as-needed'] },
+    { code: '(a, b) => {}', options: ['as-needed'] },
+    { code: 'async a => a', options: ['as-needed'] },
+    { code: 'async ([a, b]) => {}', options: ['as-needed'] },
+    { code: 'async (a, b) => {}', options: ['as-needed'] },
+
+    // "as-needed", { requireForBlockBody: true }
+    { code: '() => {}', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: 'a => a', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: 'a => (a)', options: ['as-needed', { requireForBlockBody: true }] },
+    { code: '(a => a)', options: ['as-needed', { requireForBlockBody: true }] },
+    {
+      code: '([a, b]) => {}',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: '([a, b]) => a',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: '({ a, b }) => {}',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: '(a = 10) => {}',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: '(...a) => a[0]',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: '(a, b) => {}',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: 'a => ({})',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: 'async a => ({})',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+    {
+      code: 'async a => a',
+      options: ['as-needed', { requireForBlockBody: true }],
+    },
+
+    // comments inside parens keep them under as-needed
+    {
+      code: 'const f = (/** @type {number} */a/**hello*/) => a + a;',
+      options: ['as-needed'],
+    },
+    { code: 'const f = (/* */a) => a + a;', options: ['as-needed'] },
+    { code: 'const f = (a/** */) => a + a;', options: ['as-needed'] },
+    { code: 'const f = (a//\n) => a + a;', options: ['as-needed'] },
+    { code: 'const f = (//\na) => a + a;', options: ['as-needed'] },
+    { code: 'const f = (/*\n */a//\n) => a + a;', options: ['as-needed'] },
+    { code: 'var foo = (a,/**/) => b;', options: ['as-needed'] },
+    { code: 'var foo = (a , /**/) => b;', options: ['as-needed'] },
+    { code: 'var foo = (a\n,\n/**/) => b;', options: ['as-needed'] },
+    { code: 'var foo = (a,//\n) => b;', options: ['as-needed'] },
+    { code: 'const i = (a/**/,) => a + a;', options: ['as-needed'] },
+    { code: 'const i = (a \n /**/,) => a + a;', options: ['as-needed'] },
+    { code: 'var bar = ({/*comment here*/a}) => a', options: ['as-needed'] },
+    { code: 'var bar = (/*comment here*/{a}) => a', options: ['as-needed'] },
+
+    // generics — use .ts (not the default .tsx) so `<T>` is parsed as type
+    // parameters rather than JSX
+    { code: '<T>(a) => b', options: ['always'], filename: 'src/virtual.ts' },
+    { code: '<T>(a) => b', options: ['as-needed'], filename: 'src/virtual.ts' },
+    {
+      code: '<T>(a) => b',
+      options: ['as-needed', { requireForBlockBody: true }],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'async <T>(a) => b',
+      options: ['always'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'async <T>(a) => b',
+      options: ['as-needed'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'async <T>(a) => b',
+      options: ['as-needed', { requireForBlockBody: true }],
+      filename: 'src/virtual.ts',
+    },
+    { code: '<T>() => b', options: ['always'], filename: 'src/virtual.ts' },
+    { code: '<T>() => b', options: ['as-needed'], filename: 'src/virtual.ts' },
+    {
+      code: '<T>() => b',
+      options: ['as-needed', { requireForBlockBody: true }],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: '<T extends A>(a) => b',
+      options: ['always'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: '<T extends A>(a) => b',
+      options: ['as-needed'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: '<T extends A>(a) => b',
+      options: ['as-needed', { requireForBlockBody: true }],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: '<T extends (A | B) & C>(a) => b',
+      options: ['always'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: '<T extends (A | B) & C>(a) => b',
+      options: ['as-needed'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: '<T extends (A | B) & C>(a) => b',
+      options: ['as-needed', { requireForBlockBody: true }],
+      filename: 'src/virtual.ts',
+    },
+  ],
+  invalid: [
+    // "always" (by default)
+    {
+      code: 'a => {}',
+      errors: [
+        { messageId: 'expectedParens', line: 1, column: 1, endColumn: 2 },
+      ],
+    },
+    {
+      code: 'a => a',
+      errors: [
+        { messageId: 'expectedParens', line: 1, column: 1, endColumn: 2 },
+      ],
+    },
+    {
+      code: 'a => {\n}',
+      errors: [
+        { messageId: 'expectedParens', line: 1, column: 1, endColumn: 2 },
+      ],
+    },
+    {
+      code: 'a.then(foo => {});',
+      errors: [
+        { messageId: 'expectedParens', line: 1, column: 8, endColumn: 11 },
+      ],
+    },
+    {
+      code: 'a.then(foo => a);',
+      errors: [
+        { messageId: 'expectedParens', line: 1, column: 8, endColumn: 11 },
+      ],
+    },
+    {
+      code: 'a(foo => { if (true) {}; });',
+      errors: [
+        { messageId: 'expectedParens', line: 1, column: 3, endColumn: 6 },
+      ],
+    },
+    {
+      code: 'a(async foo => { if (true) {}; });',
+      errors: [
+        { messageId: 'expectedParens', line: 1, column: 9, endColumn: 12 },
+      ],
+    },
+
+    // "as-needed"
+    {
+      code: '(a) => a',
+      options: ['as-needed'],
+      errors: [
+        { messageId: 'unexpectedParens', line: 1, column: 2, endColumn: 3 },
+      ],
+    },
+    {
+      code: '(  a  ) => b',
+      options: ['as-needed'],
+      errors: [
+        { messageId: 'unexpectedParens', line: 1, column: 4, endColumn: 5 },
+      ],
+    },
+    {
+      code: '(\na\n) => b',
+      options: ['as-needed'],
+      errors: [
+        { messageId: 'unexpectedParens', line: 2, column: 1, endColumn: 2 },
+      ],
+    },
+    {
+      code: '(a,) => a',
+      options: ['as-needed'],
+      errors: [
+        { messageId: 'unexpectedParens', line: 1, column: 2, endColumn: 3 },
+      ],
+    },
+    {
+      code: 'async (a) => a',
+      options: ['as-needed'],
+      errors: [
+        { messageId: 'unexpectedParens', line: 1, column: 8, endColumn: 9 },
+      ],
+    },
+    {
+      code: 'async(a) => a',
+      options: ['as-needed'],
+      errors: [
+        { messageId: 'unexpectedParens', line: 1, column: 7, endColumn: 8 },
+      ],
+    },
+    {
+      code: 'typeof((a) => {})',
+      options: ['as-needed'],
+      errors: [
+        { messageId: 'unexpectedParens', line: 1, column: 9, endColumn: 10 },
+      ],
+    },
+    {
+      code: 'function *f() { yield(a) => a; }',
+      options: ['as-needed'],
+      errors: [
+        { messageId: 'unexpectedParens', line: 1, column: 23, endColumn: 24 },
+      ],
+    },
+
+    // "as-needed", { requireForBlockBody: true }
+    {
+      code: 'a => {}',
+      options: ['as-needed', { requireForBlockBody: true }],
+      errors: [
+        { messageId: 'expectedParensBlock', line: 1, column: 1, endColumn: 2 },
+      ],
+    },
+    {
+      code: '(a) => a',
+      options: ['as-needed', { requireForBlockBody: true }],
+      errors: [
+        {
+          messageId: 'unexpectedParensInline',
+          line: 1,
+          column: 2,
+          endColumn: 3,
+        },
+      ],
+    },
+    {
+      code: 'async a => {}',
+      options: ['as-needed', { requireForBlockBody: true }],
+      errors: [
+        { messageId: 'expectedParensBlock', line: 1, column: 7, endColumn: 8 },
+      ],
+    },
+    {
+      code: 'async (a) => a',
+      options: ['as-needed', { requireForBlockBody: true }],
+      errors: [
+        {
+          messageId: 'unexpectedParensInline',
+          line: 1,
+          column: 8,
+          endColumn: 9,
+        },
+      ],
+    },
+    {
+      code: 'async(a) => a',
+      options: ['as-needed', { requireForBlockBody: true }],
+      errors: [
+        {
+          messageId: 'unexpectedParensInline',
+          line: 1,
+          column: 7,
+          endColumn: 8,
+        },
+      ],
+    },
+    {
+      code: 'const f = /** @type {number} */(a)/**hello*/ => a + a;',
+      options: ['as-needed'],
+      errors: [
+        {
+          messageId: 'unexpectedParens',
+          line: 1,
+          column: 33,
+          endLine: 1,
+          endColumn: 34,
+        },
+      ],
+    },
+    {
+      code: 'const f = //\n(a) => a + a;',
+      options: ['as-needed'],
+      errors: [
+        {
+          messageId: 'unexpectedParens',
+          line: 2,
+          column: 2,
+          endLine: 2,
+          endColumn: 3,
+        },
+      ],
+    },
+    {
+      code: 'var foo = /**/ a => b;',
+      errors: [
+        {
+          messageId: 'expectedParens',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+    },
+    {
+      code: 'var bar = a /**/ =>  b;',
+      errors: [
+        {
+          messageId: 'expectedParens',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 12,
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -333,6 +333,7 @@ relinting
 relints
 renderable
 Reparsed
+reparser
 reqs
 rethrowing
 rivo


### PR DESCRIPTION
## Summary

Port the [`@stylistic/arrow-parens`](https://eslint.style/rules/arrow-parens) rule from `@stylistic/eslint-plugin` to rslint. The rule enforces consistent parentheses around arrow function arguments — `'always'` (default) requires parens for every single-parameter arrow; `'as-needed'` removes parens when the parameter is a plain identifier without annotation/default/optional/rest; `{ requireForBlockBody: true }` (with `'as-needed'`) reverses the requirement when the body is a block.

Implementation highlights:

- Detects parens via the tsgo parser invariant `arrowFn.Parameters.Pos() - 1 == '('` (rejects outer-call `(` with `parenPos >= node.Pos()`).
- Uses `scanner.ScanTokenAtPosition` / `GetRangeOfTokenAtPosition` for closing-`)` location (handles trailing comma, Unicode whitespace).
- Uses `scanner.IsIdentifierPart` for the token-fusion guard (Unicode-aware equivalent of upstream's `canTokensBeAdjacent`).
- Locked-in branches: every as-needed guard (`Identifier` / `!optional` / `!type` / `!returnType` / `!comments` / `!generics`), plus tsgo-specific `FullSignature` (JSDoc `@type`), curried arrows, multi-line trailing commas, async + generics combos.

Verification: 247 Go tests pass (upstream-mirror + extras with Dimension 4 walk + branch lock-ins + real-user shapes anchored to `eslint-stylistic#498`, `eslint#12570`, `eslint#8834`). JS suite mirrors the upstream Layer-1 set and passes. Differential validation against rsbuild + rspack on `'as-needed'` mode produced 1083 reports, every one verified position-accurate with zero false positives or false negatives in the scanned-file set.

## Related Links

- [@stylistic/arrow-parens](https://eslint.style/rules/arrow-parens)
- Upstream source: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/arrow-parens/arrow-parens.ts

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).