### PR TITLE
fix: prevent codebox renderer panic on invalid UTF-8 and whitespace-only lines

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -317,14 +317,19 @@ func printDiagnosticDefault(d rule.RuleDiagnostic, w *bufio.Writer, comparePathO
 	lineStarts := make([]int, numLines)
 	lineEnds := make([]int, numLines)
 
-	// Iterate by runes to correctly handle multi-byte UTF-8 characters,
-	// but track byte positions for string slicing
+	// Iterate by runes to correctly handle multi-byte UTF-8 characters.
+	// Use utf8.DecodeRuneInString to get the true byte width of each rune
+	// (including invalid UTF-8 bytes, which decode as RuneError with size=1).
+	// `for _, char := range str` plus `utf8.RuneLen(char)` is unsafe here
+	// because invalid bytes yield RuneError (U+FFFD) and RuneLen returns 3
+	// (the encoded length of U+FFFD), throwing off the byte counter and
+	// eventually slicing past len(text).
 	codeboxText := text[codeboxStart:codeboxEnd]
-	bytePos := codeboxStart
-	for _, char := range codeboxText {
-		charBytes := utf8.RuneLen(char)
-		current, next := bytePos, bytePos+charBytes
-		bytePos = next
+	for i := 0; i < len(codeboxText); {
+		char, size := utf8.DecodeRuneInString(codeboxText[i:])
+		current := codeboxStart + i
+		next := current + size
+		i += size
 
 		if char == '\n' {
 			if line != codeboxEndLine {
@@ -348,6 +353,14 @@ func printDiagnosticDefault(d rule.RuleDiagnostic, w *bufio.Writer, comparePathO
 	}
 	if line == codeboxEndLine {
 		lineEnds[line-codeboxStartLine] = lastNonSpaceByteIndex - int(lineMap[line])
+	}
+	// If no non-space content was seen anywhere in the codebox,
+	// `indentSize` was never updated from the math.MaxInt sentinel.
+	// Clamping to 0 prevents `lineMap[line] + indentSize` from overflowing
+	// int in the render loop below (which would wrap to a large negative
+	// number and slice out of bounds).
+	if indentSize == math.MaxInt {
+		indentSize = 0
 	}
 
 	diagnosticHighlightActive := false

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -410,6 +410,53 @@ func TestPrintDiagnosticEdgeCases(t *testing.T) {
 			t.Errorf("4-line codebox should show all lines.\nOutput:\n%s", output)
 		}
 	})
+
+	t.Run("source contains invalid UTF-8 bytes", func(t *testing.T) {
+		// Regression: the codebox renderer iterated `for _, char := range
+		// codeboxText` and advanced a manual byte counter by
+		// `utf8.RuneLen(char)`. Go's range yields utf8.RuneError (U+FFFD)
+		// for each invalid UTF-8 byte but only advances 1 byte — yet
+		// utf8.RuneLen(RuneError) is 3 (the encoded length of U+FFFD).
+		// The manual counter fell out of sync and downstream sliced the
+		// source text past its length, panicking with
+		// `slice bounds out of range [:17] with length 7`.
+		//
+		// Source: `//` + 5 invalid UTF-8 first bytes (0xFF 0xFE 0xFD
+		// 0xFC 0xFB) — mirrors a real swc-loader fixture in rspack that
+		// triggered this in production.
+		source := "//\xff\xfe\xfd\xfc\xfb"
+		d, opts := createTestDiagnostic(t, source, len(source), len(source))
+		output := renderDiagnostic(t, d, opts)
+
+		// The render must complete without panic and produce a non-empty
+		// codebox containing the leading `//`.
+		if !strings.Contains(output, "//") {
+			t.Errorf("Should render the `//` prefix without panicking.\nOutput:\n%s", output)
+		}
+		if !strings.Contains(output, "╰") {
+			t.Errorf("Should have closing border.\nOutput:\n%s", output)
+		}
+	})
+
+	t.Run("codebox contains only whitespace", func(t *testing.T) {
+		// Regression: indentSize was initialized to math.MaxInt and only
+		// updated inside `if !lineIndentCalculated && !unicode.IsSpace`.
+		// When every codebox line was whitespace-only (e.g. a 1-byte
+		// `"\n"` source), indentSize stayed MaxInt, and
+		// `lineMap[line] + indentSize` overflowed int — wrapping to a
+		// large negative number that then sliced out of bounds.
+		//
+		// Source: single LF — the simplest shape that produces a
+		// whitespace-only codebox. The diagnostic covers the LF itself
+		// (mirrors what eol-last 'never' emits on a 1-byte file).
+		source := "\n"
+		d, opts := createTestDiagnostic(t, source, 0, 1)
+		output := renderDiagnostic(t, d, opts)
+
+		if !strings.Contains(output, "╰") {
+			t.Errorf("Should have closing border.\nOutput:\n%s", output)
+		}
+	})
 }
 
 // TestSyntaxErrorFormat tests that syntax errors produce clean, readable messages


### PR DESCRIPTION
## Summary

\`printDiagnosticDefault\` (the default codebox renderer in \`cmd/rslint/cmd.go\`) had two latent panic paths that became reachable in production once a rule emitted a diagnostic on the affected input shape.

### Bug 1 — invalid UTF-8 bytes

The codebox loop iterated via \`for _, char := range str\` (dropping range's byte index) and advanced a manual byte counter by \`utf8.RuneLen(char)\`. Go's range yields \`utf8.RuneError\` (U+FFFD) for each invalid UTF-8 byte but only advances 1 byte — yet \`utf8.RuneLen(RuneError)\` is 3 (the encoded length of U+FFFD). After N invalid bytes the counter overshot by 2N, and the renderer sliced past \`len(text)\`:

\`\`\`
panic: runtime error: slice bounds out of range [:17] with length 7
  cmd/rslint/cmd.go:410
\`\`\`

Reproduced on a real 7-byte rspack swc-loader fixture: \`//\` + 5 invalid UTF-8 first bytes (\`0xFF 0xFE 0xFD 0xFC 0xFB\`).

### Bug 2 — whitespace-only codebox

\`indentSize\` was initialized to \`math.MaxInt\` as a sentinel and updated only when a non-space character was seen. On a fully-whitespace codebox (e.g. a 1-byte \`"\n"\` source) the sentinel survived, and the render loop's \`int(lineMap[line]) + indentSize\` overflowed \`int\` — wrapping to a large negative number and slicing out of bounds.

## Fix

- Switch the codebox iteration to \`utf8.DecodeRuneInString\` with an explicit \`i += size\` loop. This is the established pattern in this repo (\`internal/utils/trivia.go:120\`, \`internal/utils/js_string_source.go:61\`, \`internal/utils/regex_charclass.go\` and others). \`DecodeRuneInString\` returns \`size=1\` for invalid first bytes and \`size=3\` for legitimately-encoded U+FFFD — a single source of truth that can't fall out of sync.
- After the loop, clamp \`indentSize == math.MaxInt\` to \`0\`. Preserves the "strip common indent" feature for normal input while preventing the overflow on whitespace-only codeboxes.

Other diagnostic formatters (\`jsonline\`, \`github\`) are unaffected — they walk different code paths that don't use this rune-iteration logic.

## Related Links

- N/A — surfaced during real-world validation of \`@stylistic/eol-last\` (#999) on rspack.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).