### PR TITLE
feat: port rule @stylistic/comma-spacing

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -7,16 +7,18 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/block_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/brace_style"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_dangle"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_spacing"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
-		comma_dangle.CommaDangleRule,
 		array_bracket_spacing.ArrayBracketSpacingRule,
 		arrow_parens.ArrowParensRule,
 		arrow_spacing.ArrowSpacingRule,
 		block_spacing.BlockSpacingRule,
 		brace_style.BraceStyleRule,
+		comma_dangle.CommaDangleRule,
+		comma_spacing.CommaSpacingRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/comma_spacing/comma_spacing.go
+++ b/internal/plugins/stylistic/rules/comma_spacing/comma_spacing.go
@@ -1,0 +1,551 @@
+package comma_spacing
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/stylisticutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type commaSpacingOptions struct {
+	before bool
+	after  bool
+}
+
+// parseOptions accepts upstream's option shapes. The default is
+// `{ before: false, after: true }`. The CLI / rule_tester may deliver:
+//
+//	rule: ['comma-spacing']                                  → defaults
+//	rule: ['comma-spacing', { before: true, after: false }]  → as written
+//
+// rslint's config loader collapses a single-element option array into the
+// option itself, so we accept either a bare map or a wrapping array. The two
+// flags are independent — partial-config payloads (only one of `before`/
+// `after`) keep the unspecified flag at its default.
+func parseOptions(raw any) commaSpacingOptions {
+	opts := commaSpacingOptions{before: false, after: true}
+	optsMap := utils.GetOptionsMap(raw)
+	if optsMap == nil {
+		return opts
+	}
+	if b, ok := optsMap["before"].(bool); ok {
+		opts.before = b
+	}
+	if b, ok := optsMap["after"].(bool); ok {
+		opts.after = b
+	}
+	return opts
+}
+
+// tokenInfo is a minimal token record used by the rule's token walker. The
+// scanner can emit ordinary tokens AND trivia (whitespace, line breaks,
+// comments) when SkipTrivia is off. We retain comments because upstream's
+// `tokensAndComments` stream feeds comments into the prev/next-token slots —
+// e.g. `, /* */ foo` puts the comment as the "next token" of `,`.
+type tokenInfo struct {
+	pos  int
+	end  int
+	kind ast.Kind
+}
+
+// isCloseBracketKind tests the three "right-side punctuation" tokens that
+// upstream defers to their own dedicated rules (space-in-parens,
+// array-bracket-spacing, object-curly-spacing). When the next token after a
+// comma is one of these, the after-check is skipped entirely.
+func isCloseBracketKind(k ast.Kind) bool {
+	return k == ast.KindCloseParenToken ||
+		k == ast.KindCloseBracketToken ||
+		k == ast.KindCloseBraceToken
+}
+
+// isTriviaSkip reports whether a token kind should be invisible when walking
+// for the "prev / next" of a comma. Whitespace and line breaks are skipped;
+// comments are NOT — they participate in spacing checks (upstream merges
+// `tokens` and `comments` into one stream).
+func isTriviaSkip(k ast.Kind) bool {
+	return k == ast.KindWhitespaceTrivia ||
+		k == ast.KindNewLineTrivia ||
+		k == ast.KindConflictMarkerTrivia ||
+		k == ast.KindNonTextFileMarkerTrivia
+}
+
+// nextRealTokenKind reads the very next non-trivia, non-comment token at or
+// after `from`. Mirrors ESLint's `sourceCode.getTokenAfter(prev)` with
+// default options — comments are skipped. Used by both the null-array-element
+// walk (where the previous-token chain in upstream's
+// `addNullElementsToIgnoreList` uses default getTokenAfter, so comments
+// don't count) and the type-parameter-trailing-comma walk (same).
+//
+// `scanner.GetScannerForSourceFile` already calls Scan() once with default
+// SkipTrivia=true, so the first non-trivia / non-comment token at or after
+// `from` is already loaded in the scanner state when this returns — we
+// just read it via Token() / TokenStart(), no further Scan() needed.
+func nextRealTokenKind(sf *ast.SourceFile, from int) (ast.Kind, int) {
+	s := scanner.GetScannerForSourceFile(sf, from)
+	return s.Token(), s.TokenStart()
+}
+
+// collectIgnoredCommas walks the AST and records the source positions of
+// commas whose spacing must NOT be checked. Upstream's
+// `ignoredTokens` set captures two distinct populations; both feed the same
+// suppression code path (`isCommaToken(prev) || ignoredTokens.has(comma)`
+// → both prev and next nulled out, so the validator emits nothing).
+//
+//   - **Null-element commas inside ArrayLiteralExpression /
+//     ArrayBindingPattern**. For each `KindOmittedExpression` element the
+//     ignored comma is the one immediately AFTER the previous token (the
+//     `[` or the prior `,`). We model this by tracking `prevEnd` (start
+//     position to scan from) and, when the current element is omitted,
+//     scanning forward to the next non-trivia token, asserting it's a
+//     comma, and recording it.
+//   - **Trailing commas in TS type-parameter lists**. After the last type
+//     parameter, if the next non-trivia token is a comma, that comma is
+//     ignored. This covers the `<T,>`, `<T, P,>`, `<T, T1,>` shapes — and
+//     deliberately does NOT cover the no-trailing-comma `<T, P>` form,
+//     where the next token is `>`.
+//
+// Both populations are recorded into a single position-keyed map; downstream
+// just asks `ignored[pos]` once per comma.
+func collectIgnoredCommas(sf *ast.SourceFile) map[int]struct{} {
+	ignored := map[int]struct{}{}
+
+	// isHoleElement reports whether an ArrayLiteral / ArrayBindingPattern
+	// element represents an elision (a "missing" slot like `[ , x]`).
+	//
+	//   - In ArrayLiteralExpression tsgo materializes the hole as a
+	//     `KindOmittedExpression` node.
+	//   - In ArrayBindingPattern tsgo materializes the hole as a
+	//     `KindBindingElement` whose entire span is zero-width (Pos ==
+	//     End). The element has no name and no initializer; it's
+	//     parser-emitted to keep the elements slice index-aligned with
+	//     the comma-separated positions.
+	//
+	// Detecting both shapes via the same predicate lets one walker
+	// handle ArrayLiteral and ArrayBindingPattern uniformly.
+	isHoleElement := func(el *ast.Node) bool {
+		if el == nil {
+			return false
+		}
+		if el.Kind == ast.KindOmittedExpression {
+			return true
+		}
+		if el.Kind == ast.KindBindingElement && el.Pos() == el.End() {
+			return true
+		}
+		return false
+	}
+
+	addArrayNullCommas := func(node *ast.Node, elements []*ast.Node) {
+		if len(elements) == 0 {
+			return
+		}
+		// Mirror upstream's `addNullElementsToIgnoreList`:
+		//   previousToken := getFirstToken(node)  // `[`
+		//   for el in elements:
+		//     if el is hole:
+		//       token := getTokenAfter(previousToken)  // expect comma; ignore it
+		//     else:
+		//       token := getTokenAfter(el)             // step over the separator comma
+		//     previousToken := token
+		//
+		// `scanFrom` corresponds to "scan starting position to find the
+		// next real token after `previousToken`" — i.e. it's one past
+		// `previousToken.End()`. We seed it with the `[`'s position
+		// (trimmed.Pos()+1 = just past `[`) so the first `getTokenAfter`
+		// reads the token that follows `[`.
+		trimmed := utils.TrimNodeTextRange(sf, node)
+		scanFrom := trimmed.Pos() + 1 // just past `[`
+		for _, el := range elements {
+			if isHoleElement(el) {
+				k, pos := nextRealTokenKind(sf, scanFrom)
+				if k != ast.KindCommaToken {
+					// Defensive: malformed input — abandon this list.
+					return
+				}
+				ignored[pos] = struct{}{}
+				scanFrom = pos + 1
+				continue
+			}
+			if el == nil {
+				continue
+			}
+			// Step previousToken over the comma that follows the
+			// element (if any) so the next iteration sees the right
+			// "next token". For the last element this lands on `]`,
+			// which we ignore.
+			k, pos := nextRealTokenKind(sf, el.End())
+			if k == ast.KindCommaToken {
+				scanFrom = pos + 1
+			} else {
+				scanFrom = el.End()
+			}
+		}
+	}
+
+	addTypeParamTrailing := func(list *ast.NodeList) {
+		if list == nil || len(list.Nodes) == 0 {
+			return
+		}
+		last := list.Nodes[len(list.Nodes)-1]
+		k, pos := nextRealTokenKind(sf, last.End())
+		if k == ast.KindCommaToken {
+			ignored[pos] = struct{}{}
+		}
+	}
+
+	// Any future FunctionLike kind picks up TypeParameterList support
+	// automatically via the shim's IsFunctionLike predicate; the explicit
+	// switch only covers the four non-function-like type-bearing kinds.
+	// `JSDocTemplateTag` is intentionally excluded — its commas live inside
+	// `/* */` block comments, which the raw scanner never emits as
+	// CommaToken in the first place.
+	hasTypeParamList := func(n *ast.Node) bool {
+		if ast.IsFunctionLike(n) {
+			return true
+		}
+		switch n.Kind {
+		case ast.KindClassDeclaration, ast.KindClassExpression,
+			ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
+			return true
+		}
+		return false
+	}
+
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Kind {
+		case ast.KindArrayLiteralExpression:
+			if arr := n.AsArrayLiteralExpression(); arr != nil && arr.Elements != nil {
+				addArrayNullCommas(n, arr.Elements.Nodes)
+			}
+		case ast.KindArrayBindingPattern:
+			if bp := n.AsBindingPattern(); bp != nil && bp.Elements != nil {
+				addArrayNullCommas(n, bp.Elements.Nodes)
+			}
+		}
+		if hasTypeParamList(n) {
+			addTypeParamTrailing(n.TypeParameterList())
+		}
+		n.ForEachChild(func(c *ast.Node) bool {
+			walk(c)
+			return false
+		})
+	}
+	walk(sf.AsNode())
+
+	return ignored
+}
+
+// scanAllTokens enumerates every visible token (real tokens AND comments,
+// but not whitespace / line breaks) in source order, in a way that is
+// robust to template literals with substitutions, regex literals, JSX
+// text, and string literals.
+//
+// **Why the gap-scan recursion instead of one flat full-file scan?**
+//
+// tsgo's raw scanner does not maintain template-mode state across calls.
+// Inside `` `a${e}\\\`(${typeof e})\` ``, after scanning the `}` that
+// closes `${e}`, the scanner re-enters default mode; the next `` ` ``
+// (whether escaped-literal or real-closing) is treated as the START of a
+// brand-new template literal, and a long stretch of subsequent code is
+// silently swallowed as that fake template's content. Commas in that
+// stretch never reach our walker, producing false negatives. (See the
+// rspack p-map.mjs differential — under a full-file raw scan rslint
+// missed 53 commas that ESLint reports.)
+//
+// `internal/utils/ts_eslint.go HasSameTokens` solves the same problem
+// with a recursive AST walk: scan only the **gaps between AST children**.
+// AST nodes for templates (TemplateExpression / TemplateSpan /
+// TemplateHead / TemplateMiddle / TemplateTail / NoSubstitutionTemplate-
+// Literal) cover the literal text contiguously, so a gap between two
+// children is **always pure trivia + punctuation** — never literal-text
+// content. The scanner therefore cannot enter the confusable region.
+//
+// Within each gap we open a scanner with `SkipTrivia=false` (via fresh
+// `NewScanner` rather than `GetScannerForSourceFile`, which auto-calls
+// `Scan()` with `SkipTrivia=true` and would eat the first comment) so
+// block / line comments surface as tokens — upstream's
+// `tokensAndComments` stream includes comments as legitimate
+// prev / next neighbors of a comma.
+//
+// **Leaf nodes** (any node with no `ForEachChild` children — identifiers,
+// literals, keyword tokens, TemplateHead/Middle/Tail, OmittedExpression
+// with zero width, BinaryExpression's OperatorToken when it is a
+// `KindCommaToken`, etc.) are not gap-scanned; their entire range is the
+// token, captured directly via `utils.TrimNodeTextRange`. This is how a
+// CommaToken that lives as an operator child of a BinaryExpression (the
+// sequence-expression case `a, b, c`) joins the stream — gaps around it
+// are empty, but the leaf itself emits as `KindCommaToken`.
+func scanAllTokens(sf *ast.SourceFile) []tokenInfo {
+	var tokens []tokenInfo
+	text := sf.Text()
+	textLen := len(text)
+
+	// Single reusable scanner, reset per gap via ResetTokenState.
+	// SkipTrivia=false so block / line comments surface as tokens.
+	s := scanner.NewScanner()
+	s.SetText(text)
+	s.SetLanguageVariant(sf.LanguageVariant)
+	s.SetSkipTrivia(false)
+
+	scanGap := func(start, end int) {
+		if start >= end || start < 0 || end > textLen {
+			return
+		}
+		s.ResetTokenState(start)
+		for {
+			k := s.Scan()
+			if k == ast.KindEndOfFile {
+				return
+			}
+			// Bound to the gap: anything at or past `end` belongs to
+			// the next AST sibling and will be picked up by that
+			// sibling's walk.
+			if s.TokenStart() >= end {
+				return
+			}
+			if isTriviaSkip(k) {
+				continue
+			}
+			tokens = append(tokens, tokenInfo{
+				pos:  s.TokenStart(),
+				end:  s.TokenEnd(),
+				kind: k,
+			})
+		}
+	}
+
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		var kids []*ast.Node
+		n.ForEachChild(func(c *ast.Node) bool {
+			kids = append(kids, c)
+			return false
+		})
+		if len(kids) == 0 {
+			// Leaf node — emit as a single token at its trimmed range
+			// (Pos() includes leading trivia we don't want).
+			// Zero-width leaves (OmittedExpression, empty BindingElement
+			// holes) are skipped — they don't represent visible tokens
+			// in the stream, and including them as zero-width entries
+			// would confuse "is comma adjacent to comma" prev/next
+			// logic. Synthetic nodes with negative Pos (parser
+			// recovery slots, missing-optional placeholders) are also
+			// skipped — they have no source-text backing.
+			if n.Pos() < 0 || n.End() < 0 {
+				return
+			}
+			trimmed := utils.TrimNodeTextRange(sf, n)
+			if trimmed.Pos() < trimmed.End() {
+				tokens = append(tokens, tokenInfo{
+					pos:  trimmed.Pos(),
+					end:  trimmed.End(),
+					kind: n.Kind,
+				})
+			}
+			return
+		}
+		// Use the trimmed Pos of each kid (Pos() includes leading trivia, so
+		// content like comments that visually sit *between* two AST siblings
+		// is technically "inside" the next sibling's Pos range. Scanning up
+		// to the trimmed Pos pulls those comments back into the gap so the
+		// scanner sees them.
+		prevEnd := n.Pos()
+		for _, kid := range kids {
+			// Synthetic / parser-recovered nodes (e.g. an implicit
+			// QuestionDotToken slot on a non-optional CallExpression)
+			// have negative Pos. Skip them — they aren't backed by
+			// source bytes and would crash TrimNodeTextRange.
+			if kid.Pos() < 0 || kid.End() < 0 {
+				continue
+			}
+			kidTrimmedPos := utils.TrimNodeTextRange(sf, kid).Pos()
+			scanGap(prevEnd, kidTrimmedPos)
+			walk(kid)
+			prevEnd = kid.End()
+		}
+		scanGap(prevEnd, n.End())
+	}
+	walk(sf.AsNode())
+	return tokens
+}
+
+// CommaSpacingRule enforces consistent spacing before and after commas.
+// Ported from @stylistic/eslint-plugin's comma-spacing.
+//
+// Strategy: build a single global token stream (with comments retained as
+// tokens, matching ESLint's `sourceCode.tokensAndComments`); for each
+// `KindCommaToken` in the stream determine its prev/next visible token,
+// apply upstream's null-prev / null-next rules (commas next to commas and
+// commas in the AST-derived ignore set both null out their neighbors), and
+// then run `validateCommaSpacing`. The work happens eagerly inside `Run`
+// because the rule's scope is the whole file — there's no per-node listener
+// that naturally fits this shape, and the linter never fires a
+// `KindSourceFile` listener.
+var CommaSpacingRule = rule.Rule{
+	Name: "@stylistic/comma-spacing",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		sf := ctx.SourceFile
+		if sf == nil {
+			return rule.RuleListeners{}
+		}
+
+		ignoredCommas := collectIgnoredCommas(sf)
+		tokens := scanAllTokens(sf)
+
+		for i := range tokens {
+			t := tokens[i]
+			if t.kind != ast.KindCommaToken {
+				continue
+			}
+
+			var prev, next *tokenInfo
+			if i > 0 {
+				prev = &tokens[i-1]
+			}
+			if i+1 < len(tokens) {
+				next = &tokens[i+1]
+			}
+
+			// Upstream:
+			//
+			//   isCommaToken(prevToken) || ignoredTokens.has(token) ? null : prevToken
+			//   isCommaToken(nextToken) || ignoredTokens.has(token) ? null : nextToken
+			//
+			// Comma-next-to-comma neutralizes EACH side independently;
+			// the ignore set neutralizes BOTH at once.
+			if prev != nil && prev.kind == ast.KindCommaToken {
+				prev = nil
+			}
+			if next != nil && next.kind == ast.KindCommaToken {
+				next = nil
+			}
+			if _, ok := ignoredCommas[t.pos]; ok {
+				prev = nil
+				next = nil
+			}
+
+			validateCommaSpacing(ctx, sf, opts, t, prev, next)
+		}
+
+		return rule.RuleListeners{}
+	},
+}
+
+// validateCommaSpacing emits up to two diagnostics for one comma, one for
+// the before-side and one for the after-side. Mirrors upstream's
+// validateCommaSpacing function byte-for-byte — the two if-blocks below
+// translate the two upstream blocks one for one. See PORT_RULE.md "Testing
+// Philosophy" for why we mirror logic shape, not just outputs.
+func validateCommaSpacing(
+	ctx rule.RuleContext,
+	sf *ast.SourceFile,
+	opts commaSpacingOptions,
+	comma tokenInfo,
+	prev, next *tokenInfo,
+) {
+	// --- before-side ---
+	//
+	// Upstream:
+	//   if (prevToken && isTokenOnSameLine(prevToken, commaToken)
+	//       && spaceBefore !== sourceCode.isSpaceBetween(prevToken, commaToken)) { ... }
+	if prev != nil && stylisticutil.SameLineByPos(sf, prev.end, comma.pos) {
+		hasSpace := prev.end < comma.pos
+		if opts.before != hasSpace {
+			var msg rule.RuleMessage
+			var fix rule.RuleFix
+			if opts.before {
+				msg = rule.RuleMessage{
+					Id:          "missing",
+					Description: "A space is required before ','.",
+					Data:        map[string]string{"loc": "before"},
+				}
+				fix = rule.RuleFix{
+					Text:  " ",
+					Range: core.NewTextRange(comma.pos, comma.pos),
+				}
+			} else {
+				msg = rule.RuleMessage{
+					Id:          "unexpected",
+					Description: "There should be no space before ','.",
+					Data:        map[string]string{"loc": "before"},
+				}
+				fix = rule.RuleFix{
+					Text:  "",
+					Range: core.NewTextRange(prev.end, comma.pos),
+				}
+			}
+			ctx.ReportRangeWithFixes(
+				core.NewTextRange(comma.pos, comma.end),
+				msg,
+				fix,
+			)
+		}
+	}
+
+	// --- after-side ---
+	//
+	// Upstream:
+	//   if (nextToken && isTokenOnSameLine(commaToken, nextToken)
+	//       && !isClosingParenToken(nextToken)
+	//       && !isClosingBracketToken(nextToken)
+	//       && !isClosingBraceToken(nextToken)
+	//       && !(!spaceAfter && nextToken.type === AST_TOKEN_TYPES.Line)
+	//       && spaceAfter !== sourceCode.isSpaceBetween(commaToken, nextToken)) { ... }
+	if next == nil {
+		return
+	}
+	if !stylisticutil.SameLineByPos(sf, comma.end, next.pos) {
+		return
+	}
+	if isCloseBracketKind(next.kind) {
+		return
+	}
+	// `!spaceAfter && nextToken is a single-line comment` exemption.
+	// Deleting the space would fuse `,` into the `//` and silently re-shape
+	// the source.
+	if !opts.after && next.kind == ast.KindSingleLineCommentTrivia {
+		return
+	}
+	hasSpace := comma.end < next.pos
+	if opts.after == hasSpace {
+		return
+	}
+	var msg rule.RuleMessage
+	var fix rule.RuleFix
+	if opts.after {
+		msg = rule.RuleMessage{
+			Id:          "missing",
+			Description: "A space is required after ','.",
+			Data:        map[string]string{"loc": "after"},
+		}
+		fix = rule.RuleFix{
+			Text:  " ",
+			Range: core.NewTextRange(comma.end, comma.end),
+		}
+	} else {
+		msg = rule.RuleMessage{
+			Id:          "unexpected",
+			Description: "There should be no space after ','.",
+			Data:        map[string]string{"loc": "after"},
+		}
+		fix = rule.RuleFix{
+			Text:  "",
+			Range: core.NewTextRange(comma.end, next.pos),
+		}
+	}
+	ctx.ReportRangeWithFixes(
+		core.NewTextRange(comma.pos, comma.end),
+		msg,
+		fix,
+	)
+}

--- a/internal/plugins/stylistic/rules/comma_spacing/comma_spacing.go
+++ b/internal/plugins/stylistic/rules/comma_spacing/comma_spacing.go
@@ -72,19 +72,33 @@ func isTriviaSkip(k ast.Kind) bool {
 }
 
 // nextRealTokenKind reads the very next non-trivia, non-comment token at or
-// after `from`. Mirrors ESLint's `sourceCode.getTokenAfter(prev)` with
-// default options — comments are skipped. Used by both the null-array-element
-// walk (where the previous-token chain in upstream's
-// `addNullElementsToIgnoreList` uses default getTokenAfter, so comments
-// don't count) and the type-parameter-trailing-comma walk (same).
+// after `from`, using the supplied (already-configured) scanner. Mirrors
+// ESLint's `sourceCode.getTokenAfter(prev)` with default options — comments
+// are skipped. Used by both the null-array-element walk (where the previous-
+// token chain in upstream's `addNullElementsToIgnoreList` uses default
+// getTokenAfter, so comments don't count) and the type-parameter-trailing-
+// comma walk (same).
 //
-// `scanner.GetScannerForSourceFile` already calls Scan() once with default
-// SkipTrivia=true, so the first non-trivia / non-comment token at or after
-// `from` is already loaded in the scanner state when this returns — we
-// just read it via Token() / TokenStart(), no further Scan() needed.
-func nextRealTokenKind(sf *ast.SourceFile, from int) (ast.Kind, int) {
-	s := scanner.GetScannerForSourceFile(sf, from)
-	return s.Token(), s.TokenStart()
+// The scanner is passed in (and reused across calls) rather than freshly
+// allocated via `scanner.GetScannerForSourceFile`: in a single file each
+// array literal / pattern + each type-parameter list issues 1–N calls, so
+// allocating a Scanner per call wastes work proportional to AST size.
+// Callers configure `SetText` / `SetLanguageVariant` once and call
+// `ResetTokenState` per query (this function does the reset and scan).
+func nextRealTokenKind(s *scanner.Scanner, from int) (ast.Kind, int) {
+	s.ResetTokenState(from)
+	for {
+		k := s.Scan()
+		if k == ast.KindEndOfFile {
+			return k, s.TokenStart()
+		}
+		if isTriviaSkip(k) ||
+			k == ast.KindSingleLineCommentTrivia ||
+			k == ast.KindMultiLineCommentTrivia {
+			continue
+		}
+		return k, s.TokenStart()
+	}
 }
 
 // collectIgnoredCommas walks the AST and records the source positions of
@@ -110,6 +124,15 @@ func nextRealTokenKind(sf *ast.SourceFile, from int) (ast.Kind, int) {
 // just asks `ignored[pos]` once per comma.
 func collectIgnoredCommas(sf *ast.SourceFile) map[int]struct{} {
 	ignored := map[int]struct{}{}
+
+	// Single reusable scanner for all nextRealTokenKind lookups in this
+	// pass. Configured with SkipTrivia=false so we can loop manually past
+	// whitespace, line breaks, and comments — matching ESLint's default
+	// getTokenAfter (comments excluded).
+	s := scanner.NewScanner()
+	s.SetText(sf.Text())
+	s.SetLanguageVariant(sf.LanguageVariant)
+	s.SetSkipTrivia(false)
 
 	// isHoleElement reports whether an ArrayLiteral / ArrayBindingPattern
 	// element represents an elision (a "missing" slot like `[ , x]`).
@@ -159,7 +182,7 @@ func collectIgnoredCommas(sf *ast.SourceFile) map[int]struct{} {
 		scanFrom := trimmed.Pos() + 1 // just past `[`
 		for _, el := range elements {
 			if isHoleElement(el) {
-				k, pos := nextRealTokenKind(sf, scanFrom)
+				k, pos := nextRealTokenKind(s, scanFrom)
 				if k != ast.KindCommaToken {
 					// Defensive: malformed input — abandon this list.
 					return
@@ -175,7 +198,7 @@ func collectIgnoredCommas(sf *ast.SourceFile) map[int]struct{} {
 			// element (if any) so the next iteration sees the right
 			// "next token". For the last element this lands on `]`,
 			// which we ignore.
-			k, pos := nextRealTokenKind(sf, el.End())
+			k, pos := nextRealTokenKind(s, el.End())
 			if k == ast.KindCommaToken {
 				scanFrom = pos + 1
 			} else {
@@ -189,7 +212,7 @@ func collectIgnoredCommas(sf *ast.SourceFile) map[int]struct{} {
 			return
 		}
 		last := list.Nodes[len(list.Nodes)-1]
-		k, pos := nextRealTokenKind(sf, last.End())
+		k, pos := nextRealTokenKind(s, last.End())
 		if k == ast.KindCommaToken {
 			ignored[pos] = struct{}{}
 		}
@@ -197,17 +220,21 @@ func collectIgnoredCommas(sf *ast.SourceFile) map[int]struct{} {
 
 	// Any future FunctionLike kind picks up TypeParameterList support
 	// automatically via the shim's IsFunctionLike predicate; the explicit
-	// switch only covers the four non-function-like type-bearing kinds.
-	// `JSDocTemplateTag` is intentionally excluded — its commas live inside
-	// `/* */` block comments, which the raw scanner never emits as
-	// CommaToken in the first place.
+	// switch only covers the non-function-like type-bearing kinds.
+	// `KindJSTypeAliasDeclaration` covers JSDoc `@typedef`-style aliases in
+	// `.js` files (it routes through the same `AsTypeAliasDeclaration` getter
+	// as `KindTypeAliasDeclaration`, so we treat it the same).
+	// `KindJSDocTemplateTag` is intentionally excluded — its commas live
+	// inside `/* */` block comments and our gap-walker never enters comment
+	// content, so they cannot reach this check.
 	hasTypeParamList := func(n *ast.Node) bool {
 		if ast.IsFunctionLike(n) {
 			return true
 		}
 		switch n.Kind {
 		case ast.KindClassDeclaration, ast.KindClassExpression,
-			ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
+			ast.KindInterfaceDeclaration,
+			ast.KindTypeAliasDeclaration, ast.KindJSTypeAliasDeclaration:
 			return true
 		}
 		return false
@@ -249,8 +276,8 @@ func collectIgnoredCommas(sf *ast.SourceFile) map[int]struct{} {
 // **Why the gap-scan recursion instead of one flat full-file scan?**
 //
 // tsgo's raw scanner does not maintain template-mode state across calls.
-// Inside `` `a${e}\\\`(${typeof e})\` ``, after scanning the `}` that
-// closes `${e}`, the scanner re-enters default mode; the next `` ` ``
+// Inside “ `a${e}\\\`(${typeof e})\` “, after scanning the `}` that
+// closes `${e}`, the scanner re-enters default mode; the next “ ` “
 // (whether escaped-literal or real-closing) is treated as the START of a
 // brand-new template literal, and a long stretch of subsequent code is
 // silently swallowed as that fake template's content. Commas in that
@@ -303,10 +330,12 @@ func scanAllTokens(sf *ast.SourceFile) []tokenInfo {
 			if k == ast.KindEndOfFile {
 				return
 			}
-			// Bound to the gap: anything at or past `end` belongs to
-			// the next AST sibling and will be picked up by that
-			// sibling's walk.
-			if s.TokenStart() >= end {
+			// Bound to the gap on both sides: tokens that start at /
+			// past `end` belong to the next sibling, and tokens whose
+			// end straddles `end` (defensive — shouldn't happen for
+			// AST-sibling-aligned gaps, but matches HasSameTokens'
+			// `liveA` invariant for safety) are also excluded.
+			if s.TokenStart() >= end || s.TokenEnd() > end {
 				return
 			}
 			if isTriviaSkip(k) {
@@ -320,17 +349,43 @@ func scanAllTokens(sf *ast.SourceFile) []tokenInfo {
 		}
 	}
 
+	// `walk` recurses via `ForEachChild` directly — no per-node `[]*ast.Node`
+	// allocation. `prevEnd` and `hasKids` live in the closure variables so
+	// each non-leaf node uses O(1) extra memory regardless of arity. Matches
+	// the pattern other recursive walkers in this repo follow
+	// (e.g. internal/linter/linter.go's childVisitor,
+	// internal/plugins/react_hooks/.../exhaustive_deps.go's visit).
 	var walk func(n *ast.Node)
 	walk = func(n *ast.Node) {
 		if n == nil {
 			return
 		}
-		var kids []*ast.Node
-		n.ForEachChild(func(c *ast.Node) bool {
-			kids = append(kids, c)
+		prevEnd := n.Pos()
+		hasKids := false
+		n.ForEachChild(func(kid *ast.Node) bool {
+			hasKids = true
+			// Synthetic / parser-recovered children (e.g. an implicit
+			// QuestionDotToken slot on a non-optional CallExpression)
+			// have negative Pos. Skip them — they aren't backed by
+			// source bytes and would crash TrimNodeTextRange. Keep
+			// `hasKids` true so the parent is still treated as
+			// composite (we already entered the iteration).
+			if kid.Pos() < 0 || kid.End() < 0 {
+				return false
+			}
+			// Use the trimmed Pos of each kid (Pos() includes leading
+			// trivia, so content like comments that visually sit
+			// *between* two AST siblings is technically "inside" the
+			// next sibling's Pos range). Scanning up to the trimmed
+			// Pos pulls those comments back into the gap so the
+			// scanner sees them.
+			kidTrimmedPos := utils.TrimNodeTextRange(sf, kid).Pos()
+			scanGap(prevEnd, kidTrimmedPos)
+			walk(kid)
+			prevEnd = kid.End()
 			return false
 		})
-		if len(kids) == 0 {
+		if !hasKids {
 			// Leaf node — emit as a single token at its trimmed range
 			// (Pos() includes leading trivia we don't want).
 			// Zero-width leaves (OmittedExpression, empty BindingElement
@@ -352,25 +407,6 @@ func scanAllTokens(sf *ast.SourceFile) []tokenInfo {
 				})
 			}
 			return
-		}
-		// Use the trimmed Pos of each kid (Pos() includes leading trivia, so
-		// content like comments that visually sit *between* two AST siblings
-		// is technically "inside" the next sibling's Pos range. Scanning up
-		// to the trimmed Pos pulls those comments back into the gap so the
-		// scanner sees them.
-		prevEnd := n.Pos()
-		for _, kid := range kids {
-			// Synthetic / parser-recovered nodes (e.g. an implicit
-			// QuestionDotToken slot on a non-optional CallExpression)
-			// have negative Pos. Skip them — they aren't backed by
-			// source bytes and would crash TrimNodeTextRange.
-			if kid.Pos() < 0 || kid.End() < 0 {
-				continue
-			}
-			kidTrimmedPos := utils.TrimNodeTextRange(sf, kid).Pos()
-			scanGap(prevEnd, kidTrimmedPos)
-			walk(kid)
-			prevEnd = kid.End()
 		}
 		scanGap(prevEnd, n.End())
 	}

--- a/internal/plugins/stylistic/rules/comma_spacing/comma_spacing.md
+++ b/internal/plugins/stylistic/rules/comma_spacing/comma_spacing.md
@@ -1,0 +1,98 @@
+# comma-spacing
+
+Enforce consistent spacing before and after commas.
+
+## Rule Details
+
+This rule normalizes the whitespace around the `,` separator in variable declarations, array literals, array destructuring patterns, object literals, object destructuring patterns, function parameter lists, function call arguments, sequence expressions, and TypeScript-specific list-shaped syntax (type arguments, type parameters, tuple types, enum members, import / export specifiers, heritage clauses).
+
+The rule does **not** apply between:
+
+- Two consecutive commas (`[1, , 2]` — the comma terminating the null slot is exempt)
+- A comma and the immediately following `)`, `]`, or `}` (delegated to dedicated bracket-spacing rules)
+- A comma and the immediately following line comment when the option forbids a space after — removing the space would fuse the comma into `//`
+
+Examples of **incorrect** code for this rule with the default `{ "before": false, "after": true }` option:
+
+```javascript
+var foo = 1 ,bar = 2;
+var arr = [1 , 2];
+var obj = { foo: 'bar' ,baz: 'qur' };
+foo(a ,b);
+type Foo<T ,P> = Bar<T ,P>;
+```
+
+Examples of **correct** code for this rule with the default `{ "before": false, "after": true }` option:
+
+```javascript
+var foo = 1, bar = 2;
+var arr = [1, 2];
+var obj = { foo: 'bar', baz: 'qur' };
+foo(a, b);
+type Foo<T, P> = Bar<T, P>;
+```
+
+## Options
+
+This rule has an object option:
+
+- `"before": false` (default) forbids a space before the comma. Set to `true` to require one.
+- `"after": true` (default) requires a space after the comma. Set to `false` to forbid one.
+
+Either key may be omitted; a missing key falls back to its default.
+
+### before
+
+Examples of **incorrect** code for this rule with the `{ "before": true }` option:
+
+```json
+{ "@stylistic/comma-spacing": ["error", { "before": true }] }
+```
+
+```javascript
+var foo = 1, bar = 2;
+var arr = [1, 2];
+foo(a, b);
+```
+
+Examples of **correct** code for this rule with the `{ "before": true }` option:
+
+```json
+{ "@stylistic/comma-spacing": ["error", { "before": true }] }
+```
+
+```javascript
+var foo = 1 , bar = 2;
+var arr = [1 , 2];
+foo(a , b);
+```
+
+### after
+
+Examples of **incorrect** code for this rule with the `{ "after": false }` option:
+
+```json
+{ "@stylistic/comma-spacing": ["error", { "after": false }] }
+```
+
+```javascript
+var foo = 1, bar = 2;
+var arr = [1, 2];
+foo(a, b);
+```
+
+Examples of **correct** code for this rule with the `{ "after": false }` option:
+
+```json
+{ "@stylistic/comma-spacing": ["error", { "after": false }] }
+```
+
+```javascript
+var foo = 1,bar = 2;
+var arr = [1,2];
+foo(a,b);
+```
+
+## Original Documentation
+
+- [@stylistic/comma-spacing](https://eslint.style/rules/comma-spacing)

--- a/internal/plugins/stylistic/rules/comma_spacing/comma_spacing_extras_test.go
+++ b/internal/plugins/stylistic/rules/comma_spacing/comma_spacing_extras_test.go
@@ -1,0 +1,758 @@
+// TestCommaSpacingExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+package comma_spacing_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestCommaSpacingExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&comma_spacing.CommaSpacingRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: empty containers (graceful degradation) ----
+			{Code: `var a = [];`},
+			{Code: `var a = {};`},
+			{Code: `fn();`},
+			{Code: `new C();`},
+			{Code: `function fn() {}`},
+			{Code: `class C<T> {}`},
+
+			// ---- Dimension 4: TS tuple types ----
+			{Code: `type T = [number, string];`},
+			{Code: `type T = [number, string, boolean];`},
+			{Code: `type T = readonly [number, string];`},
+			{Code: `let t: [number, string] = [1, 'a'];`},
+
+			// ---- Dimension 4: TS type-argument lists ----
+			{Code: `let m: Map<string, number>;`},
+			{Code: `function f<T>(x: Array<T>): Array<T, number> { return x; }`},
+			{Code: `type P = Pick<T, 'a' | 'b'>;`},
+
+			// ---- Dimension 4: TS enum members ----
+			{Code: `enum E { A, B, C }`},
+			{Code: `enum E { A = 1, B = 2 }`},
+			{Code: `const enum E { A, B }`},
+
+			// ---- Dimension 4: import / export specifiers ----
+			{Code: `import { a, b } from 'mod';`},
+			{Code: `import { a, b, } from 'mod';`},
+			{Code: `import { a, b as c } from 'mod';`},
+			{Code: `export { a, b };`},
+			{Code: `export { a, b, };`},
+
+			// ---- Dimension 4: spread / rest with commas ----
+			{Code: `function fn(a, b, ...rest) {}`},
+			{Code: `var [a, b, ...rest] = arr;`},
+			{Code: `var [, , c] = arr;`},
+			{Code: `var obj = { ...a, b: 1 };`},
+			{Code: `var { a, ...rest } = obj;`},
+			{Code: `fn(a, ...args);`},
+
+			// ---- Dimension 4: nested arrays / objects / mixed ----
+			{Code: `var a = [[1, 2], [3, 4]];`},
+			{Code: `var a = [{x: 1, y: 2}, {x: 3, y: 4}];`},
+			{Code: `fn({a: 1, b: 2}, [3, 4]);`},
+			{Code: `var deep = {a: [{b: {c: [1, 2, 3]}}]};`},
+
+			// ---- Dimension 4: declaration / container forms ----
+			{Code: `class C { m(a, b) {} }`},
+			{Code: `class C { static m(a, b) {} }`},
+			{Code: `class C { get p() { return 1; } set p(v) {} }`},
+			{Code: `var o = { m(a, b) {} };`},
+			{Code: `var o = { get p() { return 1; }, set p(v) {} };`},
+			{Code: `async function f(a, b) {}`},
+			{Code: `function* g(a, b) {}`},
+			{Code: `async function* ag(a, b) {}`},
+			{Code: `var f = async (a, b) => {};`},
+			{Code: `var f = async (a, b) => a + b;`},
+
+			// ---- Dimension 4: TS heritage / generics interplay ----
+			{Code: `class C<T extends U, V extends W> {}`},
+			{Code: `interface I<T, U> extends A<T>, B<U> {}`},
+
+			// ---- Dimension 4: BinaryExpression with CommaToken (sequence) ----
+			// Locks in upstream: validateCommaSpacing sequence-expression path.
+			{Code: `var x = (a, b, c);`},
+			{Code: `for (var i = 0, j = 0; i < 10; i++, j++) {}`},
+
+			// ---- Dimension 4: for-statement initializer commas ----
+			{Code: `for (let i = 0, j = 10; i < j; i++) {}`},
+
+			// ---- Dimension 4: receiver-wrapper interactions ----
+			// tsgo preserves ParenthesizedExpression where ESTree flattens.
+			// Locks in: prev-token end position correctly anchored to `)`.
+			{Code: `fn((a), b);`},
+			{Code: `fn((a + b), c, (d));`},
+			{Code: `var x = [(1), (2), (3)];`},
+
+			// ---- Dimension 4: TS non-null + type assertion + satisfies wrappers ----
+			{Code: `fn(a!, b);`},
+			{Code: `fn(a as number, b);`},
+			{Code: `fn(a satisfies number, b);`},
+			{Code: `var arr = [a!, b!];`},
+
+			// ---- Dimension 4: optional chain receivers ----
+			{Code: `fn(a?.b, c?.d);`},
+			{Code: `fn(a?.(), b);`},
+
+			// ---- Dimension 4: computed property keys ----
+			{Code: `var o = {[k]: 1, [k2]: 2};`},
+			{Code: `var o = {[k++]: 1, [k++]: 2};`},
+
+			// ---- Real-user: literal string with comma must not be flagged ----
+			// Strings are single tokens at scanner level — defensive cover.
+			{Code: `var s = "a,b,c";`},
+			{Code: `var s = 'a,b';`},
+			{Code: "var s = `a,b`;"},
+			{Code: "var s = `a${1},b`;"},
+
+			// ---- Real-user: regex literal containing commas ----
+			// Locks in collectExcludeRanges' KindRegularExpressionLiteral arm.
+			{Code: `var r = /a,b,c/;`},
+			{Code: `var r = /,/g;`},
+			{Code: `var arr = [/,/, /,,/];`},
+
+			// ---- Real-user: template literal between substitutions with commas ----
+			// Locks in collectExcludeRanges' KindTemplateMiddle/Tail arms.
+			{Code: "var s = `${a}, ${b}`;"},
+			{Code: "var s = `a${b}, ${c}d`;"},
+			{Code: "var s = `${a}, ${b}, ${c}`;"},
+
+			// ---- Real-user: JSX text with commas ----
+			{Code: `<a>hello, world</a>`, Tsx: true},
+			{Code: `<a>{x}, {y}</a>`, Tsx: true},
+			{Code: `<a attr="a,b,c" />`, Tsx: true},
+
+			// ---- Real-user: line comment immediately after comma (before-side) ----
+			// Locks in the `nextToken === Line && !spaceAfter` exemption.
+			{Code: "var a = 1,// comment\nb = 2;", Options: optsNeither()},
+			{Code: "fn(a,// c\n b);", Options: optsNeither()},
+
+			// ---- Real-user: comma at very end of file (no next token) ----
+			{Code: `var x,`},
+
+			// ---- Locks in upstream validateCommaSpacing arm: prev=null when prev is comma ----
+			// In `[a,,b]` the middle comma's prev token (in our token stream)
+			// is `,1`, which collapses to nil. No before-report should fire on
+			// `,2` even though there's no space before it.
+			{Code: `var arr = [a,,b];`},
+			{Code: `var arr = [a, ,b];`},
+			{Code: `var arr = [a,, b];`},
+
+			// ---- Locks in upstream validateCommaSpacing arm: next=null when next is comma ----
+			{Code: `var arr = [a,,b];`},
+
+			// ---- Locks in same-line short-circuit on before-side ----
+			// `,` on its own line. prev (`1`) is on prior line ⇒ before-check skipped.
+			{Code: "var arr = [\n  1\n  , 2\n];"},
+			// Same shape, but with before:false, after:false — only the
+			// after-check should run (it does match: comma is followed by
+			// newline so after-check also skips since `2` is on next line).
+			{Code: "var arr = [\n  1\n  ,\n  2\n];", Options: optsNeither()},
+
+			// ---- Locks in same-line short-circuit on after-side ----
+			// `2` is on the next line, so the after-check is skipped even
+			// when there's no space after the comma.
+			{Code: "var arr = [1,\n  2];"},
+			// optsBoth requires space before too; we provide it. The after side
+			// is short-circuited by the line break.
+			{Code: "var arr = [1 ,\n  2];", Options: optsBoth()},
+
+			// ---- Locks in close-paren exemption ----
+			// The trailing comma's `next` token is `)`, which suppresses the
+			// after-side check even when `, )` has a space — and conversely
+			// `,)` with no space is fine under `optsNeither`.
+			{Code: `fn(a,);`},
+			{Code: `fn(a,b,);`, Options: optsNeither()},
+
+			// ---- Locks in close-brace exemption ----
+			{Code: `var o = {a: 1,};`, Options: optsNeither()},
+			{Code: `var { a, } = x;`, Options: optsNeither()},
+
+			// ---- Locks in close-bracket exemption ----
+			{Code: `var a = [1,];`, Options: optsNeither()},
+
+			// ---- Multiple comma-sites in one file ----
+			{Code: `var x = [1, 2]; var y = {a: 1, b: 2}; fn(x, y);`},
+			// optsBefore: space before comma, no space after.
+			{Code: `var x = [1 ,2]; var y = {a: 1 ,b: 2}; fn(x ,y);`, Options: optsBefore()},
+
+			// ---- Options shape: array-wrapped (exercises GetOptionsMap array branch) ----
+			{Code: `var a = 1 ,b = 2;`, Options: []interface{}{map[string]interface{}{"before": true, "after": false}}},
+			{Code: `var a = 1, b = 2;`, Options: []interface{}{map[string]interface{}{"before": false, "after": true}}},
+
+			// ---- Options shape: partial — only `before` specified, `after` defaults to true ----
+			{Code: `var a = 1, b = 2;`, Options: map[string]interface{}{"before": false}},
+
+			// ---- TS-specific Dimension 4: trailing comma in TSX arrow generics ----
+			// Upstream covers `<T,>(foo) =>` once; broaden to multi-param +
+			// constrained variants.
+			{Code: `const f = <T,>(x: T) => x;`, Tsx: true},
+			{Code: `const f = <T, U,>(x: T, y: U) => x;`, Tsx: true},
+			{Code: `const f = <T extends number,>(x: T) => x;`, Tsx: true},
+
+			// ---- Real-user: JSX fragment with text comma ----
+			// JsxFragment <>...</> children include JsxText same as JsxElement;
+			// the comma inside the text content must NOT fire.
+			{Code: `var x = <>,</>;`, Tsx: true},
+			{Code: `var x = <>a, b, c</>;`, Tsx: true},
+
+			// ---- Real-user: TS template literal type with literal-text commas ----
+			// Template literal types reuse KindTemplateHead/Middle/Tail.
+			// Comma INSIDE the literal portion must NOT fire; commas in
+			// substituted type unions don't exist (unions use `|`).
+			{Code: "type T = `Hello, ${string}`;"},
+			{Code: "type T = `${A}, ${B}`;"},
+			{Code: "type T = `a, b, c`;"},
+
+			// ---- Real-user: shebang at start of file ----
+			// scanShebangTrivia runs before any tokens; our scanner pass
+			// starting at byte 0 must not see a leading `#!` as a stray token
+			// stream that throws off downstream comma detection.
+			{Code: "#!/usr/bin/env node\nvar a = 1, b = 2;"},
+
+			// ---- Real-user: decorator with comma-separated arguments ----
+			{Code: `@deco(a, b) class C {}`},
+			{Code: `@deco(a, b, c) function fn() {}`},
+
+			// ---- Real-user: TS conditional type with infer + tuple ----
+			// The `, ` between `infer A` and `infer B` inside the tuple must
+			// be checked normally; the conditional's `?:` shouldn't interfere.
+			{Code: `type Head<T> = T extends [infer A, infer B] ? A : never;`},
+			{Code: `type Tail<T> = T extends [any, ...infer R] ? R : never;`},
+
+			// ---- Real-user: import type / export type with named specifiers ----
+			{Code: `import type { A, B } from 'mod';`},
+			{Code: `export type { A, B } from 'mod';`},
+			{Code: `import { type A, type B } from 'mod';`},
+
+			// ---- Real-user: class fields don't use comma separators, but
+			// initializer expressions can contain comma-separated lists ----
+			{Code: `class C { a = [1, 2]; b = { x: 1, y: 2 }; }`},
+
+			// ---- Real-user: tagged template + sequence expression ----
+			{Code: "var r = tag`hello`, x = 1;"},
+
+			// ---- Real-user: destructuring with defaults ----
+			{Code: `var { a = 1, b = 2 } = obj;`},
+			{Code: `var [a = 1, b = 2] = arr;`},
+			{Code: `function f({ a = 1, b = 2 } = {}, [c, d] = []) {}`},
+
+			// ---- Real-user: parameter properties (TS constructor) ----
+			{Code: `class C { constructor(public a: number, private b: string) {} }`},
+			{Code: `class C { constructor(readonly a: number, protected b: string) {} }`},
+
+			// ---- Dimension 4: ParenthesizedExpression deep nesting ----
+			// tsgo preserves every paren level (ESTree flattens). The prev/next
+			// token-end positions stay anchored to the LAST `)` or FIRST `(`,
+			// independent of nesting depth.
+			{Code: `fn(((a)), (((b))));`},
+			{Code: `fn(((((a))))), (b);`},
+			{Code: `var arr = [((a)), ((b))];`},
+			{Code: `var x = (((a, b, c)));`},
+
+			// ---- Dimension 4: Optional chain across receiver + access + call ----
+			// In tsgo optional chains are flag-bearing (no ChainExpression
+			// wrapper). The comma's prev token is the last child's end.
+			{Code: `fn(a?.b, c?.d);`},
+			{Code: `fn(a?.b?.c, d?.e?.f);`},
+			{Code: `fn(a?.(), b?.(c, d));`},
+			{Code: `fn(a?.[0], b?.[1]);`},
+			{Code: `fn(a?.b?.c?.[0]?.(d, e), f);`},
+
+			// ---- Dimension 4: TS expression wrapper combinations ----
+			{Code: `fn(a!, b?.c, d as T);`},
+			{Code: `fn((a as T)!, b satisfies U);`},
+			{Code: `fn(a as T | U, b as V & W);`},
+			{Code: `fn(<T>a, <U>b);`}, // legacy type assertion (non-JSX)
+
+			// ---- Dimension 4: TS type-argument list combinations ----
+			{Code: `var m: Map<string, number>;`},
+			{Code: `var m: Map<Array<string>, Set<number>>;`},
+			{Code: `var m: Map<keyof T, T[keyof T]>;`},
+			{Code: `type R = Record<'a' | 'b', number>;`},
+			{Code: `var x = fn<A, B, C>();`},
+			{Code: `var x = new Cls<A, B>(p, q);`},
+
+			// ---- Dimension 4: tuple type variants ----
+			{Code: `type T = [];`},
+			{Code: `type T = [number];`},
+			{Code: `type T = [number, string];`},
+			{Code: `type T = [number, string?];`},               // optional element
+			{Code: `type T = [number, ...string[]];`},           // rest element
+			{Code: `type T = [a: number, b: string];`},          // labeled tuple
+			{Code: `type T = [a: number, b?: string];`},
+			{Code: `type T = [a: number, ...rest: string[]];`},
+			{Code: `type T = readonly [A, B];`},
+			{Code: `type T = [[A, B], [C, D]];`},                // nested
+			{Code: `type T = [{a: A, b: B}, [C, D]];`},          // mixed
+
+			// ---- Dimension 4: union / intersection inside list element ----
+			{Code: `function f(x: A | B, y: C & D) {}`},
+			{Code: `var arr: (A | B)[] = [a, b];`},
+
+			// ---- Dimension 4: complex destructuring ----
+			{Code: `var {a: [b, c], d: {e, f}} = obj;`},
+			{Code: `var [{a, b}, {c, d}] = arr;`},
+			{Code: `var [[a, b], [c, d]] = matrix;`},
+			{Code: `var { a: [b, , c], ...rest } = obj;`},
+			{Code: `function fn({ a, b: { c, d } } = {}, [e, ...f] = []) {}`},
+
+			// ---- Dimension 4: arrow function variants ----
+			{Code: `var f = (a, b) => a + b;`},
+			{Code: `var f = async (a, b) => a + b;`},
+			{Code: `var f = (a, b): number => a + b;`},
+			{Code: `var f = async (a, b): Promise<number> => a + b;`},
+			{Code: `var f = <T>(a: T, b: T): T => a;`},
+			{Code: `var f = async <T>(a: T, b: T): Promise<T> => a;`},
+
+			// ---- Dimension 4: generator / async generator ----
+			{Code: `function* g(a, b) { yield a; yield b; }`},
+			{Code: `async function* ag(a, b) { yield a; yield b; }`},
+			{Code: `class C { *m(a, b) {} async *m2(a, b) {} }`},
+
+			// ---- Dimension 4: class member variants ----
+			{Code: `class C { static a = 1; static b = 2; }`},
+			{Code: `class C { readonly a: number = 1; readonly b: number = 2; }`},
+			{Code: `class C { #priv = 1; #other = 2; m() { return [this.#priv, this.#other]; } }`},
+			{Code: `abstract class C { abstract m(a: A, b: B): void; }`},
+
+			// ---- Dimension 4: TS overload signatures ----
+			{Code: `function f(a: A): void; function f(a: A, b: B): void; function f(a: A, b?: B): void {}`},
+			{Code: `interface I { f(a: A): void; f(a: A, b: B): void; }`},
+
+			// ---- Dimension 4: enum variants ----
+			{Code: `enum E { A = 1, B = 2, C = 3 }`},
+			{Code: `enum E { A = 'a', B = 'b' }`},
+			{Code: `enum E { A = 1, B = 'b' }`}, // heterogeneous
+			{Code: `enum E { 'a-b' = 1, 'c-d' = 2 }`},
+
+			// ---- Dimension 4: namespace / module ----
+			{Code: `namespace N { export const a = 1, b = 2; }`},
+			{Code: `declare module 'm' { export const a: number, b: string; }`},
+
+			// ---- Dimension 4: heritage clauses ----
+			{Code: `class C extends Base implements A, B, C {}`},
+			{Code: `interface I extends A, B, C {}`},
+			{Code: `class C<T, U> extends Base<T, U> implements I<T>, J<U> {}`},
+
+			// ---- Dimension 4: JSX combinations ----
+			{Code: `<C a={[1, 2]} b={{x: 1, y: 2}} c={fn(a, b)} />`, Tsx: true},
+			{Code: `<C {...props} a={1} />`, Tsx: true},
+			{Code: `<C><D a={1} b={2} /><E /></C>`, Tsx: true},
+			{Code: `<C>{[a, b, c].map(x => x)}</C>`, Tsx: true},
+
+			// ---- Dimension 4: nested templates with substitutions and commas ----
+			{Code: "var s = `${[1, 2]}, ${[3, 4]}`;"},
+			{Code: "var s = `outer ${ `inner ${a, b}` }, ${c}`;"}, // nested template
+			{Code: "var s = tag`${a}, ${b}`;"},                    // tagged template
+
+			// ---- Dimension 4: regex variants ----
+			{Code: `var r = /[,]/g;`},                  // regex char class with comma
+			{Code: `var r = /,{2,4}/;`},                // regex quantifier braces (also contains comma!)
+			{Code: `fn(/foo/g, /bar/i, /baz/m);`},     // multiple regex args
+			{Code: `var arr = [/,/, /;/, /[,]/g];`},   // regex in array
+
+			// ---- Dimension 4: for-loop variants ----
+			{Code: `for (let i = 0, j = 10; i < j; i++, j--) {}`},
+			{Code: `for (var [a, b] of arr) {}`},
+			{Code: `for (var [a, , b] of arr) {}`},
+			{Code: `for (var {a, b} in obj) {}`},
+
+			// ---- Dimension 4: try-catch destructuring ----
+			{Code: `try {} catch ({code, message}) {}`},
+			{Code: `try {} catch (e: any) {}`}, // TS catch type
+
+			// ---- Real-user: multi-line + multi-byte identifiers ----
+			{Code: "var café = 1, naïve = 2, fiancé = 3;"},
+			{Code: "fn(δ, λ, μ);"},
+			{Code: "var emoji = '🌟', star = '⭐';"},
+
+			// ---- Real-user: typeof / keyof / infer in type expressions ----
+			{Code: `type T = typeof a; var x: T, y: T;`},
+			{Code: `type T<U> = U extends [infer A, infer B, infer C] ? [A, B, C] : never;`},
+			{Code: `type K = keyof T; var x: Record<K, number>;`},
+
+			// ---- Real-user: const assertion ----
+			{Code: `var arr = [1, 2, 3] as const;`},
+			{Code: `var obj = { a: 1, b: 2 } as const;`},
+			{Code: `fn([1, 2] as const, {a: 1} as const);`},
+
+			// ---- Real-user: switch case lists (no commas, but defensive) ----
+			{Code: `switch (x) { case 1: case 2: case 3: break; }`},
+
+			// ---- Real-user: complex import patterns ----
+			{Code: `import a, { b, c } from 'mod';`},                 // default + named
+			{Code: `import a, * as ns from 'mod';`},                  // default + namespace
+			{Code: `import { a as a1, b as b1, c } from 'mod';`},     // aliasing
+			{Code: `export { a as a1, b as b1, c };`},
+			{Code: `export { a, b } from 'mod';`},
+			{Code: `export * from 'mod';`},                           // no commas
+			{Code: `export * as ns from 'mod';`},                     // no commas
+
+			// ---- Real-user: TS `import type` mixed forms ----
+			{Code: `import { type A, type B, c } from 'mod';`},
+
+			// ---- Real-user: function with `this` parameter ----
+			{Code: `function fn(this: T, a: A, b: B) {}`},
+			{Code: `function fn(this: void, a: A, b: B): void {}`},
+
+			// ---- Real-user: complex default initializers ----
+			{Code: `function fn(a = (1, 2), b = [3, 4], c = { x: 5 }) {}`},
+			{Code: `function fn(a = fn2(x, y), b = obj.m(z, w)) {}`},
+
+			// ---- Real-user: type predicates & asserts ----
+			{Code: `function isFoo(x: any): x is Foo { return true; }`},
+			{Code: `function assertFoo(x: any): asserts x is Foo {}`},
+			{Code: `function fn(x: T, y: U): x is T & U { return true; }`},
+
+			// ---- Real-user: yield + sequence ----
+			{Code: `function* g() { yield (a, b, c); }`},
+			{Code: `function* g() { var r = yield a; r = yield b; }`},
+
+			// ---- Real-user: bigint / numeric separator literal in list ----
+			{Code: `var arr = [1n, 2n, 3n];`},
+			{Code: `var arr = [1_000_000, 2_000_000];`},
+			{Code: `var arr = [0xff, 0o77, 0b11];`},
+
+			// ---- Real-user: deep mixed nesting (worst-case integration) ----
+			{Code: `var deep = { a: [{ b: fn(c, [d, e]), f: g?.h?.(i, j) }, [k, ...l]], m: <C a={[1, 2]}><D /></C> };`, Tsx: true},
+
+			// ---- Real-user: comment between operand and comma (multi-shape) ----
+			{Code: `fn(a /* x */ /* y */, b);`},
+			{Code: `fn(a /*1*/, /*2*/ b, /*3*/ c);`},
+			// `,//` is only valid under {after:false}; with default
+			// (after:true) the comma needs a space before `//`.
+			{Code: "fn(\n  a,// trailing\n  b,/* trailing */\n  c\n);", Options: optsNeither()},
+
+			// ---- Real-user: trailing comma in TSX arrow generic ----
+			// TSX-arrow trailing comma `<T,>` is the only place a trailing
+			// comma in a type-arg-shaped list is currently legal in TS; it's
+			// a type-parameter DECLARATION (not arguments). collectIgnored-
+			// Commas adds the trailing comma to ignored so spacing doesn't
+			// fire on it.
+			{Code: `const a = <T,>(x: T) => x;`, Tsx: true},
+			{Code: `const a = <T, U,>(x: T, y: U) => x;`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Locks in: comma after `(` exemption — the prev=`(` case ----
+			// `fn( ,a)` is a syntax error so we use a normal call with the
+			// space *between* args.
+			{
+				Code:    `fn(a , b);`,
+				Output:  []string{`fn(a, b);`},
+				Options: optsAfter(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 6},
+				},
+			},
+
+			// ---- Locks in: sequence-expression branch ----
+			{
+				Code:    `(a , b);`,
+				Output:  []string{`(a, b);`},
+				Options: optsAfter(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 4},
+				},
+			},
+
+			// ---- Locks in: for-statement update list with comma ----
+			{
+				Code:    `for (var i = 0,j = 0; i < 10; i++,j++) {}`,
+				Output:  []string{`for (var i = 0, j = 0; i < 10; i++, j++) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 15},
+					{MessageId: "missing", Line: 1, Column: 34},
+				},
+			},
+
+			// ---- Locks in: import-specifier comma fires ----
+			{
+				Code:    `import {a ,b} from 'm';`,
+				Output:  []string{`import {a, b} from 'm';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 11},
+					{MessageId: "missing", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Locks in: export-specifier comma fires ----
+			{
+				Code:    `export {a ,b};`,
+				Output:  []string{`export {a, b};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 11},
+					{MessageId: "missing", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Locks in: enum members ----
+			{
+				Code:   `enum E { A ,B }`,
+				Output: []string{`enum E { A, B }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+					{MessageId: "missing", Line: 1, Column: 12},
+				},
+			},
+
+			// ---- Locks in: tuple type ----
+			{
+				Code:   `type T = [number ,string];`,
+				Output: []string{`type T = [number, string];`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+					{MessageId: "missing", Line: 1, Column: 18},
+				},
+			},
+
+			// ---- Locks in: type-argument list ----
+			{
+				Code:   `let m: Map<string ,number>;`,
+				Output: []string{`let m: Map<string, number>;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+					{MessageId: "missing", Line: 1, Column: 19},
+				},
+			},
+
+			// ---- Locks in: rest element comma fires correctly ----
+			{
+				Code:   `function fn(a ,...rest) {}`,
+				Output: []string{`function fn(a, ...rest) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+					{MessageId: "missing", Line: 1, Column: 15},
+				},
+			},
+
+			// ---- Locks in: spread element comma fires correctly ----
+			{
+				Code:   `fn(...a ,b);`,
+				Output: []string{`fn(...a, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 9},
+					{MessageId: "missing", Line: 1, Column: 9},
+				},
+			},
+
+			// ---- Locks in: paren-wrapped receiver ----
+			// tsgo preserves ParenthesizedExpression — make sure the
+			// prev-token range still falls on `)` and not inside the parens.
+			{
+				Code:   `fn((a) ,b);`,
+				Output: []string{`fn((a), b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+					{MessageId: "missing", Line: 1, Column: 8},
+				},
+			},
+
+			// ---- Locks in: non-null assertion wrapper as comma neighbor ----
+			{
+				Code:   `fn(a! ,b);`,
+				Output: []string{`fn(a!, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 7},
+					{MessageId: "missing", Line: 1, Column: 7},
+				},
+			},
+
+			// ---- Locks in: `as` type assertion wrapper as comma neighbor ----
+			{
+				Code:   `fn(a as number ,b);`,
+				Output: []string{`fn(a as number, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+					{MessageId: "missing", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- Locks in: optional chain receiver as comma neighbor ----
+			{
+				Code:   `fn(a?.b ,c);`,
+				Output: []string{`fn(a?.b, c);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 9},
+					{MessageId: "missing", Line: 1, Column: 9},
+				},
+			},
+
+			// ---- Locks in: nested array — only inner comma triggers ----
+			{
+				Code:   `var a = [[1 ,2], [3, 4]];`,
+				Output: []string{`var a = [[1, 2], [3, 4]];`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+					{MessageId: "missing", Line: 1, Column: 13},
+				},
+			},
+
+			// ---- Locks in: class method params ----
+			{
+				Code:   `class C { m(a ,b) {} }`,
+				Output: []string{`class C { m(a, b) {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+					{MessageId: "missing", Line: 1, Column: 15},
+				},
+			},
+
+			// ---- Locks in: shorthand object property ----
+			{
+				Code:   `var o = {a ,b};`,
+				Output: []string{`var o = {a, b};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+					{MessageId: "missing", Line: 1, Column: 12},
+				},
+			},
+
+			// ---- Locks in: array-wrapped option still routes through GetOptionsMap ----
+			{
+				Code:    `var a = 1, b = 2;`,
+				Output:  []string{`var a = 1 ,b = 2;`},
+				Options: []interface{}{map[string]interface{}{"before": true, "after": false}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 10},
+					{MessageId: "unexpected", Line: 1, Column: 10},
+				},
+			},
+
+			// ---- Locks in: multi-byte (Unicode) identifier — column is
+			// per-character, not per-byte. `é` occupies 1 UTF-16 unit
+			// (2 UTF-8 bytes), so the comma after `café = 1 ` sits at
+			// column 14 the same as for `var cafe = 1 ,b`. Pins the
+			// behavior so a future column-counting change is caught.
+			{
+				Code:   `var café = 1 ,b = 2;`,
+				Output: []string{`var café = 1, b = 2;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14},
+					{MessageId: "missing", Line: 1, Column: 14},
+				},
+			},
+
+			// ---- Locks in: comma in JSX expression child fires for its operand ----
+			{
+				Code:   `<a>{fn(b ,c)}</a>`,
+				Output: []string{`<a>{fn(b, c)}</a>`},
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10},
+					{MessageId: "missing", Line: 1, Column: 10},
+				},
+			},
+
+			// ---- Locks in: JSX text content commas don't trigger; only commas in
+			// embedded expressions do (this case has both — only one should fire) ----
+			{
+				Code:   `<a>foo, bar {fn(1 ,2)}</a>`,
+				Output: []string{`<a>foo, bar {fn(1, 2)}</a>`},
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+					{MessageId: "missing", Line: 1, Column: 19},
+				},
+			},
+
+			// ---- Locks in: regex literal containing commas does NOT fire,
+			// but a real comma immediately after the regex DOES ----
+			{
+				Code:   `fn(/,/ ,b);`,
+				Output: []string{`fn(/,/, b);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+					{MessageId: "missing", Line: 1, Column: 8},
+				},
+			},
+
+			// ---- Locks in: template literal text commas don't fire, but
+			// commas in `${...}` substitutions do ----
+			{
+				Code:   "var s = `${a ,b}`;",
+				Output: []string{"var s = `${a, b}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14},
+					{MessageId: "missing", Line: 1, Column: 14},
+				},
+			},
+
+			// ---- Locks in: for-statement update list fires on real comma ----
+			{
+				Code:   `for (var i = 0, j = 0; i < 10; i++ ,j++) {}`,
+				Output: []string{`for (var i = 0, j = 0; i < 10; i++, j++) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+					{MessageId: "missing", Line: 1, Column: 36},
+				},
+			},
+
+			// ---- Locks in: decorator argument list fires ----
+			{
+				Code:   `@deco(a ,b) class C {}`,
+				Output: []string{`@deco(a, b) class C {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 9},
+					{MessageId: "missing", Line: 1, Column: 9},
+				},
+			},
+
+			// ---- Locks in: TS infer-tuple comma fires ----
+			{
+				Code:   `type Head<T> = T extends [infer A ,infer B] ? A : never;`,
+				Output: []string{`type Head<T> = T extends [infer A, infer B] ? A : never;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+					{MessageId: "missing", Line: 1, Column: 35},
+				},
+			},
+
+			// ---- Locks in: JSX fragment text content doesn't fire, but
+			// commas inside embedded expressions do ----
+			{
+				Code:   `var x = <>{fn(1 ,2)}</>;`,
+				Output: []string{`var x = <>{fn(1, 2)}</>;`},
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+					{MessageId: "missing", Line: 1, Column: 17},
+				},
+			},
+
+			// ---- Locks in: parameter property modifiers ----
+			{
+				Code:   `class C { constructor(public a: number ,private b: string) {} }`,
+				Output: []string{`class C { constructor(public a: number, private b: string) {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 40},
+					{MessageId: "missing", Line: 1, Column: 40},
+				},
+			},
+
+			// ---- Locks in: shebang doesn't shift positions ----
+			// The comma is on line 2 (after the shebang newline). If
+			// shebang handling broke positions or kind detection, this
+			// would mis-fire or mis-report.
+			{
+				Code:   "#!/usr/bin/env node\nvar a = 1 ,b = 2;",
+				Output: []string{"#!/usr/bin/env node\nvar a = 1, b = 2;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 11},
+					{MessageId: "missing", Line: 2, Column: 11},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/comma_spacing/comma_spacing_upstream_test.go
+++ b/internal/plugins/stylistic/rules/comma_spacing/comma_spacing_upstream_test.go
@@ -1,0 +1,493 @@
+// TestCommaSpacingUpstream migrates the full valid/invalid suite from upstream
+// packages/eslint-plugin/rules/comma-spacing/comma-spacing._js_.test.ts and
+// comma-spacing._ts_.test.ts 1:1. Position assertions cover line/column for
+// every invalid case. rslint-specific lock-in cases live in
+// comma_spacing_extras_test.go.
+package comma_spacing_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Option shortcuts — match upstream's `{ before, after }` shape exactly.
+// We feed bare maps (the CLI-facing single-option shape, which goes through
+// `utils.GetOptionsMap`'s map branch). Mixing in some array-wrapped cases
+// in the extras file exercises the other branch.
+func optsNeither() map[string]interface{} {
+	return map[string]interface{}{"before": false, "after": false}
+}
+func optsAfter() map[string]interface{} {
+	return map[string]interface{}{"before": false, "after": true}
+}
+func optsBefore() map[string]interface{} {
+	return map[string]interface{}{"before": true, "after": false}
+}
+func optsBoth() map[string]interface{} {
+	return map[string]interface{}{"before": true, "after": true}
+}
+
+func TestCommaSpacingUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&comma_spacing.CommaSpacingRule,
+		[]rule_tester.ValidTestCase{
+			// ---- _js_ valid: comment-around-comma shapes (default) ----
+			{Code: `myfunc(404, true/* bla bla bla */, 'hello');`},
+			{Code: `myfunc(404, true /* bla bla bla */, 'hello');`},
+			{Code: `myfunc(404, true/* bla bla bla *//* hi */, 'hello');`},
+			{Code: `myfunc(404, true/* bla bla bla */ /* hi */, 'hello');`},
+			{Code: `myfunc(404, true, /* bla bla bla */ 'hello');`},
+			{Code: "myfunc(404, // comment\n true, /* bla bla bla */ 'hello');"},
+			{Code: "myfunc(404, // comment\n true,/* bla bla bla */ 'hello');", Options: optsNeither()},
+
+			// ---- _js_ valid: arrays and array holes (default) ----
+			{Code: `var a = 1, b = 2;`},
+			{Code: `var arr = [,];`},
+			{Code: `var arr = [, ];`},
+			{Code: `var arr = [ ,];`},
+			{Code: `var arr = [ , ];`},
+			{Code: `var arr = [1,];`},
+			{Code: `var arr = [1, ];`},
+			{Code: `var arr = [, 2];`},
+			{Code: `var arr = [ , 2];`},
+			{Code: `var arr = [1, 2];`},
+			{Code: `var arr = [,,];`},
+			{Code: `var arr = [ ,,];`},
+			{Code: `var arr = [, ,];`},
+			{Code: `var arr = [,, ];`},
+			{Code: `var arr = [ , ,];`},
+			{Code: `var arr = [ ,, ];`},
+			{Code: `var arr = [, , ];`},
+			{Code: `var arr = [ , , ];`},
+			{Code: `var arr = [1, , ];`},
+			{Code: `var arr = [, 2, ];`},
+			{Code: `var arr = [, , 3];`},
+			{Code: `var arr = [,, 3];`},
+			{Code: `var arr = [1, 2, ];`},
+			{Code: `var arr = [, 2, 3];`},
+			{Code: `var arr = [1, , 3];`},
+			{Code: `var arr = [1, 2, 3];`},
+			{Code: `var arr = [1, 2, 3,];`},
+			{Code: `var arr = [1, 2, 3, ];`},
+
+			// ---- _js_ valid: objects (default) ----
+			{Code: `var obj = {'foo':'bar', 'baz':'qur'};`},
+			{Code: `var obj = {'foo':'bar', 'baz':'qur', };`},
+			{Code: `var obj = {'foo':'bar', 'baz':'qur',};`},
+			{Code: "var obj = {'foo':'bar', 'baz':\n'qur'};"},
+			{Code: "var obj = {'foo':\n'bar', 'baz':\n'qur'};"},
+
+			// ---- _js_ valid: functions / arrows (default) ----
+			{Code: `function foo(a, b){}`},
+			{Code: `function foo(a, b = 1){}`},
+			{Code: `function foo(a = 1, b, c){}`},
+			{Code: `var foo = (a, b) => {}`},
+			{Code: `var foo = (a=1, b) => {}`},
+			{Code: `var foo = a => a + 2`},
+
+			// ---- _js_ valid: sequence expressions and parens (default) ----
+			{Code: `a, b`},
+			{Code: `var a = (1 + 2, 2);`},
+			{Code: `a(b, c)`},
+			{Code: `new A(b, c)`},
+			{Code: `foo((a), b)`},
+			{Code: `var b = ((1 + 2), 2);`},
+			{Code: `parseInt((a + b), 10)`},
+			{Code: `go.boom((a + b), 10)`},
+			{Code: `go.boom((a + b), 10, (4))`},
+			{Code: `var x = [ (a + c), (b + b) ]`},
+			{Code: `['  ,  ']`},
+			{Code: "[`  ,  `]"},
+			{Code: "`${[1, 2]}`"},
+			{Code: `fn(a, b,)`},                  // #11295
+			{Code: `const fn = (a, b,) => {}`},   // #11295
+			{Code: `const fn = function (a, b,) {}`}, // #11295
+			{Code: `function fn(a, b,) {}`},      // #11295
+			{Code: `foo(/,/, 'a')`},
+			{Code: `var x = ',,,,,';`},
+			{Code: `var code = 'var foo = 1, bar = 3;'`},
+			{Code: "['apples', \n 'oranges'];"},
+			{Code: `{x: 'var x,y,z'}`},
+
+			// ---- _js_ valid: { before:true, after:false } ----
+			{Code: "var obj = {'foo':\n'bar' ,'baz':\n'qur'};", Options: optsBefore()},
+			{Code: `var a = 1 ,b = 2;`, Options: optsBefore()},
+			{Code: `function foo(a ,b){}`, Options: optsBefore()},
+			{Code: `var arr = [,];`, Options: optsBefore()},
+			{Code: `var arr = [ ,];`, Options: optsBefore()},
+			{Code: `var arr = [, ];`, Options: optsBefore()},
+			{Code: `var arr = [ , ];`, Options: optsBefore()},
+			{Code: `var arr = [1 ,];`, Options: optsBefore()},
+			{Code: `var arr = [1 , ];`, Options: optsBefore()},
+			{Code: `var arr = [ ,2];`, Options: optsBefore()},
+			{Code: `var arr = [1 ,2];`, Options: optsBefore()},
+			{Code: `var arr = [,,];`, Options: optsBefore()},
+			{Code: `var arr = [ ,,];`, Options: optsBefore()},
+			{Code: `var arr = [, ,];`, Options: optsBefore()},
+			{Code: `var arr = [,, ];`, Options: optsBefore()},
+			{Code: `var arr = [ , ,];`, Options: optsBefore()},
+			{Code: `var arr = [ ,, ];`, Options: optsBefore()},
+			{Code: `var arr = [, , ];`, Options: optsBefore()},
+			{Code: `var arr = [ , , ];`, Options: optsBefore()},
+			{Code: `var arr = [1 , ,];`, Options: optsBefore()},
+			{Code: `var arr = [ ,2 ,];`, Options: optsBefore()},
+			{Code: `var arr = [,2 , ];`, Options: optsBefore()},
+			{Code: `var arr = [ , ,3];`, Options: optsBefore()},
+			{Code: `var arr = [1 ,2 ,];`, Options: optsBefore()},
+			{Code: `var arr = [ ,2 ,3];`, Options: optsBefore()},
+			{Code: `var arr = [1 , ,3];`, Options: optsBefore()},
+			{Code: `var arr = [1 ,2 ,3];`, Options: optsBefore()},
+
+			// ---- _js_ valid: { before:true, after:true } ----
+			{Code: `var obj = {'foo':'bar' , 'baz':'qur'};`, Options: optsBoth()},
+			{Code: `var obj = {'foo':'bar' ,'baz':'qur' , };`, Options: optsBefore()},
+			{Code: `var a = 1 , b = 2;`, Options: optsBoth()},
+			{Code: `var arr = [, ];`, Options: optsBoth()},
+			{Code: `var arr = [,,];`, Options: optsBoth()},
+			{Code: `var arr = [1 , ];`, Options: optsBoth()},
+			{Code: `var arr = [ , 2];`, Options: optsBoth()},
+			{Code: `var arr = [1 , 2];`, Options: optsBoth()},
+			{Code: `var arr = [, , ];`, Options: optsBoth()},
+			{Code: `var arr = [1 , , ];`, Options: optsBoth()},
+			{Code: `var arr = [ , 2 , ];`, Options: optsBoth()},
+			{Code: `var arr = [ , , 3];`, Options: optsBoth()},
+			{Code: `var arr = [1 , 2 , ];`, Options: optsBoth()},
+			{Code: `var arr = [, 2 , 3];`, Options: optsBoth()},
+			{Code: `var arr = [1 , , 3];`, Options: optsBoth()},
+			{Code: `var arr = [1 , 2 , 3];`, Options: optsBoth()},
+			{Code: `a , b`, Options: optsBoth()},
+
+			// ---- _js_ valid: { before:false, after:false } ----
+			{Code: `var arr = [,];`, Options: optsNeither()},
+			{Code: `var arr = [ ,];`, Options: optsNeither()},
+			{Code: `var arr = [1,];`, Options: optsNeither()},
+			{Code: `var arr = [,2];`, Options: optsNeither()},
+			{Code: `var arr = [ ,2];`, Options: optsNeither()},
+			{Code: `var arr = [1,2];`, Options: optsNeither()},
+			{Code: `var arr = [,,];`, Options: optsNeither()},
+			{Code: `var arr = [ , , ];`, Options: optsNeither()},
+			{Code: `var arr = [ ,,];`, Options: optsNeither()},
+			{Code: `var arr = [1,,];`, Options: optsNeither()},
+			{Code: `var arr = [,2,];`, Options: optsNeither()},
+			{Code: `var arr = [ ,2,];`, Options: optsNeither()},
+			{Code: `var arr = [,,3];`, Options: optsNeither()},
+			{Code: `var arr = [1,2,];`, Options: optsNeither()},
+			{Code: `var arr = [,2,3];`, Options: optsNeither()},
+			{Code: `var arr = [1,,3];`, Options: optsNeither()},
+			{Code: `var arr = [1,2,3];`, Options: optsNeither()},
+			{Code: `var a = (1 + 2,2)`, Options: optsNeither()},
+
+			// ---- _js_ valid: ES6 features and templates (default) ----
+			{Code: "var a; console.log(`${a}`, \"a\");"},
+
+			// ---- _js_ valid: destructuring (default) ----
+			{Code: `var [a, b] = [1, 2];`},
+			{Code: `var [a, b, ] = [1, 2];`},
+			{Code: `var [a, b,] = [1, 2];`},
+			{Code: `var [a, , b] = [1, 2, 3];`},
+			{Code: `var [a,, b] = [1, 2, 3];`},
+			{Code: `var [ , b] = a;`},
+			{Code: `var [, b] = a;`},
+			{Code: `var { a,} = a;`},
+			{Code: `import { a,} from 'mod';`},
+
+			// ---- _js_ valid: JSX (default) ----
+			{Code: `<a>,</a>`, Tsx: true},
+			{Code: `<a>  ,  </a>`, Tsx: true},
+			{Code: `<a>Hello, world</a>`, Options: optsBefore(), Tsx: true},
+
+			// ---- _js_ valid: backwards-compatibility null-element + comment shapes ----
+			// "Ignoring spacing between a comment and comma of a null element was possibly unintentional." (upstream)
+			{Code: `[a, /**/ , ]`, Options: optsAfter()},
+			{Code: `[a , /**/, ]`, Options: optsBoth()},
+			{Code: `[a, /**/ , ] = foo`, Options: optsAfter()},
+			{Code: `[a , /**/, ] = foo`, Options: optsBoth()},
+
+			// ---- _ts_ valid ----
+			{Code: `const Foo = <T,>(foo: T) => {}`, Tsx: true},
+			{Code: `function foo<T,>() {}`},
+			{Code: `class Foo<T, T1> {}`},
+			{Code: `type Foo<T, P,> = Bar<T, P>`},
+			{Code: `interface Foo<T, T1,>{}`},
+			{Code: `let foo,`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- _js_ invalid ----
+			{
+				Code:    `a(b,c)`,
+				Output:  []string{`a(b , c)`},
+				Options: optsBoth(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 4},
+					{MessageId: "missing", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:    `new A(b,c)`,
+				Output:  []string{`new A(b , c)`},
+				Options: optsBoth(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 8},
+					{MessageId: "missing", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code:   `var a = 1 ,b = 2;`,
+				Output: []string{`var a = 1, b = 2;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 11},
+					{MessageId: "missing", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var arr = [1 , 2];`,
+				Output: []string{`var arr = [1, 2];`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:   `var arr = [1 , ];`,
+				Output: []string{`var arr = [1, ];`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:   `var arr = [1 ,2];`,
+				Output: []string{`var arr = [1, 2];`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 14},
+					{MessageId: "missing", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:   `var arr = [(1) , 2];`,
+				Output: []string{`var arr = [(1), 2];`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:    `var arr = [1, 2];`,
+				Output:  []string{`var arr = [1 ,2];`},
+				Options: optsBefore(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 13},
+					{MessageId: "unexpected", Message: "There should be no space after ','.", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:    "var arr = [1\n  , 2];",
+				Output:  []string{"var arr = [1\n  ,2];"},
+				Options: optsNeither(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space after ','.", Line: 2, Column: 3},
+				},
+			},
+			{
+				Code:    "var arr = [1,\n  2];",
+				Output:  []string{"var arr = [1 ,\n  2];"},
+				Options: optsBefore(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:    "var obj = {'foo':\n'bar', 'baz':\n'qur'};",
+				Output:  []string{"var obj = {'foo':\n'bar' ,'baz':\n'qur'};"},
+				Options: optsBefore(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 6},
+					{MessageId: "unexpected", Message: "There should be no space after ','.", Line: 2, Column: 6},
+				},
+			},
+			{
+				Code:   "var obj = {a: 1\n  ,b: 2};",
+				Output: []string{"var obj = {a: 1\n  , b: 2};"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 3},
+				},
+			},
+			{
+				Code:    "var obj = {a: 1 ,\n  b: 2};",
+				Output:  []string{"var obj = {a: 1,\n  b: 2};"},
+				Options: optsNeither(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code:    `var arr = [1 ,2];`,
+				Output:  []string{`var arr = [1 , 2];`},
+				Options: optsBoth(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:    `var arr = [1,2];`,
+				Output:  []string{`var arr = [1 , 2];`},
+				Options: optsBoth(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 13},
+					{MessageId: "missing", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:    "var obj = {'foo':\n'bar','baz':\n'qur'};",
+				Output:  []string{"var obj = {'foo':\n'bar' , 'baz':\n'qur'};"},
+				Options: optsBoth(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 6},
+					{MessageId: "missing", Line: 2, Column: 6},
+				},
+			},
+			{
+				Code:    `var arr = [1 , 2];`,
+				Output:  []string{`var arr = [1,2];`},
+				Options: optsNeither(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 14},
+					{MessageId: "unexpected", Message: "There should be no space after ','.", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:    `a ,b`,
+				Output:  []string{`a, b`},
+				Options: optsAfter(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 3},
+					{MessageId: "missing", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:    `function foo(a,b){}`,
+				Output:  []string{`function foo(a , b){}`},
+				Options: optsBoth(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 15},
+					{MessageId: "missing", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code:    `var foo = (a,b) => {}`,
+				Output:  []string{`var foo = (a , b) => {}`},
+				Options: optsBoth(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 13},
+					{MessageId: "missing", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:    `var foo = (a = 1,b) => {}`,
+				Output:  []string{`var foo = (a = 1 , b) => {}`},
+				Options: optsBoth(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 17},
+					{MessageId: "missing", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code:    `function foo(a = 1 ,b = 2) {}`,
+				Output:  []string{`function foo(a = 1, b = 2) {}`},
+				Options: optsAfter(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 20},
+					{MessageId: "missing", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code:   `<a>{foo(1 ,2)}</a>`,
+				Output: []string{`<a>{foo(1, 2)}</a>`},
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 11},
+					{MessageId: "missing", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `myfunc(404, true/* bla bla bla */ , 'hello');`,
+				Output: []string{`myfunc(404, true/* bla bla bla */, 'hello');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Message: "There should be no space before ','.", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code:   `myfunc(404, true,/* bla bla bla */ 'hello');`,
+				Output: []string{`myfunc(404, true, /* bla bla bla */ 'hello');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code:   "myfunc(404,// comment\n true, 'hello');",
+				Output: []string{"myfunc(404, // comment\n true, 'hello');"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- _ts_ invalid ----
+			{
+				Code:   `function Foo<T,T1>() {}`,
+				Output: []string{`function Foo<T, T1>() {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code:   `function Foo<T , T1>() {}`,
+				Output: []string{`function Foo<T, T1>() {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   `function Foo<T ,T1>() {}`,
+				Output: []string{`function Foo<T, T1>() {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+					{MessageId: "missing", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:    `function Foo<T, T1>() {}`,
+				Output:  []string{`function Foo<T,T1>() {}`},
+				Options: optsNeither(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code:    `function Foo<T,T1>() {}`,
+				Output:  []string{`function Foo<T ,T1>() {}`},
+				Options: optsBefore(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code:   `let foo ,`,
+				Output: []string{`let foo,`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `type Foo<T,P,> = Bar<T,P>`,
+				Output: []string{`type Foo<T, P,> = Bar<T, P>`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 11},
+					{MessageId: "missing", Line: 1, Column: 23},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -456,6 +456,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/arrow-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/block-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/brace-style.test.ts',
+    './tests/eslint-plugin-stylistic/rules/comma-spacing.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/comma-spacing.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/comma-spacing.test.ts
@@ -1,0 +1,471 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('comma-spacing', null as never, {
+  valid: [
+    // comment-around-comma shapes (default)
+    { code: `myfunc(404, true/* bla bla bla */, 'hello');` },
+    { code: `myfunc(404, true /* bla bla bla */, 'hello');` },
+    { code: `myfunc(404, true/* bla bla bla *//* hi */, 'hello');` },
+    { code: `myfunc(404, true/* bla bla bla */ /* hi */, 'hello');` },
+    { code: `myfunc(404, true, /* bla bla bla */ 'hello');` },
+    { code: "myfunc(404, // comment\n true, /* bla bla bla */ 'hello');" },
+    {
+      code: "myfunc(404, // comment\n true,/* bla bla bla */ 'hello');",
+      options: [{ before: false, after: false }],
+    },
+
+    // arrays and array holes
+    { code: `var a = 1, b = 2;` },
+    { code: `var arr = [,];` },
+    { code: `var arr = [, ];` },
+    { code: `var arr = [ ,];` },
+    { code: `var arr = [ , ];` },
+    { code: `var arr = [1,];` },
+    { code: `var arr = [1, ];` },
+    { code: `var arr = [, 2];` },
+    { code: `var arr = [ , 2];` },
+    { code: `var arr = [1, 2];` },
+    { code: `var arr = [,,];` },
+    { code: `var arr = [ ,,];` },
+    { code: `var arr = [, ,];` },
+    { code: `var arr = [,, ];` },
+    { code: `var arr = [ , ,];` },
+    { code: `var arr = [ ,, ];` },
+    { code: `var arr = [, , ];` },
+    { code: `var arr = [ , , ];` },
+    { code: `var arr = [1, , ];` },
+    { code: `var arr = [, 2, ];` },
+    { code: `var arr = [, , 3];` },
+    { code: `var arr = [,, 3];` },
+    { code: `var arr = [1, 2, ];` },
+    { code: `var arr = [, 2, 3];` },
+    { code: `var arr = [1, , 3];` },
+    { code: `var arr = [1, 2, 3];` },
+    { code: `var arr = [1, 2, 3,];` },
+    { code: `var arr = [1, 2, 3, ];` },
+
+    // objects
+    { code: `var obj = {'foo':'bar', 'baz':'qur'};` },
+    { code: `var obj = {'foo':'bar', 'baz':'qur', };` },
+    { code: `var obj = {'foo':'bar', 'baz':'qur',};` },
+    { code: "var obj = {'foo':'bar', 'baz':\n'qur'};" },
+    { code: "var obj = {'foo':\n'bar', 'baz':\n'qur'};" },
+
+    // functions / arrows
+    { code: `function foo(a, b){}` },
+    { code: `function foo(a, b = 1){}` },
+    { code: `function foo(a = 1, b, c){}` },
+    { code: `var foo = (a, b) => {}` },
+    { code: `var foo = (a=1, b) => {}` },
+    { code: `var foo = a => a + 2` },
+
+    // sequence expressions and parens
+    { code: `a, b` },
+    { code: `var a = (1 + 2, 2);` },
+    { code: `a(b, c)` },
+    { code: `new A(b, c)` },
+    { code: `foo((a), b)` },
+    { code: `var b = ((1 + 2), 2);` },
+    { code: `parseInt((a + b), 10)` },
+    { code: `go.boom((a + b), 10)` },
+    { code: `go.boom((a + b), 10, (4))` },
+    { code: `var x = [ (a + c), (b + b) ]` },
+    { code: `['  ,  ']` },
+    { code: '[`  ,  `]' },
+    { code: '`${[1, 2]}`' },
+    { code: `fn(a, b,)` },
+    { code: `const fn = (a, b,) => {}` },
+    { code: `const fn = function (a, b,) {}` },
+    { code: `function fn(a, b,) {}` },
+    { code: `foo(/,/, 'a')` },
+    { code: `var x = ',,,,,';` },
+    { code: `var code = 'var foo = 1, bar = 3;'` },
+    { code: "['apples', \n 'oranges'];" },
+    { code: `({x: 'var x,y,z'})` },
+
+    // { before:true, after:false }
+    {
+      code: "var obj = {'foo':\n'bar' ,'baz':\n'qur'};",
+      options: [{ before: true, after: false }],
+    },
+    { code: `var a = 1 ,b = 2;`, options: [{ before: true, after: false }] },
+    { code: `function foo(a ,b){}`, options: [{ before: true, after: false }] },
+    { code: `var arr = [,];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [ ,];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [, ];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [ , ];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [1 ,];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [1 , ];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [ ,2];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [1 ,2];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [,,];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [ ,,];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [, ,];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [,, ];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [ , ,];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [ ,, ];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [, , ];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [ , , ];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [1 , ,];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [ ,2 ,];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [,2 , ];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [ , ,3];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [1 ,2 ,];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [ ,2 ,3];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [1 , ,3];`, options: [{ before: true, after: false }] },
+    { code: `var arr = [1 ,2 ,3];`, options: [{ before: true, after: false }] },
+
+    // { before:true, after:true }
+    {
+      code: `var obj = {'foo':'bar' , 'baz':'qur'};`,
+      options: [{ before: true, after: true }],
+    },
+    {
+      code: `var obj = {'foo':'bar' ,'baz':'qur' , };`,
+      options: [{ before: true, after: false }],
+    },
+    { code: `var a = 1 , b = 2;`, options: [{ before: true, after: true }] },
+    { code: `var arr = [, ];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [,,];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [1 , ];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [ , 2];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [1 , 2];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [, , ];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [1 , , ];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [ , 2 , ];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [ , , 3];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [1 , 2 , ];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [, 2 , 3];`, options: [{ before: true, after: true }] },
+    { code: `var arr = [1 , , 3];`, options: [{ before: true, after: true }] },
+    {
+      code: `var arr = [1 , 2 , 3];`,
+      options: [{ before: true, after: true }],
+    },
+    { code: `a , b`, options: [{ before: true, after: true }] },
+
+    // { before:false, after:false }
+    { code: `var arr = [,];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [ ,];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [1,];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [,2];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [ ,2];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [1,2];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [,,];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [ , , ];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [ ,,];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [1,,];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [,2,];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [ ,2,];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [,,3];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [1,2,];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [,2,3];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [1,,3];`, options: [{ before: false, after: false }] },
+    { code: `var arr = [1,2,3];`, options: [{ before: false, after: false }] },
+    { code: `var a = (1 + 2,2)`, options: [{ before: false, after: false }] },
+
+    // templates and destructuring
+    { code: 'var a; console.log(`${a}`, "a");' },
+    { code: `var [a, b] = [1, 2];` },
+    { code: `var [a, b, ] = [1, 2];` },
+    { code: `var [a, b,] = [1, 2];` },
+    { code: `var [a, , b] = [1, 2, 3];` },
+    { code: `var [a,, b] = [1, 2, 3];` },
+    { code: `var [ , b] = a;` },
+    { code: `var [, b] = a;` },
+    { code: `var { a,} = a;` },
+    { code: `import { a,} from 'mod';` },
+
+    // JSX
+    { code: `<a>,</a>` },
+    { code: `<a>  ,  </a>` },
+    {
+      code: `<a>Hello, world</a>`,
+      options: [{ before: true, after: false }],
+    },
+
+    // Backwards-compat null-element + comment shapes
+    { code: `[a, /**/ , ]`, options: [{ before: false, after: true }] },
+    { code: `[a , /**/, ]`, options: [{ before: true, after: true }] },
+    { code: `[a, /**/ , ] = foo`, options: [{ before: false, after: true }] },
+    { code: `[a , /**/, ] = foo`, options: [{ before: true, after: true }] },
+
+    // TS
+    { code: `const Foo = <T,>(foo: T) => {}` },
+    { code: `function foo<T,>() {}` },
+    { code: `class Foo<T, T1> {}` },
+    { code: `type Foo<T, P,> = Bar<T, P>` },
+    { code: `interface Foo<T, T1,>{}` },
+    { code: `let foo,` },
+  ],
+
+  invalid: [
+    {
+      code: `a(b,c)`,
+      output: `a(b , c)`,
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'missing', data: { loc: 'before' } },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `new A(b,c)`,
+      output: `new A(b , c)`,
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'missing', data: { loc: 'before' } },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `var a = 1 ,b = 2;`,
+      output: `var a = 1, b = 2;`,
+      errors: [
+        { message: `There should be no space before ','.` },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `var arr = [1 , 2];`,
+      output: `var arr = [1, 2];`,
+      errors: [{ message: `There should be no space before ','.` }],
+    },
+    {
+      code: `var arr = [1 , ];`,
+      output: `var arr = [1, ];`,
+      errors: [{ message: `There should be no space before ','.` }],
+    },
+    {
+      code: `var arr = [1 ,2];`,
+      output: `var arr = [1, 2];`,
+      errors: [
+        { message: `There should be no space before ','.` },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `var arr = [(1) , 2];`,
+      output: `var arr = [(1), 2];`,
+      errors: [{ message: `There should be no space before ','.` }],
+    },
+    {
+      code: `var arr = [1, 2];`,
+      output: `var arr = [1 ,2];`,
+      options: [{ before: true, after: false }],
+      errors: [
+        { messageId: 'missing', data: { loc: 'before' } },
+        { message: `There should be no space after ','.` },
+      ],
+    },
+    {
+      code: 'var arr = [1\n  , 2];',
+      output: 'var arr = [1\n  ,2];',
+      options: [{ before: false, after: false }],
+      errors: [{ message: `There should be no space after ','.` }],
+    },
+    {
+      code: 'var arr = [1,\n  2];',
+      output: 'var arr = [1 ,\n  2];',
+      options: [{ before: true, after: false }],
+      errors: [{ messageId: 'missing', data: { loc: 'before' } }],
+    },
+    {
+      code: "var obj = {'foo':\n'bar', 'baz':\n'qur'};",
+      output: "var obj = {'foo':\n'bar' ,'baz':\n'qur'};",
+      options: [{ before: true, after: false }],
+      errors: [
+        { messageId: 'missing', data: { loc: 'before' } },
+        { message: `There should be no space after ','.` },
+      ],
+    },
+    {
+      code: 'var obj = {a: 1\n  ,b: 2};',
+      output: 'var obj = {a: 1\n  , b: 2};',
+      errors: [{ messageId: 'missing', data: { loc: 'after' } }],
+    },
+    {
+      code: 'var obj = {a: 1 ,\n  b: 2};',
+      output: 'var obj = {a: 1,\n  b: 2};',
+      options: [{ before: false, after: false }],
+      errors: [{ message: `There should be no space before ','.` }],
+    },
+    {
+      code: `var arr = [1 ,2];`,
+      output: `var arr = [1 , 2];`,
+      options: [{ before: true, after: true }],
+      errors: [{ messageId: 'missing', data: { loc: 'after' } }],
+    },
+    {
+      code: `var arr = [1,2];`,
+      output: `var arr = [1 , 2];`,
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'missing', data: { loc: 'before' } },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: "var obj = {'foo':\n'bar','baz':\n'qur'};",
+      output: "var obj = {'foo':\n'bar' , 'baz':\n'qur'};",
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'missing', data: { loc: 'before' } },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `var arr = [1 , 2];`,
+      output: `var arr = [1,2];`,
+      options: [{ before: false, after: false }],
+      errors: [
+        { message: `There should be no space before ','.` },
+        { message: `There should be no space after ','.` },
+      ],
+    },
+    {
+      code: `a ,b`,
+      output: `a, b`,
+      options: [{ before: false, after: true }],
+      errors: [
+        { message: `There should be no space before ','.` },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `function foo(a,b){}`,
+      output: `function foo(a , b){}`,
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'missing', data: { loc: 'before' } },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `var foo = (a,b) => {}`,
+      output: `var foo = (a , b) => {}`,
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'missing', data: { loc: 'before' } },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `var foo = (a = 1,b) => {}`,
+      output: `var foo = (a = 1 , b) => {}`,
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'missing', data: { loc: 'before' } },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `function foo(a = 1 ,b = 2) {}`,
+      output: `function foo(a = 1, b = 2) {}`,
+      options: [{ before: false, after: true }],
+      errors: [
+        { message: `There should be no space before ','.` },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `<a>{foo(1 ,2)}</a>`,
+      output: `<a>{foo(1, 2)}</a>`,
+      errors: [
+        { message: `There should be no space before ','.` },
+        { messageId: 'missing', data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `myfunc(404, true/* bla bla bla */ , 'hello');`,
+      output: `myfunc(404, true/* bla bla bla */, 'hello');`,
+      errors: [{ message: `There should be no space before ','.` }],
+    },
+    {
+      code: `myfunc(404, true,/* bla bla bla */ 'hello');`,
+      output: `myfunc(404, true, /* bla bla bla */ 'hello');`,
+      errors: [{ messageId: 'missing', data: { loc: 'after' } }],
+    },
+    {
+      code: "myfunc(404,// comment\n true, 'hello');",
+      output: "myfunc(404, // comment\n true, 'hello');",
+      errors: [{ messageId: 'missing', data: { loc: 'after' } }],
+    },
+
+    // TS
+    {
+      code: `function Foo<T,T1>() {}`,
+      output: `function Foo<T, T1>() {}`,
+      errors: [
+        { messageId: 'missing', column: 15, line: 1, data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `function Foo<T , T1>() {}`,
+      output: `function Foo<T, T1>() {}`,
+      errors: [
+        {
+          messageId: 'unexpected',
+          column: 16,
+          line: 1,
+          data: { loc: 'before' },
+        },
+      ],
+    },
+    {
+      code: `function Foo<T ,T1>() {}`,
+      output: `function Foo<T, T1>() {}`,
+      errors: [
+        {
+          messageId: 'unexpected',
+          column: 16,
+          line: 1,
+          data: { loc: 'before' },
+        },
+        { messageId: 'missing', column: 16, line: 1, data: { loc: 'after' } },
+      ],
+    },
+    {
+      code: `function Foo<T, T1>() {}`,
+      output: `function Foo<T,T1>() {}`,
+      options: [{ before: false, after: false }],
+      errors: [
+        {
+          messageId: 'unexpected',
+          column: 15,
+          line: 1,
+          data: { loc: 'after' },
+        },
+      ],
+    },
+    {
+      code: `function Foo<T,T1>() {}`,
+      output: `function Foo<T ,T1>() {}`,
+      options: [{ before: true, after: false }],
+      errors: [
+        { messageId: 'missing', column: 15, line: 1, data: { loc: 'before' } },
+      ],
+    },
+    {
+      code: `let foo ,`,
+      output: `let foo,`,
+      errors: [
+        {
+          messageId: 'unexpected',
+          column: 9,
+          line: 1,
+          data: { loc: 'before' },
+        },
+      ],
+    },
+    {
+      code: `type Foo<T,P,> = Bar<T,P>`,
+      output: `type Foo<T, P,> = Bar<T, P>`,
+      errors: [
+        { messageId: 'missing', column: 11, line: 1, data: { loc: 'after' } },
+        { messageId: 'missing', column: 23, line: 1, data: { loc: 'after' } },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/comma-spacing` rule from `@stylistic/eslint-plugin` to rslint.

Enforces consistent spacing before and after commas in variable declarations, array literals, object literals, function parameters, sequence expressions, and TypeScript-specific list-shaped syntax (type arguments, type parameters, tuple types, enum members, import / export specifiers, heritage lists).

Default options: `{ "before": false, "after": true }`.

### Approach

- Uses the **gap-scan via `ForEachChild`** pattern (the same technique `internal/utils/ts_eslint.go HasSameTokens` uses) to enumerate tokens without ever entering template-expression / regex / JSX-text content. A naive full-file `scanner` loop produces false negatives on files containing templates with `${...}` substitutions plus escaped backticks (e.g. `` `…${e}\` (${typeof e})\` ``) — verified against rspack's `tests/.../p-map.mjs`.
- Leaf nodes emit as a single token via `utils.TrimNodeTextRange`; composite-node gaps are scanned with `SkipTrivia=false` so comments surface as prev/next neighbors (matching ESLint's `tokensAndComments`).
- Ignored commas (null-element commas in array literals / patterns, trailing commas in TS type-parameter lists) are collected from the AST.
- Reuses `stylisticutil.SameLineByPos`, `utils.GetOptionsMap`, `utils.TrimNodeTextRange`, `ast.IsFunctionLike`.

### Test coverage

- `comma_spacing_upstream_test.go`: 153 valid + 33 invalid = **186** cases, 1:1 mirror of upstream's `_js_` + `_ts_` tests (147+26+6+7).
- `comma_spacing_extras_test.go`: 228 valid + 29 invalid = **257** cases covering tsgo↔ESTree shape divergences: paren nesting, optional-chain combos, TS expression wrappers (`!` / `as` / `satisfies`), template literal types, JSX Fragments, shebang, decorators, infer-tuple, parameter properties, multi-byte identifiers, etc.
- JS test mirrors Layer 1.

### Differential validation (Phase 4 Step 8)

Diffed rslint against ESLint (`@stylistic/eslint-plugin` v5) on rspack's full test corpus:
- ESLint findings (non-gitignored): 123
- rslint findings: 124 → **123/123 common**, only-rslint = 1 (`fixtures/errors/has-syntax-error.js` — ESLint bails on parse error; tsgo's parser recovery lets rslint still run the rule). Every finding verified against source bytes (no sampling): 124/124 confirmed real `,X` violations.
- rsbuild (Prettier-formatted): 0 findings, 0 false positives.

## Related Links

- ESLint rule: https://eslint.style/rules/comma-spacing
- Source code: https://github.com/eslint-stylistic/eslint-stylistic/tree/main/packages/eslint-plugin/rules/comma-spacing

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).