### PR TITLE
feat: port rule @stylistic/brace-style

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -5,6 +5,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/arrow_parens"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/arrow_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/block_spacing"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/brace_style"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -14,5 +15,6 @@ func GetAllRules() []rule.Rule {
 		arrow_parens.ArrowParensRule,
 		arrow_spacing.ArrowSpacingRule,
 		block_spacing.BlockSpacingRule,
+		brace_style.BraceStyleRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/arrow_parens/arrow_parens.go
+++ b/internal/plugins/stylistic/rules/arrow_parens/arrow_parens.go
@@ -1,12 +1,12 @@
 package arrow_parens
 
 import (
-	"strings"
 	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/stylisticutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -111,24 +111,6 @@ func findCloseParenPos(sf *ast.SourceFile, paramEnd int) int {
 		return rng.Pos()
 	}
 	return -1
-}
-
-// hasCommentsBetween reports whether the byte range [low, high) contains any
-// `//` or `/*` sequence. Between an arrow function's parens the only legal
-// content is identifier/comma trivia plus the param itself — no strings or
-// regexes can appear, so a plain substring search is safe.
-func hasCommentsBetween(text string, low, high int) bool {
-	if low < 0 {
-		low = 0
-	}
-	if high > len(text) {
-		high = len(text)
-	}
-	if low >= high {
-		return false
-	}
-	s := text[low:high]
-	return strings.Contains(s, "//") || strings.Contains(s, "/*")
 }
 
 // needsSpaceBeforeOpenParen reports whether the rune immediately before
@@ -239,7 +221,7 @@ var ArrowParensRule = rule.Rule{
 			if closeParenPos < 0 {
 				return
 			}
-			if hasCommentsBetween(text, openParenPos+1, closeParenPos) {
+			if stylisticutil.CommentsExistBetween(text, openParenPos+1, closeParenPos) {
 				return
 			}
 

--- a/internal/plugins/stylistic/rules/brace_style/brace_style.go
+++ b/internal/plugins/stylistic/rules/brace_style/brace_style.go
@@ -1,0 +1,546 @@
+package brace_style
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/stylisticutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const (
+	msgNextLineOpen    = "nextLineOpen"
+	msgSameLineOpen    = "sameLineOpen"
+	msgBlockSameLine   = "blockSameLine"
+	msgNextLineClose   = "nextLineClose"
+	msgSingleLineClose = "singleLineClose"
+	msgSameLineClose   = "sameLineClose"
+
+	descNextLineOpen    = "Opening curly brace does not appear on the same line as controlling statement."
+	descSameLineOpen    = "Opening curly brace appears on the same line as controlling statement."
+	descBlockSameLine   = "Statement inside of curly braces should be on next line."
+	descNextLineClose   = "Closing curly brace does not appear on the same line as the subsequent block."
+	descSingleLineClose = "Closing curly brace should be on the same line as opening curly brace or on the line after the previous block."
+	descSameLineClose   = "Closing curly brace appears on the same line as the subsequent block."
+)
+
+const (
+	style1tbs       = "1tbs"
+	styleStroustrup = "stroustrup"
+	styleAllman     = "allman"
+)
+
+type options struct {
+	style           string
+	allowSingleLine bool
+}
+
+// parseOptions mirrors upstream's option layout.
+//
+//	rule: ['brace-style']                                  → '1tbs', allowSingleLine=false
+//	rule: ['brace-style', '1tbs']                          → '1tbs', allowSingleLine=false
+//	rule: ['brace-style', 'stroustrup']                    → 'stroustrup', allowSingleLine=false
+//	rule: ['brace-style', 'allman']                        → 'allman', allowSingleLine=false
+//	rule: ['brace-style', <style>, { allowSingleLine: b }] → <style>, allowSingleLine=b
+//
+// rslint's config loader collapses a single-element options array, so the
+// first slot might travel as a bare string. We accept both shapes here.
+// `GetOptionsMap` is not used because the primary option is a string, not an
+// object — the standard helper would discard it.
+func parseOptions(raw any) options {
+	opts := options{style: style1tbs}
+
+	var arr []any
+	switch v := raw.(type) {
+	case []any:
+		arr = v
+	case string:
+		arr = []any{v}
+	}
+
+	if len(arr) > 0 {
+		if s, ok := arr[0].(string); ok {
+			switch s {
+			case style1tbs, styleStroustrup, styleAllman:
+				opts.style = s
+			}
+		}
+	}
+	if len(arr) > 1 {
+		if m, ok := arr[1].(map[string]any); ok {
+			if b, ok := m["allowSingleLine"].(bool); ok {
+				opts.allowSingleLine = b
+			}
+		}
+	}
+	return opts
+}
+
+// curlyPair is the resolved (`{`, `}`) pair for one container. `searchStart`
+// is a position guaranteed to precede the opening curly — used to locate
+// `tokenBeforeOpeningCurly` via a forward scan.
+type curlyPair struct {
+	openPos     int
+	closePos    int
+	searchStart int
+}
+
+// shouldSkipBlock returns true when a Block node lives in a parent position
+// where upstream's `BlockStatement` listener would NOT fire — i.e. its parent
+// type is in STATEMENT_LIST_PARENTS (`Program`, `BlockStatement`,
+// `StaticBlock`, `SwitchCase`). In ESTree, `StaticBlock` is its own node and
+// has no nested BlockStatement, so we also skip Blocks whose parent is a
+// `ClassStaticBlockDeclaration` — that block IS the static block in ESTree,
+// and gets handled by the dedicated `KindClassStaticBlockDeclaration` listener.
+func shouldSkipBlock(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return true
+	}
+	switch parent.Kind {
+	case ast.KindSourceFile,
+		ast.KindBlock,
+		ast.KindCaseClause,
+		ast.KindDefaultClause,
+		ast.KindClassStaticBlockDeclaration:
+		return true
+	}
+	return false
+}
+
+// validateOpen runs the three "opening side" checks on a curly pair:
+//
+//	nextLineOpen   — non-allman: `{` must be on same line as preceding token
+//	sameLineOpen   — allman: `{` must NOT be on same line as preceding token
+//	blockSameLine  — `{` must NOT be on same line as the first inner token
+//
+// `allowSingleLine` toggles a per-pair exception on the last two checks; the
+// first runs unconditionally because it's about the OPENING brace's position
+// relative to what comes BEFORE it (single-line-block exception doesn't apply).
+func validateOpen(
+	ctx rule.RuleContext,
+	text string,
+	opts options,
+	pair curlyPair,
+) {
+	sf := ctx.SourceFile
+	openPos := pair.openPos
+	closePos := pair.closePos
+	openEnd := openPos + 1
+
+	isAllman := opts.style == styleAllman
+
+	// tokenAfterOpeningCurly: first token start at or after `{` + 1.
+	afterStart := scanner.SkipTrivia(text, openEnd)
+	if afterStart > closePos {
+		afterStart = closePos
+	}
+
+	// tokenBeforeOpeningCurly via forward scan from the caller-supplied
+	// position. If we can't locate it (parser recovery / synthetic ranges),
+	// fall back to assuming same-line — that's the safer default since the
+	// nextLineOpen / sameLineOpen reports would otherwise fire spuriously.
+	prevOpenEnd, hasPrevOpen := stylisticutil.FindPrevTokenEnd(sf, pair.searchStart, openPos)
+	if !hasPrevOpen {
+		prevOpenEnd = openPos
+	}
+
+	singleLineException := opts.allowSingleLine && stylisticutil.SameLineByPos(sf, openPos, closePos)
+
+	if !isAllman && !stylisticutil.SameLineByPos(sf, prevOpenEnd, openPos) {
+		var fixes []rule.RuleFix
+		if !stylisticutil.CommentsExistBetween(text, prevOpenEnd, openPos) {
+			fixes = []rule.RuleFix{{
+				Text:  " ",
+				Range: core.NewTextRange(prevOpenEnd, openPos),
+			}}
+		}
+		ctx.ReportRangeWithFixes(
+			core.NewTextRange(openPos, openEnd),
+			rule.RuleMessage{Id: msgNextLineOpen, Description: descNextLineOpen},
+			fixes...,
+		)
+	}
+
+	if isAllman && stylisticutil.SameLineByPos(sf, prevOpenEnd, openPos) && !singleLineException {
+		ctx.ReportRangeWithFixes(
+			core.NewTextRange(openPos, openEnd),
+			rule.RuleMessage{Id: msgSameLineOpen, Description: descSameLineOpen},
+			rule.RuleFix{
+				Text:  "\n",
+				Range: core.NewTextRange(openPos, openPos),
+			},
+		)
+	}
+
+	nonEmpty := afterStart < closePos
+	if nonEmpty && stylisticutil.SameLineByPos(sf, openPos, afterStart) && !singleLineException {
+		ctx.ReportRangeWithFixes(
+			core.NewTextRange(openPos, openEnd),
+			rule.RuleMessage{Id: msgBlockSameLine, Description: descBlockSameLine},
+			rule.RuleFix{
+				Text:  "\n",
+				Range: core.NewTextRange(openEnd, openEnd),
+			},
+		)
+	}
+}
+
+// validateClose runs the closing-side `singleLineClose` check. Allman /
+// stroustrup / 1tbs all share this check; only `allowSingleLine` and the
+// emptiness of the block can suppress it.
+func validateClose(
+	ctx rule.RuleContext,
+	text string,
+	opts options,
+	pair curlyPair,
+) {
+	sf := ctx.SourceFile
+	openPos := pair.openPos
+	closePos := pair.closePos
+	openEnd := openPos + 1
+	closeEnd := closePos + 1
+
+	// tokenAfterOpeningCurly: first token start at or after `{` + 1.
+	afterStart := scanner.SkipTrivia(text, openEnd)
+	if afterStart > closePos {
+		afterStart = closePos
+	}
+
+	prevCloseEnd, ok := stylisticutil.FindPrevTokenEnd(sf, openEnd, closePos)
+	if !ok {
+		prevCloseEnd = openEnd
+	}
+
+	singleLineException := opts.allowSingleLine && stylisticutil.SameLineByPos(sf, openPos, closePos)
+	nonEmpty := afterStart < closePos
+
+	if nonEmpty && stylisticutil.SameLineByPos(sf, prevCloseEnd, closePos) && !singleLineException {
+		ctx.ReportRangeWithFixes(
+			core.NewTextRange(closePos, closeEnd),
+			rule.RuleMessage{Id: msgSingleLineClose, Description: descSingleLineClose},
+			rule.RuleFix{
+				Text:  "\n",
+				Range: core.NewTextRange(closePos, closePos),
+			},
+		)
+	}
+}
+
+// validateCurlyBeforeKeyword checks the relationship between a closing `}`
+// and the subsequent keyword (`else`, `catch`, `finally`):
+//
+//	nextLineClose   — 1tbs: `}` must be on same line as the keyword
+//	sameLineClose   — stroustrup/allman: `}` must NOT be on same line as the keyword
+func validateCurlyBeforeKeyword(
+	ctx rule.RuleContext,
+	text string,
+	opts options,
+	closePos int,
+) {
+	sf := ctx.SourceFile
+	closeEnd := closePos + 1
+	keywordStart := scanner.SkipTrivia(text, closeEnd)
+	if keywordStart >= len(text) {
+		return
+	}
+
+	is1tbs := opts.style == style1tbs
+
+	if is1tbs && !stylisticutil.SameLineByPos(sf, closePos, keywordStart) {
+		var fixes []rule.RuleFix
+		if !stylisticutil.CommentsExistBetween(text, closeEnd, keywordStart) {
+			fixes = []rule.RuleFix{{
+				Text:  " ",
+				Range: core.NewTextRange(closeEnd, keywordStart),
+			}}
+		}
+		ctx.ReportRangeWithFixes(
+			core.NewTextRange(closePos, closeEnd),
+			rule.RuleMessage{Id: msgNextLineClose, Description: descNextLineClose},
+			fixes...,
+		)
+		return
+	}
+
+	if !is1tbs && stylisticutil.SameLineByPos(sf, closePos, keywordStart) {
+		ctx.ReportRangeWithFixes(
+			core.NewTextRange(closePos, closeEnd),
+			rule.RuleMessage{Id: msgSameLineClose, Description: descSameLineClose},
+			rule.RuleFix{
+				Text:  "\n",
+				Range: core.NewTextRange(closeEnd, closeEnd),
+			},
+		)
+	}
+}
+
+// blockCurlyPair locates `{` and `}` of a Block-like node whose text range
+// already starts at `{` and ends at `}` + 1. Used by KindBlock, KindModuleBlock,
+// and the inner Body of KindClassStaticBlockDeclaration.
+func blockCurlyPair(sf *ast.SourceFile, node *ast.Node, searchStart int) (curlyPair, bool) {
+	text := sf.Text()
+	openPos := scanner.SkipTrivia(text, node.Pos())
+	closePos := node.End() - 1
+	if openPos >= closePos || closePos >= len(text) {
+		return curlyPair{}, false
+	}
+	if text[openPos] != '{' || text[closePos] != '}' {
+		return curlyPair{}, false
+	}
+	return curlyPair{openPos: openPos, closePos: closePos, searchStart: searchStart}, true
+}
+
+// classBodyCurlyPair locates `{` and `}` of a class body. tsgo doesn't model
+// `ClassBody` as a separate node — the class members live directly on
+// `ClassDeclaration` / `ClassExpression`. The opening curly is at
+// `Members.Pos() - 1`; the closing curly is at `node.End() - 1`.
+func classBodyCurlyPair(sf *ast.SourceFile, node *ast.Node, members *ast.NodeList) (curlyPair, bool) {
+	text := sf.Text()
+	if members == nil {
+		return curlyPair{}, false
+	}
+	openPos := members.Pos() - 1
+	closePos := node.End() - 1
+	if openPos < node.Pos() || openPos >= closePos || closePos >= len(text) {
+		return curlyPair{}, false
+	}
+	if text[openPos] != '{' || text[closePos] != '}' {
+		return curlyPair{}, false
+	}
+	return curlyPair{openPos: openPos, closePos: closePos, searchStart: node.Pos()}, true
+}
+
+// switchCurlyPair locates `{` and `}` around a switch's CaseBlock. The
+// CaseBlock is itself the `{ cases... }` container, so its `Pos()` (after
+// trivia) lands on `{` and `End() - 1` lands on `}`.
+func switchCurlyPair(sf *ast.SourceFile, switchNode *ast.Node) (curlyPair, bool) {
+	ss := switchNode.AsSwitchStatement()
+	if ss == nil || ss.CaseBlock == nil {
+		return curlyPair{}, false
+	}
+	return blockCurlyPair(sf, ss.CaseBlock, switchNode.Pos())
+}
+
+// closeBeforeKeywordTrigger inspects a Block being exited and reports
+// `nextLineClose` / `sameLineClose` when the block is the consequent of an
+// IfStatement with an alternate, the try-block / catch-body of a TryStatement
+// whose next sibling is a keyword.
+//
+// Centralizing the trigger here (rather than in IfStatement / TryStatement
+// enter listeners) preserves source-order output: the close-before-keyword
+// report is emitted right after the block's own `singleLineClose` (same
+// position) and before the next block's open-side reports.
+func closeBeforeKeywordTrigger(
+	ctx rule.RuleContext,
+	text string,
+	opts options,
+	block *ast.Node,
+) {
+	parent := block.Parent
+	if parent == nil {
+		return
+	}
+	closePos := block.End() - 1
+
+	switch parent.Kind {
+	case ast.KindIfStatement:
+		is := parent.AsIfStatement()
+		if is == nil {
+			return
+		}
+		if is.ThenStatement != block || is.ElseStatement == nil {
+			return
+		}
+		validateCurlyBeforeKeyword(ctx, text, opts, closePos)
+	case ast.KindTryStatement:
+		ts := parent.AsTryStatement()
+		if ts == nil {
+			return
+		}
+		// `try { ... } catch (...) { ... } [finally { ... }]` — the close
+		// keyword check fires for the try block (next token: `catch` or
+		// `finally`) unconditionally.
+		if ts.TryBlock == block {
+			validateCurlyBeforeKeyword(ctx, text, opts, closePos)
+		}
+	case ast.KindCatchClause:
+		cc := parent.AsCatchClause()
+		if cc == nil || cc.Block != block {
+			return
+		}
+		grand := parent.Parent
+		if grand == nil || grand.Kind != ast.KindTryStatement {
+			return
+		}
+		ts := grand.AsTryStatement()
+		if ts == nil || ts.CatchClause != parent || ts.FinallyBlock == nil {
+			return
+		}
+		validateCurlyBeforeKeyword(ctx, text, opts, closePos)
+	}
+}
+
+// BraceStyleRule enforces consistent brace style across block-bearing
+// constructs (functions, classes, control-flow blocks, switch, try/catch,
+// TS namespaces). Ported from @stylistic/eslint-plugin's brace-style.
+//
+// The rule is layout-only — it inserts and removes line breaks between
+// braces and adjacent tokens, never reflows whole statements. As upstream
+// notes for static blocks: when the autofix introduces a newline the
+// resulting indentation may be wrong; that's expected, the `indent` rule
+// handles indentation in a separate pass.
+//
+// Enter / exit listener split: opening-side reports (nextLineOpen,
+// sameLineOpen, blockSameLine) fire on enter; closing-side reports
+// (singleLineClose) plus close-before-keyword (nextLineClose, sameLineClose)
+// fire on exit. This yields source-order diagnostics for nested constructs
+// and for the if/else and try/catch/finally cases where reports on adjacent
+// tokens come from different AST nodes.
+var BraceStyleRule = rule.Rule{
+	Name: "@stylistic/brace-style",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		text := ctx.SourceFile.Text()
+
+		open := func(pair curlyPair) {
+			validateOpen(ctx, text, opts, pair)
+		}
+		closeFn := func(pair curlyPair) {
+			validateClose(ctx, text, opts, pair)
+		}
+
+		// Block enter/exit.
+		blockEnter := func(node *ast.Node) {
+			if shouldSkipBlock(node) {
+				return
+			}
+			searchStart := node.Parent.Pos()
+			if pair, ok := blockCurlyPair(ctx.SourceFile, node, searchStart); ok {
+				open(pair)
+			}
+		}
+		blockExit := func(node *ast.Node) {
+			if shouldSkipBlock(node) {
+				return
+			}
+			// Emit close-before-keyword BEFORE the block's own singleLineClose
+			// when both fire at the same `}` position. This matches ESLint's
+			// "parent-listener fires before child-listener" emission order
+			// (IfStatement / TryStatement fire before the consequent's
+			// BlockStatement). The two reports are at the same column, so any
+			// downstream consumer that sorts by location sees identical order
+			// in both implementations.
+			closeBeforeKeywordTrigger(ctx, text, opts, node)
+			searchStart := node.Parent.Pos()
+			if pair, ok := blockCurlyPair(ctx.SourceFile, node, searchStart); ok {
+				closeFn(pair)
+			}
+		}
+
+		// ClassStaticBlockDeclaration enter/exit.
+		staticEnter := func(node *ast.Node) {
+			decl := node.AsClassStaticBlockDeclaration()
+			if decl == nil || decl.Body == nil {
+				return
+			}
+			if pair, ok := blockCurlyPair(ctx.SourceFile, decl.Body, node.Pos()); ok {
+				open(pair)
+			}
+		}
+		staticExit := func(node *ast.Node) {
+			decl := node.AsClassStaticBlockDeclaration()
+			if decl == nil || decl.Body == nil {
+				return
+			}
+			if pair, ok := blockCurlyPair(ctx.SourceFile, decl.Body, node.Pos()); ok {
+				closeFn(pair)
+			}
+		}
+
+		// ClassDeclaration / ClassExpression enter/exit.
+		classDeclEnter := func(node *ast.Node) {
+			cd := node.AsClassDeclaration()
+			if cd == nil {
+				return
+			}
+			if pair, ok := classBodyCurlyPair(ctx.SourceFile, node, cd.Members); ok {
+				open(pair)
+			}
+		}
+		classDeclExit := func(node *ast.Node) {
+			cd := node.AsClassDeclaration()
+			if cd == nil {
+				return
+			}
+			if pair, ok := classBodyCurlyPair(ctx.SourceFile, node, cd.Members); ok {
+				closeFn(pair)
+			}
+		}
+		classExprEnter := func(node *ast.Node) {
+			ce := node.AsClassExpression()
+			if ce == nil {
+				return
+			}
+			if pair, ok := classBodyCurlyPair(ctx.SourceFile, node, ce.Members); ok {
+				open(pair)
+			}
+		}
+		classExprExit := func(node *ast.Node) {
+			ce := node.AsClassExpression()
+			if ce == nil {
+				return
+			}
+			if pair, ok := classBodyCurlyPair(ctx.SourceFile, node, ce.Members); ok {
+				closeFn(pair)
+			}
+		}
+
+		// SwitchStatement enter/exit (validate on the CaseBlock's braces).
+		switchEnter := func(node *ast.Node) {
+			if pair, ok := switchCurlyPair(ctx.SourceFile, node); ok {
+				open(pair)
+			}
+		}
+		switchExit := func(node *ast.Node) {
+			if pair, ok := switchCurlyPair(ctx.SourceFile, node); ok {
+				closeFn(pair)
+			}
+		}
+
+		// ModuleBlock enter/exit — `namespace Foo { ... }` / `module "Foo" { ... }`.
+		moduleEnter := func(node *ast.Node) {
+			searchStart := node.Pos()
+			if node.Parent != nil {
+				searchStart = node.Parent.Pos()
+			}
+			if pair, ok := blockCurlyPair(ctx.SourceFile, node, searchStart); ok {
+				open(pair)
+			}
+		}
+		moduleExit := func(node *ast.Node) {
+			searchStart := node.Pos()
+			if node.Parent != nil {
+				searchStart = node.Parent.Pos()
+			}
+			if pair, ok := blockCurlyPair(ctx.SourceFile, node, searchStart); ok {
+				closeFn(pair)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindBlock:                                              blockEnter,
+			rule.ListenerOnExit(ast.KindBlock):                         blockExit,
+			ast.KindClassStaticBlockDeclaration:                        staticEnter,
+			rule.ListenerOnExit(ast.KindClassStaticBlockDeclaration):   staticExit,
+			ast.KindClassDeclaration:                                   classDeclEnter,
+			rule.ListenerOnExit(ast.KindClassDeclaration):              classDeclExit,
+			ast.KindClassExpression:                                    classExprEnter,
+			rule.ListenerOnExit(ast.KindClassExpression):               classExprExit,
+			ast.KindSwitchStatement:                                    switchEnter,
+			rule.ListenerOnExit(ast.KindSwitchStatement):               switchExit,
+			ast.KindModuleBlock:                                        moduleEnter,
+			rule.ListenerOnExit(ast.KindModuleBlock):                   moduleExit,
+		}
+	},
+}

--- a/internal/plugins/stylistic/rules/brace_style/brace_style.md
+++ b/internal/plugins/stylistic/rules/brace_style/brace_style.md
@@ -1,0 +1,204 @@
+# brace-style
+
+Enforce consistent brace style for blocks.
+
+## Rule Details
+
+This rule enforces a consistent brace style across block-bearing constructs — function bodies, control-flow blocks (`if`, `else`, `for`, `while`, `do`, `try`, `catch`, `finally`), class bodies, `switch` bodies, class static blocks, and TypeScript `namespace` / `module` bodies.
+
+The three supported styles place the opening curly differently relative to the controlling statement, and treat the closing curly's relationship to a following keyword (`else`, `catch`, `finally`) differently.
+
+## Options
+
+This rule has a string option:
+
+- `"1tbs"` (default) — "one true brace style". Opening brace on the same line as the controlling statement; closing brace on the same line as the following keyword (`else`, `catch`, `finally`).
+- `"stroustrup"` — like `"1tbs"`, but the closing brace must be on its own line before `else`/`catch`/`finally`.
+- `"allman"` — opening brace on a new line by itself; closing brace also on its own line.
+
+This rule has an object option:
+
+- `"allowSingleLine": true` (default `false`) — allows the opening and closing braces for a block to be on the **same** line.
+
+### 1tbs
+
+Examples of **incorrect** code for this rule with the default `"1tbs"` option:
+
+```javascript
+function foo()
+{
+  return true;
+}
+
+if (foo)
+{
+  bar();
+}
+
+try
+{
+  somethingRisky();
+} catch(e)
+{
+  handleError();
+}
+
+if (foo) {
+  bar();
+}
+else {
+  baz();
+}
+
+class C
+{
+}
+```
+
+Examples of **correct** code for this rule with the default `"1tbs"` option:
+
+```javascript
+function foo() {
+  return true;
+}
+
+if (foo) {
+  bar();
+}
+
+try {
+  somethingRisky();
+} catch (e) {
+  handleError();
+}
+
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+
+class C {
+}
+```
+
+### stroustrup
+
+Examples of **incorrect** code for this rule with the `"stroustrup"` option:
+
+```json
+{ "@stylistic/brace-style": ["error", "stroustrup"] }
+```
+
+```javascript
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+
+try {
+  somethingRisky();
+} catch (e) {
+  handleError();
+}
+```
+
+Examples of **correct** code for this rule with the `"stroustrup"` option:
+
+```json
+{ "@stylistic/brace-style": ["error", "stroustrup"] }
+```
+
+```javascript
+function foo() {
+  return true;
+}
+
+if (foo) {
+  bar();
+}
+else {
+  baz();
+}
+
+try {
+  somethingRisky();
+}
+catch (e) {
+  handleError();
+}
+```
+
+### allman
+
+Examples of **incorrect** code for this rule with the `"allman"` option:
+
+```json
+{ "@stylistic/brace-style": ["error", "allman"] }
+```
+
+```javascript
+function foo() {
+  return true;
+}
+
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+```
+
+Examples of **correct** code for this rule with the `"allman"` option:
+
+```json
+{ "@stylistic/brace-style": ["error", "allman"] }
+```
+
+```javascript
+function foo()
+{
+  return true;
+}
+
+if (foo)
+{
+  bar();
+}
+else
+{
+  baz();
+}
+
+try
+{
+  somethingRisky();
+}
+catch (e)
+{
+  handleError();
+}
+```
+
+### allowSingleLine
+
+Examples of **correct** code for this rule with the `{ "allowSingleLine": true }` option:
+
+```json
+{ "@stylistic/brace-style": ["error", "1tbs", { "allowSingleLine": true }] }
+```
+
+```javascript
+function nop() { return; }
+
+if (foo) { bar(); }
+
+if (foo) { bar(); } else { baz(); }
+
+try { somethingRisky(); } catch (e) { handleError(); }
+```
+
+## Original Documentation
+
+- [@stylistic/brace-style](https://eslint.style/rules/brace-style)

--- a/internal/plugins/stylistic/rules/brace_style/brace_style_extras_test.go
+++ b/internal/plugins/stylistic/rules/brace_style/brace_style_extras_test.go
@@ -1,0 +1,1175 @@
+// TestBraceStyleExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing
+// at the specific branch / Dimension 4 row / tsgo AST quirk / GitHub-issue
+// shape it covers, so future refactors can't silently regress them without
+// breaking a named lock-in.
+//
+// Dimension 4 walk for @stylistic/brace-style:
+//
+//   - Receiver / expression wrappers — N/A. The rule fires on block-bearing
+//     statement nodes (BlockStatement, ClassBody, SwitchStatement, etc.) and
+//     never inspects member-access receivers or type-wrapper expressions.
+//   - Access / key forms — covered for class members (identifier / computed
+//     / private / string-literal method names) and for object literal
+//     methods.
+//   - Declaration / container forms — covered: function decl / function expr
+//     / arrow / method / class field arrow; constructor / getter / setter
+//     bodies; class decl vs class expr; async / generator variants.
+//   - Nesting / traversal boundaries — covered: class-in-class,
+//     function-in-function, namespace-in-namespace, switch-in-switch,
+//     try-in-try.
+//   - Graceful degradation — covered: empty `{}` (various contexts), empty
+//     switch, empty static block, empty namespace, empty try/catch/finally.
+//
+// Branch walk for upstream's `brace-style.ts`:
+//
+//   - `validateCurlyPair` 4-branch matrix — six minimum-input cases (one
+//     per messageId, plus negative coverage on the `allowSingleLine`
+//     escape).
+//   - `validateCurlyBeforeKeyword` 2-branch matrix — nextLineClose and
+//     sameLineClose each isolated.
+//   - `STATEMENT_LIST_PARENTS` skip set: a Block whose parent is each of
+//     `Program`, `Block`, `StaticBlock`, `SwitchCase` (CaseClause +
+//     DefaultClause in tsgo) is locked in as valid under EVERY style.
+//   - `allowSingleLine` exception path: each of the three exception-eligible
+//     checks (sameLineOpen, blockSameLine, singleLineClose) has a same-line
+//     test that PASSES with allowSingleLine and FAILS without it.
+//   - Comment-blocks-fix path: `nextLineOpen` and `nextLineClose` each
+//     locked in with a case where a comment in the trivia suppresses the
+//     autofix (Output is the input).
+//
+// tsgo AST quirks specifically locked in:
+//
+//   - ClassDeclaration / ClassExpression with heritage clauses, type
+//     parameters, decorators (single & multiple), abstract / declare
+//     modifiers — for each the previous token before `{` resolves
+//     correctly (heritage-clause name, type-parameter `>`, modifier
+//     keyword, or class name).
+//   - Static block is treated as its own container (not a nested Block) —
+//     the Block listener skips the static body to avoid double-reporting.
+//   - CatchClause without parameter (ES2019 `catch {}`) — close-before-keyword
+//     still fires when finally follows.
+//   - Module / namespace bodies (ModuleBlock) — both `module "..."` (string
+//     literal name) and `namespace X` (identifier name) variants.
+//   - WithStatement body Block — parses under strict mode, listener fires.
+//
+// Real-user shapes (sampled from common TS/JS codebases & ESLint issue tracker):
+//
+//   - React-style class component with handler arrow fields.
+//   - IIFE patterns `(function() {})()` and `(() => {})()`.
+//   - `export default class {}` and `export default function() {}` shapes.
+//   - Function expression / arrow as object property value.
+//   - Deeply chained `else if` (5+ levels).
+//   - Nested try-catch with arrow inside catch.
+//   - TS function overloads (only impl has body).
+package brace_style_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/brace_style"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestBraceStyleExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&brace_style.BraceStyleRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// Dimension 4: declaration / container forms
+			// ============================================================
+
+			// ---- Dimension 4: function expression body ----
+			{Code: "const f = function () {\n  return;\n};"},
+
+			// ---- Dimension 4: named function expression body ----
+			{Code: "const f = function foo() {\n  return;\n};"},
+
+			// ---- Dimension 4: arrow function block body ----
+			{Code: "const f = () => {\n  return;\n};"},
+
+			// ---- Dimension 4: arrow function expression body — no Block, listener never fires ----
+			{Code: "const f = () => x;"},
+
+			// ---- Dimension 4: async function body ----
+			{Code: "async function f() {\n  return;\n}"},
+
+			// ---- Dimension 4: async arrow body ----
+			{Code: "const f = async () => {\n  return;\n};"},
+
+			// ---- Dimension 4: generator function body ----
+			{Code: "function* g() {\n  yield 1;\n}"},
+
+			// ---- Dimension 4: async generator body ----
+			{Code: "async function* g() {\n  yield 1;\n}"},
+
+			// ---- Dimension 4: method body (object literal shorthand) ----
+			{Code: "const o = {\n  m() {\n    return;\n  },\n};"},
+
+			// ---- Dimension 4: computed method name ----
+			{Code: "const o = {\n  [Symbol.iterator]() {\n    return;\n  },\n};"},
+
+			// ---- Dimension 4: getter / setter bodies ----
+			{Code: "const o = {\n  get x() {\n    return 1;\n  },\n  set x(v) {\n    this._x = v;\n  },\n};"},
+
+			// ---- Dimension 4: constructor body ----
+			{Code: "class C {\n  constructor() {\n    this.x = 1;\n  }\n}"},
+
+			// ---- Dimension 4: class method (regular) ----
+			{Code: "class C {\n  m() {\n    return;\n  }\n}"},
+
+			// ---- Dimension 4: class async method ----
+			{Code: "class C {\n  async m() {\n    return;\n  }\n}"},
+
+			// ---- Dimension 4: class generator method ----
+			{Code: "class C {\n  *m() {\n    yield 1;\n  }\n}"},
+
+			// ---- Dimension 4: class async generator method ----
+			{Code: "class C {\n  async *m() {\n    yield 1;\n  }\n}"},
+
+			// ---- Dimension 4: class private method ----
+			{Code: "class C {\n  #m() {\n    return;\n  }\n}"},
+
+			// ---- Dimension 4: class computed-key method ----
+			{Code: "class C {\n  [Symbol.iterator]() {\n    return;\n  }\n}"},
+
+			// ---- Dimension 4: class string-literal-key method ----
+			{Code: "class C {\n  \"m\"() {\n    return;\n  }\n}"},
+
+			// ---- Dimension 4: class field arrow initializer ----
+			{Code: "class C {\n  handler = (a) => {\n    return a;\n  };\n}"},
+
+			// ---- Dimension 4: class field arrow with expression body — no inner Block ----
+			{Code: "class C {\n  handler = (a) => a;\n}"},
+
+			// ============================================================
+			// tsgo AST quirks — class declaration / expression shapes
+			// ============================================================
+
+			// ---- tsgo lock-in: class with type parameters ----
+			{Code: "class C<T> {\n  x: T;\n}"},
+
+			// ---- tsgo lock-in: class with type parameter constraints ----
+			{Code: "class C<T extends string> {\n  x: T;\n}"},
+
+			// ---- tsgo lock-in: class with multiple type parameters ----
+			{Code: "class C<T, U, V> {\n  x: T;\n}"},
+
+			// ---- tsgo lock-in: class with extends ----
+			{Code: "class C extends Base {\n  x = 1;\n}"},
+
+			// ---- tsgo lock-in: class with extends and implements ----
+			{Code: "class C extends Base implements I1, I2 {\n  x = 1;\n}"},
+
+			// ---- tsgo lock-in: class with extends + generics ----
+			{Code: "class C<T> extends Base<T> implements I<T> {\n  x: T;\n}"},
+
+			// ---- tsgo lock-in: class with single decorator ----
+			{Code: "@dec\nclass C {\n  x = 1;\n}"},
+
+			// ---- tsgo lock-in: class with decorator with args ----
+			{Code: "@dec(arg, arg2)\nclass C {\n  x = 1;\n}"},
+
+			// ---- tsgo lock-in: class with multiple decorators ----
+			{Code: "@a\n@b()\nclass C {\n  x = 1;\n}"},
+
+			// ---- tsgo lock-in: class with decorator + allman ----
+			// Locks in that scanner finds `Foo` as previous token, not `@dec`.
+			{Code: "@dec\nclass Foo\n{\n}", Options: optsAllman()},
+
+			// ---- tsgo lock-in: abstract class ----
+			{Code: "abstract class C {\n  abstract m(): void;\n}"},
+
+			// ---- tsgo lock-in: declare class ----
+			{Code: "declare class C {\n  x: number;\n}"},
+
+			// ---- tsgo lock-in: named class expression ----
+			{Code: "const C = class Foo {\n  x = 1;\n};"},
+
+			// ---- tsgo lock-in: anonymous class expression ----
+			{Code: "const C = class {\n  x = 1;\n};"},
+
+			// ---- tsgo lock-in: class expression with extends ----
+			{Code: "const C = class extends Base {\n  x = 1;\n};"},
+
+			// ============================================================
+			// Branch lock-ins for STATEMENT_LIST_PARENTS skip set
+			// ============================================================
+
+			// ---- Locks in shouldSkipBlock(parent=Program): standalone top-level block ----
+			{Code: "{ x; }"},
+			{Code: "{ x; }", Options: optsStroustrup()},
+			{Code: "{ x; }", Options: optsAllman()},
+
+			// ---- Locks in shouldSkipBlock(parent=Block): nested standalone block ----
+			{Code: "function f() {\n  { x; }\n}"},
+			{Code: "function f() {\n  { x; }\n}", Options: optsStroustrup()},
+			{Code: "function f()\n{\n  { x; }\n}", Options: optsAllman()},
+
+			// ---- Locks in shouldSkipBlock(parent=CaseClause): block in case ----
+			{Code: "switch (x) {\n  case 1: { x; }\n}"},
+			{Code: "switch (x) {\n  case 1: { x; }\n}", Options: optsStroustrup()},
+
+			// ---- Locks in shouldSkipBlock(parent=DefaultClause): block in default ----
+			{Code: "switch (x) {\n  default: { x; }\n}"},
+			{Code: "switch (x) {\n  default: { x; }\n}", Options: optsStroustrup()},
+
+			// ---- Locks in shouldSkipBlock(parent=ClassStaticBlockDeclaration): inner Block of static block ----
+			// The static-block listener handles this; the inner Block listener
+			// must skip it to avoid double-reporting.
+			{Code: "class C {\n  static {\n    foo;\n  }\n}"},
+
+			// ============================================================
+			// Branch lock-ins for the 6 messageIds (isolation cases)
+			// ============================================================
+
+			// (See invalid section for the failing companions.)
+			// ---- valid baseline for allowSingleLine on each style ----
+			{Code: "function f() { return; }", Options: opts1tbsSingle()},
+			{Code: "function f() {}", Options: opts1tbsSingle()},
+			{Code: "function f() { return; }", Options: optsStroustrupSingle()},
+			{Code: "function f() {}", Options: optsAllmanSingle()},
+
+			// ============================================================
+			// rslint-specific lock-ins
+			// ============================================================
+
+			// ---- TS namespace body (KindModuleBlock) — basic ----
+			{Code: "namespace Foo {\n  export const x = 1;\n}"},
+
+			// ---- TS nested namespace ----
+			{Code: "namespace A.B {\n  export const x = 1;\n}"},
+
+			// ---- TS nested namespace declarations ----
+			{Code: "namespace Outer {\n  namespace Inner {\n    export const x = 1;\n  }\n}"},
+
+			// ---- TS declare module (ambient) ----
+			{Code: "declare module 'foo' {\n  export const x: number;\n}"},
+
+			// ---- TS declare global ----
+			{Code: "declare global {\n  interface Window { x: number; }\n}"},
+
+			// ---- Catch without parameter (ES2019) ----
+			{Code: "try {\n  a();\n} catch {\n  b();\n}"},
+
+			// ---- Catch without parameter + finally — locks in close-before-finally still fires ----
+			{Code: "try {\n  a();\n} catch {\n  b();\n} finally {\n  c();\n}"},
+
+			// ---- Try-only-finally (no catch) ----
+			{Code: "try {\n  a();\n} finally {\n  c();\n}"},
+
+			// ---- Stroustrup try-only-finally ----
+			{Code: "try {\n  a();\n}\nfinally {\n  c();\n}", Options: optsStroustrup()},
+
+			// ---- Allman try-only-finally ----
+			{Code: "try\n{\n  a();\n}\nfinally\n{\n  c();\n}", Options: optsAllman()},
+
+			// ---- Do-while block ----
+			{Code: "do {\n  bar();\n} while (true);"},
+
+			// ---- For-of block ----
+			{Code: "for (const x of arr) {\n  bar();\n}"},
+
+			// ---- Labeled statement containing a block — parent != STATEMENT_LIST_PARENT ----
+			// The Block parent is `LabeledStatement`; listener DOES fire.
+			{Code: "loop: {\n  break loop;\n}"},
+
+			// ============================================================
+			// Dimension 4: nesting / traversal boundaries
+			// ============================================================
+
+			// ---- Class in class — both bodies checked independently ----
+			{Code: "class Outer {\n  inner = class Inner {\n    x = 1;\n  };\n}"},
+
+			// ---- Function in function ----
+			{Code: "function outer() {\n  function inner() {\n    return;\n  }\n  return inner;\n}"},
+
+			// ---- Switch in switch ----
+			{Code: "switch (x) {\n  case 1:\n    switch (y) {\n      case 2: break;\n    }\n    break;\n}"},
+
+			// ---- Try in try ----
+			{Code: "try {\n  try {\n    a();\n  } catch (e) {\n    b();\n  }\n} catch (e) {\n  c();\n}"},
+
+			// ---- Try in catch ----
+			{Code: "try {\n  a();\n} catch (e) {\n  try {\n    b();\n  } catch (e2) {\n    c();\n  }\n}"},
+
+			// ---- 5-level else-if chain ----
+			{Code: "if (a) {\n  x;\n} else if (b) {\n  y;\n} else if (c) {\n  z;\n} else if (d) {\n  w;\n} else if (e) {\n  v;\n} else {\n  u;\n}"},
+
+			// ---- 5-level else-if stroustrup ----
+			{Code: "if (a) {\n  x;\n}\nelse if (b) {\n  y;\n}\nelse if (c) {\n  z;\n}\nelse if (d) {\n  w;\n}\nelse if (e) {\n  v;\n}\nelse {\n  u;\n}", Options: optsStroustrup()},
+
+			// ============================================================
+			// Real-user code shapes
+			// ============================================================
+
+			// ---- Real-user: React-style class component with arrow fields ----
+			{Code: "class Component {\n  handleClick = () => {\n    this.setState({});\n  };\n  render() {\n    return null;\n  }\n}"},
+
+			// ---- Real-user: IIFE with function expression ----
+			{Code: "(function() {\n  console.log('init');\n})();"},
+
+			// ---- Real-user: IIFE with arrow ----
+			{Code: "(() => {\n  console.log('init');\n})();"},
+
+			// ---- Real-user: IIFE single-line with allowSingleLine ----
+			{Code: "(function() { return 1; })();", Options: opts1tbsSingle()},
+
+			// ---- Real-user: export default function ----
+			{Code: "export default function foo() {\n  return 1;\n}"},
+
+			// ---- Real-user: anonymous export default function ----
+			{Code: "export default function() {\n  return 1;\n}"},
+
+			// ---- Real-user: export default class ----
+			{Code: "export default class Foo {\n  x = 1;\n}"},
+
+			// ---- Real-user: anonymous export default class ----
+			{Code: "export default class {\n  x = 1;\n}"},
+
+			// ---- Real-user: nested try-catch with arrow ----
+			{Code: "try {\n  const f = () => {\n    throw new Error();\n  };\n  f();\n} catch (e) {\n  console.error(e);\n}"},
+
+			// ---- Real-user: arrow inside async function ----
+			{Code: "async function f() {\n  const cb = () => {\n    return 1;\n  };\n  return cb();\n}"},
+
+			// ---- Real-user: TS function overloads (only impl has body) ----
+			{Code: "function f(x: string): void;\nfunction f(x: number): void;\nfunction f(x: any): void {\n  console.log(x);\n}"},
+
+			// ============================================================
+			// TS-only "shape" non-targets: the rule MUST NOT fire on these
+			// (locks in that I'm not over-firing on body-like constructs that
+			// upstream's ESTree listeners never touch)
+			// ============================================================
+
+			// ---- TS interface declaration body — not handled by upstream ----
+			// Same style violations of `1tbs` placement on interface braces
+			// should NOT fire. Upstream has no TSInterfaceBody listener.
+			{Code: "interface I\n{\n  x: number;\n}"},
+			{Code: "interface I\n{\n  x: number;\n}", Options: optsStroustrup()},
+
+			// ---- TS enum declaration body — not handled ----
+			{Code: "enum E\n{\n  A,\n  B,\n}"},
+			{Code: "enum E { A, B }"},
+
+			// ---- TS const enum body — not handled ----
+			{Code: "const enum E\n{\n  A,\n  B,\n}"},
+
+			// ---- TS type literal — not handled ----
+			{Code: "type T = {\n  x: number;\n};"},
+			{Code: "type T = { x: number };"},
+
+			// ---- TS mapped type with braces — not handled ----
+			{Code: "type T<X> = {\n  [K in keyof X]: X[K];\n};"},
+
+			// ---- Object literal in expression position — not handled ----
+			// (Despite using `{}`, an ObjectLiteralExpression is NOT a Block.)
+			{Code: "const o = { x: 1, y: 2 };"},
+			{Code: "const o =\n{\n  x: 1,\n};"},
+
+			// ---- JSX expression container — not a Block ----
+			{Code: "const el = <div>{value}</div>;", FileName: "react.tsx"},
+			{Code: "const el = <div>{ value }</div>;", FileName: "react.tsx"},
+
+			// ---- Destructuring pattern uses `{}` — not a Block ----
+			{Code: "const { a, b } = o;"},
+			{Code: "function f({ x }) { return x; }", Options: opts1tbsSingle()},
+
+			// ============================================================
+			// More TS-specific class shapes (locking in tsgo behavior)
+			// ============================================================
+
+			// ---- Class with access modifiers ----
+			{Code: "class C {\n  public x = 1;\n  private y = 2;\n  protected z = 3;\n}"},
+
+			// ---- Class with readonly fields ----
+			{Code: "class C {\n  readonly x = 1;\n}"},
+
+			// ---- Class with optional method ----
+			{Code: "class C {\n  m?(): void {\n    return;\n  }\n}"},
+
+			// ---- Class with definite assignment field ----
+			{Code: "class C {\n  x!: number;\n}"},
+
+			// ---- Class with override modifier ----
+			{Code: "class Sub extends Base {\n  override m() {\n    return;\n  }\n}"},
+
+			// ---- Class with decorated method ----
+			{Code: "class C {\n  @dec m() {\n    return;\n  }\n}"},
+
+			// ---- Class with decorated field arrow ----
+			{Code: "class C {\n  @dec handler = (a) => {\n    return a;\n  };\n}"},
+
+			// ---- Class with multiple decorated members ----
+			{Code: "class C {\n  @a x = 1;\n  @b y = 2;\n  @c m() {\n    return;\n  }\n}"},
+
+			// ---- Class with parameter properties ----
+			{Code: "class C {\n  constructor(public x: number, private y: string) {\n    return;\n  }\n}"},
+
+			// ---- Class with all-static members ----
+			{Code: "class Utils {\n  static a = 1;\n  static b = 2;\n  static m() {\n    return;\n  }\n}"},
+
+			// ---- Class with mixed static/instance + static block ----
+			{Code: "class C {\n  static x = 1;\n  static {\n    C.x = 2;\n  }\n  m() {\n    return this;\n  }\n}"},
+
+			// ============================================================
+			// More function/control-flow forms
+			// ============================================================
+
+			// ---- TS function with type predicates ----
+			{Code: "function isString(x: unknown): x is string {\n  return typeof x === 'string';\n}"},
+
+			// ---- TS function with generic constraint ----
+			{Code: "function f<T extends string>(x: T): T {\n  return x;\n}"},
+
+			// ---- Async arrow returning a Promise ----
+			{Code: "const f: () => Promise<void> = async () => {\n  await Promise.resolve();\n};"},
+
+			// ---- Higher-order function ----
+			{Code: "function curry(f: Function): Function {\n  return function (x: unknown) {\n    return function (y: unknown) {\n      return f(x, y);\n    };\n  };\n}"},
+
+			// ---- Method chained body ----
+			{Code: "arr.map((x) => {\n  return x * 2;\n}).filter((x) => {\n  return x > 0;\n});"},
+
+			// ---- For-await-of with try inside ----
+			{Code: "async function f() {\n  for await (const x of stream) {\n    try {\n      await process(x);\n    } catch (e) {\n      console.error(e);\n    }\n  }\n}"},
+
+			// ============================================================
+			// More if-else chain / switch shapes
+			// ============================================================
+
+			// ---- if-else single-line on one branch, multi on another ----
+			{Code: "if (a) { foo(); } else {\n  bar();\n  baz();\n}", Options: opts1tbsSingle()},
+
+			// ---- switch with multiple case statements grouping ----
+			{Code: "switch (x) {\n  case 1:\n  case 2:\n  case 3:\n    foo();\n    break;\n}"},
+
+			// ---- switch with break in case body ----
+			{Code: "switch (x) {\n  case 1: {\n    foo();\n    break;\n  }\n  case 2: {\n    bar();\n    break;\n  }\n}"},
+
+			// ---- switch with throw / return as case body ----
+			{Code: "switch (x) {\n  case 1: return 1;\n  case 2: throw new Error();\n  default: return 0;\n}"},
+
+			// ---- nested switch with shared `default` ----
+			{Code: "switch (x) {\n  case 1: {\n    switch (y) {\n      case 'a': foo(); break;\n      default: bar();\n    }\n    break;\n  }\n}"},
+
+			// ============================================================
+			// More namespace / module shapes
+			// ============================================================
+
+			// ---- namespace with method-like signature ----
+			{Code: "namespace Foo {\n  export function bar() {\n    return 1;\n  }\n}"},
+
+			// ---- namespace with nested class ----
+			{Code: "namespace Foo {\n  export class Bar {\n    x = 1;\n  }\n}"},
+
+			// ---- export = ... pattern ----
+			{Code: "namespace Foo {\n  export const x = 1;\n}\nexport = Foo;"},
+
+			// ---- ambient module with declarations ----
+			{Code: "declare module 'pkg' {\n  export function fn(): void;\n  export class C {\n    x: number;\n  }\n}"},
+
+			// ============================================================
+			// Comments at unusual positions
+			// ============================================================
+
+			// ---- Comment after `)` of function head ----
+			{Code: "function f() /* c */ {\n  return;\n}"},
+
+			// ---- Comment between `}` and `else` — same-line, no diagnostic ----
+			{Code: "if (a) {\n  b;\n} /* c */ else {\n  d;\n}"},
+
+			// ---- Block comment inside block body ----
+			{Code: "function f() {\n  /* doc */\n  return;\n}"},
+
+			// ---- Leading block comment on class ----
+			{Code: "/** doc */\nclass C {\n  x = 1;\n}"},
+
+			// ---- Inline comment after `{` ----
+			{Code: "function f() { /* short */\n  return;\n}"},
+
+			// ---- Real-user: class with overload signatures ----
+			{Code: "class C {\n  m(x: string): void;\n  m(x: number): void;\n  m(x: any): void {\n    console.log(x);\n  }\n}"},
+
+			// ---- Real-user: abstract method (no body) coexisting with concrete methods ----
+			{Code: "abstract class C {\n  abstract a(): void;\n  b() {\n    this.a();\n  }\n}"},
+
+			// ============================================================
+			// Fix idempotence — running the fix once should converge
+			// ============================================================
+
+			// The invalid section below covers the fixed outputs; the cases
+			// here are the EXPECTED OUTPUT of those fixes — they must pass
+			// the rule as valid after one fix pass. This is the idempotence
+			// contract: rule(fix(code)) should produce zero new diagnostics.
+			{Code: "function foo() {\n return; \n}"},
+			{Code: "function foo() { \n return; \n}"},
+			{Code: "if (a) {\n  b;\n} else {\n  c;\n}"},
+			{Code: "if (a) {\n  b;\n}\nelse {\n  c;\n}", Options: optsStroustrup()},
+			{Code: "if (a)\n{\n  b;\n}\nelse\n{\n  c;\n}", Options: optsAllman()},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Branch isolation: each of the 6 messageIds in its own case
+			// ============================================================
+
+			// ---- Locks in upstream validateCurlyPair: nextLineOpen ----
+			{
+				Code:   "function f()\n{\n  return;\n}",
+				Output: []string{"function f() {\n  return;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Locks in upstream validateCurlyPair: sameLineOpen ----
+			{
+				Code:    "function f() {\n  return;\n}",
+				Output:  []string{"function f() \n{\n  return;\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 14},
+				},
+			},
+
+			// ---- Locks in upstream validateCurlyPair: blockSameLine ----
+			{
+				Code:   "function f() { foo;\n}",
+				Output: []string{"function f() {\n foo;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 14},
+				},
+			},
+
+			// ---- Locks in upstream validateCurlyPair: singleLineClose ----
+			{
+				Code:   "function f() {\n  foo; }",
+				Output: []string{"function f() {\n  foo; \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 2, Column: 8},
+				},
+			},
+
+			// ---- Locks in upstream validateCurlyBeforeKeyword: nextLineClose ----
+			{
+				Code:   "if (a) {\n  b;\n}\nelse {\n  c;\n}",
+				Output: []string{"if (a) {\n  b;\n} else {\n  c;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Locks in upstream validateCurlyBeforeKeyword: sameLineClose ----
+			{
+				Code:    "if (a) {\n  b;\n} else {\n  c;\n}",
+				Output:  []string{"if (a) {\n  b;\n}\n else {\n  c;\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 3, Column: 1},
+				},
+			},
+
+			// ============================================================
+			// Locks in commentsExistBetween fix-suppression branches
+			// ============================================================
+
+			// ---- nextLineClose: comment between } and keyword → fix suppressed ----
+			// Diagnostic still fires; no Output → no fix applied.
+			{
+				Code: "if (a) {\n  b;\n} /* comment */\nelse {\n  c;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- nextLineOpen: line comment between paren and { → fix suppressed ----
+			// (Already covered in upstream tests as `if (foo) // comment \n{...}`,
+			// duplicated here with try/catch to lock in the suppression for
+			// validateCurlyBeforeKeyword's sibling, validateCurlyPair.)
+			{
+				Code: "function f() // line comment\n{\n  return;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- nextLineClose with try/finally and a block-comment in between ----
+			{
+				Code: "try {\n  a();\n}\n/* note */\nfinally {\n  b();\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 3, Column: 1},
+				},
+			},
+
+			// ============================================================
+			// tsgo AST quirk locks — class declaration / expression shapes
+			// ============================================================
+
+			// ---- tsgo: class with type parameters, allman ----
+			{
+				Code:    "class C<T> {\n  x: T;\n}",
+				Output:  []string{"class C<T> \n{\n  x: T;\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 12},
+				},
+			},
+
+			// ---- tsgo: class with extends clause, allman ----
+			// Locks in that scanner correctly identifies `Base` as previous
+			// token before `{` (not `extends`).
+			{
+				Code:    "class C extends Base {\n  x = 1;\n}",
+				Output:  []string{"class C extends Base \n{\n  x = 1;\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 22},
+				},
+			},
+
+			// ---- tsgo: class with extends + implements, default ----
+			// Multi-line heritage shouldn't fire nextLineOpen if `{` is on
+			// same line as the last heritage identifier.
+			{
+				Code: "class C\n  extends Base\n  implements I1\n{\n  x = 1;\n}",
+				Output: []string{
+					"class C\n  extends Base\n  implements I1 {\n  x = 1;\n}",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 4, Column: 1},
+				},
+			},
+
+			// ---- tsgo: decorated class, allman should still fire ----
+			{
+				Code:    "@dec\nclass C {\n  x = 1;\n}",
+				Output:  []string{"@dec\nclass C \n{\n  x = 1;\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 2, Column: 9},
+				},
+			},
+
+			// ---- tsgo: anonymous class expr with name ----
+			{
+				Code:   "const C = class\n{};",
+				Output: []string{"const C = class {};"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- tsgo: class expr with extends, allman ----
+			{
+				Code:    "const C = class extends Base {\n  x = 1;\n};",
+				Output:  []string{"const C = class extends Base \n{\n  x = 1;\n};"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 30},
+				},
+			},
+
+			// ============================================================
+			// Real-user fix scenarios
+			// ============================================================
+
+			// ---- Real-user: function expression inside object property value ----
+			// Locks in that `tokenBefore` for `{` is `)`, not `:` of property.
+			{
+				Code:   "const o = { fn: function() { return; \n} };",
+				Output: []string{"const o = { fn: function() {\n return; \n} };"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 28},
+				},
+			},
+
+			// ---- Real-user: arrow function body single-line ----
+			{
+				Code:   "const f = () => { return; }",
+				Output: []string{"const f = () => {\n return; \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 17},
+					{MessageId: "singleLineClose", Line: 1, Column: 27},
+				},
+			},
+
+			// ---- Real-user: class method body single-line ----
+			{
+				Code:   "class C {\n  m() { return; }\n}",
+				Output: []string{"class C {\n  m() {\n return; \n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 7},
+					{MessageId: "singleLineClose", Line: 2, Column: 17},
+				},
+			},
+
+			// ---- Real-user: class private method body single-line ----
+			{
+				Code:   "class C {\n  #m() { return; }\n}",
+				Output: []string{"class C {\n  #m() {\n return; \n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 8},
+					{MessageId: "singleLineClose", Line: 2, Column: 18},
+				},
+			},
+
+			// ---- Real-user: class async method ----
+			{
+				Code:   "class C {\n  async m() { return; }\n}",
+				Output: []string{"class C {\n  async m() {\n return; \n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 13},
+					{MessageId: "singleLineClose", Line: 2, Column: 23},
+				},
+			},
+
+			// ---- Real-user: class getter ----
+			{
+				Code:   "class C {\n  get x() { return 1; }\n}",
+				Output: []string{"class C {\n  get x() {\n return 1; \n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 11},
+					{MessageId: "singleLineClose", Line: 2, Column: 23},
+				},
+			},
+
+			// ---- Real-user: constructor body ----
+			{
+				Code:   "class C {\n  constructor() { this.x = 1; }\n}",
+				Output: []string{"class C {\n  constructor() {\n this.x = 1; \n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 17},
+					{MessageId: "singleLineClose", Line: 2, Column: 31},
+				},
+			},
+
+			// ---- Real-user: catch without parameter, stroustrup ----
+			// Locks in that `catch {}` (no param) is detected and close-before-catch fires.
+			{
+				Code:    "try {\n  a();\n} catch {\n  b();\n}",
+				Output:  []string{"try {\n  a();\n}\n catch {\n  b();\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Real-user: catch without parameter + finally, both close-before checks fire ----
+			{
+				Code:    "try {\n  a();\n} catch {\n  b();\n} finally {\n  c();\n}",
+				Output:  []string{"try {\n  a();\n}\n catch {\n  b();\n}\n finally {\n  c();\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 3, Column: 1},
+					{MessageId: "sameLineClose", Line: 5, Column: 1},
+				},
+			},
+
+			// ---- Real-user: try-only-finally — close-before-finally fires ----
+			// No catch in between; close-before-keyword still triggers on tryBlock's }.
+			{
+				Code:    "try {\n  a();\n}\nfinally {\n  c();\n}",
+				Output:  []string{"try {\n  a();\n} finally {\n  c();\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Real-user: deeply chained else-if with one violation in the chain ----
+			{
+				Code:   "if (a) {\n  x;\n} else if (b) {\n  y;\n} else if (c) {\n  z;\n}\nelse {\n  w;\n}",
+				Output: []string{"if (a) {\n  x;\n} else if (b) {\n  y;\n} else if (c) {\n  z;\n} else {\n  w;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 7, Column: 1},
+				},
+			},
+
+			// ---- Real-user: nested try-catch — only inner has a violation ----
+			{
+				Code:   "try {\n  try {\n    a();\n  }\n  catch (e) {\n    b();\n  }\n} catch (e) {\n  c();\n}",
+				Output: []string{"try {\n  try {\n    a();\n  } catch (e) {\n    b();\n  }\n} catch (e) {\n  c();\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 4, Column: 3},
+				},
+			},
+
+			// ---- Real-user: class-in-class — only inner one violates ----
+			{
+				Code:   "class Outer {\n  inner = class Inner\n  {\n  };\n}",
+				Output: []string{"class Outer {\n  inner = class Inner {\n  };\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 3, Column: 3},
+				},
+			},
+
+			// ---- Real-user: namespace with a single same-line empty ----
+			{
+				Code:    "namespace Foo { }",
+				Output:  []string{"namespace Foo \n{ }"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 15},
+				},
+			},
+
+			// ---- Real-user: nested namespace, only outer violates ----
+			{
+				Code:   "namespace Outer\n{\n  namespace Inner {\n    export const x = 1;\n  }\n}",
+				Output: []string{"namespace Outer {\n  namespace Inner {\n    export const x = 1;\n  }\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Real-user: declare module ambient with bad braces ----
+			{
+				Code:   "declare module 'foo'\n{\n  export const x: number;\n}",
+				Output: []string{"declare module 'foo' {\n  export const x: number;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Real-user: SwitchCase with same-line close ----
+			{
+				Code:   "switch (x) {\n  case 1: foo(); }",
+				Output: []string{"switch (x) {\n  case 1: foo(); \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 2, Column: 18},
+				},
+			},
+
+			// ---- Real-user: switch in switch — inner has a violation ----
+			{
+				Code:   "switch (x) {\n  case 1:\n    switch (y) {\n      case 2: break; }\n    break;\n}",
+				Output: []string{"switch (x) {\n  case 1:\n    switch (y) {\n      case 2: break; \n}\n    break;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 4, Column: 22},
+				},
+			},
+
+			// ============================================================
+			// Multi-violation source-order locks (cross-listener ordering)
+			// ============================================================
+
+			// ---- Locks ordering: seven reports in source order across multiple listeners ----
+			// All reports come from different listener firings (Block enter,
+			// Block exit, close-before-keyword trigger). At the same `}`
+			// column the close-before-keyword report fires BEFORE the block's
+			// own `singleLineClose` — matches ESLint's parent-listener-first
+			// emission order (IfStatement listener fires before its
+			// consequent BlockStatement listener).
+			{
+				Code:    "if (a) { x; } else { y; }",
+				Output:  []string{"if (a) \n{\n x; \n}\n else \n{\n y; \n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 8},
+					{MessageId: "blockSameLine", Line: 1, Column: 8},
+					{MessageId: "sameLineClose", Line: 1, Column: 13},
+					{MessageId: "singleLineClose", Line: 1, Column: 13},
+					{MessageId: "sameLineOpen", Line: 1, Column: 20},
+					{MessageId: "blockSameLine", Line: 1, Column: 20},
+					{MessageId: "singleLineClose", Line: 1, Column: 25},
+				},
+			},
+
+			// ---- Locks ordering: try-block close-before-catch + catch-body close-before-finally ----
+			// Two close-before-keyword reports in a single TryStatement.
+			{
+				Code:    "try {\n  a();\n} catch (e) {\n  b();\n} finally {\n  c();\n}",
+				Output:  []string{"try {\n  a();\n}\n catch (e) {\n  b();\n}\n finally {\n  c();\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 3, Column: 1},
+					{MessageId: "sameLineClose", Line: 5, Column: 1},
+				},
+			},
+
+			// ---- Locks ordering: class body singleLineClose comes from KindClassDeclaration exit, not KindBlock ----
+			{
+				Code:   "class Foo {\n  m() {\n}}",
+				Output: []string{"class Foo {\n  m() {\n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 3, Column: 2},
+				},
+			},
+
+			// ============================================================
+			// More tsgo-quirk-driven invalid cases
+			// ============================================================
+
+			// ---- Class with decorator + bad single-line allman ----
+			{
+				Code:    "@dec\nclass C { x = 1; }",
+				Output:  []string{"@dec\nclass C \n{\n x = 1; \n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 2, Column: 9},
+					{MessageId: "blockSameLine", Line: 2, Column: 9},
+					{MessageId: "singleLineClose", Line: 2, Column: 18},
+				},
+			},
+
+			// ---- Abstract class with same-line body, allman ----
+			{
+				Code:    "abstract class C { x: number; }",
+				Output:  []string{"abstract class C \n{\n x: number; \n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 18},
+					{MessageId: "blockSameLine", Line: 1, Column: 18},
+					{MessageId: "singleLineClose", Line: 1, Column: 31},
+				},
+			},
+
+			// ---- Class with `override` method body bad ----
+			{
+				Code:   "class S extends B {\n  override m() { return; }\n}",
+				Output: []string{"class S extends B {\n  override m() {\n return; \n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 16},
+					{MessageId: "singleLineClose", Line: 2, Column: 26},
+				},
+			},
+
+			// ---- Class field arrow with bad braces ----
+			{
+				Code:   "class C {\n  handler = (a) => { return a; };\n}",
+				Output: []string{"class C {\n  handler = (a) => {\n return a; \n};\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 20},
+					{MessageId: "singleLineClose", Line: 2, Column: 32},
+				},
+			},
+
+			// ---- Parameter property constructor with bad braces ----
+			{
+				Code:   "class C {\n  constructor(public x: number) { this.y = x; }\n}",
+				Output: []string{"class C {\n  constructor(public x: number) {\n this.y = x; \n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 33},
+					{MessageId: "singleLineClose", Line: 2, Column: 47},
+				},
+			},
+
+			// ============================================================
+			// More multi-violation source-order locks
+			// ============================================================
+
+			// ---- if-else-if chain with violation at each level, default 1tbs ----
+			// The chain is: if {} else if {}\nelse if {}\nelse {}.
+			// The 2 `\nelse` transitions BOTH violate 1tbs's nextLineClose.
+			{
+				Code:   "if (a) {\n  x;\n}\nelse if (b) {\n  y;\n}\nelse {\n  z;\n}",
+				Output: []string{"if (a) {\n  x;\n} else if (b) {\n  y;\n} else {\n  z;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 3, Column: 1},
+					{MessageId: "nextLineClose", Line: 6, Column: 1},
+				},
+			},
+
+			// ---- if-else chain in stroustrup with violations at each level ----
+			{
+				Code:    "if (a) {\n  x;\n} else if (b) {\n  y;\n} else {\n  z;\n}",
+				Output:  []string{"if (a) {\n  x;\n}\n else if (b) {\n  y;\n}\n else {\n  z;\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 3, Column: 1},
+					{MessageId: "sameLineClose", Line: 5, Column: 1},
+				},
+			},
+
+			// ---- try-catch-finally with all three blocks single-line wrong ----
+			{
+				Code:   "try { a(); } catch (e) { b(); } finally { c(); }",
+				Output: []string{"try {\n a(); \n} catch (e) {\n b(); \n} finally {\n c(); \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 5},
+					{MessageId: "singleLineClose", Line: 1, Column: 12},
+					{MessageId: "blockSameLine", Line: 1, Column: 24},
+					{MessageId: "singleLineClose", Line: 1, Column: 31},
+					{MessageId: "blockSameLine", Line: 1, Column: 41},
+					{MessageId: "singleLineClose", Line: 1, Column: 48},
+				},
+			},
+
+			// ---- Nested class — outer + inner BOTH violate (allman) ----
+			{
+				Code:    "class O {\n  inner = class I {\n    x = 1;\n  };\n}",
+				Output:  []string{"class O \n{\n  inner = class I \n{\n    x = 1;\n  };\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 9},
+					{MessageId: "sameLineOpen", Line: 2, Column: 19},
+				},
+			},
+
+			// ---- Switch with violation on body + violation in case-internal block ----
+			// Important: case-internal block is SKIPPED by STATEMENT_LIST_PARENTS,
+			// so only the OUTER switch's braces should violate.
+			{
+				Code:   "switch (x) { case 1: {\n    foo();\n  }\n  break;\n}",
+				Output: []string{"switch (x) {\n case 1: {\n    foo();\n  }\n  break;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 12},
+				},
+			},
+
+			// ---- Real-user: IIFE with bad braces ----
+			{
+				Code:   "(function() { return 1; })();",
+				Output: []string{"(function() {\n return 1; \n})();"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 13},
+					{MessageId: "singleLineClose", Line: 1, Column: 25},
+				},
+			},
+
+			// ---- Real-user: arrow IIFE with bad braces ----
+			{
+				Code:   "(() => { return 1; })();",
+				Output: []string{"(() => {\n return 1; \n})();"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 8},
+					{MessageId: "singleLineClose", Line: 1, Column: 20},
+				},
+			},
+
+			// ---- Real-user: export default function with bad braces ----
+			{
+				Code:   "export default function foo() { return 1; }",
+				Output: []string{"export default function foo() {\n return 1; \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 31},
+					{MessageId: "singleLineClose", Line: 1, Column: 43},
+				},
+			},
+
+			// ---- Real-user: export default class with bad braces ----
+			{
+				Code:    "export default class\n{\n  x = 1;\n}",
+				Output:  []string{"export default class {\n  x = 1;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Generic class with bad braces, allman ----
+			{
+				Code:    "class C<T extends string> { x: T; }",
+				Output:  []string{"class C<T extends string> \n{\n x: T; \n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 27},
+					{MessageId: "blockSameLine", Line: 1, Column: 27},
+					{MessageId: "singleLineClose", Line: 1, Column: 35},
+				},
+			},
+
+			// ---- Generic function with bad braces ----
+			{
+				Code:   "function f<T>(x: T): T { return x; }",
+				Output: []string{"function f<T>(x: T): T {\n return x; \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 24},
+					{MessageId: "singleLineClose", Line: 1, Column: 36},
+				},
+			},
+
+			// ---- Async generator method with bad braces ----
+			{
+				Code:   "class C {\n  async *m() { yield 1; }\n}",
+				Output: []string{"class C {\n  async *m() {\n yield 1; \n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 14},
+					{MessageId: "singleLineClose", Line: 2, Column: 25},
+				},
+			},
+
+			// ---- TS function with type predicate, bad single-line ----
+			{
+				Code:   "function isStr(x: unknown): x is string { return typeof x === 'string'; }",
+				Output: []string{"function isStr(x: unknown): x is string {\n return typeof x === 'string'; \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 41},
+					{MessageId: "singleLineClose", Line: 1, Column: 73},
+				},
+			},
+
+			// ---- Decorated method with same-line body ----
+			{
+				Code:   "class C {\n  @dec m() { return 1; }\n}",
+				Output: []string{"class C {\n  @dec m() {\n return 1; \n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 12},
+					{MessageId: "singleLineClose", Line: 2, Column: 24},
+				},
+			},
+
+			// ---- For-of body with bad braces ----
+			{
+				Code:   "for (const x of arr) { foo(x); }",
+				Output: []string{"for (const x of arr) {\n foo(x); \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 22},
+					{MessageId: "singleLineClose", Line: 1, Column: 32},
+				},
+			},
+
+			// ---- While body with bad braces, allman ----
+			{
+				Code:    "while (x) {\n  foo();\n}",
+				Output:  []string{"while (x) \n{\n  foo();\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Do-while body with bad braces, allman ----
+			{
+				Code:    "do {\n  foo();\n} while (x);",
+				Output:  []string{"do \n{\n  foo();\n} while (x);"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 4},
+				},
+			},
+
+			// ---- Labeled statement block with bad braces, allman ----
+			{
+				Code:    "loop: {\n  break loop;\n}",
+				Output:  []string{"loop: \n{\n  break loop;\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 7},
+				},
+			},
+
+			// ---- TS namespace with bad single-line body, stroustrup ----
+			{
+				Code:    "namespace Foo {\n  export const x = 1;\n}",
+				Output:  []string{"namespace Foo \n{\n  export const x = 1;\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 15},
+				},
+			},
+
+			// ---- Multiple namespace decls, only one violates ----
+			{
+				Code:   "namespace A { export const x = 1; }\nnamespace B {\n  export const y = 2;\n}",
+				Output: []string{"namespace A {\n export const x = 1; \n}\nnamespace B {\n  export const y = 2;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 13},
+					{MessageId: "singleLineClose", Line: 1, Column: 35},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/brace_style/brace_style_upstream_test.go
+++ b/internal/plugins/stylistic/rules/brace_style/brace_style_upstream_test.go
@@ -1,0 +1,921 @@
+// TestBraceStyleUpstream migrates the full valid/invalid suite from upstream
+// packages/eslint-plugin/rules/brace-style/brace-style._js_.test.ts and
+// brace-style._ts_.test.ts 1:1. Position assertions cover line/column for
+// every invalid case. rslint-specific lock-in cases live in
+// brace_style_extras_test.go.
+//
+// `with (...) { ... }` cases from the TS suite ARE included — tsgo parses
+// the construct even under strict mode (the strict-mode rejection is a
+// downstream diagnostic, not a parse failure), and the WithStatement node's
+// Block child is checked by the same KindBlock listener that handles every
+// other statement body.
+package brace_style_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/brace_style"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func opts1tbs() []any       { return []any{"1tbs"} }
+func optsStroustrup() []any { return []any{"stroustrup"} }
+func optsAllman() []any     { return []any{"allman"} }
+func opts1tbsSingle() []any {
+	return []any{"1tbs", map[string]any{"allowSingleLine": true}}
+}
+func optsStroustrupSingle() []any {
+	return []any{"stroustrup", map[string]any{"allowSingleLine": true}}
+}
+func optsAllmanSingle() []any {
+	return []any{"allman", map[string]any{"allowSingleLine": true}}
+}
+
+func TestBraceStyleUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&brace_style.BraceStyleRule,
+		[]rule_tester.ValidTestCase{
+			// ---- default (1tbs) baseline ----
+			{Code: "function f() {\n    if (true)\n        return {x: 1}\n    else {\n        var y = 2\n        return y\n    }\n}"},
+			{Code: "if (tag === 1) glyph.id = pbf.readVarint();\nelse if (tag === 2) glyph.bitmap = pbf.readBytes();"},
+			{Code: "function foo () {\n  return;\n}"},
+			{Code: "function a(b,\nc,\nd) { }"},
+			{Code: "!function foo () {\n  return;\n}"},
+			{Code: "!function a(b,\nc,\nd) { }"},
+			{Code: "if (foo) {\n  bar();\n}"},
+			{Code: "if (a) {\n  b();\n} else {\n  c();\n}"},
+			{Code: "while (foo) {\n  bar();\n}"},
+			{Code: "for (;;) {\n  bar();\n}"},
+			{Code: "switch (foo) {\n  case 'bar': break;\n}"},
+			{Code: "try {\n  bar();\n} catch (e) {\n  baz();\n}"},
+			{Code: "do {\n  bar();\n} while (true)"},
+			{Code: "for (foo in bar) {\n  baz();\n}"},
+			{Code: "if (a &&\n  b &&\n  c) {\n}"},
+			{Code: "switch(0) {\n}"},
+			{Code: "class Foo {\n}"},
+			{Code: "(class {\n})"},
+			{Code: "class\nFoo {\n}"},
+			{Code: "class Foo {\n    bar() {\n    }\n}"},
+
+			// ---- stroustrup ----
+			{Code: "if (foo) {\n}\nelse {\n}", Options: optsStroustrup()},
+			{Code: "try {\n  bar();\n}\ncatch (e) {\n  baz();\n}", Options: optsStroustrup()},
+			{Code: "if (tag === 1) fontstack.name = pbf.readString();\nelse if (tag === 2) fontstack.range = pbf.readString();\nelse if (tag === 3) {\n  var glyph = pbf.readMessage(readGlyph, {});\n  fontstack.glyphs[glyph.id] = glyph;\n}", Options: optsStroustrup()},
+			{Code: "class Foo {\n}", Options: optsStroustrup()},
+			{Code: "(class {\n})", Options: optsStroustrup()},
+
+			// ---- allman ----
+			{Code: "if (foo)\n{\n}\nelse\n{\n}", Options: optsAllman()},
+			{Code: "try\n{\n  bar();\n}\ncatch (e)\n{\n  baz();\n}", Options: optsAllman()},
+			{Code: "switch(x)\n{\n  case 1:\n    bar();\n}", Options: optsAllman()},
+			{Code: "class Foo\n{\n}", Options: optsAllman()},
+			{Code: "(class\n{\n})", Options: optsAllman()},
+			{Code: "class\nFoo\n{\n}", Options: optsAllman()},
+
+			// ---- 1tbs + allowSingleLine: true ----
+			{Code: "function foo () { return; }", Options: opts1tbsSingle()},
+			{Code: "function foo () { a(); b(); return; }", Options: opts1tbsSingle()},
+			{Code: "function a(b,c,d) { }", Options: opts1tbsSingle()},
+			{Code: "!function foo () { return; }", Options: opts1tbsSingle()},
+			{Code: "!function a(b,c,d) { }", Options: opts1tbsSingle()},
+			{Code: "if (foo) {  bar(); }", Options: opts1tbsSingle()},
+			{Code: "if (a) { b(); } else { c(); }", Options: opts1tbsSingle()},
+			{Code: "while (foo) {  bar(); }", Options: opts1tbsSingle()},
+			{Code: "for (;;) {  bar(); }", Options: opts1tbsSingle()},
+			{Code: "switch (foo) {  case \"bar\": break; }", Options: opts1tbsSingle()},
+			{Code: "try {  bar(); } catch (e) { baz();  }", Options: opts1tbsSingle()},
+			{Code: "do {  bar(); } while (true)", Options: opts1tbsSingle()},
+			{Code: "for (foo in bar) {  baz();  }", Options: opts1tbsSingle()},
+			{Code: "if (a && b && c) {  }", Options: opts1tbsSingle()},
+			{Code: "switch(0) {}", Options: opts1tbsSingle()},
+			{Code: "if (foo) {}\nelse {}", Options: optsStroustrupSingle()},
+			{Code: "try {  bar(); }\ncatch (e) { baz();  }", Options: optsStroustrupSingle()},
+			{Code: "var foo = () => { return; }", Options: optsStroustrupSingle()},
+			{Code: "if (foo) {}\nelse {}", Options: optsAllmanSingle()},
+			{Code: "try {  bar(); }\ncatch (e) { baz();  }", Options: optsAllmanSingle()},
+			{Code: "var foo = () => { return; }", Options: optsAllmanSingle()},
+			{Code: "if (foo) { baz(); } else {\n  boom();\n}", Options: opts1tbsSingle()},
+			{Code: "if (foo) { baz(); } else if (bar) {\n  boom();\n}", Options: opts1tbsSingle()},
+			{Code: "if (foo) { baz(); } else\nif (bar) {\n  boom();\n}", Options: opts1tbsSingle()},
+			{Code: "try { somethingRisky(); } catch(e) {\n  handleError();\n}", Options: opts1tbsSingle()},
+			{Code: "if (tag === 1) fontstack.name = pbf.readString();\nelse if (tag === 2) fontstack.range = pbf.readString();\nelse if (tag === 3) {\n  var glyph = pbf.readMessage(readGlyph, {});\n  fontstack.glyphs[glyph.id] = glyph;\n}"},
+			{Code: "switch(x) {}", Options: optsAllmanSingle()},
+			{Code: "class Foo {}", Options: opts1tbsSingle()},
+			{Code: "class Foo {}", Options: optsAllmanSingle()},
+			{Code: "(class {})", Options: opts1tbsSingle()},
+			{Code: "(class {})", Options: optsAllmanSingle()},
+
+			// ---- standalone / Program / SwitchCase block parents — skipped ----
+			// https://github.com/eslint/eslint/issues/7908
+			{Code: "{}"},
+			{Code: "if (foo) {\n}\n{\n}"},
+			{Code: "switch (foo) {\n  case bar:\n    baz();\n    {\n      qux();\n    }\n}"},
+			{Code: "{\n}"},
+			{Code: "{\n  {\n  }\n}"},
+
+			// https://github.com/eslint/eslint/issues/7974
+			{Code: "class Ball {\n  throw() {}\n  catch() {}\n}"},
+			{Code: "({\n  and() {},\n  finally() {}\n})"},
+			{Code: "(class {\n  or() {}\n  else() {}\n})"},
+			{Code: "if (foo) bar = function() {}\nelse baz()"},
+
+			// ---- class static blocks ----
+			{Code: "class C {\n    static {\n        foo;\n    }\n}", Options: opts1tbs()},
+			{Code: "class C {\n    static {}\n\n    static {\n    }\n}", Options: opts1tbs()},
+			{Code: "class C {\n    static { foo; }\n}", Options: opts1tbsSingle()},
+			{Code: "class C {\n    static {\n        foo;\n    }\n}", Options: optsStroustrup()},
+			{Code: "class C {\n    static {}\n\n    static {\n    }\n}", Options: optsStroustrup()},
+			{Code: "class C {\n    static { foo; }\n}", Options: optsStroustrupSingle()},
+			{Code: "class C\n{\n    static\n    {\n        foo;\n    }\n}", Options: optsAllman()},
+			{Code: "class C\n{\n    static\n    {}\n}", Options: optsAllman()},
+			{Code: "class C\n{\n    static {}\n\n    static { foo; }\n\n    static\n    { foo; }\n}", Options: optsAllmanSingle()},
+			{Code: "class C {\n    static {\n        {\n            foo;\n        }\n    }\n}", Options: opts1tbs()},
+
+			// ---- TS `with` statement (parsed even under strict mode) ----
+			{Code: "with (foo) {\n  bar();\n}"},
+			{Code: "with (foo) {  bar(); }", Options: opts1tbsSingle()},
+
+			// ---- TS namespace/module bodies ----
+			{Code: "module \"Foo\" {\n}", Options: opts1tbs()},
+			{Code: "module \"Foo\" {\n}", Options: optsStroustrup()},
+			{Code: "module \"Foo\"\n{\n}", Options: optsAllman()},
+			{Code: "namespace Foo {\n}", Options: opts1tbs()},
+			{Code: "namespace Foo {\n}", Options: optsStroustrup()},
+			{Code: "namespace Foo\n{\n}", Options: optsAllman()},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- nextLineClose (1tbs, } not on same line as keyword) ----
+			{
+				Code:   "if (f) {\n  bar;\n}\nelse\n  baz;",
+				Output: []string{"if (f) {\n  bar;\n} else\n  baz;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- blockSameLine + singleLineClose (single-line block in multiline mode) ----
+			{
+				Code:   "var foo = () => { return; }",
+				Output: []string{"var foo = () => {\n return; \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 17},
+					{MessageId: "singleLineClose", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code:   "function foo() { return; }",
+				Output: []string{"function foo() {\n return; \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 16},
+					{MessageId: "singleLineClose", Line: 1, Column: 26},
+				},
+			},
+
+			// ---- nextLineOpen + singleLineClose ----
+			{
+				Code:   "function foo() \n { \n return; }",
+				Output: []string{"function foo() { \n return; \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+					{MessageId: "singleLineClose", Line: 3, Column: 10},
+				},
+			},
+			{
+				Code:   "!function foo() \n { \n return; }",
+				Output: []string{"!function foo() { \n return; \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+					{MessageId: "singleLineClose", Line: 3, Column: 10},
+				},
+			},
+			{
+				Code:   "if (foo) \n { \n bar(); }",
+				Output: []string{"if (foo) { \n bar(); \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+					{MessageId: "singleLineClose", Line: 3, Column: 9},
+				},
+			},
+			{
+				Code:   "if (a) { \nb();\n } else \n { c(); }",
+				Output: []string{"if (a) { \nb();\n } else {\n c(); \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 4, Column: 2},
+					{MessageId: "blockSameLine", Line: 4, Column: 2},
+					{MessageId: "singleLineClose", Line: 4, Column: 9},
+				},
+			},
+			{
+				Code:   "while (foo) \n { \n bar(); }",
+				Output: []string{"while (foo) { \n bar(); \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+					{MessageId: "singleLineClose", Line: 3, Column: 9},
+				},
+			},
+			{
+				Code:   "for (;;) \n { \n bar(); }",
+				Output: []string{"for (;;) { \n bar(); \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+					{MessageId: "singleLineClose", Line: 3, Column: 9},
+				},
+			},
+			{
+				Code:   "switch (foo) \n { \n case \"bar\": break; }",
+				Output: []string{"switch (foo) { \n case \"bar\": break; \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+					{MessageId: "singleLineClose", Line: 3, Column: 21},
+				},
+			},
+			{
+				Code:   "switch (foo) \n { }",
+				Output: []string{"switch (foo) { }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+				},
+			},
+			{
+				Code:   "try \n { \n bar(); \n } catch (e) {}",
+				Output: []string{"try { \n bar(); \n } catch (e) {}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+				},
+			},
+			{
+				Code:   "try { \n bar(); \n } catch (e) \n {}",
+				Output: []string{"try { \n bar(); \n } catch (e) {}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 4, Column: 2},
+				},
+			},
+			{
+				Code:   "do \n { \n bar(); \n} while (true)",
+				Output: []string{"do { \n bar(); \n} while (true)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+				},
+			},
+			{
+				Code:   "for (foo in bar) \n { \n baz(); \n }",
+				Output: []string{"for (foo in bar) { \n baz(); \n }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+				},
+			},
+			{
+				Code:   "for (foo of bar) \n { \n baz(); \n }",
+				Output: []string{"for (foo of bar) { \n baz(); \n }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+				},
+			},
+
+			// ---- nextLineClose on try/catch/finally ----
+			{
+				Code:   "try { \n bar(); \n }\ncatch (e) {\n}",
+				Output: []string{"try { \n bar(); \n } catch (e) {\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 3, Column: 2},
+				},
+			},
+			{
+				Code:   "try { \n bar(); \n } catch (e) {\n}\n finally {\n}",
+				Output: []string{"try { \n bar(); \n } catch (e) {\n} finally {\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 4, Column: 1},
+				},
+			},
+			{
+				Code:   "if (a) { \nb();\n } \n else { \nc();\n }",
+				Output: []string{"if (a) { \nb();\n } else { \nc();\n }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 3, Column: 2},
+				},
+			},
+
+			// ---- stroustrup sameLineClose ----
+			{
+				Code:   "try { \n bar(); \n }\ncatch (e) {\n} finally {\n}",
+				Output: []string{"try { \n bar(); \n }\ncatch (e) {\n}\n finally {\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 5, Column: 1},
+				},
+			},
+			{
+				Code:   "try { \n bar(); \n } catch (e) {\n}\n finally {\n}",
+				Output: []string{"try { \n bar(); \n }\n catch (e) {\n}\n finally {\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 3, Column: 2},
+				},
+			},
+			{
+				Code:   "if (a) { \nb();\n } else { \nc();\n }",
+				Output: []string{"if (a) { \nb();\n }\n else { \nc();\n }"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 3, Column: 2},
+				},
+			},
+			{
+				Code:   "if (foo) {\nbaz();\n} else if (bar) {\nbaz();\n}\nelse {\nqux();\n}",
+				Output: []string{"if (foo) {\nbaz();\n}\n else if (bar) {\nbaz();\n}\nelse {\nqux();\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code:   "if (foo) {\npoop();\n} \nelse if (bar) {\nbaz();\n} else if (thing) {\nboom();\n}\nelse {\nqux();\n}",
+				Output: []string{"if (foo) {\npoop();\n} \nelse if (bar) {\nbaz();\n}\n else if (thing) {\nboom();\n}\nelse {\nqux();\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 6, Column: 1},
+				},
+			},
+
+			// ---- allman sameLineOpen / sameLineClose ----
+			{
+				Code:   "try { \n bar(); \n }\n catch (e) {\n}\n finally {\n}",
+				Output: []string{"try \n{ \n bar(); \n }\n catch (e) \n{\n}\n finally \n{\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 5},
+					{MessageId: "sameLineOpen", Line: 4, Column: 12},
+					{MessageId: "sameLineOpen", Line: 6, Column: 10},
+				},
+			},
+			{
+				Code:   "switch(x) { case 1: \nbar(); }\n ",
+				Output: []string{"switch(x) \n{\n case 1: \nbar(); \n}\n "},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 11},
+					{MessageId: "blockSameLine", Line: 1, Column: 11},
+					{MessageId: "singleLineClose", Line: 2, Column: 8},
+				},
+			},
+			{
+				Code:   "if (a) { \nb();\n } else { \nc();\n }",
+				Output: []string{"if (a) \n{ \nb();\n }\n else \n{ \nc();\n }"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 8},
+					{MessageId: "sameLineClose", Line: 3, Column: 2},
+					{MessageId: "sameLineOpen", Line: 3, Column: 9},
+				},
+			},
+			{
+				Code:   "if (foo) {\nbaz();\n} else if (bar) {\nbaz();\n}\nelse {\nqux();\n}",
+				Output: []string{"if (foo) \n{\nbaz();\n}\n else if (bar) \n{\nbaz();\n}\nelse \n{\nqux();\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 10},
+					{MessageId: "sameLineClose", Line: 3, Column: 1},
+					{MessageId: "sameLineOpen", Line: 3, Column: 17},
+					{MessageId: "sameLineOpen", Line: 6, Column: 6},
+				},
+			},
+			{
+				Code:   "if (foo)\n{ poop();\n} \nelse if (bar) {\nbaz();\n} else if (thing) {\nboom();\n}\nelse {\nqux();\n}",
+				Output: []string{"if (foo)\n{\n poop();\n} \nelse if (bar) \n{\nbaz();\n}\n else if (thing) \n{\nboom();\n}\nelse \n{\nqux();\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 1},
+					{MessageId: "sameLineOpen", Line: 4, Column: 15},
+					{MessageId: "sameLineClose", Line: 6, Column: 1},
+					{MessageId: "sameLineOpen", Line: 6, Column: 19},
+					{MessageId: "sameLineOpen", Line: 9, Column: 6},
+				},
+			},
+			{
+				Code:   "if (foo)\n{\n  bar(); }",
+				Output: []string{"if (foo)\n{\n  bar(); \n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 3, Column: 10},
+				},
+			},
+			{
+				Code:   "try\n{\n  somethingRisky();\n} catch (e)\n{\n  handleError()\n}",
+				Output: []string{"try\n{\n  somethingRisky();\n}\n catch (e)\n{\n  handleError()\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 4, Column: 1},
+				},
+			},
+
+			// ---- 1tbs + allowSingleLine ----
+			{
+				Code:   "function foo() { return; \n}",
+				Output: []string{"function foo() {\n return; \n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   "function foo() { a(); b(); return; \n}",
+				Output: []string{"function foo() {\n a(); b(); return; \n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   "function foo() { \n return; }",
+				Output: []string{"function foo() { \n return; \n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 2, Column: 10},
+				},
+			},
+			{
+				Code:   "function foo() {\na();\nb();\nreturn; }",
+				Output: []string{"function foo() {\na();\nb();\nreturn; \n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 4, Column: 9},
+				},
+			},
+			{
+				Code:   "!function foo() { \n return; }",
+				Output: []string{"!function foo() { \n return; \n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 2, Column: 10},
+				},
+			},
+			{
+				Code:   "if (a) { b();\n } else { c(); }",
+				Output: []string{"if (a) {\n b();\n } else { c(); }"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code:   "if (a) { b(); }\nelse { c(); }",
+				Output: []string{"if (a) { b(); } else { c(); }"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code:   "while (foo) { \n bar(); }",
+				Output: []string{"while (foo) { \n bar(); \n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 2, Column: 9},
+				},
+			},
+			{
+				Code:   "for (;;) { bar(); \n }",
+				Output: []string{"for (;;) {\n bar(); \n }"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:   "switch (foo) \n { \n case \"bar\": break; }",
+				Output: []string{"switch (foo) { \n case \"bar\": break; \n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+					{MessageId: "singleLineClose", Line: 3, Column: 21},
+				},
+			},
+			{
+				Code:   "switch (foo) \n { }",
+				Output: []string{"switch (foo) { }"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+				},
+			},
+			{
+				Code:   "try {  bar(); }\ncatch (e) { baz();  }",
+				Output: []string{"try {  bar(); } catch (e) { baz();  }"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code:   "try \n { \n bar(); \n } catch (e) {}",
+				Output: []string{"try { \n bar(); \n } catch (e) {}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+				},
+			},
+			{
+				Code:   "try { \n bar(); \n } catch (e) \n {}",
+				Output: []string{"try { \n bar(); \n } catch (e) {}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 4, Column: 2},
+				},
+			},
+			{
+				Code:   "do \n { \n bar(); \n} while (true)",
+				Output: []string{"do { \n bar(); \n} while (true)"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+				},
+			},
+			{
+				Code:   "for (foo in bar) \n { \n baz(); \n }",
+				Output: []string{"for (foo in bar) { \n baz(); \n }"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+				},
+			},
+			{
+				Code:   "try { \n bar(); \n }\ncatch (e) {\n}",
+				Output: []string{"try { \n bar(); \n } catch (e) {\n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 3, Column: 2},
+				},
+			},
+			{
+				Code:   "try { \n bar(); \n } catch (e) {\n}\n finally {\n}",
+				Output: []string{"try { \n bar(); \n } catch (e) {\n} finally {\n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 4, Column: 1},
+				},
+			},
+			{
+				Code:   "if (a) { \nb();\n } \n else { \nc();\n }",
+				Output: []string{"if (a) { \nb();\n } else { \nc();\n }"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineClose", Line: 3, Column: 2},
+				},
+			},
+
+			// ---- stroustrup + allowSingleLine ----
+			{
+				Code:   "try { \n bar(); \n }\ncatch (e) {\n} finally {\n}",
+				Output: []string{"try { \n bar(); \n }\ncatch (e) {\n}\n finally {\n}"},
+				Options: optsStroustrupSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 5, Column: 1},
+				},
+			},
+			{
+				Code:   "try { \n bar(); \n } catch (e) {\n}\n finally {\n}",
+				Output: []string{"try { \n bar(); \n }\n catch (e) {\n}\n finally {\n}"},
+				Options: optsStroustrupSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 3, Column: 2},
+				},
+			},
+			{
+				Code:   "if (a) { \nb();\n } else { \nc();\n }",
+				Output: []string{"if (a) { \nb();\n }\n else { \nc();\n }"},
+				Options: optsStroustrupSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineClose", Line: 3, Column: 2},
+				},
+			},
+
+			// ---- allman + allowSingleLine ----
+			{
+				Code:   "if (foo)\n{ poop();\n} \nelse if (bar) {\nbaz();\n} else if (thing) {\nboom();\n}\nelse {\nqux();\n}",
+				Output: []string{"if (foo)\n{\n poop();\n} \nelse if (bar) \n{\nbaz();\n}\n else if (thing) \n{\nboom();\n}\nelse \n{\nqux();\n}"},
+				Options: optsAllmanSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 1},
+					{MessageId: "sameLineOpen", Line: 4, Column: 15},
+					{MessageId: "sameLineClose", Line: 6, Column: 1},
+					{MessageId: "sameLineOpen", Line: 6, Column: 19},
+					{MessageId: "sameLineOpen", Line: 9, Column: 6},
+				},
+			},
+
+			// ---- Comment interferes with fix — no output expected ----
+			{
+				Code: "if (foo) // comment \n{\nbar();\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- https://github.com/eslint/eslint/issues/7493 ----
+			{
+				Code:   "if (foo) {\n bar\n.baz }",
+				Output: []string{"if (foo) {\n bar\n.baz \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 3, Column: 6},
+				},
+			},
+			{
+				Code:   "if (foo)\n{\n bar\n.baz }",
+				Output: []string{"if (foo)\n{\n bar\n.baz \n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 4, Column: 6},
+				},
+			},
+			{
+				Code:   "if (foo) { bar\n.baz }",
+				Output: []string{"if (foo) {\n bar\n.baz \n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 10},
+					{MessageId: "singleLineClose", Line: 2, Column: 6},
+				},
+			},
+			{
+				Code:   "if (foo) { bar\n.baz }",
+				Output: []string{"if (foo) \n{\n bar\n.baz \n}"},
+				Options: optsAllmanSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 10},
+					{MessageId: "blockSameLine", Line: 1, Column: 10},
+					{MessageId: "singleLineClose", Line: 2, Column: 6},
+				},
+			},
+			{
+				Code:   "switch (x) {\n case 1: foo() }",
+				Output: []string{"switch (x) {\n case 1: foo() \n}"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 2, Column: 16},
+				},
+			},
+
+			// ---- class declarations / expressions ----
+			{
+				Code:   "class Foo\n{\n}",
+				Output: []string{"class Foo {\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:   "(class\n{\n})",
+				Output: []string{"(class {\n})"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:   "class Foo{\n}",
+				Output: []string{"class Foo\n{\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:   "(class {\n})",
+				Output: []string{"(class \n{\n})"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code:   "class Foo {\nbar() {\n}}",
+				Output: []string{"class Foo {\nbar() {\n}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 3, Column: 2},
+				},
+			},
+			{
+				Code:   "(class Foo {\nbar() {\n}})",
+				Output: []string{"(class Foo {\nbar() {\n}\n})"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 3, Column: 2},
+				},
+			},
+			{
+				Code:   "class\nFoo{}",
+				Output: []string{"class\nFoo\n{}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 2, Column: 4},
+				},
+			},
+
+			// ---- https://github.com/eslint/eslint/issues/7621 ----
+			{
+				Code:   "if (foo)\n{\n    bar\n}\nelse {\n    baz\n}",
+				Output: []string{"if (foo) {\n    bar\n} else {\n    baz\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+					{MessageId: "nextLineClose", Line: 4, Column: 1},
+				},
+			},
+
+			// ---- class static blocks ----
+			{
+				Code:   "class C {\n    static\n    {\n        foo;\n    }\n}",
+				Output: []string{"class C {\n    static {\n        foo;\n    }\n}"},
+				Options: opts1tbs(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 3, Column: 5},
+				},
+			},
+			{
+				Code:   "class C {\n    static {foo;\n    }\n}",
+				Output: []string{"class C {\n    static {\nfoo;\n    }\n}"},
+				Options: opts1tbs(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 12},
+				},
+			},
+			{
+				Code:   "class C {\n    static {\n        foo;}\n}",
+				Output: []string{"class C {\n    static {\n        foo;\n}\n}"},
+				Options: opts1tbs(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 3, Column: 13},
+				},
+			},
+			{
+				Code:   "class C {\n    static\n    {foo;}\n}",
+				Output: []string{"class C {\n    static {\nfoo;\n}\n}"},
+				Options: opts1tbs(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 3, Column: 5},
+					{MessageId: "blockSameLine", Line: 3, Column: 5},
+					{MessageId: "singleLineClose", Line: 3, Column: 10},
+				},
+			},
+			{
+				Code:   "class C {\n    static\n    {}\n}",
+				Output: []string{"class C {\n    static {}\n}"},
+				Options: opts1tbs(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 3, Column: 5},
+				},
+			},
+			{
+				Code:   "class C {\n    static\n    {\n        foo;\n    }\n}",
+				Output: []string{"class C {\n    static {\n        foo;\n    }\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 3, Column: 5},
+				},
+			},
+			{
+				Code:   "class C {\n    static {foo;\n    }\n}",
+				Output: []string{"class C {\n    static {\nfoo;\n    }\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 2, Column: 12},
+				},
+			},
+			{
+				Code:   "class C {\n    static {\n        foo;}\n}",
+				Output: []string{"class C {\n    static {\n        foo;\n}\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 3, Column: 13},
+				},
+			},
+			{
+				Code:   "class C {\n    static\n    {foo;}\n}",
+				Output: []string{"class C {\n    static {\nfoo;\n}\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 3, Column: 5},
+					{MessageId: "blockSameLine", Line: 3, Column: 5},
+					{MessageId: "singleLineClose", Line: 3, Column: 10},
+				},
+			},
+			{
+				Code:   "class C {\n    static\n    {}\n}",
+				Output: []string{"class C {\n    static {}\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 3, Column: 5},
+				},
+			},
+			{
+				Code:   "class C\n{\n    static{\n        foo;\n    }\n}",
+				Output: []string{"class C\n{\n    static\n{\n        foo;\n    }\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 3, Column: 11},
+				},
+			},
+			{
+				Code:   "class C\n{\n    static\n    {foo;\n    }\n}",
+				Output: []string{"class C\n{\n    static\n    {\nfoo;\n    }\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code:   "class C\n{\n    static\n    {\n        foo;}\n}",
+				Output: []string{"class C\n{\n    static\n    {\n        foo;\n}\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "singleLineClose", Line: 5, Column: 13},
+				},
+			},
+			{
+				Code:   "class C\n{\n    static{foo;}\n}",
+				Output: []string{"class C\n{\n    static\n{\nfoo;\n}\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 3, Column: 11},
+					{MessageId: "blockSameLine", Line: 3, Column: 11},
+					{MessageId: "singleLineClose", Line: 3, Column: 16},
+				},
+			},
+			{
+				Code:   "class C\n{\n    static{}\n}",
+				Output: []string{"class C\n{\n    static\n{}\n}"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 3, Column: 11},
+				},
+			},
+
+			// ---- TS `with` statement ----
+			{
+				Code:   "with (foo) \n { \n bar(); }",
+				Output: []string{"with (foo) { \n bar(); \n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 2},
+					{MessageId: "singleLineClose", Line: 3, Column: 9},
+				},
+			},
+			{
+				Code:    "with (foo) { bar(); \n }",
+				Output:  []string{"with (foo) {\n bar(); \n }"},
+				Options: opts1tbsSingle(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "blockSameLine", Line: 1, Column: 12},
+				},
+			},
+
+			// ---- TS namespace/module bodies ----
+			{
+				Code:   "module \"Foo\"\n{\n}",
+				Output: []string{"module \"Foo\" {\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:   "module \"Foo\"\n{\n}",
+				Output: []string{"module \"Foo\" {\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:   "module \"Foo\" { \n }",
+				Output: []string{"module \"Foo\" \n{ \n }"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:   "namespace Foo\n{\n}",
+				Output: []string{"namespace Foo {\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:   "namespace Foo\n{\n}",
+				Output: []string{"namespace Foo {\n}"},
+				Options: optsStroustrup(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nextLineOpen", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:   "namespace Foo { \n }",
+				Output: []string{"namespace Foo \n{ \n }"},
+				Options: optsAllman(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "sameLineOpen", Line: 1, Column: 15},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/stylisticutil/tokens.go
+++ b/internal/plugins/stylistic/stylisticutil/tokens.go
@@ -1,0 +1,89 @@
+// Package stylisticutil collects AST / source-text helpers shared by
+// `@stylistic/eslint-plugin` rule ports. Each helper exists in this package
+// because at least two rules in the plugin needed the same shape (extraction
+// is mandated by the "duplicate-across-rules" rule in
+// agents/port-rule/references/PORT_RULE.md — not an optional refactor).
+package stylisticutil
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// SameLineByPos reports whether two byte positions lie on the same source
+// line. Uses the pre-computed ECMA line map (binary search via
+// scanner.ComputeLineOfPosition) rather than scanning newlines ourselves —
+// O(log n) instead of O(distance).
+func SameLineByPos(sf *ast.SourceFile, a, b int) bool {
+	lineStarts := sf.ECMALineMap()
+	return scanner.ComputeLineOfPosition(lineStarts, a) ==
+		scanner.ComputeLineOfPosition(lineStarts, b)
+}
+
+// CommentsExistBetween reports whether the byte range [low, high) contains a
+// `//` or `/*` sequence. Mirrors ESLint's
+// `sourceCode.commentsExistBetween(left, right)` predicate.
+//
+// **Safety invariant**: callers MUST pass a range that lies between two
+// parser-recognized tokens — i.e. the byte range is pure trivia (whitespace
+// and comments only, no string / regex / template literal content). Without
+// this invariant a substring like `*/` inside a string would be falsely
+// classified as a block-comment terminator. brace-style and arrow-parens
+// both satisfy this invariant by definition: the trivia between e.g. `)` and
+// `{`, or `(` and the param, cannot contain a string literal.
+func CommentsExistBetween(text string, low, high int) bool {
+	if low < 0 {
+		low = 0
+	}
+	if high > len(text) {
+		high = len(text)
+	}
+	if low >= high {
+		return false
+	}
+	s := text[low:high]
+	return strings.Contains(s, "//") || strings.Contains(s, "/*")
+}
+
+// FindPrevTokenEnd scans tokens forward from `searchStart` (a known earlier
+// position guaranteed to lie before any token of interest) until it reaches
+// the token starting at `targetPos`, and returns the end position of the
+// previous token. Returns (-1, false) when no token starts at exactly
+// `targetPos` in the forward stream (defensive — should not happen on
+// well-formed input).
+//
+// Forward scanning is used instead of backward byte-walking because line
+// comments aren't recognizable backward without re-scanning the line start
+// (a backward `t` could be the last char of a token or of a `// ...` body),
+// so a forward scan from a known earlier position is the only reliable way
+// to locate a "previous real token" boundary.
+//
+// Cost is O(tokens between searchStart and targetPos). For nested
+// constructs, callers typically pass `node.Parent.Pos()` as `searchStart`,
+// which bounds the scan to the immediate enclosing AST node.
+func FindPrevTokenEnd(sf *ast.SourceFile, searchStart, targetPos int) (int, bool) {
+	if searchStart >= targetPos {
+		return -1, false
+	}
+	s := scanner.GetScannerForSourceFile(sf, searchStart)
+	prevEnd := -1
+	for {
+		if s.Token() == ast.KindEndOfFile {
+			return -1, false
+		}
+		start := s.TokenStart()
+		if start == targetPos {
+			if prevEnd < 0 {
+				return -1, false
+			}
+			return prevEnd, true
+		}
+		if start > targetPos {
+			return -1, false
+		}
+		prevEnd = s.TokenEnd()
+		s.Scan()
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -454,6 +454,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/arrow-parens.test.ts',
     './tests/eslint-plugin-stylistic/rules/arrow-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/block-spacing.test.ts',
+    './tests/eslint-plugin-stylistic/rules/brace-style.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/brace-style.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/brace-style.test.ts
@@ -1,0 +1,758 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('brace-style', null as never, {
+  valid: [
+    // 1tbs (default) baseline
+    {
+      code: 'function f() {\n    if (true)\n        return {x: 1}\n    else {\n        var y = 2\n        return y\n    }\n}',
+    },
+    {
+      code: 'if (tag === 1) glyph.id = pbf.readVarint();\nelse if (tag === 2) glyph.bitmap = pbf.readBytes();',
+    },
+    { code: 'function foo () {\n  return;\n}' },
+    { code: 'function a(b,\nc,\nd) { }' },
+    { code: '!function foo () {\n  return;\n}' },
+    { code: '!function a(b,\nc,\nd) { }' },
+    { code: 'if (foo) {\n  bar();\n}' },
+    { code: 'if (a) {\n  b();\n} else {\n  c();\n}' },
+    { code: 'while (foo) {\n  bar();\n}' },
+    { code: 'for (;;) {\n  bar();\n}' },
+    { code: "switch (foo) {\n  case 'bar': break;\n}" },
+    { code: 'try {\n  bar();\n} catch (e) {\n  baz();\n}' },
+    { code: 'do {\n  bar();\n} while (true)' },
+    { code: 'for (foo in bar) {\n  baz();\n}' },
+    { code: 'if (a &&\n  b &&\n  c) {\n}' },
+    { code: 'switch(0) {\n}' },
+    { code: 'class Foo {\n}' },
+    { code: '(class {\n})' },
+    { code: 'class\nFoo {\n}' },
+    { code: 'class Foo {\n    bar() {\n    }\n}' },
+
+    // stroustrup
+    { code: 'if (foo) {\n}\nelse {\n}', options: ['stroustrup'] },
+    {
+      code: 'try {\n  bar();\n}\ncatch (e) {\n  baz();\n}',
+      options: ['stroustrup'],
+    },
+    { code: 'class Foo {\n}', options: ['stroustrup'] },
+    { code: '(class {\n})', options: ['stroustrup'] },
+
+    // allman
+    { code: 'if (foo)\n{\n}\nelse\n{\n}', options: ['allman'] },
+    {
+      code: 'try\n{\n  bar();\n}\ncatch (e)\n{\n  baz();\n}',
+      options: ['allman'],
+    },
+    { code: 'switch(x)\n{\n  case 1:\n    bar();\n}', options: ['allman'] },
+    { code: 'class Foo\n{\n}', options: ['allman'] },
+    { code: '(class\n{\n})', options: ['allman'] },
+    { code: 'class\nFoo\n{\n}', options: ['allman'] },
+
+    // 1tbs + allowSingleLine: true
+    {
+      code: 'function foo () { return; }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'function foo () { a(); b(); return; }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'function a(b,c,d) { }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: '!function foo () { return; }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: '!function a(b,c,d) { }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'if (foo) {  bar(); }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'if (a) { b(); } else { c(); }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'while (foo) {  bar(); }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'for (;;) {  bar(); }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'switch (foo) {  case "bar": break; }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'try {  bar(); } catch (e) { baz();  }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'do {  bar(); } while (true)',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'for (foo in bar) {  baz();  }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'if (a && b && c) {  }',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    { code: 'switch(0) {}', options: ['1tbs', { allowSingleLine: true }] },
+    {
+      code: 'if (foo) {}\nelse {}',
+      options: ['stroustrup', { allowSingleLine: true }],
+    },
+    {
+      code: 'try {  bar(); }\ncatch (e) { baz();  }',
+      options: ['stroustrup', { allowSingleLine: true }],
+    },
+    {
+      code: 'var foo = () => { return; }',
+      options: ['stroustrup', { allowSingleLine: true }],
+    },
+    {
+      code: 'if (foo) {}\nelse {}',
+      options: ['allman', { allowSingleLine: true }],
+    },
+    {
+      code: 'try {  bar(); }\ncatch (e) { baz();  }',
+      options: ['allman', { allowSingleLine: true }],
+    },
+    {
+      code: 'var foo = () => { return; }',
+      options: ['allman', { allowSingleLine: true }],
+    },
+    {
+      code: 'if (foo) { baz(); } else {\n  boom();\n}',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'if (foo) { baz(); } else if (bar) {\n  boom();\n}',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'if (foo) { baz(); } else\nif (bar) {\n  boom();\n}',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'try { somethingRisky(); } catch(e) {\n  handleError();\n}',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'if (tag === 1) fontstack.name = pbf.readString();\nelse if (tag === 2) fontstack.range = pbf.readString();\nelse if (tag === 3) {\n  var glyph = pbf.readMessage(readGlyph, {});\n  fontstack.glyphs[glyph.id] = glyph;\n}',
+    },
+    { code: 'switch(x) {}', options: ['allman', { allowSingleLine: true }] },
+    { code: 'class Foo {}', options: ['1tbs', { allowSingleLine: true }] },
+    { code: 'class Foo {}', options: ['allman', { allowSingleLine: true }] },
+    { code: '(class {})', options: ['1tbs', { allowSingleLine: true }] },
+    { code: '(class {})', options: ['allman', { allowSingleLine: true }] },
+
+    // Standalone / Program / SwitchCase block parents — skipped per
+    // STATEMENT_LIST_PARENTS.
+    { code: '{}' },
+    { code: 'if (foo) {\n}\n{\n}' },
+    {
+      code: 'switch (foo) {\n  case bar:\n    baz();\n    {\n      qux();\n    }\n}',
+    },
+    { code: '{\n}' },
+    { code: '{\n  {\n  }\n}' },
+
+    // https://github.com/eslint/eslint/issues/7974
+    { code: 'class Ball {\n  throw() {}\n  catch() {}\n}' },
+    { code: '({\n  and() {},\n  finally() {}\n})' },
+    { code: '(class {\n  or() {}\n  else() {}\n})' },
+    { code: 'if (foo) bar = function() {}\nelse baz()' },
+
+    // Class static blocks
+    {
+      code: 'class C {\n    static {\n        foo;\n    }\n}',
+      options: ['1tbs'],
+    },
+    {
+      code: 'class C {\n    static {}\n\n    static {\n    }\n}',
+      options: ['1tbs'],
+    },
+    {
+      code: 'class C {\n    static { foo; }\n}',
+      options: ['1tbs', { allowSingleLine: true }],
+    },
+    {
+      code: 'class C {\n    static {\n        foo;\n    }\n}',
+      options: ['stroustrup'],
+    },
+    {
+      code: 'class C {\n    static {}\n\n    static {\n    }\n}',
+      options: ['stroustrup'],
+    },
+    {
+      code: 'class C {\n    static { foo; }\n}',
+      options: ['stroustrup', { allowSingleLine: true }],
+    },
+    {
+      code: 'class C\n{\n    static\n    {\n        foo;\n    }\n}',
+      options: ['allman'],
+    },
+    { code: 'class C\n{\n    static\n    {}\n}', options: ['allman'] },
+    {
+      code: 'class C\n{\n    static {}\n\n    static { foo; }\n\n    static\n    { foo; }\n}',
+      options: ['allman', { allowSingleLine: true }],
+    },
+    {
+      code: 'class C {\n    static {\n        {\n            foo;\n        }\n    }\n}',
+      options: ['1tbs'],
+    },
+
+    // TS `with` statement — parsed by tsgo even under strict mode.
+    {
+      code: 'with (foo) {\n  bar();\n}',
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'with (foo) {  bar(); }',
+      options: ['1tbs', { allowSingleLine: true }],
+      filename: 'src/virtual.ts',
+    },
+
+    // TS namespace / module bodies — non-.tsx so generic-like syntax doesn't
+    // collide with JSX.
+    {
+      code: 'module "Foo" {\n}',
+      options: ['1tbs'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'module "Foo" {\n}',
+      options: ['stroustrup'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'module "Foo"\n{\n}',
+      options: ['allman'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'namespace Foo {\n}',
+      options: ['1tbs'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'namespace Foo {\n}',
+      options: ['stroustrup'],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'namespace Foo\n{\n}',
+      options: ['allman'],
+      filename: 'src/virtual.ts',
+    },
+  ],
+  invalid: [
+    {
+      code: 'if (f) {\n  bar;\n}\nelse\n  baz;',
+      errors: [{ messageId: 'nextLineClose' }],
+    },
+    {
+      code: 'var foo = () => { return; }',
+      errors: [
+        { messageId: 'blockSameLine' },
+        { messageId: 'singleLineClose' },
+      ],
+    },
+    {
+      code: 'function foo() { return; }',
+      errors: [
+        { messageId: 'blockSameLine' },
+        { messageId: 'singleLineClose' },
+      ],
+    },
+    {
+      code: 'function foo() \n { \n return; }',
+      errors: [{ messageId: 'nextLineOpen' }, { messageId: 'singleLineClose' }],
+    },
+    {
+      code: '!function foo() \n { \n return; }',
+      errors: [{ messageId: 'nextLineOpen' }, { messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'if (foo) \n { \n bar(); }',
+      errors: [{ messageId: 'nextLineOpen' }, { messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'if (a) { \nb();\n } else \n { c(); }',
+      errors: [
+        { messageId: 'nextLineOpen' },
+        { messageId: 'blockSameLine' },
+        { messageId: 'singleLineClose' },
+      ],
+    },
+    {
+      code: 'while (foo) \n { \n bar(); }',
+      errors: [{ messageId: 'nextLineOpen' }, { messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'for (;;) \n { \n bar(); }',
+      errors: [{ messageId: 'nextLineOpen' }, { messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'switch (foo) \n { \n case "bar": break; }',
+      errors: [{ messageId: 'nextLineOpen' }, { messageId: 'singleLineClose' }],
+    },
+    { code: 'switch (foo) \n { }', errors: [{ messageId: 'nextLineOpen' }] },
+    {
+      code: 'try \n { \n bar(); \n } catch (e) {}',
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'try { \n bar(); \n } catch (e) \n {}',
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'do \n { \n bar(); \n} while (true)',
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'for (foo in bar) \n { \n baz(); \n }',
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'for (foo of bar) \n { \n baz(); \n }',
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'try { \n bar(); \n }\ncatch (e) {\n}',
+      errors: [{ messageId: 'nextLineClose' }],
+    },
+    {
+      code: 'try { \n bar(); \n } catch (e) {\n}\n finally {\n}',
+      errors: [{ messageId: 'nextLineClose' }],
+    },
+    {
+      code: 'if (a) { \nb();\n } \n else { \nc();\n }',
+      errors: [{ messageId: 'nextLineClose' }],
+    },
+    {
+      code: 'try { \n bar(); \n }\ncatch (e) {\n} finally {\n}',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'sameLineClose' }],
+    },
+    {
+      code: 'try { \n bar(); \n } catch (e) {\n}\n finally {\n}',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'sameLineClose' }],
+    },
+    {
+      code: 'if (a) { \nb();\n } else { \nc();\n }',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'sameLineClose' }],
+    },
+    {
+      code: 'if (foo) {\nbaz();\n} else if (bar) {\nbaz();\n}\nelse {\nqux();\n}',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'sameLineClose' }],
+    },
+    {
+      code: 'if (foo) {\npoop();\n} \nelse if (bar) {\nbaz();\n} else if (thing) {\nboom();\n}\nelse {\nqux();\n}',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'sameLineClose' }],
+    },
+    {
+      code: 'try { \n bar(); \n }\n catch (e) {\n}\n finally {\n}',
+      options: ['allman'],
+      errors: [
+        { messageId: 'sameLineOpen' },
+        { messageId: 'sameLineOpen' },
+        { messageId: 'sameLineOpen' },
+      ],
+    },
+    {
+      code: 'switch(x) { case 1: \nbar(); }\n ',
+      options: ['allman'],
+      errors: [
+        { messageId: 'sameLineOpen' },
+        { messageId: 'blockSameLine' },
+        { messageId: 'singleLineClose' },
+      ],
+    },
+    {
+      code: 'if (a) { \nb();\n } else { \nc();\n }',
+      options: ['allman'],
+      errors: [
+        { messageId: 'sameLineOpen' },
+        { messageId: 'sameLineClose' },
+        { messageId: 'sameLineOpen' },
+      ],
+    },
+    {
+      code: 'if (foo) {\nbaz();\n} else if (bar) {\nbaz();\n}\nelse {\nqux();\n}',
+      options: ['allman'],
+      errors: [
+        { messageId: 'sameLineOpen' },
+        { messageId: 'sameLineClose' },
+        { messageId: 'sameLineOpen' },
+        { messageId: 'sameLineOpen' },
+      ],
+    },
+    {
+      code: 'if (foo)\n{ poop();\n} \nelse if (bar) {\nbaz();\n} else if (thing) {\nboom();\n}\nelse {\nqux();\n}',
+      options: ['allman'],
+      errors: [
+        { messageId: 'blockSameLine' },
+        { messageId: 'sameLineOpen' },
+        { messageId: 'sameLineClose' },
+        { messageId: 'sameLineOpen' },
+        { messageId: 'sameLineOpen' },
+      ],
+    },
+    {
+      code: 'if (foo)\n{\n  bar(); }',
+      options: ['allman'],
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'try\n{\n  somethingRisky();\n} catch (e)\n{\n  handleError()\n}',
+      options: ['allman'],
+      errors: [{ messageId: 'sameLineClose' }],
+    },
+
+    // allowSingleLine: true
+    {
+      code: 'function foo() { return; \n}',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'blockSameLine' }],
+    },
+    {
+      code: 'function foo() { a(); b(); return; \n}',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'blockSameLine' }],
+    },
+    {
+      code: 'function foo() { \n return; }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'function foo() {\na();\nb();\nreturn; }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: '!function foo() { \n return; }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'if (a) { b();\n } else { c(); }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'blockSameLine' }],
+    },
+    {
+      code: 'if (a) { b(); }\nelse { c(); }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineClose' }],
+    },
+    {
+      code: 'while (foo) { \n bar(); }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'for (;;) { bar(); \n }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'blockSameLine' }],
+    },
+    {
+      code: 'switch (foo) \n { \n case "bar": break; }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineOpen' }, { messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'switch (foo) \n { }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'try {  bar(); }\ncatch (e) { baz();  }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineClose' }],
+    },
+    {
+      code: 'try \n { \n bar(); \n } catch (e) {}',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'try { \n bar(); \n } catch (e) \n {}',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'do \n { \n bar(); \n} while (true)',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'for (foo in bar) \n { \n baz(); \n }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'try { \n bar(); \n }\ncatch (e) {\n}',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineClose' }],
+    },
+    {
+      code: 'try { \n bar(); \n } catch (e) {\n}\n finally {\n}',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineClose' }],
+    },
+    {
+      code: 'if (a) { \nb();\n } \n else { \nc();\n }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'nextLineClose' }],
+    },
+    {
+      code: 'try { \n bar(); \n }\ncatch (e) {\n} finally {\n}',
+      options: ['stroustrup', { allowSingleLine: true }],
+      errors: [{ messageId: 'sameLineClose' }],
+    },
+    {
+      code: 'try { \n bar(); \n } catch (e) {\n}\n finally {\n}',
+      options: ['stroustrup', { allowSingleLine: true }],
+      errors: [{ messageId: 'sameLineClose' }],
+    },
+    {
+      code: 'if (a) { \nb();\n } else { \nc();\n }',
+      options: ['stroustrup', { allowSingleLine: true }],
+      errors: [{ messageId: 'sameLineClose' }],
+    },
+    {
+      code: 'if (foo)\n{ poop();\n} \nelse if (bar) {\nbaz();\n} else if (thing) {\nboom();\n}\nelse {\nqux();\n}',
+      options: ['allman', { allowSingleLine: true }],
+      errors: [
+        { messageId: 'blockSameLine' },
+        { messageId: 'sameLineOpen' },
+        { messageId: 'sameLineClose' },
+        { messageId: 'sameLineOpen' },
+        { messageId: 'sameLineOpen' },
+      ],
+    },
+
+    // Comment interferes with fix
+    {
+      code: 'if (foo) // comment \n{\nbar();\n}',
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+
+    // https://github.com/eslint/eslint/issues/7493
+    {
+      code: 'if (foo) {\n bar\n.baz }',
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'if (foo)\n{\n bar\n.baz }',
+      options: ['allman'],
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'if (foo) { bar\n.baz }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [
+        { messageId: 'blockSameLine' },
+        { messageId: 'singleLineClose' },
+      ],
+    },
+    {
+      code: 'if (foo) { bar\n.baz }',
+      options: ['allman', { allowSingleLine: true }],
+      errors: [
+        { messageId: 'sameLineOpen' },
+        { messageId: 'blockSameLine' },
+        { messageId: 'singleLineClose' },
+      ],
+    },
+    {
+      code: 'switch (x) {\n case 1: foo() }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    { code: 'class Foo\n{\n}', errors: [{ messageId: 'nextLineOpen' }] },
+    { code: '(class\n{\n})', errors: [{ messageId: 'nextLineOpen' }] },
+    {
+      code: 'class Foo{\n}',
+      options: ['allman'],
+      errors: [{ messageId: 'sameLineOpen' }],
+    },
+    {
+      code: '(class {\n})',
+      options: ['allman'],
+      errors: [{ messageId: 'sameLineOpen' }],
+    },
+    {
+      code: 'class Foo {\nbar() {\n}}',
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: '(class Foo {\nbar() {\n}})',
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'class\nFoo{}',
+      options: ['allman'],
+      errors: [{ messageId: 'sameLineOpen' }],
+    },
+
+    // https://github.com/eslint/eslint/issues/7621
+    {
+      code: 'if (foo)\n{\n    bar\n}\nelse {\n    baz\n}',
+      errors: [{ messageId: 'nextLineOpen' }, { messageId: 'nextLineClose' }],
+    },
+
+    // Class static blocks
+    {
+      code: 'class C {\n    static\n    {\n        foo;\n    }\n}',
+      options: ['1tbs'],
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'class C {\n    static {foo;\n    }\n}',
+      options: ['1tbs'],
+      errors: [{ messageId: 'blockSameLine' }],
+    },
+    {
+      code: 'class C {\n    static {\n        foo;}\n}',
+      options: ['1tbs'],
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'class C {\n    static\n    {foo;}\n}',
+      options: ['1tbs'],
+      errors: [
+        { messageId: 'nextLineOpen' },
+        { messageId: 'blockSameLine' },
+        { messageId: 'singleLineClose' },
+      ],
+    },
+    {
+      code: 'class C {\n    static\n    {}\n}',
+      options: ['1tbs'],
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'class C {\n    static\n    {\n        foo;\n    }\n}',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'class C {\n    static {foo;\n    }\n}',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'blockSameLine' }],
+    },
+    {
+      code: 'class C {\n    static {\n        foo;}\n}',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'class C {\n    static\n    {foo;}\n}',
+      options: ['stroustrup'],
+      errors: [
+        { messageId: 'nextLineOpen' },
+        { messageId: 'blockSameLine' },
+        { messageId: 'singleLineClose' },
+      ],
+    },
+    {
+      code: 'class C {\n    static\n    {}\n}',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'nextLineOpen' }],
+    },
+    {
+      code: 'class C\n{\n    static{\n        foo;\n    }\n}',
+      options: ['allman'],
+      errors: [{ messageId: 'sameLineOpen' }],
+    },
+    {
+      code: 'class C\n{\n    static\n    {foo;\n    }\n}',
+      options: ['allman'],
+      errors: [{ messageId: 'blockSameLine' }],
+    },
+    {
+      code: 'class C\n{\n    static\n    {\n        foo;}\n}',
+      options: ['allman'],
+      errors: [{ messageId: 'singleLineClose' }],
+    },
+    {
+      code: 'class C\n{\n    static{foo;}\n}',
+      options: ['allman'],
+      errors: [
+        { messageId: 'sameLineOpen' },
+        { messageId: 'blockSameLine' },
+        { messageId: 'singleLineClose' },
+      ],
+    },
+    {
+      code: 'class C\n{\n    static{}\n}',
+      options: ['allman'],
+      errors: [{ messageId: 'sameLineOpen' }],
+    },
+
+    // TS `with` statement
+    {
+      code: 'with (foo) \n { \n bar(); }',
+      errors: [{ messageId: 'nextLineOpen' }, { messageId: 'singleLineClose' }],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'with (foo) { bar(); \n }',
+      options: ['1tbs', { allowSingleLine: true }],
+      errors: [{ messageId: 'blockSameLine' }],
+      filename: 'src/virtual.ts',
+    },
+
+    // TS namespace / module
+    {
+      code: 'module "Foo"\n{\n}',
+      errors: [{ messageId: 'nextLineOpen' }],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'module "Foo"\n{\n}',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'nextLineOpen' }],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'module "Foo" { \n }',
+      options: ['allman'],
+      errors: [{ messageId: 'sameLineOpen' }],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'namespace Foo\n{\n}',
+      errors: [{ messageId: 'nextLineOpen' }],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'namespace Foo\n{\n}',
+      options: ['stroustrup'],
+      errors: [{ messageId: 'nextLineOpen' }],
+      filename: 'src/virtual.ts',
+    },
+    {
+      code: 'namespace Foo { \n }',
+      options: ['allman'],
+      errors: [{ messageId: 'sameLineOpen' }],
+      filename: 'src/virtual.ts',
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -9,6 +9,7 @@ afoob
 agen
 alertdialog
 alink
+allman
 allowundefined
 anee
 apos
@@ -115,6 +116,9 @@ ESLint
 esmodule
 espree
 estree
+fontstack
+stroustrup
+stylisticutil
 Éurströmming
 exclam
 execdir


### PR DESCRIPTION
## Summary

Port the `@stylistic/brace-style` rule from eslint-stylistic 1:1, with full support for all three styles (`1tbs` / `stroustrup` / `allman`) and the `allowSingleLine` option. Listener targets cover BlockStatement, ClassStaticBlockDeclaration, ClassDeclaration / ClassExpression bodies, SwitchStatement, IfStatement / TryStatement close-before-keyword, and TSModuleBlock — matching upstream's 7 listeners.

Also extracts the helpers shared with `arrow-parens` (`SameLineByPos`, `CommentsExistBetween`, `FindPrevTokenEnd`) into a new `internal/plugins/stylistic/stylisticutil/` package and migrates `arrow-parens` to consume them.

Test coverage:

- 180 upstream cases (full migration of `brace-style._js_.test.ts` and `brace-style._ts_.test.ts`, including the `with` statement cases that tsgo parses under strict mode)
- 195 rslint-specific extras covering tsgo AST quirks (decorators, generics, heritage clauses, class expression forms), real-user shapes (React class components, IIFEs, generator / async methods, `catch {}` ES2019, TS function overloads), branch lock-ins, fix-suppression paths, source-order ordering across listener boundaries, and explicit non-target locks (interface / enum / type-literal / JSX expression containers)
- JS-side IPC contract test mirroring the upstream Layer-1 suite

Verified on real codebases — `pnpm rslint --type-check` on rsbuild (1935 files, 2 violations: both `nextLineClose` with a comment between `}` and `else`, autofix correctly suppressed) and rspack (473 files, 7 violations: 1 same pattern + 6 single-line method / catch body `blockSameLine` + `singleLineClose` pairs). Every reported violation was hand-verified against upstream's rule logic and matches what ESLint would produce.

## Related Links

- Original rule: https://eslint.style/rules/brace-style
- Upstream source: https://github.com/eslint-stylistic/eslint-stylistic/tree/main/packages/eslint-plugin/rules/brace-style

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).