### PR TITLE
feat: port rule @stylistic/comma-style

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -8,6 +8,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/brace_style"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_dangle"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_spacing"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_style"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/computed_property_spacing"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -21,6 +22,7 @@ func GetAllRules() []rule.Rule {
 		brace_style.BraceStyleRule,
 		comma_dangle.CommaDangleRule,
 		comma_spacing.CommaSpacingRule,
+		comma_style.CommaStyleRule,
 		computed_property_spacing.ComputedPropertySpacingRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/comma_style/comma_style.go
+++ b/internal/plugins/stylistic/rules/comma_style/comma_style.go
@@ -1,0 +1,1083 @@
+package comma_style
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/stylisticutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const (
+	styleFirst = "first"
+	styleLast  = "last"
+
+	msgUnexpectedLineBeforeAndAfterComma = "unexpectedLineBeforeAndAfterComma"
+	msgExpectedCommaFirst                = "expectedCommaFirst"
+	msgExpectedCommaLast                 = "expectedCommaLast"
+
+	descUnexpectedLineBeforeAndAfterComma = "Bad line breaking before and after ','."
+	descExpectedCommaFirst                = "',' should be placed first."
+	descExpectedCommaLast                 = "',' should be placed last."
+
+	fixStyleBetween = "between"
+)
+
+// Upstream exception keys (ESTree node-type names). Each key gates one of the
+// listener fan-outs below. We match upstream verbatim so user-facing option
+// shapes are byte-for-byte identical.
+const (
+	excVariableDeclaration             = "VariableDeclaration"
+	excObjectExpression                = "ObjectExpression"
+	excObjectPattern                   = "ObjectPattern"
+	excArrayExpression                 = "ArrayExpression"
+	excArrayPattern                    = "ArrayPattern"
+	excFunctionDeclaration             = "FunctionDeclaration"
+	excFunctionExpression              = "FunctionExpression"
+	excArrowFunctionExpression         = "ArrowFunctionExpression"
+	excCallExpression                  = "CallExpression"
+	excImportDeclaration               = "ImportDeclaration"
+	excNewExpression                   = "NewExpression"
+	excExportAllDeclaration            = "ExportAllDeclaration"
+	excExportNamedDeclaration          = "ExportNamedDeclaration"
+	excImportExpression                = "ImportExpression"
+	excSequenceExpression              = "SequenceExpression"
+	excClassDeclaration                = "ClassDeclaration"
+	excClassExpression                 = "ClassExpression"
+	excTSDeclareFunction               = "TSDeclareFunction"
+	excTSFunctionType                  = "TSFunctionType"
+	excTSConstructorType               = "TSConstructorType"
+	excTSEmptyBodyFunctionExpression   = "TSEmptyBodyFunctionExpression"
+	excTSEnumBody                      = "TSEnumBody"
+	excTSTypeLiteral                   = "TSTypeLiteral"
+	excTSIndexSignature                = "TSIndexSignature"
+	excTSMethodSignature               = "TSMethodSignature"
+	excTSCallSignatureDeclaration      = "TSCallSignatureDeclaration"
+	excTSConstructSignatureDeclaration = "TSConstructSignatureDeclaration"
+	excTSInterfaceBody                 = "TSInterfaceBody"
+	excTSInterfaceDeclaration          = "TSInterfaceDeclaration"
+	excTSTupleType                     = "TSTupleType"
+	excTSTypeParameterDeclaration      = "TSTypeParameterDeclaration"
+	excTSTypeParameterInstantiation    = "TSTypeParameterInstantiation"
+)
+
+type options struct {
+	style      string
+	exceptions map[string]bool
+}
+
+// parseOptions mirrors upstream's schema:
+//
+//	rule: ['comma-style']                                    → 'last', no exceptions
+//	rule: ['comma-style', 'first' | 'last']                  → style, no exceptions
+//	rule: ['comma-style', <style>, { exceptions: { … } }]    → style + exception map
+//
+// rslint's config loader collapses a single trailing option element into the
+// option directly, so the first slot might travel as a bare string. We accept
+// both shapes here.
+func parseOptions(raw any) options {
+	opts := options{style: styleLast}
+
+	var arr []any
+	switch v := raw.(type) {
+	case []any:
+		arr = v
+	case string:
+		arr = []any{v}
+	}
+
+	if len(arr) > 0 {
+		if s, ok := arr[0].(string); ok {
+			switch s {
+			case styleFirst, styleLast:
+				opts.style = s
+			}
+		}
+	}
+	if len(arr) > 1 {
+		if m, ok := arr[1].(map[string]any); ok {
+			if e, ok := m["exceptions"].(map[string]any); ok {
+				exc := make(map[string]bool, len(e))
+				for k, val := range e {
+					if b, ok := val.(bool); ok {
+						exc[k] = b
+					}
+				}
+				opts.exceptions = exc
+			}
+		}
+	}
+	return opts
+}
+
+// tk is a single token captured by the forward scan over a list range.
+// Stored as a flat slice so per-comma neighbor lookups are O(1).
+type tk struct {
+	kind ast.Kind
+	pos  int
+	end  int
+}
+
+type scanCtx struct {
+	ctx   rule.RuleContext
+	sf    *ast.SourceFile
+	text  string
+	style string
+}
+
+// listScanSpec describes a single list validation.
+//
+//   - startPos / scanEnd: byte range to forward-scan. For bracketed lists
+//     pass `list.Pos()` and a position past the close bracket (typically
+//     `parent.End()` — the close-bracket token gets pulled into the token
+//     slice so trailing-comma neighbors are well-defined).
+//   - items: the AST elements of the list (NodeList.Nodes). Used to filter
+//     out commas that fall *inside* an element's range (heritage-clause
+//     types, sequence operands containing class expressions, …). Pass the
+//     element list as-is — `KindOmittedExpression` entries are zero-width
+//     and don't shadow any token.
+//   - startsAfterArrayOpen: true for `ArrayLiteralExpression` /
+//     `ArrayBindingPattern` lists, where upstream's array-hole carve-out
+//     skips a comma whose preceding context (walking back through any
+//     contiguous comma chain) reaches the `[` token. Our scan starts AFTER
+//     `[`, so this flag stands in for "no earlier token in the slice =
+//     the `[` is what's there in the source."
+type listScanSpec struct {
+	startPos             int
+	scanEnd              int
+	items                []*ast.Node
+	startsAfterArrayOpen bool
+}
+
+// validateList forward-scans [spec.startPos, spec.scanEnd), collects every
+// comma whose position falls *outside* every item's range (those are
+// separator commas at this list's level), then dispatches each to
+// `validateOneComma`.
+//
+// The "outside every item range" filter is what makes this AST-driven scan
+// resilient to nested unbracketed comma-bearing constructs (heritage
+// clauses, sequence expressions containing classes, etc.) — those commas
+// physically live inside one of the list's items, so they're skipped here
+// and picked up by the dedicated listener for the inner node.
+func (sc *scanCtx) validateList(spec listScanSpec) {
+	if spec.startPos < 0 || spec.scanEnd <= spec.startPos {
+		return
+	}
+
+	itemRanges := make([][2]int, 0, len(spec.items))
+	for _, it := range spec.items {
+		if it == nil {
+			continue
+		}
+		// OmittedExpression carries a zero-width range at the position of
+		// the surrounding `,` — it can't contain any token, so skipping it
+		// here keeps the filter from masking the separator comma whose
+		// position it shares.
+		if it.Kind == ast.KindOmittedExpression {
+			continue
+		}
+		// Compute the item's "first significant token" position by
+		// skipping leading trivia (whitespace + comments). Used as the
+		// pseudo-token's `pos` so adjacent-comma sameLine checks
+		// reference the real token, not the trivia run.
+		startTok := scanner.SkipTrivia(sc.text, it.Pos())
+		// tsgo's `parseTypeMemberSemicolon` consumes a trailing `,` or `;`
+		// AS PART OF the TypeElement's parse, so member.End() lands past
+		// the separator (often at the start of the next member). The
+		// `insideItem` filter would then incorrectly classify the separator
+		// comma as "inside this member". `itemContentEnd` walks the item's
+		// own tokens and returns the position right after its LAST
+		// significant (non-`,`, non-`;`) token, which gives us the real
+		// content end. For items whose parser does NOT consume the
+		// separator (most kinds — array elements, object literal
+		// properties, parameters, …), this is a no-op.
+		end := sc.itemContentEnd(it)
+		itemRanges = append(itemRanges, [2]int{startTok, end})
+	}
+
+	// itemContaining returns the (pos, end) of the smallest item-range
+	// that strictly contains `pos` (pos in [r[0], r[1])), or
+	// (-1, -1, false) when `pos` is outside every item. Used to skip
+	// the scanner past list items whose interior content could confuse
+	// tokenization (notably templated strings — when scanned without
+	// template-state context, a nested closing back-tick is
+	// mis-tokenized as a fresh `NoSubstitutionTemplateLiteral`,
+	// swallowing every byte until the next back-tick or EOF).
+	itemContaining := func(pos int) (int, int, bool) {
+		for _, r := range itemRanges {
+			if pos >= r[0] && pos < r[1] {
+				return r[0], r[1], true
+			}
+		}
+		return -1, -1, false
+	}
+
+	s := scanner.GetScannerForSourceFile(sc.sf, spec.startPos)
+	var tokens []tk
+	var commaIdx []int
+
+	for {
+		kind := s.Token()
+		if kind == ast.KindEndOfFile {
+			break
+		}
+		start := s.TokenStart()
+		if start >= spec.scanEnd {
+			break
+		}
+		if itemPos, itemEnd, ok := itemContaining(start); ok {
+			// Append a pseudo-token representing the item as a single
+			// opaque unit. The `kind` is `Unknown` — deliberately not
+			// `,` and not `[` so the validateOneComma skip-conditions
+			// don't fire on it; only its (pos, end) is used, for the
+			// sameLine check against an adjacent separator comma.
+			tokens = append(tokens, tk{ast.KindUnknown, itemPos, itemEnd})
+			s = scanner.GetScannerForSourceFile(sc.sf, itemEnd)
+			continue
+		}
+		end := s.TokenEnd()
+		tokens = append(tokens, tk{kind, start, end})
+		if kind == ast.KindCommaToken {
+			commaIdx = append(commaIdx, len(tokens)-1)
+		}
+		s.Scan()
+	}
+
+	for _, i := range commaIdx {
+		sc.validateOneComma(tokens, i, spec.startsAfterArrayOpen)
+	}
+}
+
+// validateOneComma applies upstream's three skip-conditions, then dispatches
+// to validateCommaItemSpacing for the actual reporting decision.
+//
+// `startsAfterArrayOpen` extends upstream's second skip-condition into our
+// scan model: upstream walks back through any preceding comma chain and
+// skips when it lands on `[`. Our token slice starts *after* the array's
+// `[`, so when the walk-back runs off the front of the slice we treat
+// that as "would have been `[`" iff the list is an array.
+func (sc *scanCtx) validateOneComma(tokens []tk, idx int, startsAfterArrayOpen bool) {
+	if idx <= 0 || idx >= len(tokens)-1 {
+		// Need both tokenBefore and tokenAfter to validate; bail otherwise.
+		return
+	}
+	before := tokens[idx-1]
+	comma := tokens[idx]
+	after := tokens[idx+1]
+
+	// Skip: token before the comma is `[` — this is the first comma of an
+	// array, i.e. `[, …]`. Upstream uses `isOpeningBracketToken` for this.
+	if before.kind == ast.KindOpenBracketToken {
+		return
+	}
+
+	// Skip: token before is a comma AND walking back past consecutive commas
+	// either lands on `[` (upstream) or runs off the front of an array
+	// scan (we started after `[`).
+	if before.kind == ast.KindCommaToken {
+		j := idx - 2
+		for j >= 0 && tokens[j].kind == ast.KindCommaToken {
+			j--
+		}
+		if j < 0 {
+			if startsAfterArrayOpen {
+				return
+			}
+		} else if tokens[j].kind == ast.KindOpenBracketToken {
+			return
+		}
+	}
+
+	// Skip: token after is a comma AND on a different line from the current
+	// comma. Two commas vertically stacked are "consecutive holes" upstream
+	// chooses to leave alone (the next iteration's comma will be reported).
+	if after.kind == ast.KindCommaToken && !sc.sameLine(comma.pos, after.pos) {
+		return
+	}
+
+	sc.validateCommaItemSpacing(before, comma, after)
+}
+
+// validateCommaItemSpacing is the direct port of upstream's same-named
+// function. The four branches map 1:1 to upstream:
+//
+//  1. before AND after on same line as comma → no diagnostic.
+//  2. before AND after both on different lines (lone comma) → report
+//     `unexpectedLineBeforeAndAfterComma`. Fix shape: "between" (strip the
+//     first linebreak from the trivia, prepend the comma) UNLESS the first
+//     comment after the comma is a block comment on the same line — in that
+//     case use the configured style so the block comment stays adjacent.
+//  3. style == 'first' && comma not on same line as `after` → report
+//     `expectedCommaFirst` with a 'first' fix.
+//  4. style == 'last' && comma on same line as `after` → report
+//     `expectedCommaLast` with a 'last' fix.
+func (sc *scanCtx) validateCommaItemSpacing(before, comma, after tk) {
+	sameLineBefore := sc.sameLine(before.end, comma.pos)
+	sameLineAfter := sc.sameLine(comma.end, after.pos)
+
+	switch {
+	case sameLineBefore && sameLineAfter:
+		return
+	case !sameLineBefore && !sameLineAfter:
+		fixStyle := fixStyleBetween
+		if sc.hasBlockCommentOnCommaLine(comma) {
+			fixStyle = sc.style
+		}
+		sc.report(comma, msgUnexpectedLineBeforeAndAfterComma, descUnexpectedLineBeforeAndAfterComma,
+			sc.buildFix(before, comma, after, fixStyle))
+	case sc.style == styleFirst && !sameLineAfter:
+		sc.report(comma, msgExpectedCommaFirst, descExpectedCommaFirst,
+			sc.buildFix(before, comma, after, styleFirst))
+	case sc.style == styleLast && sameLineAfter:
+		sc.report(comma, msgExpectedCommaLast, descExpectedCommaLast,
+			sc.buildFix(before, comma, after, styleLast))
+	}
+}
+
+// hasBlockCommentOnCommaLine mirrors upstream's
+// `getCommentsAfter(commaToken)[0]` + "Block && same line" guard. Walks
+// trivia bytes after the comma; returns true iff the FIRST comment-like
+// trivia we encounter is a `/* … */` block comment that starts before any
+// linebreak (i.e. on the same line as the comma).
+//
+// Operates on byte-level trivia rather than asking the scanner because the
+// scanner skips comments entirely — once it's moved past `comma`, comment
+// tokens are gone. The trivia between the comma and the next significant
+// position is by construction not inside a string / regex / template
+// literal, so byte-level `//` / `/*` detection is unambiguous.
+//
+// Linebreak detection mirrors ECMAScript LineTerminator (§12.3): LF, CR,
+// LS (U+2028, UTF-8 `E2 80 A8`), PS (U+2029, UTF-8 `E2 80 A9`).
+func (sc *scanCtx) hasBlockCommentOnCommaLine(comma tk) bool {
+	p := comma.end
+	for p < len(sc.text) {
+		b := sc.text[p]
+		switch {
+		case b == ' ' || b == '\t' || b == '\v' || b == '\f':
+			p++
+		case b == '\n' || b == '\r':
+			return false
+		case b == 0xE2 && p+2 < len(sc.text) && sc.text[p+1] == 0x80 &&
+			(sc.text[p+2] == 0xA8 || sc.text[p+2] == 0xA9):
+			// LS / PS — counts as a linebreak under ECMA §12.3.
+			return false
+		case b == '/' && p+1 < len(sc.text):
+			next := sc.text[p+1]
+			if next == '/' {
+				return false
+			}
+			if next == '*' {
+				return true
+			}
+			return false
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// buildFix constructs the (replacement-text, range) pair for a comma move.
+// The range covers [before.end, after.pos) — everything between the two
+// neighbor tokens, including the comma itself and surrounding trivia. The
+// replacement is derived from upstream's `getReplacedText`:
+//
+//	between → ',' + trivia-with-first-linebreak-removed
+//	first   → trivia + ','
+//	last    → ',' + trivia
+//
+// `trivia` is the original byte range with the comma carved out.
+func (sc *scanCtx) buildFix(before, comma, after tk, fixStyle string) rule.RuleFix {
+	trivia := sc.text[before.end:comma.pos] + sc.text[comma.end:after.pos]
+	var replaced string
+	switch fixStyle {
+	case fixStyleBetween:
+		replaced = "," + removeFirstLinebreak(trivia)
+	case styleFirst:
+		replaced = trivia + ","
+	case styleLast:
+		replaced = "," + trivia
+	}
+	return rule.RuleFix{
+		Text:  replaced,
+		Range: core.NewTextRange(before.end, after.pos),
+	}
+}
+
+// removeFirstLinebreak strips the first ECMAScript LineTerminator sequence
+// from `s`: CR LF (treated as one), LF, CR, U+2028 (LS), or U+2029 (PS).
+// Mirrors `text.replace(LINEBREAK_MATCHER, '')` upstream — non-global,
+// only the first match is removed.
+func removeFirstLinebreak(s string) string {
+	for i := range len(s) {
+		c := s[i]
+		switch c {
+		case '\r':
+			if i+1 < len(s) && s[i+1] == '\n' {
+				return s[:i] + s[i+2:]
+			}
+			return s[:i] + s[i+1:]
+		case '\n':
+			return s[:i] + s[i+1:]
+		case 0xE2:
+			if i+2 < len(s) && s[i+1] == 0x80 && (s[i+2] == 0xA8 || s[i+2] == 0xA9) {
+				return s[:i] + s[i+3:]
+			}
+		}
+	}
+	return s
+}
+
+// report emits the diagnostic anchored on the comma's single-char range,
+// matching upstream's `loc: commaToken.loc`.
+func (sc *scanCtx) report(comma tk, id, desc string, fix rule.RuleFix) {
+	sc.ctx.ReportRangeWithFixes(
+		core.NewTextRange(comma.pos, comma.end),
+		rule.RuleMessage{Id: id, Description: desc},
+		fix,
+	)
+}
+
+func (sc *scanCtx) sameLine(a, b int) bool {
+	return stylisticutil.SameLineByPos(sc.sf, a, b)
+}
+
+// itemContentEnd returns the position right after the LAST significant
+// token (non-`,`, non-`;`) inside `item`'s source range. Necessary because
+// tsgo's `parseTypeMemberSemicolon` folds a trailing separator into the
+// TypeElement's range; without this, the separator-comma filter would
+// flag those commas as "inside this member" and skip them.
+func (sc *scanCtx) itemContentEnd(item *ast.Node) int {
+	if item == nil {
+		return 0
+	}
+	end := item.End()
+	pos := item.Pos()
+	if pos >= end {
+		return end
+	}
+	s := scanner.GetScannerForSourceFile(sc.sf, pos)
+	contentEnd := pos
+	for {
+		kind := s.Token()
+		if kind == ast.KindEndOfFile {
+			break
+		}
+		start := s.TokenStart()
+		if start >= end {
+			break
+		}
+		tokEnd := s.TokenEnd()
+		if kind != ast.KindCommaToken && kind != ast.KindSemicolonToken {
+			contentEnd = tokEnd
+		}
+		s.Scan()
+	}
+	if contentEnd > end {
+		contentEnd = end
+	}
+	return contentEnd
+}
+
+// validateBracketedList wraps the common shape for "scan a NodeList that
+// sits inside brackets". The scan goes from `list.Pos()` to `parent.End()`
+// so the close bracket lands in the token slice as the trailing-comma
+// neighbor.
+func (sc *scanCtx) validateBracketedList(list *ast.NodeList, parentEnd int, startsAfterArrayOpen bool) {
+	if list == nil {
+		return
+	}
+	sc.validateList(listScanSpec{
+		startPos:             list.Pos(),
+		scanEnd:              parentEnd,
+		items:                list.Nodes,
+		startsAfterArrayOpen: startsAfterArrayOpen,
+	})
+}
+
+// validateBracketedListAtCloseChar is like validateBracketedList but bounds
+// `scanEnd` to one byte past the actual close character, located by
+// `scanner.SkipTrivia` from `list.End()`. Required for containers whose
+// "node" extends past the close bracket (e.g. function-like — `node.End()`
+// includes the body, not just the parameter `)`).
+//
+// `closeChar` is the expected close byte (`)`, `]`, etc.). When the byte
+// at the located position doesn't match, falls back to `list.End()` —
+// defensive against parser recovery shapes.
+func (sc *scanCtx) validateBracketedListAtCloseChar(list *ast.NodeList, closeChar byte, startsAfterArrayOpen bool) {
+	if list == nil {
+		return
+	}
+	scanEnd := list.End()
+	closePos := scanner.SkipTrivia(sc.text, list.End())
+	if closePos < len(sc.text) && sc.text[closePos] == closeChar {
+		scanEnd = closePos + 1
+	}
+	sc.validateList(listScanSpec{
+		startPos:             list.Pos(),
+		scanEnd:              scanEnd,
+		items:                list.Nodes,
+		startsAfterArrayOpen: startsAfterArrayOpen,
+	})
+}
+
+// findHeritageClause returns the first HeritageClause matching `tokenKind`
+// (KindImplementsKeyword or KindExtendsKeyword) on a class / interface
+// declaration, or nil. Used to surface the only clause comma-style cares
+// about for each container — `implements` for classes, `extends` for
+// interfaces.
+func findHeritageClause(list *ast.NodeList, tokenKind ast.Kind) *ast.Node {
+	if list == nil {
+		return nil
+	}
+	for _, clause := range list.Nodes {
+		hc := clause.AsHeritageClause()
+		if hc != nil && hc.Token == tokenKind {
+			return clause
+		}
+	}
+	return nil
+}
+
+// CommaStyleRule enforces consistent comma placement (last / first) across
+// every comma-separated list ESLint Stylistic's comma-style recognizes:
+// arrays, objects, parameter lists, import / export specifiers, sequence
+// expressions, TS enums / type literals / interfaces / tuples / type params,
+// etc. Ported from `@stylistic/eslint-plugin`'s comma-style.
+//
+// Listener fan-out vs. upstream ESTree:
+//
+//   - tsgo collapses ESLint's `VariableDeclaration` (statement-level
+//     `var a, b`) and the for-init form into a `VariableDeclarationList`. We
+//     listen on that single kind to cover both.
+//   - tsgo collapses ESTree's `MethodDefinition.value = FunctionExpression`
+//     into standalone `MethodDeclaration` / `Constructor` / `Get|SetAccessor`
+//     nodes. We fire them with the `FunctionExpression` exception bucket so
+//     class methods retain upstream's coverage; body-less forms (abstract
+//     methods, overload signatures) switch to the
+//     `TSEmptyBodyFunctionExpression` bucket.
+//   - tsgo has no separate `TSDeclareFunction` kind; `declare function f()`
+//     parses as a body-less `FunctionDeclaration`. We split by `Body == nil`
+//     to pick between the `FunctionDeclaration` and `TSDeclareFunction`
+//     exception buckets.
+//   - tsgo has no `ImportExpression` kind; dynamic `import(source, opts)`
+//     parses as a `CallExpression` whose `Expression.Kind` is
+//     `KindImportKeyword`. We branch on that inside the CallExpression
+//     listener.
+//   - tsgo has no flat `SequenceExpression`; `a, b, c` is left-associative
+//     `BinaryExpression(BinaryExpression(a, ',', b), ',', c)`. We only fire
+//     on the outermost comma-BinaryExpression (parent isn't itself a
+//     comma-BinaryExpression), then scan its whole range for separator
+//     commas. Nested parenthesized sequences fire independently because
+//     their parent is a `ParenthesizedExpression`, not a comma-BinExpr.
+//   - tsgo has no `TSTypeParameterDeclaration` / `TSTypeParameterInstantiation`
+//     kinds; type-param / type-arg lists are fields on a wide set of carrier
+//     nodes. We delegate to `node.TypeArgumentList()` /
+//     `node.TypeParameterList()` (typescript-go/internal/ast/ast.go:483, 515)
+//     so the carrier-kind set stays in lockstep with tsgo's own dispatch.
+//   - tsgo has no separate `TSInterfaceBody` / `TSEnumBody` nodes; the
+//     members live directly on `InterfaceDeclaration` / `EnumDeclaration`.
+//     The InterfaceDeclaration listener handles both the `extends` clause
+//     (TSInterfaceDeclaration exception) and the member list (TSInterfaceBody
+//     exception) in one pass.
+//   - For class `implements` / interface `extends`, tsgo wraps the type list
+//     inside a `HeritageClause` keyed by token kind (Implements/Extends).
+//     We pick the relevant clause and scan its `Types` NodeList.
+//
+// Separator detection is AST-driven: every comma found in a list's scan
+// range is filtered against the children's source ranges, and only commas
+// that fall *outside* every child's range are treated as list-level
+// separators. This is what lets a `VariableDeclarationList` listener
+// scan over `var a = class implements X, Y {}` without misclassifying the
+// heritage-clause comma as a var-decl separator — the comma sits inside the
+// `VariableDeclaration` child's range, so the filter rejects it.
+var CommaStyleRule = rule.Rule{
+	Name: "@stylistic/comma-style",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		sc := &scanCtx{
+			ctx:   ctx,
+			sf:    ctx.SourceFile,
+			text:  ctx.SourceFile.Text(),
+			style: opts.style,
+		}
+		exc := opts.exceptions
+
+		// checkTypeArgs / checkTypeParams handle the type-argument /
+		// type-parameter lists exposed on a wide set of carrier kinds.
+		// `node.TypeArgumentList()` / `.TypeParameterList()` keep the
+		// carrier set in lockstep with tsgo's own dispatch.
+		// Type-arg / type-param lists end at the `>` close token, whose
+		// position is `list.End()`. We pass `list.End() + 1` so the scan
+		// includes the close `>` itself (needed for the trailing-comma
+		// `tokenAfter` check). Using `node.End()` would pull in tokens
+		// from BEYOND the close `>` — e.g. `type Foo<A> = Bar<A>` would
+		// have a TypeAlias-level scan that bleeds into Bar's contents.
+		checkTypeArgs := func(node *ast.Node) {
+			if exc[excTSTypeParameterInstantiation] {
+				return
+			}
+			list := node.TypeArgumentList()
+			if list == nil || len(list.Nodes) == 0 {
+				return
+			}
+			sc.validateBracketedListAtCloseChar(list, '>', false)
+		}
+		checkTypeParams := func(node *ast.Node) {
+			if exc[excTSTypeParameterDeclaration] {
+				return
+			}
+			list := node.TypeParameterList()
+			if list == nil || len(list.Nodes) == 0 {
+				return
+			}
+			sc.validateBracketedListAtCloseChar(list, '>', false)
+		}
+
+		// checkFunctionLike validates a function-like node's parameters
+		// against `paramsBucket` and (when applicable) its type parameters.
+		// Upstream splits the parameter check across `FunctionDeclaration`,
+		// `FunctionExpression`, `TSDeclareFunction`, `TSEmptyBodyFunctionExpression`
+		// based on AST kind + body presence; we recover that split at the
+		// call site by choosing `paramsBucket`.
+		//
+		// scanEnd MUST be `Parameters.End()+1` (just past the close `)`)
+		// rather than `node.End()` — `node.End()` for a function-like
+		// extends past the close paren into the body, and our
+		// AST-driven separator filter only excludes commas inside the
+		// listed `items` (= parameters). Body-level commas would
+		// otherwise be misclassified as parameter-list separators.
+		checkFunctionLike := func(node *ast.Node, paramsBucket string) {
+			if !exc[paramsBucket] {
+				fl := node.FunctionLikeData()
+				if fl != nil && fl.Parameters != nil {
+					sc.validateBracketedListAtCloseChar(fl.Parameters, ')', false)
+				}
+			}
+			checkTypeParams(node)
+		}
+
+		return rule.RuleListeners{
+			ast.KindVariableDeclarationList: func(node *ast.Node) {
+				if exc[excVariableDeclaration] {
+					return
+				}
+				vdl := node.AsVariableDeclarationList()
+				if vdl == nil || vdl.Declarations == nil {
+					return
+				}
+				sc.validateList(listScanSpec{
+					startPos: vdl.Declarations.Pos(),
+					scanEnd:  node.End(),
+					items:    vdl.Declarations.Nodes,
+				})
+			},
+			ast.KindObjectLiteralExpression: func(node *ast.Node) {
+				if exc[excObjectExpression] {
+					return
+				}
+				obj := node.AsObjectLiteralExpression()
+				if obj == nil {
+					return
+				}
+				sc.validateBracketedList(obj.Properties, node.End(), false)
+			},
+			ast.KindObjectBindingPattern: func(node *ast.Node) {
+				if exc[excObjectPattern] {
+					return
+				}
+				bp := node.AsBindingPattern()
+				if bp == nil {
+					return
+				}
+				sc.validateBracketedList(bp.Elements, node.End(), false)
+			},
+			ast.KindArrayLiteralExpression: func(node *ast.Node) {
+				if exc[excArrayExpression] {
+					return
+				}
+				arr := node.AsArrayLiteralExpression()
+				if arr == nil {
+					return
+				}
+				sc.validateBracketedList(arr.Elements, node.End(), true)
+			},
+			ast.KindArrayBindingPattern: func(node *ast.Node) {
+				if exc[excArrayPattern] {
+					return
+				}
+				bp := node.AsBindingPattern()
+				if bp == nil {
+					return
+				}
+				sc.validateBracketedList(bp.Elements, node.End(), true)
+			},
+			ast.KindFunctionDeclaration: func(node *ast.Node) {
+				bucket := excFunctionDeclaration
+				if node.Body() == nil {
+					bucket = excTSDeclareFunction
+				}
+				checkFunctionLike(node, bucket)
+			},
+			ast.KindFunctionExpression: func(node *ast.Node) {
+				checkFunctionLike(node, excFunctionExpression)
+			},
+			ast.KindArrowFunction: func(node *ast.Node) {
+				checkFunctionLike(node, excArrowFunctionExpression)
+			},
+			// Class members map to the FunctionExpression bucket when they
+			// have a body and to TSEmptyBodyFunctionExpression when they
+			// don't — mirroring upstream's MethodDefinition.value =
+			// FunctionExpression vs. TSEmptyBodyFunctionExpression split.
+			ast.KindMethodDeclaration: func(node *ast.Node) {
+				bucket := excFunctionExpression
+				if node.Body() == nil {
+					bucket = excTSEmptyBodyFunctionExpression
+				}
+				checkFunctionLike(node, bucket)
+			},
+			ast.KindConstructor: func(node *ast.Node) {
+				bucket := excFunctionExpression
+				if node.Body() == nil {
+					bucket = excTSEmptyBodyFunctionExpression
+				}
+				if !exc[bucket] {
+					fl := node.FunctionLikeData()
+					if fl != nil && fl.Parameters != nil {
+						sc.validateBracketedListAtCloseChar(fl.Parameters, ')', false)
+					}
+				}
+				// Constructor has no type parameters in tsgo's model.
+			},
+			ast.KindGetAccessor: func(node *ast.Node) {
+				bucket := excFunctionExpression
+				if node.Body() == nil {
+					bucket = excTSEmptyBodyFunctionExpression
+				}
+				checkFunctionLike(node, bucket)
+			},
+			ast.KindSetAccessor: func(node *ast.Node) {
+				bucket := excFunctionExpression
+				if node.Body() == nil {
+					bucket = excTSEmptyBodyFunctionExpression
+				}
+				checkFunctionLike(node, bucket)
+			},
+			ast.KindFunctionType: func(node *ast.Node) {
+				checkFunctionLike(node, excTSFunctionType)
+			},
+			ast.KindConstructorType: func(node *ast.Node) {
+				checkFunctionLike(node, excTSConstructorType)
+			},
+			ast.KindMethodSignature: func(node *ast.Node) {
+				checkFunctionLike(node, excTSMethodSignature)
+			},
+			ast.KindCallSignature: func(node *ast.Node) {
+				checkFunctionLike(node, excTSCallSignatureDeclaration)
+			},
+			ast.KindConstructSignature: func(node *ast.Node) {
+				checkFunctionLike(node, excTSConstructSignatureDeclaration)
+			},
+			ast.KindIndexSignature: func(node *ast.Node) {
+				if exc[excTSIndexSignature] {
+					return
+				}
+				fl := node.FunctionLikeData()
+				if fl != nil && fl.Parameters != nil {
+					// IndexSignature's params are inside `[ ]`; the type
+					// (after `:`) follows and could contain its own
+					// commas (object-type literals). Bound the scan
+					// strictly to the `[ ]` so those don't leak in.
+					sc.validateBracketedListAtCloseChar(fl.Parameters, ']', false)
+				}
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if call == nil {
+					return
+				}
+				// Dynamic `import(...)` lives under the ImportExpression
+				// exception bucket; everything else is a regular call.
+				isImport := call.Expression != nil && call.Expression.Kind == ast.KindImportKeyword
+				argBucket := excCallExpression
+				if isImport {
+					argBucket = excImportExpression
+				}
+				if !exc[argBucket] && call.Arguments != nil {
+					sc.validateBracketedList(call.Arguments, node.End(), false)
+				}
+				if !isImport {
+					checkTypeArgs(node)
+				}
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				ne := node.AsNewExpression()
+				if ne == nil {
+					return
+				}
+				if !exc[excNewExpression] && ne.Arguments != nil {
+					sc.validateBracketedList(ne.Arguments, node.End(), false)
+				}
+				checkTypeArgs(node)
+			},
+			ast.KindImportDeclaration: func(node *ast.Node) {
+				// Upstream's whole `ImportDeclaration` visitor is gated on
+				// `!exceptions.ImportDeclaration` — both the specifier list
+				// and the with-attributes are skipped together.
+				if exc[excImportDeclaration] {
+					return
+				}
+				id := node.AsImportDeclaration()
+				if id == nil {
+					return
+				}
+				sc.checkImportDeclarationSpecifiers(id)
+				if id.Attributes != nil {
+					sc.checkImportAttributes(id.Attributes)
+				}
+			},
+			ast.KindExportDeclaration: func(node *ast.Node) {
+				ed := node.AsExportDeclaration()
+				if ed == nil {
+					return
+				}
+				if ed.ExportClause == nil {
+					// `export * from 'x'` — gated by ExportAllDeclaration.
+					if !exc[excExportAllDeclaration] && ed.Attributes != nil {
+						sc.checkImportAttributes(ed.Attributes)
+					}
+					return
+				}
+				// `export { … } from 'x'` / `export { … }` — gated by
+				// ExportNamedDeclaration. Both the specifier list and the
+				// attributes are guarded by the same bucket upstream.
+				if exc[excExportNamedDeclaration] {
+					return
+				}
+				if ed.ExportClause.Kind == ast.KindNamedExports {
+					ne := ed.ExportClause.AsNamedExports()
+					if ne != nil {
+						sc.validateBracketedList(ne.Elements, ed.ExportClause.End(), false)
+					}
+				}
+				if ed.Attributes != nil {
+					sc.checkImportAttributes(ed.Attributes)
+				}
+			},
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				if exc[excSequenceExpression] {
+					return
+				}
+				bin := node.AsBinaryExpression()
+				if bin == nil || bin.OperatorToken == nil ||
+					bin.OperatorToken.Kind != ast.KindCommaToken {
+					return
+				}
+				// Only validate from the top-level comma-BinExpr — otherwise
+				// each nested level would re-validate already-covered commas.
+				if parent := node.Parent; parent != nil && parent.Kind == ast.KindBinaryExpression {
+					if parentBin := parent.AsBinaryExpression(); parentBin != nil &&
+						parentBin.OperatorToken != nil &&
+						parentBin.OperatorToken.Kind == ast.KindCommaToken {
+						return
+					}
+				}
+				// Flatten the left-associative comma chain into a flat
+				// `items` list so the filter excludes commas hidden inside
+				// any operand (parens around a class with implements, etc.).
+				items := flattenCommaChain(node)
+				sc.validateList(listScanSpec{
+					startPos: node.Pos(),
+					scanEnd:  node.End(),
+					items:    items,
+				})
+			},
+			ast.KindClassDeclaration: func(node *ast.Node) {
+				cd := node.AsClassDeclaration()
+				if cd == nil {
+					return
+				}
+				if !exc[excClassDeclaration] {
+					if clause := findHeritageClause(cd.HeritageClauses, ast.KindImplementsKeyword); clause != nil {
+						hc := clause.AsHeritageClause()
+						if hc != nil && hc.Types != nil {
+							sc.validateList(listScanSpec{
+								startPos: hc.Types.Pos(),
+								scanEnd:  clause.End(),
+								items:    hc.Types.Nodes,
+							})
+						}
+					}
+				}
+				checkTypeParams(node)
+			},
+			ast.KindClassExpression: func(node *ast.Node) {
+				ce := node.AsClassExpression()
+				if ce == nil {
+					return
+				}
+				if !exc[excClassExpression] {
+					if clause := findHeritageClause(ce.HeritageClauses, ast.KindImplementsKeyword); clause != nil {
+						hc := clause.AsHeritageClause()
+						if hc != nil && hc.Types != nil {
+							sc.validateList(listScanSpec{
+								startPos: hc.Types.Pos(),
+								scanEnd:  clause.End(),
+								items:    hc.Types.Nodes,
+							})
+						}
+					}
+				}
+				checkTypeParams(node)
+			},
+			ast.KindInterfaceDeclaration: func(node *ast.Node) {
+				id := node.AsInterfaceDeclaration()
+				if id == nil {
+					return
+				}
+				// extends clause — TSInterfaceDeclaration bucket
+				if !exc[excTSInterfaceDeclaration] {
+					if clause := findHeritageClause(id.HeritageClauses, ast.KindExtendsKeyword); clause != nil {
+						hc := clause.AsHeritageClause()
+						if hc != nil && hc.Types != nil {
+							sc.validateList(listScanSpec{
+								startPos: hc.Types.Pos(),
+								scanEnd:  clause.End(),
+								items:    hc.Types.Nodes,
+							})
+						}
+					}
+				}
+				// member list — TSInterfaceBody bucket
+				if !exc[excTSInterfaceBody] && id.Members != nil {
+					sc.validateBracketedList(id.Members, node.End(), false)
+				}
+				checkTypeParams(node)
+			},
+			ast.KindTypeAliasDeclaration: func(node *ast.Node) {
+				checkTypeParams(node)
+			},
+			ast.KindEnumDeclaration: func(node *ast.Node) {
+				if exc[excTSEnumBody] {
+					return
+				}
+				ed := node.AsEnumDeclaration()
+				if ed == nil {
+					return
+				}
+				sc.validateBracketedList(ed.Members, node.End(), false)
+			},
+			ast.KindTypeLiteral: func(node *ast.Node) {
+				if exc[excTSTypeLiteral] {
+					return
+				}
+				tl := node.AsTypeLiteralNode()
+				if tl == nil {
+					return
+				}
+				sc.validateBracketedList(tl.Members, node.End(), false)
+			},
+			ast.KindTupleType: func(node *ast.Node) {
+				if exc[excTSTupleType] {
+					return
+				}
+				tt := node.AsTupleTypeNode()
+				if tt == nil {
+					return
+				}
+				sc.validateBracketedList(tt.Elements, node.End(), false)
+			},
+			// Pure type-arg carriers — only `TSTypeParameterInstantiation`
+			// in upstream terms.
+			ast.KindTaggedTemplateExpression:    checkTypeArgs,
+			ast.KindTypeReference:               checkTypeArgs,
+			ast.KindExpressionWithTypeArguments: checkTypeArgs,
+			ast.KindImportType:                  checkTypeArgs,
+			ast.KindTypeQuery:                   checkTypeArgs,
+			ast.KindJsxOpeningElement:           checkTypeArgs,
+			ast.KindJsxSelfClosingElement:       checkTypeArgs,
+		}
+	},
+}
+
+// flattenCommaChain walks a left-associative `a, b, c` chain
+// (`BinaryExpression(BinaryExpression(a, ',', b), ',', c)`) back into its
+// flat operand list `[a, b, c]`. Required so the separator-comma filter
+// can correctly exclude commas hidden inside any single operand (e.g. a
+// class expression with multiple `implements` types).
+func flattenCommaChain(node *ast.Node) []*ast.Node {
+	var out []*ast.Node
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		if n.Kind == ast.KindBinaryExpression {
+			bin := n.AsBinaryExpression()
+			if bin != nil && bin.OperatorToken != nil &&
+				bin.OperatorToken.Kind == ast.KindCommaToken {
+				walk(bin.Left)
+				walk(bin.Right)
+				return
+			}
+		}
+		out = append(out, n)
+	}
+	walk(node)
+	return out
+}
+
+// checkImportDeclarationSpecifiers reproduces upstream's
+// `validateComma(node, node.specifiers)` semantics on tsgo's split shape.
+//
+// ESTree's `specifiers` flattens default / namespace / named imports into
+// one list; tsgo splits them across `ImportClause.name` (default),
+// `ImportClause.NamedBindings` (namespace OR named), so the commas of
+// interest are:
+//
+//  1. The comma between default and named-bindings, when both exist
+//     (e.g. `import a, { b } from 'x'`).
+//  2. The commas inside `{ a, b, c }` (NamedImports.Elements).
+//
+// We make two scans — one over a synthetic two-item list (default,
+// named-bindings) bounded by [default.Pos(), namedBindings.End()] so the
+// inside-item filter naturally hides the commas inside `{ … }` — and one
+// over the bracketed elements.
+func (sc *scanCtx) checkImportDeclarationSpecifiers(id *ast.ImportDeclaration) {
+	if id == nil || id.ImportClause == nil {
+		return
+	}
+	ic := id.ImportClause.AsImportClause()
+	if ic == nil {
+		return
+	}
+	def := ic.Name()
+	nb := ic.NamedBindings
+	if def != nil && nb != nil {
+		sc.validateList(listScanSpec{
+			startPos: def.Pos(),
+			scanEnd:  nb.End(),
+			items:    []*ast.Node{def, nb},
+		})
+	}
+	if nb != nil && nb.Kind == ast.KindNamedImports {
+		named := nb.AsNamedImports()
+		if named != nil {
+			sc.validateBracketedList(named.Elements, nb.End(), false)
+		}
+	}
+}
+
+// checkImportAttributes validates commas inside an import / export
+// `with { a: 'v', b: 'v' }` clause. The clause's grammar is the same shape
+// as a NamedImports `{ … }` list, so we reuse the bracketed-list helper.
+func (sc *scanCtx) checkImportAttributes(attrs *ast.Node) {
+	if attrs == nil {
+		return
+	}
+	ia := attrs.AsImportAttributes()
+	if ia == nil || ia.Attributes == nil {
+		return
+	}
+	sc.validateBracketedList(ia.Attributes, attrs.End(), false)
+}

--- a/internal/plugins/stylistic/rules/comma_style/comma_style.md
+++ b/internal/plugins/stylistic/rules/comma_style/comma_style.md
@@ -1,0 +1,113 @@
+# comma-style
+
+Enforce consistent comma style.
+
+## Rule Details
+
+This rule enforces a consistent comma placement across comma-separated lists in JavaScript and TypeScript — array literals, object literals, variable declarations, function parameters, call arguments, import / export specifiers, sequence expressions, and the TypeScript-only lists (type / interface members, enum members, tuples, type parameters and type arguments, function / constructor signatures, import attributes).
+
+The rule does NOT flag commas in single-line lists. A comma surrounded by linebreaks on both sides (a "lone" comma) reports under its own message regardless of the configured style.
+
+## Options
+
+This rule has a string option:
+
+- `"last"` (default) — commas at the end of the current line.
+- `"first"` — commas at the start of the next line.
+
+This rule has an object option:
+
+- `"exceptions"` — disables the rule for specific AST node types. Keys match the upstream ESTree / `@typescript-eslint/parser` node-type names so configuration is portable from ESLint Stylistic. Supported keys: `ArrayExpression`, `ArrayPattern`, `ObjectExpression`, `ObjectPattern`, `VariableDeclaration`, `FunctionDeclaration`, `FunctionExpression`, `ArrowFunctionExpression`, `CallExpression`, `NewExpression`, `ImportExpression`, `ImportDeclaration`, `ExportNamedDeclaration`, `ExportAllDeclaration`, `SequenceExpression`, `ClassDeclaration`, `ClassExpression`, `TSDeclareFunction`, `TSFunctionType`, `TSConstructorType`, `TSEmptyBodyFunctionExpression`, `TSMethodSignature`, `TSCallSignatureDeclaration`, `TSConstructSignatureDeclaration`, `TSEnumBody`, `TSTypeLiteral`, `TSInterfaceBody`, `TSInterfaceDeclaration`, `TSIndexSignature`, `TSTupleType`, `TSTypeParameterDeclaration`, `TSTypeParameterInstantiation`.
+
+### last
+
+Examples of **incorrect** code for this rule with the default `"last"` option:
+
+```javascript
+var foo = 1
+,
+bar = 2;
+
+var foo = 1
+  , bar = 2;
+
+var foo = ["apples"
+           , "oranges"];
+
+function baz() {
+  return {
+    a: 1
+    , b: 2
+  };
+}
+```
+
+Examples of **correct** code for this rule with the default `"last"` option:
+
+```javascript
+var foo = 1, bar = 2;
+
+var foo = 1,
+    bar = 2;
+
+var foo = ["apples",
+           "oranges"];
+
+function baz() {
+  return {
+    a: 1,
+    b: 2,
+  };
+}
+```
+
+### first
+
+Examples of **incorrect** code for this rule with the `"first"` option:
+
+```json
+{ "@stylistic/comma-style": ["error", "first"] }
+```
+
+```javascript
+var foo = 1,
+    bar = 2;
+
+var foo = ["apples",
+           "oranges"];
+```
+
+Examples of **correct** code for this rule with the `"first"` option:
+
+```json
+{ "@stylistic/comma-style": ["error", "first"] }
+```
+
+```javascript
+var foo = 1, bar = 2;
+
+var foo = 1
+    ,bar = 2;
+
+var foo = ["apples"
+          ,"oranges"];
+```
+
+### exceptions
+
+Examples of **correct** code for this rule with `"first", { "exceptions": { "ArrayExpression": true, "ObjectExpression": true } }`:
+
+```json
+{ "@stylistic/comma-style": ["error", "first", { "exceptions": { "ArrayExpression": true, "ObjectExpression": true } }] }
+```
+
+```javascript
+var ar = {fst:1,
+          snd: [1,
+                2]}
+  , a = [];
+```
+
+## Original Documentation
+
+- [@stylistic/comma-style](https://eslint.style/rules/comma-style)

--- a/internal/plugins/stylistic/rules/comma_style/comma_style_extras_test.go
+++ b/internal/plugins/stylistic/rules/comma_style/comma_style_extras_test.go
@@ -1,0 +1,510 @@
+// TestCommaStyleExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing
+// at the specific branch / Dimension 4 row / tsgo AST quirk it covers, so
+// future refactors can't silently regress them without breaking a named
+// lock-in.
+package comma_style_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_style"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestCommaStyleExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&comma_style.CommaStyleRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: receiver wrappers — N/A ----
+			// N/A: comma-style validates the *position* of `,` tokens
+			// between list elements, never the shape of any element itself.
+			// Receiver wrappers around list elements (parens, non-null,
+			// `as`, `satisfies`, optional-chain) don't change the
+			// before-token / after-token text-position lookup.
+			//
+			// ---- Dimension 4: access / key forms — N/A ----
+			// N/A: the rule never inspects member access or property keys.
+			//
+			// ---- Dimension 4: declaration / container forms ----
+			// Lock the FunctionExpression / ArrowFunction / FunctionDeclaration
+			// listener fan-out: each must validate its parameters list against
+			// the configured style.
+			{Code: "function f(a,\n b) {}"},
+			{Code: "const f = function (a,\n b) {};"},
+			{Code: "const f = (a,\n b) => {};"},
+			{Code: "class A { m(a,\n b) {} }"},
+			{Code: "class A { constructor(a,\n b) {} }"},
+			{Code: "class A { get x() { return 0; } set x(v,\n) {} }"},
+
+			// ---- Dimension 4: same-kind nesting — listener boundary ----
+			// Nested classes / functions each have their own param lists.
+			// The outer listener must NOT pick up commas inside the inner
+			// container's lists (that's the inner listener's job, with the
+			// "filter by inner item range" guarantee in `validateList`).
+			{Code: "function outer(a, b) {\n  function inner(c, d) {}\n}"},
+			{Code: "class A { m() { class B { n() {} } } }"},
+
+			// ---- Dimension 4: graceful degradation — empty / one-element lists ----
+			{Code: "function f() {}"},
+			{Code: "f();"},
+			{Code: "new Foo();"},
+			{Code: "var foo = [];"},
+			{Code: "var foo = {};"},
+			{Code: "var foo = [a];"},
+			{Code: "var foo = {a: 1};"},
+			{Code: "type T = [];"},
+			{Code: "type T = {};"},
+			{Code: "type Foo<A> = A;"},
+
+			// ---- tsgo AST quirk: class expression with multi-implements
+			// inside a variable initializer ----
+			// VariableDeclarationList scan reaches the implements types
+			// `X, Y` at no enclosing-bracket depth; the "comma inside the
+			// declaration's range" filter is what prevents the heritage
+			// commas from being attributed to the var-decl level. Removed
+			// the filter would attribute the implements commas as
+			// var-decl separators and over-report.
+			{Code: "interface X {} interface Y {}\nvar a = class implements X, Y {};"},
+			{Code: "interface X {} interface Y {}\nfunction f(x = class implements X, Y {}) {}"},
+
+			// ---- tsgo AST quirk: TypeAliasDeclaration RHS with type
+			// arguments ----
+			// `type Foo<A, B> = Bar<C, D>` — without the `list.End() + 1`
+			// scanEnd bound, checkTypeParams would scan past Foo's `>`
+			// into the Bar<C, D> region and double-report the inner commas.
+			{Code: "type X = number; type Y = string;\ntype Foo<A, B> = Map<X, Y>;"},
+
+			// ---- tsgo AST quirk: TypeElement separator absorbed ----
+			// tsgo's `parseTypeMemberSemicolon` consumes the trailing `,`
+			// (or `;`) AS PART OF each TypeElement's range, so member.End()
+			// lands past the separator. `itemContentEnd` walks the item's
+			// tokens to find the real content end so the separator-comma
+			// filter doesn't classify the separator as "inside" the
+			// member and skip it.
+			{Code: "type T = { a: string, b: string };"},
+			{Code: "interface I { a: string; b: string }"},
+
+			// ---- tsgo AST quirk: nested sequence expression ----
+			// `(a, (b, c))` — outer BinaryExpression-comma fires on outer
+			// `,`; inner fires on its own. Both validate independently
+			// since the inner's parent is `ParenthesizedExpression`, not a
+			// comma-BinExpr.
+			{Code: "var x = (a, (b, c));"},
+
+			// ---- Locks in validateCommaItemSpacing arm 1: all on same line ----
+			// Single-line lists hit arm 1 of the switch — every same-line
+			// list shape, default or "first", should yield no diagnostic.
+			{Code: "var a = [1, 2, 3];"},
+			{Code: "var a = {x: 1, y: 2};"},
+			{Code: "f(1, 2, 3);"},
+			{Code: "var a = [1, 2, 3];", Options: optStr("first")},
+
+			// ---- Locks in upstream "consecutive holes on separate lines"
+			// skip-condition (validateOneComma skip 3) ----
+			// `[a,\n,\nb]` has two commas vertically stacked. The first
+			// gets skipped by the "tokenAfter is comma & not same-line"
+			// check; the lone second comma is what reports.
+			{Code: "var a = [\n , \n 1, \n 2 \n];"},
+
+			// ---- Locks in array-hole skip (validateOneComma skips 1+2) ----
+			// `[, a]` (single hole) — leading comma's `tokenBefore` is `[`,
+			// upstream skips. Multi-hole `[, , a]` — second comma's
+			// `tokenBefore` walks back through commas to `[`, also skipped.
+			// Lock both shapes in.
+			{Code: "var a = [, 1];"},
+			{Code: "var a = [, , 1];"},
+			{Code: "var a = [, , , 1];"},
+
+			// ---- Locks in: TSX-tagged file with type-args / type-params ----
+			// `<>` in `.tsx` is JSX. Inside type-args / type-params we
+			// still need to recognize `<` / `>`. checkTypeArgs uses
+			// `list.End() + 1` so the close `>` is in the scan token
+			// slice for trailing-comma `tokenAfter` lookups.
+			{Code: "function f<A, B>() {}", Tsx: true},
+			{Code: "var x = foo<A,\n B>();", Tsx: true},
+
+			// ---- Audit: default parameter with nested object literal ----
+			// Inner object's commas must NOT be attributed to the parameter
+			// list. Confirmed by the "comma inside item range" filter on
+			// the FunctionDeclaration's Parameters list.
+			{Code: "function f(a = { b: 1,\n c: 2 }, d) {}"},
+
+			// ---- Audit: computed property name shape ----
+			{Code: "var x = { [a]: 1 };"},
+
+			// ---- Audit: JSX self-closing with type args (TSX) ----
+			{Code: "var x = <Foo<A,\n B> />;", Tsx: true},
+
+			// ---- Audit: as / satisfies wrappers ----
+			{Code: "var x = [1,\n 2] as const;"},
+			{Code: "var x = [1,\n 2] satisfies number[];"},
+
+			// ---- Audit: decorator-call expression ----
+			{Code: "function dec(): any { return () => {}; }\n@dec({a: 1,\n b: 2}) class A {}"},
+
+			// ---- Audit: generator / async function params ----
+			{Code: "function* g(a,\n b) { yield a; }"},
+			{Code: "async function f(a,\n b) { return a; }"},
+
+			// ---- Audit: generic constraint with nested object type ----
+			// Object-type member commas live inside the TypeParameter's
+			// range; the filter excludes them at the type-param-list
+			// level.
+			{Code: "function f<T extends { a: number,\n b: string }>(x: T) { return x; }"},
+
+			// ---- Audit: nested generic type args ----
+			// `Array<Map<string,\nnumber>>` — outer has 1 type-arg, no
+			// comma; inner Map has 2 type-args separated by a violating
+			// comma — but inner Map's `,` is on the same line as `number`,
+			// so under "last" no diagnostic fires.
+			{Code: "type T = Array<Map<string,\n number>>;"},
+
+			// ---- Audit: abstract method (TSEmptyBodyFunctionExpression bucket) ----
+			{
+				Code:    "abstract class A {\n  abstract m(a,\n b): void;\n}",
+				Options: optWithExc("last", map[string]any{"TSEmptyBodyFunctionExpression": true}),
+			},
+
+			// ---- Audit: overload signatures ----
+			// First decl body-less (→ TSDeclareFunction bucket), second
+			// has a body (→ FunctionDeclaration bucket).
+			{
+				Code:    "function f(a,\n b): number;\nfunction f(a, b) { return 0; }",
+				Options: optWithExc("last", map[string]any{"TSDeclareFunction": true}),
+			},
+
+			// ---- Audit: for-init VariableDeclarationList ----
+			// for-init wraps a VariableDeclarationList without a
+			// surrounding VariableStatement; the same listener fires.
+			{Code: "for (var i = 0, j = 1; i < 10; i++) {}"},
+			{
+				Code:    "for (var i = 0,\n j = 1; i < 10; i++) {}",
+				Options: optWithExc("last", map[string]any{"VariableDeclaration": true}),
+			},
+
+			// ---- Audit: SequenceExpression inside `if` ----
+			{Code: "if (a, b) {}", Options: optStr("first")},
+
+			// ---- Audit: all-empty containers ----
+			{Code: "function f() {}"},
+			{Code: "f();"},
+			{Code: "[];"},
+			{Code: "({});"},
+			{Code: "type T = [];"},
+			{Code: "type T = {};"},
+
+			// ---- Real-user: eslint/eslint#6006 — parenthesized array item ----
+			// `[\n  ('',\n  ),\n  def,\n]` — the `,` after `)` is on same
+			// line as `)`, so sameLineBefore=true, sameLineAfter=false →
+			// no diagnostic under style=last. Historic false-positive.
+			{
+				Code: "const def: any = {};\nconst abc = [\n  (''\n  ),\n  def,\n];",
+			},
+
+			// ---- Real-user: eslint/eslint#10273 — sparse array w/ nested parens ----
+			// Trailing-comma items + leading-hole separators across lines
+			// should NOT report under style=last; each separator comma is
+			// on the same line as its preceding `]`-terminated element.
+			{
+				Code: "class Thing {}\n" +
+					"function f(_n: any) {}\n" +
+					"const testArray = [\n" +
+					"  [1],,\n" +
+					"  [new Thing()],\n" +
+					"  [new Thing(),],\n" +
+					"  [new Thing()],\n" +
+					"  [{an: 'object'}],,\n" +
+					"  [[7, 8]],,\n" +
+					"  [9]\n" +
+					"];",
+			},
+
+			// ---- Real-user: eslint/eslint#12756 — consecutive holes on
+			// separate lines should not error ----
+			// `const [\n  ,,\n  a, b,\n] = arr` and the variant with each
+			// hole on its own line. Skip path: tokenAfter is comma AND
+			// not on same line as current comma → don't report.
+			{
+				Code: "const [\n  ,,\n  cp = 'config.json',\n  af = 'auth',\n] = ['1','2','3','4'];",
+			},
+			{
+				Code: "const [\n  ,\n  ,\n  cp = 'config.json',\n  af = 'auth',\n] = ['1','2','3','4'];",
+			},
+
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Locks in validateCommaItemSpacing arm 2 (lone comma) ----
+			// `a,\n,\nb` — both before and after the second `,` are on
+			// different lines; arm 2 fires with the 'between' fix shape
+			// (strip first linebreak, prepend comma).
+			{
+				Code:   "var a = 1\n,\nb = 2;\n",
+				Output: []string{"var a = 1,\nb = 2;\n"},
+				Errors: errLone(2, 1),
+			},
+
+			// ---- Locks in arm-2 block-comment branch ----
+			// When the first comment after the lone comma is a Block
+			// comment on the same line, the fix uses the configured style
+			// (here 'last') instead of 'between' so the block comment
+			// keeps its line relative to the comma. Style=last leaves the
+			// trivia after the comma untouched, so the `\n` between the
+			// block comment and `b` is preserved verbatim.
+			{
+				Code:   "[a\n,/*block*/\nb];",
+				Output: []string{"[a,\n/*block*/\nb];"},
+				Errors: errLone(2, 1),
+			},
+
+			// ---- Locks in arm 3 (style=first && !sameLineAfter) ----
+			{
+				Code:    "var x = [1,\n2];",
+				Output:  []string{"var x = [1\n,2];"},
+				Options: optStr("first"),
+				Errors:  errFirst(1, 11),
+			},
+
+			// ---- Locks in arm 4 (style=last && sameLineAfter) ----
+			{
+				Code:   "var x = [1\n, 2];",
+				Output: []string{"var x = [1,\n 2];"},
+				Errors: errLast(2, 1),
+			},
+
+			// ---- Locks in CRLF-aware linebreak removal ----
+			// `removeFirstLinebreak` must treat CR LF as one sequence, not
+			// strip only LF and leave the CR behind. Without this, the
+			// 'between' fix would leave a stray `\r` in the output.
+			{
+				Code:   "var a = 1\r\n,\r\nb = 2;\r\n",
+				Output: []string{"var a = 1,\r\nb = 2;\r\n"},
+				Errors: errLone(2, 1),
+			},
+
+			// ---- Locks in sequence-comma chain validation ----
+			// `(a, b, c)` — left-associative `BinaryExpression(BinaryExpression(a, b), c)`.
+			// The OUTER comma-BinExpr fires once, flattens the chain into
+			// `[a, b, c]`, and finds 2 separator commas. Inner level
+			// doesn't re-fire because parent is comma-BinExpr.
+			{
+				Code:    "(a\n, b\n, c);",
+				Output:  []string{"(a,\n b,\n c);"},
+				Options: optStr("last"),
+				Errors: errs(
+					errSpec{"expectedCommaLast", 2, 1},
+					errSpec{"expectedCommaLast", 3, 1},
+				),
+			},
+
+			// ---- Locks in: trailing comma after lone item reports under "last" ----
+			// `[a,\n]` — trailing `,` has tokenAfter = `]`. sameLineBefore
+			// = true (a on same line as comma), sameLineAfter = false
+			// (comma on prev line vs `]`). With style=last, the arm
+			// !sameLineBefore && !sameLineAfter doesn't fire (only one
+			// side differs), and arm 4 doesn't fire either (sameLineAfter
+			// is false). So no report — confirm green.
+			//
+			// (Confirmed green: no entry needed here; included in valid
+			// set above as `var foo = [1, ];` style cases.)
+			//
+			// What we *do* lock: trailing comma where comma is on its own
+			// line, both before AND after are different lines → arm 2.
+			{
+				Code:   "var a = [1\n,\n];",
+				Output: []string{"var a = [1,\n];"},
+				Errors: errLone(2, 1),
+			},
+
+			// ---- tsgo quirk lock-in: heritage clause inside class
+			// expression inside variable initializer ----
+			// Regression test for the original implementation that scanned
+			// VariableDeclarationList with depth tracking and incorrectly
+			// reported the `implements X, Y` comma as a var-decl separator.
+			// The AST-driven filter must keep this green.
+			{
+				Code:    "interface X {} interface Y {}\nvar a = class implements\nX\n, Y {};",
+				Output:  []string{"interface X {} interface Y {}\nvar a = class implements\nX,\n Y {};"},
+				Options: optStr("last"),
+				Errors:  errLast(4, 1),
+			},
+
+			// ---- tsgo quirk lock-in: typeMember separator absorbed
+			// (style=first reordering) ----
+			// `type T = { a: T1, b: T2 }` style=first should report the
+			// member separator `a: T1,` and move the `,` to start of
+			// `b: T2`'s line. The `itemContentEnd` trim is what surfaces
+			// this comma as a separator; without it the comma is hidden
+			// inside the member's range.
+			{
+				Code: "type T = {\n" +
+					"  a: string,\n" +
+					"  b: number\n" +
+					"};",
+				Output: []string{
+					"type T = {\n" +
+						"  a: string\n" +
+						"  ,b: number\n" +
+						"};",
+				},
+				Options: optStr("first"),
+				Errors:  errFirst(2, 12),
+			},
+
+			// ---- Audit: trailing comma in multi-line array under "first" ----
+			// All three commas (between elements + trailing) violate; the
+			// fix moves each to the start of the following item's line.
+			{
+				Code:    "var x = [1,\n2,\n3,\n];",
+				Output:  []string{"var x = [1\n,2\n,3\n,];"},
+				Options: optStr("first"),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 1, 11},
+					errSpec{"expectedCommaFirst", 2, 2},
+					errSpec{"expectedCommaFirst", 3, 2},
+				),
+			},
+
+			// ---- Audit: nested ArrayLiteral inside ObjectLiteral ----
+			// Only the OUTER object property comma is reported (the inner
+			// `[1, 2]` is single-line and quiet).
+			{
+				Code:    "var x = {\n  a: [1, 2],\n  b: [3, 4]\n  , c: 5\n};",
+				Output:  []string{"var x = {\n  a: [1, 2],\n  b: [3, 4],\n   c: 5\n};"},
+				Options: optStr("last"),
+				Errors:  errLast(4, 3),
+			},
+
+			// ---- Audit: class with extends + implements + type-args ----
+			// Multi-line type-args under "last" report the leading comma.
+			{
+				Code:    "class A extends X<\n  P\n  , Q\n> implements Y {}\ninterface X<T1, T2> {}\ninterface Y {}",
+				Output:  []string{"class A extends X<\n  P,\n   Q\n> implements Y {}\ninterface X<T1, T2> {}\ninterface Y {}"},
+				Options: optStr("last"),
+				Errors:  errLast(3, 3),
+			},
+
+			// ---- Real-user: eslint-stylistic#598 — trailing comma in
+			// object should report (used to be missed pre-fix) ----
+			// `{a, b\n  ,}` with style=last: trailing `,` is on a
+			// different line from `b` but on the same line as `}` → arm 4
+			// fires (expectedCommaLast).
+			{
+				Code:   "let a: any, b: any; const c = {a, b\n  ,};",
+				Output: []string{"let a: any, b: any; const c = {a, b,\n  };"},
+				Errors: errLast(2, 3),
+			},
+
+			// ---- Real-user: eslint-stylistic#599 — comma between default
+			// import and named bindings should report ----
+			{
+				Code:   "import a\n  , {Foo} from 'module';",
+				Output: []string{"import a,\n   {Foo} from 'module';"},
+				Errors: errLast(2, 3),
+			},
+			{
+				Code:    "import c,\n  {Bar} from 'module';",
+				Output:  []string{"import c\n  ,{Bar} from 'module';"},
+				Options: optStr("first"),
+				Errors:  errFirst(1, 9),
+			},
+
+			// ---- Real-user: import/export with attributes (`with`)
+			// — comma between attributes spanning lines ----
+			{
+				Code:   "import x from 'x' with {type: 'json'\n  ,foo: 'bar'};",
+				Output: []string{"import x from 'x' with {type: 'json',\n  foo: 'bar'};"},
+				Errors: errLast(2, 3),
+			},
+
+			// ---- Real-user: dynamic import with options arg ----
+			{
+				Code:   "import('x'\n  ,{with: {type: 'json'}});",
+				Output: []string{"import('x',\n  {with: {type: 'json'}});"},
+				Errors: errLast(2, 3),
+			},
+
+			// ---- Real-user: type alias with multi-line generics ----
+			{
+				Code:   "type G1<A\n  ,B> = Map<A, B>;",
+				Output: []string{"type G1<A,\n  B> = Map<A, B>;"},
+				Errors: errLast(2, 3),
+			},
+
+			// ---- Real-user: rsbuild bulk diff — function-like
+			// parameter list with trailing comma under style=first ----
+			// Regression: an earlier impl used `node.End()` as scanEnd
+			// for function-like parameter lists, which extended past
+			// the close `)` and into the body, mis-classifying any
+			// body-level commas as parameter-list separators. Then
+			// fixed to `list.End()+1`, but that was off-by-one due to
+			// tsgo's `nodePos() == TokenFullStart`. Now uses
+			// `validateBracketedListAtCloseChar` which SkipTrivia's to
+			// the actual `)` byte. Lock both shapes in.
+			{
+				Code:    "const f = (\n  a: number,\n  b: number,\n) => {};",
+				Output:  []string{"const f = (\n  a: number\n  ,b: number\n,) => {};"},
+				Options: optStr("first"),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 2, 12},
+					errSpec{"expectedCommaFirst", 3, 12},
+				),
+			},
+
+			// ---- Real-user: rsbuild bulk diff — trailing comma in call
+			// argument containing a template literal ----
+			// Regression: the scanner doesn't carry template state across
+			// `GetScannerForSourceFile(sf, pos)`, so a closing back-tick
+			// inside a call argument was mis-tokenized as a fresh
+			// `NoSubstitutionTemplateLiteral` swallowing every byte up
+			// to EOF — including the call's trailing `,` and `)`. Now
+			// `validateList` skips PAST each item's range by re-creating
+			// the scanner at item.End(), AND inserts a pseudo-token
+			// representing the item so adjacent-comma sameLine checks
+			// still resolve correctly.
+			{
+				Code: "function bar(x: any): string { return ''; }\n" +
+					"function foo() {\n" +
+					"  return `foo ${bar(\n" +
+					"    'x'\n" +
+					"  )} baz`\n" +
+					"  ,'y';\n" +
+					"}",
+				Output: []string{
+					"function bar(x: any): string { return ''; }\n" +
+						"function foo() {\n" +
+						"  return `foo ${bar(\n" +
+						"    'x'\n" +
+						"  )} baz`,\n" +
+						"  'y';\n" +
+						"}",
+				},
+				Errors: errLast(6, 3),
+			},
+
+			// ---- Real-user: type literal with method signatures ----
+			// Member separator commas + parameter commas — independently
+			// reported. The reported position is for the method's
+			// param-list comma (the TypeLiteral's member-comma reports
+			// would only fire if a member's `,` were itself on a wrong
+			// line).
+			{
+				Code: "type ML = {\n" +
+					"  m1(a: number\n" +
+					"  ,b: number): void;\n" +
+					"};",
+				Output: []string{
+					"type ML = {\n" +
+						"  m1(a: number,\n" +
+						"  b: number): void;\n" +
+						"};",
+				},
+				Errors: errLast(3, 3),
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/comma_style/comma_style_upstream_test.go
+++ b/internal/plugins/stylistic/rules/comma_style/comma_style_upstream_test.go
@@ -1,0 +1,1552 @@
+// TestCommaStyleUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/rules/comma-style/comma-style.test.ts 1:1.
+// Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases (tsgo AST edge shapes, branch lock-ins,
+// real-user shapes) live in comma_style_extras_test.go.
+//
+// cspell:ignore nsnd fifi
+// `nsnd` is a tokenization artifact from cspell merging the `n` of `\n` with
+// the following `snd` token in the `{fst:1,\nsnd: [1,\n2]};` fixtures —
+// `snd` is upstream's "second" abbreviation, kept verbatim. `fifi` is a
+// person-name string literal upstream uses in `[\n ,'fifi' \n]`.
+package comma_style_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_style"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// optStr wraps a single string option in the array form rule_tester expects.
+func optStr(s string) []any { return []any{s} }
+
+// optWithExc wraps a (style, exceptions) pair into the multi-element array
+// form the rule_tester / CLI emits. Using a bare map alongside the style
+// string exercises the JSON path the CLI takes, not a typed struct path.
+func optWithExc(style string, exc map[string]any) []any {
+	return []any{style, map[string]any{"exceptions": exc}}
+}
+
+func errLast(line, col int) []rule_tester.InvalidTestCaseError {
+	return []rule_tester.InvalidTestCaseError{
+		{MessageId: "expectedCommaLast", Line: line, Column: col, EndLine: line, EndColumn: col + 1},
+	}
+}
+
+func errFirst(line, col int) []rule_tester.InvalidTestCaseError {
+	return []rule_tester.InvalidTestCaseError{
+		{MessageId: "expectedCommaFirst", Line: line, Column: col, EndLine: line, EndColumn: col + 1},
+	}
+}
+
+func errLone(line, col int) []rule_tester.InvalidTestCaseError {
+	return []rule_tester.InvalidTestCaseError{
+		{MessageId: "unexpectedLineBeforeAndAfterComma", Line: line, Column: col, EndLine: line, EndColumn: col + 1},
+	}
+}
+
+type errSpec struct {
+	id        string
+	line, col int
+}
+
+func errs(specs ...errSpec) []rule_tester.InvalidTestCaseError {
+	out := make([]rule_tester.InvalidTestCaseError, len(specs))
+	for i, s := range specs {
+		out[i] = rule_tester.InvalidTestCaseError{
+			MessageId: s.id,
+			Line:      s.line,
+			Column:    s.col,
+			EndLine:   s.line,
+			EndColumn: s.col + 1,
+		}
+	}
+	return out
+}
+
+func TestCommaStyleUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&comma_style.CommaStyleRule,
+		[]rule_tester.ValidTestCase{
+			// ---- baseline single-line / multi-line shapes (default "last") ----
+			{Code: `var foo = 1, bar = 3;`},
+			{Code: `var foo = {'a': 1, 'b': 2};`},
+			{Code: `var foo = [1, 2];`},
+			{Code: `var foo = [, 2];`},
+			{Code: `var foo = [1, ];`},
+			{Code: "var foo = ['apples', \n 'oranges'];"},
+			{Code: "var foo = {'a': 1, \n 'b': 2, \n'c': 3};"},
+			{Code: "var foo = {'a': 1, \n 'b': 2, 'c':\n 3};"},
+			{Code: "var foo = {'a': 1, \n 'b': 2, 'c': [{'d': 1}, \n {'e': 2}, \n {'f': 3}]};"},
+			{Code: "var foo = [1, \n2, \n3];"},
+			{Code: "function foo(){var a=[1,\n 2]}"},
+			{Code: "function foo(){return {'a': 1,\n'b': 2}}"},
+			{Code: "var foo = \n1, \nbar = \n2;"},
+			{Code: "var foo = [\n(bar),\nbaz\n];"},
+			{Code: "var foo = [\n(bar\n),\nbaz\n];"},
+			{Code: "var foo = [\n(\nbar\n),\nbaz\n];"},
+			{Code: "new Foo(a\n,b);", Options: optWithExc("last", map[string]any{"NewExpression": true})},
+			{Code: "var foo = [\n(bar\n)\n,baz\n];", Options: optStr("first")},
+			{Code: "var foo = \n1, \nbar = [1,\n2,\n3]"},
+			{Code: "var foo = ['apples'\n,'oranges'];", Options: optStr("first")},
+			{Code: `var foo = 1, bar = 2;`, Options: optStr("first")},
+			{Code: "var foo = 1 \n ,bar = 2;", Options: optStr("first")},
+			{Code: "var foo = {'a': 1 \n ,'b': 2 \n,'c': 3};", Options: optStr("first")},
+			{Code: "var foo = [1 \n ,2 \n, 3];", Options: optStr("first")},
+			{Code: "function foo(){return {'a': 1\n,'b': 2}}", Options: optStr("first")},
+			{Code: "function foo(){var a=[1\n, 2]}", Options: optStr("first")},
+			{Code: "new Foo(a,\nb);", Options: optWithExc("first", map[string]any{"NewExpression": true})},
+			{Code: "f(1\n, 2);", Options: optWithExc("last", map[string]any{"CallExpression": true})},
+			{Code: "function foo(a\n, b) { return a + b; }", Options: optWithExc("last", map[string]any{"FunctionDeclaration": true})},
+			{
+				Code:    "var a = 'a',\no = 'o';",
+				Options: optWithExc("first", map[string]any{"VariableDeclaration": true}),
+			},
+			{
+				Code:    "var arr = ['a',\n'o'];",
+				Options: optWithExc("first", map[string]any{"ArrayExpression": true}),
+			},
+			{
+				Code:    "var obj = {a: 'a',\nb: 'b'};",
+				Options: optWithExc("first", map[string]any{"ObjectExpression": true}),
+			},
+			{
+				Code:    "var a = 'a',\no = 'o',\narr = [1,\n2];",
+				Options: optWithExc("first", map[string]any{"VariableDeclaration": true, "ArrayExpression": true}),
+			},
+			{
+				Code:    "var ar ={fst:1,\nsnd: [1,\n2]};",
+				Options: optWithExc("first", map[string]any{"ArrayExpression": true, "ObjectExpression": true}),
+			},
+			{
+				Code: "var a = 'a',\nar ={fst:1,\nsnd: [1,\n2]};",
+				Options: optWithExc("first", map[string]any{
+					"ArrayExpression":     true,
+					"ObjectExpression":    true,
+					"VariableDeclaration": true,
+				}),
+			},
+			{
+				Code:    "const foo = (a\n, b) => { return a + b; }",
+				Options: optWithExc("last", map[string]any{"ArrowFunctionExpression": true}),
+			},
+			{
+				Code:    "function foo([a\n, b]) { return a + b; }",
+				Options: optWithExc("last", map[string]any{"ArrayPattern": true}),
+			},
+			{
+				Code:    "const foo = ([a\n, b]) => { return a + b; }",
+				Options: optWithExc("last", map[string]any{"ArrayPattern": true}),
+			},
+			{
+				Code:    "import { a\n, b } from './source';",
+				Options: optWithExc("last", map[string]any{"ImportDeclaration": true}),
+			},
+			{
+				Code:    "const foo = function (a\n, b) { return a + b; }",
+				Options: optWithExc("last", map[string]any{"FunctionExpression": true}),
+			},
+			{
+				Code:    "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
+				Options: optWithExc("last", map[string]any{"ObjectPattern": true}),
+			},
+			{
+				Code:    "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
+				Options: optWithExc("first", map[string]any{"ObjectPattern": true}),
+			},
+			{
+				Code:    "new Foo(a,\nb);",
+				Options: optWithExc("first", map[string]any{"NewExpression": true}),
+			},
+			{
+				Code:    "f(1\n, 2);",
+				Options: optWithExc("last", map[string]any{"CallExpression": true}),
+			},
+			{
+				Code:    "function foo(a\n, b) { return a + b; }",
+				Options: optWithExc("last", map[string]any{"FunctionDeclaration": true}),
+			},
+			{
+				Code:    "const foo = function (a\n, b) { return a + b; }",
+				Options: optWithExc("last", map[string]any{"FunctionExpression": true}),
+			},
+			{
+				Code:    "function foo([a\n, b]) { return a + b; }",
+				Options: optWithExc("last", map[string]any{"ArrayPattern": true}),
+			},
+			{
+				Code:    "const foo = (a\n, b) => { return a + b; }",
+				Options: optWithExc("last", map[string]any{"ArrowFunctionExpression": true}),
+			},
+			{
+				Code:    "const foo = ([a\n, b]) => { return a + b; }",
+				Options: optWithExc("last", map[string]any{"ArrayPattern": true}),
+			},
+			{
+				Code:    "import { a\n, b } from './source';",
+				Options: optWithExc("last", map[string]any{"ImportDeclaration": true}),
+			},
+			{
+				Code:    "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
+				Options: optWithExc("last", map[string]any{"ObjectPattern": true}),
+			},
+			{
+				Code:    "new Foo(a,\nb);",
+				Options: optWithExc("last", map[string]any{"NewExpression": false}),
+			},
+			{
+				Code:    "new Foo(a\n,b);",
+				Options: optWithExc("last", map[string]any{"NewExpression": true}),
+			},
+			{Code: "var foo = [\n , \n 1, \n 2 \n];"},
+			{
+				Code:    "const [\n , \n , \n a, \n b, \n] = arr;",
+				Options: optWithExc("last", map[string]any{"ArrayPattern": false}),
+			},
+			{
+				Code:    "const [\n ,, \n a, \n b, \n] = arr;",
+				Options: optWithExc("last", map[string]any{"ArrayPattern": false}),
+			},
+			{
+				Code:    "const arr = [\n 1 \n , \n ,2 \n]",
+				Options: optStr("first"),
+			},
+			{
+				Code:    "const arr = [\n ,'fifi' \n]",
+				Options: optStr("first"),
+			},
+
+			// ---- exception: ImportDeclaration ----
+			{
+				Code: "import {\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"} from 'module3' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};\n" +
+					"import 'module4' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};",
+				Options: optWithExc("last", map[string]any{"ImportDeclaration": true}),
+			},
+			// ---- exception: ExportAllDeclaration + ExportNamedDeclaration ----
+			{
+				Code: "let a, b, c;\n" +
+					"export {\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					"};\n" +
+					"export {\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"} from 'module1' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};\n" +
+					"export * from 'module2' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};",
+				Options: optWithExc("last", map[string]any{
+					"ExportAllDeclaration":   true,
+					"ExportNamedDeclaration": true,
+				}),
+			},
+			// ---- exception: ImportExpression ----
+			{
+				Code: "import(\n" +
+					"  a,\n" +
+					"  b\n" +
+					");\n" +
+					"import(\n" +
+					"  c\n" +
+					"  , d\n" +
+					");",
+				Options: optWithExc("first", map[string]any{"ImportExpression": true}),
+			},
+			// ---- ImportExpression: false / unset still validates calls ----
+			{
+				Code: "import(\n" +
+					"  a,\n" +
+					");\n" +
+					"import(\n" +
+					"  b, c,\n" +
+					");",
+				Options: optWithExc("last", map[string]any{"ImportExpression": false}),
+			},
+			{
+				Code: "import(\n" +
+					"  a\n" +
+					",);\n" +
+					"import(\n" +
+					"  b, c\n" +
+					",);",
+				Options: optWithExc("first", map[string]any{"ImportExpression": false}),
+			},
+			// ---- exception: SequenceExpression ----
+			{
+				Code: "const x = (\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					");",
+				Options: optWithExc("first", map[string]any{"SequenceExpression": true}),
+			},
+			// ---- exception: ClassDeclaration + ClassExpression (implements) ----
+			{
+				Code: "class MyClass implements\n" +
+					"  A,\n" +
+					"  B\n" +
+					", C {\n" +
+					"}\n" +
+					"const a = class implements\n" +
+					"  A,\n" +
+					"  B\n" +
+					", C {\n" +
+					"}",
+				Options: optWithExc("first", map[string]any{
+					"ClassDeclaration": true,
+					"ClassExpression":  true,
+				}),
+			},
+			// ---- exception: TSDeclareFunction / TSFunctionType / TSConstructorType / TSEmptyBodyFunctionExpression ----
+			{
+				Code: "function f(\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					");\n" +
+					"type a = (\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					") => r\n" +
+					"type a = new (\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					") => r\n" +
+					"abstract class Base {\n" +
+					"  f(\n" +
+					"    a,\n" +
+					"    b\n" +
+					"    , c\n" +
+					"  );\n" +
+					"}",
+				Options: optWithExc("first", map[string]any{
+					"TSDeclareFunction":             true,
+					"TSFunctionType":                true,
+					"TSConstructorType":             true,
+					"TSEmptyBodyFunctionExpression": true,
+				}),
+			},
+			// ---- exception: TSEnumBody ----
+			{
+				Code: "enum MyEnum {\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"}",
+				Options: optWithExc("first", map[string]any{"TSEnumBody": true}),
+			},
+			// ---- exception: TSTypeLiteral ----
+			{
+				Code: "type foo = {\n" +
+					"  a: string,\n" +
+					"  b: string\n" +
+					"  , c: string\n" +
+					"}",
+				Options: optWithExc("first", map[string]any{"TSTypeLiteral": true}),
+			},
+			// ---- exception: TSTypeLiteral + signatures + TSIndexSignature ----
+			{
+				Code: "type foo = {\n" +
+					"  new (\n" +
+					"    a,\n" +
+					"    b\n" +
+					"    , c\n" +
+					"  ): any,\n" +
+					"  (\n" +
+					"    a,\n" +
+					"    b\n" +
+					"    , c\n" +
+					"  ): any,\n" +
+					"  [\n" +
+					"    a: string,\n" +
+					"    b: string\n" +
+					"    , c: string\n" +
+					"  ]: string,\n" +
+					"\n" +
+					"  f(\n" +
+					"    a: string,\n" +
+					"    b: string\n" +
+					"    , c: string\n" +
+					"  ): number,\n" +
+					"}",
+				Options: optWithExc("first", map[string]any{
+					"TSTypeLiteral":                  true,
+					"TSCallSignatureDeclaration":     true,
+					"TSConstructSignatureDeclaration": true,
+					"TSIndexSignature":               true,
+					"TSMethodSignature":              true,
+				}),
+			},
+			// ---- exception: TSInterfaceBody + TSInterfaceDeclaration ----
+			{
+				Code: "interface Foo extends\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"{\n" +
+					"  a: string,\n" +
+					"  b: string\n" +
+					"  , c: string\n" +
+					"}",
+				Options: optWithExc("first", map[string]any{
+					"TSInterfaceBody":        true,
+					"TSInterfaceDeclaration": true,
+				}),
+			},
+			// ---- exception: TSTupleType ----
+			{
+				Code: "type Foo = [\n" +
+					"  \"A\",\n" +
+					"  \"B\"\n" +
+					"  , \"C\"\n" +
+					"];",
+				Options: optWithExc("first", map[string]any{"TSTupleType": true}),
+			},
+			// ---- exception: TSTypeParameterDeclaration + TSTypeParameterInstantiation ----
+			{
+				Code: "type Foo<\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"> = Bar<\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					">;",
+				Options: optWithExc("first", map[string]any{
+					"TSTypeParameterDeclaration":    true,
+					"TSTypeParameterInstantiation":  true,
+				}),
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   "var foo = { a: 1. //comment \n, b: 2\n}",
+				Output: []string{"var foo = { a: 1., //comment \n b: 2\n}"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "var foo = { a: 1. //comment \n //comment1 \n //comment2 \n, b: 2\n}",
+				Output: []string{"var foo = { a: 1., //comment \n //comment1 \n //comment2 \n b: 2\n}"},
+				Errors: errLast(4, 1),
+			},
+			{
+				Code:   "var foo = 1\n,\nbar = 2;",
+				Output: []string{"var foo = 1,\nbar = 2;"},
+				Errors: errLone(2, 1),
+			},
+			{
+				Code:   "var foo = 1 //comment\n,\nbar = 2;",
+				Output: []string{"var foo = 1, //comment\nbar = 2;"},
+				Errors: errLone(2, 1),
+			},
+			{
+				Code:   "var foo = 1 //comment\n, // comment 2\nbar = 2;",
+				Output: []string{"var foo = 1, //comment // comment 2\nbar = 2;"},
+				Errors: errLone(2, 1),
+			},
+			{
+				Code:   "new Foo(a\n,\nb);",
+				Output: []string{"new Foo(a,\nb);"},
+				Errors: errLone(2, 1),
+			},
+			{
+				Code:   "var foo = 1\n,bar = 2;",
+				Output: []string{"var foo = 1,\nbar = 2;"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "f([1,2\n,3]);",
+				Output: []string{"f([1,2,\n3]);"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "f([1,2\n,]);",
+				Output: []string{"f([1,2,\n]);"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "f([,2\n,3]);",
+				Output: []string{"f([,2,\n3]);"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "var foo = ['apples'\n, 'oranges'];",
+				Output: []string{"var foo = ['apples',\n 'oranges'];"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "var [foo\n, bar] = ['apples', 'oranges'];",
+				Output: []string{"var [foo,\n bar] = ['apples', 'oranges'];"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "f(1\n, 2);",
+				Output: []string{"f(1,\n 2);"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "function foo(a\n, b) { return a + b; }",
+				Output: []string{"function foo(a,\n b) { return a + b; }"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "const foo = function (a\n, b) { return a + b; }",
+				Output: []string{"const foo = function (a,\n b) { return a + b; }"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "function foo([a\n, b]) { return a + b; }",
+				Output: []string{"function foo([a,\n b]) { return a + b; }"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "const foo = (a\n, b) => { return a + b; }",
+				Output: []string{"const foo = (a,\n b) => { return a + b; }"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "const foo = ([a\n, b]) => { return a + b; }",
+				Output: []string{"const foo = ([a,\n b]) => { return a + b; }"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "import { a\n, b } from './source';",
+				Output: []string{"import { a,\n b } from './source';"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
+				Output: []string{"var {foo,\n bar} = {foo:'apples', bar:'oranges'};"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:    "var foo = 1,\nbar = 2;",
+				Output:  []string{"var foo = 1\n,bar = 2;"},
+				Options: optStr("first"),
+				Errors:  errFirst(1, 12),
+			},
+			{
+				Code:    "f([1,\n2,3]);",
+				Output:  []string{"f([1\n,2,3]);"},
+				Options: optStr("first"),
+				Errors:  errFirst(1, 5),
+			},
+			{
+				Code:    "var foo = ['apples', \n 'oranges'];",
+				Output:  []string{"var foo = ['apples' \n ,'oranges'];"},
+				Options: optStr("first"),
+				Errors:  errFirst(1, 20),
+			},
+			{
+				Code:    "var foo = {'a': 1, \n 'b': 2\n ,'c': 3};",
+				Output:  []string{"var foo = {'a': 1 \n ,'b': 2\n ,'c': 3};"},
+				Options: optStr("first"),
+				Errors:  errFirst(1, 18),
+			},
+			{
+				Code:    "var a = 'a',\no = 'o',\narr = [1,\n2];",
+				Output:  []string{"var a = 'a',\no = 'o',\narr = [1\n,2];"},
+				Options: optWithExc("first", map[string]any{"VariableDeclaration": true}),
+				Errors:  errFirst(3, 9),
+			},
+			{
+				Code:    "var a = 'a',\nobj = {a: 'a',\nb: 'b'};",
+				Output:  []string{"var a = 'a',\nobj = {a: 'a'\n,b: 'b'};"},
+				Options: optWithExc("first", map[string]any{"VariableDeclaration": true}),
+				Errors:  errFirst(2, 14),
+			},
+			{
+				Code:    "var a = 'a',\nobj = {a: 'a',\nb: 'b'};",
+				Output:  []string{"var a = 'a'\n,obj = {a: 'a',\nb: 'b'};"},
+				Options: optWithExc("first", map[string]any{"ObjectExpression": true}),
+				Errors:  errFirst(1, 12),
+			},
+			{
+				Code:    "var a = 'a',\narr = [1,\n2];",
+				Output:  []string{"var a = 'a'\n,arr = [1,\n2];"},
+				Options: optWithExc("first", map[string]any{"ArrayExpression": true}),
+				Errors:  errFirst(1, 12),
+			},
+			{
+				Code:    "var ar =[1,\n{a: 'a',\nb: 'b'}];",
+				Output:  []string{"var ar =[1,\n{a: 'a'\n,b: 'b'}];"},
+				Options: optWithExc("first", map[string]any{"ArrayExpression": true}),
+				Errors:  errFirst(2, 8),
+			},
+			{
+				Code:    "var ar =[1,\n{a: 'a',\nb: 'b'}];",
+				Output:  []string{"var ar =[1\n,{a: 'a',\nb: 'b'}];"},
+				Options: optWithExc("first", map[string]any{"ObjectExpression": true}),
+				Errors:  errFirst(1, 11),
+			},
+			{
+				Code:    "var ar ={fst:1,\nsnd: [1,\n2]};",
+				Output:  []string{"var ar ={fst:1,\nsnd: [1\n,2]};"},
+				Options: optWithExc("first", map[string]any{"ObjectExpression": true}),
+				Errors:  errFirst(2, 8),
+			},
+			{
+				Code:    "var ar ={fst:1,\nsnd: [1,\n2]};",
+				Output:  []string{"var ar ={fst:1\n,snd: [1,\n2]};"},
+				Options: optWithExc("first", map[string]any{"ArrayExpression": true}),
+				Errors:  errFirst(1, 15),
+			},
+			{
+				Code:    "new Foo(a,\nb);",
+				Output:  []string{"new Foo(a\n,b);"},
+				Options: optStr("first"),
+				Errors:  errFirst(1, 10),
+			},
+			{
+				Code:   "var foo = [\n(bar\n)\n,\nbaz\n];",
+				Output: []string{"var foo = [\n(bar\n),\nbaz\n];"},
+				Errors: errLone(4, 1),
+			},
+			{
+				Code:   "[(foo),\n,\nbar]",
+				Output: []string{"[(foo),,\nbar]"},
+				Errors: errLone(2, 1),
+			},
+			{
+				Code:   "new Foo(a\n,b);",
+				Output: []string{"new Foo(a,\nb);"},
+				Errors: errLast(2, 1),
+			},
+			{
+				Code:   "[\n[foo(3)],\n,\nbar\n];",
+				Output: []string{"[\n[foo(3)],,\nbar\n];"},
+				Errors: errLone(3, 1),
+			},
+			{
+				// https://github.com/eslint/eslint/issues/10632
+				Code:   "[foo//\n,/*block\ncomment*/];",
+				Output: []string{"[foo,//\n/*block\ncomment*/];"},
+				Errors: errLone(2, 1),
+			},
+			// ---- import / with attributes — default "last" ----
+			{
+				Code: "import {\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"} from 'module3' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};\n" +
+					"import 'module4' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};",
+				Output: []string{
+					"import {\n" +
+						"  A,\n" +
+						"  B,\n" +
+						"   C\n" +
+						"} from 'module3' with {\n" +
+						"  a: 'v',\n" +
+						"  b: 'v',\n" +
+						"   c: 'v'\n" +
+						"};\n" +
+						"import 'module4' with {\n" +
+						"  a: 'v',\n" +
+						"  b: 'v',\n" +
+						"   c: 'v'\n" +
+						"};",
+				},
+				Errors: errs(
+					errSpec{"expectedCommaLast", 4, 3},
+					errSpec{"expectedCommaLast", 8, 3},
+					errSpec{"expectedCommaLast", 13, 3},
+				),
+			},
+			// ---- import / with attributes — "first" ----
+			{
+				Code: "import {\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"} from 'module3' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};\n" +
+					"import 'module4' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};",
+				Output: []string{
+					"import {\n" +
+						"  A\n" +
+						"  ,B\n" +
+						"  , C\n" +
+						"} from 'module3' with {\n" +
+						"  a: 'v'\n" +
+						"  ,b: 'v'\n" +
+						"  , c: 'v'\n" +
+						"};\n" +
+						"import 'module4' with {\n" +
+						"  a: 'v'\n" +
+						"  ,b: 'v'\n" +
+						"  , c: 'v'\n" +
+						"};",
+				},
+				Options: optStr("first"),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 2, 4},
+					errSpec{"expectedCommaFirst", 6, 9},
+					errSpec{"expectedCommaFirst", 11, 9},
+				),
+			},
+			// ---- export {} / with attributes — default "last" ----
+			{
+				Code: "let a, b, c;\n" +
+					"export {\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					"};\n" +
+					"export {\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"} from 'module1' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};\n" +
+					"export * from 'module2' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};",
+				Output: []string{
+					"let a, b, c;\n" +
+						"export {\n" +
+						"  a,\n" +
+						"  b,\n" +
+						"   c\n" +
+						"};\n" +
+						"export {\n" +
+						"  A,\n" +
+						"  B,\n" +
+						"   C\n" +
+						"} from 'module1' with {\n" +
+						"  a: 'v',\n" +
+						"  b: 'v',\n" +
+						"   c: 'v'\n" +
+						"};\n" +
+						"export * from 'module2' with {\n" +
+						"  a: 'v',\n" +
+						"  b: 'v',\n" +
+						"   c: 'v'\n" +
+						"};",
+				},
+				Errors: errs(
+					errSpec{"expectedCommaLast", 5, 3},
+					errSpec{"expectedCommaLast", 10, 3},
+					errSpec{"expectedCommaLast", 14, 3},
+					errSpec{"expectedCommaLast", 19, 3},
+				),
+			},
+			// ---- export {} / with attributes — "first" ----
+			{
+				Code: "let a, b, c;\n" +
+					"export {\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					"};\n" +
+					"export {\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"} from 'module1' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};\n" +
+					"export * from 'module2' with {\n" +
+					"  a: 'v',\n" +
+					"  b: 'v'\n" +
+					"  , c: 'v'\n" +
+					"};",
+				Output: []string{
+					"let a, b, c;\n" +
+						"export {\n" +
+						"  a\n" +
+						"  ,b\n" +
+						"  , c\n" +
+						"};\n" +
+						"export {\n" +
+						"  A\n" +
+						"  ,B\n" +
+						"  , C\n" +
+						"} from 'module1' with {\n" +
+						"  a: 'v'\n" +
+						"  ,b: 'v'\n" +
+						"  , c: 'v'\n" +
+						"};\n" +
+						"export * from 'module2' with {\n" +
+						"  a: 'v'\n" +
+						"  ,b: 'v'\n" +
+						"  , c: 'v'\n" +
+						"};",
+				},
+				Options: optStr("first"),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 3, 4},
+					errSpec{"expectedCommaFirst", 8, 4},
+					errSpec{"expectedCommaFirst", 12, 9},
+					errSpec{"expectedCommaFirst", 17, 9},
+				),
+			},
+			// ---- SequenceExpression — default "last" ----
+			{
+				Code: "const x = (\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					");",
+				Output: []string{
+					"const x = (\n" +
+						"  a,\n" +
+						"  b,\n" +
+						"   c\n" +
+						");",
+				},
+				Errors: errLast(4, 3),
+			},
+			// ---- SequenceExpression — "first" ----
+			{
+				Code: "const x = (\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					");",
+				Output: []string{
+					"const x = (\n" +
+						"  a\n" +
+						"  ,b\n" +
+						"  , c\n" +
+						");",
+				},
+				Options: optStr("first"),
+				Errors:  errFirst(2, 4),
+			},
+			// ---- ImportExpression — default "last" ----
+			{
+				Code: "import(\n" +
+					"  a,\n" +
+					"  b\n" +
+					");\n" +
+					"import(\n" +
+					"  c\n" +
+					"  , d\n" +
+					");",
+				Output: []string{
+					"import(\n" +
+						"  a,\n" +
+						"  b\n" +
+						");\n" +
+						"import(\n" +
+						"  c,\n" +
+						"   d\n" +
+						");",
+				},
+				Errors: errLast(7, 3),
+			},
+			// ---- ImportExpression — "first" ----
+			{
+				Code: "import(\n" +
+					"  a,\n" +
+					"  b\n" +
+					");\n" +
+					"import(\n" +
+					"  c\n" +
+					"  , d\n" +
+					");",
+				Output: []string{
+					"import(\n" +
+						"  a\n" +
+						"  ,b\n" +
+						");\n" +
+						"import(\n" +
+						"  c\n" +
+						"  , d\n" +
+						");",
+				},
+				Options: optStr("first"),
+				Errors:  errFirst(2, 4),
+			},
+			// ---- Class implements — default "last" ----
+			{
+				Code: "class MyClass implements\n" +
+					"  A,\n" +
+					"  B\n" +
+					", C {\n" +
+					"}\n" +
+					"const a = class implements\n" +
+					"  A,\n" +
+					"  B\n" +
+					", C {\n" +
+					"}",
+				Output: []string{
+					"class MyClass implements\n" +
+						"  A,\n" +
+						"  B,\n" +
+						" C {\n" +
+						"}\n" +
+						"const a = class implements\n" +
+						"  A,\n" +
+						"  B,\n" +
+						" C {\n" +
+						"}",
+				},
+				Errors: errs(
+					errSpec{"expectedCommaLast", 4, 1},
+					errSpec{"expectedCommaLast", 9, 1},
+				),
+			},
+			// ---- Class implements — "first" ----
+			{
+				Code: "class MyClass implements\n" +
+					"  A,\n" +
+					"  B\n" +
+					", C {\n" +
+					"}\n" +
+					"const a = class implements\n" +
+					"  A,\n" +
+					"  B\n" +
+					", C {\n" +
+					"}",
+				Output: []string{
+					"class MyClass implements\n" +
+						"  A\n" +
+						"  ,B\n" +
+						", C {\n" +
+						"}\n" +
+						"const a = class implements\n" +
+						"  A\n" +
+						"  ,B\n" +
+						", C {\n" +
+						"}",
+				},
+				Options: optStr("first"),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 2, 4},
+					errSpec{"expectedCommaFirst", 7, 4},
+				),
+			},
+			// ---- TSDeclareFunction / TSFunctionType / TSConstructorType / TSEmptyBodyFunctionExpression — default "last" ----
+			{
+				Code: "function f(\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					")\n" +
+					"type a = (\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					") => r\n" +
+					"type a = new (\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					") => r\n" +
+					"abstract class Base {\n" +
+					"  f(\n" +
+					"    a,\n" +
+					"    b\n" +
+					"    , c\n" +
+					"  );\n" +
+					"}",
+				Output: []string{
+					"function f(\n" +
+						"  a,\n" +
+						"  b,\n" +
+						"   c\n" +
+						")\n" +
+						"type a = (\n" +
+						"  a,\n" +
+						"  b,\n" +
+						"   c\n" +
+						") => r\n" +
+						"type a = new (\n" +
+						"  a,\n" +
+						"  b,\n" +
+						"   c\n" +
+						") => r\n" +
+						"abstract class Base {\n" +
+						"  f(\n" +
+						"    a,\n" +
+						"    b,\n" +
+						"     c\n" +
+						"  );\n" +
+						"}",
+				},
+				Errors: errs(
+					errSpec{"expectedCommaLast", 4, 3},
+					errSpec{"expectedCommaLast", 9, 3},
+					errSpec{"expectedCommaLast", 14, 3},
+					errSpec{"expectedCommaLast", 20, 5},
+				),
+			},
+			// ---- Same code — "first" ----
+			{
+				Code: "function f(\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					")\n" +
+					"type a = (\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					") => r\n" +
+					"type a = new (\n" +
+					"  a,\n" +
+					"  b\n" +
+					"  , c\n" +
+					") => r\n" +
+					"abstract class Base {\n" +
+					"  f(\n" +
+					"    a,\n" +
+					"    b\n" +
+					"    , c\n" +
+					"  );\n" +
+					"}",
+				Output: []string{
+					"function f(\n" +
+						"  a\n" +
+						"  ,b\n" +
+						"  , c\n" +
+						")\n" +
+						"type a = (\n" +
+						"  a\n" +
+						"  ,b\n" +
+						"  , c\n" +
+						") => r\n" +
+						"type a = new (\n" +
+						"  a\n" +
+						"  ,b\n" +
+						"  , c\n" +
+						") => r\n" +
+						"abstract class Base {\n" +
+						"  f(\n" +
+						"    a\n" +
+						"    ,b\n" +
+						"    , c\n" +
+						"  );\n" +
+						"}",
+				},
+				Options: optStr("first"),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 2, 4},
+					errSpec{"expectedCommaFirst", 7, 4},
+					errSpec{"expectedCommaFirst", 12, 4},
+					errSpec{"expectedCommaFirst", 18, 6},
+				),
+			},
+			// ---- enum — default "last" ----
+			{
+				Code: "enum MyEnum {\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"}",
+				Output: []string{
+					"enum MyEnum {\n" +
+						"  A,\n" +
+						"  B,\n" +
+						"   C\n" +
+						"}",
+				},
+				Errors: errLast(4, 3),
+			},
+			// ---- enum — "first" ----
+			{
+				Code: "enum MyEnum {\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"}",
+				Output: []string{
+					"enum MyEnum {\n" +
+						"  A\n" +
+						"  ,B\n" +
+						"  , C\n" +
+						"}",
+				},
+				Options: optStr("first"),
+				Errors:  errFirst(2, 4),
+			},
+			// ---- TSTypeLiteral — default "last" ----
+			{
+				Code: "type foo = {\n" +
+					"  a: string,\n" +
+					"  b: string\n" +
+					"  , c: string\n" +
+					"}",
+				Output: []string{
+					"type foo = {\n" +
+						"  a: string,\n" +
+						"  b: string,\n" +
+						"   c: string\n" +
+						"}",
+				},
+				Errors: errLast(4, 3),
+			},
+			// ---- TSTypeLiteral — "first" ----
+			{
+				Code: "type foo = {\n" +
+					"  a: string,\n" +
+					"  b: string\n" +
+					"  , c: string\n" +
+					"}",
+				Output: []string{
+					"type foo = {\n" +
+						"  a: string\n" +
+						"  ,b: string\n" +
+						"  , c: string\n" +
+						"}",
+				},
+				Options: optStr("first"),
+				Errors:  errFirst(2, 12),
+			},
+			// ---- TSTypeLiteral with signatures — default "last" ----
+			{
+				Code: "type foo = {\n" +
+					"  new (\n" +
+					"    a,\n" +
+					"    b\n" +
+					"    , c\n" +
+					"  ): any,\n" +
+					"  (\n" +
+					"    a,\n" +
+					"    b\n" +
+					"    , c\n" +
+					"  ): any,\n" +
+					"  [\n" +
+					"    a: string,\n" +
+					"    b: string\n" +
+					"    , c: string\n" +
+					"  ]: string,\n" +
+					"\n" +
+					"  f(\n" +
+					"    a: string,\n" +
+					"    b: string\n" +
+					"    , c: string\n" +
+					"  ): number,\n" +
+					"}",
+				Output: []string{
+					"type foo = {\n" +
+						"  new (\n" +
+						"    a,\n" +
+						"    b,\n" +
+						"     c\n" +
+						"  ): any,\n" +
+						"  (\n" +
+						"    a,\n" +
+						"    b,\n" +
+						"     c\n" +
+						"  ): any,\n" +
+						"  [\n" +
+						"    a: string,\n" +
+						"    b: string,\n" +
+						"     c: string\n" +
+						"  ]: string,\n" +
+						"\n" +
+						"  f(\n" +
+						"    a: string,\n" +
+						"    b: string,\n" +
+						"     c: string\n" +
+						"  ): number,\n" +
+						"}",
+				},
+				Errors: errs(
+					errSpec{"expectedCommaLast", 5, 5},
+					errSpec{"expectedCommaLast", 10, 5},
+					errSpec{"expectedCommaLast", 15, 5},
+					errSpec{"expectedCommaLast", 21, 5},
+				),
+			},
+			// ---- TSTypeLiteral with signatures — "first" ----
+			// Listener firing order: outer KindTypeLiteral first (the four
+			// member-separator commas), then each nested signature in
+			// source order (their `a,`-shaped param-list commas).
+			{
+				Code: "type foo = {\n" +
+					"  new (\n" +
+					"    a,\n" +
+					"    b\n" +
+					"    , c\n" +
+					"  ): any,\n" +
+					"  (\n" +
+					"    a,\n" +
+					"    b\n" +
+					"    , c\n" +
+					"  ): any,\n" +
+					"  [\n" +
+					"    a: string,\n" +
+					"    b: string\n" +
+					"    , c: string\n" +
+					"  ]: string,\n" +
+					"\n" +
+					"  f(\n" +
+					"    a: string,\n" +
+					"    b: string\n" +
+					"    , c: string\n" +
+					"  ): number,\n" +
+					"}",
+				Output: []string{
+					"type foo = {\n" +
+						"  new (\n" +
+						"    a\n" +
+						"    ,b\n" +
+						"    , c\n" +
+						"  ): any\n" +
+						"  ,(\n" +
+						"    a\n" +
+						"    ,b\n" +
+						"    , c\n" +
+						"  ): any\n" +
+						"  ,[\n" +
+						"    a: string\n" +
+						"    ,b: string\n" +
+						"    , c: string\n" +
+						"  ]: string\n" +
+						"\n" +
+						"  ,f(\n" +
+						"    a: string\n" +
+						"    ,b: string\n" +
+						"    , c: string\n" +
+						"  ): number\n" +
+						",}",
+				},
+				Options: optStr("first"),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 6, 9},
+					errSpec{"expectedCommaFirst", 11, 9},
+					errSpec{"expectedCommaFirst", 16, 12},
+					errSpec{"expectedCommaFirst", 22, 12},
+					errSpec{"expectedCommaFirst", 3, 6},
+					errSpec{"expectedCommaFirst", 8, 6},
+					errSpec{"expectedCommaFirst", 13, 14},
+					errSpec{"expectedCommaFirst", 19, 14},
+				),
+			},
+			// ---- TSInterfaceBody + TSInterfaceDeclaration — default "last" ----
+			{
+				Code: "interface Foo extends\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"{\n" +
+					"  a: string,\n" +
+					"  b: string\n" +
+					"  , c: string\n" +
+					"}",
+				Output: []string{
+					"interface Foo extends\n" +
+						"  A,\n" +
+						"  B,\n" +
+						"   C\n" +
+						"{\n" +
+						"  a: string,\n" +
+						"  b: string,\n" +
+						"   c: string\n" +
+						"}",
+				},
+				Errors: errs(
+					errSpec{"expectedCommaLast", 4, 3},
+					errSpec{"expectedCommaLast", 8, 3},
+				),
+			},
+			// ---- TSInterfaceBody + TSInterfaceDeclaration — "first" ----
+			{
+				Code: "interface Foo extends\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"{\n" +
+					"  a: string,\n" +
+					"  b: string\n" +
+					"  , c: string\n" +
+					"}",
+				Output: []string{
+					"interface Foo extends\n" +
+						"  A\n" +
+						"  ,B\n" +
+						"  , C\n" +
+						"{\n" +
+						"  a: string\n" +
+						"  ,b: string\n" +
+						"  , c: string\n" +
+						"}",
+				},
+				Options: optStr("first"),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 2, 4},
+					errSpec{"expectedCommaFirst", 6, 12},
+				),
+			},
+			// ---- TSTupleType — default "last" ----
+			{
+				Code: "type Foo = [\n" +
+					"  \"A\",\n" +
+					"  \"B\"\n" +
+					"  , \"C\"\n" +
+					"];",
+				Output: []string{
+					"type Foo = [\n" +
+						"  \"A\",\n" +
+						"  \"B\",\n" +
+						"   \"C\"\n" +
+						"];",
+				},
+				Errors: errLast(4, 3),
+			},
+			// ---- TSTupleType — "first" ----
+			{
+				Code: "type Foo = [\n" +
+					"  \"A\",\n" +
+					"  \"B\"\n" +
+					"  , \"C\"\n" +
+					"];",
+				Output: []string{
+					"type Foo = [\n" +
+						"  \"A\"\n" +
+						"  ,\"B\"\n" +
+						"  , \"C\"\n" +
+						"];",
+				},
+				Options: optStr("first"),
+				Errors:  errFirst(2, 6),
+			},
+			// ---- TSTypeParameterDeclaration + TSTypeParameterInstantiation — default "last" ----
+			{
+				Code: "type Foo<\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"> = Bar<\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					">;",
+				Output: []string{
+					"type Foo<\n" +
+						"  A,\n" +
+						"  B,\n" +
+						"   C\n" +
+						"> = Bar<\n" +
+						"  A,\n" +
+						"  B,\n" +
+						"   C\n" +
+						">;",
+				},
+				Errors: errs(
+					errSpec{"expectedCommaLast", 4, 3},
+					errSpec{"expectedCommaLast", 8, 3},
+				),
+			},
+			// ---- TSTypeParameterDeclaration + TSTypeParameterInstantiation — "first" ----
+			{
+				Code: "type Foo<\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					"> = Bar<\n" +
+					"  A,\n" +
+					"  B\n" +
+					"  , C\n" +
+					">;",
+				Output: []string{
+					"type Foo<\n" +
+						"  A\n" +
+						"  ,B\n" +
+						"  , C\n" +
+						"> = Bar<\n" +
+						"  A\n" +
+						"  ,B\n" +
+						"  , C\n" +
+						">;",
+				},
+				Options: optStr("first"),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 2, 4},
+					errSpec{"expectedCommaFirst", 6, 4},
+				),
+			},
+			// ---- ImportDeclaration: default specifier + named bindings comma — "last" ----
+			{
+				Code: "import a\n" +
+					"  , {Foo} from 'module'\n" +
+					"import b\n" +
+					"  , {} from 'module'\n" +
+					"import c,\n" +
+					"  {Bar} from 'module'\n" +
+					"import d,\n" +
+					"  {} from 'module'",
+				Output: []string{
+					"import a,\n" +
+						"   {Foo} from 'module'\n" +
+						"import b,\n" +
+						"   {} from 'module'\n" +
+						"import c,\n" +
+						"  {Bar} from 'module'\n" +
+						"import d,\n" +
+						"  {} from 'module'",
+				},
+				Options: optWithExc("last", map[string]any{"ImportDeclaration": false}),
+				Errors: errs(
+					errSpec{"expectedCommaLast", 2, 3},
+					errSpec{"expectedCommaLast", 4, 3},
+				),
+			},
+			// ---- ImportDeclaration: default + named bindings comma — "first" ----
+			{
+				Code: "import a\n" +
+					"  , {Foo} from 'module'\n" +
+					"import b\n" +
+					"  , {} from 'module'\n" +
+					"import c,\n" +
+					"  {Bar} from 'module'\n" +
+					"import d,\n" +
+					"  {} from 'module'",
+				Output: []string{
+					"import a\n" +
+						"  , {Foo} from 'module'\n" +
+						"import b\n" +
+						"  , {} from 'module'\n" +
+						"import c\n" +
+						"  ,{Bar} from 'module'\n" +
+						"import d\n" +
+						"  ,{} from 'module'",
+				},
+				Options: optWithExc("first", map[string]any{"ImportDeclaration": false}),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 5, 9},
+					errSpec{"expectedCommaFirst", 7, 9},
+				),
+			},
+			// ---- trailing comma at end of multi-line object — "last" ----
+			{
+				Code: "const x = {a,b\n" +
+					",}",
+				Output: []string{
+					"const x = {a,b,\n" +
+						"}",
+				},
+				Options: optStr("last"),
+				Errors:  errLast(2, 1),
+			},
+			// ---- trailing comma at end of multi-line object — "first" ----
+			{
+				Code: "const x = {a,b,\n" +
+					"}",
+				Output: []string{
+					"const x = {a,b\n" +
+						",}",
+				},
+				Options: optStr("first"),
+				Errors:  errFirst(1, 15),
+			},
+			// ---- complex array with parenthesized elements — "last" ----
+			{
+				Code: "const x = [,\n" +
+					"  (a),\n" +
+					"  (b),\n" +
+					"  (c),\n" +
+					"]\n" +
+					"const y = [\n" +
+					"  ,(a)\n" +
+					"  ,(b)\n" +
+					"  ,(c)\n" +
+					"  ,]",
+				Output: []string{
+					"const x = [,\n" +
+						"  (a),\n" +
+						"  (b),\n" +
+						"  (c),\n" +
+						"]\n" +
+						"const y = [\n" +
+						"  ,(a),\n" +
+						"  (b),\n" +
+						"  (c),\n" +
+						"  ]",
+				},
+				Options: optStr("last"),
+				Errors: errs(
+					errSpec{"expectedCommaLast", 8, 3},
+					errSpec{"expectedCommaLast", 9, 3},
+					errSpec{"expectedCommaLast", 10, 3},
+				),
+			},
+			// ---- complex array with parenthesized elements — "first" ----
+			{
+				Code: "const x = [,\n" +
+					"  (a),\n" +
+					"  (b),\n" +
+					"  (c),\n" +
+					"]\n" +
+					"const y = [\n" +
+					"  ,(a)\n" +
+					"  ,(b)\n" +
+					"  ,(c)\n" +
+					"  ,]",
+				Output: []string{
+					"const x = [,\n" +
+						"  (a)\n" +
+						"  ,(b)\n" +
+						"  ,(c)\n" +
+						",]\n" +
+						"const y = [\n" +
+						"  ,(a)\n" +
+						"  ,(b)\n" +
+						"  ,(c)\n" +
+						"  ,]",
+				},
+				Options: optStr("first"),
+				Errors: errs(
+					errSpec{"expectedCommaFirst", 2, 6},
+					errSpec{"expectedCommaFirst", 3, 6},
+					errSpec{"expectedCommaFirst", 4, 6},
+				),
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -451,6 +451,7 @@ export default defineConfig({
 
     // eslint-plugin-stylistic
     './tests/eslint-plugin-stylistic/rules/comma-dangle.test.ts',
+    './tests/eslint-plugin-stylistic/rules/comma-style.test.ts',
     './tests/eslint-plugin-stylistic/rules/array-bracket-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/arrow-parens.test.ts',
     './tests/eslint-plugin-stylistic/rules/arrow-spacing.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/comma-style.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/comma-style.test.ts
@@ -1,0 +1,130 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('comma-style', null as never, {
+  valid: [
+    // default ("last")
+    { code: 'var foo = 1, bar = 3;' },
+    { code: "var foo = {'a': 1, 'b': 2};" },
+    { code: 'var foo = [1, 2];' },
+    { code: 'var foo = [, 2];' },
+    { code: 'var foo = [1, ];' },
+    { code: "var foo = ['apples', \n 'oranges'];" },
+    { code: "var foo = {'a': 1, \n 'b': 2, \n'c': 3};" },
+    { code: 'var foo = [1, \n2, \n3];' },
+    { code: 'function foo(){var a=[1,\n 2]}' },
+    { code: "function foo(){return {'a': 1,\n'b': 2}}" },
+    { code: 'var foo = \n1, \nbar = \n2;' },
+    { code: 'var foo = [\n(bar),\nbaz\n];' },
+
+    // explicit "first"
+    { code: 'var foo = 1, bar = 2;', options: ['first'] },
+    { code: 'var foo = 1 \n ,bar = 2;', options: ['first'] },
+    { code: "var foo = {'a': 1 \n ,'b': 2 \n,'c': 3};", options: ['first'] },
+    { code: 'var foo = [1 \n ,2 \n, 3];', options: ['first'] },
+
+    // exceptions
+    {
+      code: "var arr = ['a',\n'o'];",
+      options: ['first', { exceptions: { ArrayExpression: true } }],
+    },
+    {
+      code: 'new Foo(a\n,b);',
+      options: ['last', { exceptions: { NewExpression: true } }],
+    },
+    {
+      code: 'f(1\n, 2);',
+      options: ['last', { exceptions: { CallExpression: true } }],
+    },
+    {
+      code: 'function foo(a\n, b) { return a + b; }',
+      options: ['last', { exceptions: { FunctionDeclaration: true } }],
+    },
+    {
+      code: 'import { a\n, b } from "./source";',
+      options: ['last', { exceptions: { ImportDeclaration: true } }],
+    },
+    {
+      code: 'enum MyEnum {\n  A,\n  B\n  , C\n}',
+      options: ['first', { exceptions: { TSEnumBody: true } }],
+    },
+    {
+      code: 'type foo = {\n  a: string,\n  b: string\n  , c: string\n}',
+      options: ['first', { exceptions: { TSTypeLiteral: true } }],
+    },
+    {
+      code: 'type Foo = [\n  "A",\n  "B"\n  , "C"\n];',
+      options: ['first', { exceptions: { TSTupleType: true } }],
+    },
+  ],
+  invalid: [
+    // default "last" — lone comma report
+    {
+      code: 'var foo = 1\n,\nbar = 2;',
+      output: 'var foo = 1,\nbar = 2;',
+      errors: [{ messageId: 'unexpectedLineBeforeAndAfterComma' }],
+    },
+    {
+      code: 'var foo = 1\n,bar = 2;',
+      output: 'var foo = 1,\nbar = 2;',
+      errors: [{ messageId: 'expectedCommaLast', column: 1, endColumn: 2 }],
+    },
+    {
+      code: "var foo = ['apples'\n, 'oranges'];",
+      output: "var foo = ['apples',\n 'oranges'];",
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: 'f(1\n, 2);',
+      output: 'f(1,\n 2);',
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: 'function foo(a\n, b) { return a + b; }',
+      output: 'function foo(a,\n b) { return a + b; }',
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: 'import { a\n, b } from "./source";',
+      output: 'import { a,\n b } from "./source";',
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: 'var {foo\n, bar} = {foo:"apples", bar:"oranges"};',
+      output: 'var {foo,\n bar} = {foo:"apples", bar:"oranges"};',
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+
+    // explicit "first"
+    {
+      code: 'var foo = 1,\nbar = 2;',
+      output: 'var foo = 1\n,bar = 2;',
+      options: ['first'],
+      errors: [{ messageId: 'expectedCommaFirst', column: 12, endColumn: 13 }],
+    },
+    {
+      code: 'new Foo(a,\nb);',
+      output: 'new Foo(a\n,b);',
+      options: ['first'],
+      errors: [{ messageId: 'expectedCommaFirst' }],
+    },
+
+    // TS member separator
+    {
+      code: 'type foo = {\n  a: string,\n  b: string\n  , c: string\n}',
+      output: 'type foo = {\n  a: string,\n  b: string,\n   c: string\n}',
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: 'enum MyEnum {\n  A,\n  B\n  , C\n}',
+      output: 'enum MyEnum {\n  A,\n  B,\n   C\n}',
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+    {
+      code: 'type Foo = [\n  "A",\n  "B"\n  , "C"\n];',
+      output: 'type Foo = [\n  "A",\n  "B",\n   "C"\n];',
+      errors: [{ messageId: 'expectedCommaLast' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/comma-style` rule from ESLint Stylistic to rslint.

Enforces a consistent comma placement (`"last"` default / `"first"`) across array literals, object literals, variable declarations, function parameters, call arguments, import / export specifiers, sequence expressions, and the TypeScript-only comma-bearing lists (type / interface members, enum members, tuples, type parameters and type arguments, function / constructor signatures, import attributes). Supports the upstream `exceptions` map (32 keys, ESTree node-type names).

## Related Links

- ESLint Stylistic rule: https://eslint.style/rules/comma-style
- Source: https://github.com/eslint-stylistic/eslint-stylistic/tree/main/packages/eslint-plugin/rules/comma-style

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).