### PR TITLE
feat: port rule @stylistic/computed-property-spacing

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -8,6 +8,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/brace_style"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_dangle"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_spacing"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/computed_property_spacing"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -20,5 +21,6 @@ func GetAllRules() []rule.Rule {
 		brace_style.BraceStyleRule,
 		comma_dangle.CommaDangleRule,
 		comma_spacing.CommaSpacingRule,
+		computed_property_spacing.ComputedPropertySpacingRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing.go
+++ b/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing.go
@@ -132,12 +132,15 @@ type pendingReport struct {
 	fix     rule.RuleFix
 }
 
-// isObjectLiteralGrandparent reports whether the member's enclosing container
-// is an ObjectLiteralExpression (`{ [k](){} }`) versus a class body
-// (`class A { [k](){} }`). Method / GetAccessor / SetAccessor share a kind
-// across object literals and classes in tsgo, so grandparent dispatch is the
-// only way to tell them apart for the enforceForClassMembers gate.
-func isObjectLiteralGrandparent(node *ast.Node) bool {
+// parentIsObjectLiteral reports whether the immediate parent of `node` is an
+// ObjectLiteralExpression. tsgo represents object-literal methods / accessors
+// directly as children of `ObjectLiteralExpression.Properties` (no
+// intermediate body node), and class methods / accessors directly as children
+// of `ClassDeclaration.Members`. The two kinds (MethodDeclaration /
+// GetAccessor / SetAccessor) are shared between both containers, so checking
+// `node.Parent.Kind` is the only way to tell an object-literal method from a
+// class method for the enforceForClassMembers gate.
+func parentIsObjectLiteral(node *ast.Node) bool {
 	if node == nil || node.Parent == nil {
 		return false
 	}
@@ -392,7 +395,7 @@ var ComputedPropertySpacingRule = rule.Rule{
 		// MethodSignature there, a distinct kind).
 		containerGated := func(resolver func(*ast.Node) resolved) func(*ast.Node) resolved {
 			return func(node *ast.Node) resolved {
-				if isObjectLiteralGrandparent(node) {
+				if parentIsObjectLiteral(node) {
 					return resolver(node)
 				}
 				parent := node.Parent

--- a/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing.go
+++ b/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing.go
@@ -1,0 +1,469 @@
+package computed_property_spacing
+
+import (
+	"sort"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	spacingNever  = "never"
+	spacingAlways = "always"
+)
+
+type options struct {
+	spaced                 bool
+	enforceForClassMembers bool
+}
+
+// parseOptions accepts upstream's two-argument shape:
+//
+//	['computed-property-spacing']                                → defaults
+//	['computed-property-spacing', 'always' | 'never']            → mode only
+//	['computed-property-spacing', mode, { enforceForClassMembers }]
+//
+// rslint's config loader unwraps single-element option arrays into a bare
+// object, so the second-position object may also arrive as a top-level
+// map[string]interface{}. Mode in that case defaults to 'never' and we honor
+// the supplied enforceForClassMembers value.
+//
+// Upstream default: ['never', { enforceForClassMembers: true }] — the
+// enforceForClassMembers default stays true regardless of whether the user
+// supplies the object at all.
+func parseOptions(raw any) options {
+	opts := options{spaced: false, enforceForClassMembers: true}
+
+	var arr []interface{}
+	switch v := raw.(type) {
+	case []interface{}:
+		arr = v
+	case string:
+		arr = []interface{}{v}
+	case map[string]interface{}:
+		arr = []interface{}{spacingNever, v}
+	}
+
+	if len(arr) > 0 {
+		if s, ok := arr[0].(string); ok && s == spacingAlways {
+			opts.spaced = true
+		}
+	}
+	if len(arr) > 1 {
+		if m, ok := arr[1].(map[string]interface{}); ok {
+			if b, ok := m["enforceForClassMembers"].(bool); ok {
+				opts.enforceForClassMembers = b
+			}
+		}
+	}
+	return opts
+}
+
+// findOpenBracketFrom returns the byte position of the next `[` token starting
+// at or after `searchStart`. Returns -1 when no `[` precedes EOF.
+//
+// Used by ElementAccessExpression / IndexedAccessType where `[` does not sit
+// at the node's left edge (the receiver / object type comes first, and may be
+// followed by trivia and — for optional chaining — a `?.` token). Using the
+// scanner instead of a byte walk is what lets us skip across `?.[…]` without
+// special-casing the optional-chain glyph.
+func findOpenBracketFrom(sf *ast.SourceFile, searchStart int) int {
+	s := scanner.GetScannerForSourceFile(sf, searchStart)
+	for s.Token() != ast.KindEndOfFile {
+		if s.Token() == ast.KindOpenBracketToken {
+			return s.TokenStart()
+		}
+		s.Scan()
+	}
+	return -1
+}
+
+// findCloseBracketFrom returns the byte position of the next `]` token
+// starting at or after `searchStart`. Returns -1 if none.
+//
+// Used instead of `node.End()-1` because some tsgo node kinds (notably
+// ComputedPropertyName accessed through `parent.Name()`) carry End() values
+// whose relationship to the literal `]` token is parser-version-dependent;
+// the scanner is the authoritative source of token positions.
+func findCloseBracketFrom(sf *ast.SourceFile, searchStart int) int {
+	s := scanner.GetScannerForSourceFile(sf, searchStart)
+	for s.Token() != ast.KindEndOfFile {
+		if s.Token() == ast.KindCloseBracketToken {
+			return s.TokenStart()
+		}
+		s.Scan()
+	}
+	return -1
+}
+
+// resolved is the per-node working set produced by the resolvers below.
+// ok=false signals the listener should skip this node (parser recovery,
+// missing inner expression, or — for computed-name parents — the name is
+// not actually a ComputedPropertyName).
+type resolved struct {
+	openPos, closePos int
+	ok                bool
+}
+
+func validRange(text string, r resolved) bool {
+	if !r.ok || r.openPos < 0 || r.closePos < 0 || r.openPos+1 > r.closePos {
+		return false
+	}
+	if r.openPos >= len(text) || r.closePos >= len(text) {
+		return false
+	}
+	return text[r.openPos] == '[' && text[r.closePos] == ']'
+}
+
+// pendingReport is one buffered diagnostic. We collect these as the listener
+// walk progresses, then sort by sortKey (source position) and emit at the
+// outermost exit. See ComputedPropertySpacingRule.Run for why buffering is
+// necessary — the rslint test framework does not sort diagnostics, and our
+// AST-traversal order doesn't always match source order (chained ElementAccess
+// like `obj[a][b]` visits outer first but the outer `[` token lives AFTER the
+// inner `]` in source).
+type pendingReport struct {
+	sortKey int
+	rng     core.TextRange
+	msg     rule.RuleMessage
+	fix     rule.RuleFix
+}
+
+// isObjectLiteralGrandparent reports whether the member's enclosing container
+// is an ObjectLiteralExpression (`{ [k](){} }`) versus a class body
+// (`class A { [k](){} }`). Method / GetAccessor / SetAccessor share a kind
+// across object literals and classes in tsgo, so grandparent dispatch is the
+// only way to tell them apart for the enforceForClassMembers gate.
+func isObjectLiteralGrandparent(node *ast.Node) bool {
+	if node == nil || node.Parent == nil {
+		return false
+	}
+	return node.Parent.Kind == ast.KindObjectLiteralExpression
+}
+
+// isAbstractMember reports whether `node` carries the `abstract` modifier.
+// Upstream's stylistic rule listens on `MethodDefinition` / `PropertyDefinition`
+// only — typescript-eslint represents abstract members as the DISTINCT AST
+// kinds `TSAbstractMethodDefinition` / `TSAbstractPropertyDefinition`, which
+// upstream does NOT listen on, so abstract members are silently skipped. tsgo
+// keeps the same MethodDeclaration / PropertyDeclaration kind for both
+// abstract and concrete members and distinguishes them via a modifier flag —
+// so to stay aligned we must skip abstract members explicitly.
+func isAbstractMember(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return ast.HasSyntacticModifier(node, ast.ModifierFlagsAbstract)
+}
+
+// inJSDoc reports whether `node` was parsed inside a JSDoc `@type {...}` (or
+// similar) annotation. tsgo parses JSDoc type expressions into the regular
+// type AST (`IndexedAccessTypeNode`, etc.) with the `NodeFlagsJSDoc` flag
+// set; typescript-eslint's parser treats JSDoc comments as plain trivia and
+// never builds AST for their interior. Upstream stylistic therefore never
+// sees `[K]` inside `/** @type {Foo[K]} */`, so we must skip JSDoc-flagged
+// nodes too to keep the rule's user-visible output aligned.
+func inJSDoc(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return node.Flags&ast.NodeFlagsJSDoc != 0
+}
+
+// ComputedPropertySpacingRule enforces consistent spacing inside computed
+// property brackets — object-literal keys, destructuring patterns, class
+// member names, indexed access types, and computed member access (including
+// optional chaining `obj?.[x]`). Ported from @stylistic/eslint-plugin's
+// computed-property-spacing.
+//
+// Listener dispatch mirrors no_useless_computed_key: we listen on the parent
+// kinds (PropertyAssignment / BindingElement / MethodDeclaration /
+// GetAccessor / SetAccessor / PropertyDeclaration) rather than on
+// KindComputedPropertyName directly. ElementAccessExpression and
+// IndexedAccessType get their own listeners.
+//
+// Reports are buffered and emitted in source-position order at the
+// outermost exit (when our listener-kind nesting depth drops back to 0).
+// Without buffering, chained ElementAccess (`obj[a][b]`) would emit outer's
+// brackets before inner's, because tsgo visits the outer ElementAccess node
+// first even though its `[` token sits AFTER the inner `]` in source. The
+// rslint test framework does not re-sort diagnostics, so the rule itself
+// must guarantee source order.
+var ComputedPropertySpacingRule = rule.Rule{
+	Name: "@stylistic/computed-property-spacing",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		sf := ctx.SourceFile
+		text := sf.Text()
+
+		// --- buffered emission state ---
+		// `depth` counts how many of our LISTENED kinds we're currently
+		// inside (across all kinds, not per-kind). When depth returns to
+		// zero we've finished the topmost subtree of listened kinds and
+		// can flush — every report inside belongs to that subtree, so
+		// sorting and emitting is order-preserving for the whole tree.
+		var depth int
+		var pending []pendingReport
+
+		addReport := func(sortKey int, rng core.TextRange, msg rule.RuleMessage, fix rule.RuleFix) {
+			pending = append(pending, pendingReport{sortKey: sortKey, rng: rng, msg: msg, fix: fix})
+		}
+
+		flush := func() {
+			if len(pending) == 0 {
+				return
+			}
+			sort.SliceStable(pending, func(i, j int) bool {
+				return pending[i].sortKey < pending[j].sortKey
+			})
+			for _, p := range pending {
+				ctx.ReportRangeWithFixes(p.rng, p.msg, p.fix)
+			}
+			pending = pending[:0]
+		}
+
+		// --- opening / closing analyzers (buffer instead of emitting) ---
+
+		collectOpening := func(r resolved) {
+			innerLow := r.openPos + 1
+			if innerLow > r.closePos {
+				return
+			}
+			firstStart := utils.SkipLeadingWhitespace(text, innerLow, r.closePos)
+			// `isTokenOnSameLine(before, first)` short-circuit — skip the
+			// opening check when a newline separates `[` from its first
+			// inner token/comment.
+			if utils.ContainsLineTerminator(text, innerLow, firstStart) {
+				return
+			}
+			hasSpace := firstStart > innerLow
+			if opts.spaced {
+				if !hasSpace {
+					addReport(
+						r.openPos,
+						core.NewTextRange(r.openPos, r.openPos+1),
+						rule.RuleMessage{
+							Id:          "missingSpaceAfter",
+							Description: "A space is required after '['.",
+							Data:        map[string]string{"tokenValue": "["},
+						},
+						rule.RuleFix{
+							Text:  " ",
+							Range: core.NewTextRange(r.openPos+1, r.openPos+1),
+						},
+					)
+				}
+				return
+			}
+			if hasSpace {
+				addReport(
+					innerLow,
+					core.NewTextRange(innerLow, firstStart),
+					rule.RuleMessage{
+						Id:          "unexpectedSpaceAfter",
+						Description: "There should be no space after '['.",
+						Data:        map[string]string{"tokenValue": "["},
+					},
+					rule.RuleFix{
+						Text:  "",
+						Range: core.NewTextRange(innerLow, firstStart),
+					},
+				)
+			}
+		}
+
+		collectClosing := func(r resolved) {
+			innerLow := r.openPos + 1
+			if innerLow > r.closePos {
+				return
+			}
+			lastEnd := utils.SkipTrailingWhitespace(text, innerLow, r.closePos)
+			if utils.ContainsLineTerminator(text, lastEnd, r.closePos) {
+				return
+			}
+			hasSpace := lastEnd < r.closePos
+			if opts.spaced {
+				if !hasSpace {
+					addReport(
+						r.closePos,
+						core.NewTextRange(r.closePos, r.closePos+1),
+						rule.RuleMessage{
+							Id:          "missingSpaceBefore",
+							Description: "A space is required before ']'.",
+							Data:        map[string]string{"tokenValue": "]"},
+						},
+						rule.RuleFix{
+							Text:  " ",
+							Range: core.NewTextRange(r.closePos, r.closePos),
+						},
+					)
+				}
+				return
+			}
+			if hasSpace {
+				addReport(
+					lastEnd,
+					core.NewTextRange(lastEnd, r.closePos),
+					rule.RuleMessage{
+						Id:          "unexpectedSpaceBefore",
+						Description: "There should be no space before ']'.",
+						Data:        map[string]string{"tokenValue": "]"},
+					},
+					rule.RuleFix{
+						Text:  "",
+						Range: core.NewTextRange(lastEnd, r.closePos),
+					},
+				)
+			}
+		}
+
+		// --- resolvers: turn each listener kind into (openPos, closePos) ---
+
+		resolveElementAccess := func(node *ast.Node) resolved {
+			eae := node.AsElementAccessExpression()
+			if eae == nil || eae.Expression == nil || eae.ArgumentExpression == nil {
+				return resolved{}
+			}
+			openPos := findOpenBracketFrom(sf, eae.Expression.End())
+			closePos := findCloseBracketFrom(sf, eae.ArgumentExpression.End())
+			return resolved{openPos: openPos, closePos: closePos, ok: true}
+		}
+
+		resolveIndexedAccessType := func(node *ast.Node) resolved {
+			iat := node.AsIndexedAccessTypeNode()
+			if iat == nil || iat.ObjectType == nil || iat.IndexType == nil {
+				return resolved{}
+			}
+			openPos := findOpenBracketFrom(sf, iat.ObjectType.End())
+			closePos := findCloseBracketFrom(sf, iat.IndexType.End())
+			return resolved{openPos: openPos, closePos: closePos, ok: true}
+		}
+
+		resolveComputedNameFromNode := func(name *ast.Node) resolved {
+			if name == nil || name.Kind != ast.KindComputedPropertyName {
+				return resolved{}
+			}
+			cpn := name.AsComputedPropertyName()
+			if cpn == nil || cpn.Expression == nil {
+				return resolved{}
+			}
+			openPos := findOpenBracketFrom(sf, name.Pos())
+			closePos := findCloseBracketFrom(sf, cpn.Expression.End())
+			return resolved{openPos: openPos, closePos: closePos, ok: true}
+		}
+
+		resolveFromName := func(node *ast.Node) resolved {
+			return resolveComputedNameFromNode(node.Name())
+		}
+
+		resolveBindingElement := func(node *ast.Node) resolved {
+			be := node.AsBindingElement()
+			if be == nil {
+				return resolved{}
+			}
+			return resolveComputedNameFromNode(be.PropertyName)
+		}
+
+		// --- gate helpers: filter on enforceForClassMembers ---
+
+		alwaysCheck := func(resolver func(*ast.Node) resolved) func(*ast.Node) resolved {
+			return resolver
+		}
+
+		classMemberGated := func(resolver func(*ast.Node) resolved) func(*ast.Node) resolved {
+			return func(node *ast.Node) resolved {
+				if !opts.enforceForClassMembers {
+					return resolved{}
+				}
+				if isAbstractMember(node) {
+					return resolved{} // see isAbstractMember docstring
+				}
+				return resolver(node)
+			}
+		}
+
+		// containerGated handles MethodDeclaration / GetAccessor / SetAccessor —
+		// always check on object literals, gate on enforceForClassMembers when
+		// the parent is a class body. Returns empty for any other parent kind
+		// (e.g. InterfaceDeclaration / TypeLiteral — defensive; tsgo uses
+		// MethodSignature there, a distinct kind).
+		containerGated := func(resolver func(*ast.Node) resolved) func(*ast.Node) resolved {
+			return func(node *ast.Node) resolved {
+				if isObjectLiteralGrandparent(node) {
+					return resolver(node)
+				}
+				parent := node.Parent
+				if parent == nil {
+					return resolved{}
+				}
+				if parent.Kind != ast.KindClassDeclaration && parent.Kind != ast.KindClassExpression {
+					return resolved{}
+				}
+				if !opts.enforceForClassMembers {
+					return resolved{}
+				}
+				if isAbstractMember(node) {
+					return resolved{} // see isAbstractMember docstring
+				}
+				return resolver(node)
+			}
+		}
+
+		// --- listener factories ---
+		// enter: bump depth, then collect reports if this node is in scope.
+		// exit:  decrement depth; if back to 0, flush sorted.
+
+		enter := func(resolver func(*ast.Node) resolved) func(*ast.Node) {
+			return func(node *ast.Node) {
+				depth++
+				if inJSDoc(node) {
+					return // see inJSDoc docstring — upstream parser drops JSDoc internals
+				}
+				r := resolver(node)
+				if validRange(text, r) {
+					collectOpening(r)
+					collectClosing(r)
+				}
+			}
+		}
+		exit := func(node *ast.Node) {
+			depth--
+			if depth == 0 {
+				flush()
+			}
+		}
+
+		// --- per-kind gated resolvers ---
+
+		eaR := alwaysCheck(resolveElementAccess)
+		iatR := alwaysCheck(resolveIndexedAccessType)
+		paR := alwaysCheck(resolveFromName)     // object-literal PropertyAssignment
+		beR := alwaysCheck(resolveBindingElement)
+		mdR := containerGated(resolveFromName)  // method (object literal OR class)
+		gaR := containerGated(resolveFromName)  // get accessor
+		saR := containerGated(resolveFromName)  // set accessor
+		pdR := classMemberGated(resolveFromName) // PropertyDeclaration (always class)
+
+		return rule.RuleListeners{
+			ast.KindElementAccessExpression:                      enter(eaR),
+			rule.ListenerOnExit(ast.KindElementAccessExpression): exit,
+			ast.KindIndexedAccessType:                            enter(iatR),
+			rule.ListenerOnExit(ast.KindIndexedAccessType):       exit,
+			ast.KindPropertyAssignment:                           enter(paR),
+			rule.ListenerOnExit(ast.KindPropertyAssignment):      exit,
+			ast.KindBindingElement:                               enter(beR),
+			rule.ListenerOnExit(ast.KindBindingElement):          exit,
+			ast.KindMethodDeclaration:                            enter(mdR),
+			rule.ListenerOnExit(ast.KindMethodDeclaration):       exit,
+			ast.KindGetAccessor:                                  enter(gaR),
+			rule.ListenerOnExit(ast.KindGetAccessor):             exit,
+			ast.KindSetAccessor:                                  enter(saR),
+			rule.ListenerOnExit(ast.KindSetAccessor):             exit,
+			ast.KindPropertyDeclaration:                          enter(pdR),
+			rule.ListenerOnExit(ast.KindPropertyDeclaration):     exit,
+		}
+	},
+}

--- a/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing.md
+++ b/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing.md
@@ -1,0 +1,106 @@
+# computed-property-spacing
+
+Enforce consistent spacing inside computed property brackets.
+
+## Rule Details
+
+This rule covers every place a computed name expression appears inside square brackets:
+
+- Member access `obj[foo]` and optional member access `obj?.[foo]`
+- Object literal keys `{ [foo]: 1 }`
+- Object destructuring patterns `const { [foo]: x } = obj`
+- Class member names (methods, accessors, fields, `accessor` properties)
+- TypeScript indexed access types `type T = A[B]`
+
+Multi-line forms are exempt — the rule only fires when the opening `[` and its first inner token (or the closing `]` and its last inner token) sit on the same source line.
+
+## Options
+
+This rule has a string option:
+
+- `"never"` (default) disallows spaces inside computed property brackets.
+- `"always"` requires one space inside computed property brackets.
+
+This rule has an object option:
+
+- `"enforceForClassMembers": true` (default) — also enforce the spacing rule on class member names. Set to `false` to leave class members unchecked.
+
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
+
+```javascript
+obj[foo ];
+obj[ 'foo'];
+const x = { [ b ]: a };
+const { [ a ]: someProp } = obj;
+class A { [ a ]() {} }
+type Foo = A[ B ];
+```
+
+Examples of **correct** code for this rule with the default `"never"` option:
+
+```javascript
+obj[foo];
+obj['foo'];
+obj?.[foo];
+const x = { [b]: a };
+const { [a]: someProp } = obj;
+class A { [a]() {} }
+type Foo = A[B];
+```
+
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/computed-property-spacing": ["error", "always"] }
+```
+
+```javascript
+obj[foo];
+const x = { [b]: a };
+const { [a]: someProp } = obj;
+class A { [a]() {} }
+type Foo = A[B];
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/computed-property-spacing": ["error", "always"] }
+```
+
+```javascript
+obj[ foo ];
+obj?.[ foo ];
+const x = { [ b ]: a };
+const { [ a ]: someProp } = obj;
+class A { [ a ]() {} }
+type Foo = A[ B ];
+```
+
+### enforceForClassMembers
+
+When set to `false`, class member names are exempt regardless of the `"never"` / `"always"` mode.
+
+Examples of **correct** code for this rule with `"never", { "enforceForClassMembers": false }`:
+
+```json
+{ "@stylistic/computed-property-spacing": ["error", "never", { "enforceForClassMembers": false }] }
+```
+
+```javascript
+class A {
+  [ a ]() {}
+  get [ b ]() {}
+  static [ c ]() {}
+  [ d ] = 1;
+  accessor [ e ] = 1;
+}
+```
+
+## Original Documentation
+
+- [@stylistic/computed-property-spacing](https://eslint.style/rules/computed-property-spacing)

--- a/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing_extras_test.go
+++ b/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing_extras_test.go
@@ -292,6 +292,44 @@ func TestComputedPropertySpacingExtras(t *testing.T) {
 			{Code: `declare class A { [k]: number }`, Options: optsNever()},
 			{Code: `declare class A { [ k ]: number }`, Options: optsAlways()},
 
+			// ---- Assumption Q: multi-byte char positions (CJK + non-BMP emoji) ----
+			// Repository convention requires multi-byte char tests for any
+			// position-calculating rule. tsgo TokenStart/TokenEnd are byte
+			// offsets (see scanner.TokenText `s.text[tokenStart:pos]` in
+			// typescript-go), and `scanner.GetECMALineAndUTF16CharacterOfPosition`
+			// converts to UTF-16 column at the diagnostic-output boundary.
+			// Verify both layers cooperate: rule reports survive CJK (3-byte
+			// UTF-8, 1 UTF-16 unit) and non-BMP emoji (4-byte UTF-8, 2 UTF-16
+			// units = surrogate pair). One invalid case below asserts exact
+			// column numbers to lock the UTF-16 conversion.
+			{Code: "const 表情 = '🎉'; obj[表情]", Options: optsNever()},
+			{Code: "const 表情 = '🎉'; obj[ 表情 ]", Options: optsAlways()},
+			{Code: "const x = '🎉🚀'; obj[x]", Options: optsNever()},
+
+			// ---- Assumption R: abstract gate covers GetAccessor / SetAccessor (not just MethodDeclaration) ----
+			// containerGated.isAbstractMember must fire uniformly across all
+			// accessor variants — abstract get/set are silent like abstract
+			// methods.
+			{Code: `abstract class A { abstract get [ k ](): number }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `abstract class A { abstract set [ k ](v: number): void }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `abstract class A { abstract get [k](): number; abstract set [k](v: number) }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+
+			// ---- Assumption S: abstract `accessor` property (stage-3 accessor + abstract dual-modifier) ----
+			// PropertyDeclaration with both `abstract` and `accessor`.
+			// classMemberGated.isAbstractMember must win over the regular
+			// accessor-property reporting path.
+			{Code: `abstract class A { abstract accessor [ k ]: number }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `abstract class A { abstract accessor [k]: number }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+
+			// ---- Assumption T: inJSDoc covers ALL JSDoc tags, not just @type ----
+			// JSDoc `@param`, `@returns`, `@typedef`, `@property`, etc. all
+			// build type AST nodes with NodeFlagsJSDoc set. inJSDoc's flag
+			// check is tag-agnostic, so each tag's interior must skip
+			// uniformly.
+			{Code: "/** @param {Foo[K]} x */\nfunction f(x: any) {}", Options: optsAlways()},
+			{Code: "/** @returns {Foo[K]} */\nfunction f(): any {}", Options: optsAlways()},
+			{Code: "/** @typedef {{ x: Foo[K] }} T */", Options: optsAlways()},
+
 			// =====================================================================
 			//   Context-coverage lock-ins: each verifies the rule fires correctly
 			//   in a specific surrounding syntactic context. Listener dispatch is
@@ -697,6 +735,26 @@ func TestComputedPropertySpacingExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
 					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+
+			// ---- Lock-in for Assumption Q: UTF-16 column output across CJK + non-BMP emoji ----
+			// Source: `const 表情 = '🎉'; obj[ 表情 ]`
+			//   UTF-16 cols 1-5 `const`, 6 space, 7-8 `表情`, 9 space, 10 `=`,
+			//   11 space, 12 `'`, 13-14 `🎉` (surrogate pair, 2 units),
+			//   15 `'`, 16 `;`, 17 space, 18-20 `obj`, 21 `[`, 22 space,
+			//   23-24 `表情`, 25 space, 26 `]`.
+			// unexpectedSpaceAfter loc = [innerLow, firstStart) = cols 22-23.
+			// unexpectedSpaceBefore loc = [lastEnd, innerHigh) = cols 25-26.
+			// If rslint accidentally byte-indexed or counted code points
+			// instead of UTF-16 units, the columns would shift.
+			{
+				Code:    "const 表情 = '🎉'; obj[ 表情 ]",
+				Output:  []string{"const 表情 = '🎉'; obj[表情]"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
 				},
 			},
 

--- a/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing_extras_test.go
+++ b/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing_extras_test.go
@@ -1,0 +1,723 @@
+// TestComputedPropertySpacingExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Each case carries an inline
+// comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk
+// it covers, so future refactors can't silently regress them without breaking
+// a named lock-in.
+package computed_property_spacing_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/computed_property_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestComputedPropertySpacingExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&computed_property_spacing.ComputedPropertySpacingRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: receiver wrappers (tsgo ParenthesizedExpression, non-null, type assertion) ----
+			// ESLint's ESTree flattens `(obj)` to just `obj`; tsgo preserves the
+			// ParenthesizedExpression. The `[`-finding scanner walks from
+			// `Expression.End()` (the `)` of `(obj)`), so paren receivers must
+			// still locate `[` correctly.
+			{Code: `(obj)[foo]`, Options: optsNever()},
+			{Code: `(obj)[ foo ]`, Options: optsAlways()},
+			{Code: `obj![foo]`, Options: optsNever()},
+			{Code: `obj![ foo ]`, Options: optsAlways()},
+			{Code: `(obj as any)[foo]`, Options: optsNever()},
+			{Code: `(obj as any)[ foo ]`, Options: optsAlways()},
+			{Code: `(obj satisfies Record<string, unknown>)[foo]`, Options: optsNever()},
+
+			// ---- Dimension 4: element access argument shapes ----
+			// Identifier / NumericLiteral / StringLiteral / TemplateLiteral /
+			// PropertyAccess — `]` is always at node.End()-1 regardless of
+			// what kind the ArgumentExpression has.
+			{Code: `obj[0]`, Options: optsNever()},
+			{Code: `obj[ 0 ]`, Options: optsAlways()},
+			{Code: "obj[`x`]", Options: optsNever()},
+			{Code: "obj[ `x` ]", Options: optsAlways()},
+			{Code: `obj[Symbol.iterator]`, Options: optsNever()},
+			{Code: `obj[ Symbol.iterator ]`, Options: optsAlways()},
+
+			// ---- Dimension 4: computed key shapes — numeric / template / member ----
+			{Code: `var x = {[0]: 1}`, Options: optsNever()},
+			{Code: `var x = {[ 0 ]: 1}`, Options: optsAlways()},
+			{Code: "var x = {[`k`]: 1}", Options: optsNever()},
+			{Code: "var x = {[ `k` ]: 1}", Options: optsAlways()},
+			{Code: `var x = {[Symbol.iterator]: 1}`, Options: optsNever()},
+
+			// ---- Dimension 4: comments-but-no-whitespace (preserves comment-as-token semantics) ----
+			// `[/* c */ a]` has zero whitespace bytes between `[` and `/*`; our
+			// SkipLeadingWhitespace stops at `/` and therefore correctly reports
+			// no opening space.
+			{Code: `obj[/* c */ a]`, Options: optsNever()},
+			{Code: `obj[a /* c */]`, Options: optsNever()},
+			{Code: "obj[// line\n a]", Options: optsNever()},
+
+			// ---- Dimension 4: nesting boundaries — ElementAccess inside ComputedPropertyName ----
+			// Verifies the three listeners cooperate independently — the inner
+			// ElementAccessExpression and the outer ComputedPropertyName share
+			// no state.
+			{Code: `var x = {[obj[k]]: 1}`, Options: optsNever()},
+			{Code: `var x = {[ obj[ k ] ]: 1}`, Options: optsAlways()},
+
+			// ---- Dimension 4: nesting — class in class / class in object ----
+			{Code: `class A { foo() { class B { [k]() {} } } }`, Options: optsNever()},
+			{Code: `var x = { foo: class { [k]() {} } }`, Options: optsNever()},
+
+			// ---- Dimension 4: IndexedAccessType — never option is NOT default ----
+			// `TSIndexedAccessType` skips the `!node.computed` guard upstream
+			// (it has no `.computed` field), so the type-side listener always
+			// fires regardless of mode. Lock both modes in:
+			{Code: `type T = A[K]`, Options: optsNever()},
+			{Code: `type T = A[ K ]`, Options: optsAlways()},
+			{Code: `type T = A[B | C]`, Options: optsNever()},
+			{Code: `type T = A[ B | C ]`, Options: optsAlways()},
+			{Code: "type T = A[\nK\n]", Options: optsNever()},
+			{Code: "type T = A[\nK\n]", Options: optsAlways()},
+
+			// ---- Dimension 4: class with `accessor` modifier — separate tsgo PropertyDeclaration shape ----
+			{Code: `class A { static accessor [k] = 1 }`, Options: optsNever()},
+			{Code: `class A { static accessor [ k ] = 1 }`, Options: optsAlways()},
+
+			// ---- Real-user: template-literal computed keys (issue tracker shapes) ----
+			{Code: "function f<T extends string>(k: T): unknown { return ({} as any)[`prefix_${k}`]; }", Options: optsNever()},
+			// ---- Real-user: ternary argument expression ----
+			{Code: `function pick(obj: any, first: boolean) { return obj[first ? "a" : "b"]; }`, Options: optsNever()},
+
+			// ---- N/A: rule scope ----
+			// "Identifier vs string / numeric / private / computed key" — the
+			// rule by definition handles ONLY ComputedPropertyName. Non-computed
+			// names (`{ a: 1 }`, `obj.a`, `class A { #x = 1 }`) are not in scope.
+			// Locked in via the upstream non-computed valid cases.
+
+			// ---- N/A: SpreadAssignment / RestElement ----
+			// The rule never inspects spread/rest siblings; spreads contain no
+			// computed bracket of their own. Locked-in implicitly by upstream
+			// "var x = {...y, [k]: 1}"-style mixes — though upstream's suite
+			// happens not to include one, the listener structure leaves spread
+			// untouched by construction (no listener registered for spreads).
+
+			// ---- N/A: graceful degradation on empty brackets ----
+			// `obj[]` / `class A { []() {} }` are parser errors, not just
+			// recovered AST shapes. Defensive guards (openPos>=closePos)
+			// covered by code path; no positive test required.
+
+			// ---- Robustness: deeper nesting ----
+			// Two-layer ComputedPropertyName: outer key contains an
+			// expression whose inner shape *also* has a ComputedPropertyName.
+			// The outer listener's `closePos` must NOT mistake an inner `]`
+			// for the outer one — the scanner-based finder cuts from the
+			// inner expression's End(), so the next `]` is the outer.
+			{Code: `var x = {[ {[ k ]: 1 }.k ]: 2}`, Options: optsAlways()},
+			{Code: `var x = {[{[k]: 1}.k]: 2}`, Options: optsNever()},
+			// IndexedAccessType nesting: `T = A[B[C]]` — outer `]` resolved
+			// via scanner from inner-most's IndexType.End().
+			{Code: `type T = A[B[C]]`, Options: optsNever()},
+			{Code: `type T = A[ B[ C ] ]`, Options: optsAlways()},
+			// Class method with ElementAccess inside the computed key — the
+			// outer ComputedPropertyName and inner ElementAccessExpression
+			// listen independently.
+			{Code: `class A { [obj[k]](){} }`, Options: optsNever()},
+			{Code: `class A { [ obj[ k ] ](){} }`, Options: optsAlways()},
+			// declare class member with computed name — PropertyDeclaration
+			// with no initializer, gated by enforceForClassMembers.
+			{Code: `declare class A { [k]: number }`, Options: optsNever()},
+
+			// =====================================================================
+			//   Adversarial verification: each test below pairs with a specific
+			//   unsafe assumption in the implementation. If the assumption breaks,
+			//   the test fails. Keep the comment that names the assumption.
+			// =====================================================================
+
+			// ---- Assumption A: `findOpenBracketFrom(sf, expr.End())` reliably finds the rule's `[` even when receiver carries TS-only suffixes ----
+			// Risk: scanner starting from `expr.End()` could mis-tokenize across
+			// `<T>` / `!` / `as const` / `satisfies T` chains. Each receiver
+			// shape below must still locate the *outer* `[`.
+			{Code: `(arr as const)[0]`, Options: optsNever()},
+			{Code: `(arr as const)[ 0 ]`, Options: optsAlways()},
+			{Code: `(x satisfies number)[k]`, Options: optsNever()},
+			{Code: `obj!!![k]`, Options: optsNever()}, // triple non-null assertion (valid TS)
+
+			// ---- Assumption B: `findCloseBracketFrom(sf, arg.End())` skips over `]` bytes embedded INSIDE the argument's tokens ----
+			// Risk: a string literal containing `]` ought to be one token, but a
+			// hand-rolled byte scan would mistake it for the closing bracket and
+			// report at the wrong column. The scanner sees one StringLiteral.
+			{Code: `obj["x]y"]`, Options: optsNever()},
+			{Code: `obj[ "x]y" ]`, Options: optsAlways()},
+			// TemplateExpression with interpolation that itself contains `]`
+			// from a nested ElementAccess — outer `]` resolution must traverse
+			// past the template's interior.
+			{Code: "obj[`pre_${other[k]}_post`]", Options: optsNever()},
+			{Code: "obj[ `pre_${other[ k ]}_post` ]", Options: optsAlways()},
+
+			// ---- Assumption C: MappedType `[P in K]` is NOT a ComputedPropertyName ----
+			// Risk: my listeners might accidentally match MappedTypeNode's
+			// type-parameter brackets. tsgo represents `[P in K]` as
+			// TypeParameterDeclaration inside MappedTypeNode — a different
+			// kind, NOT KindComputedPropertyName. The `T[P]` on the RHS IS an
+			// IndexedAccessType and DOES get checked. So `[P in K]` must be
+			// silent in both modes; the inner `T[P]` is the only thing under
+			// audit.
+			{Code: `type Pick<T, K extends keyof T> = { [P in K]: T[P] }`, Options: optsNever()},
+			{Code: `type Pick<T, K extends keyof T> = { [P in K]: T[ P ] }`, Options: optsAlways()},
+
+			// ---- Assumption D: IndexSignature `[k: string]` is NOT a ComputedPropertyName ----
+			// Risk: same as Assumption C — tsgo uses IndexSignature, not
+			// ComputedPropertyName. Both modes must remain silent.
+			{Code: `interface I { [k: string]: any }`, Options: optsNever()},
+			{Code: `interface I { [k: string]: any }`, Options: optsAlways()},
+			{Code: `type T = { [k: number]: string }`, Options: optsNever()},
+
+			// ---- Assumption E: chained `?.[]` / `[][]` each fire independently in source order ----
+			// Risk: incorrect listener registration could miss one or report
+			// out of order. Each link must report on its own.
+			{Code: `obj?.[x]?.[y]`, Options: optsNever()},
+			{Code: `obj?.[ x ]?.[ y ]`, Options: optsAlways()},
+			{Code: `obj[a][b][c]`, Options: optsNever()},
+			{Code: `obj[ a ][ b ][ c ]`, Options: optsAlways()},
+
+			// ---- Assumption F: PropertyDeclaration / MethodDeclaration parent dispatch covers TS-only modifiers ----
+			// Risk: `override`, `accessor`, decorators could change tsgo's
+			// parent layout and silently make the listener stop firing.
+			{Code: `class B extends A { override [k]() {} }`, Options: optsNever()},
+			{Code: `class B extends A { override [ k ]() {} }`, Options: optsAlways()},
+
+			// ---- Upstream parity: JSDoc `@type {...}` interior is silently SKIPPED ----
+			// tsgo parses JSDoc type expressions into the regular type AST
+			// (IndexedAccessTypeNode etc.) with NodeFlagsJSDoc set. The
+			// upstream parser (@typescript-eslint/parser) drops JSDoc bodies
+			// entirely, so upstream never sees these nodes and never reports.
+			// Without the `inJSDoc` skip we'd over-report by ~30 cases when
+			// auditing real codebases like rspack (rspack.config.js files
+			// with `/** @type {ConstructorParameters<typeof X>[0]} */` are
+			// the dominant case). Verified via differential audit against
+			// ESLint+@stylistic on rspack@main.
+			{Code: "/** @type {Foo[K]} */\nconst x = 1;", Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: "/** @type {Foo[ K ]} */\nconst x = 1;", Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: "/** @type {Arr[0]} */\nconst x = 1;", Options: optsAlways()},
+			{Code: "const x = /** @type {Foo[ K ]} */ (val);", Options: optsNever()},
+
+			// ---- Upstream parity: abstract members are silently SKIPPED ----
+			// typescript-eslint represents `abstract [k](): void` as the
+			// distinct AST kind TSAbstractMethodDefinition (likewise for
+			// TSAbstractPropertyDefinition); upstream stylistic only listens
+			// on MethodDefinition / PropertyDefinition, so abstract members
+			// are silently skipped. tsgo keeps the same kind and uses a
+			// modifier flag, so without the explicit abstract-skip in
+			// isAbstractMember (see rule source) we'd over-report. These
+			// pairs lock in the upstream-aligned silent behavior — note
+			// that intentionally-bad spacing on the abstract member also
+			// emits NO diagnostic.
+			{Code: `abstract class A { abstract [k](): void }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `abstract class A { abstract [ k ](): void }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `abstract class A { abstract [ k ](): void }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `abstract class A { abstract [k]: number }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `abstract class A { abstract [ k ]: number }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+
+			// ---- Assumption G: `Symbol.iterator`-style class member names — by far the most common real-user computed name ----
+			// Risk: PropertyAccess receiver inside ComputedPropertyName should
+			// pass through without confusing the closePos scanner.
+			{Code: `class Iter { [Symbol.iterator]() { return this; } async [Symbol.asyncIterator]() {} }`, Options: optsNever()},
+			{Code: `class Iter { [ Symbol.iterator ]() { return this; } }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+
+			// ---- Assumption H: destructuring with default / nested-pattern / rest sibling ----
+			// Risk: BindingElement's PropertyName must still be picked up when
+			// there's a default-value initializer, and rest elements (no
+			// PropertyName) must be silently skipped.
+			{Code: `const { [k]: x = 1 } = obj`, Options: optsNever()},
+			{Code: `const { [ k ]: x = 1 } = obj`, Options: optsAlways()},
+			{Code: `const { [k]: { a, b } = {} } = obj`, Options: optsNever()},
+			{Code: `const { ...rest } = obj`, Options: optsNever()}, // no PropertyName — must not fire
+			{Code: `const [a, b, ...rest] = arr`, Options: optsNever()}, // array binding — must not fire
+
+			// ---- Assumption I: spread before a computed key is invisible to the rule ----
+			{Code: `const opts = { ...defaults, [key]: value }`, Options: optsNever()},
+			{Code: `const opts = { ...defaults, [ key ]: value }`, Options: optsAlways()},
+
+			// ---- Assumption J: `super[k]` / `this[k]` / `new f[k]()` — keyword receivers ----
+			{Code: `class B extends A { foo() { return super[k]; } }`, Options: optsNever()},
+			{Code: `class B extends A { foo() { return super[ k ]; } }`, Options: optsAlways()},
+			{Code: `class B { foo(k) { return this[k]; } }`, Options: optsNever()},
+			{Code: `const x = new factory[key]()`, Options: optsNever()},
+
+			// ---- Assumption K: numeric BigInt literal in computed slot ----
+			// Risk: tsgo splits Literal into KindNumericLiteral / KindBigIntLiteral.
+			// BigInt args must traverse correctly.
+			{Code: `obj[1n]`, Options: optsNever()},
+			{Code: `obj[ 1n ]`, Options: optsAlways()},
+			{Code: `const x = { [1n]: 'one' }`, Options: optsNever()},
+
+			// ---- Assumption L: tuple-type indexed access `T[0]` ----
+			{Code: `type First<T extends readonly unknown[]> = T[0]`, Options: optsNever()},
+			{Code: `type First<T extends readonly unknown[]> = T[ 0 ]`, Options: optsAlways()},
+
+			// ---- Assumption M: 4-layer same-kind nesting ----
+			// Stress test for scanner-based closePos. Each layer's `]` must
+			// resolve to the matching `]`, not a sibling.
+			{Code: `obj[a[b[c[d]]]]`, Options: optsNever()},
+			{Code: `obj[ a[ b[ c[ d ] ] ] ]`, Options: optsAlways()},
+			{Code: `type T = A[B[C[D[E]]]]`, Options: optsNever()},
+
+			// ---- Assumption N: BindingElement fires in every binding context ----
+			// BindingElement appears under several different parent shapes;
+			// each one must dispatch correctly. tsgo uses the same kind
+			// regardless of context, so this validates the listener doesn't
+			// have an implicit context assumption.
+			{Code: `function f({ [a]: x }) {}`, Options: optsNever()},
+			{Code: `function f({ [ a ]: x }) {}`, Options: optsAlways()},
+			{Code: `try {} catch ({ [a]: x }) {}`, Options: optsNever()},
+			{Code: `for (const { [k]: v } of arr) {}`, Options: optsNever()},
+			{Code: `for (const { [ k ]: v } of arr) {}`, Options: optsAlways()},
+
+			// ---- Assumption O: decorator on class member with computed name ----
+			// Decorators are modifiers in tsgo; they don't change kind or
+			// parent layout. Verifies parent dispatch still finds the
+			// ComputedPropertyName.
+			{Code: `class A { @dec [k]() {} }`, Options: optsNever()},
+			{Code: `class A { @dec [ k ]() {} }`, Options: optsAlways()},
+			{Code: `class A { @dec [k] = 0 }`, Options: optsNever()},
+
+			// ---- Assumption P: declare class member fires (declare ≠ abstract) ----
+			// Unlike `abstract`, the `declare` modifier in typescript-eslint
+			// does NOT change the AST kind (member stays MethodDefinition /
+			// PropertyDefinition). Upstream DOES report on it, so we must
+			// too. This locks in that the abstract-skip in isAbstractMember
+			// is correctly scoped to JUST abstract, not all TS modifiers.
+			{Code: `declare class A { [k]: number }`, Options: optsNever()},
+			{Code: `declare class A { [ k ]: number }`, Options: optsAlways()},
+
+			// =====================================================================
+			//   Context-coverage lock-ins: each verifies the rule fires correctly
+			//   in a specific surrounding syntactic context. Listener dispatch is
+			//   parent-kind-based; if a context routes nodes through unexpected
+			//   parents, listener could silently fail to fire OR fire in wrong
+			//   order. These are the spots where "I implemented it and tests
+			//   pass" but "a real codebase finds the bug".
+			// =====================================================================
+
+			// ---- JSX expression container as ElementAccess host ----
+			// (skipped here — shared stylistic fixtures/tsconfig.json doesn't
+			// enable jsx. JSX dispatch is verified via the differential audit
+			// in the rule README's audit notes; the ElementAccess listener
+			// fires regardless of parent kind by construction.)
+
+			// ---- Class static block (ES2022) ----
+			// `class A { static { obj[k]; } }` — ElementAccess inside Block
+			// inside ClassStaticBlockDeclaration. Our listener fires anyway.
+			{Code: `class A { static { const x = obj[k]; } }`, Options: optsNever()},
+			{Code: `class A { static { const x = obj[ k ]; } }`, Options: optsAlways()},
+
+			// ---- For-of / for-in with ElementAccess as iterable / object ----
+			{Code: `for (const x of arr[k]) {}`, Options: optsNever()},
+			{Code: `for (const x of arr[ k ]) {}`, Options: optsAlways()},
+			{Code: `for (const x in obj[k]) {}`, Options: optsNever()},
+
+			// ---- Switch case expression ----
+			{Code: `function f(x: any) { switch (x) { case obj[k]: break; } }`, Options: optsNever()},
+			{Code: `function f(x: any) { switch (x) { case obj[ k ]: break; } }`, Options: optsAlways()},
+
+			// ---- Throw / Return / Yield / Await ----
+			{Code: `function f() { throw obj[k]; }`, Options: optsNever()},
+			{Code: `function f() { return obj[k]; }`, Options: optsNever()},
+			{Code: `async function f() { return await obj[k]; }`, Options: optsNever()},
+			{Code: `function* g() { yield obj[k]; }`, Options: optsNever()},
+
+			// ---- Dynamic import argument ----
+			{Code: `const x = import(obj[k])`, Options: optsNever()},
+			{Code: `const x = import(obj[ k ])`, Options: optsAlways()},
+
+			// ---- NewExpression receiver-chain: `new Cls()[k]` ----
+			// outermost is ElementAccess with receiver = NewExpression.
+			{Code: `const x = new Cls()[k]`, Options: optsNever()},
+			{Code: `const x = new Cls()[ k ]`, Options: optsAlways()},
+
+			// ---- Tagged template tag itself is ElementAccess ----
+			{Code: "const x = obj[k]`tpl`", Options: optsNever()},
+			{Code: "const x = obj[ k ]`tpl`", Options: optsAlways()},
+
+			// ---- IndexedAccessType inside generic type argument ----
+			{Code: `type X = Array<T[K]>`, Options: optsNever()},
+			{Code: `type X = Array<T[ K ]>`, Options: optsAlways()},
+			// As type assertion target
+			{Code: `const x = val as T[K]`, Options: optsNever()},
+			{Code: `const x = val as T[ K ]`, Options: optsAlways()},
+			// Function return / parameter type
+			{Code: `function f(x: A[K]): B[J] { return x as any }`, Options: optsNever()},
+			{Code: `function f(x: A[ K ]): B[ J ] { return x as any }`, Options: optsAlways()},
+			// Conditional type containing IndexedAccessType
+			{Code: `type T<X, K extends keyof X> = X extends Array<infer U> ? U[0] : X[K]`, Options: optsNever()},
+
+			// ---- Namespace / module class member ----
+			// MethodDeclaration's parent is ClassDeclaration even inside a
+			// namespace; our containerGated dispatch unchanged.
+			{Code: `namespace N { class A { [k]() {} } }`, Options: optsNever()},
+			{Code: `namespace N { class A { [ k ]() {} } }`, Options: optsAlways()},
+			// Module declaration form
+			{Code: `module M { class A { [k]() {} } }`, Options: optsNever()},
+
+			// ---- Default export with ElementAccess ----
+			{Code: `export default obj[k]`, Options: optsNever()},
+			{Code: `export default obj[ k ]`, Options: optsAlways()},
+
+			// ---- `super[k]` / `this[k]` inside class methods (already in J above, re-verifying in get/set/static contexts) ----
+			{Code: `class B extends A { static foo() { return super[k] } }`, Options: optsNever()},
+			{Code: `class B extends A { get bar() { return super[k] } }`, Options: optsNever()},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Locks in upstream checkSpacing() arm B.1 (always + missing opening): ElementAccess paren receiver ----
+			{
+				Code:    `(obj)[foo]`,
+				Output:  []string{`(obj)[ foo ]`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				},
+			},
+			// ---- Locks in upstream checkSpacing() arm B.2 (never + unexpected opening): non-null receiver ----
+			{
+				Code:    `obj![ foo ]`,
+				Output:  []string{`obj![foo]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				},
+			},
+			// ---- Locks in: type-assertion wrapped receiver, never mode ----
+			{
+				Code:    `(obj as any)[ foo ]`,
+				Output:  []string{`(obj as any)[foo]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+				},
+			},
+
+			// ---- Locks in: IndexedAccessType listener arm (no `.computed` guard upstream) ----
+			// TSIndexedAccessType is always checked regardless of mode-or-shape
+			// of the outer node. Without the dedicated listener, type-level
+			// `A[ B ]` would silently pass.
+			{
+				Code:    `type T = A[B | C]`,
+				Output:  []string{`type T = A[ B | C ]`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+
+			// ---- Locks in: ComputedPropertyName dispatch — ObjectLiteral method (not class member) ----
+			// MethodDeclaration in ObjectLiteral shares its kind with class
+			// methods; the grandparent dispatch must classify it as an object
+			// property so it's NOT gated by enforceForClassMembers.
+			{
+				Code:    `var x = {[ k ]() { return 1 }}`,
+				Output:  []string{`var x = {[k]() { return 1 }}`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+				},
+			},
+			// ---- Locks in: ComputedPropertyName dispatch — ObjectLiteral getter (not class member) ----
+			{
+				Code:    `var x = {get [ k ]() { return 1 }}`,
+				Output:  []string{`var x = {get [k]() { return 1 }}`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": false}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+			// ---- Locks in: BindingElement (destructuring) dispatch ----
+			// Destructuring patterns route through `BindingElement.PropertyName`,
+			// not `PropertyAssignment` — a separate parent kind in tsgo.
+			{
+				Code:    `const { [ a]: x } = obj;`,
+				Output:  []string{`const { [a]: x } = obj;`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				},
+			},
+
+			// ---- Locks in: optional chain receiver (`?.[`) — the `?.` token sits between Expression.End() and `[` ----
+			// The scanner-based `[`-finder skips across `?.` correctly; a
+			// byte-walking implementation would mis-classify `?.` as
+			// non-trivia and stop early.
+			{
+				Code:    `(maybe ?? other)?.[ foo ]`,
+				Output:  []string{`(maybe ?? other)?.[foo]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+				},
+			},
+
+			// ---- Locks in: tabs are whitespace (ECMAScript §12.2 WhiteSpace covers HT) ----
+			// SkipLeadingWhitespace / SkipTrailingWhitespace treat `\t` as
+			// whitespace; without that, `[\tfoo\t]` (never) would silently pass.
+			{
+				Code:    "obj[\tfoo\t]",
+				Output:  []string{`obj[foo]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter"},
+					{MessageId: "unexpectedSpaceBefore"},
+				},
+			},
+
+			// ---- Locks in: opening-only multi-line short-circuit (closing still reported) ----
+			// Upstream's `isTokenOnSameLine(before, first)` short-circuits the
+			// opening report when a newline intervenes. The closing report
+			// runs independently — if the close-side first/last are same-line
+			// with `]`, that side still fires.
+			{
+				Code:    "obj[\nfoo ]",
+				Output:  []string{"obj[\nfoo]"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 2, Column: 4, EndLine: 2, EndColumn: 5},
+				},
+			},
+
+			// ---- Locks in: nested ElementAccess inside ComputedPropertyName ----
+			// Inner brackets belong to ElementAccessExpression, outer to
+			// ComputedPropertyName — both listeners report independently.
+			{
+				Code:    `var x = {[obj[ k ]]: 1}`,
+				Output:  []string{`var x = {[obj[k]]: 1}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+
+			// ---- Locks in: PropertyDeclaration without initializer (class field) ----
+			// PropertyDeclaration → isClassMember=true unconditionally
+			// (PropertyDeclaration only appears in classes).
+			{
+				Code:    `class A { [ k ]; }`,
+				Output:  []string{`class A { [k]; }`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+
+			// ---- Locks in: 2-layer IndexedAccessType nesting — closePos must anchor at matching `]` ----
+			// In `A[B[ C ]]` (always), the inner `[ C ]` is already spaced
+			// — only outer brackets need fixes. The scanner-based closePos
+			// for the outer layer must skip past the inner `]` and land on
+			// the outer `]`; a naive `node.End()-1` could collide with
+			// trailing trivia and misreport.
+			{
+				Code:    `type T = A[B[ C ]]`,
+				Output:  []string{`type T = A[ B[ C ] ]`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+				},
+			},
+
+			// ---- Locks in: ElementAccess inside class member's computed key ----
+			// Outer key brackets are class-member-gated; inner ElementAccess
+			// brackets always fire. Both should report independently in
+			// source order.
+			{
+				Code:    `class A { [obj[ k ]](){} }`,
+				Output:  []string{`class A { [obj[k]](){} }`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+				},
+			},
+
+			// =====================================================================
+			//   Adversarial invalid lock-ins — each pairs with one of the
+			//   assumptions in the valid section above; if the implementation's
+			//   listener wiring or position resolution drifts, the failure
+			//   surfaces here.
+			// =====================================================================
+
+			// ---- Lock-in for Assumption E: chained optional access must report in source order ----
+			// `obj?.[ x ]?.[ y ]` → 4 errors, columns must increase strictly,
+			// alternating opening/closing per `?.[]` group.
+			{
+				Code:    `obj?.[ x ]?.[ y ]`,
+				Output:  []string{`obj?.[x]?.[y]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+				},
+			},
+
+			// ---- Lock-in for Assumption E: chained access without optional ----
+			{
+				Code:    `obj[ a ][ b ]`,
+				Output:  []string{`obj[a][b]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+
+			// ---- Lock-in for Assumption B: template-literal arg with interpolation ----
+			// `obj[ \`pre_${k}\` ]` never → 2 errors. The interpolated `${k}`
+			// must not confuse the closePos scanner (no stray `]` inside the
+			// template substitution).
+			{
+				Code:    "obj[ `pre_${k}_post` ]",
+				Output:  []string{"obj[`pre_${k}_post`]"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 21, EndLine: 1, EndColumn: 22},
+				},
+			},
+
+			// ---- Lock-in for Assumption B: string literal containing `]` byte ----
+			// The closing `]` is at the trailing byte; the embedded `]` inside
+			// the string must not confuse the scanner.
+			{
+				Code:    `obj[ "x]y" ]`,
+				Output:  []string{`obj["x]y"]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+
+			// ---- Lock-in for Assumption K: BigInt argument ----
+			{
+				Code:    `obj[ 1n ]`,
+				Output:  []string{`obj[1n]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+
+			// ---- Lock-in for Assumption H: destructuring with default value ----
+			{
+				Code:    `const { [ k ]: x = 1 } = obj`,
+				Output:  []string{`const { [k]: x = 1 } = obj`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+
+			// ---- Lock-in for Assumption C: MappedType `[P in K]` MUST NOT report; only `T[P]` does ----
+			// This is the critical false-positive guard. If the listener
+			// accidentally matches MappedTypeNode's type-parameter brackets,
+			// we'd report 4 errors. The correct behavior is exactly 2.
+			{
+				Code:    `type Pick<T, K extends keyof T> = { [P in K]: T[ P ] }`,
+				Output:  []string{`type Pick<T, K extends keyof T> = { [P in K]: T[P] }`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 49, EndLine: 1, EndColumn: 50},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 51, EndLine: 1, EndColumn: 52},
+				},
+			},
+
+			// ---- Lock-in for Assumption F: `override` modifier ----
+			{
+				Code:    `class B extends A { override [ k ]() {} }`,
+				Output:  []string{`class B extends A { override [k]() {} }`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 33, EndLine: 1, EndColumn: 34},
+				},
+			},
+
+			// ---- Lock-in for Assumption G: Symbol.iterator class member ----
+			{
+				Code:    `class Iter { [ Symbol.iterator ]() {} }`,
+				Output:  []string{`class Iter { [Symbol.iterator]() {} }`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+				},
+			},
+
+			// ---- Lock-in for Assumption N: BindingElement in function parameter destructuring ----
+			{
+				Code:    `function f({ [ k ]: x }) {}`,
+				Output:  []string{`function f({ [k]: x }) {}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+
+			// ---- Lock-in for Assumption O: decorator on computed class member ----
+			{
+				Code:    `class A { @dec [ k ]() {} }`,
+				Output:  []string{`class A { @dec [k]() {} }`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+				},
+			},
+
+			// ---- Lock-in for Assumption P: declare class member IS reported (not skipped like abstract) ----
+			{
+				Code:    `declare class A { [ k ]: number }`,
+				Output:  []string{`declare class A { [k]: number }`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+
+			// ---- Lock-in for Assumption M: 4-layer ElementAccess source order ----
+			// `obj[ a[ b[ c[ d ] ] ] ]` never → 8 errors strictly increasing
+			// columns (outer-open, ..., inner-open, inner-close, ..., outer-close).
+			{
+				Code:    `obj[ a[ b[ c[ d ] ] ] ]`,
+				Output:  []string{`obj[a[b[c[d]]]]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 18, EndLine: 1, EndColumn: 19},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing_upstream_test.go
+++ b/internal/plugins/stylistic/rules/computed_property_spacing/computed_property_spacing_upstream_test.go
@@ -1,0 +1,737 @@
+// TestComputedPropertySpacingUpstream migrates the full valid/invalid suite
+// from upstream packages/eslint-plugin/rules/computed-property-spacing/
+// computed-property-spacing._js_.test.ts and computed-property-spacing._ts_.test.ts
+// 1:1. Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in
+// computed_property_spacing_extras_test.go.
+package computed_property_spacing_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/computed_property_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func optsAlways() []interface{} { return []interface{}{"always"} }
+func optsNever() []interface{}  { return []interface{}{"never"} }
+func optsAlwaysObj(o map[string]interface{}) []any {
+	return []interface{}{"always", o}
+}
+func optsNeverObj(o map[string]interface{}) []any {
+	return []interface{}{"never", o}
+}
+
+func TestComputedPropertySpacingUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&computed_property_spacing.ComputedPropertySpacingRule,
+		[]rule_tester.ValidTestCase{
+			// ---- default - never ----
+			{Code: `obj[foo]`},
+			{Code: `obj['foo']`},
+			{Code: `var x = {[b]: a}`},
+
+			// ---- always ----
+			{Code: `obj[ foo ]`, Options: optsAlways()},
+			{Code: "obj[\nfoo\n]", Options: optsAlways()},
+			{Code: `obj[ 'foo' ]`, Options: optsAlways()},
+			{Code: `obj[ 'foo' + 'bar' ]`, Options: optsAlways()},
+			{Code: `obj[ obj2[ foo ] ]`, Options: optsAlways()},
+			{Code: "obj.map(function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsAlways()},
+			{Code: "obj[ 'map' ](function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsAlways()},
+			{Code: "obj[ 'for' + 'Each' ](function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsAlways()},
+			{Code: `var foo = obj[ 1 ]`, Options: optsAlways()},
+			{Code: `var foo = obj[ 'foo' ];`, Options: optsAlways()},
+			{Code: `var foo = obj[ [1, 1] ];`, Options: optsAlways()},
+
+			// ---- always - objectLiteralComputedProperties ----
+			{Code: `var x = {[ "a" ]: a}`, Options: optsAlways()},
+			{Code: `var y = {[ x ]: a}`, Options: optsAlways()},
+			{Code: `var x = {[ "a" ]() {}}`, Options: optsAlways()},
+			{Code: `var y = {[ x ]() {}}`, Options: optsAlways()},
+
+			// ---- always - unrelated cases ----
+			{Code: `var foo = {};`, Options: optsAlways()},
+			{Code: `var foo = [];`, Options: optsAlways()},
+
+			// ---- never ----
+			{Code: `obj[foo]`, Options: optsNever()},
+			{Code: `obj['foo']`, Options: optsNever()},
+			{Code: `obj['foo' + 'bar']`, Options: optsNever()},
+			{Code: `obj['foo'+'bar']`, Options: optsNever()},
+			{Code: `obj[obj2[foo]]`, Options: optsNever()},
+			{Code: "obj.map(function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsNever()},
+			{Code: "obj['map'](function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsNever()},
+			{Code: "obj['for' + 'Each'](function(item) { return [\n1,\n2,\n3,\n4\n]; })", Options: optsNever()},
+			{Code: "obj[\nfoo]", Options: optsNever()},
+			{Code: "obj[foo\n]", Options: optsNever()},
+			{Code: `var foo = obj[1]`, Options: optsNever()},
+			{Code: `var foo = obj['foo'];`, Options: optsNever()},
+			{Code: `var foo = obj[[ 1, 1 ]];`, Options: optsNever()},
+
+			// ---- never - objectLiteralComputedProperties ----
+			{Code: `var x = {["a"]: a}`, Options: optsNever()},
+			{Code: `var y = {[x]: a}`, Options: optsNever()},
+			{Code: `var x = {["a"]() {}}`, Options: optsNever()},
+			{Code: `var y = {[x]() {}}`, Options: optsNever()},
+
+			// ---- never - unrelated cases ----
+			{Code: `var foo = {};`, Options: optsNever()},
+			{Code: `var foo = [];`, Options: optsNever()},
+
+			// ---- Classes — enforceForClassMembers: false ----
+			{Code: `class A { [ a ](){} }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": false})},
+			{Code: `A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": false})},
+			{Code: `A = class { [a](){} }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": false})},
+			{Code: `class A { [a](){} get [b](){} set [b](foo){} static [c](){} static get [d](){} static set [d](bar){} }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": false})},
+			{Code: `class A { [ a ]; }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": false})},
+			{Code: `class A { [a]; }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": false})},
+
+			// ---- Classes — valid spacing ----
+			{Code: `A = class { [a](){} }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `class A { [a] ( ) { } }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: "A = class { [ \n a \n ](){} }", Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `class A { [a](){} get [b](){} set [b](foo){} static [c](){} static get [d](){} static set [d](bar){} }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `class A { [ a ](){} }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `class A { [ a ](){}[ b ](){} }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: "A = class { [\na\n](){} }", Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `A = class { [a]; static [a]; [a] = 0; static [a] = 0; }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `A = class { [ a ]; static [ a ]; [ a ] = 0; static [ a ] = 0; }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+
+			// ---- Classes — non-computed ----
+			{Code: `class A { a ( ) { } get b(){} set b ( foo ){} static c (){} static get d() {} static set d( bar ) {} }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `A = class {a(){}get b(){}set b(foo){}static c(){}static get d(){}static set d(bar){} }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `A = class { foo; #a; static #b; #c = 0; static #d = 0; }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `A = class { foo; #a; static #b; #c = 0; static #d = 0; }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true})},
+
+			// ---- handling of parens and comments ----
+			{Code: "const foo = {\n  [ (a) ]: 1\n}", Options: optsAlways()},
+			{Code: "const foo = {\n  [ ( a ) ]: 1\n}", Options: optsAlways()},
+			{Code: "const foo = {\n  [( a )]: 1\n}", Options: optsNever()},
+			{Code: "const foo = {\n  [ /**/ a /**/ ]: 1\n}", Options: optsAlways()},
+			{Code: "const foo = {\n  [/**/ a /**/]: 1\n}", Options: optsNever()},
+			{Code: "const foo = {\n  [ a[ b ] ]: 1\n}", Options: optsAlways()},
+			{Code: "const foo = {\n  [a[b]]: 1\n}", Options: optsNever()},
+			{Code: "const foo = {\n  [ a[ /**/ b ]/**/ ]: 1\n}", Options: optsAlways()},
+			{Code: "const foo = {\n  [/**/a[b /**/] /**/]: 1\n}", Options: optsNever()},
+
+			// ---- Destructuring assignment ----
+			{Code: `const { [a]: someProp } = obj;`, Options: optsNever()},
+			{Code: `({ [a]: someProp } = obj);`, Options: optsNever()},
+			{Code: `const { [ a ]: someProp } = obj;`, Options: optsAlways()},
+			{Code: `({ [ a ]: someProp } = obj);`, Options: optsAlways()},
+
+			// ---- TS only: accessor properties and indexed-access types ----
+			{Code: `class A { accessor [ b ]; }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": false})},
+			{Code: `class A { accessor [b]; }`, Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": false})},
+			{Code: `A = class { accessor [b] = 1 }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `class A { accessor [b] = 1 }`, Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: "A = class {\n  accessor [\n    b\n  ] = 1\n}", Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true})},
+			{Code: `type Foo = A[B]`},
+
+			// ---- Regression: non-computed property is a no-op (eslint-stylistic#1053) ----
+			{Code: `obj = { foo: bar }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:    `var foo = obj[ 1];`,
+				Output:  []string{`var foo = obj[ 1 ];`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:    `var foo = obj[1 ];`,
+				Output:  []string{`var foo = obj[ 1 ];`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:    `var foo = obj[ 1];`,
+				Output:  []string{`var foo = obj[1];`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code:    `var foo = obj[1 ];`,
+				Output:  []string{`var foo = obj[1];`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    `obj[ foo ]`,
+				Output:  []string{`obj[foo]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code:    `obj[foo ]`,
+				Output:  []string{`obj[foo]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+			{
+				Code:    `obj[ foo]`,
+				Output:  []string{`obj[foo]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+				},
+			},
+			{
+				Code:    `var foo = obj[1]`,
+				Output:  []string{`var foo = obj[ 1 ]`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+				},
+			},
+
+			// ---- multiple spaces ----
+			{
+				Code:    `obj[    foo]`,
+				Output:  []string{`obj[foo]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 9},
+				},
+			},
+			{
+				Code:    `obj[  foo  ]`,
+				Output:  []string{`obj[foo]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 7},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 10, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code:    `obj[   foo ]`,
+				Output:  []string{`obj[foo]`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 8},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code:    "obj[ foo + \n  bar   ]",
+				Output:  []string{"obj[foo + \n  bar]"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+					{MessageId: "unexpectedSpaceBefore", Line: 2, Column: 6, EndLine: 2, EndColumn: 9},
+				},
+			},
+			{
+				Code:    "obj[\n foo  ]",
+				Output:  []string{"obj[\n foo]"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 2, Column: 5, EndLine: 2, EndColumn: 7},
+				},
+			},
+
+			// ---- always - objectLiteralComputedProperties ----
+			{
+				Code:    `var x = {[a]: b}`,
+				Output:  []string{`var x = {[ a ]: b}`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:    `var x = {[a ]: b}`,
+				Output:  []string{`var x = {[ a ]: b}`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
+				Code:    `var x = {[ a]: b}`,
+				Output:  []string{`var x = {[ a ]: b}`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+				},
+			},
+
+			// ---- never - objectLiteralComputedProperties ----
+			{
+				Code:    `var x = {[ a ]: b}`,
+				Output:  []string{`var x = {[a]: b}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code:    `var x = {[a ]: b}`,
+				Output:  []string{`var x = {[a]: b}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:    `var x = {[ a]: b}`,
+				Output:  []string{`var x = {[a]: b}`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code:    "var x = {[ a\n]: b}",
+				Output:  []string{"var x = {[a\n]: b}"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+
+			// ---- default settings for classes ----
+			{
+				Code:   `class A { [ a ](){} }`,
+				Output: []string{`class A { [a](){} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:    `class A { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }`,
+				Output:  []string{`class A { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 26, EndLine: 1, EndColumn: 27},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 28, EndLine: 1, EndColumn: 29},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 40, EndLine: 1, EndColumn: 41},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 42, EndLine: 1, EndColumn: 43},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 60, EndLine: 1, EndColumn: 61},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 62, EndLine: 1, EndColumn: 63},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 81, EndLine: 1, EndColumn: 82},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 83, EndLine: 1, EndColumn: 84},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 102, EndLine: 1, EndColumn: 103},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 104, EndLine: 1, EndColumn: 105},
+				},
+			},
+			{
+				Code:    `A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }`,
+				Output:  []string{`A = class { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }`},
+				Options: []interface{}{"never", map[string]interface{}{}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 28, EndLine: 1, EndColumn: 29},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 30, EndLine: 1, EndColumn: 31},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 42, EndLine: 1, EndColumn: 43},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 44, EndLine: 1, EndColumn: 45},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 62, EndLine: 1, EndColumn: 63},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 64, EndLine: 1, EndColumn: 65},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 83, EndLine: 1, EndColumn: 84},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 85, EndLine: 1, EndColumn: 86},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 104, EndLine: 1, EndColumn: 105},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 106, EndLine: 1, EndColumn: 107},
+				},
+			},
+			{
+				Code:    `A = class { [a](){} }`,
+				Output:  []string{`A = class { [ a ](){} }`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code:    `A = class { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }`,
+				Output:  []string{`A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 27, EndLine: 1, EndColumn: 28},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 37, EndLine: 1, EndColumn: 38},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 39, EndLine: 1, EndColumn: 40},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 55, EndLine: 1, EndColumn: 56},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 57, EndLine: 1, EndColumn: 58},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 74, EndLine: 1, EndColumn: 75},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 76, EndLine: 1, EndColumn: 77},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 93, EndLine: 1, EndColumn: 94},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 95, EndLine: 1, EndColumn: 96},
+				},
+			},
+			{
+				Code:    `class A { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }`,
+				Output:  []string{`class A { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }`},
+				Options: []interface{}{"always", map[string]interface{}{}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 35, EndLine: 1, EndColumn: 36},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 37, EndLine: 1, EndColumn: 38},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 53, EndLine: 1, EndColumn: 54},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 55, EndLine: 1, EndColumn: 56},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 72, EndLine: 1, EndColumn: 73},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 74, EndLine: 1, EndColumn: 75},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 91, EndLine: 1, EndColumn: 92},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 93, EndLine: 1, EndColumn: 94},
+				},
+			},
+
+			// ---- never - classes ----
+			{
+				Code:    `class A { [ a](){} }`,
+				Output:  []string{`class A { [a](){} }`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:    `A = class { [a](){} b(){} static [c ](){} static [d](){}}`,
+				Output:  []string{`A = class { [a](){} b(){} static [c](){} static [d](){}}`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 36, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				Code:    `class A { get [a ](){} set [ a](foo){} get b(){} static set b(bar){} static get [ a](){} static set [a ](baz){} }`,
+				Output:  []string{`class A { get [a](){} set [a](foo){} get b(){} static set b(bar){} static get [a](){} static set [a](baz){} }`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 29, EndLine: 1, EndColumn: 30},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 82, EndLine: 1, EndColumn: 83},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 103, EndLine: 1, EndColumn: 104},
+				},
+			},
+			{
+				Code:    `A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }`,
+				Output:  []string{`A = class { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 28, EndLine: 1, EndColumn: 29},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 30, EndLine: 1, EndColumn: 31},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 42, EndLine: 1, EndColumn: 43},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 44, EndLine: 1, EndColumn: 45},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 62, EndLine: 1, EndColumn: 63},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 64, EndLine: 1, EndColumn: 65},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 83, EndLine: 1, EndColumn: 84},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 85, EndLine: 1, EndColumn: 86},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 104, EndLine: 1, EndColumn: 105},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 106, EndLine: 1, EndColumn: 107},
+				},
+			},
+			{
+				Code:    `class A { [ a]; [b ]; [ c ]; [ a] = 0; [b ] = 0; [ c ] = 0; }`,
+				Output:  []string{`class A { [a]; [b]; [c]; [a] = 0; [b] = 0; [c] = 0; }`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 24, EndLine: 1, EndColumn: 25},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 26, EndLine: 1, EndColumn: 27},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 42, EndLine: 1, EndColumn: 43},
+					{MessageId: "unexpectedSpaceAfter", Line: 1, Column: 51, EndLine: 1, EndColumn: 52},
+					{MessageId: "unexpectedSpaceBefore", Line: 1, Column: 53, EndLine: 1, EndColumn: 54},
+				},
+			},
+
+			// ---- always - classes ----
+			{
+				Code:    `class A { [ a](){} }`,
+				Output:  []string{`class A { [ a ](){} }`},
+				Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:    `A = class { [ a ](){} b(){} static [c ](){} static [ d ](){}}`,
+				Output:  []string{`A = class { [ a ](){} b(){} static [ c ](){} static [ d ](){}}`},
+				Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 36, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				Code:    `class A { get [a ](){} set [ a](foo){} get b(){} static set b(bar){} static get [ a](){} static set [a ](baz){} }`,
+				Output:  []string{`class A { get [ a ](){} set [ a ](foo){} get b(){} static set b(bar){} static get [ a ](){} static set [ a ](baz){} }`},
+				Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 84, EndLine: 1, EndColumn: 85},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 101, EndLine: 1, EndColumn: 102},
+				},
+			},
+			{
+				Code:    `A = class { [a](){} get [b](){} set [c](foo){} static [d](){} static get [e](){} static set [f](bar){} }`,
+				Output:  []string{`A = class { [ a ](){} get [ b ](){} set [ c ](foo){} static [ d ](){} static get [ e ](){} static set [ f ](bar){} }`},
+				Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 27, EndLine: 1, EndColumn: 28},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 37, EndLine: 1, EndColumn: 38},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 39, EndLine: 1, EndColumn: 40},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 55, EndLine: 1, EndColumn: 56},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 57, EndLine: 1, EndColumn: 58},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 74, EndLine: 1, EndColumn: 75},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 76, EndLine: 1, EndColumn: 77},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 93, EndLine: 1, EndColumn: 94},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 95, EndLine: 1, EndColumn: 96},
+				},
+			},
+			{
+				Code:    `class A { [ a]; [b ]; [c]; [ a] = 0; [b ] = 0; [c] = 0; }`,
+				Output:  []string{`class A { [ a ]; [ b ]; [ c ]; [ a ] = 0; [ b ] = 0; [ c ] = 0; }`},
+				Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 38, EndLine: 1, EndColumn: 39},
+					{MessageId: "missingSpaceAfter", Line: 1, Column: 48, EndLine: 1, EndColumn: 49},
+					{MessageId: "missingSpaceBefore", Line: 1, Column: 50, EndLine: 1, EndColumn: 51},
+				},
+			},
+
+			// ---- handling of parens and comments ----
+			{
+				Code:    "const foo = {\n  [(a)]: 1\n}",
+				Output:  []string{"const foo = {\n  [ (a) ]: 1\n}"},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 2, Column: 3, EndLine: 2, EndColumn: 4},
+					{MessageId: "missingSpaceBefore", Line: 2, Column: 7, EndLine: 2, EndColumn: 8},
+				},
+			},
+			{
+				Code:    "const foo = {\n  [( a )]: 1\n}",
+				Output:  []string{"const foo = {\n  [ ( a ) ]: 1\n}"},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 2, Column: 3, EndLine: 2, EndColumn: 4},
+					{MessageId: "missingSpaceBefore", Line: 2, Column: 9, EndLine: 2, EndColumn: 10},
+				},
+			},
+			{
+				Code:    "const foo = {\n  [ ( a ) ]: 1\n}",
+				Output:  []string{"const foo = {\n  [( a )]: 1\n}"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 2, Column: 4, EndLine: 2, EndColumn: 5},
+					{MessageId: "unexpectedSpaceBefore", Line: 2, Column: 10, EndLine: 2, EndColumn: 11},
+				},
+			},
+			{
+				Code:    "const foo = {\n  [/**/ a /**/]: 1\n}",
+				Output:  []string{"const foo = {\n  [ /**/ a /**/ ]: 1\n}"},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 2, Column: 3, EndLine: 2, EndColumn: 4},
+					{MessageId: "missingSpaceBefore", Line: 2, Column: 15, EndLine: 2, EndColumn: 16},
+				},
+			},
+			{
+				Code:    "const foo = {\n  [ /**/ a /**/ ]: 1\n}",
+				Output:  []string{"const foo = {\n  [/**/ a /**/]: 1\n}"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 2, Column: 4, EndLine: 2, EndColumn: 5},
+					{MessageId: "unexpectedSpaceBefore", Line: 2, Column: 16, EndLine: 2, EndColumn: 17},
+				},
+			},
+			{
+				Code:    "const foo = {\n  [a[b]]: 1\n}",
+				Output:  []string{"const foo = {\n  [ a[ b ] ]: 1\n}"},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 2, Column: 3, EndLine: 2, EndColumn: 4},
+					{MessageId: "missingSpaceAfter", Line: 2, Column: 5, EndLine: 2, EndColumn: 6},
+					{MessageId: "missingSpaceBefore", Line: 2, Column: 7, EndLine: 2, EndColumn: 8},
+					{MessageId: "missingSpaceBefore", Line: 2, Column: 8, EndLine: 2, EndColumn: 9},
+				},
+			},
+			{
+				Code:    "const foo = {\n  [ a[ b ] ]: 1\n}",
+				Output:  []string{"const foo = {\n  [a[b]]: 1\n}"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 2, Column: 4, EndLine: 2, EndColumn: 5},
+					{MessageId: "unexpectedSpaceAfter", Line: 2, Column: 7, EndLine: 2, EndColumn: 8},
+					{MessageId: "unexpectedSpaceBefore", Line: 2, Column: 9, EndLine: 2, EndColumn: 10},
+					{MessageId: "unexpectedSpaceBefore", Line: 2, Column: 11, EndLine: 2, EndColumn: 12},
+				},
+			},
+			{
+				Code:    "const foo = {\n  [a[/**/ b ]/**/]: 1\n}",
+				Output:  []string{"const foo = {\n  [ a[ /**/ b ]/**/ ]: 1\n}"},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Line: 2, Column: 3, EndLine: 2, EndColumn: 4},
+					{MessageId: "missingSpaceAfter", Line: 2, Column: 5, EndLine: 2, EndColumn: 6},
+					{MessageId: "missingSpaceBefore", Line: 2, Column: 18, EndLine: 2, EndColumn: 19},
+				},
+			},
+			{
+				Code:    "const foo = {\n  [ /**/a[ b /**/ ] /**/]: 1\n}",
+				Output:  []string{"const foo = {\n  [/**/a[b /**/] /**/]: 1\n}"},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Line: 2, Column: 4, EndLine: 2, EndColumn: 5},
+					{MessageId: "unexpectedSpaceAfter", Line: 2, Column: 11, EndLine: 2, EndColumn: 12},
+					{MessageId: "unexpectedSpaceBefore", Line: 2, Column: 18, EndLine: 2, EndColumn: 19},
+				},
+			},
+
+			// ---- Optional chaining ----
+			{
+				Code:    `obj?.[1];`,
+				Output:  []string{`obj?.[ 1 ];`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter"},
+					{MessageId: "missingSpaceBefore"},
+				},
+			},
+			{
+				Code:    `obj?.[ 1 ];`,
+				Output:  []string{`obj?.[1];`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter"},
+					{MessageId: "unexpectedSpaceBefore"},
+				},
+			},
+
+			// ---- Destructuring Assignment ----
+			{
+				Code:    `const { [ a]: someProp } = obj;`,
+				Output:  []string{`const { [a]: someProp } = obj;`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter"},
+				},
+			},
+			{
+				Code:    `const { [a ]: someProp } = obj;`,
+				Output:  []string{`const { [a]: someProp } = obj;`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceBefore"},
+				},
+			},
+			{
+				Code:    `const { [ a ]: someProp } = obj;`,
+				Output:  []string{`const { [a]: someProp } = obj;`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter"},
+					{MessageId: "unexpectedSpaceBefore"},
+				},
+			},
+			{
+				Code:    `({ [ a ]: someProp } = obj);`,
+				Output:  []string{`({ [a]: someProp } = obj);`},
+				Options: optsNever(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter"},
+					{MessageId: "unexpectedSpaceBefore"},
+				},
+			},
+			{
+				Code:    `const { [a]: someProp } = obj;`,
+				Output:  []string{`const { [ a ]: someProp } = obj;`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter"},
+					{MessageId: "missingSpaceBefore"},
+				},
+			},
+			{
+				Code:    `({ [a]: someProp } = obj);`,
+				Output:  []string{`({ [ a ]: someProp } = obj);`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter"},
+					{MessageId: "missingSpaceBefore"},
+				},
+			},
+
+			// ---- TS — AccessorProperty and IndexedAccessType ----
+			{
+				Code:    `class A { accessor [ a ] = 0 }`,
+				Output:  []string{`class A { accessor [a] = 0 }`},
+				Options: optsNeverObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter", Column: 21, EndColumn: 22},
+					{MessageId: "unexpectedSpaceBefore", Column: 23, EndColumn: 24},
+				},
+			},
+			{
+				Code:    `class A { accessor [a] = 0 }`,
+				Output:  []string{`class A { accessor [ a ] = 0 }`},
+				Options: optsAlwaysObj(map[string]interface{}{"enforceForClassMembers": true}),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter", Column: 20, EndColumn: 21},
+					{MessageId: "missingSpaceBefore", Column: 22, EndColumn: 23},
+				},
+			},
+			{
+				Code:   `type Foo = A[ B ]`,
+				Output: []string{`type Foo = A[B]`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSpaceAfter"},
+					{MessageId: "unexpectedSpaceBefore"},
+				},
+			},
+			{
+				Code:    `type Foo = A[B]`,
+				Output:  []string{`type Foo = A[ B ]`},
+				Options: optsAlways(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSpaceAfter"},
+					{MessageId: "missingSpaceBefore"},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -457,6 +457,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/block-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/brace-style.test.ts',
     './tests/eslint-plugin-stylistic/rules/comma-spacing.test.ts',
+    './tests/eslint-plugin-stylistic/rules/computed-property-spacing.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/computed-property-spacing.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/computed-property-spacing.test.ts
@@ -1,0 +1,342 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('computed-property-spacing', null as never, {
+  valid: [
+    // default - never
+    { code: 'obj[foo]' },
+    { code: "obj['foo']" },
+    { code: 'var x = {[b]: a}' },
+
+    // always
+    { code: 'obj[ foo ]', options: ['always'] },
+    { code: 'obj[\nfoo\n]', options: ['always'] },
+    { code: "obj[ 'foo' ]", options: ['always'] },
+    { code: "obj[ 'foo' + 'bar' ]", options: ['always'] },
+    { code: 'obj[ obj2[ foo ] ]', options: ['always'] },
+    { code: 'var foo = obj[ 1 ]', options: ['always'] },
+    { code: "var foo = obj[ 'foo' ];", options: ['always'] },
+    { code: 'var foo = obj[ [1, 1] ];', options: ['always'] },
+
+    // always - objectLiteralComputedProperties
+    { code: 'var x = {[ "a" ]: a}', options: ['always'] },
+    { code: 'var y = {[ x ]: a}', options: ['always'] },
+    { code: 'var x = {[ "a" ]() {}}', options: ['always'] },
+    { code: 'var y = {[ x ]() {}}', options: ['always'] },
+
+    // never
+    { code: 'obj[foo]', options: ['never'] },
+    { code: "obj['foo']", options: ['never'] },
+    { code: "obj['foo' + 'bar']", options: ['never'] },
+    { code: 'obj[obj2[foo]]', options: ['never'] },
+    { code: 'obj[\nfoo]', options: ['never'] },
+    { code: 'obj[foo\n]', options: ['never'] },
+    { code: 'var foo = obj[1]', options: ['never'] },
+    { code: 'var foo = obj[[ 1, 1 ]];', options: ['never'] },
+
+    // never - objectLiteralComputedProperties
+    { code: 'var x = {["a"]: a}', options: ['never'] },
+    { code: 'var y = {[x]: a}', options: ['never'] },
+    { code: 'var x = {["a"]() {}}', options: ['never'] },
+    { code: 'var y = {[x]() {}}', options: ['never'] },
+
+    // Classes — enforceForClassMembers
+    {
+      code: 'class A { [ a ](){} }',
+      options: ['never', { enforceForClassMembers: false }],
+    },
+    {
+      code: 'A = class { [a](){} }',
+      options: ['always', { enforceForClassMembers: false }],
+    },
+    {
+      code: 'class A { [ a ]; }',
+      options: ['never', { enforceForClassMembers: false }],
+    },
+    {
+      code: 'class A { [a]; }',
+      options: ['always', { enforceForClassMembers: false }],
+    },
+
+    // Classes — valid spacing
+    {
+      code: 'A = class { [a](){} }',
+      options: ['never', { enforceForClassMembers: true }],
+    },
+    {
+      code: 'class A { [ a ](){} }',
+      options: ['always', { enforceForClassMembers: true }],
+    },
+    {
+      code: 'A = class { [a]; static [a]; [a] = 0; static [a] = 0; }',
+      options: ['never', { enforceForClassMembers: true }],
+    },
+
+    // Destructuring Assignment
+    { code: 'const { [a]: someProp } = obj;', options: ['never'] },
+    { code: '({ [a]: someProp } = obj);', options: ['never'] },
+    { code: 'const { [ a ]: someProp } = obj;', options: ['always'] },
+
+    // TS — AccessorProperty & IndexedAccessType
+    {
+      code: 'class A { accessor [b] = 1 }',
+      options: ['never', { enforceForClassMembers: true }],
+    },
+    { code: 'type Foo = A[B]' },
+  ],
+
+  invalid: [
+    {
+      code: 'var foo = obj[ 1];',
+      output: 'var foo = obj[ 1 ];',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 17,
+          endLine: 1,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'var foo = obj[1 ];',
+      output: 'var foo = obj[ 1 ];',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 15,
+        },
+      ],
+    },
+    {
+      code: 'obj[ foo ]',
+      output: 'obj[foo]',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 6,
+        },
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 10,
+        },
+      ],
+    },
+    {
+      code: 'var foo = obj[1]',
+      output: 'var foo = obj[ 1 ]',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 15,
+        },
+        {
+          messageId: 'missingSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+    },
+
+    // always - objectLiteralComputedProperties
+    {
+      code: 'var x = {[a]: b}',
+      output: 'var x = {[ a ]: b}',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 10,
+          endLine: 1,
+          endColumn: 11,
+        },
+        {
+          messageId: 'missingSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+
+    // never - objectLiteralComputedProperties
+    {
+      code: 'var x = {[ a ]: b}',
+      output: 'var x = {[a]: b}',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 12,
+        },
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+
+    // default class behavior (enforceForClassMembers: true)
+    {
+      code: 'class A { [ a ](){} }',
+      output: 'class A { [a](){} }',
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 15,
+        },
+      ],
+    },
+
+    // never - classes
+    {
+      code: 'class A { [ a](){} }',
+      output: 'class A { [a](){} }',
+      options: ['never', { enforceForClassMembers: true }],
+      errors: [
+        {
+          messageId: 'unexpectedSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+
+    // always - classes
+    {
+      code: 'A = class { [a](){} }',
+      output: 'A = class { [ a ](){} }',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingSpaceAfter',
+          data: { tokenValue: '[' },
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 14,
+        },
+        {
+          messageId: 'missingSpaceBefore',
+          data: { tokenValue: ']' },
+          line: 1,
+          column: 15,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+
+    // Optional chaining
+    {
+      code: 'obj?.[1];',
+      output: 'obj?.[ 1 ];',
+      options: ['always'],
+      errors: [
+        { messageId: 'missingSpaceAfter', data: { tokenValue: '[' } },
+        { messageId: 'missingSpaceBefore', data: { tokenValue: ']' } },
+      ],
+    },
+    {
+      code: 'obj?.[ 1 ];',
+      output: 'obj?.[1];',
+      options: ['never'],
+      errors: [
+        { messageId: 'unexpectedSpaceAfter', data: { tokenValue: '[' } },
+        { messageId: 'unexpectedSpaceBefore', data: { tokenValue: ']' } },
+      ],
+    },
+
+    // Destructuring
+    {
+      code: 'const { [ a ]: someProp } = obj;',
+      output: 'const { [a]: someProp } = obj;',
+      options: ['never'],
+      errors: [
+        { messageId: 'unexpectedSpaceAfter', data: { tokenValue: '[' } },
+        { messageId: 'unexpectedSpaceBefore', data: { tokenValue: ']' } },
+      ],
+    },
+
+    // TS — AccessorProperty + IndexedAccessType
+    {
+      code: 'class A { accessor [ a ] = 0 }',
+      output: 'class A { accessor [a] = 0 }',
+      options: ['never', { enforceForClassMembers: true }],
+      errors: [
+        { messageId: 'unexpectedSpaceAfter', column: 21, endColumn: 22 },
+        { messageId: 'unexpectedSpaceBefore', column: 23, endColumn: 24 },
+      ],
+    },
+    {
+      code: 'type Foo = A[ B ]',
+      output: 'type Foo = A[B]',
+      errors: [
+        { messageId: 'unexpectedSpaceAfter', data: { tokenValue: '[' } },
+        { messageId: 'unexpectedSpaceBefore', data: { tokenValue: ']' } },
+      ],
+    },
+    {
+      code: 'type Foo = A[B]',
+      output: 'type Foo = A[ B ]',
+      options: ['always'],
+      errors: [
+        { messageId: 'missingSpaceAfter', data: { tokenValue: '[' } },
+        { messageId: 'missingSpaceBefore', data: { tokenValue: ']' } },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the [`@stylistic/computed-property-spacing`](https://eslint.style/rules/computed-property-spacing) rule to rslint with 1:1 behavior parity (default `"never"`, optional `"always"`, plus `enforceForClassMembers` boolean).

Coverage verified by a 3-codebase differential audit against `eslint + @stylistic/eslint-plugin` (rsbuild, rspack, typescript-go); reports are byte-identical on every file linted by both tools (1330 vs 1330 on rsbuild incl. .tsx, 4964 vs 4964 on rspack incl. .tsx, 7058 vs 7058 on non-baseline real source in typescript-go). Two upstream-alignment skips needed by tsgo (abstract class members; JSDoc `@type {...}` interior) are encoded in `isAbstractMember` / `inJSDoc` with rationale in source comments and lock-in tests.

## Related Links

- ESLint rule: https://eslint.style/rules/computed-property-spacing
- Source code: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/computed-property-spacing/computed-property-spacing.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).