### PR TITLE
feat: port rule @stylistic/eol-last

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_style"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/computed_property_spacing"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/eol_last"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -24,5 +25,6 @@ func GetAllRules() []rule.Rule {
 		comma_spacing.CommaSpacingRule,
 		comma_style.CommaStyleRule,
 		computed_property_spacing.ComputedPropertySpacingRule,
+		eol_last.EolLastRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/eol_last/eol_last.go
+++ b/internal/plugins/stylistic/rules/eol_last/eol_last.go
@@ -1,0 +1,125 @@
+package eol_last
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const (
+	optionAlways = "always"
+	optionNever  = "never"
+)
+
+// parseMode unwraps the single positional string option. Accepted shapes:
+//
+//	['eol-last']            → 'always' (default)
+//	['eol-last', 'never']   → 'never'
+//	['eol-last', 'always']  → 'always'
+//
+// rslint's config loader collapses the single trailing option element, so the
+// rule may receive either []interface{}{"never"} (Go test / multi-element
+// config) or a bare string (CLI single-option config). Anything that does not
+// resolve to a known string keeps the upstream-equivalent behavior of leaving
+// `mode` un-matched (no diagnostic on either branch); we only short-circuit
+// to the default when no value was supplied at all.
+func parseMode(options any) string {
+	switch v := options.(type) {
+	case string:
+		return v
+	case []interface{}:
+		if len(v) > 0 {
+			if s, ok := v[0].(string); ok {
+				return s
+			}
+		}
+	}
+	return optionAlways
+}
+
+// EolLastRule enforces or disallows a trailing newline at the end of files.
+// https://eslint.style/rules/eol-last
+//
+// This is a whole-file rule: it does not visit AST nodes. rslint does not fire
+// a KindSourceFile listener, so the check runs eagerly inside Run and returns
+// an empty listener map.
+var EolLastRule = rule.Rule{
+	Name: "@stylistic/eol-last",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		mode := parseMode(options)
+		text := ctx.SourceFile.Text()
+		n := len(text)
+
+		if n == 0 {
+			return rule.RuleListeners{}
+		}
+
+		endsWithLF := strings.HasSuffix(text, "\n")
+
+		switch mode {
+		case optionAlways:
+			if !endsWithLF {
+				// Diagnostic loc is a zero-width span at src.length, matching
+				// upstream's `loc: getLocFromIndex(src.length)`. The renderer
+				// resolves position n to the line/column just past the final
+				// byte, even when that byte is on the same line.
+				ctx.ReportRangeWithFixes(
+					core.NewTextRange(n, n),
+					rule.RuleMessage{
+						Id:          "missing",
+						Description: "Newline required at end of file but not found.",
+					},
+					rule.RuleFix{
+						Text:  "\n",
+						Range: core.NewTextRange(n, n),
+					},
+				)
+			}
+		case optionNever:
+			if endsWithLF {
+				// Diagnostic span covers exactly the final newline sequence
+				// (`\r\n` when present, else `\n`), so end-of-range falls on
+				// the start of the next line — matching upstream's
+				// `[length-(CRLF?2:1), length]` loc.
+				startPos := n - 1
+				if strings.HasSuffix(text, "\r\n") {
+					startPos = n - 2
+				}
+				// Fix removes the entire trailing run of `(\r?\n)+`, matching
+				// upstream's `/(?:\r?\n)+$/u` greedy strip. This collapses
+				// multiple terminators (e.g. `\n\n`, `\r\n\r\n`) in one fix.
+				fixStart := trailingNewlineRunStart(text)
+				ctx.ReportRangeWithFixes(
+					core.NewTextRange(startPos, n),
+					rule.RuleMessage{
+						Id:          "unexpected",
+						Description: "Newline not allowed at end of file.",
+					},
+					rule.RuleFix{
+						Text:  "",
+						Range: core.NewTextRange(fixStart, n),
+					},
+				)
+			}
+		}
+
+		return rule.RuleListeners{}
+	},
+}
+
+// trailingNewlineRunStart returns the byte index where the trailing
+// `(\r?\n)+` sequence begins. Mirrors upstream's `/(?:\r?\n)+$/u.exec(src)`
+// — each step consumes a `\n` and, when immediately preceded by `\r`, also
+// consumes that `\r`. Callers must only invoke this when text actually ends
+// with `\n`; otherwise it returns len(text) unchanged.
+func trailingNewlineRunStart(text string) int {
+	pos := len(text)
+	for pos > 0 && text[pos-1] == '\n' {
+		pos--
+		if pos > 0 && text[pos-1] == '\r' {
+			pos--
+		}
+	}
+	return pos
+}

--- a/internal/plugins/stylistic/rules/eol_last/eol_last.md
+++ b/internal/plugins/stylistic/rules/eol_last/eol_last.md
@@ -1,0 +1,66 @@
+# eol-last
+
+Require or disallow newline at the end of files.
+
+## Rule Details
+
+This rule enforces at least one newline (or the absence thereof) at the end of non-empty files.
+
+Trailing newlines in non-empty files are a common UNIX idiom. Benefits include the ability to concatenate or append to files and to output files to the terminal without interfering with shell prompts.
+
+## Options
+
+This rule has a string option:
+
+- `"always"` (default) requires the file to end with at least one newline (`\n` or `\r\n`).
+- `"never"` disallows any trailing newline at the end of the file.
+
+### always
+
+Examples of **incorrect** code for this rule with the default `"always"` option:
+
+```javascript
+function doSomething() {
+  var foo = 2;
+}
+```
+
+Examples of **correct** code for this rule with the default `"always"` option:
+
+```javascript
+function doSomething() {
+  var foo = 2;
+}
+
+```
+
+### never
+
+Examples of **incorrect** code for this rule with the `"never"` option:
+
+```json
+{ "@stylistic/eol-last": ["error", "never"] }
+```
+
+```javascript
+function doSomething() {
+  var foo = 2;
+}
+
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```json
+{ "@stylistic/eol-last": ["error", "never"] }
+```
+
+```javascript
+function doSomething() {
+  var foo = 2;
+}
+```
+
+## Original Documentation
+
+- [@stylistic/eol-last](https://eslint.style/rules/eol-last)

--- a/internal/plugins/stylistic/rules/eol_last/eol_last_extras_test.go
+++ b/internal/plugins/stylistic/rules/eol_last/eol_last_extras_test.go
@@ -1,0 +1,353 @@
+// TestEolLastExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the
+// specific branch / Dimension 4 row / Go-port-specific concern it covers, so
+// future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// Group layout:
+//   1. Dimension 4 walk (mostly N/A — this is a whole-file rule)
+//   2. Empty / single-terminator boundary
+//   3. Mode-shape coverage (explicit 'always', bare-string CLI shape)
+//   4. Fix-regex `(?:\r?\n)+$` coverage (3-plus runs, mixed terminators)
+//   5. Whitespace / tab preservation under 'never'
+//   6. Encoding edges (multi-byte UTF-8, surrogate pair, non-`\n` line
+//      terminators like `\f` and U+2028)
+//   7. Real-user syntactic shapes (function body, single-line comment, JSX,
+//      shebang, multi-line file)
+//   8. Message text lock-ins
+package eol_last_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/eol_last"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestEolLastExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&eol_last.EolLastRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: N/A — receiver / expression wrappers ----
+			// N/A: this rule inspects only the final byte(s) of the source
+			// buffer, not any AST node. Paren / non-null / as-cast /
+			// satisfies / optional-chain wrappers anywhere inside the file
+			// are invisible to it; the decision depends solely on
+			// `endsWithLF`.
+			//
+			// ---- Dimension 4: N/A — access / key forms ----
+			// N/A: rule never inspects member-access or computed-key shapes.
+			//
+			// ---- Dimension 4: N/A — declaration / container forms ----
+			// N/A: rule never inspects function / class / arrow declarations.
+			//
+			// ---- Dimension 4: N/A — nesting / traversal boundaries ----
+			// N/A: rule fires once per file at Run setup; there is no AST
+			// traversal and therefore no boundary to bleed across.
+			//
+			// ---- Dimension 4: graceful degradation — empty file ----
+			// Empty source must not crash and must produce zero diagnostics
+			// under either mode. Upstream covers `''` only under default
+			// 'always'; lock in the 'never' side here.
+			{Code: ``, Options: optStr("never")},
+
+			// ---- Locks in upstream create() arm: explicit 'always' ----
+			// Upstream's valid suite tests only the default (omitted) options
+			// path. Explicit `["always"]` must behave identically — lock in
+			// both LF and CRLF terminators so the `parseMode` string
+			// round-trip stays equivalent to the default.
+			{Code: "var a = 1;\n", Options: optStr("always")},
+			{Code: "var a = 1;\r\n", Options: optStr("always")},
+
+			// ---- Encoding: file ending in multi-byte unicode under 'always' ----
+			// Source ending with a multi-byte rune followed by `\n` must stay
+			// valid under 'always'. Locks in that `strings.HasSuffix` on the
+			// raw byte buffer correctly detects the trailing `\n` regardless
+			// of what precedes it.
+			{Code: "var a = '中文';\n"},
+
+			// ---- Encoding: surrogate-pair (emoji) ending under 'always' ----
+			// Astral characters (4-byte UTF-8, 2 UTF-16 code units) before
+			// the final `\n` must not throw off the byte-level newline check.
+			{Code: "var a = '😀';\n"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// =========================================================
+			// 2. Empty / single-terminator boundary
+			// =========================================================
+
+			// Locks in upstream create() arm 2 with src.length == 1 (single
+			// LF). Upstream's `[length-1, length]` becomes `[0, 1]`; the
+			// diagnostic must report at line 1 col 1 → line 2 col 1, and
+			// the fix wipes the whole file.
+			{
+				Code:    "\n",
+				Output:  []string{``},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1, EndLine: 2, EndColumn: 1},
+				},
+			},
+			// Same as above for a single CRLF. Locks in the
+			// `endsWithCRLF ? 2 : 1` ternary on a 2-byte source.
+			{
+				Code:    "\r\n",
+				Output:  []string{``},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1, EndLine: 2, EndColumn: 1},
+				},
+			},
+
+			// =========================================================
+			// 3. Mode-shape coverage
+			// =========================================================
+
+			// Bare-string option — the shape rslint's config loader
+			// produces from CLI / `rslint.config.mjs` when the rule entry
+			// is `['error', 'never']`. Upstream tests always pass options
+			// as `['never']` (array form). The Go test framework lets us
+			// pass the bare string directly; lock in that `parseMode`
+			// accepts both shapes.
+			{
+				Code:    "var a = 1;\n",
+				Output:  []string{"var a = 1;"},
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 11, EndLine: 2, EndColumn: 1},
+				},
+			},
+
+			// =========================================================
+			// 4. Fix-regex `(?:\r?\n)+$` coverage
+			// =========================================================
+			// Upstream only tests doubled `\n\n` and `\r\n\r\n`; these
+			// lock in 3-plus runs and mixed `\r\n` / `\n` terminators.
+
+			// Three trailing LFs — all stripped in one fix.
+			{
+				Code:    "var a = 1;\n\n\n",
+				Output:  []string{`var a = 1;`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 3, Column: 1, EndLine: 4, EndColumn: 1},
+				},
+			},
+			// Three trailing CRLFs — all stripped.
+			{
+				Code:    "var a = 1;\r\n\r\n\r\n",
+				Output:  []string{`var a = 1;`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 3, Column: 1, EndLine: 4, EndColumn: 1},
+				},
+			},
+			// Mixed: LF after CRLF. Final terminator is a bare `\n`
+			// (endsWithCRLF=false), so diagnostic span is `[n-1, n]`.
+			// Fix-regex matches the whole `\r\n\n` run and strips it.
+			{
+				Code:    "var a = 1;\r\n\n",
+				Output:  []string{`var a = 1;`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 1, EndLine: 3, EndColumn: 1},
+				},
+			},
+			// Mixed: CRLF after LF. Final terminator is `\r\n`
+			// (endsWithCRLF=true), so diagnostic span is `[n-2, n]`.
+			// Fix-regex strips the whole `\n\r\n` run.
+			{
+				Code:    "var a = 1;\n\r\n",
+				Output:  []string{`var a = 1;`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 1, EndLine: 3, EndColumn: 1},
+				},
+			},
+
+			// =========================================================
+			// 5. Whitespace / tab preservation under 'never'
+			// =========================================================
+
+			// Real-user: trailing whitespace then newline under 'never'.
+			// Upstream covers `\n   ` (LF then spaces, no final newline)
+			// under 'always'; this is the inverse. The fix must remove
+			// only the trailing `\n` (the spaces are not part of the
+			// `(?:\r?\n)+` run). Guards against accidental adoption of
+			// `utils.SkipTrailingWhitespace` which would also chew the
+			// spaces.
+			{
+				Code:    "var a = 1;\n   \n",
+				Output:  []string{"var a = 1;\n   "},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 4, EndLine: 3, EndColumn: 1},
+				},
+			},
+			// Tabs before final `\n` under 'never' — fix preserves tabs;
+			// only the final `\n` is removed by `(?:\r?\n)+$`.
+			{
+				Code:    "var a = 1;\n\t\t\n",
+				Output:  []string{"var a = 1;\n\t\t"},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 3, EndLine: 3, EndColumn: 1},
+				},
+			},
+			// Whitespace-only file under 'never' — diagnostic at
+			// end-of-spaces; fix wipes only the `\n`.
+			{
+				Code:    "   \n",
+				Output:  []string{"   "},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 4, EndLine: 2, EndColumn: 1},
+				},
+			},
+
+			// =========================================================
+			// 6. Encoding edges
+			// =========================================================
+
+			// Multi-byte UTF-8 (CJK) at end, no LF, 'always' → 'missing'.
+			// `中` is 3 bytes UTF-8 but 1 UTF-16 code unit; the column
+			// must be UTF-16-based (12 in 1-based form), not byte-based
+			// (14). Locks in that rslint's position renderer uses UTF-16
+			// width for the column on a non-ASCII line — matching ESLint.
+			{
+				Code:   `var a = "中"`,
+				Output: []string{"var a = \"中\"\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 12},
+				},
+			},
+			// Surrogate pair (emoji) at end, no LF. `😀` is 4 bytes UTF-8
+			// AND 2 UTF-16 code units; the column reflects the
+			// surrogate-pair width (13 in 1-based form).
+			{
+				Code:   `var a = "😀"`,
+				Output: []string{"var a = \"😀\"\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 13},
+				},
+			},
+			// Form feed (`\f`, U+000C) at end — NOT an ECMA line
+			// terminator. `endsWith('\n')` is false → 'always' fires
+			// 'missing'. The `\f` is counted as one column on line 1.
+			// Locks in that we don't accidentally treat `\f` as a
+			// terminator (e.g., via an over-eager `IsWhitespaceLike`
+			// check).
+			{
+				Code:   "var a = 1;\f",
+				Output: []string{"var a = 1;\f\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 12},
+				},
+			},
+			// U+2028 LINE SEPARATOR at end — ECMA line terminator but
+			// NOT `\n`. `endsWith('\n')` is false → 'always' fires.
+			// Position is on the line AFTER the LS (line 2, col 1)
+			// because tsgo's `ComputeECMALineStarts` recognizes U+2028
+			// as a line break — matching ESLint's `getLocFromIndex`
+			// behavior.
+			{
+				Code:   "var a = 1; ",
+				Output: []string{"var a = 1; \n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 1},
+				},
+			},
+
+			// =========================================================
+			// 7. Real-user syntactic shapes
+			// =========================================================
+
+			// Real-user: bare empty-body function with no trailing newline.
+			{
+				Code:   "function f() {}",
+				Output: []string{"function f() {}\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 16},
+				},
+			},
+			// Real-user: single-line comment as the entire file, no LF.
+			// Locks in that comment-only files go through the same
+			// `endsWithLF` path (no statement-list special-casing).
+			{
+				Code:   "// only a comment",
+				Output: []string{"// only a comment\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 18},
+				},
+			},
+			// Real-user: JSX self-closing element as last token, no LF.
+			// Locks in that the rule fires for `.tsx` files too — the
+			// whole-file check is language-agnostic.
+			{
+				Code:   "const x = <div/>",
+				Output: []string{"const x = <div/>\n"},
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 17},
+				},
+			},
+			// Real-user: shebang start + valid statement, no trailing
+			// LF. Position must be on the LAST line (line 2), confirming
+			// the line-map walks the body, not just the file head.
+			{
+				Code:   "#!/usr/bin/env node\nvar a = 1;",
+				Output: []string{"#!/usr/bin/env node\nvar a = 1;\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 11},
+				},
+			},
+			// Real-user: multi-line function body under 'never'. Locks
+			// in position computation on a non-trivial 4-line file
+			// (column on line 3, end position on line 4). Guards
+			// against off-by-one regressions in line-start scan when
+			// there are several intermediate `\n`s.
+			{
+				Code:    "function f() {\n  return 1;\n}\n",
+				Output:  []string{"function f() {\n  return 1;\n}"},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 3, Column: 2, EndLine: 4, EndColumn: 1},
+				},
+			},
+
+			// =========================================================
+			// 8. Message text lock-ins
+			// =========================================================
+			// Lock in the exact upstream message strings so a copy-paste
+			// refactor of the Description fields can't silently drift.
+			{
+				Code:   "var a = 1;",
+				Output: []string{"var a = 1;\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missing",
+						Message:   "Newline required at end of file but not found.",
+						Line:      1,
+						Column:    11,
+					},
+				},
+			},
+			{
+				Code:    "var a = 1;\n",
+				Output:  []string{`var a = 1;`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Message:   "Newline not allowed at end of file.",
+						Line:      1, Column: 11, EndLine: 2, EndColumn: 1,
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/eol_last/eol_last_upstream_test.go
+++ b/internal/plugins/stylistic/rules/eol_last/eol_last_upstream_test.go
@@ -1,0 +1,110 @@
+// TestEolLastUpstream migrates the full valid/invalid suite from upstream
+// packages/eslint-plugin/rules/eol-last/eol-last.test.ts 1:1. Position
+// assertions cover line/column (and endLine/endColumn for 'never' cases) for
+// every invalid case. rslint-specific lock-in cases (tsgo AST edge shapes,
+// branch lock-ins, real-user shapes) live in eol_last_extras_test.go.
+package eol_last_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/eol_last"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func optStr(s string) []any { return []any{s} }
+
+func TestEolLastUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&eol_last.EolLastRule,
+		[]rule_tester.ValidTestCase{
+			// ---- default 'always' ----
+			{Code: ``},
+			{Code: "\n"},
+			{Code: "var a = 123;\n"},
+			{Code: "var a = 123;\n\n"},
+			{Code: "var a = 123;\n   \n"},
+
+			{Code: "\r\n"},
+			{Code: "var a = 123;\r\n"},
+			{Code: "var a = 123;\r\n\r\n"},
+			{Code: "var a = 123;\r\n   \r\n"},
+
+			// ---- 'never' ----
+			{Code: `var a = 123;`, Options: optStr("never")},
+			{Code: "var a = 123;\nvar b = 456;", Options: optStr("never")},
+			{Code: "var a = 123;\r\nvar b = 456;", Options: optStr("never")},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- default 'always' — missing trailing newline ----
+			{
+				Code:   `var a = 123;`,
+				Output: []string{"var a = 123;\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   "var a = 123;\n   ",
+				Output: []string{"var a = 123;\n   \n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missing", Line: 2, Column: 4},
+				},
+			},
+
+			// ---- 'never' — unexpected trailing newline ----
+			{
+				Code:    "var a = 123;\n",
+				Output:  []string{`var a = 123;`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13, EndLine: 2, EndColumn: 1},
+				},
+			},
+			{
+				Code:    "var a = 123;\r\n",
+				Output:  []string{`var a = 123;`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13, EndLine: 2, EndColumn: 1},
+				},
+			},
+			{
+				Code:    "var a = 123;\r\n\r\n",
+				Output:  []string{`var a = 123;`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 1, EndLine: 3, EndColumn: 1},
+				},
+			},
+			{
+				Code:    "var a = 123;\nvar b = 456;\n",
+				Output:  []string{"var a = 123;\nvar b = 456;"},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 13, EndLine: 3, EndColumn: 1},
+				},
+			},
+			{
+				Code:    "var a = 123;\r\nvar b = 456;\r\n",
+				Output:  []string{"var a = 123;\r\nvar b = 456;"},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 13, EndLine: 3, EndColumn: 1},
+				},
+			},
+			{
+				Code:    "var a = 123;\n\n",
+				Output:  []string{`var a = 123;`},
+				Options: optStr("never"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 1, EndLine: 3, EndColumn: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -459,6 +459,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/brace-style.test.ts',
     './tests/eslint-plugin-stylistic/rules/comma-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/computed-property-spacing.test.ts',
+    './tests/eslint-plugin-stylistic/rules/eol-last.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/eol-last.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/eol-last.test.ts
@@ -1,0 +1,124 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('eol-last', null as never, {
+  valid: [
+    // default 'always'
+    { code: '' },
+    { code: '\n' },
+    { code: 'var a = 123;\n' },
+    { code: 'var a = 123;\n\n' },
+    { code: 'var a = 123;\n   \n' },
+
+    { code: '\r\n' },
+    { code: 'var a = 123;\r\n' },
+    { code: 'var a = 123;\r\n\r\n' },
+    { code: 'var a = 123;\r\n   \r\n' },
+
+    // 'never'
+    { code: 'var a = 123;', options: ['never'] },
+    { code: 'var a = 123;\nvar b = 456;', options: ['never'] },
+    { code: 'var a = 123;\r\nvar b = 456;', options: ['never'] },
+  ],
+
+  invalid: [
+    // default 'always' — missing trailing newline
+    {
+      code: 'var a = 123;',
+      output: 'var a = 123;\n',
+      errors: [{ messageId: 'missing', line: 1, column: 13 }],
+    },
+    {
+      code: 'var a = 123;\n   ',
+      output: 'var a = 123;\n   \n',
+      errors: [{ messageId: 'missing', line: 2, column: 4 }],
+    },
+
+    // 'never' — unexpected trailing newline
+    {
+      code: 'var a = 123;\n',
+      output: 'var a = 123;',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 1,
+          column: 13,
+          endLine: 2,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: 'var a = 123;\r\n',
+      output: 'var a = 123;',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 1,
+          column: 13,
+          endLine: 2,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: 'var a = 123;\r\n\r\n',
+      output: 'var a = 123;',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 2,
+          column: 1,
+          endLine: 3,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: 'var a = 123;\nvar b = 456;\n',
+      output: 'var a = 123;\nvar b = 456;',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 2,
+          column: 13,
+          endLine: 3,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: 'var a = 123;\r\nvar b = 456;\r\n',
+      output: 'var a = 123;\r\nvar b = 456;',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 2,
+          column: 13,
+          endLine: 3,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: 'var a = 123;\n\n',
+      output: 'var a = 123;',
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 2,
+          column: 1,
+          endLine: 3,
+          endColumn: 1,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/eol-last` rule from `eslint-stylistic` to rslint.

Enforces (or disallows) a trailing newline at the end of non-empty files. Supports the `"always"` (default) and `"never"` string options, with autofix for both directions.

## Related Links

- ESLint rule: https://eslint.style/rules/eol-last
- Upstream source: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/eol-last/eol-last.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).