### PR TITLE
feat: port rule @stylistic/dot-location

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/comma_style"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/computed_property_spacing"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/dot_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/eol_last"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -25,6 +26,7 @@ func GetAllRules() []rule.Rule {
 		comma_spacing.CommaSpacingRule,
 		comma_style.CommaStyleRule,
 		computed_property_spacing.ComputedPropertySpacingRule,
+		dot_location.DotLocationRule,
 		eol_last.EolLastRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/dot_location/dot_location.go
+++ b/internal/plugins/stylistic/rules/dot_location/dot_location.go
@@ -1,0 +1,404 @@
+package dot_location
+
+import (
+	"regexp"
+	"sort"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/stylisticutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const locationProperty = "property"
+
+type options struct {
+	onObject bool
+}
+
+// parseOptions accepts upstream's single-argument shape:
+//
+//	['dot-location']                       → defaults (onObject = true)
+//	['dot-location', 'object' | 'property']
+//
+// rslint's config loader may unwrap a single-element option array into a bare
+// string, so we accept the bare form too.
+func parseOptions(raw any) options {
+	opts := options{onObject: true}
+	var arr []interface{}
+	switch v := raw.(type) {
+	case []interface{}:
+		arr = v
+	case string:
+		arr = []interface{}{v}
+	}
+	if len(arr) > 0 {
+		if s, ok := arr[0].(string); ok && s == locationProperty {
+			opts.onObject = false
+		}
+	}
+	return opts
+}
+
+// decimalIntegerPattern mirrors ESLint's isDecimalIntegerNumericToken regex
+// (used by the autofix to decide whether `5\n.x` needs a space when collapsed
+// to `5 .x` — without the space, `5.` would re-tokenize as a decimal float).
+//
+//	`0`                  — single zero
+//	`0[0-7]*[89][0-9]*`  — starts with `0` but contains `8` or `9` (so it
+//	                       can't be parsed as legacy octal — pure decimal)
+//	`[1-9](_?[0-9])*`    — starts with 1-9, optional `_` numeric separators
+//
+// Hex (`0x`), binary (`0b`), octal-explicit (`0o`), legacy-octal (`0[0-7]+`),
+// exponent (`1e3`), and float-with-dot (`5.0`) all fail this pattern — none
+// of them would token-fuse with a trailing `.` to produce a different parse,
+// so no space is needed in the fix.
+var decimalIntegerPattern = regexp.MustCompile(`^(?:0|0[0-7]*[89][0-9]*|[1-9](?:_?[0-9])*)$`)
+
+// dotInfo holds the resolved dot location and the immediately-preceding
+// non-trivia token end position for one node visit. `ok=false` signals the
+// listener should skip this node (parser recovery, missing child, or the
+// optional `Qualifier` of an ImportType being absent).
+type dotInfo struct {
+	dotStart     int
+	dotEnd       int
+	dotText      string // "." or "?."
+	prevTokenEnd int    // end of the receiver/qualifier token preceding the dot
+	isDecInt     bool   // prev token is a decimal-integer NumericLiteral
+	propPos      int    // real (post-trivia) start of the property identifier
+	ok           bool
+}
+
+// findDotInRange scans tokens forward from `scanFrom` and returns the first
+// `.` or `?.` token whose start lies strictly before `propPos`.
+//
+// **Pre-condition (critical)**: `scanFrom` MUST sit OUTSIDE any receiver
+// expression that could contain a template literal. tsgo's raw scanner does
+// not track template-substitution brace depth — if started inside a template
+// substitution (or just after one without re-entering the outer template's
+// scan state), it can mis-tokenize a closing backtick as the start of a new
+// template literal and silently eat the surrounding source. Concretely:
+// starting at `Expression.End()` / `Left.End()` / `Attributes.End()` is
+// safe; starting at `Expression.Pos()` is NOT (would re-scan the receiver
+// from scratch and get confused on `\`${x}\``-containing arguments). This
+// pre-condition is encoded in each per-kind resolver below.
+func findDotInRange(sf *ast.SourceFile, scanFrom, propPos int) (dotStart, dotEnd int, dotText string, ok bool) {
+	if scanFrom >= propPos {
+		return 0, 0, "", false
+	}
+	s := scanner.GetScannerForSourceFile(sf, scanFrom)
+	for s.Token() != ast.KindEndOfFile {
+		start := s.TokenStart()
+		if start >= propPos {
+			return 0, 0, "", false
+		}
+		switch s.Token() {
+		case ast.KindDotToken:
+			return start, s.TokenEnd(), ".", true
+		case ast.KindQuestionDotToken:
+			return start, s.TokenEnd(), "?.", true
+		}
+		s.Scan()
+	}
+	return 0, 0, "", false
+}
+
+// DotLocationRule enforces consistent newline placement around `.` in member
+// expressions, type qualifiers, JSX tag names, meta-properties, and import
+// types. Ported from @stylistic/eslint-plugin's dot-location.
+//
+// Listener coverage:
+//   - PropertyAccessExpression — covers `obj.prop`, `obj?.prop`, `this.#a`,
+//     and JSX `<Form.Input />` (tsgo represents the JSX tag name as a
+//     PropertyAccessExpression — see `JsxTagNameExpression` in the tsgo AST).
+//   - MetaProperty            — covers `import.meta`, `new.target`.
+//   - QualifiedName           — TypeScript type-position `A.B`.
+//   - ImportType              — `import('foo').Qualifier`.
+//
+// ElementAccessExpression (`obj['prop']`) is intentionally NOT listened to —
+// upstream skips MemberExpression when `node.computed === true`, and the
+// computed form lives in a distinct tsgo node kind so we simply don't
+// register a listener for it.
+var DotLocationRule = rule.Rule{
+	Name: "@stylistic/dot-location",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		sf := ctx.SourceFile
+
+		// propTokenStart skips leading trivia from a child node's full-start
+		// (`node.Pos()`, which includes the trivia between its previous
+		// sibling/token and its first real token). The dot/property line
+		// comparison must use the token start, not the trivia start —
+		// otherwise `obj.\nprop` (where `prop.Pos()` lands ON the `\n`)
+		// compares dot.End to a position on the same line as the dot and
+		// silently passes.
+		propTokenStart := func(name *ast.Node) int {
+			return scanner.SkipTrivia(sf.Text(), name.Pos())
+		}
+
+		resolvePropAccess := func(node *ast.Node) dotInfo {
+			pae := node.AsPropertyAccessExpression()
+			if pae == nil || pae.Expression == nil {
+				return dotInfo{}
+			}
+			name := node.Name()
+			if name == nil {
+				return dotInfo{}
+			}
+			propPos := propTokenStart(name)
+			exprEnd := pae.Expression.End()
+			ds, de, dt, ok := findDotInRange(sf, exprEnd, propPos)
+			if !ok {
+				return dotInfo{}
+			}
+			info := dotInfo{
+				dotStart:     ds,
+				dotEnd:       de,
+				dotText:      dt,
+				prevTokenEnd: exprEnd,
+				propPos:      propPos,
+				ok:           true,
+			}
+			// Decimal-integer autofix gate: only when the receiver is a bare
+			// NumericLiteral whose source text is a pure decimal integer.
+			// `5\n.x` (NumericLiteral receiver) → space needed: `5 .x`.
+			// `(5)\n.x` (ParenthesizedExpression receiver) → no space:
+			// `(5).x` re-parses cleanly. The Expression.Kind check makes
+			// this distinction directly from the AST, avoiding the need
+			// to backward-scan tokens.
+			if pae.Expression.Kind == ast.KindNumericLiteral {
+				realStart := scanner.SkipTrivia(sf.Text(), pae.Expression.Pos())
+				if realStart < exprEnd {
+					info.isDecInt = decimalIntegerPattern.MatchString(sf.Text()[realStart:exprEnd])
+				}
+			}
+			return info
+		}
+
+		resolveQualifiedName := func(node *ast.Node) dotInfo {
+			qn := node.AsQualifiedName()
+			if qn == nil || qn.Left == nil || qn.Right == nil {
+				return dotInfo{}
+			}
+			propPos := propTokenStart(qn.Right)
+			leftEnd := qn.Left.End()
+			ds, de, dt, ok := findDotInRange(sf, leftEnd, propPos)
+			if !ok {
+				return dotInfo{}
+			}
+			return dotInfo{
+				dotStart:     ds,
+				dotEnd:       de,
+				dotText:      dt,
+				prevTokenEnd: leftEnd,
+				propPos:      propPos,
+				ok:           true,
+			}
+		}
+
+		resolveImportType := func(node *ast.Node) dotInfo {
+			it := node.AsImportTypeNode()
+			if it == nil || it.Qualifier == nil || it.Argument == nil {
+				return dotInfo{}
+			}
+			propPos := propTokenStart(it.Qualifier)
+			// Start scanning just past the argument (or attributes, when
+			// present). The interval between this point and the qualifier
+			// contains only `)`, the dot, optional commas, and trivia — no
+			// template literal context — so the raw scanner re-enters
+			// safely.
+			afterArg := it.Argument.End()
+			if it.Attributes != nil {
+				afterArg = it.Attributes.End()
+			}
+			// Walk forward to locate the closing `)` (whose line is the
+			// "object-side" line for this dot) and then the dot itself.
+			info := dotInfo{propPos: propPos}
+			s := scanner.GetScannerForSourceFile(sf, afterArg)
+			closeParenEnd := -1
+			for s.Token() != ast.KindEndOfFile {
+				start := s.TokenStart()
+				if start >= propPos {
+					return info
+				}
+				tok := s.Token()
+				if tok == ast.KindCloseParenToken {
+					closeParenEnd = s.TokenEnd()
+				}
+				if tok == ast.KindDotToken {
+					info.dotStart = start
+					info.dotEnd = s.TokenEnd()
+					info.dotText = "."
+					info.prevTokenEnd = closeParenEnd
+					info.ok = closeParenEnd >= 0
+					return info
+				}
+				s.Scan()
+			}
+			return info
+		}
+
+		resolveMetaProperty := func(node *ast.Node) dotInfo {
+			mp := node.AsMetaProperty()
+			if mp == nil {
+				return dotInfo{}
+			}
+			name := node.Name()
+			if name == nil {
+				return dotInfo{}
+			}
+			propPos := propTokenStart(name)
+			// `import.meta` / `new.target`: scanning from node.Pos() is
+			// safe — only a keyword (`import`/`new`), a `.`, and the name
+			// identifier live in this range; no template-literal context
+			// to confuse the scanner.
+			info := dotInfo{propPos: propPos}
+			s := scanner.GetScannerForSourceFile(sf, node.Pos())
+			prevEnd := -1
+			for s.Token() != ast.KindEndOfFile {
+				start := s.TokenStart()
+				if start >= propPos {
+					return info
+				}
+				if s.Token() == ast.KindDotToken {
+					info.dotStart = start
+					info.dotEnd = s.TokenEnd()
+					info.dotText = "."
+					info.prevTokenEnd = prevEnd
+					info.ok = prevEnd >= 0
+					return info
+				}
+				prevEnd = s.TokenEnd()
+				s.Scan()
+			}
+			return info
+		}
+
+		// pendingReport buffers one diagnostic so we can emit them in source
+		// position order at the outermost exit. See depth/flush logic below
+		// for why buffering is necessary.
+		type pendingReport struct {
+			rng  core.TextRange
+			msg  rule.RuleMessage
+			fix  rule.RuleFix
+			sort int
+		}
+		var depth int
+		var pending []pendingReport
+
+		addReport := func(info dotInfo, msg rule.RuleMessage, fix rule.RuleFix) {
+			pending = append(pending, pendingReport{
+				rng:  core.NewTextRange(info.dotStart, info.dotEnd),
+				msg:  msg,
+				fix:  fix,
+				sort: info.dotStart,
+			})
+		}
+
+		flush := func() {
+			if len(pending) == 0 {
+				return
+			}
+			sort.SliceStable(pending, func(i, j int) bool {
+				return pending[i].sort < pending[j].sort
+			})
+			for _, p := range pending {
+				ctx.ReportRangeWithFixes(p.rng, p.msg, p.fix)
+			}
+			pending = pending[:0]
+		}
+
+		check := func(info dotInfo) {
+			if !info.ok {
+				return
+			}
+			if opts.onObject {
+				if stylisticutil.SameLineByPos(sf, info.prevTokenEnd, info.dotStart) {
+					return
+				}
+				// Fix: move dot up to sit right after the previous token,
+				// keeping all surrounding trivia intact.
+				//
+				// ESLint's two-op fix (insertTextAfter(prev, dotText) +
+				// remove(dot)) reduces to a single replace from prevEnd to
+				// dotEnd:
+				//   original: <trivia_a><dot>
+				//   replaced: <insertText><trivia_a>
+				// where insertText prepends a space when the prev token is a
+				// decimal integer literal and dotText starts with `.` —
+				// otherwise `5\n.x` → `5.x` would re-lex `5.` as a float.
+				insertText := info.dotText
+				if info.dotText[0] == '.' && info.isDecInt {
+					insertText = " " + insertText
+				}
+				triviaA := sf.Text()[info.prevTokenEnd:info.dotStart]
+				addReport(info,
+					rule.RuleMessage{
+						Id:          "expectedDotAfterObject",
+						Description: "Expected dot to be on same line as object.",
+					},
+					rule.RuleFix{
+						Text:  insertText + triviaA,
+						Range: core.NewTextRange(info.prevTokenEnd, info.dotEnd),
+					},
+				)
+				return
+			}
+			if stylisticutil.SameLineByPos(sf, info.dotEnd, info.propPos) {
+				return
+			}
+			// Fix: move dot down to sit right before the property.
+			//   original: <dot><trivia_b>
+			//   replaced: <trivia_b><dotText>
+			triviaB := sf.Text()[info.dotEnd:info.propPos]
+			addReport(info,
+				rule.RuleMessage{
+					Id:          "expectedDotBeforeProperty",
+					Description: "Expected dot to be on same line as property.",
+				},
+				rule.RuleFix{
+					Text:  triviaB + info.dotText,
+					Range: core.NewTextRange(info.dotStart, info.propPos),
+				},
+			)
+		}
+
+		// Enter: bump depth, resolve and buffer any report for this node.
+		// Exit:  decrement depth; flush sorted when we return to depth 0
+		//        (i.e. we've finished the outermost listened subtree).
+		//
+		// Buffering is needed because pre-order tsgo traversal does NOT
+		// match source order for our listener mix:
+		//   - Chained PAE: `a.b.c` → outer's `.c` visits first but its dot
+		//     sits AFTER the inner `a.b` dot in source.
+		//   - ImportType + QualifiedName: `import('m').A.B` → outer
+		//     ImportType visits first AND its dot sits before the inner
+		//     QualifiedName dot — pre-order happens to be correct.
+		// Neither pure pre-order nor pure post-order works for both shapes,
+		// so we collect everything and sort by dot position at the end.
+		enter := func(resolver func(*ast.Node) dotInfo) func(*ast.Node) {
+			return func(node *ast.Node) {
+				depth++
+				check(resolver(node))
+			}
+		}
+		exit := func(_ *ast.Node) {
+			depth--
+			if depth == 0 {
+				flush()
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindPropertyAccessExpression:                      enter(resolvePropAccess),
+			rule.ListenerOnExit(ast.KindPropertyAccessExpression): exit,
+			ast.KindMetaProperty:                                  enter(resolveMetaProperty),
+			rule.ListenerOnExit(ast.KindMetaProperty):             exit,
+			ast.KindQualifiedName:                                 enter(resolveQualifiedName),
+			rule.ListenerOnExit(ast.KindQualifiedName):            exit,
+			ast.KindImportType:                                    enter(resolveImportType),
+			rule.ListenerOnExit(ast.KindImportType):               exit,
+		}
+	},
+}

--- a/internal/plugins/stylistic/rules/dot_location/dot_location.md
+++ b/internal/plugins/stylistic/rules/dot_location/dot_location.md
@@ -1,0 +1,108 @@
+# dot-location
+
+Enforce consistent newline placement before or after dots in member expressions.
+
+## Rule Details
+
+JavaScript permits the dot in a member expression to sit on either the line of the object or the line of the property. Inconsistent placement reduces readability.
+
+This rule applies to property access (`a.b`, `a?.b`), TypeScript type qualifiers (`A.B`), import-type qualifiers (`import('m').A`), `import.meta` / `new.target`, and JSX member tag names (`<Form.Input />`). Computed member access (`obj['prop']`) and indexed type access (`Foo[K]`) are not checked.
+
+Examples of **incorrect** code for this rule with the default `"object"` option:
+
+```javascript
+var foo = object
+.property;
+
+type Foo = Obj
+  .Prop;
+
+type Bar = import('Obj')
+  .Prop;
+```
+
+Examples of **correct** code for this rule with the default `"object"` option:
+
+```javascript
+var foo = object.
+property;
+
+var baz = object.property;
+
+type Foo = Obj.
+  Prop;
+
+type Bar = import('Obj').
+  Prop;
+```
+
+## Options
+
+This rule has a string option:
+
+- `"object"` (default) requires the dot to be on the same line as the object portion.
+- `"property"` requires the dot to be on the same line as the property portion.
+
+### object
+
+Examples of **incorrect** code for this rule with the `"object"` option:
+
+```json
+{ "@stylistic/dot-location": ["error", "object"] }
+```
+
+```javascript
+var foo = object
+.property;
+
+<Form
+  .Input />
+```
+
+Examples of **correct** code for this rule with the `"object"` option:
+
+```json
+{ "@stylistic/dot-location": ["error", "object"] }
+```
+
+```javascript
+var foo = object.
+property;
+
+<Form.
+  Input />
+```
+
+### property
+
+Examples of **incorrect** code for this rule with the `"property"` option:
+
+```json
+{ "@stylistic/dot-location": ["error", "property"] }
+```
+
+```javascript
+var foo = object.
+property;
+
+<Form.
+  Input />
+```
+
+Examples of **correct** code for this rule with the `"property"` option:
+
+```json
+{ "@stylistic/dot-location": ["error", "property"] }
+```
+
+```javascript
+var foo = object
+.property;
+
+<Form
+  .Input />
+```
+
+## Original Documentation
+
+- [@stylistic/dot-location](https://eslint.style/rules/dot-location)

--- a/internal/plugins/stylistic/rules/dot_location/dot_location_extras_test.go
+++ b/internal/plugins/stylistic/rules/dot_location/dot_location_extras_test.go
@@ -1,0 +1,970 @@
+// TestDotLocationExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing
+// at the specific branch / Dimension 4 row / tsgo AST quirk it covers, so
+// future refactors can't silently regress them without breaking a named
+// lock-in.
+package dot_location_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/dot_location"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestDotLocationExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&dot_location.DotLocationRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: TS non-null assertion receiver ----
+			{Code: "obj!.\nprop", Options: optsObject()},
+			{Code: "obj!\n.prop", Options: optsProperty()},
+
+			// ---- Dimension 4: TS as-expression receiver (lives inside parens) ----
+			{Code: "(obj as Foo).\nprop", Options: optsObject()},
+			{Code: "(obj as Foo)\n.prop", Options: optsProperty()},
+
+			// ---- Dimension 4: TS satisfies-expression receiver (lives inside parens) ----
+			{Code: "(obj satisfies Foo).\nprop", Options: optsObject()},
+			{Code: "(obj satisfies Foo)\n.prop", Options: optsProperty()},
+
+			// ---- Dimension 4: chained property access — each dot on object-side ----
+			{Code: "a.\nb.\nc", Options: optsObject()},
+			{Code: "a\n.b\n.c", Options: optsProperty()},
+
+			// ---- Dimension 4: chained TS QualifiedName ----
+			{Code: "type T = A.\nB.\nC", Options: optsObject()},
+			{Code: "type T = A\n.B\n.C", Options: optsProperty()},
+
+			// ---- Dimension 4: ImportType with chained qualifier ----
+			{Code: "type T = import('m').\nA.\nB", Options: optsObject()},
+			{Code: "type T = import('m')\n.A\n.B", Options: optsProperty()},
+
+			// ---- Dimension 4: chained JSX tag name (<A.B.C />) ----
+			{Code: "const _ = <A.B.\nC />", Options: optsObject(), Tsx: true},
+			{Code: "const _ = <A\n.B\n.C />", Options: optsProperty(), Tsx: true},
+
+			// ---- Branch lock-in: ElementAccessExpression skipped — arr[x] is never reported ----
+			{Code: "arr\n[\n0\n]\n[\n1\n]", Options: optsObject()},
+			{Code: "arr\n[\n0\n]\n[\n1\n]", Options: optsProperty()},
+
+			// ---- Branch lock-in: ImportType with no qualifier → checkDotLocation returns early ----
+			{Code: "type Foo = import('m')\n", Options: optsObject()},
+			{Code: "type Foo = import('m')\n", Options: optsProperty()},
+
+			// ---- Branch lock-in: ImportType with import attributes ----
+			{Code: "type T = import('m', { with: { type: 'json' } }).\nA", Options: optsObject()},
+			{Code: "type T = import('m', { with: { type: 'json' } })\n.A", Options: optsProperty()},
+
+			// ---- Branch lock-in: typeof ImportType ----
+			{Code: "type T = typeof import('m').\nA", Options: optsObject()},
+			{Code: "type T = typeof import('m')\n.A", Options: optsProperty()},
+
+			// ---- Real-user: Promise / fluent method chain ----
+			{Code: "fetch(url).\nthen(r => r.json()).\nthen(data => use(data))", Options: optsObject()},
+			{Code: "fetch(url)\n.then(r => r.json())\n.then(data => use(data))", Options: optsProperty()},
+
+			// ---- Real-user: jQuery-style chain on string-method call ----
+			{Code: "name.trim().\nsplit(' ').\nfilter(Boolean)", Options: optsObject()},
+			{Code: "name.trim()\n.split(' ')\n.filter(Boolean)", Options: optsProperty()},
+
+			// ---- Dimension 4: NewExpression as receiver ----
+			// tsgo: outer PAE.Expression.Kind = KindNewExpression. Verifies
+			// the scan skips through `new Foo(...)` (including its argument
+			// list with internal tokens like `,`) and lands on `)` as prev.
+			{Code: "new Foo().\nbar", Options: optsObject()},
+			{Code: "new Foo()\n.bar", Options: optsProperty()},
+
+			// ---- Dimension 4: receiver is a CallExpression with TS type arguments ----
+			// `Array.from<T>(x)` — the `<T>` inside Expression must not trip
+			// scanner up (TS angle brackets coexist with JSX angle brackets
+			// in tsx mode). Validates Expression.End() lands on the `)` of
+			// the call, not on the `>` of the type argument list.
+			{Code: "Array.from<number>([1]).\nmap(fn)", Options: optsObject()},
+			{Code: "Array.from<number>([1])\n.map(fn)", Options: optsProperty()},
+
+			// ---- Dimension 4: receiver is paren-wrapped await / yield ----
+			// tsgo: Expression.Kind = ParenthesizedExpression, prev-token = `)`.
+			{Code: "async function f() { return (await foo).\nbar }", Options: optsObject()},
+			{Code: "function* g() { yield (yield 1)\n.x }", Options: optsProperty()},
+
+			// ---- Dimension 4: chained NonNullExpression `obj!!.prop` ----
+			// tsgo allows redundant `!!`; the outer NonNullExpression wraps
+			// the inner one. prev-token to dot is still `!`, on same line.
+			{Code: "obj!!\n.prop", Options: optsProperty()},
+			{Code: "obj!!.\nprop", Options: optsObject()},
+
+			// ---- Dimension 4: multi-stage `as` chain `(a as B as C).prop` ----
+			// Each `as` keeps the expression flat (no extra paren); the
+			// paren wraps the outermost AsExpression. prev-token = `)`.
+			{Code: "(a as B as C).\nprop", Options: optsObject()},
+			{Code: "(a as B as C)\n.prop", Options: optsProperty()},
+
+			// ---- Dimension 4: nested ImportType in type arguments ----
+			// `import('m').A<import('n').B>` — outer ImportType qualifier=A
+			// with TypeArguments containing an inner ImportType. Verifies
+			// depth-counting buffer flushes BOTH dots in source order.
+			{Code: "type T = import('m').\nA<import('n').\nB>", Options: optsObject()},
+			{Code: "type T = import('m')\n.A<import('n')\n.B>", Options: optsProperty()},
+
+			// ---- Dimension 4: ImportType inside TypeReference generic ----
+			// `Array<import('m').A.B>` — outer TypeReference (not listened),
+			// inner ImportType + QualifiedName both fire. depth counts only
+			// our listened kinds, so flushing happens when ImportType exits.
+			{Code: "type T = Array<import('m').\nA.\nB>", Options: optsObject()},
+
+			// ---- Dimension 4: deep chain (5 segments) — depth+sort stress ----
+			{Code: "a.\nb.\nc.\nd.\ne", Options: optsObject()},
+
+			// ---- Dimension 4: mixed optional + regular chain ----
+			// `a?.b.c?.d.e` — alternating optional/regular dots. All on
+			// object side when option='object'.
+			{Code: "a?.\nb.\nc?.\nd.\ne", Options: optsObject()},
+
+			// ---- Branch lock-in: receiver with `delete` operator ----
+			// `delete obj\n.prop` — the PAE is `obj\n.prop`, UnaryExpression
+			// wraps it. dot still detected via normal path.
+			{Code: "delete obj.\nprop", Options: optsObject()},
+
+			// ---- Real-user: eslint#2504 historical regression ----
+			// `(console)\n.log("hi")` in property mode — paren-wrapped
+			// receiver MUST NOT be reported when dot is on same line as
+			// property. Was a long-standing bug fixed in eslint/eslint#11933.
+			{Code: "(console)\n.log('hi')", Options: optsProperty()},
+
+			// ---- Real-user: React class instance state access ----
+			// `this.state.foo.bar` — three-level PAE chain typical in class
+			// components. No newlines, no reports.
+			{Code: "class C { x = 1; m() { return this.state.foo.bar; } }", Options: optsObject()},
+
+			// ---- Real-user: DOM query chain ----
+			{Code: "document.querySelector('.x').\naddEventListener('click', fn)", Options: optsObject()},
+			{Code: "document.querySelector('.x')\n.addEventListener('click', fn)", Options: optsProperty()},
+
+			// ---- Real-user: styled-components style template tag ----
+			// `styled.div` is PAE on identifier — tagged template doesn't
+			// change the PAE shape. Dot single-line, no report.
+			{Code: "const Btn = styled.div`color: red`", Options: optsObject()},
+
+			// ---- Real-user: typeof import qualifier (Drizzle/Prisma pattern) ----
+			{Code: "type Schema = typeof import('./schema').\nschema", Options: optsObject()},
+
+			// ---- Real-user: lodash-style deep chain ----
+			{Code: "_.chain(arr).map(f).filter(g).reduce(h, 0).value()", Options: optsObject()},
+			{Code: "_.chain(arr)\n.map(f)\n.filter(g)\n.reduce(h, 0)\n.value()", Options: optsProperty()},
+
+			// ---- Dimension 4: JSX tag name with `this` (TS-allowed) ----
+			// tsgo: tag name = PAE(Expression=KindThisKeyword, name=Component).
+			// `this` is a valid JsxTagNameExpression member.
+			{Code: "const X = <this.Component />", Options: optsObject(), Tsx: true},
+			{Code: "const X = <this.\nComponent />", Options: optsObject(), Tsx: true},
+			{Code: "const X = <this\n.Component />", Options: optsProperty(), Tsx: true},
+
+			// ---- Dimension 4: JSX element wrapped in paren as receiver ----
+			// `(<Foo />).props` — PAE.Expression.Kind = ParenthesizedExpression
+			// containing JsxSelfClosingElement. prev-token = `)`.
+			{Code: "const x = (<Foo />).props", Options: optsObject(), Tsx: true},
+			{Code: "const x = (<Foo />).\nprops", Options: optsObject(), Tsx: true},
+			{Code: "const x = (<Foo />)\n.props", Options: optsProperty(), Tsx: true},
+
+			// ---- Dimension 4: ClassExpression receiver ----
+			// `(class {}).constructor` — paren-wrapped class expression.
+			{Code: "const c = (class {}).\nconstructor", Options: optsObject()},
+			{Code: "const c = (class {})\n.constructor", Options: optsProperty()},
+
+			// ---- Dimension 4: TaggedTemplateExpression as PAE receiver ----
+			// `styled.div\`...\`.attrs({})` — outer PAE.Expression is a
+			// TaggedTemplateExpression spanning the tag + template literal.
+			{Code: "const B = styled.div`x`.\nattrs({})", Options: optsObject()},
+			{Code: "const B = styled.div`x`\n.attrs({})", Options: optsProperty()},
+
+			// ---- Dimension 4: Unicode identifier (BMP) ----
+			// Greek / CJK identifiers — verifies byte-offset position math
+			// works on non-ASCII code points. tsgo source positions are
+			// byte offsets; column reporting uses UTF-16 code units (see
+			// rule_tester's GetECMALineAndUTF16CharacterOfPosition).
+			{Code: "var α = {}; α.\nβ", Options: optsObject()},
+			{Code: "var 变量 = {}; 变量.\n属性", Options: optsObject()},
+
+			// ---- Dimension 4: Unicode identifier (SMP / surrogate pair) ----
+			// `𝕒` is U+1D552, encoded as a UTF-16 surrogate pair (2 code
+			// units, 4 UTF-8 bytes). Locks in that column counts go through
+			// UTF-16 — otherwise positions on lines containing surrogate
+			// pairs would be off by 1 per occurrence.
+			{Code: "var 𝕒: any = {}; 𝕒.\n𝕓", Options: optsObject()},
+
+			// ---- Dimension 4: MetaProperty nested as PAE.Expression ----
+			// `import.meta.url` — outer PAE wraps inner MetaProperty.
+			// Buffer+sort must emit MetaProperty's dot (if any) before
+			// PAE's dot when both exist.
+			{Code: "const u = import.meta.\nurl", Options: optsObject()},
+			{Code: "const u = import.meta\n.url", Options: optsProperty()},
+
+			// ---- Dimension 4: MetaProperty `new.target` nested ----
+			{Code: "function f() { return new.target.\nname }", Options: optsObject()},
+
+			// ---- Dimension 4: ElementAccessExpression as PAE.Expression ----
+			// `obj[k].method` — outer PAE prev-token is `]`. We don't fire
+			// on the inner ElementAccess; only the outer PAE.
+			{Code: "obj[k].\nmethod()", Options: optsObject()},
+			{Code: "obj[k]\n.method()", Options: optsProperty()},
+
+			// ---- Dimension 4: ConditionalExpression in paren receiver ----
+			{Code: "(cond ? a : b).\nmethod()", Options: optsObject()},
+			{Code: "(cond ? a : b)\n.method()", Options: optsProperty()},
+
+			// ---- Dimension 4: ArrayLiteralExpression as receiver ----
+			// prev-token = `]`. Same shape as ElementAccess closing bracket.
+			{Code: "[1, 2].\nlength", Options: optsObject()},
+			{Code: "[1, 2]\n.length", Options: optsProperty()},
+
+			// ---- Dimension 4: StringLiteral / RegExp literal as receiver ----
+			{Code: "'x'.\nlength", Options: optsObject()},
+			{Code: "/foo/.\ntest('x')", Options: optsObject()},
+			{Code: "'x'\n.length", Options: optsProperty()},
+
+			// ---- Dimension 4: ObjectLiteralExpression in paren ----
+			{Code: "({a: 1}).\na", Options: optsObject()},
+			{Code: "({a: 1})\n.a", Options: optsProperty()},
+
+			// ---- Dimension 4: Block comment crossing newlines (valid in property mode) ----
+			// `obj /* a\nb */.x` — block comment puts the dot on a different
+			// SOURCE line than `obj`. In property mode, dot and property `x`
+			// are still on the same line (line 2), so no report.
+			{Code: "obj /* a\nb */.x", Options: optsProperty()},
+
+			// ---- Dimension 4: Line comment between obj and dot (property mode) ----
+			// `obj // c\n.x` — line comment forces `\n`. In property mode,
+			// dot and prop are on the same line (line 2), so no report.
+			{Code: "obj // c\n.x", Options: optsProperty()},
+
+			// ---- Dimension 4: Line comment between dot and property (object mode) ----
+			// `obj.// c\nx` — line comment forces `\n` after dot. In object
+			// mode, dot is still adjacent to obj on line 1 → no report.
+			{Code: "obj.// c\nx", Options: optsObject()},
+
+			// ---- Dimension 4: Multiple comments around dot ----
+			// Already partially covered by upstream `foo /* a */ . /* b */ \n /* c */ bar`.
+			// Property-mode variant where dot and prop are forced apart by
+			// a line comment.
+			{Code: "obj /* a */ // b\n.x", Options: optsProperty()},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: TS non-null assertion — token before dot is `!` ----
+			// Locks in that prev-token detection captures `!` (not the identifier
+			// before it) when the receiver is `obj!`.
+			{
+				Code:    "obj!\n.prop",
+				Output:  []string{"obj!.\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:    "obj!.\nprop",
+				Output:  []string{"obj!\n.prop"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty", Line: 1, Column: 5},
+				},
+			},
+
+			// ---- Dimension 4: TS as-expression — token before dot is `)` ----
+			{
+				Code:    "(obj as Foo)\n.prop",
+				Output:  []string{"(obj as Foo).\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:    "(obj as Foo).\nprop",
+				Output:  []string{"(obj as Foo)\n.prop"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty", Line: 1, Column: 13},
+				},
+			},
+
+			// ---- Dimension 4: chained PropertyAccessExpression — independent dots ----
+			// Verifies inner and outer dots each get their own diagnostic.
+			{
+				Code:    "a\n.b\n.c",
+				Output:  []string{"a.\nb.\nc"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4: chained TS QualifiedName — independent dots ----
+			{
+				Code:    "type T = A\n.B\n.C",
+				Output:  []string{"type T = A.\nB.\nC"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4: ImportType + nested QualifiedName ----
+			// Locks in that the outer ImportType node and the inner
+			// QualifiedName node each report independently.
+			{
+				Code:    "type T = import('m')\n.A\n.B",
+				Output:  []string{"type T = import('m').\nA.\nB"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4: JSX tag name chain ----
+			{
+				Code:    "const _ = <A.B\n.C />",
+				Output:  []string{"const _ = <A.B.\nC />"},
+				Options: optsObject(),
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Branch lock-in upstream getProperty arm C (PropertyAccess) ×
+			//      fix branch I (non-decimal-integer numeric token) ----
+			// BigInt literal `5n` — Kind is BigIntLiteral, NOT NumericLiteral,
+			// so isDecimalIntegerNumericToken returns false. Fix collapses to
+			// `5n.\ntoString()` with no space; `5n.foo` parses fine since
+			// BigInt literal consumes the trailing `n`.
+			{
+				Code:    "5n\n.toString()",
+				Output:  []string{"5n.\ntoString()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Branch lock-in fix branch I: scientific notation ----
+			// `5e10` has an exponent, fails the decimal-integer regex even
+			// though it is a NumericLiteral. No leading space inserted.
+			{
+				Code:    "5e10\n.toString()",
+				Output:  []string{"5e10.\ntoString()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Branch lock-in fix branch I: hex literal ----
+			{
+				Code:    "0xff\n.toString()",
+				Output:  []string{"0xff.\ntoString()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Branch lock-in fix branch I: float literal (has decimal point) ----
+			// `5.5` is NumericLiteral but the regex `^(?:0|0[0-7]*[89][0-9]*|[1-9](?:_?[0-9])*)$`
+			// doesn't match (contains `.`). Resulting `5.5.toExp()` is a valid
+			// property access on a float.
+			{
+				Code:    "5.5\n.toExp()",
+				Output:  []string{"5.5.\ntoExp()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Branch lock-in fix branch H ×  questionDot dotText ----
+			// `10\n?.prop` exercises the path where the prev token IS a
+			// decimal integer literal but dotText is `?.` (starts with `?`,
+			// not `.`) — branch H's condition requires BOTH, so we take
+			// branch I and emit no space. Locks in `10?.\nprop`, not
+			// `10 ?.\nprop`.
+			{
+				Code:    "100\n?.prop",
+				Output:  []string{"100?.\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1, EndLine: 2, EndColumn: 3},
+				},
+			},
+
+			// ---- Branch lock-in: MetaProperty newline (import.meta) ----
+			// Upstream tests MetaProperty only as a `valid` case (`import.meta`).
+			// We lock in the report path for whitespace splits — `import\n.meta`
+			// is syntactically legal even though linter-formatted code never
+			// produces it.
+			{
+				Code:    "const m = import\n.meta",
+				Output:  []string{"const m = import.\nmeta"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:    "const m = import.\nmeta",
+				Output:  []string{"const m = import\n.meta"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty", Line: 1, Column: 17},
+				},
+			},
+
+			// ---- Branch lock-in: MetaProperty newline (new.target) ----
+			// `new.target` is only valid inside a function body in JS, hence
+			// the wrapping `function f() { ... }`.
+			{
+				Code:    "function f() { return new\n.target }",
+				Output:  []string{"function f() { return new.\ntarget }"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:    "function f() { return new.\ntarget }",
+				Output:  []string{"function f() { return new\n.target }"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty", Line: 1, Column: 26},
+				},
+			},
+
+			// ---- Branch lock-in: ImportType with ImportAttributes — token-before-dot is `)` ----
+			// Locks in that scanning from node.Pos() correctly skips OVER the
+			// attributes object literal `{ with: { type: 'json' } }` (containing
+			// its own dots) and lands on the `)` token as prev-token. Without
+			// the `minDotPos` filter we'd false-positive on the attribute's
+			// internal `with:` colon-prefixed property — but those aren't dots
+			// so this is mostly a defensive lock-in.
+			{
+				Code:    "type T = import('m', { with: { type: 'json' } })\n.A",
+				Output:  []string{"type T = import('m', { with: { type: 'json' } }).\nA"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Branch lock-in: `typeof import(...)` — IsTypeOf=true ----
+			// Verifies the `typeof` prefix doesn't break ImportType dot
+			// resolution: prev-token is still `)`, dot is between `)` and
+			// the qualifier.
+			{
+				Code:    "type T = typeof import('m')\n.A",
+				Output:  []string{"type T = typeof import('m').\nA"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Branch lock-in: optional chain on chained PAE ----
+			// `a?.b?.c?.d` — three optional-chain dots, all should report
+			// independently when each lands on its own line.
+			{
+				Code:    "a\n?.b\n?.c\n?.d",
+				Output:  []string{"a?.\nb?.\nc?.\nd"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1, EndLine: 2, EndColumn: 3},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1, EndLine: 3, EndColumn: 3},
+					{MessageId: "expectedDotAfterObject", Line: 4, Column: 1, EndLine: 4, EndColumn: 3},
+				},
+			},
+
+			// ---- Real-user: long fluent chain in option=object mode ----
+			// Mirrors a common Promise-chain shape that gets lint-cleaned-up
+			// by the rule.
+			{
+				Code:    "fetch(url)\n.then(r => r.json())\n.then(data => use(data))",
+				Output:  []string{"fetch(url).\nthen(r => r.json()).\nthen(data => use(data))"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code:    "name.trim().\nsplit(' ').\nfilter(Boolean)",
+				Output:  []string{"name.trim()\n.split(' ')\n.filter(Boolean)"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty", Line: 1, Column: 12},
+					{MessageId: "expectedDotBeforeProperty", Line: 2, Column: 11},
+				},
+			},
+
+			// ---- Dimension 4 invalid: NewExpression receiver — prev-token is `)` ----
+			{
+				Code:    "new Foo()\n.bar",
+				Output:  []string{"new Foo().\nbar"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: CallExpression with type arguments ----
+			// Locks in that the TS `<number>` angle brackets inside the
+			// receiver expression don't confuse dot detection.
+			{
+				Code:    "Array.from<number>([1])\n.map(fn)",
+				Output:  []string{"Array.from<number>([1]).\nmap(fn)"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: paren-wrapped await receiver ----
+			{
+				Code:    "async function f() { return (await foo)\n.bar }",
+				Output:  []string{"async function f() { return (await foo).\nbar }"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: multi-stage `as` chain ----
+			// `(a as B as C).prop` — prev-token to dot is `)`.
+			{
+				Code:    "(a as B as C)\n.prop",
+				Output:  []string{"(a as B as C).\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: chained NonNullExpression `obj!!\n.prop` ----
+			// Two `!` tokens — prev-token-of-dot is still `!`.
+			{
+				Code:    "obj!!\n.prop",
+				Output:  []string{"obj!!.\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: nested ImportType in type arguments ----
+			// `import('m')\n.A<import('n')\n.B>` — two ImportType nodes; the
+			// inner one is INSIDE the outer's TypeArguments. Buffer+sort must
+			// emit outer's dot (line 2 col 1) before inner's (line 3 col 1).
+			{
+				Code:    "type T = import('m')\n.A<import('n')\n.B>",
+				Output:  []string{"type T = import('m').\nA<import('n').\nB>"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: ImportType inside Array<...> generic ----
+			// Outer is non-listened TypeReference. Inner ImportType + QN
+			// both fire — depth counting must flush together.
+			{
+				Code:    "type T = Array<import('m')\n.A\n.B>",
+				Output:  []string{"type T = Array<import('m').\nA.\nB>"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: 5-segment deep chain ----
+			// Stress-test depth+sort with all dots on separate lines.
+			{
+				Code:    "a\n.b\n.c\n.d\n.e",
+				Output:  []string{"a.\nb.\nc.\nd.\ne"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 4, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 5, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: mixed optional + regular chain ----
+			// `a\n?.b\n.c\n?.d\n.e` — verifies `?.` and `.` both detected,
+			// AND their report ranges differ (2 chars for `?.`, 1 for `.`).
+			{
+				Code:    "a\n?.b\n.c\n?.d\n.e",
+				Output:  []string{"a?.\nb.\nc?.\nd.\ne"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1, EndLine: 2, EndColumn: 3},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1, EndLine: 3, EndColumn: 2},
+					{MessageId: "expectedDotAfterObject", Line: 4, Column: 1, EndLine: 4, EndColumn: 3},
+					{MessageId: "expectedDotAfterObject", Line: 5, Column: 1, EndLine: 5, EndColumn: 2},
+				},
+			},
+
+			// ---- Real-user: React this.state chain across lines ----
+			// `this.state.value\n.toString()` — common pattern in legacy
+			// React class components. PAE chain with newline only on
+			// the outermost dot.
+			{
+				Code:    "class C { x = 1; m() { return this.state.value\n.toString(); } }",
+				Output:  []string{"class C { x = 1; m() { return this.state.value.\ntoString(); } }"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Real-user: DOM querySelector chain ----
+			{
+				Code:    "document.querySelector('.x')\n.addEventListener('click', fn)",
+				Output:  []string{"document.querySelector('.x').\naddEventListener('click', fn)"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Real-user: typeof ImportType — Drizzle/Prisma schema pattern ----
+			{
+				Code:    "type S = typeof import('./schema')\n.schema",
+				Output:  []string{"type S = typeof import('./schema').\nschema"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Real-user: Lodash chain (5+ links) ----
+			{
+				Code:    "_.chain(arr)\n.map(f)\n.filter(g)\n.reduce(h, 0)\n.value()",
+				Output:  []string{"_.chain(arr).\nmap(f).\nfilter(g).\nreduce(h, 0).\nvalue()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 4, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 5, Column: 1},
+				},
+			},
+
+			// ---- Real-user: styled-components-like template tag ----
+			// `styled.div\`...\`` — dot in styled.div is on same line, no
+			// report. But `styled\n.div\`...\`` would report.
+			{
+				Code:    "const Btn = styled\n.div`color: red`",
+				Output:  []string{"const Btn = styled.\ndiv`color: red`"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: JSX `<this.X />` with newline ----
+			{
+				Code:    "const X = <this\n.Component />",
+				Output:  []string{"const X = <this.\nComponent />"},
+				Options: optsObject(),
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: paren-wrapped JSX as receiver ----
+			{
+				Code:    "const x = (<Foo />)\n.props",
+				Output:  []string{"const x = (<Foo />).\nprops"},
+				Options: optsObject(),
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: ClassExpression receiver ----
+			{
+				Code:    "const c = (class {})\n.constructor",
+				Output:  []string{"const c = (class {}).\nconstructor"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: TaggedTemplateExpression as receiver ----
+			// PAE.Expression spans the entire `tag\`...\``; prev-token is the
+			// closing backtick of the template.
+			{
+				Code:    "const B = styled.div`x`\n.attrs({})",
+				Output:  []string{"const B = styled.div`x`.\nattrs({})"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: Unicode identifier — column math ----
+			// CJK identifiers are 1 UTF-16 code unit per char but multi-byte
+			// in UTF-8. Locks in that the rule_tester's column assertion
+			// (UTF-16) matches our diagnostic Range positions even across
+			// multi-byte sources.
+			{
+				Code:    "var 变量 = {}; 变量\n.属性",
+				Output:  []string{"var 变量 = {}; 变量.\n属性"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+				},
+			},
+
+			// ---- Dimension 4 invalid: SMP surrogate pair on the dot line ----
+			// `𝕒` is U+1D552 (4 UTF-8 bytes, 2 UTF-16 code units). The dot
+			// follows on a new line, so column position is unambiguous.
+			{
+				Code:    "var 𝕒: any = {}; 𝕒\n.𝕓",
+				Output:  []string{"var 𝕒: any = {}; 𝕒.\n𝕓"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+				},
+			},
+
+			// ---- Dimension 4 invalid: MetaProperty nested as PAE.Expression ----
+			// `import.meta\n.url` — only the outer PAE reports (its dot is
+			// cross-line); the inner MetaProperty is single-line and stays
+			// silent. depth=2 builds inside MetaProperty visit.
+			{
+				Code:    "const u = import.meta\n.url",
+				Output:  []string{"const u = import.meta.\nurl"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			// And the reverse: MetaProperty dot cross-line, outer PAE dot OK.
+			// Locks in that only one diagnostic fires (no double-report).
+			{
+				Code:    "const u = import\n.meta.url",
+				Output:  []string{"const u = import.\nmeta.url"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			// Both dots cross-line — both report, sorted by source position.
+			{
+				Code:    "const u = import\n.meta\n.url",
+				Output:  []string{"const u = import.\nmeta.\nurl"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: ElementAccess as PAE receiver ----
+			{
+				Code:    "obj[k]\n.method()",
+				Output:  []string{"obj[k].\nmethod()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: Conditional in paren ----
+			{
+				Code:    "(cond ? a : b)\n.method()",
+				Output:  []string{"(cond ? a : b).\nmethod()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: ArrayLiteralExpression receiver ----
+			{
+				Code:    "[1, 2]\n.length",
+				Output:  []string{"[1, 2].\nlength"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: ObjectLiteralExpression in paren ----
+			{
+				Code:    "({a: 1})\n.a",
+				Output:  []string{"({a: 1}).\na"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: RegExpLiteral receiver ----
+			{
+				Code:    "/foo/\n.test('x')",
+				Output:  []string{"/foo/.\ntest('x')"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: block comment newline pushes dot off-line ----
+			// `obj /* a\nb */.x` — the block comment internally crosses a
+			// line, so the dot SOURCE line differs from `obj`'s line. ESLint
+			// reports `expectedDotAfterObject`. Locks in that our
+			// SameLineByPos check uses raw byte positions and correctly
+			// detects the cross-line dot through trailing trivia.
+			{
+				Code:    "obj /* a\nb */.x",
+				Output:  []string{"obj. /* a\nb */x"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 5},
+				},
+			},
+
+			// ---- Dimension 4 invalid: line comment after object ----
+			// `obj // c\n.x` — line comment ends at `\n`. dot is on line 2.
+			// object mode: dot not on obj's line → report.
+			{
+				Code:    "obj // c\n.x",
+				Output:  []string{"obj. // c\nx"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Dimension 4 invalid: line comment after dot ----
+			// `obj.// c\nx` — line comment forces `\n` AFTER dot. dot on
+			// line 1, prop on line 2. property mode reports.
+			{
+				Code:    "obj.// c\nx",
+				Output:  []string{"obj// c\n.x"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty", Line: 1, Column: 4},
+				},
+			},
+
+			// ---- Real-user regression lock-in: tsgo template-literal
+			// scanner re-entry in chained calls ----
+			//
+			// rsbuild `packages/core/src/plugins/asset.ts:43-47` shape:
+			// `rule\n  .oneOf(\`${assetType}-asset-url\`)\n  .type(...)
+			//  \n  .resourceQuery(...)\n  .set(...)`. Earlier port
+			// scanned from `pae.Expression.Pos()` for prev-token tracking,
+			// which forced tsgo's raw scanner to re-tokenize the inner
+			// `\`${x}\`` template substitution out-of-context — the
+			// closing backtick was mis-classified as the START of a new
+			// template literal and the scanner silently swallowed the
+			// rest of the chain. Outcome: only the innermost dot got
+			// reported, every dot AFTER the template was missed (3
+			// silent false-negatives per chain link of this shape).
+			// Fix: scan from `Expression.End()` instead, sidestepping
+			// the receiver's template scanner state entirely.
+			//
+			// This lock-in fails on the buggy implementation with
+			// 1/4 reports; passes on the fixed implementation with
+			// the correct 4/4.
+			{
+				Code: "declare const rule: any;\n" +
+					"declare const assetType: string;\n" +
+					"declare const URL_QUERY_REGEX: RegExp;\n" +
+					"declare const generatorOptions: any;\n" +
+					"rule\n" +
+					"  .oneOf(`${assetType}-asset-url`)\n" +
+					"  .type('asset/resource')\n" +
+					"  .resourceQuery(URL_QUERY_REGEX)\n" +
+					"  .set('generator', generatorOptions);",
+				Output: []string{"declare const rule: any;\n" +
+					"declare const assetType: string;\n" +
+					"declare const URL_QUERY_REGEX: RegExp;\n" +
+					"declare const generatorOptions: any;\n" +
+					"rule.\n" +
+					"  oneOf(`${assetType}-asset-url`).\n" +
+					"  type('asset/resource').\n" +
+					"  resourceQuery(URL_QUERY_REGEX).\n" +
+					"  set('generator', generatorOptions);"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 6, Column: 3},
+					{MessageId: "expectedDotAfterObject", Line: 7, Column: 3},
+					{MessageId: "expectedDotAfterObject", Line: 8, Column: 3},
+					{MessageId: "expectedDotAfterObject", Line: 9, Column: 3},
+				},
+			},
+
+			// ---- Real-user regression lock-in: short variant ----
+			// Minimum case that triggers the same template-literal scanner
+			// confusion — `r\n.a(\`${x}\`)\n.b()`. Reproduces with one
+			// inner-substitution template and two chain links.
+			{
+				Code: "declare const r: any;\n" +
+					"declare const x: string;\n" +
+					"r\n" +
+					".a(`${x}`)\n" +
+					".b()",
+				Output: []string{"declare const r: any;\n" +
+					"declare const x: string;\n" +
+					"r.\n" +
+					"a(`${x}`).\n" +
+					"b()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 4, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 5, Column: 1},
+				},
+			},
+
+			// ---- Real-user regression lock-in: multi-substitution
+			// template + chain ----
+			// `r\n.a(\`${x}-${y}\`)\n.b()` — two `${...}` placeholders.
+			// Verifies that scanner state doesn't break across multiple
+			// substitution boundaries either.
+			{
+				Code: "declare const r: any;\n" +
+					"declare const x: string;\n" +
+					"declare const y: string;\n" +
+					"r\n" +
+					".a(`${x}-${y}`)\n" +
+					".b()",
+				Output: []string{"declare const r: any;\n" +
+					"declare const x: string;\n" +
+					"declare const y: string;\n" +
+					"r.\n" +
+					"a(`${x}-${y}`).\n" +
+					"b()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 5, Column: 1},
+					{MessageId: "expectedDotAfterObject", Line: 6, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/dot_location/dot_location_upstream_test.go
+++ b/internal/plugins/stylistic/rules/dot_location/dot_location_upstream_test.go
@@ -1,0 +1,427 @@
+// TestDotLocationUpstream migrates the full valid/invalid suite from upstream
+// packages/eslint-plugin/rules/dot-location/dot-location._js_.test.ts (plus
+// the sibling _ts_ and _jsx_ test files) 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// dot_location_extras_test.go.
+package dot_location_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/dot_location"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func optsObject() []interface{}   { return []interface{}{"object"} }
+func optsProperty() []interface{} { return []interface{}{"property"} }
+
+func TestDotLocationUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&dot_location.DotLocationRule,
+		[]rule_tester.ValidTestCase{
+			// ---- _js_ valid: default option (object) ----
+			{Code: `obj.prop`},
+			{Code: "obj.\nprop"},
+			{Code: "obj. \nprop"},
+			{Code: "obj.\n prop"},
+			{Code: "(obj).\nprop"},
+			{Code: "obj\n['prop']"},
+			{Code: `obj['prop']`},
+
+			// ---- _js_ valid: explicit options ----
+			{Code: "obj.\nprop", Options: optsObject()},
+			{Code: "obj\n.prop", Options: optsProperty()},
+			{Code: "(obj)\n.prop", Options: optsProperty()},
+			{Code: `obj . prop`, Options: optsObject()},
+			{Code: `obj /* a */ . prop`, Options: optsObject()},
+			{Code: "obj . \nprop", Options: optsObject()},
+			{Code: `obj . prop`, Options: optsProperty()},
+			{Code: `obj . /* a */ prop`, Options: optsProperty()},
+			{Code: "obj\n. prop", Options: optsProperty()},
+			{Code: "f(a\n).prop", Options: optsObject()},
+			{Code: "`\n`.prop", Options: optsObject()},
+			{Code: `obj[prop]`, Options: optsObject()},
+			{Code: "obj\n[prop]", Options: optsObject()},
+			{Code: "obj[\nprop]", Options: optsObject()},
+			{Code: "obj\n[\nprop\n]", Options: optsObject()},
+			{Code: `obj[prop]`, Options: optsProperty()},
+			{Code: "obj\n[prop]", Options: optsProperty()},
+			{Code: "obj[\nprop]", Options: optsProperty()},
+			{Code: "obj\n[\nprop\n]", Options: optsProperty()},
+
+			// ---- _js_ valid: parenthesized receiver (eslint/eslint#11868) ----
+			{Code: `(obj).prop`, Options: optsObject()},
+			{Code: "(obj).\nprop", Options: optsObject()},
+			{Code: "(obj\n).\nprop", Options: optsObject()},
+			{Code: "(\nobj\n).\nprop", Options: optsObject()},
+			{Code: "((obj\n)).\nprop", Options: optsObject()},
+			{Code: "(f(a)\n).\nprop", Options: optsObject()},
+			{Code: "((obj\n)\n).\nprop", Options: optsObject()},
+			{Code: "(\na &&\nb()\n).toString()", Options: optsObject()},
+
+			// ---- _js_ valid: optional chaining ----
+			{Code: `obj?.prop`, Options: optsObject()},
+			{Code: `obj?.[key]`, Options: optsObject()},
+			{Code: "obj?.\nprop", Options: optsObject()},
+			{Code: "obj\n?.[key]", Options: optsObject()},
+			{Code: "obj?.\n[key]", Options: optsObject()},
+			{Code: "obj?.[\nkey]", Options: optsObject()},
+			{Code: `obj?.prop`, Options: optsProperty()},
+			{Code: `obj?.[key]`, Options: optsProperty()},
+			{Code: "obj\n?.prop", Options: optsProperty()},
+			{Code: "obj\n?.[key]", Options: optsProperty()},
+			{Code: "obj?.\n[key]", Options: optsProperty()},
+			{Code: "obj?.[\nkey]", Options: optsProperty()},
+
+			// ---- _js_ valid: private properties ----
+			{Code: "class C { #a; foo() { this.\n#a; } }", Options: optsObject()},
+			{Code: "class C { #a; foo() { this\n.#a; } }", Options: optsProperty()},
+
+			// ---- _js_ valid: MetaProperty ----
+			{Code: `import.meta`},
+
+			// ---- _ts_ valid: TSImportType / TSQualifiedName ----
+			{Code: `type Foo = import('foo')`},
+			{Code: "type Foo = import('foo').\nProp", Options: optsObject()},
+			{Code: "type Foo = import('foo')\n.Prop", Options: optsProperty()},
+			{Code: "type Foo = Obj.\nProp", Options: optsObject()},
+			{Code: "type Foo = Obj\n.Prop", Options: optsProperty()},
+
+			// ---- _jsx_ valid: JSXMemberExpression ----
+			{Code: "const _ = <Form.\nInput />", Options: optsObject(), Tsx: true},
+			{Code: "const _ = <Form\n.Input />", Options: optsProperty(), Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- _js_ invalid: basic ----
+			{
+				Code:    "obj\n.property",
+				Output:  []string{"obj.\nproperty"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "obj.\nproperty",
+				Output:  []string{"obj\n.property"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty", Line: 1, Column: 4, EndLine: 1, EndColumn: 5},
+				},
+			},
+			{
+				Code:    "(obj).\nproperty",
+				Output:  []string{"(obj)\n.property"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty", Line: 1, Column: 6},
+				},
+			},
+
+			// ---- _js_ invalid: numeric receiver — needs space when fixed in 'object' mode ----
+			{
+				Code:    "5\n.toExponential()",
+				Output:  []string{"5 .\ntoExponential()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:    "-5\n.toExponential()",
+				Output:  []string{"-5 .\ntoExponential()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			// Upstream covers three leading-zero variants (`01`, `08`, `0190`)
+			// using `parserOptions: { sourceType: 'script' }` so the legacy /
+			// quasi-legacy octal forms parse. tsgo always reports them as
+			// TS1489 "Decimals with leading zeros are not allowed" — we can't
+			// run them under our default tsconfig. The non-leading-zero cases
+			// below (`5`, `-5`, `5_000`, `5_000_00`, `5.000_000`, `0b...`)
+			// already exercise both arms of isDecimalIntegerNumericToken, so
+			// no extra branch is unlocked by re-enabling these.
+			{
+				Skip:    true,
+				Code:    "01\n.toExponential()",
+				Output:  []string{"01.\ntoExponential()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Skip:    true,
+				Code:    "08\n.toExponential()",
+				Output:  []string{"08 .\ntoExponential()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Skip:    true,
+				Code:    "0190\n.toExponential()",
+				Output:  []string{"0190 .\ntoExponential()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:    "5_000\n.toExponential()",
+				Output:  []string{"5_000 .\ntoExponential()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:    "5_000_00\n.toExponential()",
+				Output:  []string{"5_000_00 .\ntoExponential()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:    "5.000_000\n.toExponential()",
+				Output:  []string{"5.000_000.\ntoExponential()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code:    "0b1010_1010\n.toExponential()",
+				Output:  []string{"0b1010_1010.\ntoExponential()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- _js_ invalid: comments around dot ----
+			{
+				Code:    "foo /* a */ . /* b */ \n /* c */ bar",
+				Output:  []string{"foo /* a */  /* b */ \n /* c */ .bar"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:    "foo /* a */ \n /* b */ . /* c */ bar",
+				Output:  []string{"foo. /* a */ \n /* b */  /* c */ bar"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 10},
+				},
+			},
+
+			// ---- _js_ invalid: parenthesized receiver, template literal ----
+			{
+				Code:    "f(a\n)\n.prop",
+				Output:  []string{"f(a\n).\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code:    "`\n`\n.prop",
+				Output:  []string{"`\n`.\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code:    "(a\n)\n.prop",
+				Output:  []string{"(a\n).\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code:    "(a\n)\n.\nprop",
+				Output:  []string{"(a\n).\n\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code:    "(f(a)\n)\n.prop",
+				Output:  []string{"(f(a)\n).\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code:    "(f(a\n)\n)\n.prop",
+				Output:  []string{"(f(a\n)\n).\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 4, Column: 1},
+				},
+			},
+			{
+				Code:    "((obj\n))\n.prop",
+				Output:  []string{"((obj\n)).\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code:    "((obj\n)\n)\n.prop",
+				Output:  []string{"((obj\n)\n).\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 4, Column: 1},
+				},
+			},
+			{
+				Code:    "(a\n) /* a */ \n.prop",
+				Output:  []string{"(a\n). /* a */ \nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code:    "(a\n)\n/* a */\n.prop",
+				Output:  []string{"(a\n).\n/* a */\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 4, Column: 1},
+				},
+			},
+			{
+				Code:    "(a\n)\n/* a */.prop",
+				Output:  []string{"(a\n).\n/* a */prop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 3, Column: 8},
+				},
+			},
+			{
+				Code:    "(5)\n.toExponential()",
+				Output:  []string{"(5).\ntoExponential()"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- _js_ invalid: optional chaining ----
+			{
+				Code:    "obj\n?.prop",
+				Output:  []string{"obj?.\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject"},
+				},
+			},
+			{
+				Code:    "10\n?.prop",
+				Output:  []string{"10?.\nprop"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject"},
+				},
+			},
+			{
+				Code:    "obj?.\nprop",
+				Output:  []string{"obj\n?.prop"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty"},
+				},
+			},
+
+			// ---- _js_ invalid: private properties ----
+			{
+				Code:    "class C { #a; foo() { this\n.#a; } }",
+				Output:  []string{"class C { #a; foo() { this.\n#a; } }"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject"},
+				},
+			},
+			{
+				Code:    "class C { #a; foo() { this.\n#a; } }",
+				Output:  []string{"class C { #a; foo() { this\n.#a; } }"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty"},
+				},
+			},
+
+			// ---- _ts_ invalid: TSImportType ----
+			{
+				Code:    "type Foo = import('foo')\n.Prop",
+				Output:  []string{"type Foo = import('foo').\nProp"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject"},
+				},
+			},
+			{
+				Code:    "type Foo = import('foo').\nProp",
+				Output:  []string{"type Foo = import('foo')\n.Prop"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty"},
+				},
+			},
+
+			// ---- _ts_ invalid: TSQualifiedName ----
+			{
+				Code:    "type Foo = Obj\n.Prop",
+				Output:  []string{"type Foo = Obj.\nProp"},
+				Options: optsObject(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject"},
+				},
+			},
+			{
+				Code:    "type Foo = Obj.\nProp",
+				Output:  []string{"type Foo = Obj\n.Prop"},
+				Options: optsProperty(),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty"},
+				},
+			},
+
+			// ---- _jsx_ invalid: JSXMemberExpression ----
+			{
+				Code:    "const _ = <Form\n.Input />",
+				Output:  []string{"const _ = <Form.\nInput />"},
+				Options: optsObject(),
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotAfterObject"},
+				},
+			},
+			{
+				Code:    "const _ = <Form.\nInput />",
+				Output:  []string{"const _ = <Form\n.Input />"},
+				Options: optsProperty(),
+				Tsx:     true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedDotBeforeProperty"},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -459,6 +459,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/brace-style.test.ts',
     './tests/eslint-plugin-stylistic/rules/comma-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/computed-property-spacing.test.ts',
+    './tests/eslint-plugin-stylistic/rules/dot-location.test.ts',
     './tests/eslint-plugin-stylistic/rules/eol-last.test.ts',
 
     // eslint-plugin-unicorn

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/dot-location.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/dot-location.test.ts
@@ -1,0 +1,194 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('dot-location', null as never, {
+  valid: [
+    // default (object)
+    { code: 'obj.prop' },
+    { code: 'obj.\nprop' },
+    { code: '(obj).\nprop' },
+    { code: "obj\n['prop']" },
+    { code: "obj['prop']" },
+
+    // explicit "object"
+    { code: 'obj.\nprop', options: ['object'] },
+    { code: 'obj . prop', options: ['object'] },
+    { code: 'obj /* a */ . prop', options: ['object'] },
+    { code: 'f(a\n).prop', options: ['object'] },
+    { code: '(obj).prop', options: ['object'] },
+    { code: '(\nobj\n).\nprop', options: ['object'] },
+
+    // explicit "property"
+    { code: 'obj\n.prop', options: ['property'] },
+    { code: '(obj)\n.prop', options: ['property'] },
+    { code: 'obj . prop', options: ['property'] },
+    { code: 'obj . /* a */ prop', options: ['property'] },
+
+    // bracket access skipped
+    { code: 'obj\n[prop]', options: ['object'] },
+    { code: 'obj\n[prop]', options: ['property'] },
+
+    // optional chaining
+    { code: 'obj?.\nprop', options: ['object'] },
+    { code: 'obj\n?.prop', options: ['property'] },
+
+    // private property
+    { code: 'class C { #a; foo() { this.\n#a; } }', options: ['object'] },
+    { code: 'class C { #a; foo() { this\n.#a; } }', options: ['property'] },
+
+    // MetaProperty
+    { code: 'import.meta' },
+
+    // TS-only valid: TSQualifiedName / TSImportType
+    { code: "type Foo = import('foo').\nProp", options: ['object'] },
+    { code: "type Foo = import('foo')\n.Prop", options: ['property'] },
+    { code: 'type Foo = Obj.\nProp', options: ['object'] },
+    { code: 'type Foo = Obj\n.Prop', options: ['property'] },
+
+    // JSX member expression (filename defaults to virtual.tsx)
+    { code: 'const _ = <Form.\nInput />', options: ['object'] },
+    { code: 'const _ = <Form\n.Input />', options: ['property'] },
+  ],
+  invalid: [
+    {
+      code: 'obj\n.property',
+      output: 'obj.\nproperty',
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'expectedDotAfterObject',
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      code: 'obj.\nproperty',
+      output: 'obj\n.property',
+      options: ['property'],
+      errors: [
+        {
+          messageId: 'expectedDotBeforeProperty',
+          line: 1,
+          column: 4,
+          endLine: 1,
+          endColumn: 5,
+        },
+      ],
+    },
+    {
+      code: '(obj).\nproperty',
+      output: '(obj)\n.property',
+      options: ['property'],
+      errors: [
+        {
+          messageId: 'expectedDotBeforeProperty',
+          line: 1,
+          column: 6,
+        },
+      ],
+    },
+    {
+      code: '5\n.toExponential()',
+      output: '5 .\ntoExponential()',
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'expectedDotAfterObject',
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: '5_000\n.toExponential()',
+      output: '5_000 .\ntoExponential()',
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'expectedDotAfterObject',
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: '0b1010_1010\n.toExponential()',
+      output: '0b1010_1010.\ntoExponential()',
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'expectedDotAfterObject',
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: 'obj\n?.prop',
+      output: 'obj?.\nprop',
+      options: ['object'],
+      errors: [{ messageId: 'expectedDotAfterObject' }],
+    },
+    {
+      code: 'obj?.\nprop',
+      output: 'obj\n?.prop',
+      options: ['property'],
+      errors: [{ messageId: 'expectedDotBeforeProperty' }],
+    },
+    {
+      code: 'class C { #a; foo() { this\n.#a; } }',
+      output: 'class C { #a; foo() { this.\n#a; } }',
+      options: ['object'],
+      errors: [{ messageId: 'expectedDotAfterObject' }],
+    },
+    {
+      code: 'class C { #a; foo() { this.\n#a; } }',
+      output: 'class C { #a; foo() { this\n.#a; } }',
+      options: ['property'],
+      errors: [{ messageId: 'expectedDotBeforeProperty' }],
+    },
+    // TSImportType
+    {
+      code: "type Foo = import('foo')\n.Prop",
+      output: "type Foo = import('foo').\nProp",
+      options: ['object'],
+      errors: [{ messageId: 'expectedDotAfterObject' }],
+    },
+    {
+      code: "type Foo = import('foo').\nProp",
+      output: "type Foo = import('foo')\n.Prop",
+      options: ['property'],
+      errors: [{ messageId: 'expectedDotBeforeProperty' }],
+    },
+    // TSQualifiedName
+    {
+      code: 'type Foo = Obj\n.Prop',
+      output: 'type Foo = Obj.\nProp',
+      options: ['object'],
+      errors: [{ messageId: 'expectedDotAfterObject' }],
+    },
+    {
+      code: 'type Foo = Obj.\nProp',
+      output: 'type Foo = Obj\n.Prop',
+      options: ['property'],
+      errors: [{ messageId: 'expectedDotBeforeProperty' }],
+    },
+    // JSX member expression
+    {
+      code: 'const _ = <Form\n.Input />',
+      output: 'const _ = <Form.\nInput />',
+      options: ['object'],
+      errors: [{ messageId: 'expectedDotAfterObject' }],
+    },
+    {
+      code: 'const _ = <Form.\nInput />',
+      output: 'const _ = <Form\n.Input />',
+      options: ['property'],
+      errors: [{ messageId: 'expectedDotBeforeProperty' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/dot-location` rule from `@stylistic/eslint-plugin` to rslint. The rule enforces consistent newline placement before or after the dot in member expressions.

Listener coverage:
- `PropertyAccessExpression` — covers `obj.prop`, `obj?.prop`, `this.#a`, and JSX `<Form.Input />` (tsgo represents JSX tag names as `PropertyAccessExpression`).
- `MetaProperty` — `import.meta`, `new.target`.
- `QualifiedName` — TS type-position `A.B`.
- `ImportType` — `import('foo').Qualifier`.

`ElementAccessExpression` is intentionally not listened to (matches upstream's `node.computed === true` skip).

Differential audit across `rsbuild`, `rspack`, `vscode`, `monaco-editor`, `typescript-go`, and rslint itself shows **zero rule-behavior divergence** from `@stylistic/eslint-plugin`. `--fix` output is byte-identical to ESLint's; fix is idempotent.

## Related Links

- ESLint rule: https://eslint.style/rules/dot-location
- Source code: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/dot-location/dot-location.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).