### PR TITLE
feat: port rule @stylistic/comma-dangle

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -6,11 +6,13 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/arrow_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/block_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/brace_style"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_dangle"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
+		comma_dangle.CommaDangleRule,
 		array_bracket_spacing.ArrayBracketSpacingRule,
 		arrow_parens.ArrowParensRule,
 		arrow_spacing.ArrowSpacingRule,

--- a/internal/plugins/stylistic/rules/comma_dangle/comma_dangle.go
+++ b/internal/plugins/stylistic/rules/comma_dangle/comma_dangle.go
@@ -1,0 +1,588 @@
+package comma_dangle
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	optionNever           = "never"
+	optionAlways          = "always"
+	optionAlwaysMultiline = "always-multiline"
+	optionOnlyMultiline   = "only-multiline"
+	optionIgnore          = "ignore"
+)
+
+// normalizedOptions is the per-slot config the predicates consult. Upstream
+// fans out a single string option to every slot; the object form lets each
+// slot be set independently. Every slot uses the same enum (never / always /
+// always-multiline / only-multiline / ignore).
+type normalizedOptions struct {
+	arrays           string
+	objects          string
+	imports          string
+	exports          string
+	functions        string
+	importAttributes string
+	dynamicImports   string
+	enums            string
+	generics         string
+	tuples           string
+}
+
+func defaultOptions() normalizedOptions {
+	return normalizedOptions{
+		arrays:           optionNever,
+		objects:          optionNever,
+		imports:          optionNever,
+		exports:          optionNever,
+		functions:        optionNever,
+		importAttributes: optionNever,
+		dynamicImports:   optionNever,
+		enums:            optionNever,
+		generics:         optionNever,
+		tuples:           optionNever,
+	}
+}
+
+func validOptionValue(s string) bool {
+	switch s {
+	case optionNever, optionAlways, optionAlwaysMultiline, optionOnlyMultiline:
+		return true
+	}
+	return false
+}
+
+func validValueWithIgnore(s string) bool {
+	return s == optionIgnore || validOptionValue(s)
+}
+
+// parseOptions mirrors upstream's normalizeOptions. Accepted shapes:
+//
+//	['comma-dangle']                                    → defaults (never everywhere)
+//	['comma-dangle', 'always']                          → broadcast 'always'
+//	['comma-dangle', { arrays: 'always', ... }]         → per-slot override
+//
+// rslint's config loader collapses a single trailing option element into the
+// option directly, so accept both `[]interface{}` (Go test / multi-element
+// config) and a bare string / map (CLI single-option config).
+func parseOptions(raw any) normalizedOptions {
+	opts := defaultOptions()
+
+	var primary any
+	switch v := raw.(type) {
+	case []interface{}:
+		if len(v) > 0 {
+			primary = v[0]
+		}
+	case string, map[string]interface{}:
+		primary = v
+	}
+
+	switch v := primary.(type) {
+	case string:
+		if validOptionValue(v) {
+			opts.arrays = v
+			opts.objects = v
+			opts.imports = v
+			opts.exports = v
+			opts.functions = v
+			opts.importAttributes = v
+			opts.dynamicImports = v
+			opts.enums = v
+			opts.generics = v
+			opts.tuples = v
+		}
+	case map[string]interface{}:
+		set := func(key string, dst *string) {
+			if s, ok := v[key].(string); ok && validValueWithIgnore(s) {
+				*dst = s
+			}
+		}
+		set("arrays", &opts.arrays)
+		set("objects", &opts.objects)
+		set("imports", &opts.imports)
+		set("exports", &opts.exports)
+		set("functions", &opts.functions)
+		set("importAttributes", &opts.importAttributes)
+		set("dynamicImports", &opts.dynamicImports)
+		set("enums", &opts.enums)
+		set("generics", &opts.generics)
+		set("tuples", &opts.tuples)
+	}
+	return opts
+}
+
+// verifyInfo holds everything a predicate needs to inspect a single trailing
+// position. `list` is one of object props / array elements / function params /
+// etc.; `closePos` is the byte position of the bracket that terminates it
+// (`}`, `]`, `)`, or `>`).
+type verifyInfo struct {
+	list     *ast.NodeList
+	closePos int
+	// lastItem is the last non-hole child of list. tsgo represents ESTree
+	// `null` array holes as KindOmittedExpression; we filter them out here
+	// for parity with upstream's `last(nodes)` (which the `??` short-circuits).
+	lastItem *ast.Node
+	// isRest is true when lastItem is a rest-binding form (ParameterDeclaration
+	// or BindingElement with `...`). In that case `always`-family options
+	// degrade to `never` — JS forbids a trailing comma after a rest binding.
+	isRest bool
+}
+
+// buildInfo scans forward from list.End() past trivia to locate the close
+// bracket. Returns nil when there's nothing to check (list nil/empty, ends
+// in a hole, or close-bracket character isn't where we'd expect — parser
+// recovery). `container` is the AST node that owns the list (ArrayLiteral,
+// ObjectLiteral, FunctionDeclaration, etc.), used to disambiguate
+// SpreadElement / SpreadAssignment in destructuring-LHS position.
+func buildInfo(text string, list *ast.NodeList, closeChar byte, container *ast.Node) *verifyInfo {
+	if list == nil || len(list.Nodes) == 0 {
+		return nil
+	}
+	last := list.Nodes[len(list.Nodes)-1]
+	if last == nil || last.Kind == ast.KindOmittedExpression {
+		return nil
+	}
+	closePos := scanner.SkipTrivia(text, list.End())
+	if closePos >= len(text) || text[closePos] != closeChar {
+		return nil
+	}
+	return &verifyInfo{
+		list:     list,
+		closePos: closePos,
+		lastItem: last,
+		isRest:   isRestElement(last, container),
+	}
+}
+
+// isRestElement mirrors upstream's `lastItem.type !== 'RestElement'` guard.
+// In ESTree, RestElement only appears in patterns (function params, array /
+// object destructuring); spread in array literals (SpreadElement) and object
+// literals (SpreadAssignment) does NOT count and may take a trailing comma.
+//
+// tsgo doesn't fork ArrayLiteralExpression / ObjectLiteralExpression into
+// pattern forms — `[a, ...rest] = []` parses as an ArrayLiteralExpression
+// with a SpreadElement, same shape as the literal `[a, ...spread]`. We
+// therefore treat SpreadElement / SpreadAssignment as rest only when the
+// containing literal sits in a destructuring-LHS position, detected via
+// `IsArrayLiteralOrObjectLiteralDestructuringPattern` (which walks up
+// through PropertyAssignment and nested patterns).
+func isRestElement(node *ast.Node, container *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindParameter:
+		if pd := node.AsParameterDeclaration(); pd != nil {
+			return pd.DotDotDotToken != nil
+		}
+	case ast.KindBindingElement:
+		if be := node.AsBindingElement(); be != nil {
+			return be.DotDotDotToken != nil
+		}
+	case ast.KindSpreadElement, ast.KindSpreadAssignment:
+		return container != nil && ast.IsArrayLiteralOrObjectLiteralDestructuringPattern(container)
+	}
+	return false
+}
+
+// findTrailingCommaPos returns the position of the trailing comma in
+// [lastItem.End(), closePos), or -1 when no comma is present. The only
+// non-trivia content allowed in that range is a single `,`.
+func findTrailingCommaPos(text string, info *verifyInfo) int {
+	pos := scanner.SkipTrivia(text, info.lastItem.End())
+	if pos < info.closePos && text[pos] == ',' {
+		return pos
+	}
+	return -1
+}
+
+// isMultiline mirrors upstream's `isMultiline(info)`. The "last token" is
+// the comma if it exists, otherwise the last item — matching how
+// `sourceCode.getTokenAfter(lastItem)` resolves in upstream.
+func isMultiline(text string, info *verifyInfo, commaPos int) bool {
+	var refEnd int
+	if commaPos >= 0 {
+		refEnd = commaPos + 1
+	} else {
+		refEnd = info.lastItem.End()
+	}
+	return utils.ContainsLineTerminator(text, refEnd, info.closePos)
+}
+
+// predicateContext bundles the inputs the predicate functions all read.
+type predicateContext struct {
+	ctx   rule.RuleContext
+	text  string
+	isTSX bool
+}
+
+// reportUnexpected emits the "unexpected trailing comma" diagnostic with
+// a removal fix. The diagnostic range is the single-char span of the comma,
+// matching upstream's `loc: trailingToken.loc`.
+func (pc *predicateContext) reportUnexpected(commaPos int) {
+	pc.ctx.ReportRangeWithFixes(
+		core.NewTextRange(commaPos, commaPos+1),
+		rule.RuleMessage{
+			Id:          "unexpected",
+			Description: "Unexpected trailing comma.",
+		},
+		rule.RuleFix{
+			Text:  "",
+			Range: core.NewTextRange(commaPos, commaPos+1),
+		},
+	)
+}
+
+// reportMissing emits the "missing trailing comma" diagnostic with an
+// insertion fix. Range is `[lastItem.End(), lastItem.End()+1)` — a 1-char
+// span starting right after the last token. When that span crosses a
+// newline (last item ends a line, `}` opens the next), the line/col
+// renderer maps the end position to (line+1, col 1), matching upstream's
+// `getNextLocation` shape.
+func (pc *predicateContext) reportMissing(info *verifyInfo) {
+	insertPos := info.lastItem.End()
+	endPos := insertPos + 1
+	// CRLF special-case: when the byte right after the last token is `\r`
+	// and the next is `\n`, extend the diagnostic span past the whole
+	// `\r\n` so the line/col renderer correctly resolves the end to the
+	// start of the next line. Without this, end maps to "line N col X+1"
+	// (still inside the CRLF sequence) instead of "line N+1 col 1",
+	// silently diverging from ESLint's `getNextLocation` shape.
+	if endPos < len(pc.text) && pc.text[insertPos] == '\r' && pc.text[endPos] == '\n' {
+		endPos++
+	}
+	if endPos > len(pc.text) {
+		endPos = len(pc.text)
+	}
+	pc.ctx.ReportRangeWithFixes(
+		core.NewTextRange(insertPos, endPos),
+		rule.RuleMessage{
+			Id:          "missing",
+			Description: "Missing trailing comma.",
+		},
+		rule.RuleFix{
+			Text:  ",",
+			Range: core.NewTextRange(insertPos, insertPos),
+		},
+	)
+}
+
+// forbidTrailingComma mirrors upstream's `forbidTrailingComma`. `tsxCarveOut`
+// is the upstream TSX `<T,>` exemption: a single-element TypeParameterDecl in
+// a `.tsx` file is the JSX-disambiguation form and must not be reported, no
+// matter which option-arm we landed in.
+func (pc *predicateContext) forbidTrailingComma(info *verifyInfo, tsxCarveOut bool) {
+	if tsxCarveOut {
+		return
+	}
+	commaPos := findTrailingCommaPos(pc.text, info)
+	if commaPos >= 0 {
+		pc.reportUnexpected(commaPos)
+	}
+}
+
+// forceTrailingComma mirrors upstream's `forceTrailingComma`. For a rest
+// binding the call degrades to forbidTrailingComma (with carve-out), since
+// JS forbids a trailing comma after a rest.
+func (pc *predicateContext) forceTrailingComma(info *verifyInfo, tsxCarveOut bool) {
+	if info.isRest {
+		pc.forbidTrailingComma(info, tsxCarveOut)
+		return
+	}
+	commaPos := findTrailingCommaPos(pc.text, info)
+	if commaPos >= 0 {
+		return
+	}
+	pc.reportMissing(info)
+}
+
+func (pc *predicateContext) forceTrailingCommaIfMultiline(info *verifyInfo, tsxCarveOut bool) {
+	commaPos := findTrailingCommaPos(pc.text, info)
+	if isMultiline(pc.text, info, commaPos) {
+		pc.forceTrailingComma(info, tsxCarveOut)
+	} else {
+		pc.forbidTrailingComma(info, tsxCarveOut)
+	}
+}
+
+func (pc *predicateContext) allowTrailingCommaIfMultiline(info *verifyInfo, tsxCarveOut bool) {
+	commaPos := findTrailingCommaPos(pc.text, info)
+	if !isMultiline(pc.text, info, commaPos) {
+		pc.forbidTrailingComma(info, tsxCarveOut)
+	}
+}
+
+// dispatch routes a verifyInfo to the predicate selected by `option`.
+// `tsxCarveOut` is the `<T,>` exemption (see forbidTrailingComma).
+func (pc *predicateContext) dispatch(info *verifyInfo, option string, tsxCarveOut bool) {
+	if info == nil || option == optionIgnore {
+		return
+	}
+	switch option {
+	case optionAlways:
+		pc.forceTrailingComma(info, tsxCarveOut)
+	case optionAlwaysMultiline:
+		pc.forceTrailingCommaIfMultiline(info, tsxCarveOut)
+	case optionOnlyMultiline:
+		pc.allowTrailingCommaIfMultiline(info, tsxCarveOut)
+	default: // "never" (also covers unknown strings — same as upstream)
+		pc.forbidTrailingComma(info, tsxCarveOut)
+	}
+}
+
+// listSpec describes one list to verify. `closeChar` is the bracket expected
+// to close it, used when scanning past trivia from list.End().
+type listSpec struct {
+	list      *ast.NodeList
+	closeChar byte
+	option    string
+	// container is the AST node that owns the list (ArrayLiteralExpression,
+	// FunctionDeclaration, NamedImports, etc.). Passed through to
+	// isRestElement so SpreadElement / SpreadAssignment can be recognized as
+	// rest when the literal is in destructuring-LHS position.
+	container *ast.Node
+	// isTypeParam=true marks a TypeParameters list, which gets the TSX `<T,>`
+	// carve-out when the list has exactly one parameter.
+	isTypeParam bool
+}
+
+func (pc *predicateContext) check(spec listSpec) {
+	info := buildInfo(pc.text, spec.list, spec.closeChar, spec.container)
+	if info == nil {
+		return
+	}
+	tsxCarveOut := pc.isTSX && spec.isTypeParam && len(spec.list.Nodes) == 1
+	pc.dispatch(info, spec.option, tsxCarveOut)
+}
+
+// CommaDangleRule enforces consistent use of trailing commas in object / array
+// literals, parameter lists, import / export specifiers, dynamic imports,
+// import attributes, TS enums, TS tuple types, TS generics, and TS function
+// types. Ported from @stylistic/eslint-plugin's comma-dangle.
+//
+// Listener fan-out vs. upstream ESTree:
+//
+//   - tsgo collapses ESTree's MethodDefinition.value = FunctionExpression
+//     into a single MethodDeclaration / accessor / Constructor node, so
+//     the `functions` option needs explicit listeners on those node kinds
+//     to match upstream's "all class-method param lists" coverage.
+//   - tsgo has no separate `TSDeclareFunction` kind; `declare function f()`
+//     is a body-less FunctionDeclaration, naturally covered by the
+//     FunctionDeclaration listener.
+//   - tsgo has no `ImportExpression` kind; dynamic `import(source, opts)`
+//     parses as a CallExpression whose `Expression.Kind` is `ImportKeyword`,
+//     which is what we branch on inside the CallExpression listener to
+//     pick the `dynamicImports` slot instead of `functions`.
+//   - tsgo has no `TSTypeParameterDeclaration` / `TSTypeParameterInstantiation`
+//     node kinds; TypeParameters / TypeArguments are fields on a wide set of
+//     declaration / type nodes. We delegate to `node.TypeArgumentList()` /
+//     `node.TypeParameterList()` (typescript-go/internal/ast/ast.go:483, 515)
+//     so the carrier-kind set stays in lockstep with tsgo. Hand-rolling a
+//     per-kind switch is what caused JsxOpeningElement / JsxSelfClosingElement
+//     to be silently skipped in an earlier revision.
+var CommaDangleRule = rule.Rule{
+	Name: "@stylistic/comma-dangle",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		text := ctx.SourceFile.Text()
+		isTSX := strings.HasSuffix(strings.ToLower(ctx.SourceFile.FileName()), ".tsx")
+		pc := &predicateContext{ctx: ctx, text: text, isTSX: isTSX}
+
+		// checkTypeArgs handles every TypeArguments-carrying node (`Bar<T>`,
+		// `foo<T>()`, `new Foo<T>()`, `tag<T>`...``, `import('x').Y<T>`,
+		// `typeof x.Y<T>`, `<Foo<T> />`, `<Foo<T>>x</Foo>`). Upstream's rule
+		// hard-codes `predicate.never` for type-argument lists
+		// (TSTypeParameterInstantiation), so the `generics` slot is bypassed
+		// in favor of a literal 'never'. Delegating to tsgo's
+		// `node.TypeArgumentList()` keeps the list of carrier kinds in one
+		// place — manually fanning out per-kind via `node.AsXxx().TypeArguments`
+		// is what caused JsxOpeningElement / JsxSelfClosingElement to be
+		// dropped in an earlier revision.
+		checkTypeArgs := func(node *ast.Node) {
+			if list := node.TypeArgumentList(); list != nil {
+				pc.check(listSpec{list: list, closeChar: '>', option: optionNever, container: node})
+			}
+		}
+
+		// checkTypeParams handles every TypeParameters-carrying node — function
+		// / method / class / interface / type-alias declarations and their
+		// expression forms. Delegates to tsgo's `node.TypeParameterList()` for
+		// the same reason as `checkTypeArgs`. The carve-out for TSX `<T,>` lives
+		// in `check` via `isTypeParam: true` + 1-element list + .tsx filename.
+		checkTypeParams := func(node *ast.Node) {
+			if list := node.TypeParameterList(); list != nil {
+				pc.check(listSpec{list: list, closeChar: '>', option: opts.generics, container: node, isTypeParam: true})
+			}
+		}
+
+		checkFunctionLike := func(node *ast.Node) {
+			// Body-less class members (abstract methods, `declare class`
+			// methods, overload signatures) are parsed by @typescript-eslint
+			// as `TSEmptyBodyFunctionExpression` — distinct from
+			// `FunctionExpression` — so upstream's `FunctionExpression`
+			// listener does not match them, and no diagnostic is emitted.
+			// tsgo collapses these into the same `MethodDeclaration` /
+			// `Constructor` / accessor kinds with a nil Body. Detect and
+			// skip the Parameters check (but still walk TypeParameters —
+			// upstream still visits TSTypeParameterDeclaration on
+			// `TSAbstractMethodDefinition`, though that requires a real
+			// abstract method to test).
+			//
+			// FunctionDeclaration is intentionally not part of this guard:
+			// upstream visits both `FunctionDeclaration` (with body) and
+			// `TSDeclareFunction` (body-less); collapsing both in tsgo's
+			// FunctionDeclaration means we must always check.
+			skipParams := false
+			switch node.Kind {
+			case ast.KindMethodDeclaration, ast.KindConstructor,
+				ast.KindGetAccessor, ast.KindSetAccessor:
+				if node.Body() == nil {
+					skipParams = true
+				}
+			}
+			fl := node.FunctionLikeData()
+			if !skipParams && fl != nil && fl.Parameters != nil {
+				pc.check(listSpec{list: fl.Parameters, closeChar: ')', option: opts.functions, container: node})
+			}
+			checkTypeParams(node)
+		}
+
+		return rule.RuleListeners{
+			ast.KindObjectLiteralExpression: func(node *ast.Node) {
+				if obj := node.AsObjectLiteralExpression(); obj != nil {
+					pc.check(listSpec{list: obj.Properties, closeChar: '}', option: opts.objects, container: node})
+				}
+			},
+			ast.KindObjectBindingPattern: func(node *ast.Node) {
+				if bp := node.AsBindingPattern(); bp != nil {
+					pc.check(listSpec{list: bp.Elements, closeChar: '}', option: opts.objects, container: node})
+				}
+			},
+			ast.KindArrayLiteralExpression: func(node *ast.Node) {
+				if arr := node.AsArrayLiteralExpression(); arr != nil {
+					pc.check(listSpec{list: arr.Elements, closeChar: ']', option: opts.arrays, container: node})
+				}
+			},
+			ast.KindArrayBindingPattern: func(node *ast.Node) {
+				if bp := node.AsBindingPattern(); bp != nil {
+					pc.check(listSpec{list: bp.Elements, closeChar: ']', option: opts.arrays, container: node})
+				}
+			},
+			ast.KindImportDeclaration: func(node *ast.Node) {
+				id := node.AsImportDeclaration()
+				if id == nil {
+					return
+				}
+				// imports: only when NamedBindings is a NamedImports `{ a, b }`
+				// group (not a namespace import or a bare default import).
+				if id.ImportClause != nil {
+					if ic := id.ImportClause.AsImportClause(); ic != nil &&
+						ic.NamedBindings != nil &&
+						ic.NamedBindings.Kind == ast.KindNamedImports {
+						named := ic.NamedBindings.AsNamedImports()
+						pc.check(listSpec{list: named.Elements, closeChar: '}', option: opts.imports, container: ic.NamedBindings})
+					}
+				}
+				// importAttributes: `with { type: 'json' }` clause.
+				if id.Attributes != nil {
+					if attrs := id.Attributes.AsImportAttributes(); attrs != nil {
+						pc.check(listSpec{list: attrs.Attributes, closeChar: '}', option: opts.importAttributes, container: id.Attributes})
+					}
+				}
+			},
+			ast.KindExportDeclaration: func(node *ast.Node) {
+				ed := node.AsExportDeclaration()
+				if ed == nil {
+					return
+				}
+				if ed.ExportClause != nil && ed.ExportClause.Kind == ast.KindNamedExports {
+					named := ed.ExportClause.AsNamedExports()
+					pc.check(listSpec{list: named.Elements, closeChar: '}', option: opts.exports, container: ed.ExportClause})
+				}
+				if ed.Attributes != nil {
+					if attrs := ed.Attributes.AsImportAttributes(); attrs != nil {
+						pc.check(listSpec{list: attrs.Attributes, closeChar: '}', option: opts.importAttributes, container: ed.Attributes})
+					}
+				}
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if call == nil {
+					return
+				}
+				// Dynamic `import(...)` lives in the `dynamicImports` slot;
+				// regular calls go to `functions`.
+				argOption := opts.functions
+				if call.Expression != nil && call.Expression.Kind == ast.KindImportKeyword {
+					argOption = opts.dynamicImports
+				}
+				if call.Arguments != nil {
+					pc.check(listSpec{list: call.Arguments, closeChar: ')', option: argOption, container: node})
+				}
+				checkTypeArgs(node)
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				ne := node.AsNewExpression()
+				if ne == nil {
+					return
+				}
+				if ne.Arguments != nil {
+					pc.check(listSpec{list: ne.Arguments, closeChar: ')', option: opts.functions, container: node})
+				}
+				checkTypeArgs(node)
+			},
+			// Pure type-argument carriers — delegating to `node.TypeArgumentList()`
+			// so the set of kinds stays in lockstep with tsgo's own dispatch.
+			ast.KindTaggedTemplateExpression:    checkTypeArgs,
+			ast.KindTypeReference:               checkTypeArgs,
+			ast.KindExpressionWithTypeArguments: checkTypeArgs,
+			ast.KindImportType:                  checkTypeArgs,
+			ast.KindTypeQuery:                   checkTypeArgs,
+			ast.KindJsxOpeningElement:           checkTypeArgs,
+			ast.KindJsxSelfClosingElement:       checkTypeArgs,
+			// Function-like kinds — Parameters (`functions`) + TypeParameters
+			// (`generics`). Mirrors upstream's listener set:
+			//   FunctionDeclaration, FunctionExpression, ArrowFunctionExpression,
+			//   TSDeclareFunction, TSFunctionType — plus the class-context
+			//   FunctionExpression sites that ESTree wraps in MethodDefinition
+			//   (collapsed in tsgo into MethodDeclaration / Constructor /
+			//   Get|SetAccessor directly).
+			//
+			// NOT included: `KindConstructorType` (TS `new (...) => T`).
+			// Upstream has no `TSConstructorType` listener — verified by running
+			// @stylistic/eslint-plugin on a test corpus. Adding it would
+			// over-report on every `new (a, b,) => T` shape that upstream
+			// silently accepts.
+			ast.KindFunctionDeclaration: checkFunctionLike,
+			ast.KindFunctionExpression:  checkFunctionLike,
+			ast.KindArrowFunction:       checkFunctionLike,
+			ast.KindMethodDeclaration:   checkFunctionLike,
+			ast.KindConstructor:         checkFunctionLike,
+			ast.KindGetAccessor:         checkFunctionLike,
+			ast.KindSetAccessor:         checkFunctionLike,
+			ast.KindFunctionType:        checkFunctionLike,
+			// Class- / interface- / alias-like kinds — generics only.
+			ast.KindClassDeclaration:     checkTypeParams,
+			ast.KindClassExpression:      checkTypeParams,
+			ast.KindInterfaceDeclaration: checkTypeParams,
+			ast.KindTypeAliasDeclaration: checkTypeParams,
+			ast.KindEnumDeclaration: func(node *ast.Node) {
+				if ed := node.AsEnumDeclaration(); ed != nil {
+					pc.check(listSpec{list: ed.Members, closeChar: '}', option: opts.enums, container: node})
+				}
+			},
+			ast.KindTupleType: func(node *ast.Node) {
+				if tt := node.AsTupleTypeNode(); tt != nil {
+					pc.check(listSpec{list: tt.Elements, closeChar: ']', option: opts.tuples, container: node})
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/stylistic/rules/comma_dangle/comma_dangle.md
+++ b/internal/plugins/stylistic/rules/comma_dangle/comma_dangle.md
@@ -1,0 +1,201 @@
+# comma-dangle
+
+Require or disallow trailing commas.
+
+## Rule Details
+
+This rule enforces consistent use of trailing commas in object and array literals, function parameters and arguments, import / export specifier lists, dynamic imports, import attributes, TS enums, TS tuple types, TS generics, and TS function types.
+
+Trailing commas simplify adding and removing items, since only the lines you are modifying must be touched.
+
+A trailing comma after a rest binding (`function f(a, ...rest)`, `[a, ...rest]`, `{a, ...rest}`) is always disallowed — even with `"always"` — because JavaScript does not permit it. In `.tsx` files, the single-parameter generic `<T,>` is the JSX-disambiguation form and is never flagged. Holes at the end of an array (`[a,,]`, `[,,]`) are not treated as the last item and are skipped.
+
+## Options
+
+This rule has a string option:
+
+- `"never"` (default) disallows trailing commas.
+- `"always"` requires trailing commas.
+- `"always-multiline"` requires trailing commas when the closing bracket is on a different line from the last item, and disallows them otherwise.
+- `"only-multiline"` allows (but does not require) trailing commas for multi-line lists, and disallows them for single-line lists.
+
+This rule also has an object option, with one key per list kind. Each key takes the same string enum plus `"ignore"` (skip checking for that list kind):
+
+- `"arrays"` — array literals and array destructuring patterns.
+- `"objects"` — object literals and object destructuring patterns.
+- `"imports"` — ES module named imports.
+- `"exports"` — ES module named exports.
+- `"functions"` — function declarations, expressions, methods, arrow functions, and call / `new` arguments.
+- `"importAttributes"` — import / export `with { ... }` attribute clauses.
+- `"dynamicImports"` — `import(source, options)` argument lists.
+- `"enums"` — TS `enum Foo { Bar }` member lists.
+- `"generics"` — TS `<T, U>` type parameter lists.
+- `"tuples"` — TS `[a, b]` tuple types.
+
+Any key left unset falls back to `"never"`. TS type-argument lists (e.g. `Bar<T>`) are always treated as `"never"` regardless of the `generics` setting.
+
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
+
+```javascript
+var foo = { bar: 'baz', qux: 'quux', };
+var arr = [1, 2,];
+foo({ bar: 'baz', qux: 'quux', });
+```
+
+Examples of **correct** code for this rule with the default `"never"` option:
+
+```javascript
+var foo = { bar: 'baz', qux: 'quux' };
+var arr = [1, 2];
+foo({ bar: 'baz', qux: 'quux' });
+```
+
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/comma-dangle": ["error", "always"] }
+```
+
+```javascript
+var foo = { bar: 'baz', qux: 'quux' };
+var arr = [1, 2];
+foo({ bar: 'baz', qux: 'quux' });
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/comma-dangle": ["error", "always"] }
+```
+
+```javascript
+var foo = { bar: 'baz', qux: 'quux', };
+var arr = [1, 2,];
+foo({ bar: 'baz', qux: 'quux', });
+```
+
+### always-multiline
+
+Examples of **incorrect** code for this rule with the `"always-multiline"` option:
+
+```json
+{ "@stylistic/comma-dangle": ["error", "always-multiline"] }
+```
+
+```javascript
+var foo = {
+    bar: 'baz',
+    qux: 'quux'
+};
+
+var foo = { bar: 'baz', qux: 'quux', };
+
+var arr = [1, 2,];
+
+var arr = [
+    1,
+    2
+];
+```
+
+Examples of **correct** code for this rule with the `"always-multiline"` option:
+
+```json
+{ "@stylistic/comma-dangle": ["error", "always-multiline"] }
+```
+
+```javascript
+var foo = {
+    bar: 'baz',
+    qux: 'quux',
+};
+
+var foo = { bar: 'baz', qux: 'quux' };
+
+var arr = [1, 2];
+
+var arr = [
+    1,
+    2,
+];
+```
+
+### only-multiline
+
+Examples of **incorrect** code for this rule with the `"only-multiline"` option:
+
+```json
+{ "@stylistic/comma-dangle": ["error", "only-multiline"] }
+```
+
+```javascript
+var foo = { bar: 'baz', qux: 'quux', };
+
+var arr = [1, 2,];
+```
+
+Examples of **correct** code for this rule with the `"only-multiline"` option:
+
+```json
+{ "@stylistic/comma-dangle": ["error", "only-multiline"] }
+```
+
+```javascript
+var foo = {
+    bar: 'baz',
+    qux: 'quux',
+};
+
+var foo = {
+    bar: 'baz',
+    qux: 'quux'
+};
+
+var foo = { bar: 'baz', qux: 'quux' };
+
+var arr = [
+    1,
+    2,
+];
+
+var arr = [
+    1,
+    2
+];
+```
+
+### functions
+
+Examples of **incorrect** code for this rule with the `{ "functions": "always" }` option:
+
+```json
+{ "@stylistic/comma-dangle": ["error", { "functions": "always" }] }
+```
+
+```javascript
+function foo(a, b) {}
+
+foo(a, b);
+new foo(a, b);
+```
+
+Examples of **correct** code for this rule with the `{ "functions": "always" }` option:
+
+```json
+{ "@stylistic/comma-dangle": ["error", { "functions": "always" }] }
+```
+
+```javascript
+function foo(a, b,) {}
+
+foo(a, b,);
+new foo(a, b,);
+```
+
+## Original Documentation
+
+- [@stylistic/comma-dangle](https://eslint.style/rules/comma-dangle)

--- a/internal/plugins/stylistic/rules/comma_dangle/comma_dangle_extras_test.go
+++ b/internal/plugins/stylistic/rules/comma_dangle/comma_dangle_extras_test.go
@@ -1,0 +1,760 @@
+// TestCommaDangleExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing
+// at the specific branch / Dimension 4 row / tsgo AST quirk it covers, so
+// future refactors can't silently regress them without breaking a named
+// lock-in.
+package comma_dangle_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_dangle"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestCommaDangleExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&comma_dangle.CommaDangleRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: N/A — receiver / expression wrappers ----
+			// N/A: this rule inspects token positions of *containers* (object
+			// literal `{`/`}`, function param `(`/`)`, etc.), not the value
+			// shape of receivers or inputs. Paren / non-null / as-cast /
+			// satisfies / optional-chain wrappers around the *contents* of
+			// a container don't change the close-bracket scan.
+			//
+			// ---- Dimension 4: N/A — access / key forms ----
+			// N/A: the rule never inspects member-access shapes or computed-
+			// vs-static keys. Dotted vs bracket vs computed access form is
+			// invisible to it.
+			//
+			// ---- Dimension 4: array holes (KindOmittedExpression) ----
+			// tsgo represents ESTree's `null` hole as a KindOmittedExpression
+			// node. Upstream's `last(nodes)` short-circuits when the last
+			// element is null/undefined; we mirror that by skipping when the
+			// last node is OmittedExpression. Without this branch, `[a,,]` and
+			// `[,,]` would incorrectly report or insert a trailing comma.
+			{Code: `[a,,]`, Options: optStr("never")},
+			{Code: `[a,,]`, Options: optStr("always")},
+			{Code: `[a,b,,]`, Options: optStr("never")},
+			{Code: `[,a,,]`, Options: optStr("always")},
+
+			// ---- Dimension 4: parenthesized last item ----
+			// tsgo preserves `(expr)` as KindParenthesizedExpression. We don't
+			// unwrap before reading list.End() because the list's End() already
+			// accounts for the paren's source range. Lock in multi-level parens.
+			{Code: `[((1)),]`, Options: optStr("always")},
+			{Code: `var x = { foo: ((1)),};`, Options: optStr("always")},
+			{Code: `var x = [((1))]`, Options: optStr("never")},
+
+			// ---- Dimension 4: spread in literal (NOT a rest binding) ----
+			// SpreadElement in ArrayLiteralExpression / SpreadAssignment in
+			// ObjectLiteralExpression are NOT rest bindings in upstream's model.
+			// Trailing comma after them is allowed (and forced by `'always'`).
+			{Code: `var a = [b, ...spread,];`, Options: optStr("always")},
+			{Code: `var a = {...spread,};`, Options: optStr("always")},
+			{Code: `var a = {a: 1, ...spread,};`, Options: optStr("always")},
+
+			// ---- Dimension 4: spread in destructuring LHS (IS rest) ----
+			// `[a, ...rest] = []` parses in tsgo as ArrayLiteralExpression with
+			// SpreadElement (same node kind as the literal-context case). We use
+			// `IsArrayLiteralOrObjectLiteralDestructuringPattern` to detect the
+			// LHS context and switch SpreadElement to "rest" semantics — JS
+			// forbids a trailing comma after a rest binding in destructuring.
+			{Code: `[a, ...rest] = [];`, Options: optStr("always")},
+			{Code: `({a, ...rest} = b);`, Options: optStr("always")},
+			{Code: `for ([a, ...rest] of []);`, Options: optStr("always")},
+
+			// ---- Dimension 4: class methods / constructors / accessors ----
+			// tsgo's MethodDeclaration / Constructor / Get|SetAccessor are
+			// distinct kinds; the `functions` slot must fire on every one to
+			// match upstream's "all class-method param lists" coverage (where
+			// upstream sees a FunctionExpression on every MethodDefinition).
+			{Code: `class A { foo(a,) {} }`, Options: optStr("always")},
+			{Code: `class A { foo(a) {} }`, Options: optStr("never")},
+			{Code: `class A { constructor(a,) {} }`, Options: optStr("always")},
+			{Code: `class A { set x(v,) {} }`, Options: optStr("always")},
+			{Code: `class A { get x() { return 1; } }`, Options: optStr("always")},
+
+			// ---- Dimension 4: nesting boundary ----
+			// `class { foo() { class { bar() {} } } }` — inner class methods
+			// must be visited by the inner-class listener, not bleed up to the
+			// outer. Verifies one diagnostic per param list, not per ancestor.
+			{Code: `class A { foo(a,) { class B { bar(c,) {} } } }`, Options: optStr("always")},
+			{Code: `class A { foo(a) { class B { bar(c) {} } } }`, Options: optStr("never")},
+
+			// ---- Branch lock-in: dynamic-import slot vs functions slot ----
+			// `import(source)` is KindCallExpression with Expression.Kind ==
+			// KindImportKeyword. We route its Arguments to `dynamicImports`,
+			// not `functions`. Lock in the slot independence.
+			{Code: `import(source)`, Options: optMap(map[string]any{"functions": "always", "dynamicImports": "never"})},
+			{Code: `import(source,)`, Options: optMap(map[string]any{"functions": "never", "dynamicImports": "always"})},
+
+			// ---- Branch lock-in: type arguments hard-coded to 'never' ----
+			// Upstream uses `predicate.never` directly for TypeArgumentList,
+			// ignoring the user's `generics` setting. Verify that even with
+			// `generics: 'always'`, type-argument lists are still 'never'.
+			{Code: `Bar<T>`, Options: optMap(map[string]any{"generics": "always"})},
+			{Code: `foo<T>()`, Options: optMap(map[string]any{"generics": "always"})},
+			{Code: `new Foo<T>()`, Options: optMap(map[string]any{"generics": "always"})},
+
+			// ---- Branch lock-in: enum members ----
+			// EnumDeclaration is a tsgo-only kind for the `enum` slot.
+			{Code: `enum E { A = 1, B = 2 }`, Options: optStr("never")},
+			{Code: `enum E { A = 1, B = 2, }`, Options: optStr("always")},
+
+			// ---- Branch lock-in: tuple type ----
+			// TupleType is a tsgo-only kind for the `tuples` slot.
+			{Code: `type T = [string, number]`, Options: optStr("never")},
+			{Code: `type T = [string, number,]`, Options: optStr("always")},
+
+			// ---- Branch lock-in: function type ----
+			// FunctionType is a tsgo-only kind for the `functions` slot.
+			{Code: `type Fn = (a: number, b: number,) => void`, Options: optStr("always")},
+			{Code: `type Fn = (a: number, b: number) => void`, Options: optStr("never")},
+
+			// ---- Branch lock-in: interface generics ----
+			// InterfaceDeclaration carries TypeParameters but no Parameters; the
+			// `generics` slot fires while `functions` does not.
+			{Code: `interface Foo<T,> { bar(): T }`, Options: optMap(map[string]any{"generics": "always"})},
+
+			// ---- Branch lock-in: type alias generics ----
+			{Code: `type Foo<T,> = T`, Options: optMap(map[string]any{"generics": "always"})},
+
+			// ---- Branch lock-in: ImportAttributes on ExportAllDeclaration ----
+			// `export * from 'foo' with {...}` has no ExportClause, only the
+			// Attributes branch. Verifies the export-clause-nil arm.
+			{Code: `export * from "foo" with {a: "b", c: "d"}`, Options: optMap(map[string]any{"importAttributes": "never"})},
+
+			// ---- Branch lock-in: `ignore` slot ----
+			// `ignore` should suppress all reports for that slot regardless of
+			// trailing-comma state. Lock the option-pass-through.
+			{Code: `var foo = {a: 1,}`, Options: optMap(map[string]any{"objects": "ignore"})},
+			{Code: `var foo = {a: 1}`, Options: optMap(map[string]any{"objects": "ignore"})},
+
+			// ---- Branch lock-in: empty container — no diagnostic ----
+			// Empty list → no last item → no check. Lock in the early-exit.
+			{Code: `var a = []`, Options: optStr("always")},
+			{Code: `var a = {}`, Options: optStr("always")},
+			{Code: `foo()`, Options: optStr("always")},
+			{Code: `enum E {}`, Options: optStr("always")},
+
+			// ---- Real-user: deeply nested literal (issue-tracker shape) ----
+			// Production codebases produce deeply nested object/array literals;
+			// nested-listener correctness is the most common drift surface.
+			{Code: "var x = {\n  a: {\n    b: {\n      c: 1,\n    },\n  },\n};", Options: optStr("always-multiline")},
+
+			// ---- Branch lock-in: JSX type-arguments (tsgo-specific carriers) ----
+			// Before delegating to `node.TypeArgumentList()`, the listener fan-out
+			// hand-rolled per-kind `As<X>().TypeArguments` paths and silently
+			// dropped JsxOpeningElement / JsxSelfClosingElement. Lock the fix in.
+			{Code: `const x = <Foo<T> />`, Tsx: true},
+			{Code: `const x = <Foo<T>>x</Foo>`, Tsx: true},
+			// Single-T TypeArguments has no TSX carve-out (carve-out is for
+			// TypeParameter*Declaration*, not Instantiation), so `<Foo<T,>>` is
+			// always unexpected — see invalid cases below.
+
+			// ---- Branch lock-in: TaggedTemplateExpression type-arguments ----
+			// Previously registered but had zero tests.
+			{Code: "tag<T>`hello`"},
+
+			// ---- Branch lock-in: TypeQuery type-arguments ----
+			// `typeof Foo<T>`. Previously registered but had zero tests.
+			{Code: `type X = typeof Foo<T>`},
+
+			// ---- Branch lock-in: ImportType type-arguments ----
+			// `import('foo').Bar<T>`. Previously registered but had zero tests.
+			{Code: `type X = import("foo").Bar<T>`},
+
+			// ---- Branch lock-in: ConstructorType NOT visited ----
+			// `new (a: number) => Foo` is KindConstructorType. Upstream has no
+			// `TSConstructorType` listener (only `TSFunctionType` for `(a) => T`),
+			// so we mirror that and skip ConstructorType. All four combinations
+			// below would emit a diagnostic if ConstructorType were listed —
+			// they're locked in here as valid.
+			{Code: `type C = new (a: number, b: number) => Foo`, Options: optStr("never")},
+			{Code: `type C = new (a: number, b: number,) => Foo`, Options: optStr("always")},
+			{Code: `type C = new (a: number, b: number,) => Foo`, Options: optStr("never")},
+			{Code: `type C = new (a: number, b: number) => Foo`, Options: optStr("always")},
+
+			// ---- Branch lock-in: async / generator / async-generator variants ----
+			// All flow through FunctionLikeData → checkFunctionLike. Lock in
+			// that none of the FunctionExpression / ArrowFunction sub-shapes
+			// flip the rest-degrade or break the listener dispatch.
+			{Code: `async function foo(a) {}`, Options: optMap(map[string]any{"functions": "never"})},
+			{Code: `async function foo(a,) {}`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `function* gen(a) {}`, Options: optMap(map[string]any{"functions": "never"})},
+			{Code: `function* gen(a,) {}`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `async function* g(a) {}`, Options: optMap(map[string]any{"functions": "never"})},
+			{Code: `async function* g(a,) {}`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `const f = async (a) => 1;`, Options: optMap(map[string]any{"functions": "never"})},
+			{Code: `const f = async (a,) => 1;`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `class C { async foo(a,) {} *gen(a,) {} async *both(a,) {} }`, Options: optMap(map[string]any{"functions": "always"})},
+
+			// ---- Branch lock-in: body-less class members are NOT checked ----
+			// `abstract method`, `declare class { method() }`, and overload
+			// signatures all map to ESTree's `TSEmptyBodyFunctionExpression`,
+			// which upstream's `FunctionExpression` listener does not match.
+			// We mirror that by skipping body-less MethodDeclaration /
+			// Constructor / Get|SetAccessor.
+			//
+			// All four cases below would emit a missing-comma diagnostic if the
+			// body-less guard were absent. Lock them in as VALID.
+			{Code: `abstract class A { abstract foo(a): void; }`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `declare class A { foo(a): void; }`, Options: optMap(map[string]any{"functions": "always"})},
+			// (overload variant moved to invalid below: only the body-having
+			// impl row reports; both overload-signature rows are skipped.)
+			{Code: `abstract class A { abstract get x(): number; abstract set x(v): void; }`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `declare class A { constructor(a); }`, Options: optMap(map[string]any{"functions": "always"})},
+			// Lock-in: trailing comma in abstract / declare methods is also NOT
+			// flagged under 'never' (the body-less guard is unconditional).
+			{Code: `abstract class A { abstract foo(a,): void; }`, Options: optStr("never")},
+			{Code: `declare class A { foo(a,): void; }`, Options: optStr("never")},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized item with `never` ----
+			{
+				Code:    `[((1)),]`,
+				Output:  []string{`[((1))]`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 7}},
+			},
+
+			// ---- Dimension 4: spread in destructuring with `'always'` AND
+			// existing trailing comma → forbid via degrade. ----
+			{
+				Code:    `[a, ...rest,] = [];`,
+				Output:  []string{`[a, ...rest] = [];`},
+				Options: optStr("always"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 12}},
+			},
+			{
+				Code:    `({a, ...rest,} = b);`,
+				Output:  []string{`({a, ...rest} = b);`},
+				Options: optStr("always"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 13}},
+			},
+
+			// ---- Dimension 4: spread in array literal (NOT destructuring) is
+			// not a rest binding — `'always'` forces a trailing comma. ----
+			{
+				Code:    `var a = [b, ...spread]`,
+				Output:  []string{`var a = [b, ...spread,]`},
+				Options: optStr("always"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 22}},
+			},
+
+			// ---- Branch lock-in: class method param with `'never'` ----
+			// MethodDeclaration listener must fire on class methods, not just
+			// FunctionExpression-as-MethodDefinition.value (which is upstream's
+			// shape). Lock the listener in.
+			{
+				Code:    `class A { foo(a,) {} }`,
+				Output:  []string{`class A { foo(a) {} }`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}},
+			},
+			{
+				Code:    `class A { constructor(a,) {} }`,
+				Output:  []string{`class A { constructor(a) {} }`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 24}},
+			},
+			{
+				Code:    `class A { set x(v,) {} }`,
+				Output:  []string{`class A { set x(v) {} }`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 18}},
+			},
+
+			// ---- Branch lock-in: dynamic-import slot independence ----
+			{
+				Code:    `import(source)`,
+				Output:  []string{`import(source,)`},
+				Options: optMap(map[string]any{"functions": "never", "dynamicImports": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 14}},
+			},
+			{
+				Code:    `import(source,)`,
+				Output:  []string{`import(source)`},
+				Options: optMap(map[string]any{"functions": "always", "dynamicImports": "never"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}},
+			},
+
+			// ---- Branch lock-in: type arguments are always 'never', regardless of `generics` ----
+			{
+				Code:    `Bar<T,>`,
+				Output:  []string{`Bar<T>`},
+				Options: optMap(map[string]any{"generics": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 6}},
+			},
+			{
+				Code:    `foo<T,>()`,
+				Output:  []string{`foo<T>()`},
+				Options: optMap(map[string]any{"generics": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 6}},
+			},
+			{
+				Code:    `new Foo<T,>()`,
+				Output:  []string{`new Foo<T>()`},
+				Options: optMap(map[string]any{"generics": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 10}},
+			},
+
+			// ---- Branch lock-in: enum members ----
+			{
+				Code:    `enum E { A = 1, B = 2 }`,
+				Output:  []string{`enum E { A = 1, B = 2, }`},
+				Options: optStr("always"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 22}},
+			},
+			{
+				Code:    `enum E { A = 1, B = 2, }`,
+				Output:  []string{`enum E { A = 1, B = 2 }`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 22}},
+			},
+
+			// ---- Branch lock-in: tuple type ----
+			{
+				Code:    `type T = [string, number]`,
+				Output:  []string{`type T = [string, number,]`},
+				Options: optStr("always"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 25}},
+			},
+			{
+				Code:    `type T = [string, number,]`,
+				Output:  []string{`type T = [string, number]`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 25}},
+			},
+
+			// ---- Branch lock-in: function type ----
+			{
+				Code:    `type Fn = (a: number, b: number) => void`,
+				Output:  []string{`type Fn = (a: number, b: number,) => void`},
+				Options: optStr("always"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 32}},
+			},
+
+			// ---- Branch lock-in: interface / type-alias generics ----
+			{
+				Code:    `interface Foo<T> {}`,
+				Output:  []string{`interface Foo<T,> {}`},
+				Options: optMap(map[string]any{"generics": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 16}},
+			},
+			{
+				Code:    `type Foo<T> = T`,
+				Output:  []string{`type Foo<T,> = T`},
+				Options: optMap(map[string]any{"generics": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 11}},
+			},
+
+			// ---- Branch lock-in: ImportAttributes on ExportAllDeclaration ----
+			{
+				Code:    `export * from "foo" with {a: "b", c: "d",}`,
+				Output:  []string{`export * from "foo" with {a: "b", c: "d"}`},
+				Options: optMap(map[string]any{"importAttributes": "never"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 41}},
+			},
+
+			// ---- Branch lock-in: only-multiline → forbid on single-line ----
+			// `only-multiline` allows trailing comma on multi-line and forbids
+			// on single-line. Lock the single-line forbid branch.
+			{
+				Code:    `var foo = {a: 1,}`,
+				Output:  []string{`var foo = {a: 1}`},
+				Options: optStr("only-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}},
+			},
+
+			// ---- Real-user: deeply nested multi-line ----
+			// Three nested object literals, each missing a trailing comma. The
+			// emit order follows listener-fire order (outermost ObjectLiteral
+			// visited first, then descending into inner ones).
+			{
+				Code:    "var x = {\n  a: {\n    b: {\n      c: 1\n    }\n  }\n};",
+				Output:  []string{"var x = {\n  a: {\n    b: {\n      c: 1,\n    },\n  },\n};"},
+				Options: optStr("always-multiline"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 6, Column: 4},
+					{MessageId: "missing", Line: 5, Column: 6},
+					{MessageId: "missing", Line: 4, Column: 11},
+				},
+			},
+
+			// ---- Branch lock-in: JSX TypeArguments (Bug fix from earlier
+			// per-kind dispatch — JsxOpeningElement / JsxSelfClosingElement
+			// were dropped). Type arguments are hard-coded 'never' regardless
+			// of `generics` setting. ----
+			{
+				Code:   `const x = <Foo<T,> />`,
+				Output: []string{`const x = <Foo<T> />`},
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 17}},
+			},
+			{
+				Code:   `const x = <Foo<T,>>x</Foo>`,
+				Output: []string{`const x = <Foo<T>>x</Foo>`},
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 17}},
+			},
+			{
+				// Multi-arg JSX: no TSX `<T,>` carve-out applies (carve-out is
+				// per-list-len, and applies only to TypeParameter*Declaration*,
+				// not Instantiation).
+				Code:   `const x = <Foo<T,U,> />`,
+				Output: []string{`const x = <Foo<T,U> />`},
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 19}},
+			},
+
+			// ---- Branch lock-in: TaggedTemplate type-arguments ----
+			{
+				Code:   "tag<T,>`hello`",
+				Output: []string{"tag<T>`hello`"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 6}},
+			},
+
+			// ---- Branch lock-in: TypeQuery type-arguments ----
+			{
+				Code:   `type X = typeof Foo<T,>`,
+				Output: []string{`type X = typeof Foo<T>`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 22}},
+			},
+
+			// ---- Branch lock-in: ImportType type-arguments ----
+			{
+				Code:   `type X = import("foo").Bar<T,>`,
+				Output: []string{`type X = import("foo").Bar<T>`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 29}},
+			},
+
+			// (removed) ConstructorType invalid asserts — upstream has no
+			// TSConstructorType listener; ConstructorType is intentionally not
+			// visited. See valid lock-in above for the 4-combination proof.
+
+			// ---- Branch lock-in: async / generator with trailing comma + 'never' ----
+			{
+				Code:    `async function foo(a,) {}`,
+				Output:  []string{`async function foo(a) {}`},
+				Options: optMap(map[string]any{"functions": "never"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 21}},
+			},
+			{
+				Code:    `function* gen(a,) {}`,
+				Output:  []string{`function* gen(a) {}`},
+				Options: optMap(map[string]any{"functions": "never"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}},
+			},
+			{
+				Code:    `const f = async (a,) => 1`,
+				Output:  []string{`const f = async (a) => 1`},
+				Options: optMap(map[string]any{"functions": "never"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 19}},
+			},
+
+			// (removed) `abstract class A { abstract foo(a): void; }` with
+			// `{functions: 'always'}` — body-less class members are skipped
+			// to match upstream's TSEmptyBodyFunctionExpression behavior.
+			// See the valid lock-in above.
+
+			// ---- Branch lock-in: overload signatures + body-having impl ----
+			// Upstream behavior (verified via @stylistic/eslint-plugin v5):
+			// body-less overload-signature rows are skipped; only the
+			// body-having impl row reports under `{functions: 'always'}`.
+			{
+				Code:    "class A {\n  foo(a): string;\n  foo(a): number;\n  foo(a) { return a; }\n}",
+				Output:  []string{"class A {\n  foo(a): string;\n  foo(a): number;\n  foo(a,) { return a; }\n}"},
+				Options: optMap(map[string]any{"functions": "always"}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 4, Column: 8},
+				},
+			},
+
+			// ---- Branch lock-in: rest-element + 'always-multiline' multi-line
+			// + existing trailing comma → forbid via degrade. This is the
+			// only invalid shape that exercises the `forceTrailingComma →
+			// forbid (rest)` path inside `forceTrailingCommaIfMultiline`'s
+			// multi-line branch. ----
+			{
+				Code:    "function f(\n  a,\n  ...rest,\n) {}",
+				Output:  []string{"function f(\n  a,\n  ...rest\n) {}"},
+				Options: optMap(map[string]any{"functions": "always-multiline"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 3, Column: 10}},
+			},
+
+			// =====================================================================
+			// Extra tsgo edge shapes + real-user scenarios beyond upstream coverage
+			// =====================================================================
+
+			// ---- Nested CallExpression: inner has trailing comma, outer doesn't ----
+			// Both Call listeners fire independently; the inner's diagnostic should
+			// not affect the outer's lastItem scan (since CallExpression.End() is
+			// after `)`).
+			{
+				Code:    `outer(inner(a, b,), c,)`,
+				Output:  []string{`outer(inner(a, b), c)`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+
+			// ---- Method chaining: each Call independent ----
+			{
+				Code:    `foo(a,).bar(b,).baz(c,)`,
+				Output:  []string{`foo(a).bar(b).baz(c)`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					// listener-fire order is preorder: outermost CallExpression
+					// (= foo(a,).bar(b,).baz(c,)) visits first, then descending.
+					{MessageId: "unexpected", Line: 1, Column: 22},
+					{MessageId: "unexpected", Line: 1, Column: 14},
+					{MessageId: "unexpected", Line: 1, Column: 6},
+				},
+			},
+
+			// ---- ComputedPropertyName key ----
+			// `{[x]: 1,}` — computed key in object literal. The OUTER list
+			// (Properties) ends after `1`, then `,`. ComputedPropertyName itself
+			// is part of the property, not a separate list.
+			{
+				Code:    `var x = {[k]: 1, [m]: 2,};`,
+				Output:  []string{`var x = {[k]: 1, [m]: 2};`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 24}},
+			},
+
+			// ---- Default parameter value ----
+			// `function f(a = 1, b = 2,) {}` — default values shouldn't break
+			// last-item end detection. Last param ends after `2`.
+			{
+				Code:    `function f(a = 1, b = 2) {}`,
+				Output:  []string{`function f(a = 1, b = 2,) {}`},
+				Options: optMap(map[string]any{"functions": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 24}},
+			},
+
+			// ---- Optional-chain call `foo?.(a,)` ----
+			// In tsgo this is a CallExpression with QuestionDotToken; same kind,
+			// same listener. The `?.` token doesn't affect end-of-list detection.
+			{
+				Code:    `foo?.(a,)`,
+				Output:  []string{`foo?.(a)`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 8}},
+			},
+			{
+				Code:    `obj?.method(a,)`,
+				Output:  []string{`obj?.method(a)`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}},
+			},
+
+			// ---- Spread in MIDDLE of call args (NOT at end) ----
+			// Last arg is `c`, not the spread — so `'always'` still forces a comma.
+			{
+				Code:    `foo(a, ...b, c)`,
+				Output:  []string{`foo(a, ...b, c,)`},
+				Options: optStr("always"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}},
+			},
+
+			// ---- TypeScript: type-only import ----
+			// `import type {Foo,} from 'bar'` — NamedImports still detected via
+			// the same NamedBindings.Kind == KindNamedImports check.
+			{
+				Code:    `import type {Foo,} from 'bar';`,
+				Output:  []string{`import type {Foo} from 'bar';`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 17}},
+			},
+			// `import {type Foo,} from 'bar'` — inline type modifier per
+			// TS 4.5+; ImportSpecifier carries an `IsTypeOnly` flag but the
+			// listener doesn't care, comma detection is purely syntactic.
+			{
+				Code:    `import {type Foo,} from 'bar';`,
+				Output:  []string{`import {type Foo} from 'bar';`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 17}},
+			},
+
+			// ---- TypeScript: export type ----
+			{
+				Code:    `export type {Foo,} from 'bar';`,
+				Output:  []string{`export type {Foo} from 'bar';`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 17}},
+			},
+
+			// ---- Class fields: arrow function with trailing comma in params ----
+			// `class A { foo = (a,) => 1; }` — the arrow is a class field
+			// initializer. ArrowFunction listener handles it; class-field
+			// nesting doesn't bleed.
+			{
+				Code:    `class A { foo = (a,) => 1; }`,
+				Output:  []string{`class A { foo = (a) => 1; }`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 19}},
+			},
+
+			// ---- IIFE: both function and outer call ----
+			// `(function f(a,) {})(b,)` — both the FunctionExpression's params
+			// and the outer call's args fire independently.
+			{
+				Code:    `(function f(a,) {})(b,)`,
+				Output:  []string{`(function f(a) {})(b)`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+					{MessageId: "unexpected", Line: 1, Column: 14},
+				},
+			},
+
+			// ---- Object methods with getter/setter ----
+			{
+				Code:    `var o = { get x() { return 1 }, set x(v,) {}, };`,
+				Output:  []string{`var o = { get x() { return 1 }, set x(v) {} };`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					// outer object trailing comma at col 45, setter param at col 40
+					{MessageId: "unexpected", Line: 1, Column: 45},
+					{MessageId: "unexpected", Line: 1, Column: 40},
+				},
+			},
+
+			// ---- Decorator on class member ----
+			// MethodDeclaration with leading decorator still processes Parameters.
+			{
+				Code:    `class A { @dec foo(a,) {} }`,
+				Output:  []string{`class A { @dec foo(a) {} }`},
+				Options: optMap(map[string]any{"functions": "never"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 21}},
+			},
+
+			// ---- TS overload signatures: each FunctionDeclaration checked ----
+			// Three overloads; the first two are body-less and the third has body.
+			// All three are KindFunctionDeclaration → checkFunctionLike fires
+			// for each. Each is a separate diagnostic.
+			{
+				Code:    "function foo(a: string,): string;\nfunction foo(a: number,): number;\nfunction foo(a: any,) { return a; }",
+				Output:  []string{"function foo(a: string): string;\nfunction foo(a: number): number;\nfunction foo(a: any) { return a; }"},
+				Options: optMap(map[string]any{"functions": "never"}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+					{MessageId: "unexpected", Line: 2, Column: 23},
+					{MessageId: "unexpected", Line: 3, Column: 20},
+				},
+			},
+
+			// ---- Labelled tuple member ----
+			// `[name: string, age: number,]` — TS labelled tuple. tsgo's
+			// TupleTypeNode.Elements list still has 2 elements, last ends after
+			// the type. Trailing comma applies the `tuples` slot.
+			{
+				Code:    `type T = [name: string, age: number,]`,
+				Output:  []string{`type T = [name: string, age: number]`},
+				Options: optMap(map[string]any{"tuples": "never"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 36}},
+			},
+
+			// ---- Tuple with rest element ----
+			// `[a: string, ...rest: number[]]` — rest in tuple is NamedTupleMember
+			// with DotDotDotToken or RestType. In either case, last item is the
+			// rest form. tsgo doesn't classify these as KindBindingElement, so my
+			// isRestElement returns false → trailing comma is allowed.
+			{
+				Code:    `type T = [string, ...number[]]`,
+				Output:  []string{`type T = [string, ...number[],]`},
+				Options: optMap(map[string]any{"tuples": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 30}},
+			},
+
+			// ---- Deep type nesting ----
+			// `Foo<Bar<Baz<T,>>>` — three nested TypeReferences with type args.
+			// Each has type-args 'never' (hard-coded). Only the innermost has
+			// a trailing comma.
+			{
+				Code:    `type X = Foo<Bar<Baz<T,>>>`,
+				Output:  []string{`type X = Foo<Bar<Baz<T>>>`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 23}},
+			},
+
+			// ---- Mixed: Call type-args + call args + dynamicImports ----
+			// `foo<T,>(a,)` with default 'never': both `T,` (type-args, hard-coded
+			// never) and `a,` (functions slot, default never) fire.
+			{
+				Code:   `foo<T,>(a,)`,
+				Output: []string{`foo<T>(a)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					// Call listener processes Arguments first, then TypeArgs:
+					{MessageId: "unexpected", Line: 1, Column: 10},
+					{MessageId: "unexpected", Line: 1, Column: 6},
+				},
+			},
+
+			// ---- Real-user: React component with many props (multi-line) ----
+			{
+				Code: "const Component = ({\n  prop1,\n  prop2,\n  prop3\n}) => null;",
+				Output: []string{
+					"const Component = ({\n  prop1,\n  prop2,\n  prop3,\n}) => null;",
+				},
+				Options: optStr("always-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 4, Column: 8}},
+			},
+
+			// ---- Real-user: large Redux action payload object ----
+			{
+				Code: "dispatch({\n  type: 'FETCH',\n  payload: {\n    id: 1,\n    items: [\n      { name: 'a' },\n      { name: 'b' }\n    ]\n  }\n});",
+				Output: []string{
+					"dispatch({\n  type: 'FETCH',\n  payload: {\n    id: 1,\n    items: [\n      { name: 'a' },\n      { name: 'b' },\n    ],\n  },\n});",
+				},
+				Options: optStr("always-multiline"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 9, Column: 4}, // outer object close `}` line
+					{MessageId: "missing", Line: 8, Column: 6}, // items array close `]` line
+					{MessageId: "missing", Line: 7, Column: 20}, // last item `{ name: 'b' }` ends at col 19, insert at col 20
+				},
+			},
+
+			// ---- Real-user: long import list with mix of default + named ----
+			{
+				Code: "import React, {\n  useState,\n  useEffect,\n  useMemo,\n  useCallback\n} from 'react';",
+				Output: []string{
+					"import React, {\n  useState,\n  useEffect,\n  useMemo,\n  useCallback,\n} from 'react';",
+				},
+				Options: optMap(map[string]any{"imports": "always-multiline"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 5, Column: 14}},
+			},
+
+			// ---- Real-user: TS function with generics + parameter + return type ----
+			// `always` forces commas in:
+			//   1. outer FunctionDecl Parameters `(arr, fn: (...))` — col 45
+			//   2. outer FunctionDecl TypeParameters `<T, U>` — col 18
+			//   3. inner FunctionType params `(x: T)` (the `fn` type) — col 39
+			//   4. inner CallExpression args `arr.map(fn)` — col 71
+			// Order is preorder DFS — but the exact relative order between (3)
+			// inside a Parameter type and (4) deeper in the body depends on
+			// listener-fire timing, so assert messageId only and let `Output`
+			// pin the substantive fix.
+			{
+				Code:    "function map<T, U>(arr: T[], fn: (x: T) => U): U[] { return arr.map(fn); }",
+				Output:  []string{"function map<T, U,>(arr: T[], fn: (x: T,) => U,): U[] { return arr.map(fn,); }"},
+				Options: optStr("always"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing"},
+					{MessageId: "missing"},
+					{MessageId: "missing"},
+					{MessageId: "missing"},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/comma_dangle/comma_dangle_upstream_test.go
+++ b/internal/plugins/stylistic/rules/comma_dangle/comma_dangle_upstream_test.go
@@ -1,0 +1,934 @@
+// TestCommaDangleUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.test.ts
+// and comma-dangle._ts_.test.ts 1:1. Position assertions cover line/column
+// for every invalid case. rslint-specific lock-in cases (tsgo AST edge
+// shapes, branch lock-ins, real-user shapes) live in
+// comma_dangle_extras_test.go.
+//
+// Cases that depend on ESLint's `parserOptions.ecmaVersion` to flip the
+// `functions` / `dynamicImports` slot to `'ignore'` (upstream's behavior
+// for ecmaVersion < 2017 / 2025 respectively) are kept here as `Skip: true`
+// with a `// SKIP: <reason>` marker — rslint does not model ecmaVersion,
+// so we always behave as if `'latest'` were in effect.
+package comma_dangle_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_dangle"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func optStr(s string) []any { return []any{s} }
+
+func optMap(m map[string]any) []any { return []any{m} }
+
+func errUnexpected(line, col int) []rule_tester.InvalidTestCaseError {
+	return []rule_tester.InvalidTestCaseError{
+		{MessageId: "unexpected", Line: line, Column: col},
+	}
+}
+
+func errMissing(line, col int) []rule_tester.InvalidTestCaseError {
+	return []rule_tester.InvalidTestCaseError{
+		{MessageId: "missing", Line: line, Column: col},
+	}
+}
+
+func TestCommaDangleUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&comma_dangle.CommaDangleRule,
+		[]rule_tester.ValidTestCase{
+			// ---- default (never) — array / object literals ----
+			{Code: `var foo = { bar: 'baz' }`},
+			{Code: "var foo = {\nbar: 'baz'\n}"},
+			{Code: `var foo = [ 'baz' ]`},
+			{Code: "var foo = [\n'baz'\n]"},
+			{Code: `[,,]`},
+			{Code: "[\n,\n,\n]"},
+			{Code: `[,]`},
+			{Code: "[\n,\n]"},
+			{Code: `[]`},
+			{Code: "[\n]"},
+			{Code: "var foo = [\n      (bar ? baz : qux),\n    ];", Options: optStr("always-multiline")},
+
+			// ---- never ----
+			{Code: `var foo = { bar: 'baz' }`, Options: optStr("never")},
+			{Code: "var foo = {\nbar: 'baz'\n}", Options: optStr("never")},
+			{Code: `var foo = [ 'baz' ]`, Options: optStr("never")},
+			{Code: `var { a, b } = foo;`, Options: optStr("never")},
+			{Code: `var [ a, b ] = foo;`, Options: optStr("never")},
+			{Code: "var { a,\n b, \n} = foo;", Options: optStr("only-multiline")},
+			{Code: "var [ a,\n b, \n] = foo;", Options: optStr("only-multiline")},
+
+			// ---- always ----
+			{Code: `[(1),]`, Options: optStr("always")},
+			{Code: `var x = { foo: (1),};`, Options: optStr("always")},
+			{Code: `var foo = { bar: 'baz', }`, Options: optStr("always")},
+			{Code: "var foo = {\nbar: 'baz',\n}", Options: optStr("always")},
+			{Code: "var foo = {\nbar: 'baz'\n,}", Options: optStr("always")},
+			{Code: `var foo = [ 'baz', ]`, Options: optStr("always")},
+			{Code: "var foo = [\n'baz',\n]", Options: optStr("always")},
+			{Code: "var foo = [\n'baz'\n,]", Options: optStr("always")},
+			{Code: `[,,]`, Options: optStr("always")},
+			{Code: "[\n,\n,\n]", Options: optStr("always")},
+			{Code: `[,]`, Options: optStr("always")},
+			{Code: "[\n,\n]", Options: optStr("always")},
+			{Code: `[]`, Options: optStr("always")},
+			{Code: "[\n]", Options: optStr("always")},
+
+			// ---- always-multiline / only-multiline ----
+			{Code: `var foo = { bar: 'baz' }`, Options: optStr("always-multiline")},
+			{Code: `var foo = { bar: 'baz' }`, Options: optStr("only-multiline")},
+			{Code: "var foo = {\nbar: 'baz',\n}", Options: optStr("always-multiline")},
+			{Code: "var foo = {\nbar: 'baz',\n}", Options: optStr("only-multiline")},
+			{Code: `var foo = [ 'baz' ]`, Options: optStr("always-multiline")},
+			{Code: `var foo = [ 'baz' ]`, Options: optStr("only-multiline")},
+			{Code: "var foo = [\n'baz',\n]", Options: optStr("always-multiline")},
+			{Code: "var foo = [\n'baz',\n]", Options: optStr("only-multiline")},
+			{Code: "var foo = { bar:\n\n'bar' }", Options: optStr("always-multiline")},
+			{Code: "var foo = { bar:\n\n'bar' }", Options: optStr("only-multiline")},
+			{Code: `var foo = {a: 1, b: 2, c: 3, d: 4}`, Options: optStr("always-multiline")},
+			{Code: `var foo = {a: 1, b: 2, c: 3, d: 4}`, Options: optStr("only-multiline")},
+			{Code: "var foo = {a: 1, b: 2,\n c: 3, d: 4}", Options: optStr("always-multiline")},
+			{Code: "var foo = {a: 1, b: 2,\n c: 3, d: 4}", Options: optStr("only-multiline")},
+			{Code: "var foo = {x: {\nfoo: 'bar',\n}}", Options: optStr("always-multiline")},
+			{Code: "var foo = {x: {\nfoo: 'bar',\n}}", Options: optStr("only-multiline")},
+			{Code: "var foo = new Map([\n[key, {\na: 1,\nb: 2,\nc: 3,\n}],\n])", Options: optStr("always-multiline")},
+			{Code: "var foo = new Map([\n[key, {\na: 1,\nb: 2,\nc: 3,\n}],\n])", Options: optStr("only-multiline")},
+
+			// ---- rest binding / spread (upstream issue #3627, #7297) ----
+			{Code: `var [a, ...rest] = [];`, Options: optStr("always")},
+			{Code: "var [\n    a,\n    ...rest\n] = [];", Options: optStr("always")},
+			{Code: "var [\n    a,\n    ...rest\n] = [];", Options: optStr("always-multiline")},
+			{Code: "var [\n    a,\n    ...rest\n] = [];", Options: optStr("only-multiline")},
+			{Code: `[a, ...rest] = [];`, Options: optStr("always")},
+			{Code: `for ([a, ...rest] of []);`, Options: optStr("always")},
+			{Code: `var a = [b, ...spread,];`, Options: optStr("always")},
+			{Code: `var {foo, ...bar} = baz`, Options: optStr("always")},
+
+			// ---- import / export (upstream issue #3794) ----
+			{Code: `import {foo,} from 'foo';`, Options: optStr("always")},
+			{Code: `import foo from 'foo';`, Options: optStr("always")},
+			{Code: `import foo, {abc,} from 'foo';`, Options: optStr("always")},
+			{Code: `import * as foo from 'foo';`, Options: optStr("always")},
+			{Code: `export {foo,} from 'foo';`, Options: optStr("always")},
+			{Code: `import {foo} from 'foo';`, Options: optStr("never")},
+			{Code: `import foo from 'foo';`, Options: optStr("never")},
+			{Code: `import foo, {abc} from 'foo';`, Options: optStr("never")},
+			{Code: `import * as foo from 'foo';`, Options: optStr("never")},
+			{Code: `export {foo} from 'foo';`, Options: optStr("never")},
+			{Code: `import {foo} from 'foo';`, Options: optStr("always-multiline")},
+			{Code: `import {foo} from 'foo';`, Options: optStr("only-multiline")},
+			{Code: `export {foo} from 'foo';`, Options: optStr("always-multiline")},
+			{Code: `export {foo} from 'foo';`, Options: optStr("only-multiline")},
+			{Code: "import {\n  foo,\n} from 'foo';", Options: optStr("always-multiline")},
+			{Code: "import {\n  foo,\n} from 'foo';", Options: optStr("only-multiline")},
+			{Code: "export {\n  foo,\n} from 'foo';", Options: optStr("always-multiline")},
+			{Code: "export {\n  foo,\n} from 'foo';", Options: optStr("only-multiline")},
+			{Code: "import {foo} from \n'foo';", Options: optStr("always-multiline")},
+			{Code: "import {foo} from \n'foo';", Options: optStr("only-multiline")},
+
+			// ---- functions ----
+			// SKIP: rslint does not honor parserOptions.ecmaVersion; the upstream
+			// rule sets `functions` to 'ignore' for ecmaVersion < 2017. With
+			// 'latest' semantics rslint correctly enforces trailing-comma rules,
+			// which would flip these cases from valid → invalid.
+			{Code: `function foo(a) {}`, Options: optStr("always"), Skip: true},
+			{Code: `foo(a)`, Options: optStr("always"), Skip: true},
+			{Code: `function foo(a) {}`, Options: optStr("never")},
+			{Code: `foo(a)`, Options: optStr("never")},
+			{Code: "function foo(a,\nb) {}", Options: optStr("always-multiline")},
+			{Code: "foo(a,\nb\n)", Options: optStr("always-multiline"), Skip: true},
+			{Code: "function foo(a,\nb\n) {}", Options: optStr("always-multiline"), Skip: true},
+			{Code: "foo(a,\nb)", Options: optStr("always-multiline")},
+			{Code: "function foo(a,\nb) {}", Options: optStr("only-multiline")},
+			{Code: "foo(a,\nb)", Options: optStr("only-multiline")},
+			{Code: `function foo(a) {}`, Options: optStr("always"), Skip: true},
+			{Code: `foo(a)`, Options: optStr("always"), Skip: true},
+			{Code: `function foo(a) {}`, Options: optStr("never")},
+			{Code: `foo(a)`, Options: optStr("never")},
+			{Code: "function foo(a,\nb) {}", Options: optStr("always-multiline")},
+			{Code: "foo(a,\nb)", Options: optStr("always-multiline")},
+			// SKIP: ecmaVersion=7 ignores functions; rslint enforces (would report
+			// missing trailing comma for the multi-line param list).
+			{Code: "function foo(a,\nb\n) {}", Options: optStr("always-multiline"), Skip: true},
+			{Code: "foo(a,\nb\n)", Options: optStr("always-multiline"), Skip: true},
+			{Code: "function foo(a,\nb) {}", Options: optStr("only-multiline")},
+			{Code: "foo(a,\nb)", Options: optStr("only-multiline")},
+
+			// ---- functions (ES8 trailing comma allowed) ----
+			{Code: `function foo(a) {}`, Options: optStr("never")},
+			{Code: `foo(a)`, Options: optStr("never")},
+			{Code: `function foo(a,) {}`, Options: optStr("always")},
+			{Code: `foo(a,)`, Options: optStr("always")},
+			{Code: "function foo(\na,\nb,\n) {}", Options: optStr("always-multiline")},
+			{Code: "foo(\na,b)", Options: optStr("always-multiline")},
+			{Code: `function foo(a,b) {}`, Options: optStr("always-multiline")},
+			{Code: `foo(a,b)`, Options: optStr("always-multiline")},
+			{Code: `function foo(a,b) {}`, Options: optStr("only-multiline")},
+			{Code: `foo(a,b)`, Options: optStr("only-multiline")},
+
+			// ---- functions slot in object form ----
+			{Code: `function foo(a) {} `, Options: optMap(map[string]any{})},
+			{Code: `foo(a)`, Options: optMap(map[string]any{})},
+			{Code: `function foo(a) {} `, Options: optMap(map[string]any{"functions": "never"})},
+			{Code: `foo(a)`, Options: optMap(map[string]any{"functions": "never"})},
+			{Code: `function foo(a,) {}`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `function bar(a, ...b) {}`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `foo(a,)`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `foo(a,)`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `bar(...a,)`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `function foo(a) {} `, Options: optMap(map[string]any{"functions": "always-multiline"})},
+			{Code: `foo(a)`, Options: optMap(map[string]any{"functions": "always-multiline"})},
+			{Code: "function foo(\na,\nb,\n) {} ", Options: optMap(map[string]any{"functions": "always-multiline"})},
+			{Code: "function foo(\na,\n...b\n) {} ", Options: optMap(map[string]any{"functions": "always-multiline"})},
+			{Code: "foo(\na,\nb,\n)", Options: optMap(map[string]any{"functions": "always-multiline"})},
+			{Code: "foo(\na,\n...b,\n)", Options: optMap(map[string]any{"functions": "always-multiline"})},
+			{Code: `function foo(a) {} `, Options: optMap(map[string]any{"functions": "only-multiline"})},
+			{Code: `foo(a)`, Options: optMap(map[string]any{"functions": "only-multiline"})},
+			{Code: "function foo(\na,\nb,\n) {} ", Options: optMap(map[string]any{"functions": "only-multiline"})},
+			{Code: "foo(\na,\nb,\n)", Options: optMap(map[string]any{"functions": "only-multiline"})},
+			{Code: "function foo(\na,\nb\n) {} ", Options: optMap(map[string]any{"functions": "only-multiline"})},
+			{Code: "foo(\na,\nb\n)", Options: optMap(map[string]any{"functions": "only-multiline"})},
+
+			// ---- arrow function single arg without parens (upstream issue #158) ----
+			{Code: `a => 42;`, Options: optStr("always")},
+
+			// ---- dynamic import ----
+			{Code: `import(source)`},
+			{Code: `import(source, )`, Options: optStr("always")},
+			{Code: `import(source, options, )`, Options: optStr("always")},
+			// SKIP: ecmaVersion 15 means dynamicImports→'ignore' upstream; rslint enforces.
+			{Code: `import(source)`, Options: optStr("always"), Skip: true},
+			{Code: `import(source,)`, Options: optStr("always")},
+			{Code: `import(source)`, Options: optStr("never")},
+			{Code: `import(source, options)`, Options: optStr("never")},
+			{Code: `import(source)`, Options: optStr("always-multiline")},
+			{Code: `import(source, options)`, Options: optStr("always-multiline")},
+			{Code: "import(\n  source,\n)", Options: optStr("always-multiline")},
+			{Code: "import(\n  source,\n  options,\n)", Options: optStr("always-multiline")},
+			{Code: `import(source)`, Options: optStr("only-multiline")},
+			{Code: `import(source, options)`, Options: optStr("only-multiline")},
+			{Code: "import(\n  source,\n)", Options: optStr("only-multiline")},
+			{Code: "import(\n  source\n)", Options: optStr("only-multiline")},
+			{Code: "import(\n  source,\n  options,\n)", Options: optStr("only-multiline")},
+			{Code: "import(\n  source,\n  options\n)", Options: optStr("only-multiline")},
+			{Code: `import(source)`, Options: optMap(map[string]any{"functions": "always"})},
+			{Code: `import(source,)`, Options: optMap(map[string]any{"functions": "never", "dynamicImports": "always"})},
+
+			// ---- import attributes ----
+			{Code: `import foo from "foo" with {type: "json"}`},
+			{Code: `import foo from "foo" with {type: "json",}`, Options: optStr("always")},
+			{Code: `import foo from "foo" with {type: "json"}`, Options: optStr("never")},
+			{Code: `import foo from "foo" with {type: "json"}`, Options: optStr("always-multiline")},
+			{Code: "import foo from \"foo\" with {\n  type: \"json\",\n}", Options: optStr("always-multiline")},
+			{Code: `import foo from "foo" with {type: "json"}`, Options: optStr("only-multiline")},
+			{Code: `import foo from "foo" with {type: "json",}`, Options: optMap(map[string]any{"functions": "never", "importAttributes": "always"})},
+			{Code: `export {foo} from "foo" with {type: "json"}`},
+			{Code: `export {foo,} from "foo" with {type: "json",}`, Options: optStr("always")},
+			{Code: `export {foo} from "foo" with {type: "json"}`, Options: optStr("never")},
+			{Code: `export {foo} from "foo" with {type: "json"}`, Options: optStr("always-multiline")},
+			{Code: "export {foo} from \"foo\" with {\n  type: \"json\",\n}", Options: optStr("always-multiline")},
+			{Code: `export {foo} from "foo" with {type: "json"}`, Options: optStr("only-multiline")},
+			{Code: `export {foo} from "foo" with {type: "json",}`, Options: optMap(map[string]any{"functions": "never", "importAttributes": "always"})},
+			{Code: `export * from "foo" with {type: "json"}`},
+			{Code: `export * from "foo" with {type: "json",}`, Options: optStr("always")},
+			{Code: `export * from "foo" with {type: "json"}`, Options: optStr("never")},
+			{Code: `export * from "foo" with {type: "json"}`, Options: optStr("always-multiline")},
+			{Code: "export * from \"foo\" with {\n  type: \"json\",\n}", Options: optStr("always-multiline")},
+			{Code: `export * from "foo" with {type: "json"}`, Options: optStr("only-multiline")},
+			{Code: `export * from "foo" with {type: "json",}`, Options: optMap(map[string]any{"functions": "never", "importAttributes": "always"})},
+
+			// ---- TS default ----
+			{Code: `enum Foo {}`},
+			{Code: "enum Foo {\n}"},
+			{Code: `enum Foo {Bar}`},
+			{Code: `function Foo<T>() {}`},
+			{Code: `type Foo = []`},
+			{Code: "type Foo = [\n]"},
+
+			// ---- TS never ----
+			{Code: `enum Foo {Bar}`, Options: optStr("never")},
+			{Code: "enum Foo {Bar\n}", Options: optStr("never")},
+			{Code: "enum Foo {Bar\n}", Options: optMap(map[string]any{"enums": "never"})},
+			{Code: `function Foo<T>() {}`, Options: optStr("never")},
+			{Code: "function Foo<T\n>() {}", Options: optStr("never")},
+			{Code: "function Foo<T\n>() {}", Options: optMap(map[string]any{"generics": "never"})},
+			{Code: `type Foo = [string]`, Options: optStr("never")},
+			{Code: `type Foo = [string]`, Options: optMap(map[string]any{"tuples": "never"})},
+
+			// ---- TS always ----
+			{Code: `enum Foo {Bar,}`, Options: optStr("always")},
+			{Code: "enum Foo {Bar,\n}", Options: optStr("always")},
+			{Code: "enum Foo {Bar,\n}", Options: optMap(map[string]any{"enums": "always"})},
+			{Code: `function Foo<T,>() {}`, Options: optStr("always")},
+			{Code: "function Foo<T,\n>() {}", Options: optStr("always")},
+			{Code: "function Foo<T,\n>() {}", Options: optMap(map[string]any{"generics": "always"})},
+			{Code: `type Foo = [string,]`, Options: optStr("always")},
+			{Code: "type Foo = [string,\n]", Options: optMap(map[string]any{"tuples": "always"})},
+
+			// ---- TS always-multiline ----
+			{Code: `enum Foo {Bar}`, Options: optStr("always-multiline")},
+			{Code: "enum Foo {Bar,\n}", Options: optStr("always-multiline")},
+			{Code: "enum Foo {Bar,\n}", Options: optMap(map[string]any{"enums": "always-multiline"})},
+			{Code: `function Foo<T>() {}`, Options: optStr("always-multiline")},
+			{Code: "function Foo<T,\n>() {}", Options: optStr("always-multiline")},
+			{Code: "function Foo<T,\n>() {}", Options: optMap(map[string]any{"generics": "always-multiline"})},
+			{Code: `type Foo = [string]`, Options: optStr("always-multiline")},
+			{Code: "type Foo = [string,\n]", Options: optStr("always-multiline")},
+			{Code: "type Foo = [string,\n]", Options: optMap(map[string]any{"tuples": "always-multiline"})},
+
+			// ---- TS only-multiline ----
+			{Code: `enum Foo {Bar}`, Options: optStr("only-multiline")},
+			{Code: "enum Foo {Bar\n}", Options: optStr("only-multiline")},
+			{Code: "enum Foo {Bar,\n}", Options: optStr("only-multiline")},
+			{Code: "enum Foo {Bar,\n}", Options: optMap(map[string]any{"enums": "only-multiline"})},
+			{Code: `function Foo<T>() {}`, Options: optStr("only-multiline")},
+			{Code: "function Foo<T\n>() {}", Options: optStr("only-multiline")},
+			{Code: "function Foo<T,\n>() {}", Options: optStr("only-multiline")},
+			{Code: "function Foo<T\n>() {}", Options: optMap(map[string]any{"generics": "only-multiline"})},
+			{Code: "function Foo<T,\n>() {}", Options: optMap(map[string]any{"generics": "only-multiline"})},
+			{Code: "type Foo = [string\n]", Options: optMap(map[string]any{"tuples": "only-multiline"})},
+			{Code: "type Foo = [string,\n]", Options: optMap(map[string]any{"tuples": "only-multiline"})},
+
+			// ---- TS ignore ----
+			{Code: `const a = <TYPE,>() => {}`, Options: optMap(map[string]any{"generics": "ignore"}), Tsx: true},
+
+			// ---- TS each option independent ----
+			{
+				Code: "const Obj = { a: 1 };\nenum Foo {Bar}\nfunction Baz<T,>() {}\ntype Qux = [string,\n]",
+				Options: optMap(map[string]any{
+					"enums":    "never",
+					"generics": "always",
+					"tuples":   "always-multiline",
+				}),
+			},
+
+			// ---- TSX <T,> disambiguation (upstream eslint-stylistic#35) ----
+			{Code: `const id = <T,>(x: T) => x;`, Tsx: true},
+			{Code: `const id = <T,R>(x: T) => x;`, Tsx: true},
+
+			// ---- Babel/Flow type-annotation cases (upstream's `if (!skipBabel)`
+			// loop block, /tmp/comma-dangle-js-test.ts L2202-2228). Migrated
+			// here because the type annotations (`{a: string,}`, `: {b: boolean}`)
+			// parse the same way under tsgo. The rule's listeners don't visit
+			// TS TypeLiteral, so the trailing comma inside the type annotation
+			// is never inspected — exactly upstream's behavior. ----
+			{Code: `function foo({a}: {a: string,}) {}`, Options: optStr("never")},
+			// SKIP: ecmaVersion=5 ignores functions slot upstream; rslint enforces.
+			{Code: `function foo({a,}: {a: string}) {}`, Options: optStr("always"), Skip: true},
+			{Code: `function foo(a): {b: boolean,} {}`, Options: optMap(map[string]any{"functions": "never"})},
+			{Code: `function foo(a,): {b: boolean} {}`, Options: optMap(map[string]any{"functions": "always"})},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- default (never) — objects ----
+			{
+				Code:   `var foo = { bar: 'baz', }`,
+				Output: []string{`var foo = { bar: 'baz' }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23, EndColumn: 24},
+				},
+			},
+			{
+				Code:   "var foo = {\nbar: 'baz',\n}",
+				Output: []string{"var foo = {\nbar: 'baz'\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 11, EndColumn: 12},
+				},
+			},
+			{
+				Code:   `foo({ bar: 'baz', qux: 'quux', });`,
+				Output: []string{`foo({ bar: 'baz', qux: 'quux' });`},
+				Errors: errUnexpected(1, 30),
+			},
+			{
+				Code:   "foo({\nbar: 'baz',\nqux: 'quux',\n});",
+				Output: []string{"foo({\nbar: 'baz',\nqux: 'quux'\n});"},
+				Errors: errUnexpected(3, 12),
+			},
+			{
+				Code:   `var foo = [ 'baz', ]`,
+				Output: []string{`var foo = [ 'baz' ]`},
+				Errors: errUnexpected(1, 18),
+			},
+			{
+				Code:   "var foo = [ 'baz',\n]",
+				Output: []string{"var foo = [ 'baz'\n]"},
+				Errors: errUnexpected(1, 18),
+			},
+			{
+				Code:   "var foo = { bar: 'bar'\n\n, }",
+				Output: []string{"var foo = { bar: 'bar'\n\n }"},
+				Errors: errUnexpected(3, 1),
+			},
+
+			// ---- never (explicit) ----
+			{Code: `var foo = { bar: 'baz', }`, Output: []string{`var foo = { bar: 'baz' }`}, Options: optStr("never"), Errors: errUnexpected(1, 23)},
+			{Code: `var foo = { bar: 'baz', }`, Output: []string{`var foo = { bar: 'baz' }`}, Options: optStr("only-multiline"), Errors: errUnexpected(1, 23)},
+			{Code: "var foo = {\nbar: 'baz',\n}", Output: []string{"var foo = {\nbar: 'baz'\n}"}, Options: optStr("never"), Errors: errUnexpected(2, 11)},
+			{Code: `foo({ bar: 'baz', qux: 'quux', });`, Output: []string{`foo({ bar: 'baz', qux: 'quux' });`}, Options: optStr("never"), Errors: errUnexpected(1, 30)},
+			{Code: `foo({ bar: 'baz', qux: 'quux', });`, Output: []string{`foo({ bar: 'baz', qux: 'quux' });`}, Options: optStr("only-multiline"), Errors: errUnexpected(1, 30)},
+
+			// ---- always: missing ----
+			{
+				Code:   `var foo = { bar: 'baz' }`,
+				Output: []string{`var foo = { bar: 'baz', }`},
+				Options: optStr("always"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code:   "var foo = {\nbar: 'baz'\n}",
+				Output: []string{"var foo = {\nbar: 'baz',\n}"},
+				Options: optStr("always"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 11, EndLine: 3, EndColumn: 1},
+				},
+			},
+			{
+				Code:   "var foo = {\nbar: 'baz'\r\n}",
+				Output: []string{"var foo = {\nbar: 'baz',\r\n}"},
+				Options: optStr("always"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 11, EndLine: 3, EndColumn: 1},
+				},
+			},
+			// SKIP: upstream test uses ecmaVersion=5 so the outer `foo(...)` call
+			// drops to functions='ignore' and only the inner object is reported.
+			// rslint always uses 'latest', so the outer call is checked too and
+			// receives a trailing comma — yielding `foo({...},)` instead of
+			// `foo({...})`. Lock-in cases for this `'always'`-on-call shape live
+			// in comma_dangle_extras_test.go.
+			{
+				Code:    `foo({ bar: 'baz', qux: 'quux' });`,
+				Output:  []string{`foo({ bar: 'baz', qux: 'quux', });`},
+				Options: optStr("always"),
+				Skip:    true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 30, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code:    "foo({\nbar: 'baz',\nqux: 'quux'\n});",
+				Output:  []string{"foo({\nbar: 'baz',\nqux: 'quux',\n});"},
+				Options: optStr("always"),
+				Skip:    true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 3, Column: 12, EndLine: 4, EndColumn: 1},
+				},
+			},
+			{
+				Code:   `var foo = [ 'baz' ]`,
+				Output: []string{`var foo = [ 'baz', ]`},
+				Options: optStr("always"),
+				Errors: errMissing(1, 18),
+			},
+			{
+				Code:   `var foo = ['baz']`,
+				Output: []string{`var foo = ['baz',]`},
+				Options: optStr("always"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 17, EndColumn: 18},
+				},
+			},
+			{
+				Code:   "var foo = [ 'baz'\n]",
+				Output: []string{"var foo = [ 'baz',\n]"},
+				Options: optStr("always"),
+				Errors: errMissing(1, 18),
+			},
+			{
+				Code:   "var foo = { bar:\n\n'bar' }",
+				Output: []string{"var foo = { bar:\n\n'bar', }"},
+				Options: optStr("always"),
+				Errors: errMissing(3, 6),
+			},
+
+			// ---- always-multiline ----
+			{
+				Code:   "var foo = {\nbar: 'baz'\n}",
+				Output: []string{"var foo = {\nbar: 'baz',\n}"},
+				Options: optStr("always-multiline"),
+				Errors: errMissing(2, 11),
+			},
+			{
+				Code:    "var foo = [\n  bar,\n  (\n    baz\n  )\n];",
+				Output:  []string{"var foo = [\n  bar,\n  (\n    baz\n  ),\n];"},
+				Options: optStr("always"),
+				Errors:  errMissing(5, 4),
+			},
+			{
+				Code:    "var foo = {\n  foo: 'bar',\n  baz: (\n    qux\n  )\n};",
+				Output:  []string{"var foo = {\n  foo: 'bar',\n  baz: (\n    qux\n  ),\n};"},
+				Options: optStr("always"),
+				Errors:  errMissing(5, 4),
+			},
+			{
+				// upstream issue #7291 — conditional inside parens
+				Code:    "var foo = [\n  (bar\n    ? baz\n    : qux\n  )\n];",
+				Output:  []string{"var foo = [\n  (bar\n    ? baz\n    : qux\n  ),\n];"},
+				Options: optStr("always"),
+				Errors:  errMissing(5, 4),
+			},
+			{Code: `var foo = { bar: 'baz', }`, Output: []string{`var foo = { bar: 'baz' }`}, Options: optStr("always-multiline"), Errors: errUnexpected(1, 23)},
+			{Code: "foo({\nbar: 'baz',\nqux: 'quux'\n});", Output: []string{"foo({\nbar: 'baz',\nqux: 'quux',\n});"}, Options: optStr("always-multiline"), Errors: errMissing(3, 12)},
+			{Code: `foo({ bar: 'baz', qux: 'quux', });`, Output: []string{`foo({ bar: 'baz', qux: 'quux' });`}, Options: optStr("always-multiline"), Errors: errUnexpected(1, 30)},
+			{Code: "var foo = [\n'baz'\n]", Output: []string{"var foo = [\n'baz',\n]"}, Options: optStr("always-multiline"), Errors: errMissing(2, 6)},
+			{Code: `var foo = ['baz',]`, Output: []string{`var foo = ['baz']`}, Options: optStr("always-multiline"), Errors: errUnexpected(1, 17)},
+			{Code: `var foo = ['baz',]`, Output: []string{`var foo = ['baz']`}, Options: optStr("only-multiline"), Errors: errUnexpected(1, 17)},
+			{Code: "var foo = {x: {\nfoo: 'bar',\n},}", Output: []string{"var foo = {x: {\nfoo: 'bar',\n}}"}, Options: optStr("always-multiline"), Errors: errUnexpected(3, 2)},
+			{Code: "var foo = {a: 1, b: 2,\nc: 3, d: 4,}", Output: []string{"var foo = {a: 1, b: 2,\nc: 3, d: 4}"}, Options: optStr("always-multiline"), Errors: errUnexpected(2, 11)},
+			{Code: "var foo = {a: 1, b: 2,\nc: 3, d: 4,}", Output: []string{"var foo = {a: 1, b: 2,\nc: 3, d: 4}"}, Options: optStr("only-multiline"), Errors: errUnexpected(2, 11)},
+			{Code: "var foo = [{\na: 1,\nb: 2,\nc: 3,\nd: 4,\n},]", Output: []string{"var foo = [{\na: 1,\nb: 2,\nc: 3,\nd: 4,\n}]"}, Options: optStr("always-multiline"), Errors: errUnexpected(6, 2)},
+
+			// ---- destructuring ----
+			{Code: `var { a, b, } = foo;`, Output: []string{`var { a, b } = foo;`}, Options: optStr("never"), Errors: errUnexpected(1, 11)},
+			{Code: `var { a, b, } = foo;`, Output: []string{`var { a, b } = foo;`}, Options: optStr("only-multiline"), Errors: errUnexpected(1, 11)},
+			{Code: `var [ a, b, ] = foo;`, Output: []string{`var [ a, b ] = foo;`}, Options: optStr("never"), Errors: errUnexpected(1, 11)},
+			{Code: `var [ a, b, ] = foo;`, Output: []string{`var [ a, b ] = foo;`}, Options: optStr("only-multiline"), Errors: errUnexpected(1, 11)},
+
+			// ---- parenthesized element ----
+			{Code: `[(1),]`, Output: []string{`[(1)]`}, Options: optStr("never"), Errors: errUnexpected(1, 5)},
+			{Code: `[(1),]`, Output: []string{`[(1)]`}, Options: optStr("only-multiline"), Errors: errUnexpected(1, 5)},
+			{Code: `var x = { foo: (1),};`, Output: []string{`var x = { foo: (1)};`}, Options: optStr("never"), Errors: errUnexpected(1, 19)},
+			{Code: `var x = { foo: (1),};`, Output: []string{`var x = { foo: (1)};`}, Options: optStr("only-multiline"), Errors: errUnexpected(1, 19)},
+
+			// ---- import / export (upstream issue #3794) ----
+			{Code: `import {foo} from 'foo';`, Output: []string{`import {foo,} from 'foo';`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 12}}},
+			{Code: `import foo, {abc} from 'foo';`, Output: []string{`import foo, {abc,} from 'foo';`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 17}}},
+			{Code: `export {foo} from 'foo';`, Output: []string{`export {foo,} from 'foo';`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 12}}},
+			{Code: `import {foo,} from 'foo';`, Output: []string{`import {foo} from 'foo';`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 12}}},
+			{Code: `import {foo,} from 'foo';`, Output: []string{`import {foo} from 'foo';`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 12}}},
+			{Code: `import foo, {abc,} from 'foo';`, Output: []string{`import foo, {abc} from 'foo';`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 17}}},
+			{Code: `import foo, {abc,} from 'foo';`, Output: []string{`import foo, {abc} from 'foo';`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 17}}},
+			{Code: `export {foo,} from 'foo';`, Output: []string{`export {foo} from 'foo';`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 12}}},
+			{Code: `export {foo,} from 'foo';`, Output: []string{`export {foo} from 'foo';`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 12}}},
+			{Code: `import {foo,} from 'foo';`, Output: []string{`import {foo} from 'foo';`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 12}}},
+			{Code: `export {foo,} from 'foo';`, Output: []string{`export {foo} from 'foo';`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 12}}},
+			{Code: "import {\n  foo\n} from 'foo';", Output: []string{"import {\n  foo,\n} from 'foo';"}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 2, Column: 6}}},
+			{Code: "export {\n  foo\n} from 'foo';", Output: []string{"export {\n  foo,\n} from 'foo';"}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 2, Column: 6}}},
+
+			// ---- parenthesized last element (upstream issue #6233) ----
+			{Code: `var foo = {a: (1)}`, Output: []string{`var foo = {a: (1),}`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 18}}},
+			{Code: `var foo = [(1)]`, Output: []string{`var foo = [(1),]`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}}},
+			{Code: "var foo = [\n1,\n(2)\n]", Output: []string{"var foo = [\n1,\n(2),\n]"}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 3, Column: 4}}},
+
+			// ---- functions: never (object form) ----
+			{Code: `function foo(a,) {}`, Output: []string{`function foo(a) {}`}, Options: optMap(map[string]any{"functions": "never"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `(function foo(a,) {})`, Output: []string{`(function foo(a) {})`}, Options: optMap(map[string]any{"functions": "never"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}}},
+			{Code: `(a,) => a`, Output: []string{`(a) => a`}, Options: optMap(map[string]any{"functions": "never"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 3}}},
+			{Code: `(a,) => (a)`, Output: []string{`(a) => (a)`}, Options: optMap(map[string]any{"functions": "never"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 3}}},
+			{Code: `({foo(a,) {}})`, Output: []string{`({foo(a) {}})`}, Options: optMap(map[string]any{"functions": "never"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 8}}},
+			{Code: `class A {foo(a,) {}}`, Output: []string{`class A {foo(a) {}}`}, Options: optMap(map[string]any{"functions": "never"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `foo(a,)`, Output: []string{`foo(a)`}, Options: optMap(map[string]any{"functions": "never"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 6}}},
+			{Code: `foo(...a,)`, Output: []string{`foo(...a)`}, Options: optMap(map[string]any{"functions": "never"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 9}}},
+
+			// ---- functions: always (object form) ----
+			{Code: `function foo(a) {}`, Output: []string{`function foo(a,) {}`}, Options: optMap(map[string]any{"functions": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}}},
+			{Code: `(function foo(a) {})`, Output: []string{`(function foo(a,) {})`}, Options: optMap(map[string]any{"functions": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 16}}},
+			{Code: `(a) => a`, Output: []string{`(a,) => a`}, Options: optMap(map[string]any{"functions": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 3}}},
+			{Code: `(a) => (a)`, Output: []string{`(a,) => (a)`}, Options: optMap(map[string]any{"functions": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 3}}},
+			{Code: `({foo(a) {}})`, Output: []string{`({foo(a,) {}})`}, Options: optMap(map[string]any{"functions": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 8}}},
+			{Code: `class A {foo(a) {}}`, Output: []string{`class A {foo(a,) {}}`}, Options: optMap(map[string]any{"functions": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}}},
+			{Code: `foo(a)`, Output: []string{`foo(a,)`}, Options: optMap(map[string]any{"functions": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 6}}},
+			{Code: `foo(...a)`, Output: []string{`foo(...a,)`}, Options: optMap(map[string]any{"functions": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 9}}},
+
+			// ---- functions: always-multiline (object form) ----
+			{Code: `function foo(a,) {}`, Output: []string{`function foo(a) {}`}, Options: optMap(map[string]any{"functions": "always-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `(function foo(a,) {})`, Output: []string{`(function foo(a) {})`}, Options: optMap(map[string]any{"functions": "always-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}}},
+			{Code: `foo(a,)`, Output: []string{`foo(a)`}, Options: optMap(map[string]any{"functions": "always-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 6}}},
+			{Code: `foo(...a,)`, Output: []string{`foo(...a)`}, Options: optMap(map[string]any{"functions": "always-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 9}}},
+			{Code: "function foo(\na,\nb\n) {}", Output: []string{"function foo(\na,\nb,\n) {}"}, Options: optMap(map[string]any{"functions": "always-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 3, Column: 2}}},
+			{Code: "foo(\na,\nb\n)", Output: []string{"foo(\na,\nb,\n)"}, Options: optMap(map[string]any{"functions": "always-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 3, Column: 2}}},
+			{Code: "foo(\n...a,\n...b\n)", Output: []string{"foo(\n...a,\n...b,\n)"}, Options: optMap(map[string]any{"functions": "always-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 3, Column: 5}}},
+
+			// ---- functions: only-multiline (object form) ----
+			{Code: `function foo(a,) {}`, Output: []string{`function foo(a) {}`}, Options: optMap(map[string]any{"functions": "only-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `(function foo(a,) {})`, Output: []string{`(function foo(a) {})`}, Options: optMap(map[string]any{"functions": "only-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}}},
+			{Code: `foo(a,)`, Output: []string{`foo(a)`}, Options: optMap(map[string]any{"functions": "only-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 6}}},
+			{Code: `foo(...a,)`, Output: []string{`foo(...a)`}, Options: optMap(map[string]any{"functions": "only-multiline"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 9}}},
+
+			// ---- functions: never (string form) ----
+			{Code: `function foo(a,) {}`, Output: []string{`function foo(a) {}`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `(function foo(a,) {})`, Output: []string{`(function foo(a) {})`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}}},
+			{Code: `(a,) => a`, Output: []string{`(a) => a`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 3}}},
+			{Code: `(a,) => (a)`, Output: []string{`(a) => (a)`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 3}}},
+			{Code: `({foo(a,) {}})`, Output: []string{`({foo(a) {}})`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 8}}},
+			{Code: `class A {foo(a,) {}}`, Output: []string{`class A {foo(a) {}}`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `foo(a,)`, Output: []string{`foo(a)`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 6}}},
+			{Code: `foo(...a,)`, Output: []string{`foo(...a)`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 9}}},
+
+			// ---- functions: always (string form) ----
+			{Code: `function foo(a) {}`, Output: []string{`function foo(a,) {}`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}}},
+			{Code: `(function foo(a) {})`, Output: []string{`(function foo(a,) {})`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 16}}},
+			{Code: `(a) => a`, Output: []string{`(a,) => a`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 3}}},
+			{Code: `(a) => (a)`, Output: []string{`(a,) => (a)`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 3}}},
+			// Note: `'always'` with `({foo(a) {}})` emits TWO missing diagnostics — one
+			// for the outer object's properties and one for the inner method's params.
+			// rslint reports them in listener-fire order (outer parent first, then
+			// inner child), so the order is [col 12, col 8] rather than source order
+			// [col 8, col 12]. Upstream doesn't assert position for this case.
+			{
+				Code:    `({foo(a) {}})`,
+				Output:  []string{`({foo(a,) {},})`},
+				Options: optStr("always"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 12},
+					{MessageId: "missing", Line: 1, Column: 8},
+				},
+			},
+			{Code: `class A {foo(a) {}}`, Output: []string{`class A {foo(a,) {}}`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}}},
+			{Code: `foo(a)`, Output: []string{`foo(a,)`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 6}}},
+			{Code: `foo(...a)`, Output: []string{`foo(...a,)`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 9}}},
+
+			// ---- functions: always-multiline (string form) ----
+			{Code: `function foo(a,) {}`, Output: []string{`function foo(a) {}`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `(function foo(a,) {})`, Output: []string{`(function foo(a) {})`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}}},
+			{Code: `foo(a,)`, Output: []string{`foo(a)`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 6}}},
+			{Code: `foo(...a,)`, Output: []string{`foo(...a)`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 9}}},
+			{Code: "function foo(\na,\nb\n) {}", Output: []string{"function foo(\na,\nb,\n) {}"}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 3, Column: 2}}},
+			{Code: "foo(\na,\nb\n)", Output: []string{"foo(\na,\nb,\n)"}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 3, Column: 2}}},
+			{Code: "foo(\n...a,\n...b\n)", Output: []string{"foo(\n...a,\n...b,\n)"}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 3, Column: 5}}},
+
+			// ---- functions: only-multiline (string form) ----
+			{Code: `function foo(a,) {}`, Output: []string{`function foo(a) {}`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `(function foo(a,) {})`, Output: []string{`(function foo(a) {})`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}}},
+			{Code: `foo(a,)`, Output: []string{`foo(a)`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 6}}},
+			{Code: `foo(...a,)`, Output: []string{`foo(...a)`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 9}}},
+			{Code: `function foo(a) {}`, Output: []string{`function foo(a,) {}`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}}},
+
+			// ---- separated options (per-slot interaction) ----
+			{
+				Code: "let {a,} = {a: 1,};\nlet [b,] = [1,];\nimport {c,} from \"foo\";\nlet d = 0;export {d,};\n(function foo(e,) {})(f,);",
+				Output: []string{
+					"let {a} = {a: 1};\nlet [b,] = [1,];\nimport {c,} from \"foo\";\nlet d = 0;export {d,};\n(function foo(e,) {})(f,);",
+				},
+				Options: optMap(map[string]any{
+					"objects":   "never",
+					"arrays":    "ignore",
+					"imports":   "ignore",
+					"exports":   "ignore",
+					"functions": "ignore",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1},
+					{MessageId: "unexpected", Line: 1},
+				},
+			},
+			{
+				Code: "let {a,} = {a: 1,};\nlet [b,] = [1,];\nimport {c,} from \"foo\";\nlet d = 0;export {d,};\n(function foo(e,) {})(f,);",
+				Output: []string{
+					"let {a,} = {a: 1,};\nlet [b] = [1];\nimport {c,} from \"foo\";\nlet d = 0;export {d,};\n(function foo(e,) {})(f,);",
+				},
+				Options: optMap(map[string]any{
+					"objects":   "ignore",
+					"arrays":    "never",
+					"imports":   "ignore",
+					"exports":   "ignore",
+					"functions": "ignore",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2},
+					{MessageId: "unexpected", Line: 2},
+				},
+			},
+			{
+				Code: "let {a,} = {a: 1,};\nlet [b,] = [1,];\nimport {c,} from \"foo\";\nlet d = 0;export {d,};\n(function foo(e,) {})(f,);",
+				Output: []string{
+					"let {a,} = {a: 1,};\nlet [b,] = [1,];\nimport {c} from \"foo\";\nlet d = 0;export {d,};\n(function foo(e,) {})(f,);",
+				},
+				Options: optMap(map[string]any{
+					"objects":   "ignore",
+					"arrays":    "ignore",
+					"imports":   "never",
+					"exports":   "ignore",
+					"functions": "ignore",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 3},
+				},
+			},
+			{
+				Code: "let {a,} = {a: 1,};\nlet [b,] = [1,];\nimport {c,} from \"foo\";\nlet d = 0;export {d,};\n(function foo(e,) {})(f,);",
+				Output: []string{
+					"let {a,} = {a: 1,};\nlet [b,] = [1,];\nimport {c,} from \"foo\";\nlet d = 0;export {d};\n(function foo(e,) {})(f,);",
+				},
+				Options: optMap(map[string]any{
+					"objects":   "ignore",
+					"arrays":    "ignore",
+					"imports":   "ignore",
+					"exports":   "never",
+					"functions": "ignore",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 4},
+				},
+			},
+			{
+				Code: "let {a,} = {a: 1,};\nlet [b,] = [1,];\nimport {c,} from \"foo\";\nlet d = 0;export {d,};\n(function foo(e,) {})(f,);",
+				Output: []string{
+					"let {a,} = {a: 1,};\nlet [b,] = [1,];\nimport {c,} from \"foo\";\nlet d = 0;export {d,};\n(function foo(e) {})(f);",
+				},
+				Options: optMap(map[string]any{
+					"objects":   "ignore",
+					"arrays":    "ignore",
+					"imports":   "ignore",
+					"exports":   "ignore",
+					"functions": "never",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 5},
+					{MessageId: "unexpected", Line: 5},
+				},
+			},
+
+			// ---- default with trailing-comma call (upstream issue #11502) ----
+			{
+				Code:   `foo(a,)`,
+				Output: []string{`foo(a)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 6}},
+			},
+
+			// ---- upstream issue #15660 — multi-line import with trailing-comma toggle ----
+			{
+				Code: "/*eslint add-named-import:1*/\nimport {\n    StyleSheet,\n    View,\n    TextInput,\n    ImageBackground,\n    Image,\n    TouchableOpacity,\n    SafeAreaView\n} from 'react-native';",
+				Output: []string{
+					"/*eslint add-named-import:1*/\nimport {\n    StyleSheet,\n    View,\n    TextInput,\n    ImageBackground,\n    Image,\n    TouchableOpacity,\n    SafeAreaView,\n} from 'react-native';",
+				},
+				Options: optMap(map[string]any{"imports": "always-multiline"}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 9, Column: 17},
+				},
+			},
+			{
+				Code: "/*eslint add-named-import:1*/\nimport {\n    StyleSheet,\n    View,\n    TextInput,\n    ImageBackground,\n    Image,\n    TouchableOpacity,\n    SafeAreaView,\n} from 'react-native';",
+				Output: []string{
+					"/*eslint add-named-import:1*/\nimport {\n    StyleSheet,\n    View,\n    TextInput,\n    ImageBackground,\n    Image,\n    TouchableOpacity,\n    SafeAreaView\n} from 'react-native';",
+				},
+				Options: optMap(map[string]any{"imports": "never"}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 9, Column: 17},
+				},
+			},
+
+			// ---- dynamic import ----
+			{
+				Code:   `import(source,)`,
+				Output: []string{`import(source)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}},
+			},
+			{
+				Code:    `import(source)`,
+				Output:  []string{`import(source,)`},
+				Options: optStr("always"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 14}},
+			},
+			{
+				Code:    `import(source, options)`,
+				Output:  []string{`import(source, options,)`},
+				Options: optStr("always"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 23}},
+			},
+			{
+				Code:    `import(source,)`,
+				Output:  []string{`import(source)`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}},
+			},
+			{
+				Code:    `import(source, options,)`,
+				Output:  []string{`import(source, options)`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 23}},
+			},
+			{
+				Code:    `import(source,)`,
+				Output:  []string{`import(source)`},
+				Options: optStr("always-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}},
+			},
+			{
+				Code:    `import(source, options,)`,
+				Output:  []string{`import(source, options)`},
+				Options: optStr("always-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 23}},
+			},
+			{
+				Code:    "import(\n  source\n)",
+				Output:  []string{"import(\n  source,\n)"},
+				Options: optStr("always-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 2, Column: 9}},
+			},
+			{
+				Code:    "import(\n  source,\n  options\n)",
+				Output:  []string{"import(\n  source,\n  options,\n)"},
+				Options: optStr("always-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 3, Column: 10}},
+			},
+			{
+				Code:    `import(source,)`,
+				Output:  []string{`import(source)`},
+				Options: optStr("only-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}},
+			},
+			{
+				Code:    `import(source, options,)`,
+				Output:  []string{`import(source, options)`},
+				Options: optStr("only-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 23}},
+			},
+			{
+				Code:    `import(source)`,
+				Output:  []string{`import(source,)`},
+				Options: optMap(map[string]any{"functions": "never", "dynamicImports": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 14}},
+			},
+
+			// ---- import attributes (invalid) ----
+			{Code: `import foo from "foo" with {type: "json",}`, Output: []string{`import foo from "foo" with {type: "json"}`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 41}}},
+			{Code: `import foo from "foo" with {type: "json"}`, Output: []string{`import foo from "foo" with {type: "json",}`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 41}}},
+			{Code: `import foo from "foo" with {type: "json",}`, Output: []string{`import foo from "foo" with {type: "json"}`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 41}}},
+			{Code: `import foo from "foo" with {type: "json",}`, Output: []string{`import foo from "foo" with {type: "json"}`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 41}}},
+			{
+				Code:    "import foo from \"foo\" with {\n  type: \"json\"\n}",
+				Output:  []string{"import foo from \"foo\" with {\n  type: \"json\",\n}"},
+				Options: optStr("always-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 2, Column: 15}},
+			},
+			{Code: `import foo from "foo" with {type: "json",}`, Output: []string{`import foo from "foo" with {type: "json"}`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 41}}},
+			{Code: `import foo from "foo" with {type: "json"}`, Output: []string{`import foo from "foo" with {type: "json",}`}, Options: optMap(map[string]any{"functions": "never", "importAttributes": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 41}}},
+			{Code: `export {foo} from "foo" with {type: "json",}`, Output: []string{`export {foo} from "foo" with {type: "json"}`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 43}}},
+			{
+				Code:    `export {foo} from "foo" with {type: "json"}`,
+				Output:  []string{`export {foo,} from "foo" with {type: "json",}`},
+				Options: optStr("always"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 12},
+					{MessageId: "missing", Line: 1, Column: 43},
+				},
+			},
+			{Code: `export {foo} from "foo" with {type: "json",}`, Output: []string{`export {foo} from "foo" with {type: "json"}`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 43}}},
+			{Code: `export {foo} from "foo" with {type: "json",}`, Output: []string{`export {foo} from "foo" with {type: "json"}`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 43}}},
+			{
+				Code:    "export {foo} from \"foo\" with {\n  type: \"json\"\n}",
+				Output:  []string{"export {foo} from \"foo\" with {\n  type: \"json\",\n}"},
+				Options: optStr("always-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 2, Column: 15}},
+			},
+			{Code: `export {foo} from "foo" with {type: "json",}`, Output: []string{`export {foo} from "foo" with {type: "json"}`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 43}}},
+			{Code: `export {foo} from "foo" with {type: "json"}`, Output: []string{`export {foo} from "foo" with {type: "json",}`}, Options: optMap(map[string]any{"functions": "never", "importAttributes": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 43}}},
+			{Code: `export * from "foo" with {type: "json",}`, Output: []string{`export * from "foo" with {type: "json"}`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 39}}},
+			{Code: `export * from "foo" with {type: "json"}`, Output: []string{`export * from "foo" with {type: "json",}`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 39}}},
+			{Code: `export * from "foo" with {type: "json",}`, Output: []string{`export * from "foo" with {type: "json"}`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 39}}},
+			{Code: `export * from "foo" with {type: "json",}`, Output: []string{`export * from "foo" with {type: "json"}`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 39}}},
+			{
+				Code:    "export * from \"foo\" with {\n  type: \"json\"\n}",
+				Output:  []string{"export * from \"foo\" with {\n  type: \"json\",\n}"},
+				Options: optStr("always-multiline"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 2, Column: 15}},
+			},
+			{Code: `export * from "foo" with {type: "json",}`, Output: []string{`export * from "foo" with {type: "json"}`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 39}}},
+			{Code: `export * from "foo" with {type: "json"}`, Output: []string{`export * from "foo" with {type: "json",}`}, Options: optMap(map[string]any{"functions": "never", "importAttributes": "always"}), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 39}}},
+
+			// ---- TS default (invalid) ----
+			{Code: `enum Foo {Bar,}`, Output: []string{`enum Foo {Bar}`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}}},
+			{Code: `function Foo<T,>() {}`, Output: []string{`function Foo<T>() {}`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `type Foo = [string,]`, Output: []string{`type Foo = [string]`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 19}}},
+
+			// ---- TS never (invalid) ----
+			{Code: `enum Foo {Bar,}`, Output: []string{`enum Foo {Bar}`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}}},
+			{Code: "enum Foo {Bar,\n}", Output: []string{"enum Foo {Bar\n}"}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}}},
+			{Code: `function Foo<T,>() {}`, Output: []string{`function Foo<T>() {}`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: "function Foo<T,\n>() {}", Output: []string{"function Foo<T\n>() {}"}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `type Foo = [string,]`, Output: []string{`type Foo = [string]`}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 19}}},
+			{Code: "type Foo = [string,\n]", Output: []string{"type Foo = [string\n]"}, Options: optStr("never"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 19}}},
+
+			// ---- TS always (invalid) ----
+			{Code: `enum Foo {Bar}`, Output: []string{`enum Foo {Bar,}`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 14}}},
+			{Code: "enum Foo {Bar\n}", Output: []string{"enum Foo {Bar,\n}"}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 14}}},
+			{Code: `function Foo<T>() {}`, Output: []string{`function Foo<T,>() {}`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}}},
+			{Code: "function Foo<T\n>() {}", Output: []string{"function Foo<T,\n>() {}"}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}}},
+			{Code: `type Foo = [string]`, Output: []string{`type Foo = [string,]`}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 19}}},
+			{Code: "type Foo = [string\n]", Output: []string{"type Foo = [string,\n]"}, Options: optStr("always"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 19}}},
+
+			// ---- TS always-multiline (invalid) ----
+			{Code: `enum Foo {Bar,}`, Output: []string{`enum Foo {Bar}`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}}},
+			{Code: "enum Foo {Bar\n}", Output: []string{"enum Foo {Bar,\n}"}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 14}}},
+			{Code: `function Foo<T,>() {}`, Output: []string{`function Foo<T>() {}`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: "function Foo<T\n>() {}", Output: []string{"function Foo<T,\n>() {}"}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}}},
+			{Code: `type Foo = [string,]`, Output: []string{`type Foo = [string]`}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 19}}},
+			{Code: "type Foo = [string\n]", Output: []string{"type Foo = [string,\n]"}, Options: optStr("always-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 19}}},
+
+			// ---- TS only-multiline (invalid) ----
+			{Code: `enum Foo {Bar,}`, Output: []string{`enum Foo {Bar}`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 14}}},
+			{Code: `function Foo<T,>() {}`, Output: []string{`function Foo<T>() {}`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}}},
+			{Code: `type Foo = [string,]`, Output: []string{`type Foo = [string]`}, Options: optStr("only-multiline"), Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 19}}},
+
+			// ---- TSX multi-generic (eslint-stylistic#35) ----
+			{
+				Code:   `const id = <T,R,>(x: T) => x;`,
+				Output: []string{`const id = <T,R>(x: T) => x;`},
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}},
+			},
+
+			// ---- TS declare function / TSFunctionType ----
+			{
+				Code:   `declare function foo(a: number, b: number,): void`,
+				Output: []string{`declare function foo(a: number, b: number): void`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 42}},
+			},
+			{
+				Code:   `type Foo = (a: number, b: number,) => void`,
+				Output: []string{`type Foo = (a: number, b: number) => void`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 33}},
+			},
+
+			// ---- TS type-argument instantiation (predicate.never) ----
+			{
+				Code:   `type Foo<T> = Bar<T,>`,
+				Output: []string{`type Foo<T> = Bar<T>`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 20}},
+			},
+
+			// ---- Babel/Flow type-annotation cases (upstream invalid section
+			// in the `if (!skipBabel)` loop, /tmp/comma-dangle-js-test.ts
+			// L2229-2262). ----
+			// SKIP: upstream uses ecmaVersion=5 to make `functions` slot 'ignore',
+			// so only the inner ObjectBindingPattern `{a}` is reported. rslint
+			// uses 'latest' and would additionally report the outer Parameters
+			// list, mismatching the expected single-error count.
+			{
+				Code:    `function foo({a}: {a: string,}) {}`,
+				Output:  []string{`function foo({a,}: {a: string,}) {}`},
+				Options: optStr("always"),
+				Skip:    true,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 16}},
+			},
+			{
+				Code:    `function foo({a,}: {a: string}) {}`,
+				Output:  []string{`function foo({a}: {a: string}) {}`},
+				Options: optStr("never"),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 16}},
+			},
+			{
+				Code:    `function foo(a): {b: boolean,} {}`,
+				Output:  []string{`function foo(a,): {b: boolean,} {}`},
+				Options: optMap(map[string]any{"functions": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missing", Line: 1, Column: 15}},
+			},
+			{
+				Code:    `function foo(a,): {b: boolean} {}`,
+				Output:  []string{`function foo(a): {b: boolean} {}`},
+				Options: optMap(map[string]any{"functions": "never"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpected", Line: 1, Column: 15}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -450,6 +450,7 @@ export default defineConfig({
     './tests/eslint-plugin-promise/rules/param-names.test.ts',
 
     // eslint-plugin-stylistic
+    './tests/eslint-plugin-stylistic/rules/comma-dangle.test.ts',
     './tests/eslint-plugin-stylistic/rules/array-bracket-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/arrow-parens.test.ts',
     './tests/eslint-plugin-stylistic/rules/arrow-spacing.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/comma-dangle.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/comma-dangle.test.ts
@@ -1,0 +1,306 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('comma-dangle', null as never, {
+  valid: [
+    // default (never)
+    { code: "var foo = { bar: 'baz' }" },
+    { code: "var foo = {\nbar: 'baz'\n}" },
+    { code: "var foo = [ 'baz' ]" },
+    { code: "var foo = [\n'baz'\n]" },
+    { code: '[,,]' },
+    { code: '[\n,\n,\n]' },
+    { code: '[,]' },
+    { code: '[\n,\n]' },
+    { code: '[]' },
+    { code: '[\n]' },
+    {
+      code: 'var foo = [\n      (bar ? baz : qux),\n    ];',
+      options: ['always-multiline'],
+    },
+
+    // never
+    { code: "var foo = { bar: 'baz' }", options: ['never'] },
+    { code: "var foo = {\nbar: 'baz'\n}", options: ['never'] },
+    { code: "var foo = [ 'baz' ]", options: ['never'] },
+    { code: 'var { a, b } = foo;', options: ['never'] },
+    { code: 'var [ a, b ] = foo;', options: ['never'] },
+    { code: 'var { a,\n b, \n} = foo;', options: ['only-multiline'] },
+    { code: 'var [ a,\n b, \n] = foo;', options: ['only-multiline'] },
+
+    // always
+    { code: '[(1),]', options: ['always'] },
+    { code: 'var x = { foo: (1),};', options: ['always'] },
+    { code: "var foo = { bar: 'baz', }", options: ['always'] },
+    { code: "var foo = {\nbar: 'baz',\n}", options: ['always'] },
+    { code: "var foo = {\nbar: 'baz'\n,}", options: ['always'] },
+    { code: "var foo = [ 'baz', ]", options: ['always'] },
+    { code: "var foo = [\n'baz',\n]", options: ['always'] },
+    { code: "var foo = [\n'baz'\n,]", options: ['always'] },
+
+    // always-multiline / only-multiline
+    { code: "var foo = { bar: 'baz' }", options: ['always-multiline'] },
+    { code: "var foo = { bar: 'baz' }", options: ['only-multiline'] },
+    { code: "var foo = {\nbar: 'baz',\n}", options: ['always-multiline'] },
+    { code: "var foo = {\nbar: 'baz',\n}", options: ['only-multiline'] },
+    { code: "var foo = [ 'baz' ]", options: ['always-multiline'] },
+    { code: "var foo = [ 'baz' ]", options: ['only-multiline'] },
+    { code: "var foo = [\n'baz',\n]", options: ['always-multiline'] },
+    { code: "var foo = [\n'baz',\n]", options: ['only-multiline'] },
+
+    // rest binding / spread
+    { code: 'var [a, ...rest] = [];', options: ['always'] },
+    {
+      code: 'var [\n    a,\n    ...rest\n] = [];',
+      options: ['always-multiline'],
+    },
+    { code: '[a, ...rest] = [];', options: ['always'] },
+    { code: 'for ([a, ...rest] of []);', options: ['always'] },
+    { code: 'var a = [b, ...spread,];', options: ['always'] },
+    { code: 'var {foo, ...bar} = baz', options: ['always'] },
+
+    // import / export
+    { code: "import {foo,} from 'foo';", options: ['always'] },
+    { code: "import foo from 'foo';", options: ['always'] },
+    { code: "import foo, {abc,} from 'foo';", options: ['always'] },
+    { code: "import * as foo from 'foo';", options: ['always'] },
+    { code: "export {foo,} from 'foo';", options: ['always'] },
+    { code: "import {foo} from 'foo';", options: ['never'] },
+    { code: "import foo from 'foo';", options: ['never'] },
+    { code: "import foo, {abc} from 'foo';", options: ['never'] },
+    { code: "import * as foo from 'foo';", options: ['never'] },
+    { code: "export {foo} from 'foo';", options: ['never'] },
+
+    // functions (object form)
+    {
+      code: 'function foo(a) {} ',
+      options: [{ functions: 'never' }],
+    },
+    {
+      code: 'function foo(a,) {}',
+      options: [{ functions: 'always' }],
+    },
+    {
+      code: 'foo(a,)',
+      options: [{ functions: 'always' }],
+    },
+    {
+      code: 'function bar(a, ...b) {}',
+      options: [{ functions: 'always' }],
+    },
+
+    // dynamic import
+    { code: 'import(source)' },
+    { code: 'import(source, )', options: ['always'] },
+    { code: 'import(source)', options: ['never'] },
+    { code: 'import(source, options)', options: ['never'] },
+
+    // import attributes
+    { code: 'import foo from "foo" with {type: "json"}' },
+    { code: 'import foo from "foo" with {type: "json",}', options: ['always'] },
+    { code: 'export {foo} from "foo" with {type: "json"}' },
+
+    // TS default
+    { code: 'enum Foo {}' },
+    { code: 'enum Foo {Bar}' },
+    { code: 'function Foo<T>() {}' },
+    { code: 'type Foo = []' },
+
+    // TS never / always
+    { code: 'enum Foo {Bar}', options: ['never'] },
+    { code: 'enum Foo {Bar,}', options: ['always'] },
+    { code: 'function Foo<T>() {}', options: ['never'] },
+    { code: 'function Foo<T,>() {}', options: ['always'] },
+    { code: 'type Foo = [string]', options: ['never'] },
+    { code: 'type Foo = [string,]', options: ['always'] },
+  ],
+  invalid: [
+    // default (never)
+    {
+      code: "var foo = { bar: 'baz', }",
+      output: "var foo = { bar: 'baz' }",
+      errors: [{ messageId: 'unexpected', line: 1, column: 23 }],
+    },
+    {
+      code: "var foo = {\nbar: 'baz',\n}",
+      output: "var foo = {\nbar: 'baz'\n}",
+      errors: [{ messageId: 'unexpected', line: 2, column: 11 }],
+    },
+    {
+      code: "foo({ bar: 'baz', qux: 'quux', });",
+      output: "foo({ bar: 'baz', qux: 'quux' });",
+      errors: [{ messageId: 'unexpected', line: 1, column: 30 }],
+    },
+    {
+      code: "var foo = [ 'baz', ]",
+      output: "var foo = [ 'baz' ]",
+      errors: [{ messageId: 'unexpected', line: 1, column: 18 }],
+    },
+
+    // never (explicit)
+    {
+      code: "var foo = { bar: 'baz', }",
+      output: "var foo = { bar: 'baz' }",
+      options: ['never'],
+      errors: [{ messageId: 'unexpected', line: 1, column: 23 }],
+    },
+
+    // always: missing
+    {
+      code: "var foo = { bar: 'baz' }",
+      output: "var foo = { bar: 'baz', }",
+      options: ['always'],
+      errors: [{ messageId: 'missing', line: 1, column: 23 }],
+    },
+    {
+      code: "var foo = {\nbar: 'baz'\n}",
+      output: "var foo = {\nbar: 'baz',\n}",
+      options: ['always'],
+      errors: [{ messageId: 'missing', line: 2, column: 11 }],
+    },
+    {
+      code: "var foo = [ 'baz' ]",
+      output: "var foo = [ 'baz', ]",
+      options: ['always'],
+      errors: [{ messageId: 'missing', line: 1, column: 18 }],
+    },
+
+    // always-multiline
+    {
+      code: "var foo = {\nbar: 'baz'\n}",
+      output: "var foo = {\nbar: 'baz',\n}",
+      options: ['always-multiline'],
+      errors: [{ messageId: 'missing', line: 2, column: 11 }],
+    },
+    {
+      code: "var foo = { bar: 'baz', }",
+      output: "var foo = { bar: 'baz' }",
+      options: ['always-multiline'],
+      errors: [{ messageId: 'unexpected', line: 1, column: 23 }],
+    },
+
+    // destructuring
+    {
+      code: 'var { a, b, } = foo;',
+      output: 'var { a, b } = foo;',
+      options: ['never'],
+      errors: [{ messageId: 'unexpected', line: 1, column: 11 }],
+    },
+    {
+      code: 'var [ a, b, ] = foo;',
+      output: 'var [ a, b ] = foo;',
+      options: ['never'],
+      errors: [{ messageId: 'unexpected', line: 1, column: 11 }],
+    },
+
+    // import / export
+    {
+      code: "import {foo} from 'foo';",
+      output: "import {foo,} from 'foo';",
+      options: ['always'],
+      errors: [{ messageId: 'missing' }],
+    },
+    {
+      code: "import {foo,} from 'foo';",
+      output: "import {foo} from 'foo';",
+      options: ['never'],
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "export {foo,} from 'foo';",
+      output: "export {foo} from 'foo';",
+      options: ['never'],
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // functions (object form)
+    {
+      code: 'function foo(a,) {}',
+      output: 'function foo(a) {}',
+      options: [{ functions: 'never' }],
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'function foo(a) {}',
+      output: 'function foo(a,) {}',
+      options: [{ functions: 'always' }],
+      errors: [{ messageId: 'missing' }],
+    },
+
+    // functions (string form)
+    {
+      code: 'foo(a,)',
+      output: 'foo(a)',
+      options: ['never'],
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'foo(a)',
+      output: 'foo(a,)',
+      options: ['always'],
+      errors: [{ messageId: 'missing' }],
+    },
+
+    // default with trailing-comma call
+    {
+      code: 'foo(a,)',
+      output: 'foo(a)',
+      errors: [{ messageId: 'unexpected', line: 1, column: 6 }],
+    },
+
+    // dynamic import
+    {
+      code: 'import(source,)',
+      output: 'import(source)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'import(source)',
+      output: 'import(source,)',
+      options: ['always'],
+      errors: [{ messageId: 'missing' }],
+    },
+
+    // import attributes
+    {
+      code: 'import foo from "foo" with {type: "json",}',
+      output: 'import foo from "foo" with {type: "json"}',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'import foo from "foo" with {type: "json"}',
+      output: 'import foo from "foo" with {type: "json",}',
+      options: ['always'],
+      errors: [{ messageId: 'missing' }],
+    },
+
+    // TS
+    {
+      code: 'enum Foo {Bar,}',
+      output: 'enum Foo {Bar}',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // SKIP: rule-tester's default filename is `.tsx`; the rule applies the
+    // upstream TSX carve-out (`<T,>` is the JSX-disambiguation form) when the
+    // type-parameter list has a single param, so this case reports 0 errors
+    // here. Covered by Go upstream/extras tests where filename is `.ts`.
+    // { code: 'function Foo<T,>() {}', ... }
+    {
+      code: 'type Foo = [string,]',
+      output: 'type Foo = [string]',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'enum Foo {Bar}',
+      output: 'enum Foo {Bar,}',
+      options: ['always'],
+      errors: [{ messageId: 'missing' }],
+    },
+    {
+      code: 'type Foo<T> = Bar<T,>',
+      output: 'type Foo<T> = Bar<T>',
+      errors: [{ messageId: 'unexpected' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the \`@stylistic/comma-dangle\` rule from \`@stylistic/eslint-plugin\` to rslint.

Enforces consistent use of trailing commas across **10 list-shaped surfaces** — object / array literals + destructuring, ES module import / export specifiers, ES dynamic import argument lists, import / export attribute clauses, function declarations / expressions / arrow functions / class methods / accessors + call / \`new\` argument lists, TS enum members, TS generic parameter lists, and TS tuple types. TS type-argument lists (e.g. \`Bar<T>\`) are always treated as \`'never'\` regardless of the \`generics\` setting.

### Approach

- Delegates the carrier-kind sets to tsgo's \`node.TypeArgumentList()\` / \`node.TypeParameterList()\` (\`typescript-go/internal/ast/ast.go:483, 515\`) instead of hand-rolling per-kind switches. This is how \`KindJsxOpeningElement\` / \`KindJsxSelfClosingElement\` stay in lockstep with tsgo's own dispatch — a hand-rolled fan-out silently dropped both in an earlier revision.
- Mirrors upstream's listener set 1:1 — body-less class members (\`abstract method\`, \`declare class\` methods, overload signatures) are explicitly skipped to match ESTree's \`TSEmptyBodyFunctionExpression\` shape (which upstream's \`FunctionExpression\` listener does not match). \`KindConstructorType\` is also intentionally **not** registered — upstream has no \`TSConstructorType\` listener, only \`TSFunctionType\`.
- Spread / rest disambiguation: tsgo doesn't fork \`ArrayLiteralExpression\` / \`ObjectLiteralExpression\` into pattern forms, so \`[a, ...rest] = []\` parses as a literal with \`SpreadElement\`. We treat \`SpreadElement\` / \`SpreadAssignment\` as a rest binding only when \`ast.IsArrayLiteralOrObjectLiteralDestructuringPattern\` reports the container is in destructuring-LHS position.
- TSX \`<T,>\` single-parameter carve-out: applied when the rule resolves to a forbid path and the type-parameter list has exactly one element on a \`.tsx\` filename.
- CRLF handling: \`missing\`-comma diagnostic span is extended past the whole \`\r\n\` sequence when applicable, so the end position correctly resolves to the start of the next line (matching upstream's \`getNextLocation\` shape).
- Reuses \`scanner.SkipTrivia\`, \`utils.ContainsLineTerminator\`, \`ast.IsArrayLiteralOrObjectLiteralDestructuringPattern\`, \`node.FunctionLikeData\`, \`node.TypeArgumentList\`, \`node.TypeParameterList\`, \`list.HasTrailingComma\` semantics (implicit via my own scan).

### Test coverage

- \`comma_dangle_upstream_test.go\`: **407** cases, 1:1 mirror of upstream's \`_js_\` + \`_ts_\` + Babel-Flow sections (\`packages/eslint-plugin/rules/comma-dangle/comma-dangle._js_.test.ts\` + \`._ts_.test.ts\`). 13 cases marked \`Skip: true\` with reason — all depend on \`parserOptions.ecmaVersion < 2017 / 2025\` to demote \`functions\` / \`dynamicImports\` to \`'ignore'\`, which rslint does not model (always uses \`'latest'\`).
- \`comma_dangle_extras_test.go\`: **125** cases covering tsgo↔ESTree shape divergences and real-user scenarios — array holes (\`KindOmittedExpression\`), spread vs rest disambiguation, JSX type-arguments, TaggedTemplate / TypeQuery / ImportType / EWA type-args, async / generator / async-generator / async-arrow / class-async-and-generator methods, abstract / declare class members (skipped), overload signatures (skipped, impl reports), TSX \`<T,>\` carve-out, CRLF, nested callExpression / methodChaining, computed-property-name, default param, optional-chain calls, spread-in-middle, type-only import / inline-type-modifier import, class-field arrow, IIFE, getter / setter, decorator on class member, TS overload signatures, labelled tuple member, tuple rest element, deep type nesting, mixed Call(type-args + args), React component props, Redux payload, long import list, TS function (generics + params + return-type-fn-type + body-call).
- JS test (\`packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/comma-dangle.test.ts\`): Layer-1 mirror of upstream.

### Differential validation (Phase 4 Step 8)

Diffed rslint against ESLint (\`@stylistic/eslint-plugin\` v5.6.0) on real codebases with default options + \`{functions: 'never'}\`:

- **rsbuild** (Prettier-formatted, \`trailingComma: 'all'\`): rslint 7913, ESLint 7913, **common 7913, rslint-only 0, ESLint-only 0**. Byte-exact match.
- **rspack** (heterogeneous test fixtures): rslint 20644, ESLint 20641, **common 20641, rslint-only 3, ESLint-only 0**. The 3 rslint-only are all in files where \`@typescript-eslint/parser\` bails with a parse error (\`has-syntax-error.js\`, a cache fixture with TS-syntax that parser rejects); tsgo's recovery parser keeps going and the rule runs on the partial AST. Language-natural divergence (Phase 1 Step 6.B).

Every one of the 28K+ \`never\`-mode diagnostics across both repos was programmatically verified — each reported (line, column) points at a literal \`,\` character (UTF-16 column units, LSP convention) with the correct 1-char range. 0 over-reports.

## Related Links

- ESLint rule: https://eslint.style/rules/comma-dangle
- Source code: https://github.com/eslint-stylistic/eslint-stylistic/tree/main/packages/eslint-plugin/rules/comma-dangle

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).