### PR TITLE
feat: port rule @stylistic/block-spacing

### DIFF
--- a/internal/plugins/react/rules/jsx_curly_spacing/jsx_curly_spacing.go
+++ b/internal/plugins/react/rules/jsx_curly_spacing/jsx_curly_spacing.go
@@ -2,6 +2,7 @@ package jsx_curly_spacing
 
 import (
 	"regexp"
+	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
@@ -245,27 +246,27 @@ func scanBraceBody(text string, low, high int) bodyScan {
 	}
 
 	// secondPos: skip leading whitespace only.
-	p := low
-	for p < high && isWhitespaceByte(text[p]) {
-		p++
-	}
-	res.secondPos = p
+	res.secondPos = utils.SkipLeadingWhitespace(text, low, high)
 
 	// penultimateEnd: skip trailing whitespace only.
-	p = high
-	for p > low && isWhitespaceByte(text[p-1]) {
-		p--
-	}
-	res.penultimateEnd = p
+	res.penultimateEnd = utils.SkipTrailingWhitespace(text, low, high)
 
 	// nextRealStart: skip whitespace + leading-edge comments. The leading
 	// edge cannot contain string/template literals (those would BE the
 	// first token), so naive byte-level comment scanning is sufficient.
-	p = low
+	p := low
 	for p < high {
-		if isWhitespaceByte(text[p]) {
-			p++
-			continue
+		if text[p] < 0x80 {
+			if utils.IsTriviaWhitespaceByte(text[p]) {
+				p++
+				continue
+			}
+		} else {
+			r, size := utf8.DecodeRuneInString(text[p:])
+			if size > 0 && r != utf8.RuneError && utils.IsTriviaWhitespaceRune(r) {
+				p += size
+				continue
+			}
 		}
 		if p+1 < high && text[p] == '/' && text[p+1] == '*' {
 			p += 2
@@ -298,9 +299,17 @@ func scanBraceBody(text string, low, high int) bodyScan {
 	// text. Aligned with upstream ESLint, which has the same gap.
 	p = high
 	for p > low {
-		if isWhitespaceByte(text[p-1]) {
-			p--
-			continue
+		if text[p-1] < 0x80 {
+			if utils.IsTriviaWhitespaceByte(text[p-1]) {
+				p--
+				continue
+			}
+		} else {
+			r, size := utf8.DecodeLastRuneInString(text[:p])
+			if size > 0 && r != utf8.RuneError && utils.IsTriviaWhitespaceRune(r) {
+				p -= size
+				continue
+			}
 		}
 		if p-2 >= low && text[p-2] == '*' && text[p-1] == '/' {
 			p -= 2
@@ -319,29 +328,6 @@ func scanBraceBody(text string, low, high int) bodyScan {
 	res.prevRealEnd = p
 
 	return res
-}
-
-func isWhitespaceByte(b byte) bool {
-	switch b {
-	case ' ', '\t', '\n', '\r', '\f', '\v':
-		return true
-	}
-	return false
-}
-
-func containsNewline(text string, from, to int) bool {
-	if from < 0 {
-		from = 0
-	}
-	if to > len(text) {
-		to = len(text)
-	}
-	for i := from; i < to; i++ {
-		if text[i] == '\n' || text[i] == '\r' {
-			return true
-		}
-	}
-	return false
 }
 
 var (
@@ -451,8 +437,8 @@ var JsxCurlySpacingRule = rule.Rule{
 
 			hasSpaceAfterOpen := scan.secondPos > innerLow
 			hasSpaceBeforeClose := scan.penultimateEnd < innerHigh
-			multilineAfterOpen := containsNewline(text, innerLow, scan.secondPos)
-			multilineBeforeClose := containsNewline(text, scan.penultimateEnd, innerHigh)
+			multilineAfterOpen := utils.ContainsLineTerminator(text, innerLow, scan.secondPos)
+			multilineBeforeClose := utils.ContainsLineTerminator(text, scan.penultimateEnd, innerHigh)
 
 			reportNoBeginningSpace := func() {
 				toLoc := scan.nextRealStart

--- a/internal/plugins/react/rules/jsx_curly_spacing/jsx_curly_spacing_test.go
+++ b/internal/plugins/react/rules/jsx_curly_spacing/jsx_curly_spacing_test.go
@@ -425,6 +425,17 @@ func TestJsxCurlySpacingRule(t *testing.T) {
 		// `always` mode with surrounding spaces and non-ASCII content — valid.
 		{Code: `<App foo={ 中文 } />`, Tsx: true, Options: []interface{}{"always"}},
 		{Code: `<App foo={ "🚀" } />`, Tsx: true, Options: []interface{}{"always"}},
+
+		// ===== Unicode WhiteSpace + LineTerminator (ECMAScript §12.2/§12.3) =====
+		// NBSP (U+00A0) counts as ECMAScript WhiteSpace → satisfies `always`,
+		// triggers `never` extra. Parity with ESLint verified via local probe.
+		{Code: "<App foo={\u00A0bar\u00A0} />", Tsx: true, Options: []interface{}{"always"}},
+		// LS (U+2028) / PS (U+2029) count as LineTerminator → cross-line
+		// short-circuit on that side. Both modes valid when the OTHER side
+		// hugs the brace.
+		{Code: "<App foo={bar\u2028} />", Tsx: true, Options: []interface{}{"never"}},
+		{Code: "<App foo={\u2028bar} />", Tsx: true, Options: []interface{}{"never"}},
+		{Code: "<App foo={bar\u2029} />", Tsx: true, Options: []interface{}{"never"}},
 		// Template literal with `${ … }` substitutions — earlier impl using
 		// the bare tsgo Scanner without parser context mis-tokenized the
 		// closing `}` of a substitution as a real `}` token, corrupting

--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/array_bracket_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/arrow_parens"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/arrow_spacing"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/block_spacing"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -12,5 +13,6 @@ func GetAllRules() []rule.Rule {
 		array_bracket_spacing.ArrayBracketSpacingRule,
 		arrow_parens.ArrowParensRule,
 		arrow_spacing.ArrowSpacingRule,
+		block_spacing.BlockSpacingRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing.go
+++ b/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing.go
@@ -1,7 +1,7 @@
 package array_bracket_spacing
 
 import (
-	"strings"
+	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
@@ -90,14 +90,6 @@ func isArrayType(node *ast.Node) bool {
 	return node.Kind == ast.KindArrayLiteralExpression || node.Kind == ast.KindArrayBindingPattern
 }
 
-func isWhitespaceByte(b byte) bool {
-	switch b {
-	case ' ', '\t', '\n', '\r', '\f', '\v':
-		return true
-	}
-	return false
-}
-
 // nextRealStart returns the position of the first non-trivia character at or
 // after `low`. Delegates to tsgo's scanner.SkipTrivia so we get UTF-8-safe
 // handling of every trivia form the parser itself recognizes (whitespace,
@@ -137,35 +129,38 @@ func nextRealStart(text string, low, high int) int {
 func prevRealEnd(text string, low, high int) int {
 	p := high
 	for p > low {
-		if isWhitespaceByte(text[p-1]) {
-			p--
-			continue
-		}
-		if p-2 >= low && text[p-2] == '*' && text[p-1] == '/' {
-			p -= 2
-			for p-2 >= low && (text[p-2] != '/' || text[p-1] != '*') {
+		// Fast path: ASCII trivia whitespace.
+		if text[p-1] < 0x80 {
+			if utils.IsTriviaWhitespaceByte(text[p-1]) {
 				p--
+				continue
 			}
-			if p-2 >= low {
+			// Block comment terminator `*/` — reverse-scan to the matching
+			// `/*` and continue. See function docstring for why this is
+			// safe here (callers guarantee the scan range is pure trivia).
+			if p-2 >= low && text[p-2] == '*' && text[p-1] == '/' {
 				p -= 2
-			} else {
-				p = low
+				for p-2 >= low && (text[p-2] != '/' || text[p-1] != '*') {
+					p--
+				}
+				if p-2 >= low {
+					p -= 2
+				} else {
+					p = low
+				}
+				continue
 			}
-			continue
+			break
 		}
-		break
+		// Slow path: non-ASCII rune — decode and dispatch to the
+		// Unicode-aware whitespace table (NBSP, IDEO, LS, PS, BOM, …).
+		r, size := utf8.DecodeLastRuneInString(text[:p])
+		if size == 0 || r == utf8.RuneError || !utils.IsTriviaWhitespaceRune(r) {
+			break
+		}
+		p -= size
 	}
 	return p
-}
-
-func containsNewline(text string, from, to int) bool {
-	if from < 0 {
-		from = 0
-	}
-	if to > len(text) {
-		to = len(text)
-	}
-	return strings.ContainsAny(text[from:to], "\n\r")
 }
 
 func elementsOf(node *ast.Node) []*ast.Node {
@@ -295,7 +290,7 @@ var ArrayBracketSpacingRule = rule.Rule{
 				secondStart = nextRealStart(text, innerLow, innerHigh)
 			}
 			hasSpaceAfterOpen := secondStart > innerLow
-			if containsNewline(text, innerLow, secondStart) {
+			if utils.ContainsLineTerminator(text, innerLow, secondStart) {
 				return
 			}
 
@@ -367,7 +362,7 @@ var ArrayBracketSpacingRule = rule.Rule{
 
 			penultimateEnd := prevRealEnd(text, scanLow, innerHigh)
 			hasSpaceBeforeClose := penultimateEnd < innerHigh
-			if containsNewline(text, penultimateEnd, innerHigh) {
+			if utils.ContainsLineTerminator(text, penultimateEnd, innerHigh) {
 				return
 			}
 

--- a/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing_extras_test.go
+++ b/internal/plugins/stylistic/rules/array_bracket_spacing/array_bracket_spacing_extras_test.go
@@ -305,6 +305,21 @@ func TestArrayBracketSpacingExtras(t *testing.T) {
 			// `=== !spaced` reference-equality check).
 			{Code: `var arr = [1];`, Options: []interface{}{"never", map[string]interface{}{"singleValue": "true"}}},
 			{Code: `var arr = [1];`, Options: []interface{}{"never", map[string]interface{}{"singleValue": 1}}},
+
+			// ---- Unicode WhiteSpace + LineTerminator (ECMAScript §12.2/§12.3) ----
+			// Parity with @stylistic/eslint-plugin's array-bracket-spacing
+			// (verified via local ESLint probe). NBSP / IDEO / ZWNBSP count
+			// as space → satisfy `always` mode; LS / PS count as line
+			// terminator → cross-line short-circuit (both modes valid).
+			// `always` with NBSP / IDEO / BOM inside brackets — valid.
+			{Code: "[\u00A0foo\u00A0]", Options: []interface{}{"always"}},
+			{Code: "[\u3000foo\u3000]", Options: []interface{}{"always"}},
+			{Code: "[\uFEFFfoo\uFEFF]", Options: []interface{}{"always"}},
+			// `never` + LS / PS one-side → that side cross-line; opposite
+			// side hugs the bracket so both sides valid.
+			{Code: "[foo\u2028]", Options: []interface{}{"never"}},
+			{Code: "[\u2028foo]", Options: []interface{}{"never"}},
+			{Code: "[foo\u2029]", Options: []interface{}{"never"}},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Locks in upstream validateArraySpacing() arm:

--- a/internal/plugins/stylistic/rules/arrow_spacing/arrow_spacing.go
+++ b/internal/plugins/stylistic/rules/arrow_spacing/arrow_spacing.go
@@ -44,56 +44,6 @@ func parseOptions(raw any) options {
 	return opts
 }
 
-func isWhitespaceByte(b byte) bool {
-	switch b {
-	case ' ', '\t', '\n', '\r', '\f', '\v':
-		return true
-	}
-	return false
-}
-
-// isWhitespaceRune handles the non-ASCII subset of ECMAScript's `\s` —
-// callers (`findBeforeToken` / `findAfterToken`) check ASCII bytes through
-// `isWhitespaceByte` on the fast path, so this function only sees runes
-// ≥ U+0080. The set is exactly:
-//
-//   - `WhiteSpace` (spec §12.2): U+00A0 NBSP, U+FEFF ZWNBSP, plus Unicode
-//     `Space_Separator` (Zs) — U+1680, U+2000-U+200A, U+202F, U+205F, U+3000.
-//   - `LineTerminator` (spec §12.3): U+2028 LS, U+2029 PS.
-//
-// Deliberately excluded — they are NOT matched by JS `\s` (verified
-// empirically against V8 with `/\s/.test('')` / `'​'`):
-//
-//   - U+0085 Next Line: in Unicode `\p{White_Space}` but NOT in ES
-//     `WhiteSpace` (only Zs and a specific allow-list count).
-//   - U+200B Zero Width Space: category Cf (Format), not Zs; tsgo's scanner
-//     treats it as whitespace internally, but that's a TypeScript-compiler
-//     quirk, not the ESLint behavior we mirror.
-func isWhitespaceRune(r rune) bool {
-	switch r {
-	case 0x00A0, // <No-Break Space>
-		0x1680, // <Ogham Space Mark>
-		0x2000, // <En Quad>
-		0x2001, // <Em Quad>
-		0x2002, // <En Space>
-		0x2003, // <Em Space>
-		0x2004, // <Three-Per-Em Space>
-		0x2005, // <Four-Per-Em Space>
-		0x2006, // <Six-Per-Em Space>
-		0x2007, // <Figure Space>
-		0x2008, // <Punctuation Space>
-		0x2009, // <Thin Space>
-		0x200A, // <Hair Space>
-		0x2028, // <Line Separator>
-		0x2029, // <Paragraph Separator>
-		0x202F, // <Narrow No-Break Space>
-		0x205F, // <Medium Mathematical Space>
-		0x3000, // <Ideographic Space>
-		0xFEFF: // <Byte Order Mark / Zero Width No-Break Space>
-		return true
-	}
-	return false
-}
 
 // findBeforeToken walks left from `arrowStart` through whitespace, then
 // locates the start of the previous token-or-comment. Returns the token range
@@ -130,14 +80,14 @@ func findBeforeToken(text string, arrowStart int) (beforeStart, beforeEnd int, i
 		// rune to catch Unicode whitespace (NBSP, ideographic space,
 		// line/paragraph separators, …) — same set ESLint's `\s` matches.
 		if text[p-1] < 0x80 {
-			if !isWhitespaceByte(text[p-1]) {
+			if !utils.IsTriviaWhitespaceByte(text[p-1]) {
 				break
 			}
 			p--
 			continue
 		}
 		r, size := utf8.DecodeLastRuneInString(text[:p])
-		if size == 0 || r == utf8.RuneError || !isWhitespaceRune(r) {
+		if size == 0 || r == utf8.RuneError || !utils.IsTriviaWhitespaceRune(r) {
 			break
 		}
 		p -= size
@@ -185,14 +135,14 @@ func findAfterToken(text string, arrowEnd int) (afterStart, afterEnd int, isSpac
 	p := arrowEnd
 	for p < len(text) {
 		if text[p] < 0x80 {
-			if !isWhitespaceByte(text[p]) {
+			if !utils.IsTriviaWhitespaceByte(text[p]) {
 				break
 			}
 			p++
 			continue
 		}
 		r, size := utf8.DecodeRuneInString(text[p:])
-		if size == 0 || r == utf8.RuneError || !isWhitespaceRune(r) {
+		if size == 0 || r == utf8.RuneError || !utils.IsTriviaWhitespaceRune(r) {
 			break
 		}
 		p += size

--- a/internal/plugins/stylistic/rules/block_spacing/block_spacing.go
+++ b/internal/plugins/stylistic/rules/block_spacing/block_spacing.go
@@ -1,0 +1,228 @@
+package block_spacing
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	spacingAlways = "always"
+	spacingNever  = "never"
+)
+
+// parseOptions mirrors upstream's single-string schema:
+//
+//	rule: ['block-spacing']              → always (default)
+//	rule: ['block-spacing', 'always']    → always
+//	rule: ['block-spacing', 'never']     → never
+//
+// rslint's config loader collapses a single trailing option element into the
+// option directly, so accept either a string or a one-string array.
+func parseOptions(raw any) bool {
+	switch v := raw.(type) {
+	case []interface{}:
+		if len(v) > 0 {
+			if s, ok := v[0].(string); ok && s == spacingNever {
+				return false
+			}
+		}
+	case string:
+		if v == spacingNever {
+			return false
+		}
+	}
+	return true
+}
+
+// nextTokenStart walks forward from `low` skipping ASCII + Unicode whitespace
+// and line terminators, stopping at the first non-trivia byte OR at the start
+// of a comment. This matches ESLint's
+// `sourceCode.getTokenAfter(openBrace, { includeComments: true })` semantics:
+// comments count as the next token. Delegates to tsgo's `SkipTriviaEx` with
+// `StopAtComments: true` so Unicode whitespace forms (e.g. ` `, ` `)
+// are handled identically to the parser. Clamps at `high` so an unterminated
+// `{ … ` defensively returns `high` rather than scanning past the brace.
+func nextTokenStart(text string, low, high int) int {
+	p := scanner.SkipTriviaEx(text, low, &scanner.SkipTriviaOptions{StopAtComments: true})
+	if p > high {
+		return high
+	}
+	return p
+}
+
+// resolveBraces returns the byte positions of the `{` and `}` that bound a
+// Block / CaseBlock node. Returns ok=false when the trimmed source range
+// doesn't actually start/end with braces (defensive — parser recovery on
+// malformed input).
+func resolveBraces(text string, sf *ast.SourceFile, node *ast.Node) (openPos, closePos int, ok bool) {
+	trimmed := utils.TrimNodeTextRange(sf, node)
+	start := trimmed.Pos()
+	end := trimmed.End()
+	if start >= end || end > len(text) {
+		return 0, 0, false
+	}
+	if text[start] != '{' || text[end-1] != '}' {
+		return 0, 0, false
+	}
+	return start, end - 1, true
+}
+
+// BlockSpacingRule enforces consistent spacing inside open/close block tokens
+// when they sit on the same line as their adjacent content token. Ported from
+// @stylistic/eslint-plugin's block-spacing.
+//
+// In the upstream ESTree rule three listeners are registered — BlockStatement,
+// StaticBlock, SwitchStatement — and each one filters its first/last brace
+// out of the wrapping node. In tsgo the same surface is reached more
+// directly:
+//
+//   - `ast.KindBlock` covers every BlockStatement, every function / arrow /
+//     method body, AND the body of a ClassStaticBlockDeclaration (which is
+//     itself an `*ast.BlockNode` field, visited as a regular Block child).
+//   - `ast.KindCaseBlock` is the `{ case … }` wrapper inside a SwitchStatement.
+//     Listening on it directly avoids the upstream pattern of skipping over
+//     `switch (e)` to find the first `{`.
+//
+// Both kinds have their `{` at `trimmed.Pos()` and their `}` at
+// `trimmed.End()-1`, so the brace locations come straight out of
+// `utils.TrimNodeTextRange`.
+var BlockSpacingRule = rule.Rule{
+	Name: "@stylistic/block-spacing",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		always := parseOptions(rawOptions)
+		text := ctx.SourceFile.Text()
+
+		// Opening-side check runs on listener enter; closing-side runs on
+		// exit. For nested blocks this interleaves the reports into source
+		// order (outer-open → inner-open → inner-close → outer-close),
+		// matching how ESLint sorts diagnostics by location and how
+		// array_bracket_spacing.go solves the same problem.
+		enter := func(node *ast.Node) {
+			openPos, closePos, ok := resolveBraces(text, ctx.SourceFile, node)
+			if !ok {
+				return
+			}
+			innerLow := openPos + 1
+			innerHigh := closePos
+
+			firstTokenStart := nextTokenStart(text, innerLow, innerHigh)
+			// Empty block (only whitespace between the braces) — upstream
+			// short-circuits via `firstToken === closeBrace`.
+			if firstTokenStart >= innerHigh {
+				return
+			}
+
+			// Only fire when `{` and the first content token are on the
+			// same line — upstream's `isTokenOnSameLine(openBrace,
+			// firstToken)` short-circuit.
+			if utils.ContainsLineTerminator(text, innerLow, firstTokenStart) {
+				return
+			}
+
+			// `never` + line-comment-starts-immediately-after-`{` is a
+			// dedicated upstream exemption: deleting the leading space
+			// before a `//` comment would fuse the comment into the
+			// `{`-line and silently change layout, so upstream skips the
+			// opening check in this exact shape. We mirror it by peeking
+			// at the next two bytes of the comment-bearing token.
+			if !always &&
+				firstTokenStart+1 < innerHigh &&
+				text[firstTokenStart] == '/' &&
+				text[firstTokenStart+1] == '/' {
+				return
+			}
+
+			hasSpace := firstTokenStart > innerLow
+			switch {
+			case always && !hasSpace:
+				ctx.ReportRangeWithFixes(
+					core.NewTextRange(openPos, openPos+1),
+					rule.RuleMessage{
+						Id:          "missing",
+						Description: "Requires a space after '{'.",
+						Data:        map[string]string{"location": "after", "token": "{"},
+					},
+					rule.RuleFix{
+						Text:  " ",
+						Range: core.NewTextRange(firstTokenStart, firstTokenStart),
+					},
+				)
+			case !always && hasSpace:
+				ctx.ReportRangeWithFixes(
+					core.NewTextRange(innerLow, firstTokenStart),
+					rule.RuleMessage{
+						Id:          "extra",
+						Description: "Unexpected space(s) after '{'.",
+						Data:        map[string]string{"location": "after", "token": "{"},
+					},
+					rule.RuleFix{
+						Text:  "",
+						Range: core.NewTextRange(innerLow, firstTokenStart),
+					},
+				)
+			}
+		}
+
+		exit := func(node *ast.Node) {
+			openPos, closePos, ok := resolveBraces(text, ctx.SourceFile, node)
+			if !ok {
+				return
+			}
+			innerLow := openPos + 1
+			innerHigh := closePos
+
+			firstTokenStart := nextTokenStart(text, innerLow, innerHigh)
+			// Empty block: nothing to check on the closing side either —
+			// upstream's `firstToken === closeBrace` subsumes the close
+			// check.
+			if firstTokenStart >= innerHigh {
+				return
+			}
+			lastTokenEnd := utils.SkipTrailingWhitespace(text, innerLow, innerHigh)
+
+			if utils.ContainsLineTerminator(text, lastTokenEnd, innerHigh) {
+				return
+			}
+
+			hasSpace := lastTokenEnd < innerHigh
+			switch {
+			case always && !hasSpace:
+				ctx.ReportRangeWithFixes(
+					core.NewTextRange(closePos, closePos+1),
+					rule.RuleMessage{
+						Id:          "missing",
+						Description: "Requires a space before '}'.",
+						Data:        map[string]string{"location": "before", "token": "}"},
+					},
+					rule.RuleFix{
+						Text:  " ",
+						Range: core.NewTextRange(lastTokenEnd, lastTokenEnd),
+					},
+				)
+			case !always && hasSpace:
+				ctx.ReportRangeWithFixes(
+					core.NewTextRange(lastTokenEnd, innerHigh),
+					rule.RuleMessage{
+						Id:          "extra",
+						Description: "Unexpected space(s) before '}'.",
+						Data:        map[string]string{"location": "before", "token": "}"},
+					},
+					rule.RuleFix{
+						Text:  "",
+						Range: core.NewTextRange(lastTokenEnd, innerHigh),
+					},
+				)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindBlock:                          enter,
+			ast.KindCaseBlock:                      enter,
+			rule.ListenerOnExit(ast.KindBlock):     exit,
+			rule.ListenerOnExit(ast.KindCaseBlock): exit,
+		}
+	},
+}

--- a/internal/plugins/stylistic/rules/block_spacing/block_spacing.md
+++ b/internal/plugins/stylistic/rules/block_spacing/block_spacing.md
@@ -1,0 +1,84 @@
+# block-spacing
+
+Disallow or enforce spaces inside of blocks after opening block and before closing block.
+
+## Rule Details
+
+This rule enforces consistent spacing inside an open block token and the next token on the same line. This rule also enforces consistent spacing inside a close block token and previous token on the same line.
+
+When the opening or closing brace and its neighboring token are on different lines, the rule does not fire — multi-line blocks are always allowed regardless of the option.
+
+The rule applies to every `{ ... }` block:
+
+- function / arrow / method / getter / setter / constructor bodies
+- `if` / `else` / `for` / `while` / `do-while` / `try` / `catch` / `finally` bodies
+- `switch` case blocks
+- class `static` blocks
+
+## Options
+
+This rule has a string option:
+
+- `"always"` (default) requires one or more spaces or newlines inside braces.
+- `"never"` disallows spaces inside braces.
+
+### always
+
+Examples of **incorrect** code for this rule with the default `"always"` option:
+
+```javascript
+function foo() {return true;}
+if (foo) { bar = 0;}
+function baz() {let i = 0;
+    return i;
+}
+class C {
+    static {this.bar = 0;}
+}
+```
+
+Examples of **correct** code for this rule with the default `"always"` option:
+
+```javascript
+function foo() { return true; }
+if (foo) { bar = 0; }
+class C {
+    static { this.bar = 0; }
+}
+```
+
+### never
+
+Examples of **incorrect** code for this rule with the `"never"` option:
+
+```json
+{ "@stylistic/block-spacing": ["error", "never"] }
+```
+
+```javascript
+function foo() { return true; }
+if (foo) { bar = 0;}
+class C {
+    static { this.bar = 0; }
+}
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```json
+{ "@stylistic/block-spacing": ["error", "never"] }
+```
+
+```javascript
+function foo() {return true;}
+if (foo) {bar = 0;}
+class C {
+    static {this.bar = 0;}
+}
+```
+
+With `"never"`, a `{` immediately followed by a `//` line comment is intentionally exempt — the closing `}` is still checked normally.
+
+## Original Documentation
+
+- [@stylistic/block-spacing](https://eslint.style/rules/block-spacing)

--- a/internal/plugins/stylistic/rules/block_spacing/block_spacing_extras_test.go
+++ b/internal/plugins/stylistic/rules/block_spacing/block_spacing_extras_test.go
@@ -1,0 +1,841 @@
+// TestBlockSpacingExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk / real-user pattern
+// it covers, so future refactors can't silently regress them without breaking
+// a named lock-in.
+//
+// Dimension 4 walk for @stylistic/block-spacing:
+//
+//   - Receiver / expression wrappers on inputs the rule inspects — N/A. The
+//     rule fires on the block / case-block node itself; outer receiver
+//     wrappers (`(arr).x`, `arr!.x`, `arr?.x`) are not in scope.
+//   - Access / key forms — N/A. The rule does not look at property accesses,
+//     computed keys, or string vs numeric literal keys.
+//   - Declaration / container forms — covered: arrow body block (paren- and
+//     brace-bodied), function declaration / function expression / method /
+//     async / generator / async-generator / class static block / getter /
+//     setter / constructor / class field arrow / namespace body / decorator-
+//     decorated method / overload-implementation pair / IIFE.
+//   - Nesting / traversal boundaries — covered: same-kind nesting up to three
+//     levels for Block-in-Block, CaseBlock-in-CaseBlock, Block-in-CaseBlock,
+//     CaseBlock-in-Block; class-static-block inside a class-static-block;
+//     switch inside a function body; back-to-back independent blocks.
+//   - Graceful degradation — covered: empty block (4 shapes), block with only
+//     a line comment, block with only a block comment, regex literal as first
+//     expression-statement, multi-byte UTF-8 identifier, mixed line endings
+//     (LF / CRLF / CR-only), comment containing `{`/`}` payload.
+//
+// Branch lock-ins enumerate the listener gates in the upstream `create`
+// function: `firstToken === closeBrace` early-return (empty), the
+// `isTokenOnSameLine` short-circuits for both braces, and the dedicated
+// `!always && firstToken.type === Line` exemption.
+//
+// Diagnostic-contract subgroup asserts the EXACT message text emitted on every
+// (mode, side) combination so future refactors can't silently flip a string.
+//
+// Listener-scope subgroup locks in which AST shapes intentionally DO NOT
+// trigger (ObjectLiteralExpression, TypeLiteralNode, InterfaceDeclaration body,
+// MappedType, EnumDeclaration body, ModuleBlock — none are KindBlock).
+package block_spacing_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/block_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestBlockSpacingExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&block_spacing.BlockSpacingRule,
+		[]rule_tester.ValidTestCase{
+			// =====================================================================
+			// Dimension 4: container forms (always)
+			// =====================================================================
+			// Arrow expression body — not a Block at all; rule never fires.
+			{Code: `const f = a => a + 1;`},
+			// Arrow with parenthesized expression body — ParenthesizedExpression,
+			// not a Block.
+			{Code: `const f = a => (a + 1);`},
+			// Arrow with object literal body (paren-wrapped) — not a Block.
+			{Code: `const f = a => ({ a });`},
+			// Single-arg arrow with brace body.
+			{Code: `const f = (a) => { return a; };`},
+			// Method shorthand body.
+			{Code: `const obj = { m() { return 1; } };`},
+			// Class method / getter / setter / constructor.
+			{Code: `class C { m() { return 1; } get x() { return this._x; } set x(v) { this._x = v; } constructor() { this._x = 0; } }`},
+			// Async / generator / async-generator function bodies.
+			{Code: `async function f() { await x; }`},
+			{Code: `function* g() { yield 1; }`},
+			{Code: `async function* h() { yield await x; }`},
+			// Class-field arrow body.
+			{Code: `class C { f = () => { return 1; }; }`},
+			// IIFE.
+			{Code: `(function () { foo(); })();`},
+			// Arrow-IIFE.
+			{Code: `(() => { foo(); })();`},
+			// Decorator-decorated method body.
+			{Code: `class C { @dec m() { return 1; } }`},
+			// Overload signatures (body-less) + implementation body.
+			{Code: `function f(a: string): void; function f(a: number): void; function f(a: any) { return a; }`},
+			// Optional method.
+			{Code: `class C { m?() { return 1; } }`},
+			// Constructor with parameter properties.
+			{Code: `class C { constructor(public x: number) { this.x = x; } }`},
+
+			// =====================================================================
+			// Dimension 4: container forms (never)
+			// =====================================================================
+			{Code: `const f = (a) => {return a;};`, Options: []interface{}{"never"}},
+			{Code: `const obj = {m() {return 1;}};`, Options: []interface{}{"never"}},
+			{Code: `class C {m() {return 1;} get x() {return this._x;}}`, Options: []interface{}{"never"}},
+			{Code: `async function f() {await x;}`, Options: []interface{}{"never"}},
+			{Code: `function* g() {yield 1;}`, Options: []interface{}{"never"}},
+			{Code: `class C {f = () => {return 1;};}`, Options: []interface{}{"never"}},
+			{Code: `(function () {foo();})();`, Options: []interface{}{"never"}},
+
+			// =====================================================================
+			// Out-of-scope kinds — must NEVER trigger (listener scope lock-in)
+			// =====================================================================
+			// Object literal `{ a: 1 }` is KindObjectLiteralExpression.
+			{Code: `const x = { a: 1 };`, Options: []interface{}{"never"}},
+			// Type literal is KindTypeLiteral.
+			{Code: `type X = {a: number};`, Options: []interface{}{"never"}},
+			// Interface body is KindInterfaceDeclaration (no Block child).
+			{Code: `interface I {a: number}`, Options: []interface{}{"never"}},
+			// Mapped type is KindMappedType.
+			{Code: `type T = { [K in 'a']: number };`, Options: []interface{}{"never"}},
+			// Enum body is KindEnumDeclaration (members are not Block).
+			{Code: `enum E {A,B,C}`, Options: []interface{}{"never"}},
+			// Namespace body is KindModuleBlock, NOT KindBlock.
+			{Code: `namespace N { export const x = 1; }`},
+			{Code: `namespace N {export const x = 1;}`, Options: []interface{}{"never"}},
+			// Class body itself is KindClassDeclaration's MemberList, not Block.
+			{Code: `class C {p = 1;}`, Options: []interface{}{"never"}},
+			// `declare class` body — same shape, no body emit either way.
+			{Code: `declare class C { p: number; m(): void; }`},
+			// Destructuring with default — object pattern is not a Block.
+			{Code: `const {a = 1} = obj;`, Options: []interface{}{"never"}},
+			// Object pattern in parameter.
+			{Code: `function f({a, b}: {a: number; b: number}) {return a + b;}`, Options: []interface{}{"never"}},
+
+			// =====================================================================
+			// Labeled statement with block body
+			// =====================================================================
+			{Code: `outer: { foo(); }`},
+			{Code: `outer: {foo();}`, Options: []interface{}{"never"}},
+			// Labeled loop with block body.
+			{Code: `outer: for (;;) { foo(); break outer; }`},
+
+			// =====================================================================
+			// Nested blocks — well-spaced under each mode
+			// =====================================================================
+			// Block-in-Block (always).
+			{Code: `function f() { if (a) { return 1; } }`},
+			// CaseBlock in function (always).
+			{Code: `function f() { switch (a) { case 1: foo(); } }`},
+			// Static block in function-scoped class (always).
+			{Code: `function f() { class C { static { foo(); } } }`},
+			// Three-level nesting (always).
+			{Code: `function f() { if (a) { if (b) { return 1; } } }`},
+			// Nested CaseBlock in CaseBlock (always).
+			{Code: `switch (a) { case 1: switch (b) { case 2: foo(); } }`},
+			// Block-in-CaseBlock (block as case clause statement).
+			{Code: `switch (a) { case 1: { foo(); break; } }`},
+			// Two back-to-back independent blocks at the same level.
+			{Code: `function f() { { foo(); } { bar(); } }`},
+			// Class with two static blocks.
+			{Code: `class C { static { foo(); } static { bar(); } }`},
+			// Class with two static blocks (never).
+			{Code: `class C {static {foo();} static {bar();}}`, Options: []interface{}{"never"}},
+
+			// =====================================================================
+			// isValid() arm: cross-line both braces
+			// =====================================================================
+			{Code: "if (a) {\n  foo();\n}"},
+			{Code: "if (a) {\n  foo();\n}", Options: []interface{}{"never"}},
+			// CRLF version.
+			{Code: "if (a) {\r\n  foo();\r\n}"},
+			{Code: "if (a) {\r\n  foo();\r\n}", Options: []interface{}{"never"}},
+
+			// =====================================================================
+			// isValid() arm: only-opening / only-closing cross-line
+			// =====================================================================
+			{Code: "{\n  foo(); }"},
+			{Code: "{ foo();\n}"},
+			{Code: "{\n  foo();}", Options: []interface{}{"never"}},
+			{Code: "{foo();\n}", Options: []interface{}{"never"}},
+
+			// =====================================================================
+			// firstToken === closeBrace short-circuit (empty block, all shapes)
+			// =====================================================================
+			{Code: `function f() {}`},
+			{Code: `function f() {}`, Options: []interface{}{"never"}},
+			{Code: `class C { static {} }`},
+			{Code: `class C { static {} }`, Options: []interface{}{"never"}},
+			{Code: `switch (a) {}`},
+			{Code: `switch (a) {}`, Options: []interface{}{"never"}},
+			{Code: `if (a) {}`},
+			{Code: `if (a) {}`, Options: []interface{}{"never"}},
+			// Block with ONLY whitespace inside.
+			{Code: `function f() {   }`, Options: []interface{}{"never"}},
+			{Code: "function f() {   \n   }", Options: []interface{}{"never"}},
+			{Code: `function f() {   }`},
+			// Try with empty bodies.
+			{Code: `try {} catch (e) {}`},
+			{Code: `try {} catch (e) {}`, Options: []interface{}{"never"}},
+			// Empty arrow body.
+			{Code: `const f = () => {};`},
+			{Code: `const f = () => {};`, Options: []interface{}{"never"}},
+
+			// =====================================================================
+			// !always && firstToken.type === Line exemption (never only)
+			// =====================================================================
+			{Code: "{ //c\n}", Options: []interface{}{"never"}},
+			{Code: "{    //c\n}", Options: []interface{}{"never"}},
+			// Same exemption for arrow body.
+			{Code: "const f = () => { //c\nreturn 1;\n};", Options: []interface{}{"never"}},
+			// Same for switch case block.
+			{Code: "switch (a) { //c\ncase 1: foo();\n}", Options: []interface{}{"never"}},
+
+			// =====================================================================
+			// Block / line comment in graceful-degradation positions
+			// =====================================================================
+			// Block with only a block comment — both ends NEED spaces in always.
+			{Code: `{ /* c */ }`},
+			// `{/* c */}` (never) — block comment hugs both braces.
+			{Code: `{/* c */}`, Options: []interface{}{"never"}},
+			// Block comment containing `}` payload — must not confuse byte scan.
+			{Code: `{ /* } */ }`},
+			{Code: `{/* } */}`, Options: []interface{}{"never"}},
+			// Block comment containing `{` payload.
+			{Code: `{ /* { */ }`},
+			// Multi-line block comment (cross-line short-circuit applies on
+			// the closing side because the comment text wraps a newline).
+			{Code: "{ /*\nc\n*/ }"},
+			{Code: "{/*\nc\n*/}", Options: []interface{}{"never"}},
+
+			// =====================================================================
+			// Multi-byte UTF-8 and emoji
+			// =====================================================================
+			// Identifier with non-ASCII chars.
+			{Code: `function f() { var é = 1; }`},
+			{Code: `function f() {var é = 1;}`, Options: []interface{}{"never"}},
+			// CJK characters in string literal inside block.
+			{Code: `function f() { return "你好"; }`},
+			// Emoji in template literal inside block.
+			{Code: "function f() { return `🚀`; }"},
+
+			// =====================================================================
+			// Try / catch with TS-only forms
+			// =====================================================================
+			// Try / catch without binding (ES2019).
+			{Code: `try { foo(); } catch { bar(); }`},
+			{Code: `try {foo();} catch {bar();}`, Options: []interface{}{"never"}},
+			// Try / catch with typed binding.
+			{Code: `try { foo(); } catch (e: unknown) { bar(); }`},
+
+			// =====================================================================
+			// TypeScript-specific function-shape variations
+			// =====================================================================
+			// Generic function with body.
+			{Code: `function f<T>(a: T): T { return a; }`},
+			// Generic non-arrow function (never).
+			{Code: `function id<T>(x: T): T {return x;}`, Options: []interface{}{"never"}},
+			// Arrow returning typed value.
+			{Code: `const f = (a: number): number => { return a; };`},
+			// Function with default param.
+			{Code: `function f(a = 1) { return a; }`},
+			// Function with rest params.
+			{Code: `function f(...xs: number[]) { return xs; }`},
+			// Conditional type inside function body — type literals don't trigger.
+			{Code: `function f(): number { type X = number extends number ? 1 : 0; return 1; }`},
+
+			// =====================================================================
+			// Option-input resilience — accept various option shapes
+			// =====================================================================
+			// Bare string instead of [string] (rslint config loader collapses).
+			{Code: `{foo();}`, Options: "never"},
+			{Code: `{ foo(); }`, Options: "always"},
+			// Empty options array — defaults to always.
+			{Code: `{ foo(); }`, Options: []interface{}{}},
+			// nil / no options.
+			{Code: `{ foo(); }`},
+			// Unknown string (treated as default 'always').
+			{Code: `{ foo(); }`, Options: []interface{}{"weird"}},
+
+			// =====================================================================
+			// Unicode WhiteSpace + LineTerminator (ECMAScript §12.2 / §12.3)
+			//
+			// ESLint's `isSpaceBetween` and `isTokenOnSameLine` recognize the
+			// full ECMAScript whitespace + line-terminator sets, NOT just
+			// ASCII. These cases were verified against `@stylistic/eslint-
+			// plugin` at parity:
+			//   - NBSP (U+00A0), EN/EM/IDEO Zs (Zs_Separator), ZWNBSP/BOM
+			//     (U+FEFF) → count as WhiteSpace → satisfy `always` mode and
+			//     trigger `never` mode extras.
+			//   - LS (U+2028), PS (U+2029) → count as LineTerminator →
+			//     trigger the cross-line short-circuit; both modes valid.
+			// =====================================================================
+			// always: NBSP between brace and token counts as a space → valid.
+			{Code: "{\u00A0foo;\u00A0}"},
+			// always: Ideographic Space (U+3000) — Zs class member.
+			{Code: "{\u3000foo;\u3000}"},
+			// always: En Space (U+2002).
+			{Code: "{\u2002foo;\u2002}"},
+			// always: ZWNBSP / BOM (U+FEFF).
+			{Code: "{\uFEFFfoo;\uFEFF}"},
+			// LS / PS on ONE side cause the cross-line short-circuit on
+			// that side only. So for `never` mode where the OTHER side
+			// hugs the brace, both sides are valid:
+			{Code: "{foo;\u2028}", Options: []interface{}{"never"}},
+			{Code: "{\u2028foo;}", Options: []interface{}{"never"}},
+			{Code: "{foo;\u2029}", Options: []interface{}{"never"}},
+			{Code: "{\u2029foo;}", Options: []interface{}{"never"}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// =====================================================================
+			// Diagnostic contract: exact Message text for every (mode, side)
+			// combination. Locks the user-facing strings against silent drift.
+			// =====================================================================
+			{
+				Code:   `{foo();}`,
+				Output: []string{`{ foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Message: "Requires a space after '{'.", Line: 1, Column: 1},
+					{MessageId: "missing", Message: "Requires a space before '}'.", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code:    `{ foo(); }`,
+				Output:  []string{`{foo();}`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Message: "Unexpected space(s) after '{'.", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+					{MessageId: "extra", Message: "Unexpected space(s) before '}'.", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+
+			// =====================================================================
+			// Asymmetric spacing — every (mode, opening-status, closing-status)
+			// combination so neither side over-reports nor under-reports.
+			// =====================================================================
+			// always: open OK, close not OK → only close fires.
+			{
+				Code:   `{ foo();}`,
+				Output: []string{`{ foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 9},
+				},
+			},
+			// always: open not OK, close OK → only open fires.
+			{
+				Code:   `{foo(); }`,
+				Output: []string{`{ foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+				},
+			},
+			// never: open extra, close OK → only open fires.
+			{
+				Code:    `{ foo();}`,
+				Output:  []string{`{foo();}`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+			// never: open OK, close extra → only close fires.
+			{
+				Code:    `{foo(); }`,
+				Output:  []string{`{foo();}`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+			// never: multi-space on one side only.
+			{
+				Code:    `{   foo();}`,
+				Output:  []string{`{foo();}`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 2, EndLine: 1, EndColumn: 5},
+				},
+			},
+
+			// =====================================================================
+			// Dimension 4: container forms — every shape fires correctly
+			// =====================================================================
+			// Arrow body block (always missing).
+			{
+				Code:   `const f = (a) => {return a;};`,
+				Output: []string{`const f = (a) => { return a; };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 18},
+					{MessageId: "missing", Line: 1, Column: 28},
+				},
+			},
+			// Method body (always missing).
+			{
+				Code:   `const obj = { m() {return 1;} };`,
+				Output: []string{`const obj = { m() { return 1; } };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 19},
+					{MessageId: "missing", Line: 1, Column: 29},
+				},
+			},
+			// Getter / setter (never extra).
+			{
+				Code:    `class C { get x() { return this._x; } }`,
+				Output:  []string{`class C { get x() {return this._x;} }`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+					{MessageId: "extra", Line: 1, Column: 36, EndLine: 1, EndColumn: 37},
+				},
+			},
+			// Async function body (always missing).
+			{
+				Code:   `async function f() {await x;}`,
+				Output: []string{`async function f() { await x; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 20},
+					{MessageId: "missing", Line: 1, Column: 29},
+				},
+			},
+			// Generator function body (always missing).
+			{
+				Code:   `function* g() {yield 1;}`,
+				Output: []string{`function* g() { yield 1; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 15},
+					{MessageId: "missing", Line: 1, Column: 24},
+				},
+			},
+			// Async-generator function body (always missing).
+			{
+				Code:   `async function* h() {yield await x;}`,
+				Output: []string{`async function* h() { yield await x; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 21},
+					{MessageId: "missing", Line: 1, Column: 36},
+				},
+			},
+			// Class static block (never extra).
+			{
+				Code:    `class C { static { foo(); } }`,
+				Output:  []string{`class C { static {foo();} }`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+					{MessageId: "extra", Line: 1, Column: 26, EndLine: 1, EndColumn: 27},
+				},
+			},
+			// Constructor body (always missing).
+			{
+				Code:   `class C { constructor() {this.x = 0;} }`,
+				Output: []string{`class C { constructor() { this.x = 0; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 25},
+					{MessageId: "missing", Line: 1, Column: 37},
+				},
+			},
+			// Decorator-decorated method body (always missing).
+			{
+				Code:   `class C { @dec m() {return 1;} }`,
+				Output: []string{`class C { @dec m() { return 1; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 20},
+					{MessageId: "missing", Line: 1, Column: 30},
+				},
+			},
+			// Overload-implementation pair — only the IMPLEMENTATION has a
+			// body. The two signature overloads do not have a body, so the
+			// listener fires only once.
+			{
+				Code:   `function f(a: string): void; function f(a: number): void; function f(a: any) {return a;}`,
+				Output: []string{`function f(a: string): void; function f(a: number): void; function f(a: any) { return a; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 78},
+					{MessageId: "missing", Line: 1, Column: 88},
+				},
+			},
+			// IIFE — function expression invoked immediately.
+			{
+				Code:    `(function () { foo(); })();`,
+				Output:  []string{`(function () {foo();})();`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+					{MessageId: "extra", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+
+			// =====================================================================
+			// Nested blocks — independent listener fires per Block
+			// =====================================================================
+			// Block-in-Block (always; outer ok, inner not) — 2 reports.
+			{
+				Code:   `function f() { if (a) {return 1;} }`,
+				Output: []string{`function f() { if (a) { return 1; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 23},
+					{MessageId: "missing", Line: 1, Column: 33},
+				},
+			},
+			// Block-in-Block (never; both bad) — 4 reports in source order.
+			{
+				Code:    `function f() { if (a) { return 1; } }`,
+				Output:  []string{`function f() {if (a) {return 1;}}`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+					{MessageId: "extra", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+					{MessageId: "extra", Line: 1, Column: 34, EndLine: 1, EndColumn: 35},
+					{MessageId: "extra", Line: 1, Column: 36, EndLine: 1, EndColumn: 37},
+				},
+			},
+			// Switch-in-Block (always; outer + CaseBlock + inner func block).
+			{
+				Code:   `function f() {switch (a) {case 1: foo();}}`,
+				Output: []string{`function f() { switch (a) { case 1: foo(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 14},
+					{MessageId: "missing", Line: 1, Column: 26},
+					{MessageId: "missing", Line: 1, Column: 41},
+					{MessageId: "missing", Line: 1, Column: 42},
+				},
+			},
+			// CaseBlock-in-CaseBlock (always; 4 reports in source order).
+			{
+				Code:   `switch (a) {case 1: switch (b) {case 2: foo();}}`,
+				Output: []string{`switch (a) { case 1: switch (b) { case 2: foo(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 12},
+					{MessageId: "missing", Line: 1, Column: 32},
+					{MessageId: "missing", Line: 1, Column: 47},
+					{MessageId: "missing", Line: 1, Column: 48},
+				},
+			},
+			// Block-in-CaseBlock (case clause contains its own block).
+			{
+				Code:   `switch (a) {case 1:{foo();}}`,
+				Output: []string{`switch (a) { case 1:{ foo(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 12},
+					{MessageId: "missing", Line: 1, Column: 20},
+					{MessageId: "missing", Line: 1, Column: 27},
+					{MessageId: "missing", Line: 1, Column: 28},
+				},
+			},
+			// Two back-to-back independent blocks at the same level — both
+			// must report independently in source order.
+			{
+				Code:   `function f() { {foo();} {bar();} }`,
+				Output: []string{`function f() { { foo(); } { bar(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 16},
+					{MessageId: "missing", Line: 1, Column: 23},
+					{MessageId: "missing", Line: 1, Column: 25},
+					{MessageId: "missing", Line: 1, Column: 32},
+				},
+			},
+			// Three-level nesting — inner-most block, mid block, outer ok.
+			{
+				Code:   `function f() { if (a) { if (b) {return 1;} } }`,
+				Output: []string{`function f() { if (a) { if (b) { return 1; } } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 32},
+					{MessageId: "missing", Line: 1, Column: 42},
+				},
+			},
+
+			// =====================================================================
+			// !always && firstToken.type === Line exemption (never)
+			// =====================================================================
+			// always mode: line comment after `{` still fires (exemption is
+			// never-only).
+			{
+				Code:   "if (a) {//c\n foo(); }",
+				Output: []string{"if (a) { //c\n foo(); }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+			// never mode: opening exemption holds; closing fires for `; }`.
+			{
+				Code:    "{//c\nfoo(); }",
+				Output:  []string{"{//c\nfoo();}"},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 2, Column: 7, EndLine: 2, EndColumn: 8},
+				},
+			},
+
+			// =====================================================================
+			// isValid() arm: only-opening / only-closing cross-line
+			// =====================================================================
+			// Opening cross-line, closing missing on same line (always).
+			{
+				Code:   "{\n  foo();}",
+				Output: []string{"{\n  foo(); }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 9},
+				},
+			},
+			// Closing cross-line, opening missing on same line (always).
+			{
+				Code:   "{foo();\n}",
+				Output: []string{"{ foo();\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+				},
+			},
+			// CRLF version — must recognize \r as line terminator.
+			{
+				Code:   "{foo();\r\n}",
+				Output: []string{"{ foo();\r\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+				},
+			},
+
+			// =====================================================================
+			// Block / line-comment-as-token contracts
+			// =====================================================================
+			// `{ /* c */ }` (never) — block comment acts as a token, both
+			// adjacent spaces fire.
+			{
+				Code:    `{ /* c */ }`,
+				Output:  []string{`{/* c */}`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+					{MessageId: "extra", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				},
+			},
+			// `{/* c */ foo; }` (always) — `{` glued to comment, opening
+			// fires; closing is OK.
+			{
+				Code:   `{/* c */ foo(); }`,
+				Output: []string{`{ /* c */ foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+				},
+			},
+			// Block comment containing `}` payload — must not confuse
+			// reverse byte scan.
+			{
+				Code:   `{/* } */ foo(); /* { */}`,
+				Output: []string{`{ /* } */ foo(); /* { */ }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+					{MessageId: "missing", Line: 1, Column: 24},
+				},
+			},
+
+			// =====================================================================
+			// Real-user shapes (issue tracker / common patterns)
+			// =====================================================================
+			// Arrow body in JSX onClick (very common React shape).
+			{
+				Code:   `const X = () => <div onClick={() => {foo();}} />;`,
+				Output: []string{`const X = () => <div onClick={() => { foo(); }} />;`},
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 37},
+					{MessageId: "missing", Line: 1, Column: 44},
+				},
+			},
+			// Express middleware shape.
+			{
+				Code:   `app.use((req, res, next) => {next();});`,
+				Output: []string{`app.use((req, res, next) => { next(); });`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 29},
+					{MessageId: "missing", Line: 1, Column: 37},
+				},
+			},
+			// Promise .then callback.
+			{
+				Code:   `p.then((r) => {return r + 1;}).catch((e) => {console.log(e);});`,
+				Output: []string{`p.then((r) => { return r + 1; }).catch((e) => { console.log(e); });`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 15},
+					{MessageId: "missing", Line: 1, Column: 29},
+					{MessageId: "missing", Line: 1, Column: 45},
+					{MessageId: "missing", Line: 1, Column: 61},
+				},
+			},
+			// setTimeout callback.
+			{
+				Code:   `setTimeout(() => {tick();}, 100);`,
+				Output: []string{`setTimeout(() => { tick(); }, 100);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 18},
+					{MessageId: "missing", Line: 1, Column: 26},
+				},
+			},
+			// Array.forEach callback (never extra).
+			{
+				Code:    `arr.forEach((x) => { console.log(x); });`,
+				Output:  []string{`arr.forEach((x) => {console.log(x);});`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 21, EndLine: 1, EndColumn: 22},
+					{MessageId: "extra", Line: 1, Column: 37, EndLine: 1, EndColumn: 38},
+				},
+			},
+			// do/while/finally trio (never extra).
+			{
+				Code:    `do { foo(); } while (a);`,
+				Output:  []string{`do {foo();} while (a);`},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "extra", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			// Try / catch without binding (ES2019).
+			{
+				Code:   `try {foo();} catch {bar();}`,
+				Output: []string{`try { foo(); } catch { bar(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 5},
+					{MessageId: "missing", Line: 1, Column: 12},
+					{MessageId: "missing", Line: 1, Column: 20},
+					{MessageId: "missing", Line: 1, Column: 27},
+				},
+			},
+			// Typed catch binding.
+			{
+				Code:   `try {foo();} catch (e: unknown) {bar();}`,
+				Output: []string{`try { foo(); } catch (e: unknown) { bar(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 5},
+					{MessageId: "missing", Line: 1, Column: 12},
+					{MessageId: "missing", Line: 1, Column: 33},
+					{MessageId: "missing", Line: 1, Column: 40},
+				},
+			},
+			// Generic function with body (TypeScript-specific).
+			{
+				Code:   `function id<T>(x: T): T {return x;}`,
+				Output: []string{`function id<T>(x: T): T { return x; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 25},
+					{MessageId: "missing", Line: 1, Column: 35},
+				},
+			},
+			// Arrow with type annotation.
+			{
+				Code:   `const f = (a: number): number => {return a;};`,
+				Output: []string{`const f = (a: number): number => { return a; };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 34},
+					{MessageId: "missing", Line: 1, Column: 44},
+				},
+			},
+
+			// =====================================================================
+			// Multi-byte UTF-8 — column comes out in UTF-16 units (parity
+			// with ESLint's ESTree positions).
+			// =====================================================================
+			{
+				Code:   "function f() {var é = 1;}",
+				Output: []string{"function f() { var é = 1; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 14},
+					{MessageId: "missing", Line: 1, Column: 25},
+				},
+			},
+			// CJK in string literal — content does not shift column of `}`.
+			{
+				Code:   `function f() {return "你好";}`,
+				Output: []string{`function f() { return "你好"; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 14},
+					{MessageId: "missing", Line: 1, Column: 27},
+				},
+			},
+
+			// =====================================================================
+			// Option-input resilience — defaults / oddly-shaped options
+			// =====================================================================
+			// Bare string "never" (rslint collapse).
+			{
+				Code:    `{ foo(); }`,
+				Output:  []string{`{foo();}`},
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+					{MessageId: "extra", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+
+			// =====================================================================
+			// Unicode WhiteSpace (NBSP / Zs / BOM) — must trigger `never` mode
+			// extras, parity with @stylistic/eslint-plugin (verified).
+			// =====================================================================
+			// NBSP after `{` and before `}` — never mode reports both sides.
+			// The reported byte range covers the NBSP (2 UTF-8 bytes,
+			// 1 UTF-16 code unit → 1 column wide).
+			{
+				Code:    "{\u00A0foo;\u00A0}",
+				Output:  []string{"{foo;}"},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+					{MessageId: "extra", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+				},
+			},
+			// Ideographic Space (U+3000) before `}` — never mode extra.
+			{
+				Code:    "{foo;\u3000}",
+				Output:  []string{"{foo;}"},
+				Options: []interface{}{"never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				},
+			},
+
+			// =====================================================================
+			// Unicode LineTerminator (LS / PS) on ONE side, opposite side
+			// still checked. The cross-line short-circuit fires per-side.
+			// Validates parity with ESLint's isTokenOnSameLine on §12.3
+			// LineTerminator set (not just LF/CR).
+			// =====================================================================
+			// LS after `;` → closing skipped (cross-line); opening fires
+			// because `{` hugs `foo` (same line, no space) under always.
+			{
+				Code:   "{foo;\u2028}",
+				Output: []string{"{ foo;\u2028}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+				},
+			},
+			// LS after `{` → opening skipped; closing fires.
+			{
+				Code:   "{\u2028foo;}",
+				Output: []string{"{\u2028foo; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 5},
+				},
+			},
+			// PS variant.
+			{
+				Code:   "{foo;\u2029}",
+				Output: []string{"{ foo;\u2029}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/block_spacing/block_spacing_upstream_test.go
+++ b/internal/plugins/stylistic/rules/block_spacing/block_spacing_upstream_test.go
@@ -1,0 +1,532 @@
+// TestBlockSpacingUpstream migrates the full valid/invalid suite from upstream
+// packages/eslint-plugin/rules/block-spacing/block-spacing.test.ts 1:1.
+// Position assertions cover line/column for every invalid case. rslint-specific
+// lock-in cases live in block_spacing_extras_test.go.
+package block_spacing_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/block_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func optsAlways() []interface{} { return []interface{}{"always"} }
+func optsNever() []interface{}  { return []interface{}{"never"} }
+
+func TestBlockSpacingUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&block_spacing.BlockSpacingRule,
+		[]rule_tester.ValidTestCase{
+			// ---- default/always ----
+			{Code: `{ foo(); }`, Options: optsAlways()},
+			{Code: `{ foo(); }`},
+			{Code: "{ foo();\n}"},
+			{Code: "{\nfoo(); }"},
+			{Code: "{\r\nfoo();\r\n}"},
+			{Code: `if (a) { foo(); }`},
+			{Code: `if (a) {} else { foo(); }`},
+			{Code: `switch (a) {}`},
+			{Code: `switch (a) { case 0: foo(); }`},
+			{Code: `while (a) { foo(); }`},
+			{Code: `do { foo(); } while (a);`},
+			{Code: `for (;;) { foo(); }`},
+			{Code: `for (var a in b) { foo(); }`},
+			{Code: `for (var a of b) { foo(); }`},
+			{Code: `try { foo(); } catch (e) { foo(); }`},
+			{Code: `function foo() { bar(); }`},
+			{Code: `(function() { bar(); });`},
+			{Code: `(() => { bar(); });`},
+			{Code: `if (a) { /* comment */ foo(); /* comment */ }`},
+			{Code: "if (a) { //comment\n foo(); }"},
+			{Code: `class C { static {} }`},
+			{Code: `class C { static { foo; } }`},
+			{Code: `class C { static { /* comment */foo;/* comment */ } }`},
+
+			// ---- never ----
+			{Code: `{foo();}`, Options: optsNever()},
+			{Code: "{foo();\n}", Options: optsNever()},
+			{Code: "{\nfoo();}", Options: optsNever()},
+			{Code: "{\r\nfoo();\r\n}", Options: optsNever()},
+			{Code: `if (a) {foo();}`, Options: optsNever()},
+			{Code: `if (a) {} else {foo();}`, Options: optsNever()},
+			{Code: `switch (a) {}`, Options: optsNever()},
+			{Code: `switch (a) {case 0: foo();}`, Options: optsNever()},
+			{Code: `while (a) {foo();}`, Options: optsNever()},
+			{Code: `do {foo();} while (a);`, Options: optsNever()},
+			{Code: `for (;;) {foo();}`, Options: optsNever()},
+			{Code: `for (var a in b) {foo();}`, Options: optsNever()},
+			{Code: `for (var a of b) {foo();}`, Options: optsNever()},
+			{Code: `try {foo();} catch (e) {foo();}`, Options: optsNever()},
+			{Code: `function foo() {bar();}`, Options: optsNever()},
+			{Code: `(function() {bar();});`, Options: optsNever()},
+			{Code: `(() => {bar();});`, Options: optsNever()},
+			{Code: `if (a) {/* comment */ foo(); /* comment */}`, Options: optsNever()},
+			{Code: "if (a) { //comment\n foo();}", Options: optsNever()},
+			{Code: `class C { static { } }`, Options: optsNever()},
+			{Code: `class C { static {foo;} }`, Options: optsNever()},
+			{Code: `class C { static {/* comment */ foo; /* comment */} }`, Options: optsNever()},
+			{Code: "class C { static { // line comment is allowed\n foo;\n} }", Options: optsNever()},
+			{Code: "class C { static {\nfoo;\n} }", Options: optsNever()},
+			{Code: "class C { static { \n foo; \n } }", Options: optsNever()},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- default/always ----
+			{
+				Code:    `{foo();}`,
+				Output:  []string{`{ foo(); }`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+					{MessageId: "missing", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code:   `{foo();}`,
+				Output: []string{`{ foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+					{MessageId: "missing", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code:   `{ foo();}`,
+				Output: []string{`{ foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `{foo(); }`,
+				Output: []string{`{ foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "{\nfoo();}",
+				Output: []string{"{\nfoo(); }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 7},
+				},
+			},
+			{
+				Code:   "{foo();\n}",
+				Output: []string{"{ foo();\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `if (a) {foo();}`,
+				Output: []string{`if (a) { foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 8},
+					{MessageId: "missing", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code:   `if (a) {} else {foo();}`,
+				Output: []string{`if (a) {} else { foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 16},
+					{MessageId: "missing", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:   `switch (a) {case 0: foo();}`,
+				Output: []string{`switch (a) { case 0: foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 12},
+					{MessageId: "missing", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code:   `while (a) {foo();}`,
+				Output: []string{`while (a) { foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 11},
+					{MessageId: "missing", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:   `do {foo();} while (a);`,
+				Output: []string{`do { foo(); } while (a);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 4},
+					{MessageId: "missing", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `for (;;) {foo();}`,
+				Output: []string{`for (;;) { foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 10},
+					{MessageId: "missing", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code:   `for (var a in b) {foo();}`,
+				Output: []string{`for (var a in b) { foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 18},
+					{MessageId: "missing", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code:   `for (var a of b) {foo();}`,
+				Output: []string{`for (var a of b) { foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 18},
+					{MessageId: "missing", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code:   `try {foo();} catch (e) {foo();} finally {foo();}`,
+				Output: []string{`try { foo(); } catch (e) { foo(); } finally { foo(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "missing", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "missing", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+					{MessageId: "missing", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+					{MessageId: "missing", Line: 1, Column: 41, EndLine: 1, EndColumn: 42},
+					{MessageId: "missing", Line: 1, Column: 48, EndLine: 1, EndColumn: 49},
+				},
+			},
+			{
+				Code:   `function foo() {bar();}`,
+				Output: []string{`function foo() { bar(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 16},
+					{MessageId: "missing", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:   `(function() {bar();});`,
+				Output: []string{`(function() { bar(); });`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 13},
+					{MessageId: "missing", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code:   `(() => {bar();});`,
+				Output: []string{`(() => { bar(); });`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 8},
+					{MessageId: "missing", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code:   `if (a) {/* comment */ foo(); /* comment */}`,
+				Output: []string{`if (a) { /* comment */ foo(); /* comment */ }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 8},
+					{MessageId: "missing", Line: 1, Column: 43},
+				},
+			},
+			{
+				Code:   "if (a) {//comment\n foo(); }",
+				Output: []string{"if (a) { //comment\n foo(); }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+
+			// ---- class static blocks (always) ----
+			{
+				Code:   `class C { static {foo; } }`,
+				Output: []string{`class C { static { foo; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code:   `class C { static { foo;} }`,
+				Output: []string{`class C { static { foo; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code:   `class C { static {foo;} }`,
+				Output: []string{`class C { static { foo; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+					{MessageId: "missing", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code:   `class C { static {/* comment */} }`,
+				Output: []string{`class C { static { /* comment */ } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+					{MessageId: "missing", Line: 1, Column: 32, EndLine: 1, EndColumn: 33},
+				},
+			},
+			{
+				Code:   `class C { static {/* comment 1 */ foo; /* comment 2 */} }`,
+				Output: []string{`class C { static { /* comment 1 */ foo; /* comment 2 */ } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+					{MessageId: "missing", Line: 1, Column: 55, EndLine: 1, EndColumn: 56},
+				},
+			},
+			{
+				Code:   "class C {\n static {foo()\nbar()} }",
+				Output: []string{"class C {\n static { foo()\nbar() } }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 9, EndLine: 2, EndColumn: 10},
+					{MessageId: "missing", Line: 3, Column: 6, EndLine: 3, EndColumn: 7},
+				},
+			},
+
+			// ---- never ----
+			{
+				Code:    `{ foo(); }`,
+				Output:  []string{`{foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+					{MessageId: "extra", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code:    `{ foo();}`,
+				Output:  []string{`{foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+			{
+				Code:    `{foo(); }`,
+				Output:  []string{`{foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+			{
+				Code:    "{\nfoo(); }",
+				Output:  []string{"{\nfoo();}"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 2, Column: 7, EndLine: 2, EndColumn: 8},
+				},
+			},
+			{
+				Code:    "{ foo();\n}",
+				Output:  []string{"{foo();\n}"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+			{
+				Code:    `if (a) { foo(); }`,
+				Output:  []string{`if (a) {foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+					{MessageId: "extra", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    `if (a) {} else { foo(); }`,
+				Output:  []string{`if (a) {} else {foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+					{MessageId: "extra", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code:    `switch (a) { case 0: foo(); }`,
+				Output:  []string{`switch (a) {case 0: foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "extra", Line: 1, Column: 28, EndLine: 1, EndColumn: 29},
+				},
+			},
+			{
+				Code:    `while (a) { foo(); }`,
+				Output:  []string{`while (a) {foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "extra", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				Code:    `do { foo(); } while (a);`,
+				Output:  []string{`do {foo();} while (a);`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "extra", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:    `for (;;) { foo(); }`,
+				Output:  []string{`for (;;) {foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "extra", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code:    `for (var a in b) { foo(); }`,
+				Output:  []string{`for (var a in b) {foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+					{MessageId: "extra", Line: 1, Column: 26, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				Code:    `for (var a of b) { foo(); }`,
+				Output:  []string{`for (var a of b) {foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+					{MessageId: "extra", Line: 1, Column: 26, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				Code:    `try { foo(); } catch (e) { foo(); } finally { foo(); }`,
+				Output:  []string{`try {foo();} catch (e) {foo();} finally {foo();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+					{MessageId: "extra", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "extra", Line: 1, Column: 27, EndLine: 1, EndColumn: 28},
+					{MessageId: "extra", Line: 1, Column: 34, EndLine: 1, EndColumn: 35},
+					{MessageId: "extra", Line: 1, Column: 46, EndLine: 1, EndColumn: 47},
+					{MessageId: "extra", Line: 1, Column: 53, EndLine: 1, EndColumn: 54},
+				},
+			},
+			{
+				Code:    `function foo() { bar(); }`,
+				Output:  []string{`function foo() {bar();}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+					{MessageId: "extra", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code:    `(function() { bar(); });`,
+				Output:  []string{`(function() {bar();});`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+					{MessageId: "extra", Line: 1, Column: 21, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				Code:    `(() => { bar(); });`,
+				Output:  []string{`(() => {bar();});`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+					{MessageId: "extra", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    `if (a) { /* comment */ foo(); /* comment */ }`,
+				Output:  []string{`if (a) {/* comment */ foo(); /* comment */}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+					{MessageId: "extra", Line: 1, Column: 44, EndLine: 1, EndColumn: 45},
+				},
+			},
+			{
+				Code:    `(() => {   bar();});`,
+				Output:  []string{`(() => {bar();});`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 9, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code:    `(() => {bar();   });`,
+				Output:  []string{`(() => {bar();});`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 15, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:    `(() => {   bar();   });`,
+				Output:  []string{`(() => {bar();});`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 9, EndLine: 1, EndColumn: 12},
+					{MessageId: "extra", Line: 1, Column: 18, EndLine: 1, EndColumn: 21},
+				},
+			},
+
+			// ---- class static blocks (never) ----
+			{
+				Code:    `class C { static { foo;} }`,
+				Output:  []string{`class C { static {foo;} }`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				Code:    `class C { static {foo; } }`,
+				Output:  []string{`class C { static {foo;} }`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code:    `class C { static { foo; } }`,
+				Output:  []string{`class C { static {foo;} }`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+					{MessageId: "extra", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code:    `class C { static { /* comment */ } }`,
+				Output:  []string{`class C { static {/* comment */} }`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+					{MessageId: "extra", Line: 1, Column: 33, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code:    `class C { static { /* comment 1 */ foo; /* comment 2 */ } }`,
+				Output:  []string{`class C { static {/* comment 1 */ foo; /* comment 2 */} }`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+					{MessageId: "extra", Line: 1, Column: 56, EndLine: 1, EndColumn: 57},
+				},
+			},
+			{
+				Code:    "class C { static\n{   foo()\nbar()  } }",
+				Output:  []string{"class C { static\n{foo()\nbar()} }"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "extra", Line: 2, Column: 2, EndLine: 2, EndColumn: 5},
+					{MessageId: "extra", Line: 3, Column: 6, EndLine: 3, EndColumn: 8},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/one_var/one_var.go
+++ b/internal/rules/one_var/one_var.go
@@ -517,7 +517,7 @@ func fixSplit(view eslintVarDeclView, declList *ast.Node, kind string, sf *ast.S
 				core.NewTextRange(commaStart, commaEnd),
 				"; "+exportPrefix+kind+" ",
 			))
-		case strings.ContainsAny(between, "\n\r") ||
+		case utils.ContainsLineTerminator(between, 0, len(between)) ||
 			strings.Contains(between, "//") ||
 			strings.Contains(between, "/*"):
 			// Line break or comment between `,` and the next declarator —

--- a/internal/utils/trivia.go
+++ b/internal/utils/trivia.go
@@ -1,0 +1,177 @@
+package utils
+
+import (
+	"unicode/utf8"
+)
+
+// IsTriviaWhitespaceByte reports whether `b` is one of the ASCII whitespace
+// or line-terminator bytes recognized by ECMAScript §12.2 / §12.3:
+//
+//	U+0009 HT, U+000A LF, U+000B VT, U+000C FF, U+000D CR, U+0020 SP.
+//
+// Used as the fast path for forward/reverse trivia scans on byte streams.
+// For non-ASCII bytes (>= 0x80), the caller MUST decode the rune and fall
+// back to IsTriviaWhitespaceRune — multi-byte UTF-8 sequences encode runes
+// like NBSP (U+00A0) whose individual bytes are >= 0x80 and would be misread
+// by a byte-only test.
+func IsTriviaWhitespaceByte(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\f', '\v':
+		return true
+	}
+	return false
+}
+
+// IsTriviaWhitespaceRune reports whether `r` is a non-ASCII whitespace or
+// line-terminator rune recognized by ECMAScript:
+//
+//   - WhiteSpace (§12.2): U+00A0 NBSP, U+FEFF ZWNBSP, plus any rune in
+//     Unicode `Space_Separator` (Zs) — U+1680 Ogham, U+2000–U+200A
+//     (En Quad through Hair Space), U+202F Narrow NBSP, U+205F Medium
+//     Mathematical Space, U+3000 Ideographic Space.
+//   - LineTerminator (§12.3): U+2028 LS, U+2029 PS.
+//
+// Should ONLY be called for runes >= U+0080. The ASCII subset is handled by
+// IsTriviaWhitespaceByte on the fast path.
+//
+// Deliberately excluded — they are NOT matched by JS `\s` / ECMAScript
+// WhiteSpace (verified empirically against V8 and ESLint with `/\s/`):
+//
+//   - U+0085 Next Line: in Unicode `\p{White_Space}` but NOT in ES
+//     WhiteSpace (only specific allow-listed runes count).
+//   - U+200B Zero Width Space: category Cf (Format), not Zs; tsgo's scanner
+//     treats it as whitespace internally, but that's a TS-compiler quirk
+//     not ESLint behavior.
+func IsTriviaWhitespaceRune(r rune) bool {
+	switch r {
+	case 0x00A0, // <No-Break Space>
+		0x1680, // <Ogham Space Mark>
+		0x2000, // <En Quad>
+		0x2001, // <Em Quad>
+		0x2002, // <En Space>
+		0x2003, // <Em Space>
+		0x2004, // <Three-Per-Em Space>
+		0x2005, // <Four-Per-Em Space>
+		0x2006, // <Six-Per-Em Space>
+		0x2007, // <Figure Space>
+		0x2008, // <Punctuation Space>
+		0x2009, // <Thin Space>
+		0x200A, // <Hair Space>
+		0x2028, // <Line Separator>
+		0x2029, // <Paragraph Separator>
+		0x202F, // <Narrow No-Break Space>
+		0x205F, // <Medium Mathematical Space>
+		0x3000, // <Ideographic Space>
+		0xFEFF: // <Byte Order Mark / Zero Width No-Break Space>
+		return true
+	}
+	return false
+}
+
+// ContainsLineTerminator reports whether the byte range `[low, high)` of
+// `text` contains any ECMAScript LineTerminator (§12.3): LF (`\n`), CR (`\r`),
+// LS (U+2028), or PS (U+2029).
+//
+// Used by spacing rules to short-circuit "tokens on different lines"
+// decisions equivalent to ESLint's `isTokenOnSameLine` helper. Out-of-range
+// indices are clamped, and an empty range yields `false`.
+//
+// LS and PS are encoded in UTF-8 as `E2 80 A8` and `E2 80 A9` respectively;
+// detecting them via byte-level prefix `E2 80 A8`/`A9` is exactly as
+// reliable as a rune scan and significantly faster on cold cache.
+func ContainsLineTerminator(text string, low, high int) bool {
+	if low < 0 {
+		low = 0
+	}
+	if high > len(text) {
+		high = len(text)
+	}
+	for i := low; i < high; i++ {
+		c := text[i]
+		if c == '\n' || c == '\r' {
+			return true
+		}
+		// Look for the LS/PS UTF-8 prefix `E2 80 A8` / `E2 80 A9`.
+		if c == 0xE2 && i+2 < high && text[i+1] == 0x80 && (text[i+2] == 0xA8 || text[i+2] == 0xA9) {
+			return true
+		}
+	}
+	return false
+}
+
+// SkipLeadingWhitespace walks forward from `low` through ECMAScript trivia
+// whitespace and line terminators (the union of §12.2 WhiteSpace and §12.3
+// LineTerminator), returning the position of the first non-whitespace byte
+// (or `high` if nothing but whitespace remains).
+//
+// Counterpart to SkipTrailingWhitespace. tsgo's `scanner.SkipTriviaEx` also
+// skips comments and conflict markers; this helper is purely whitespace +
+// line-terminator, useful when callers need to handle comments / other
+// tokens separately. ASCII bytes take the fast path; non-ASCII bytes
+// decode via `utf8.DecodeRune` and dispatch to `IsTriviaWhitespaceRune`.
+func SkipLeadingWhitespace(text string, low, high int) int {
+	if low < 0 {
+		low = 0
+	}
+	if high > len(text) {
+		high = len(text)
+	}
+	p := low
+	for p < high {
+		if text[p] < 0x80 {
+			if !IsTriviaWhitespaceByte(text[p]) {
+				return p
+			}
+			p++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(text[p:])
+		if size == 0 || r == utf8.RuneError || !IsTriviaWhitespaceRune(r) {
+			return p
+		}
+		p += size
+	}
+	return high
+}
+
+// SkipTrailingWhitespace walks back from `high` through ECMAScript trivia
+// whitespace and line terminators (the union of §12.2 WhiteSpace and §12.3
+// LineTerminator), returning the position one past the last non-whitespace
+// byte (i.e. the end-exclusive of the last token in `[low, high)`). Returns
+// `low` when nothing but whitespace remains.
+//
+// tsgo exposes `scanner.SkipTriviaEx` for forward scanning only; this
+// function is the missing reverse counterpart. ASCII bytes are handled on
+// the fast path; non-ASCII bytes decode the rune via `utf8.DecodeLastRune`
+// and dispatch to `IsTriviaWhitespaceRune`.
+//
+// Does NOT skip block or line comments — callers that need to skip those
+// (or recognize comment boundaries) must do it themselves. This mirrors
+// `SkipTriviaEx`'s `StopAtComments: true` mode, where the forward scan also
+// stops at the start of a comment.
+func SkipTrailingWhitespace(text string, low, high int) int {
+	if low < 0 {
+		low = 0
+	}
+	if high > len(text) {
+		high = len(text)
+	}
+	p := high
+	for p > low {
+		// Fast path: ASCII byte.
+		if text[p-1] < 0x80 {
+			if !IsTriviaWhitespaceByte(text[p-1]) {
+				return p
+			}
+			p--
+			continue
+		}
+		// Slow path: decode the previous rune.
+		r, size := utf8.DecodeLastRuneInString(text[:p])
+		if size == 0 || r == utf8.RuneError || !IsTriviaWhitespaceRune(r) {
+			return p
+		}
+		p -= size
+	}
+	return low
+}

--- a/internal/utils/trivia_test.go
+++ b/internal/utils/trivia_test.go
@@ -1,0 +1,170 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestIsTriviaWhitespaceByte(t *testing.T) {
+	for _, c := range []byte{' ', '\t', '\n', '\r', '\f', '\v'} {
+		if !IsTriviaWhitespaceByte(c) {
+			t.Errorf("expected byte %q to be whitespace", c)
+		}
+	}
+	for _, c := range []byte{'a', '0', '_', '/', '*', 0x00, 0x7F, 0x80} {
+		if IsTriviaWhitespaceByte(c) {
+			t.Errorf("expected byte %q to NOT be whitespace", c)
+		}
+	}
+}
+
+func TestIsTriviaWhitespaceRune(t *testing.T) {
+	// All ECMAScript-recognized non-ASCII WhiteSpace + LineTerminator runes.
+	whitespace := []rune{
+		0x00A0, // NBSP
+		0x1680, // Ogham
+		0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008, 0x2009, 0x200A,
+		0x2028, // LS
+		0x2029, // PS
+		0x202F, 0x205F, 0x3000,
+		0xFEFF, // ZWNBSP/BOM
+	}
+	for _, r := range whitespace {
+		if !IsTriviaWhitespaceRune(r) {
+			t.Errorf("expected rune U+%04X to be whitespace", r)
+		}
+	}
+
+	// Runes that look whitespace-ish but are NOT ECMAScript WhiteSpace.
+	nonWhitespace := []rune{
+		0x0085, // NEL — in \p{White_Space} but not in ES WhiteSpace
+		0x200B, // ZWSP — category Cf, not Zs
+		0x200C, // ZWNJ
+		0x200D, // ZWJ
+		'a', '0', '/', 0x4E2D, // CJK "中" — NOT whitespace
+	}
+	for _, r := range nonWhitespace {
+		if IsTriviaWhitespaceRune(r) {
+			t.Errorf("expected rune U+%04X to NOT be whitespace", r)
+		}
+	}
+}
+
+func TestContainsLineTerminator(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"empty", "", false},
+		{"plain ascii", "abc", false},
+		{"only spaces", "   \t   ", false},
+		{"LF", "a\nb", true},
+		{"CR", "a\rb", true},
+		{"CRLF", "a\r\nb", true},
+		{"LS", "a b", true},
+		{"PS", "a b", true},
+		{"NBSP only — NOT a line terminator", "a b", false},
+		{"IDEO only", "a\u3000b", false},
+		{"LS at start", " b", true},
+		{"LS at end", "a ", true},
+		{"PS at end", "a ", true},
+		// CJK "啊" is E5 95 8A — must NOT trigger.
+		{"CJK no false-positive", "\u554A\u554A", false},
+		// U+2030 = E2 80 B0 (per mille) — has E2 80 prefix but third byte
+		// is B0, not A8/A9, so must NOT trigger.
+		{"0xE2-0x80 prefix but not LS/PS", "a\u2030b", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ContainsLineTerminator(c.text, 0, len(c.text)); got != c.want {
+				t.Errorf("ContainsLineTerminator(%q) = %v, want %v", c.text, got, c.want)
+			}
+		})
+	}
+}
+
+func TestContainsLineTerminator_RangeClamping(t *testing.T) {
+	text := "a\nb"
+	if !ContainsLineTerminator(text, -10, 100) {
+		t.Error("expected clamping to find LF")
+	}
+	if ContainsLineTerminator(text, 0, 0) {
+		t.Error("expected empty range to be false")
+	}
+	if ContainsLineTerminator(text, 2, 1) {
+		t.Error("expected reversed range to be false")
+	}
+}
+
+func TestSkipTrailingWhitespace(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want int // expected returned position (relative to start; high = len(text))
+	}{
+		{"empty", "", 0},
+		{"no whitespace", "abc", 3},
+		{"single trailing space", "ab ", 2},
+		{"multi ASCII whitespace", "ab \t\n", 2},
+		{"only whitespace returns low", "   ", 0},
+		// NBSP is 2 bytes; trailing NBSP must be fully skipped.
+		{"NBSP trailing", "ab ", 2},
+		{"NBSP + ASCII trailing", "ab  \t", 2},
+		// LS is 3 bytes.
+		{"LS trailing", "ab ", 2},
+		{"PS + space trailing", "ab  ", 2},
+		{"IDEO trailing", "ab\u3000", 2},
+		{"BOM trailing", "ab\uFEFF", 2},
+		// Non-whitespace non-ASCII must NOT be skipped.
+		{"CJK trailing", "ab\u4E2D", 5},
+		// Whitespace then non-WS non-ASCII = stop AT the non-WS end.
+		{"WS then CJK from right", "a\u4E2D ", 4},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := SkipTrailingWhitespace(c.text, 0, len(c.text))
+			if got != c.want {
+				t.Errorf("SkipTrailingWhitespace(%q) = %d, want %d", c.text, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSkipTrailingWhitespace_RangeClamping(t *testing.T) {
+	text := "abc   "
+	if got := SkipTrailingWhitespace(text, -5, 100); got != 3 {
+		t.Errorf("expected clamped scan to return 3, got %d", got)
+	}
+	if got := SkipTrailingWhitespace(text, 0, 0); got != 0 {
+		t.Errorf("expected empty range to return low (0), got %d", got)
+	}
+}
+
+func TestSkipLeadingWhitespace(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want int
+	}{
+		{"empty", "", 0},
+		{"no whitespace", "abc", 0},
+		{"single leading space", " ab", 1},
+		{"multi ASCII whitespace", " \t\nab", 3},
+		{"only whitespace returns high", "   ", 3},
+		// NBSP is 2 bytes.
+		{"NBSP leading", "\u00A0ab", 2},
+		// LS is 3 bytes.
+		{"LS leading", "\u2028ab", 3},
+		{"IDEO leading", "\u3000ab", 3},
+		// Non-whitespace non-ASCII must NOT be skipped.
+		{"CJK leading", "\u4E2Dab", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := SkipLeadingWhitespace(c.text, 0, len(c.text))
+			if got != c.want {
+				t.Errorf("SkipLeadingWhitespace(%q) = %d, want %d", c.text, got, c.want)
+			}
+		})
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -453,6 +453,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/array-bracket-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/arrow-parens.test.ts',
     './tests/eslint-plugin-stylistic/rules/arrow-spacing.test.ts',
+    './tests/eslint-plugin-stylistic/rules/block-spacing.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/block-spacing.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/block-spacing.test.ts
@@ -1,0 +1,367 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('block-spacing', null as never, {
+  valid: [
+    // default/always
+    { code: '{ foo(); }', options: ['always'] },
+    { code: '{ foo(); }' },
+    { code: '{ foo();\n}' },
+    { code: '{\nfoo(); }' },
+    { code: '{\r\nfoo();\r\n}' },
+    { code: 'if (a) { foo(); }' },
+    { code: 'if (a) {} else { foo(); }' },
+    { code: 'switch (a) {}' },
+    { code: 'switch (a) { case 0: foo(); }' },
+    { code: 'while (a) { foo(); }' },
+    { code: 'do { foo(); } while (a);' },
+    { code: 'for (;;) { foo(); }' },
+    { code: 'for (var a in b) { foo(); }' },
+    { code: 'for (var a of b) { foo(); }' },
+    { code: 'try { foo(); } catch (e) { foo(); }' },
+    { code: 'function foo() { bar(); }' },
+    { code: '(function() { bar(); });' },
+    { code: '(() => { bar(); });' },
+    { code: 'if (a) { /* comment */ foo(); /* comment */ }' },
+    { code: 'if (a) { //comment\n foo(); }' },
+    { code: 'class C { static {} }' },
+    { code: 'class C { static { foo; } }' },
+    { code: 'class C { static { /* comment */foo;/* comment */ } }' },
+
+    // never
+    { code: '{foo();}', options: ['never'] },
+    { code: '{foo();\n}', options: ['never'] },
+    { code: '{\nfoo();}', options: ['never'] },
+    { code: '{\r\nfoo();\r\n}', options: ['never'] },
+    { code: 'if (a) {foo();}', options: ['never'] },
+    { code: 'if (a) {} else {foo();}', options: ['never'] },
+    { code: 'switch (a) {}', options: ['never'] },
+    { code: 'switch (a) {case 0: foo();}', options: ['never'] },
+    { code: 'while (a) {foo();}', options: ['never'] },
+    { code: 'do {foo();} while (a);', options: ['never'] },
+    { code: 'for (;;) {foo();}', options: ['never'] },
+    { code: 'for (var a in b) {foo();}', options: ['never'] },
+    { code: 'for (var a of b) {foo();}', options: ['never'] },
+    { code: 'try {foo();} catch (e) {foo();}', options: ['never'] },
+    { code: 'function foo() {bar();}', options: ['never'] },
+    { code: '(function() {bar();});', options: ['never'] },
+    { code: '(() => {bar();});', options: ['never'] },
+    {
+      code: 'if (a) {/* comment */ foo(); /* comment */}',
+      options: ['never'],
+    },
+    { code: 'if (a) { //comment\n foo();}', options: ['never'] },
+    { code: 'class C { static { } }', options: ['never'] },
+    { code: 'class C { static {foo;} }', options: ['never'] },
+    {
+      code: 'class C { static {/* comment */ foo; /* comment */} }',
+      options: ['never'],
+    },
+    {
+      code: 'class C { static { // line comment is allowed\n foo;\n} }',
+      options: ['never'],
+    },
+    { code: 'class C { static {\nfoo;\n} }', options: ['never'] },
+    { code: 'class C { static { \n foo; \n } }', options: ['never'] },
+  ],
+  invalid: [
+    // default/always
+    {
+      code: '{foo();}',
+      output: '{ foo(); }',
+      options: ['always'],
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'missing',
+          data: { location: 'after', token: '{' },
+        },
+        {
+          line: 1,
+          column: 8,
+          messageId: 'missing',
+          data: { location: 'before', token: '}' },
+        },
+      ],
+    },
+    {
+      code: '{foo();}',
+      output: '{ foo(); }',
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'missing',
+          data: { location: 'after', token: '{' },
+        },
+        {
+          line: 1,
+          column: 8,
+          messageId: 'missing',
+          data: { location: 'before', token: '}' },
+        },
+      ],
+    },
+    {
+      code: '{ foo();}',
+      output: '{ foo(); }',
+      errors: [
+        {
+          line: 1,
+          column: 9,
+          messageId: 'missing',
+          data: { location: 'before', token: '}' },
+        },
+      ],
+    },
+    {
+      code: '{foo(); }',
+      output: '{ foo(); }',
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'missing',
+          data: { location: 'after', token: '{' },
+        },
+      ],
+    },
+    {
+      code: '{\nfoo();}',
+      output: '{\nfoo(); }',
+      errors: [
+        {
+          line: 2,
+          column: 7,
+          messageId: 'missing',
+          data: { location: 'before', token: '}' },
+        },
+      ],
+    },
+    {
+      code: '{foo();\n}',
+      output: '{ foo();\n}',
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'missing',
+          data: { location: 'after', token: '{' },
+        },
+      ],
+    },
+    {
+      code: 'if (a) {foo();}',
+      output: 'if (a) { foo(); }',
+      errors: [
+        {
+          line: 1,
+          column: 8,
+          messageId: 'missing',
+          data: { location: 'after', token: '{' },
+        },
+        {
+          line: 1,
+          column: 15,
+          messageId: 'missing',
+          data: { location: 'before', token: '}' },
+        },
+      ],
+    },
+    {
+      code: 'switch (a) {case 0: foo();}',
+      output: 'switch (a) { case 0: foo(); }',
+      errors: [
+        {
+          line: 1,
+          column: 12,
+          messageId: 'missing',
+          data: { location: 'after', token: '{' },
+        },
+        {
+          line: 1,
+          column: 27,
+          messageId: 'missing',
+          data: { location: 'before', token: '}' },
+        },
+      ],
+    },
+    {
+      code: 'function foo() {bar();}',
+      output: 'function foo() { bar(); }',
+      errors: [
+        {
+          line: 1,
+          column: 16,
+          messageId: 'missing',
+          data: { location: 'after', token: '{' },
+        },
+        {
+          line: 1,
+          column: 23,
+          messageId: 'missing',
+          data: { location: 'before', token: '}' },
+        },
+      ],
+    },
+    {
+      code: '(() => {bar();});',
+      output: '(() => { bar(); });',
+      errors: [
+        {
+          line: 1,
+          column: 8,
+          messageId: 'missing',
+          data: { location: 'after', token: '{' },
+        },
+        {
+          line: 1,
+          column: 15,
+          messageId: 'missing',
+          data: { location: 'before', token: '}' },
+        },
+      ],
+    },
+    {
+      code: 'class C { static {foo;} }',
+      output: 'class C { static { foo; } }',
+      errors: [
+        {
+          messageId: 'missing',
+          data: { location: 'after', token: '{' },
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 19,
+        },
+        {
+          messageId: 'missing',
+          data: { location: 'before', token: '}' },
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 24,
+        },
+      ],
+    },
+
+    // never
+    {
+      code: '{ foo(); }',
+      output: '{foo();}',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'extra',
+          data: { location: 'after', token: '{' },
+          line: 1,
+          column: 2,
+          endLine: 1,
+          endColumn: 3,
+        },
+        {
+          messageId: 'extra',
+          data: { location: 'before', token: '}' },
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 10,
+        },
+      ],
+    },
+    {
+      code: 'if (a) { foo(); }',
+      output: 'if (a) {foo();}',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'extra',
+          data: { location: 'after', token: '{' },
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 10,
+        },
+        {
+          messageId: 'extra',
+          data: { location: 'before', token: '}' },
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+    },
+    {
+      code: 'switch (a) { case 0: foo(); }',
+      output: 'switch (a) {case 0: foo();}',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'extra',
+          data: { location: 'after', token: '{' },
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 14,
+        },
+        {
+          messageId: 'extra',
+          data: { location: 'before', token: '}' },
+          line: 1,
+          column: 28,
+          endLine: 1,
+          endColumn: 29,
+        },
+      ],
+    },
+    {
+      code: 'function foo() { bar(); }',
+      output: 'function foo() {bar();}',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'extra',
+          data: { location: 'after', token: '{' },
+          line: 1,
+          column: 17,
+          endLine: 1,
+          endColumn: 18,
+        },
+        {
+          messageId: 'extra',
+          data: { location: 'before', token: '}' },
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: 'class C { static { foo; } }',
+      output: 'class C { static {foo;} }',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'extra',
+          data: { location: 'after', token: '{' },
+          line: 1,
+          column: 19,
+          endLine: 1,
+          endColumn: 20,
+        },
+        {
+          messageId: 'extra',
+          data: { location: 'before', token: '}' },
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 25,
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -506,6 +506,8 @@ xoff
 xtest
 yutil
 ZWNBSP
+ZWNJ
+ZWSP
 πfoo
 Πfoo
 дelta


### PR DESCRIPTION
## Summary

Port the `@stylistic/block-spacing` rule from ESLint to rslint.

Enforces consistent spacing inside open/close block tokens when they sit on the same line as their adjacent content token. Supports the standard `"always"` (default) and `"never"` string options.

## Related Links

- ESLint rule: https://eslint.style/rules/block-spacing
- Source code: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/block-spacing/block-spacing.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).