### PR TITLE
feat: port rule @stylistic/generator-star-spacing

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -12,6 +12,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/computed_property_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/dot_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/eol_last"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/generator_star_spacing"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -28,5 +29,6 @@ func GetAllRules() []rule.Rule {
 		computed_property_spacing.ComputedPropertySpacingRule,
 		dot_location.DotLocationRule,
 		eol_last.EolLastRule,
+		generator_star_spacing.GeneratorStarSpacingRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/generator_star_spacing/generator_star_spacing.go
+++ b/internal/plugins/stylistic/rules/generator_star_spacing/generator_star_spacing.go
@@ -1,0 +1,322 @@
+package generator_star_spacing
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/stylisticutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const (
+	msgMissingBefore    = "missingBefore"
+	msgMissingAfter     = "missingAfter"
+	msgUnexpectedBefore = "unexpectedBefore"
+	msgUnexpectedAfter  = "unexpectedAfter"
+
+	descMissingBefore    = "Missing space before *."
+	descMissingAfter     = "Missing space after *."
+	descUnexpectedBefore = "Unexpected space before *."
+	descUnexpectedAfter  = "Unexpected space after *."
+)
+
+type sides struct {
+	before, after bool
+}
+
+type kindModes struct {
+	named, anonymous, method, shorthand sides
+}
+
+// stringPresets mirrors upstream's `optionDefinitions`. Unknown strings fall
+// back to the supplied defaults (matches upstream where `optionDefinitions[s]`
+// would be `undefined` and `Object.assign({}, defaults, undefined)` keeps the
+// defaults).
+var stringPresets = map[string]sides{
+	"before":  {before: true, after: false},
+	"after":   {before: false, after: true},
+	"both":    {before: true, after: true},
+	"neither": {before: false, after: false},
+}
+
+// optionToDefinition mirrors upstream's `optionToDefinition`:
+//   - nil → defaults
+//   - string → preset lookup (unknown string → defaults)
+//   - map → Object.assign({}, defaults, {before, after})
+func optionToDefinition(option any, defaults sides) sides {
+	if option == nil {
+		return defaults
+	}
+	if s, ok := option.(string); ok {
+		if preset, present := stringPresets[s]; present {
+			return preset
+		}
+		return defaults
+	}
+	if m, ok := option.(map[string]any); ok {
+		out := defaults
+		if v, ok := m["before"].(bool); ok {
+			out.before = v
+		}
+		if v, ok := m["after"].(bool); ok {
+			out.after = v
+		}
+		return out
+	}
+	return defaults
+}
+
+// parseOptions resolves the per-kind modes. Mirrors upstream's create()
+// option-resolution block exactly, including the `shorthand ?? method`
+// fallback so an explicit `method` override propagates to shorthand methods
+// when shorthand is not separately specified.
+func parseOptions(raw any) kindModes {
+	var top any
+	switch v := raw.(type) {
+	case nil:
+		top = nil
+	case []any:
+		if len(v) > 0 {
+			top = v[0]
+		}
+	default:
+		top = raw
+	}
+
+	rootDefault := stringPresets["before"]
+	defaults := optionToDefinition(top, rootDefault)
+
+	var namedOpt, anonOpt, methodOpt, shorthandOpt any
+	if m, ok := top.(map[string]any); ok {
+		namedOpt = m["named"]
+		anonOpt = m["anonymous"]
+		methodOpt = m["method"]
+		shorthandOpt = m["shorthand"]
+	}
+	if shorthandOpt == nil {
+		shorthandOpt = methodOpt
+	}
+
+	return kindModes{
+		named:     optionToDefinition(namedOpt, defaults),
+		anonymous: optionToDefinition(anonOpt, defaults),
+		method:    optionToDefinition(methodOpt, defaults),
+		shorthand: optionToDefinition(shorthandOpt, defaults),
+	}
+}
+
+// asteriskNode returns the generator `*` token field for a function-like node,
+// or nil if the node is not a generator (or not one of the function-like kinds
+// we handle).
+func asteriskNode(node *ast.Node) *ast.Node {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return node.AsFunctionDeclaration().AsteriskToken
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().AsteriskToken
+	case ast.KindMethodDeclaration:
+		return node.AsMethodDeclaration().AsteriskToken
+	}
+	return nil
+}
+
+// functionName returns the identifier-name node of a FunctionDeclaration /
+// FunctionExpression, or nil when the function is anonymous.
+func functionName(node *ast.Node) *ast.Node {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return node.AsFunctionDeclaration().Name()
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().Name()
+	}
+	return nil
+}
+
+// hasAnyModifier reports whether the node carries at least one modifier
+// keyword (static, async, public, override, …). For MethodDeclaration this is
+// equivalent to "the `*` is NOT the first real token of the method node" —
+// which is the condition upstream uses to gate the before-side check via
+// `starToken === sourceCode.getFirstToken(node.parent)`.
+func hasAnyModifier(node *ast.Node) bool {
+	mods := node.Modifiers()
+	return mods != nil && len(mods.Nodes) > 0
+}
+
+// starTokenRange returns the precise [pos, end) byte range of the generator
+// `*` token. tsgo's raw `Pos()` on the AsteriskToken includes any leading
+// trivia; GetRangeOfTokenAtPosition lands on the actual punctuator.
+func starTokenRange(sf *ast.SourceFile, asterisk *ast.Node) (start, end int, ok bool) {
+	if asterisk == nil {
+		return 0, 0, false
+	}
+	rng := scanner.GetRangeOfTokenAtPosition(sf, asterisk.Pos())
+	if rng.End() <= rng.Pos() {
+		return 0, 0, false
+	}
+	return rng.Pos(), rng.End(), true
+}
+
+// nextRealTokenStart returns the start position of the next non-trivia token
+// at or after `from`. Returns (-1, false) on end-of-file.
+func nextRealTokenStart(sf *ast.SourceFile, from int) (int, bool) {
+	s := scanner.GetScannerForSourceFile(sf, from)
+	if s.Token() == ast.KindEndOfFile {
+		return -1, false
+	}
+	return s.TokenStart(), true
+}
+
+// reportBefore emits the missing/unexpected diagnostic for the before side.
+// Anchors the report range on the `*` token itself (matches upstream where
+// `node = rightToken` and `rightToken === starToken` for the before side).
+func reportBefore(
+	ctx rule.RuleContext,
+	spaced bool,
+	required bool,
+	prevEnd int,
+	starStart, starEnd int,
+) {
+	if spaced == required {
+		return
+	}
+	reportRange := core.NewTextRange(starStart, starEnd)
+	if required {
+		ctx.ReportRangeWithFixes(
+			reportRange,
+			rule.RuleMessage{Id: msgMissingBefore, Description: descMissingBefore},
+			rule.RuleFix{Text: " ", Range: core.NewTextRange(starStart, starStart)},
+		)
+	} else {
+		ctx.ReportRangeWithFixes(
+			reportRange,
+			rule.RuleMessage{Id: msgUnexpectedBefore, Description: descUnexpectedBefore},
+			rule.RuleFix{Text: "", Range: core.NewTextRange(prevEnd, starStart)},
+		)
+	}
+}
+
+// reportAfter emits the missing/unexpected diagnostic for the after side.
+// Anchored on the `*` (matches upstream where `node = leftToken` and
+// `leftToken === starToken` for the after side).
+func reportAfter(
+	ctx rule.RuleContext,
+	spaced bool,
+	required bool,
+	nextStart int,
+	starStart, starEnd int,
+) {
+	if spaced == required {
+		return
+	}
+	reportRange := core.NewTextRange(starStart, starEnd)
+	if required {
+		ctx.ReportRangeWithFixes(
+			reportRange,
+			rule.RuleMessage{Id: msgMissingAfter, Description: descMissingAfter},
+			rule.RuleFix{Text: " ", Range: core.NewTextRange(starEnd, starEnd)},
+		)
+	} else {
+		ctx.ReportRangeWithFixes(
+			reportRange,
+			rule.RuleMessage{Id: msgUnexpectedAfter, Description: descUnexpectedAfter},
+			rule.RuleFix{Text: "", Range: core.NewTextRange(starEnd, nextStart)},
+		)
+	}
+}
+
+// checkGenerator runs the full before/after pair for one function-like node.
+// `kind` selects the mode (named / anonymous / method / shorthand); the
+// before-side check is skipped for method/shorthand when there is no
+// preceding modifier, matching upstream's
+// `(method||shorthand) && star === firstToken(parent)` short-circuit.
+func checkGenerator(ctx rule.RuleContext, node *ast.Node, kind string, modes kindModes) {
+	asterisk := asteriskNode(node)
+	if asterisk == nil {
+		return
+	}
+	starStart, starEnd, ok := starTokenRange(ctx.SourceFile, asterisk)
+	if !ok {
+		return
+	}
+
+	var mode sides
+	switch kind {
+	case "named":
+		mode = modes.named
+	case "anonymous":
+		mode = modes.anonymous
+	case "method":
+		mode = modes.method
+	case "shorthand":
+		mode = modes.shorthand
+	}
+
+	// Skip the before-check when the `*` is the first real token of a
+	// method/shorthand (upstream's `(method||shorthand) && star ===
+	// firstToken(parent)` short-circuit). Equivalent here: only skip when
+	// kind is method/shorthand AND the node has no leading modifier (incl.
+	// decorators, which tsgo also stores in Modifiers()).
+	isMethodLike := kind == "method" || kind == "shorthand"
+	if !isMethodLike || hasAnyModifier(node) {
+		prevEnd, ok := stylisticutil.FindPrevTokenEnd(ctx.SourceFile, node.Pos(), starStart)
+		if ok {
+			spaced := starStart-prevEnd > 0
+			reportBefore(ctx, spaced, mode.before, prevEnd, starStart, starEnd)
+		}
+	}
+
+	nextStart, ok := nextRealTokenStart(ctx.SourceFile, starEnd)
+	if ok {
+		spaced := nextStart-starEnd > 0
+		reportAfter(ctx, spaced, mode.after, nextStart, starStart, starEnd)
+	}
+}
+
+// methodKind classifies a MethodDeclaration node by its container:
+//   - ObjectLiteralExpression parent → "shorthand"
+//   - ClassDeclaration / ClassExpression parent → "method"
+//
+// Returns "" for any other container; the caller should skip those.
+func methodKind(node *ast.Node) string {
+	parent := node.Parent
+	if parent == nil {
+		return ""
+	}
+	switch parent.Kind {
+	case ast.KindObjectLiteralExpression:
+		return "shorthand"
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		return "method"
+	}
+	return ""
+}
+
+// GeneratorStarSpacingRule enforces consistent spacing around the `*` in
+// generator function declarations, function expressions, and method
+// shorthand. Ported from @stylistic/eslint-plugin's generator-star-spacing.
+var GeneratorStarSpacingRule = rule.Rule{
+	Name: "@stylistic/generator-star-spacing",
+	Run: func(ctx rule.RuleContext, raw any) rule.RuleListeners {
+		modes := parseOptions(raw)
+
+		checkFunc := func(node *ast.Node) {
+			kind := "named"
+			if functionName(node) == nil {
+				kind = "anonymous"
+			}
+			checkGenerator(ctx, node, kind, modes)
+		}
+
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration: checkFunc,
+			ast.KindFunctionExpression:  checkFunc,
+			ast.KindMethodDeclaration: func(node *ast.Node) {
+				kind := methodKind(node)
+				if kind == "" {
+					return
+				}
+				checkGenerator(ctx, node, kind, modes)
+			},
+		}
+	},
+}

--- a/internal/plugins/stylistic/rules/generator_star_spacing/generator_star_spacing.md
+++ b/internal/plugins/stylistic/rules/generator_star_spacing/generator_star_spacing.md
@@ -1,0 +1,171 @@
+# generator-star-spacing
+
+Enforce consistent spacing around `*` operators in generator functions.
+
+## Rule Details
+
+Generators are a type of function in ECMAScript 6 that can return multiple values over time. These functions are indicated by placing an `*` after the `function` keyword.
+
+To keep a sense of consistency when using generators this rule standardizes the spacing around the `*` token.
+
+Examples of **incorrect** code for this rule with the default `"before"` option:
+
+```javascript
+function*foo() {}
+function* foo() {}
+var foo = function*(){};
+var foo = { * bar(){} };
+class Foo { * bar(){} }
+class Foo { static* bar(){} }
+```
+
+Examples of **correct** code for this rule with the default `"before"` option:
+
+```javascript
+function *foo() {}
+var foo = function *(){};
+var foo = { *bar(){} };
+class Foo { *bar(){} }
+class Foo { static *bar(){} }
+```
+
+## Options
+
+This rule takes one option, which can be a string or an object.
+
+String shorthands:
+
+- `"before"` (default) requires a space before the `*` and forbids a space after — equivalent to `{ "before": true, "after": false }`.
+- `"after"` requires a space after the `*` and forbids a space before — equivalent to `{ "before": false, "after": true }`.
+- `"both"` requires a space both before and after the `*` — equivalent to `{ "before": true, "after": true }`.
+- `"neither"` forbids a space both before and after the `*` — equivalent to `{ "before": false, "after": false }`.
+
+Object option:
+
+- `"before"` (boolean, default `true`) — controls the space before the `*` token.
+- `"after"` (boolean, default `false`) — controls the space after the `*` token.
+
+Per-kind overrides (each accepts a shorthand string or a `{ "before", "after" }` object):
+
+- `"named"` — overrides the top-level setting for named functions.
+- `"anonymous"` — overrides the top-level setting for anonymous function expressions.
+- `"method"` — overrides the top-level setting for class methods and object shorthand methods.
+- `"shorthand"` — overrides the `"method"` setting specifically for object shorthand methods; falls back to `"method"` when omitted.
+
+### after
+
+Examples of **incorrect** code for this rule with the `"after"` option:
+
+```json
+{ "@stylistic/generator-star-spacing": ["error", "after"] }
+```
+
+```javascript
+function *foo() {}
+var foo = function *(){};
+class Foo { static *bar(){} }
+```
+
+Examples of **correct** code for this rule with the `"after"` option:
+
+```json
+{ "@stylistic/generator-star-spacing": ["error", "after"] }
+```
+
+```javascript
+function* foo() {}
+var foo = function* (){};
+class Foo { static* bar(){} }
+```
+
+### both
+
+Examples of **incorrect** code for this rule with the `"both"` option:
+
+```json
+{ "@stylistic/generator-star-spacing": ["error", "both"] }
+```
+
+```javascript
+function*foo() {}
+var foo = function*(){};
+class Foo { static*bar(){} }
+```
+
+Examples of **correct** code for this rule with the `"both"` option:
+
+```json
+{ "@stylistic/generator-star-spacing": ["error", "both"] }
+```
+
+```javascript
+function * foo() {}
+var foo = function * (){};
+class Foo { static * bar(){} }
+```
+
+### neither
+
+Examples of **incorrect** code for this rule with the `"neither"` option:
+
+```json
+{ "@stylistic/generator-star-spacing": ["error", "neither"] }
+```
+
+```javascript
+function * foo() {}
+var foo = function * (){};
+class Foo { static * bar(){} }
+```
+
+Examples of **correct** code for this rule with the `"neither"` option:
+
+```json
+{ "@stylistic/generator-star-spacing": ["error", "neither"] }
+```
+
+```javascript
+function*foo() {}
+var foo = function*(){};
+class Foo { static*bar(){} }
+```
+
+### Overrides per function type
+
+Examples of **incorrect** code for this rule with `{ "before": false, "after": true, "anonymous": "neither", "method": "both" }`:
+
+```json
+{
+  "@stylistic/generator-star-spacing": [
+    "error",
+    { "before": false, "after": true, "anonymous": "neither", "method": "both" }
+  ]
+}
+```
+
+```javascript
+function * generator() {}
+var anonymous = function* () {};
+class Foo { static* method() {} }
+```
+
+Examples of **correct** code for this rule with `{ "before": false, "after": true, "anonymous": "neither", "method": "both" }`:
+
+```json
+{
+  "@stylistic/generator-star-spacing": [
+    "error",
+    { "before": false, "after": true, "anonymous": "neither", "method": "both" }
+  ]
+}
+```
+
+```javascript
+function* generator() {}
+var anonymous = function*() {};
+class Foo { static * method() {} }
+```
+
+## Original Documentation
+
+- [@stylistic/generator-star-spacing](https://eslint.style/rules/generator-star-spacing)

--- a/internal/plugins/stylistic/rules/generator_star_spacing/generator_star_spacing_extras_test.go
+++ b/internal/plugins/stylistic/rules/generator_star_spacing/generator_star_spacing_extras_test.go
@@ -1,0 +1,556 @@
+// TestGeneratorStarSpacingExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+//
+// Coverage summary:
+//   - Dimension 4 walk for the function-header location (most rows are N/A
+//     because the `*` is not a child expression the rule inspects — those
+//     rows carry an explicit `// N/A: ...` marker)
+//   - tsgo trivia detection: tabs, multiple spaces, CR/LF newlines, line +
+//     block comments between `function`/`*` and `*`/name
+//   - container variants: class declaration vs class expression, named vs
+//     anonymous function expression, TS class with `declare`, async generator
+//     in class / object literal
+//   - same-kind nesting: generator inside generator reports both
+//   - upstream-branch lock-ins: `shorthand ?? method` fallback, partial
+//     object overrides inheriting from defaults, unknown-string fallback
+//   - real-user shapes from the ES module ecosystem
+package generator_star_spacing_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/generator_star_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestGeneratorStarSpacingExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&generator_star_spacing.GeneratorStarSpacingRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: trivia kinds — any non-zero distance between tokens counts as "spaced" ----
+
+			// multiple spaces between `function` and `*` — distance > 0, treated
+			// as spaced by upstream's `!!(rightToken.range[0] - leftToken.range[1])`
+			{Code: "function   *foo(){}"},
+			// tab between `function` and `*`
+			{Code: "function\t*foo(){}"},
+			// newline between `function` and `*` — Layer-2: tsgo line maps line/col
+			// independently; we only care that the trivia counts as spacing
+			{Code: "function\n*foo(){}"},
+			// CRLF newline between
+			{Code: "function\r\n*foo(){}"},
+			// block comment between `function` and `*` — non-zero distance, valid
+			// under default 'before'
+			{Code: "function/*c*/ *foo(){}"},
+			// line comment terminated by newline between `function` and `*`
+			{Code: "function //c\n*foo(){}"},
+
+			// ---- Dimension 4: method name forms ----
+
+			// string-literal key in object shorthand
+			{Code: "var foo = { *'bar'(){} };"},
+			// numeric-literal key in object shorthand
+			{Code: "var foo = { *0(){} };"},
+			// computed key in object shorthand (already in upstream, but with brackets-direct)
+			{Code: "var foo = { *[x](){} };"},
+			// private identifier in class method (TS / ES2022)
+			{Code: "class Foo { *#bar(){} }"},
+			// string-literal key in class method
+			{Code: "class Foo { *'bar'(){} }"},
+			// numeric-literal key in class method
+			{Code: "class Foo { *0(){} }"},
+
+			// ---- Dimension 4: container forms ----
+
+			// class expression
+			{Code: "var X = class { *foo(){} };"},
+			// named class expression
+			{Code: "var X = class Y { *foo(){} };"},
+			// anonymous function expression named via assignment
+			{Code: "var foo = function *(){};"},
+			// FE inside object literal as PropertyAssignment value (NOT shorthand)
+			// — kind is `anonymous`, before-check applies (function keyword)
+			{Code: "var foo = { bar: function *() {} };"},
+
+			// ---- Dimension 4: async generators (modifier presence enables before-check) ----
+
+			// async generator: function declaration form
+			{Code: "async function *foo(){}"},
+			// async generator: anonymous function expression
+			{Code: "var foo = async function *(){};"},
+			// async generator: class method without static
+			{Code: "class Foo { async *foo(){} }"},
+			// N/A: `*` cannot appear on an arrow function — arrow functions are
+			// not generators in any ECMAScript version
+
+			// ---- Dimension 4: nesting (same-kind boundaries) ----
+
+			// outer generator with inner non-generator — only outer is a generator
+			{Code: "function *outer() { function inner() {} }"},
+
+			// ---- Dimension 4: graceful degradation ----
+
+			// abstract generator method (TS-only) — body absent; before-check
+			// still applies because `abstract` is a modifier
+			{Code: "abstract class Foo { abstract *foo(): IterableIterator<number>; }"},
+			// declared class with generator method overload (body-absent)
+			{Code: "declare class Foo { *foo(): IterableIterator<number>; }"},
+			// overload signature followed by implementation, both generators
+			{Code: "class Foo { *foo(x: number): IterableIterator<number>; *foo(x: string): IterableIterator<string>; *foo(x: any) { yield x; } }"},
+
+			// N/A: paren wrapper around the function — `(*foo()...)` is not valid
+			//      syntax; `*` is part of the header not an expression child
+			// N/A: optional chain on `*` — same reason
+			// N/A: TS `as`/`satisfies`/non-null on `*` — same reason
+
+			// ---- Branch lock-ins ----
+
+			// Locks in upstream `shorthand ?? method` arm: when shorthand override
+			// is omitted, falls back to the method override (not to top-level
+			// before/after). Without the `??` fallback, this would error on the
+			// missing space after `*`.
+			{
+				Code:    "var foo = { *foo() {} };",
+				Options: optObj(map[string]any{"before": false, "after": false, "method": "neither"}),
+			},
+
+			// Locks in upstream `optionToDefinition` object arm: partial object
+			// merges with defaults. Here `named.after` is omitted, so it must
+			// inherit from top-level `after: false` (not from any built-in
+			// default that would be `false` only by coincidence).
+			{
+				Code:    "function *foo(){}",
+				Options: optObj(map[string]any{"before": true, "after": true, "named": map[string]any{"after": false}}),
+			},
+
+			// Locks in upstream `optionToDefinition` unknown-string arm: an
+			// unknown string falls through to the defaults (top-level before:
+			// true, after: false), so `function *foo(){}` stays valid.
+			{
+				Code:    "function *foo(){}",
+				Options: optStr("nonsense"),
+			},
+
+			// Locks in upstream `defaultOptions` resolution: an empty object at
+			// top level falls back to the rule's defaults (before: true,
+			// after: false), so the default-before behavior holds.
+			{
+				Code:    "function *foo(){}",
+				Options: optObj(map[string]any{}),
+			},
+
+			// ---- Real-user shapes (ESM exports — common in libraries) ----
+
+			// named export of a generator declaration
+			{Code: "export function *foo() { yield 1; }"},
+			// default export of an anonymous generator
+			{Code: "export default function *() { yield 1; }"},
+			// default export of a named generator
+			{Code: "export default function *foo() { yield 1; }"},
+			// const-bound generator expression
+			{Code: "export const foo = function *() { yield 1; };"},
+
+			// ---- Real-user shapes (redux-saga style — generator as the dominant pattern) ----
+
+			// saga: named generator with yield-call (the dominant pattern in the
+			// redux-saga ecosystem; the rule must not flag the inner `yield call`).
+			{Code: "function *saga() { yield call(api, payload); }"},
+			// saga with `yield* delegate(...)` — yield delegation token is `*`
+			// too, but it lives on YieldExpression (NOT on a function/method),
+			// so the rule must not see it. Locks in that the listener set is
+			// scoped correctly.
+			{Code: "function *saga() { yield* delegate(); }"},
+			// saga loop with multiple yield-delegations
+			{Code: "function *root() { while (true) { yield* listen(); yield* poll(); } }"},
+
+			// ---- Robustness: listener must NOT fire on non-monitored AST kinds ----
+
+			// N/A: TS interface / type-literal method signatures cannot use `*`
+			// at all (TS parse error: "Property or signature expected") because
+			// generators require a body. So there is no MethodSignature-shaped
+			// regression to lock in here — the rule's listener exclusion of
+			// MethodSignature is correct *and* untestable through valid input.
+
+			// Getter / setter on class — KindGetAccessor / KindSetAccessor,
+			// not monitored by the rule, must not error
+			{Code: "class Foo { get bar() { return 1; } set bar(v) {} }"},
+			// Constructor — KindConstructor, not monitored
+			{Code: "class Foo { constructor() {} }"},
+			// async non-generator method — has no AsteriskToken, checkGenerator
+			// returns early on nil
+			{Code: "class Foo { async bar() {} }"},
+			// regular non-generator method
+			{Code: "class Foo { bar() {} }"},
+			// Object property assignment with non-generator function expression
+			// — checkGenerator returns early because AsteriskToken is nil
+			{Code: "var foo = { bar: function() {} };"},
+
+			// ---- Robustness: container nesting (the rule walks into every body) ----
+
+			// generator IIFE — anonymous FunctionExpression as a CallExpression's
+			// callee. Locks in that traversal reaches CallExpression children.
+			{Code: "(function *() { yield 1; })()"},
+			// generator as a CallExpression argument (common: setTimeout etc.)
+			{Code: "setTimeout(function *() { yield 1; }, 0);"},
+			// generator inside a default parameter value
+			{Code: "function foo(cb = function *() { yield 1; }) {}"},
+			// generator returned from a generator
+			{Code: "function *outer() { return function *() { yield 1; }; }"},
+			// 4-level nesting: class > method (gen) > inner gen > deepest gen
+			{
+				Code: "class A {\n" +
+					"  *m() {\n" +
+					"    var x = class B {\n" +
+					"      *n() {\n" +
+					"        return function *() { return function *() { yield 1; }; };\n" +
+					"      }\n" +
+					"    };\n" +
+					"    yield 1;\n" +
+					"  }\n" +
+					"}",
+			},
+
+			// ---- Robustness: TS-specific shapes ----
+
+			// TS generic generator — type parameters between `name` and `(`
+			// don't affect the `*` spacing check
+			{Code: "function *foo<T>(x: T): IterableIterator<T> { yield x; }"},
+			// TS generic anonymous generator expression
+			{Code: "var foo = function *<T>(x: T): IterableIterator<T> { yield x; };"},
+			// TS generic generator class method
+			{Code: "class Foo { *bar<T>(x: T): IterableIterator<T> { yield x; } }"},
+			// TS parameter destructuring + rest — params don't touch `*`
+			{Code: "function *foo({ a, b }, ...rest) { yield a; yield b; }"},
+			// TS multi-modifier class method: public + static + async + generator
+			{Code: "class Foo { public static async *bar() { yield 1; } }"},
+			// TS protected modifier + generator
+			{Code: "class Foo { protected *bar() { yield 1; } }"},
+			// TS private modifier + generator
+			{Code: "class Foo { private *bar() { yield 1; } }"},
+			// TS override modifier + generator
+			{Code: "class Bar extends Foo { override *bar() { yield 1; } }"},
+			// private identifier method name (#priv) + static modifier
+			{Code: "class Foo { static *#priv() { yield 1; } }"},
+			// Decorator + generator method — decorators sit in tsgo's
+			// `Modifiers()` list as `KindDecorator` entries (see
+			// class_methods_use_this.go:576), so `hasAnyModifier` returns
+			// true and the before-check engages. Without this behavior we
+			// would mis-skip the before-check on decorated generators and
+			// silently miss spacing violations on `@dec*foo()`.
+			{Code: "class Foo { @dec *bar() { yield 1; } }"},
+
+			// ---- Robustness: control-flow containment ----
+
+			// generator declaration inside switch case — function declarations
+			// are hoisted to the enclosing block; the listener must still fire
+			{Code: "switch (x) { case 1: function *foo() { yield 1; } break; }"},
+			// generator declaration inside if-block
+			{Code: "if (x) { function *foo() { yield 1; } }"},
+			// generator declaration inside for-loop body
+			{Code: "for (var i = 0; i < 1; i++) { (function *() { yield i; })(); }"},
+
+			// ---- Mixed class members: only the generator member is inspected ----
+
+			// generator + getter + setter + normal in same class — only *gen
+			// would have been inspected; here it satisfies default 'before'
+			{Code: "class Mixed { *gen() { yield 1; } normal() {} get prop() { return 1; } set prop(v) {} }"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: comment trivia interacts with autofix ----
+
+			// Block comment after `*` — under default 'before', the after-side
+			// is `unexpected` since distance from `*` to `/` is 0... wait, the
+			// block comment IS distance > 0 — actually `function*/*c*/foo`:
+			// `*` at col 9, `/` at col 10, name `f` at col 15. After-distance =
+			// 15 - 10 = 5 > 0 → spaced. With 'before' default (after: false),
+			// this is `unexpected after`. Autofix removes the comment.
+			{
+				Code:    "function */*c*/foo(){}",
+				Output:  []string{"function *foo(){}"},
+				Errors:  []rule_tester.InvalidTestCaseError{errUA(10)},
+			},
+
+			// ---- Dimension 4: nesting — both generators reported independently ----
+
+			// Outer + inner both violate default 'before'
+			{
+				Code:   "function* outer() { function* inner() { yield 1; } yield 2; }",
+				Output: []string{"function *outer() { function *inner() { yield 1; } yield 2; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					errMB(9), errUA(9),
+					{MessageId: "missingBefore", Line: 1, Column: 29, EndLine: 1, EndColumn: 30},
+					{MessageId: "unexpectedAfter", Line: 1, Column: 29, EndLine: 1, EndColumn: 30},
+				},
+			},
+
+			// Generator method nested inside a class expression assigned to a property
+			// — class expression body is traversed; the inner generator reports.
+			// No modifier on the method, so before-check is skipped (upstream's
+			// `(method||shorthand) && star === firstToken(parent)` short-circuit).
+			{
+				Code:    "var x = { y: class { *foo(){} } };",
+				Output:  []string{"var x = { y: class { * foo(){} } };"},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+
+			// ---- Dimension 4: TS-modifier prefixes engage before-check on methods ----
+
+			// `public` modifier in class — `*` is no longer the first token
+			{
+				Code:    "class Foo { public*foo(){} }",
+				Output:  []string{"class Foo { public * foo(){} }"},
+				Options: optBA(true, true),
+				Errors:  []rule_tester.InvalidTestCaseError{errMB(19), errMA(19)},
+			},
+
+			// async generator object shorthand with 'neither' — both unexpected
+			{
+				Code:    "var foo = { async * bar(){} };",
+				Output:  []string{"var foo = { async*bar(){} };"},
+				Options: optBA(false, false),
+				Errors:  []rule_tester.InvalidTestCaseError{errUB(19), errUA(19)},
+			},
+
+			// ---- Branch lock-in: shorthand fallback to method ----
+
+			// Locks in upstream `shorthand ?? method`: shorthand undefined,
+			// method=both → object shorthand requires both spaces. Without the
+			// fallback, would report under top-level (false,false) instead.
+			{
+				Code:    "var foo = { *bar() {} };",
+				Output:  []string{"var foo = { * bar() {} };"},
+				Options: optObj(map[string]any{"before": false, "after": false, "method": "both"}),
+				Errors:  []rule_tester.InvalidTestCaseError{errMA(13)},
+			},
+
+			// Locks in upstream override-isolation: anonymous override applies
+			// to anonymous FE only; named FunctionDeclaration uses top-level.
+			{
+				Code:    "function * foo(){}",
+				Output:  []string{"function*foo(){}"},
+				Options: optObj(map[string]any{"before": false, "after": false, "anonymous": "both"}),
+				Errors:  []rule_tester.InvalidTestCaseError{errUB(10), errUA(10)},
+			},
+
+			// Locks in upstream `Object.assign({}, defaults, option)`: partial
+			// object override inherits unspecified key from top-level (here
+			// `named.after` inherits `after: true`, so missing after on
+			// `function *foo` reports).
+			{
+				Code:    "function *foo(){}",
+				Output:  []string{"function * foo(){}"},
+				Options: optObj(map[string]any{"before": true, "after": true, "named": map[string]any{"before": true}}),
+				Errors:  []rule_tester.InvalidTestCaseError{errMA(10)},
+			},
+
+			// ---- Real-user shapes ----
+
+			// Named export with generator — default options ('before')
+			{
+				Code:   "export function*foo(){ yield 1; }",
+				Output: []string{"export function *foo(){ yield 1; }"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(16)},
+			},
+
+			// Default export anonymous generator — default options ('before')
+			{
+				Code:   "export default function* (){ yield 1; }",
+				Output: []string{"export default function *(){ yield 1; }"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(24), errUA(24)},
+			},
+
+			// Locks in upstream `!node.id → anonymous` for the
+			// FunctionDeclaration path: `export default function() {}` is a
+			// FunctionDeclaration whose Name is nil. The anonymous override
+			// must apply to it. Without this routing, top-level defaults
+			// (false, false) would be used and no error would be reported.
+			{
+				Code:    "export default function*() { yield 1; }",
+				Output:  []string{"export default function * () { yield 1; }"},
+				Options: optObj(map[string]any{"before": false, "after": false, "anonymous": "both"}),
+				Errors:  []rule_tester.InvalidTestCaseError{errMB(24), errMA(24)},
+			},
+
+			// Class with static async generator — common modern shape
+			{
+				Code:    "class Foo { static async*bar() { yield 1; } }",
+				Output:  []string{"class Foo { static async * bar() { yield 1; } }"},
+				Options: optBA(true, true),
+				Errors:  []rule_tester.InvalidTestCaseError{errMB(25), errMA(25)},
+			},
+
+			// ---- Multi-line cases (Contract Alignment Checklist: ≥1 multi-line per container) ----
+
+			// Multi-line function declaration with violation on line 1
+			{
+				Code: "function*foo() {\n  yield 1;\n}",
+				Output: []string{"function *foo() {\n  yield 1;\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingBefore", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+
+			// Multi-line class method
+			{
+				Code: "class Foo {\n  static *bar() {\n    yield 1;\n  }\n}",
+				Output: []string{"class Foo {\n  static* bar() {\n    yield 1;\n  }\n}"},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedBefore", Line: 2, Column: 10, EndLine: 2, EndColumn: 11},
+					{MessageId: "missingAfter", Line: 2, Column: 10, EndLine: 2, EndColumn: 11},
+				},
+			},
+
+			// Multi-line object shorthand
+			{
+				Code: "var x = {\n  *foo() {\n    yield 1;\n  },\n};",
+				Output: []string{"var x = {\n  * foo() {\n    yield 1;\n  },\n};"},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingAfter", Line: 2, Column: 3, EndLine: 2, EndColumn: 4},
+				},
+			},
+
+			// ---- Real-user shape: redux-saga ----
+
+			// Common saga style: named generator, must not let the yield-delegation
+			// `*` (yield* call(...)) interfere with the function-`*` check
+			{
+				Code:   "function*saga() { yield call(api); yield* delegate(); }",
+				Output: []string{"function *saga() { yield call(api); yield* delegate(); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9)},
+			},
+
+			// ---- Robustness: container nesting (rule must traverse into bodies) ----
+
+			// IIFE generator violating 'neither' — anonymous, modifier-less
+			// FunctionExpression as CallExpression callee
+			{
+				Code:    "(function * () { yield 1; })()",
+				Output:  []string{"(function*() { yield 1; })()"},
+				Options: optStr("neither"),
+				Errors:  []rule_tester.InvalidTestCaseError{errUB(11), errUA(11)},
+			},
+
+			// Generator inside default parameter — anonymous FE, default 'before'
+			// catches `function*` with no leading space
+			{
+				Code:   "function foo(cb = function*() { yield 1; }) {}",
+				Output: []string{"function foo(cb = function *() { yield 1; }) {}"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(27)},
+			},
+
+			// Generator as setTimeout argument — anonymous FE in CallExpression
+			// arguments list. Default 'before', missing before.
+			{
+				Code:   "setTimeout(function*() { yield 1; }, 0);",
+				Output: []string{"setTimeout(function *() { yield 1; }, 0);"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(20)},
+			},
+
+			// 4-level nesting reports every violating generator independently.
+			// Default 'before' / no option:
+			//   - col 11 `*m()` and col 36 `*n()` are MethodDeclarations with
+			//     no modifier → before-check skipped, after-check passes (no
+			//     space before `(`), so they don't report.
+			//   - col 58 `function* ()` anonymous FE: missingBefore (function
+			//     immediately precedes `*`) AND unexpectedAfter (space after `*`)
+			//   - col 80 `function*()` anonymous FE: missingBefore only
+			{
+				Code: "class A { *m() { var x = class B { *n() { return function* () { return function*() { yield 1; }; }; } }; } }",
+				Output: []string{
+					"class A { *m() { var x = class B { *n() { return function *() { return function *() { yield 1; }; }; } }; } }",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingBefore", Line: 1, Column: 58, EndLine: 1, EndColumn: 59},
+					{MessageId: "unexpectedAfter", Line: 1, Column: 58, EndLine: 1, EndColumn: 59},
+					{MessageId: "missingBefore", Line: 1, Column: 80, EndLine: 1, EndColumn: 81},
+				},
+			},
+
+			// ---- Robustness: TS-specific modifier combinations engage before-check ----
+
+			// Multi-modifier method: `public static async *foo` violating 'neither'
+			// — three modifiers, then `*`. Before is spaced (after async), after
+			// is spaced (before foo). Both unexpected.
+			{
+				Code:    "class Foo { public static async * foo() { yield 1; } }",
+				Output:  []string{"class Foo { public static async*foo() { yield 1; } }"},
+				Options: optStr("neither"),
+				Errors:  []rule_tester.InvalidTestCaseError{errUB(33), errUA(33)},
+			},
+
+			// `override` modifier (TS) engages before-check
+			{
+				Code:    "class Bar extends Foo { override*bar() { yield 1; } }",
+				Output:  []string{"class Bar extends Foo { override * bar() { yield 1; } }"},
+				Options: optBA(true, true),
+				Errors:  []rule_tester.InvalidTestCaseError{errMB(33), errMA(33)},
+			},
+
+			// Private identifier + static modifier: `static*#priv` violates
+			// default 'before' — missing space between `static` and `*`
+			{
+				Code:   "class Foo { static*#priv() { yield 1; } }",
+				Output: []string{"class Foo { static *#priv() { yield 1; } }"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19)},
+			},
+
+			// Decorator + missing space before `*` — decorator is part of
+			// the Modifiers list (tsgo design), so before-check engages and
+			// catches `@dec*bar()` violating default 'before'.
+			{
+				Code:   "class Foo { @dec*bar() { yield 1; } }",
+				Output: []string{"class Foo { @dec *bar() { yield 1; } }"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(17)},
+			},
+
+			// TS generic generator: type parameters don't affect `*` check
+			{
+				Code:   "function*foo<T>(x: T): IterableIterator<T> { yield x; }",
+				Output: []string{"function *foo<T>(x: T): IterableIterator<T> { yield x; }"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9)},
+			},
+
+			// ---- Robustness: control-flow containment ----
+
+			// generator declaration inside switch case — listener must fire
+			{
+				Code:   "switch (x) { case 1: function*foo() { yield 1; } break; }",
+				Output: []string{"switch (x) { case 1: function *foo() { yield 1; } break; }"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(30)},
+			},
+
+			// generator declaration inside if-block
+			{
+				Code:   "if (x) { function*foo() { yield 1; } }",
+				Output: []string{"if (x) { function *foo() { yield 1; } }"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(18)},
+			},
+
+			// ---- Robustness: mixed class members — only the generator member reports ----
+
+			// Class with generator + regular + getter + setter. With default
+			// 'before', only `*gen` and `static*g2` are checked; the others
+			// are different node kinds (regular MethodDeclaration with no
+			// AsteriskToken, GetAccessor, SetAccessor) and must not produce
+			// false positives. `*gen` passes (no modifier → before skipped);
+			// `static*g2` violates (modifier present, no space before `*`).
+			{
+				Code:   "class Mixed { *gen() { yield 1; } normal() {} get prop() { return 1; } set prop(v) {} static*g2() {} }",
+				Output: []string{"class Mixed { *gen() { yield 1; } normal() {} get prop() { return 1; } set prop(v) {} static *g2() {} }"},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(93)},
+			},
+		},
+	)
+}

--- a/internal/plugins/stylistic/rules/generator_star_spacing/generator_star_spacing_upstream_test.go
+++ b/internal/plugins/stylistic/rules/generator_star_spacing/generator_star_spacing_upstream_test.go
@@ -1,0 +1,745 @@
+// TestGeneratorStarSpacingUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/rules/generator-star-spacing/generator-star-spacing.test.ts
+// 1:1. Position assertions cover line/column for every invalid case (all
+// upstream cases are single-line; the * report span is one byte, so endColumn
+// is always column+1). rslint-specific lock-in cases (tsgo AST edge shapes,
+// branch lock-ins, real-user shapes, multi-line + comment fixtures) live in
+// generator_star_spacing_extras_test.go.
+package generator_star_spacing_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/generator_star_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// ---- option helpers (mirror upstream shorthand string vs object forms) ----
+
+func optStr(s string) []any { return []any{s} }
+
+func optObj(m map[string]any) []any { return []any{m} }
+
+// optBA shorthand — `{ before, after }` only.
+func optBA(b, a bool) []any {
+	return []any{map[string]any{"before": b, "after": a}}
+}
+
+// ---- error helpers (Line is always 1; EndColumn is always Column+1) ----
+
+func errMB(col int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{MessageId: "missingBefore", Line: 1, Column: col}
+}
+func errMA(col int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{MessageId: "missingAfter", Line: 1, Column: col}
+}
+func errUB(col int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{MessageId: "unexpectedBefore", Line: 1, Column: col}
+}
+func errUA(col int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{MessageId: "unexpectedAfter", Line: 1, Column: col}
+}
+
+func TestGeneratorStarSpacingUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&generator_star_spacing.GeneratorStarSpacingRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Default ("before") ----
+			{Code: `function foo(){}`},
+			{Code: `function *foo(){}`},
+			{Code: `function *foo(arg1, arg2){}`},
+			{Code: `var foo = function *foo(){};`},
+			{Code: `var foo = function *(){};`},
+			{Code: `var foo = { *foo(){} };`},
+			{Code: `var foo = {*foo(){} };`},
+			{Code: `class Foo { *foo(){} }`},
+			{Code: `class Foo {*foo(){} }`},
+			{Code: `class Foo { static *foo(){} }`},
+			{Code: `var foo = {*[ foo ](){} };`},
+			{Code: `class Foo {*[ foo ](){} }`},
+
+			// ---- "before" ----
+			{Code: `function foo(){}`, Options: optStr("before")},
+			{Code: `function *foo(){}`, Options: optStr("before")},
+			{Code: `function *foo(arg1, arg2){}`, Options: optStr("before")},
+			{Code: `var foo = function *foo(){};`, Options: optStr("before")},
+			{Code: `var foo = function *(){};`, Options: optStr("before")},
+			{Code: `var foo = { *foo(){} };`, Options: optStr("before")},
+			{Code: `var foo = {*foo(){} };`, Options: optStr("before")},
+			{Code: `class Foo { *foo(){} }`, Options: optStr("before")},
+			{Code: `class Foo {*foo(){} }`, Options: optStr("before")},
+			{Code: `class Foo { static *foo(){} }`, Options: optStr("before")},
+			{Code: `class Foo {*[ foo ](){} }`, Options: optStr("before")},
+			{Code: `var foo = {*[ foo ](){} };`, Options: optStr("before")},
+
+			// ---- "after" ----
+			{Code: `function foo(){}`, Options: optStr("after")},
+			{Code: `function* foo(){}`, Options: optStr("after")},
+			{Code: `function* foo(arg1, arg2){}`, Options: optStr("after")},
+			{Code: `var foo = function* foo(){};`, Options: optStr("after")},
+			{Code: `var foo = function* (){};`, Options: optStr("after")},
+			{Code: `var foo = {* foo(){} };`, Options: optStr("after")},
+			{Code: `var foo = { * foo(){} };`, Options: optStr("after")},
+			{Code: `class Foo {* foo(){} }`, Options: optStr("after")},
+			{Code: `class Foo { * foo(){} }`, Options: optStr("after")},
+			{Code: `class Foo { static* foo(){} }`, Options: optStr("after")},
+			{Code: `var foo = {* [foo](){} };`, Options: optStr("after")},
+			{Code: `class Foo {* [foo](){} }`, Options: optStr("after")},
+
+			// ---- "both" ----
+			{Code: `function foo(){}`, Options: optStr("both")},
+			{Code: `function * foo(){}`, Options: optStr("both")},
+			{Code: `function * foo(arg1, arg2){}`, Options: optStr("both")},
+			{Code: `var foo = function * foo(){};`, Options: optStr("both")},
+			{Code: `var foo = function * (){};`, Options: optStr("both")},
+			{Code: `var foo = { * foo(){} };`, Options: optStr("both")},
+			{Code: `var foo = {* foo(){} };`, Options: optStr("both")},
+			{Code: `class Foo { * foo(){} }`, Options: optStr("both")},
+			{Code: `class Foo {* foo(){} }`, Options: optStr("both")},
+			{Code: `class Foo { static * foo(){} }`, Options: optStr("both")},
+			{Code: `var foo = {* [foo](){} };`, Options: optStr("both")},
+			{Code: `class Foo {* [foo](){} }`, Options: optStr("both")},
+
+			// ---- "neither" ----
+			{Code: `function foo(){}`, Options: optStr("neither")},
+			{Code: `function*foo(){}`, Options: optStr("neither")},
+			{Code: `function*foo(arg1, arg2){}`, Options: optStr("neither")},
+			{Code: `var foo = function*foo(){};`, Options: optStr("neither")},
+			{Code: `var foo = function*(){};`, Options: optStr("neither")},
+			{Code: `var foo = {*foo(){} };`, Options: optStr("neither")},
+			{Code: `var foo = { *foo(){} };`, Options: optStr("neither")},
+			{Code: `class Foo {*foo(){} }`, Options: optStr("neither")},
+			{Code: `class Foo { *foo(){} }`, Options: optStr("neither")},
+			{Code: `class Foo { static*foo(){} }`, Options: optStr("neither")},
+			{Code: `var foo = {*[ foo ](){} };`, Options: optStr("neither")},
+			{Code: `class Foo {*[ foo ](){} }`, Options: optStr("neither")},
+
+			// ---- { "before": true, "after": false } ----
+			{Code: `function foo(){}`, Options: optBA(true, false)},
+			{Code: `function *foo(){}`, Options: optBA(true, false)},
+			{Code: `function *foo(arg1, arg2){}`, Options: optBA(true, false)},
+			{Code: `var foo = function *foo(){};`, Options: optBA(true, false)},
+			{Code: `var foo = function *(){};`, Options: optBA(true, false)},
+			{Code: `var foo = { *foo(){} };`, Options: optBA(true, false)},
+			{Code: `var foo = {*foo(){} };`, Options: optBA(true, false)},
+			{Code: `class Foo { *foo(){} }`, Options: optBA(true, false)},
+			{Code: `class Foo {*foo(){} }`, Options: optBA(true, false)},
+			{Code: `class Foo { static *foo(){} }`, Options: optBA(true, false)},
+
+			// ---- { "before": false, "after": true } ----
+			{Code: `function foo(){}`, Options: optBA(false, true)},
+			{Code: `function* foo(){}`, Options: optBA(false, true)},
+			{Code: `function* foo(arg1, arg2){}`, Options: optBA(false, true)},
+			{Code: `var foo = function* foo(){};`, Options: optBA(false, true)},
+			{Code: `var foo = function* (){};`, Options: optBA(false, true)},
+			{Code: `var foo = {* foo(){} };`, Options: optBA(false, true)},
+			{Code: `var foo = { * foo(){} };`, Options: optBA(false, true)},
+			{Code: `class Foo {* foo(){} }`, Options: optBA(false, true)},
+			{Code: `class Foo { * foo(){} }`, Options: optBA(false, true)},
+			{Code: `class Foo { static* foo(){} }`, Options: optBA(false, true)},
+
+			// ---- { "before": true, "after": true } ----
+			{Code: `function foo(){}`, Options: optBA(true, true)},
+			{Code: `function * foo(){}`, Options: optBA(true, true)},
+			{Code: `function * foo(arg1, arg2){}`, Options: optBA(true, true)},
+			{Code: `var foo = function * foo(){};`, Options: optBA(true, true)},
+			{Code: `var foo = function * (){};`, Options: optBA(true, true)},
+			{Code: `var foo = { * foo(){} };`, Options: optBA(true, true)},
+			{Code: `var foo = {* foo(){} };`, Options: optBA(true, true)},
+			{Code: `class Foo { * foo(){} }`, Options: optBA(true, true)},
+			{Code: `class Foo {* foo(){} }`, Options: optBA(true, true)},
+			{Code: `class Foo { static * foo(){} }`, Options: optBA(true, true)},
+
+			// ---- { "before": false, "after": false } ----
+			{Code: `function foo(){}`, Options: optBA(false, false)},
+			{Code: `function*foo(){}`, Options: optBA(false, false)},
+			{Code: `function*foo(arg1, arg2){}`, Options: optBA(false, false)},
+			{Code: `var foo = function*foo(){};`, Options: optBA(false, false)},
+			{Code: `var foo = function*(){};`, Options: optBA(false, false)},
+			{Code: `var foo = {*foo(){} };`, Options: optBA(false, false)},
+			{Code: `var foo = { *foo(){} };`, Options: optBA(false, false)},
+			{Code: `class Foo {*foo(){} }`, Options: optBA(false, false)},
+			{Code: `class Foo { *foo(){} }`, Options: optBA(false, false)},
+			{Code: `class Foo { static*foo(){} }`, Options: optBA(false, false)},
+
+			// ---- full configurability ----
+			{Code: `function * foo(){}`, Options: optObj(map[string]any{"before": false, "after": false, "named": "both"})},
+			{Code: `var foo = function * (){};`, Options: optObj(map[string]any{"before": false, "after": false, "anonymous": "both"})},
+			{Code: `class Foo { * foo(){} }`, Options: optObj(map[string]any{"before": false, "after": false, "method": "both"})},
+			{Code: `var foo = { * foo(){} }`, Options: optObj(map[string]any{"before": false, "after": false, "method": "both"})},
+			{Code: `var foo = { bar: function * () {} }`, Options: optObj(map[string]any{"before": false, "after": false, "anonymous": "both"})},
+			{Code: `class Foo { static * foo(){} }`, Options: optObj(map[string]any{"before": false, "after": false, "method": "both"})},
+			{Code: `var foo = { * foo(){} }`, Options: optObj(map[string]any{"before": false, "after": false, "shorthand": "both"})},
+
+			// ---- default to top level "before" ----
+			{Code: `function *foo(){}`, Options: optObj(map[string]any{"method": "both"})},
+
+			// ---- don't apply unrelated override ----
+			{Code: `function*foo(){}`, Options: optObj(map[string]any{"before": false, "after": false, "method": "both"})},
+
+			// ---- ensure using object-type override works ----
+			{Code: `function * foo(){}`, Options: optObj(map[string]any{"before": false, "after": false, "named": map[string]any{"before": true, "after": true}})},
+
+			// ---- unspecified option uses default ----
+			{Code: `function *foo(){}`, Options: optObj(map[string]any{"before": false, "after": false, "named": map[string]any{"before": true}})},
+
+			// ---- async / arrow (ecmaVersion 8) - generator-star-spacing must not flag non-generators ----
+			{Code: `async function foo() { }`},
+			{Code: `(async function() { })`},
+			{Code: `async () => { }`},
+			{Code: `({async foo() { }})`},
+			{Code: `class A {async foo() { }}`},
+			{Code: `(class {async foo() { }})`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Default ("before") ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function *foo(){}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingBefore", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code:   `function* foo(arg1, arg2){}`,
+				Output: []string{`function *foo(arg1, arg2){}`},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9), errUA(9)},
+			},
+			{
+				Code:   `var foo = function*foo(){};`,
+				Output: []string{`var foo = function *foo(){};`},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19)},
+			},
+			{
+				Code:   `var foo = function* (){};`,
+				Output: []string{`var foo = function *(){};`},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errUA(19)},
+			},
+			{
+				Code:   `var foo = {* foo(){} };`,
+				Output: []string{`var foo = {*foo(){} };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:   `class Foo {* foo(){} }`,
+				Output: []string{`class Foo {*foo(){} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedAfter", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:   `class Foo { static* foo(){} }`,
+				Output: []string{`class Foo { static *foo(){} }`},
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errUA(19)},
+			},
+
+			// ---- "before" ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function *foo(){}`},
+				Options: optStr("before"),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9)},
+			},
+			{
+				Code:   `function* foo(arg1, arg2){}`,
+				Output: []string{`function *foo(arg1, arg2){}`},
+				Options: optStr("before"),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9), errUA(9)},
+			},
+			{
+				Code:   `var foo = function*foo(){};`,
+				Output: []string{`var foo = function *foo(){};`},
+				Options: optStr("before"),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19)},
+			},
+			{
+				Code:   `var foo = function* (){};`,
+				Output: []string{`var foo = function *(){};`},
+				Options: optStr("before"),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errUA(19)},
+			},
+			{
+				Code:   `var foo = {* foo(){} };`,
+				Output: []string{`var foo = {*foo(){} };`},
+				Options: optStr("before"),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(12)},
+			},
+			{
+				Code:   `class Foo {* foo(){} }`,
+				Output: []string{`class Foo {*foo(){} }`},
+				Options: optStr("before"),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(12)},
+			},
+			{
+				Code:   `var foo = {* [ foo ](){} };`,
+				Output: []string{`var foo = {*[ foo ](){} };`},
+				Options: optStr("before"),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(12)},
+			},
+			{
+				Code:   `class Foo {* [ foo ](){} }`,
+				Output: []string{`class Foo {*[ foo ](){} }`},
+				Options: optStr("before"),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(12)},
+			},
+
+			// ---- "after" ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function* foo(){}`},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(9)},
+			},
+			{
+				Code:   `function *foo(arg1, arg2){}`,
+				Output: []string{`function* foo(arg1, arg2){}`},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(10), errMA(10)},
+			},
+			{
+				Code:   `var foo = function *foo(){};`,
+				Output: []string{`var foo = function* foo(){};`},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errMA(20)},
+			},
+			{
+				Code:   `var foo = function *(){};`,
+				Output: []string{`var foo = function* (){};`},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errMA(20)},
+			},
+			{
+				Code:   `var foo = { *foo(){} };`,
+				Output: []string{`var foo = { * foo(){} };`},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(13)},
+			},
+			{
+				Code:   `class Foo { *foo(){} }`,
+				Output: []string{`class Foo { * foo(){} }`},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(13)},
+			},
+			{
+				Code:   `class Foo { static *foo(){} }`,
+				Output: []string{`class Foo { static* foo(){} }`},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errMA(20)},
+			},
+			{
+				Code:   `var foo = { *[foo](){} };`,
+				Output: []string{`var foo = { * [foo](){} };`},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(13)},
+			},
+			{
+				Code:   `class Foo { *[foo](){} }`,
+				Output: []string{`class Foo { * [foo](){} }`},
+				Options: optStr("after"),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(13)},
+			},
+
+			// ---- "both" ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function * foo(){}`},
+				Options: optStr("both"),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9), errMA(9)},
+			},
+			{
+				Code:   `function*foo(arg1, arg2){}`,
+				Output: []string{`function * foo(arg1, arg2){}`},
+				Options: optStr("both"),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9), errMA(9)},
+			},
+			{
+				Code:   `var foo = function*foo(){};`,
+				Output: []string{`var foo = function * foo(){};`},
+				Options: optStr("both"),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errMA(19)},
+			},
+			{
+				Code:   `var foo = function*(){};`,
+				Output: []string{`var foo = function * (){};`},
+				Options: optStr("both"),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errMA(19)},
+			},
+			{
+				Code:   `var foo = {*foo(){} };`,
+				Output: []string{`var foo = {* foo(){} };`},
+				Options: optStr("both"),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(12)},
+			},
+			{
+				Code:   `class Foo {*foo(){} }`,
+				Output: []string{`class Foo {* foo(){} }`},
+				Options: optStr("both"),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(12)},
+			},
+			{
+				Code:   `class Foo { static*foo(){} }`,
+				Output: []string{`class Foo { static * foo(){} }`},
+				Options: optStr("both"),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errMA(19)},
+			},
+			{
+				Code:   `var foo = {*[foo](){} };`,
+				Output: []string{`var foo = {* [foo](){} };`},
+				Options: optStr("both"),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(12)},
+			},
+			{
+				Code:   `class Foo {*[foo](){} }`,
+				Output: []string{`class Foo {* [foo](){} }`},
+				Options: optStr("both"),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(12)},
+			},
+
+			// ---- "neither" ----
+			{
+				Code:   `function * foo(){}`,
+				Output: []string{`function*foo(){}`},
+				Options: optStr("neither"),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(10), errUA(10)},
+			},
+			{
+				Code:   `function * foo(arg1, arg2){}`,
+				Output: []string{`function*foo(arg1, arg2){}`},
+				Options: optStr("neither"),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(10), errUA(10)},
+			},
+			{
+				Code:   `var foo = function * foo(){};`,
+				Output: []string{`var foo = function*foo(){};`},
+				Options: optStr("neither"),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errUA(20)},
+			},
+			{
+				Code:   `var foo = function * (){};`,
+				Output: []string{`var foo = function*(){};`},
+				Options: optStr("neither"),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errUA(20)},
+			},
+			{
+				Code:   `var foo = { * foo(){} };`,
+				Output: []string{`var foo = { *foo(){} };`},
+				Options: optStr("neither"),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(13)},
+			},
+			{
+				Code:   `class Foo { * foo(){} }`,
+				Output: []string{`class Foo { *foo(){} }`},
+				Options: optStr("neither"),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(13)},
+			},
+			{
+				Code:   `class Foo { static * foo(){} }`,
+				Output: []string{`class Foo { static*foo(){} }`},
+				Options: optStr("neither"),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errUA(20)},
+			},
+			{
+				Code:   `var foo = { * [ foo ](){} };`,
+				Output: []string{`var foo = { *[ foo ](){} };`},
+				Options: optStr("neither"),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(13)},
+			},
+			{
+				Code:   `class Foo { * [ foo ](){} }`,
+				Output: []string{`class Foo { *[ foo ](){} }`},
+				Options: optStr("neither"),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(13)},
+			},
+
+			// ---- { "before": true, "after": false } ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function *foo(){}`},
+				Options: optBA(true, false),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9)},
+			},
+			{
+				Code:   `function* foo(arg1, arg2){}`,
+				Output: []string{`function *foo(arg1, arg2){}`},
+				Options: optBA(true, false),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9), errUA(9)},
+			},
+			{
+				Code:   `var foo = function*foo(){};`,
+				Output: []string{`var foo = function *foo(){};`},
+				Options: optBA(true, false),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19)},
+			},
+			{
+				Code:   `var foo = function* (){};`,
+				Output: []string{`var foo = function *(){};`},
+				Options: optBA(true, false),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errUA(19)},
+			},
+			{
+				Code:   `var foo = {* foo(){} };`,
+				Output: []string{`var foo = {*foo(){} };`},
+				Options: optBA(true, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(12)},
+			},
+			{
+				Code:   `class Foo {* foo(){} }`,
+				Output: []string{`class Foo {*foo(){} }`},
+				Options: optBA(true, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(12)},
+			},
+
+			// ---- { "before": false, "after": true } ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function* foo(){}`},
+				Options: optBA(false, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(9)},
+			},
+			{
+				Code:   `function *foo(arg1, arg2){}`,
+				Output: []string{`function* foo(arg1, arg2){}`},
+				Options: optBA(false, true),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(10), errMA(10)},
+			},
+			{
+				Code:   `var foo = function *foo(){};`,
+				Output: []string{`var foo = function* foo(){};`},
+				Options: optBA(false, true),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errMA(20)},
+			},
+			{
+				Code:   `var foo = function *(){};`,
+				Output: []string{`var foo = function* (){};`},
+				Options: optBA(false, true),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errMA(20)},
+			},
+			{
+				Code:   `var foo = { *foo(){} };`,
+				Output: []string{`var foo = { * foo(){} };`},
+				Options: optBA(false, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(13)},
+			},
+			{
+				Code:   `class Foo { *foo(){} }`,
+				Output: []string{`class Foo { * foo(){} }`},
+				Options: optBA(false, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(13)},
+			},
+			{
+				Code:   `class Foo { static *foo(){} }`,
+				Output: []string{`class Foo { static* foo(){} }`},
+				Options: optBA(false, true),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errMA(20)},
+			},
+
+			// ---- { "before": true, "after": true } ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function * foo(){}`},
+				Options: optBA(true, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9), errMA(9)},
+			},
+			{
+				Code:   `function*foo(arg1, arg2){}`,
+				Output: []string{`function * foo(arg1, arg2){}`},
+				Options: optBA(true, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9), errMA(9)},
+			},
+			{
+				Code:   `var foo = function*foo(){};`,
+				Output: []string{`var foo = function * foo(){};`},
+				Options: optBA(true, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errMA(19)},
+			},
+			{
+				Code:   `var foo = function*(){};`,
+				Output: []string{`var foo = function * (){};`},
+				Options: optBA(true, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errMA(19)},
+			},
+			{
+				Code:   `var foo = {*foo(){} };`,
+				Output: []string{`var foo = {* foo(){} };`},
+				Options: optBA(true, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(12)},
+			},
+			{
+				Code:   `class Foo {*foo(){} }`,
+				Output: []string{`class Foo {* foo(){} }`},
+				Options: optBA(true, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(12)},
+			},
+			{
+				Code:   `class Foo { static*foo(){} }`,
+				Output: []string{`class Foo { static * foo(){} }`},
+				Options: optBA(true, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errMA(19)},
+			},
+
+			// ---- { "before": false, "after": false } ----
+			{
+				Code:   `function * foo(){}`,
+				Output: []string{`function*foo(){}`},
+				Options: optBA(false, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(10), errUA(10)},
+			},
+			{
+				Code:   `function * foo(arg1, arg2){}`,
+				Output: []string{`function*foo(arg1, arg2){}`},
+				Options: optBA(false, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(10), errUA(10)},
+			},
+			{
+				Code:   `var foo = function * foo(){};`,
+				Output: []string{`var foo = function*foo(){};`},
+				Options: optBA(false, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errUA(20)},
+			},
+			{
+				Code:   `var foo = function * (){};`,
+				Output: []string{`var foo = function*(){};`},
+				Options: optBA(false, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errUA(20)},
+			},
+			{
+				Code:   `var foo = { * foo(){} };`,
+				Output: []string{`var foo = { *foo(){} };`},
+				Options: optBA(false, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(13)},
+			},
+			{
+				Code:   `class Foo { * foo(){} }`,
+				Output: []string{`class Foo { *foo(){} }`},
+				Options: optBA(false, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUA(13)},
+			},
+			{
+				Code:   `class Foo { static * foo(){} }`,
+				Output: []string{`class Foo { static*foo(){} }`},
+				Options: optBA(false, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(20), errUA(20)},
+			},
+
+			// ---- full configurability ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function * foo(){}`},
+				Options: optObj(map[string]any{"before": false, "after": false, "named": "both"}),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9), errMA(9)},
+			},
+			{
+				Code:   `var foo = function*(){};`,
+				Output: []string{`var foo = function * (){};`},
+				Options: optObj(map[string]any{"before": false, "after": false, "anonymous": "both"}),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errMA(19)},
+			},
+			{
+				Code:   `class Foo { *foo(){} }`,
+				Output: []string{`class Foo { * foo(){} }`},
+				Options: optObj(map[string]any{"before": false, "after": false, "method": "both"}),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(13)},
+			},
+			{
+				Code:   `var foo = { *foo(){} }`,
+				Output: []string{`var foo = { * foo(){} }`},
+				Options: optObj(map[string]any{"before": false, "after": false, "method": "both"}),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(13)},
+			},
+			{
+				Code:   `var foo = { bar: function*() {} }`,
+				Output: []string{`var foo = { bar: function * () {} }`},
+				Options: optObj(map[string]any{"before": false, "after": false, "anonymous": "both"}),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(26), errMA(26)},
+			},
+			{
+				Code:   `class Foo { static*foo(){} }`,
+				Output: []string{`class Foo { static * foo(){} }`},
+				Options: optObj(map[string]any{"before": false, "after": false, "method": "both"}),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(19), errMA(19)},
+			},
+			{
+				Code:   `var foo = { *foo(){} }`,
+				Output: []string{`var foo = { * foo(){} }`},
+				Options: optObj(map[string]any{"before": false, "after": false, "shorthand": "both"}),
+				Errors: []rule_tester.InvalidTestCaseError{errMA(13)},
+			},
+
+			// ---- default to top level "before" ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function *foo(){}`},
+				Options: optObj(map[string]any{"method": "both"}),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9)},
+			},
+
+			// ---- don't apply unrelated override ----
+			{
+				Code:   `function * foo(){}`,
+				Output: []string{`function*foo(){}`},
+				Options: optObj(map[string]any{"before": false, "after": false, "method": "both"}),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(10), errUA(10)},
+			},
+
+			// ---- ensure using object-type override works ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function * foo(){}`},
+				Options: optObj(map[string]any{"before": false, "after": false, "named": map[string]any{"before": true, "after": true}}),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9), errMA(9)},
+			},
+
+			// ---- unspecified option uses default ----
+			{
+				Code:   `function*foo(){}`,
+				Output: []string{`function *foo(){}`},
+				Options: optObj(map[string]any{"before": false, "after": false, "named": map[string]any{"before": true}}),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9)},
+			},
+
+			// ---- async generators ----
+			{
+				Code:   `({ async * foo(){} })`,
+				Output: []string{`({ async*foo(){} })`},
+				Options: optBA(false, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(10), errUA(10)},
+			},
+			{
+				Code:   `({ async*foo(){} })`,
+				Output: []string{`({ async * foo(){} })`},
+				Options: optBA(true, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(9), errMA(9)},
+			},
+			{
+				Code:   `class Foo { async * foo(){} }`,
+				Output: []string{`class Foo { async*foo(){} }`},
+				Options: optBA(false, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(19), errUA(19)},
+			},
+			{
+				Code:   `class Foo { async*foo(){} }`,
+				Output: []string{`class Foo { async * foo(){} }`},
+				Options: optBA(true, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(18), errMA(18)},
+			},
+			{
+				Code:   `class Foo { static async * foo(){} }`,
+				Output: []string{`class Foo { static async*foo(){} }`},
+				Options: optBA(false, false),
+				Errors: []rule_tester.InvalidTestCaseError{errUB(26), errUA(26)},
+			},
+			{
+				Code:   `class Foo { static async*foo(){} }`,
+				Output: []string{`class Foo { static async * foo(){} }`},
+				Options: optBA(true, true),
+				Errors: []rule_tester.InvalidTestCaseError{errMB(25), errMA(25)},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -461,6 +461,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/computed-property-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/dot-location.test.ts',
     './tests/eslint-plugin-stylistic/rules/eol-last.test.ts',
+    './tests/eslint-plugin-stylistic/rules/generator-star-spacing.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/generator-star-spacing.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/generator-star-spacing.test.ts
@@ -1,0 +1,152 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('generator-star-spacing', null as never, {
+  valid: [
+    // default ('before')
+    { code: 'function foo(){}' },
+    { code: 'function *foo(){}' },
+    { code: 'var foo = function *foo(){};' },
+    { code: 'var foo = function *(){};' },
+    { code: 'var foo = { *foo(){} };' },
+    { code: 'class Foo { *foo(){} }' },
+    { code: 'class Foo { static *foo(){} }' },
+
+    // 'before'
+    { code: 'function *foo(){}', options: ['before'] },
+    { code: 'var foo = { *foo(){} };', options: ['before'] },
+
+    // 'after'
+    { code: 'function* foo(){}', options: ['after'] },
+    { code: 'var foo = { * foo(){} };', options: ['after'] },
+    { code: 'class Foo { static* foo(){} }', options: ['after'] },
+
+    // 'both'
+    { code: 'function * foo(){}', options: ['both'] },
+
+    // 'neither'
+    { code: 'function*foo(){}', options: ['neither'] },
+
+    // object form
+    { code: 'function *foo(){}', options: [{ before: true, after: false }] },
+    { code: 'function* foo(){}', options: [{ before: false, after: true }] },
+
+    // full configurability
+    {
+      code: 'class Foo { * foo(){} }',
+      options: [{ before: false, after: false, method: 'both' }],
+    },
+    {
+      code: 'var foo = { * foo(){} }',
+      options: [{ before: false, after: false, shorthand: 'both' }],
+    },
+    {
+      code: 'function * foo(){}',
+      options: [
+        { before: false, after: false, named: { before: true, after: true } },
+      ],
+    },
+
+    // non-generator: rule must not flag
+    { code: 'async function foo() { }' },
+    { code: 'class A { async foo() { } }' },
+  ],
+
+  invalid: [
+    // default ('before')
+    {
+      code: 'function*foo(){}',
+      output: 'function *foo(){}',
+      errors: [{ messageId: 'missingBefore', line: 1, column: 9 }],
+    },
+    {
+      code: 'function* foo(arg1, arg2){}',
+      output: 'function *foo(arg1, arg2){}',
+      errors: [
+        { messageId: 'missingBefore', line: 1, column: 9 },
+        { messageId: 'unexpectedAfter', line: 1, column: 9 },
+      ],
+    },
+    {
+      code: 'class Foo { static* foo(){} }',
+      output: 'class Foo { static *foo(){} }',
+      errors: [
+        { messageId: 'missingBefore', line: 1, column: 19 },
+        { messageId: 'unexpectedAfter', line: 1, column: 19 },
+      ],
+    },
+
+    // 'after'
+    {
+      code: 'function *foo(){}',
+      output: 'function* foo(){}',
+      options: ['after'],
+      errors: [
+        { messageId: 'unexpectedBefore', line: 1, column: 10 },
+        { messageId: 'missingAfter', line: 1, column: 10 },
+      ],
+    },
+
+    // 'both'
+    {
+      code: 'function*foo(){}',
+      output: 'function * foo(){}',
+      options: ['both'],
+      errors: [
+        { messageId: 'missingBefore', line: 1, column: 9 },
+        { messageId: 'missingAfter', line: 1, column: 9 },
+      ],
+    },
+
+    // 'neither'
+    {
+      code: 'function * foo(){}',
+      output: 'function*foo(){}',
+      options: ['neither'],
+      errors: [
+        { messageId: 'unexpectedBefore', line: 1, column: 10 },
+        { messageId: 'unexpectedAfter', line: 1, column: 10 },
+      ],
+    },
+
+    // method override
+    {
+      code: 'class Foo { *foo(){} }',
+      output: 'class Foo { * foo(){} }',
+      options: [{ before: false, after: false, method: 'both' }],
+      errors: [{ messageId: 'missingAfter', line: 1, column: 13 }],
+    },
+
+    // anonymous override
+    {
+      code: 'var foo = function*(){};',
+      output: 'var foo = function * (){};',
+      options: [{ before: false, after: false, anonymous: 'both' }],
+      errors: [
+        { messageId: 'missingBefore', line: 1, column: 19 },
+        { messageId: 'missingAfter', line: 1, column: 19 },
+      ],
+    },
+
+    // async generator
+    {
+      code: '({ async*foo(){} })',
+      output: '({ async * foo(){} })',
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'missingBefore', line: 1, column: 9 },
+        { messageId: 'missingAfter', line: 1, column: 9 },
+      ],
+    },
+    {
+      code: 'class Foo { static async*foo(){} }',
+      output: 'class Foo { static async * foo(){} }',
+      options: [{ before: true, after: true }],
+      errors: [
+        { messageId: 'missingBefore', line: 1, column: 25 },
+        { messageId: 'missingAfter', line: 1, column: 25 },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the \`@stylistic/generator-star-spacing\` rule from \`@stylistic/eslint-plugin\` to rslint.

The rule enforces consistent spacing around the \`*\` in generator function declarations, function expressions, class methods, and object shorthand methods. Accepts the upstream string shortcuts (\`before\` / \`after\` / \`both\` / \`neither\`) and the object form with per-kind overrides (\`named\` / \`anonymous\` / \`method\` / \`shorthand\`), including the \`shorthand ?? method\` fallback.

## Related Links

- ESLint rule: https://eslint.style/rules/generator-star-spacing
- Source code: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/generator-star-spacing/generator-star-spacing.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).