### PR TITLE
feat: port rule @stylistic/jsx-closing-bracket-location

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -13,6 +13,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/dot_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/eol_last"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/generator_star_spacing"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_closing_bracket_location"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -30,5 +31,6 @@ func GetAllRules() []rule.Rule {
 		dot_location.DotLocationRule,
 		eol_last.EolLastRule,
 		generator_star_spacing.GeneratorStarSpacingRule,
+		jsx_closing_bracket_location.JsxClosingBracketLocationRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/jsx_closing_bracket_location/jsx_closing_bracket_location.go
+++ b/internal/plugins/stylistic/rules/jsx_closing_bracket_location/jsx_closing_bracket_location.go
@@ -1,0 +1,546 @@
+// Package jsx_closing_bracket_location ports `@stylistic/jsx-closing-bracket-location`
+// to rslint. Behavior mirrors the upstream rule (which originated as
+// `react/jsx-closing-bracket-location` and added trailing-comment handling
+// when it moved into eslint-stylistic). The trailing-comment branch — when
+// expectedLocation is `after-props` or `after-tag` but a comment sits between
+// the last attribute (or the tag name, in the zero-prop case) and the closing
+// bracket, the location is upgraded to `line-aligned` — is the principal
+// semantic delta vs. `react/jsx-closing-bracket-location`.
+package jsx_closing_bracket_location
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const defaultLocation = "tag-aligned"
+
+var locationMessages = map[string]string{
+	"after-props":   "placed after the last prop",
+	"after-tag":     "placed after the opening tag",
+	"props-aligned": "aligned with the last prop",
+	"tag-aligned":   "aligned with the opening tag",
+	"line-aligned":  "aligned with the line containing the opening tag",
+}
+
+type bracketOptions struct {
+	nonEmpty       string
+	selfClosing    string
+	nonEmptyOff    bool
+	selfClosingOff bool
+}
+
+// parseOptions accepts every shape upstream's JSON schema permits:
+//
+//	string                              → both nonEmpty & selfClosing
+//	{ location: string }                → both nonEmpty & selfClosing
+//	{ nonEmpty?: string|false,
+//	  selfClosing?: string|false }      → per-form configuration
+//
+// rslint's CLI / config loader collapses a single-element option array into
+// the option value directly, so the rule may receive any of `string`,
+// `map[string]interface{}`, or `[]interface{}` at the top level. We accept all
+// three to stay byte-compatible with both the JS rule-tester and the
+// production CLI shape.
+func parseOptions(options any) bracketOptions {
+	opts := bracketOptions{nonEmpty: defaultLocation, selfClosing: defaultLocation}
+	if options == nil {
+		return opts
+	}
+
+	raw := options
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) == 0 {
+			return opts
+		}
+		raw = arr[0]
+	}
+
+	switch v := raw.(type) {
+	case string:
+		opts.nonEmpty = v
+		opts.selfClosing = v
+	case map[string]interface{}:
+		applyMap(&opts, v)
+	}
+	return opts
+}
+
+func applyMap(opts *bracketOptions, m map[string]interface{}) {
+	// Upstream's `'location' in config!` makes the two object shapes
+	// mutually exclusive: if `location` is present, nonEmpty / selfClosing
+	// are IGNORED (upstream destructures `{ nonEmpty: config.location,
+	// selfClosing: config.location }` and never reads the other keys). The
+	// JSON schema rejects mixing them upstream-side; rslint has no schema
+	// validation, so we enforce the same precedence here in code to keep
+	// runtime behavior identical on any input the user might pass.
+	if v, exists := m["location"]; exists {
+		if s, ok := v.(string); ok {
+			opts.nonEmpty = s
+			opts.selfClosing = s
+		}
+		return
+	}
+	if v, exists := m["nonEmpty"]; exists {
+		if s, ok := v.(string); ok {
+			opts.nonEmpty = s
+			opts.nonEmptyOff = false
+		} else if b, ok := v.(bool); ok && !b {
+			opts.nonEmptyOff = true
+		}
+	}
+	if v, exists := m["selfClosing"]; exists {
+		if s, ok := v.(string); ok {
+			opts.selfClosing = s
+			opts.selfClosingOff = false
+		} else if b, ok := v.(bool); ok && !b {
+			opts.selfClosingOff = true
+		}
+	}
+}
+
+type tokenInfo struct {
+	openingPos    int
+	openingLine   int
+	openingColumn int
+
+	closingPos    int
+	closingLine   int
+	closingColumn int
+
+	tagLine int
+
+	hasLastProp       bool
+	lastPropEnd       int
+	lastPropFirstLine int
+	lastPropLastLine  int
+	lastPropColumn    int
+
+	openingStartCol int
+
+	openTab  bool
+	closeTab bool
+
+	selfClosing bool
+
+	// Trailing-comment span. `hasTrailingComment` is upstream's
+	//   lastComment.range[0] > (lastAttributeNode ?? node.name).range[1]
+	// — i.e. the last comment **inside** the opening element starts AFTER the
+	// last attribute (or the tag name when there are no attributes). When set,
+	// the fix's range start is moved to lastCommentEnd so the comment isn't
+	// swept into the rewrite.
+	hasTrailingComment bool
+	lastCommentEnd     int
+}
+
+func leadingWhitespace(text string, lineStart int) string {
+	if lineStart >= len(text) {
+		return ""
+	}
+	return reactutil.HorizontalWhitespacePrefix(text[lineStart:])
+}
+
+// JsxClosingBracketLocationRule enforces closing bracket location for JSX
+// multiline elements.
+var JsxClosingBracketLocationRule = rule.Rule{
+	Name: "@stylistic/jsx-closing-bracket-location",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		check := func(node *ast.Node) {
+			var tagName *ast.Node
+			var attrs []*ast.Node
+			var selfClosing bool
+
+			switch node.Kind {
+			case ast.KindJsxOpeningElement:
+				opening := node.AsJsxOpeningElement()
+				tagName = opening.TagName
+				if opening.Attributes != nil {
+					jsxAttrs := opening.Attributes.AsJsxAttributes()
+					if jsxAttrs.Properties != nil {
+						attrs = jsxAttrs.Properties.Nodes
+					}
+				}
+				selfClosing = false
+			case ast.KindJsxSelfClosingElement:
+				self := node.AsJsxSelfClosingElement()
+				tagName = self.TagName
+				if self.Attributes != nil {
+					jsxAttrs := self.Attributes.AsJsxAttributes()
+					if jsxAttrs.Properties != nil {
+						attrs = jsxAttrs.Properties.Nodes
+					}
+				}
+				selfClosing = true
+			default:
+				return
+			}
+
+			// Parser error recovery: an incomplete `<` may produce a JSX
+			// opening element with a missing tag name. Skip gracefully —
+			// upstream's `getFirstToken(node.name)` would also throw.
+			if tagName == nil {
+				return
+			}
+
+			text := ctx.SourceFile.Text()
+			lineStarts := ctx.SourceFile.ECMALineMap()
+
+			elemTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			openingPos := elemTrimmed.Pos()
+			elemEnd := elemTrimmed.End()
+
+			// elemEnd should land right after the closing `>`. The reverse
+			// scan is defensive against parser recovery shapes that emit
+			// trailing trivia. If `>` is genuinely absent (truncated source),
+			// bail.
+			gtPos := elemEnd - 1
+			for gtPos > openingPos && gtPos < len(text) && text[gtPos] != '>' {
+				gtPos--
+			}
+			if gtPos < 0 || gtPos >= len(text) || text[gtPos] != '>' {
+				return
+			}
+
+			closingPos := gtPos
+			if selfClosing {
+				slash := gtPos - 1
+				for slash > openingPos && (text[slash] == ' ' || text[slash] == '\t' || text[slash] == '\n' || text[slash] == '\r') {
+					slash--
+				}
+				if slash <= openingPos || text[slash] != '/' {
+					return
+				}
+				closingPos = slash
+			}
+
+			openingLine := scanner.ComputeLineOfPosition(lineStarts, openingPos)
+			openingLineStart := int(lineStarts[openingLine])
+			openingColumn := reactutil.UTF16Length(text[openingLineStart:openingPos])
+
+			closingLine := scanner.ComputeLineOfPosition(lineStarts, closingPos)
+			closingLineStart := int(lineStarts[closingLine])
+			closingColumn := reactutil.UTF16Length(text[closingLineStart:closingPos])
+
+			tagTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, tagName)
+			tagLine := scanner.ComputeLineOfPosition(lineStarts, tagTrimmed.Pos())
+
+			openingStartIndent := leadingWhitespace(text, openingLineStart)
+
+			info := tokenInfo{
+				openingPos:      openingPos,
+				openingLine:     openingLine,
+				openingColumn:   openingColumn,
+				closingPos:      closingPos,
+				closingLine:     closingLine,
+				closingColumn:   closingColumn,
+				tagLine:         tagLine,
+				openingStartCol: reactutil.UTF16Length(openingStartIndent),
+				openTab:         openingLineStart < len(text) && text[openingLineStart] == '\t',
+				closeTab:        closingLineStart < len(text) && text[closingLineStart] == '\t',
+				selfClosing:     selfClosing,
+			}
+
+			if len(attrs) > 0 {
+				lastProp := attrs[len(attrs)-1]
+				lpTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, lastProp)
+				lpStart := lpTrimmed.Pos()
+				lpEnd := lpTrimmed.End()
+				lpFirstLine := scanner.ComputeLineOfPosition(lineStarts, lpStart)
+				lpLastLine := scanner.ComputeLineOfPosition(lineStarts, lpEnd-1)
+				lpLineStart := int(lineStarts[lpFirstLine])
+				lpColumn := reactutil.UTF16Length(text[lpLineStart:lpStart])
+				info.hasLastProp = true
+				info.lastPropEnd = lpEnd
+				info.lastPropFirstLine = lpFirstLine
+				info.lastPropLastLine = lpLastLine
+				info.lastPropColumn = lpColumn
+			}
+
+			// Locate the last comment **inside** the opening element that sits
+			// AFTER the last attribute (or the tag name when zero attributes).
+			// Mirrors upstream's `sourceCode.getCommentsInside(node).at(-1)` +
+			// `lastComment.range[0] > (lastAttributeNode ?? node.name).range[1]`.
+			gateEnd := tagTrimmed.End()
+			if info.hasLastProp {
+				gateEnd = info.lastPropEnd
+			}
+			info.hasTrailingComment, info.lastCommentEnd = findTrailingComment(text, gateEnd, closingPos)
+
+			expectedLocation, disabled := getExpectedLocation(info, opts)
+			if disabled {
+				return
+			}
+
+			usingSameIndentation := true
+			if expectedLocation == "tag-aligned" {
+				usingSameIndentation = info.openTab == info.closeTab
+			}
+
+			// Upstream upgrade: when expectedLocation is `after-props` or
+			// `after-tag` and the bracket is misplaced AND a trailing comment
+			// exists, switch to `line-aligned`. Without this branch the fix
+			// would move the closing bracket onto the comment's line, breaking
+			// the comment.
+			if (expectedLocation == "after-props" || expectedLocation == "after-tag") &&
+				(!hasCorrectLocation(info, expectedLocation) || !usingSameIndentation) &&
+				info.hasTrailingComment {
+				expectedLocation = "line-aligned"
+			}
+
+			if hasCorrectLocation(info, expectedLocation) && usingSameIndentation {
+				return
+			}
+
+			locationDesc, ok := locationMessages[expectedLocation]
+			if !ok {
+				return
+			}
+
+			details := ""
+			expectedNextLine := info.hasLastProp && info.lastPropLastLine == info.closingLine
+			correctColumn, hasCorrectColumn := getCorrectColumn(info, expectedLocation)
+			if hasCorrectColumn {
+				if expectedNextLine {
+					details = fmt.Sprintf(" (expected column %d on the next line)", correctColumn+1)
+				} else {
+					details = fmt.Sprintf(" (expected column %d)", correctColumn+1)
+				}
+			}
+
+			fix := buildFix(text, info, expectedLocation, expectedNextLine, correctColumn, lineStarts, elemEnd, tagTrimmed.End(), selfClosing)
+
+			msg := rule.RuleMessage{
+				Id:          "bracketLocation",
+				Description: fmt.Sprintf("The closing bracket must be %s%s", locationDesc, details),
+			}
+
+			closingEnd := closingPos + 1
+			if closingEnd > len(text) {
+				closingEnd = len(text)
+			}
+			reportRange := core.NewTextRange(closingPos, closingEnd)
+
+			if fix != nil {
+				ctx.ReportRangeWithFixes(reportRange, msg, *fix)
+			} else {
+				ctx.ReportRange(reportRange, msg)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}
+
+func getExpectedLocation(info tokenInfo, opts bracketOptions) (string, bool) {
+	if !info.hasLastProp {
+		return "after-tag", false
+	}
+	if info.openingLine == info.lastPropLastLine {
+		return "after-props", false
+	}
+	if info.selfClosing {
+		if opts.selfClosingOff {
+			return "", true
+		}
+		return opts.selfClosing, false
+	}
+	if opts.nonEmptyOff {
+		return "", true
+	}
+	return opts.nonEmpty, false
+}
+
+func hasCorrectLocation(info tokenInfo, expectedLocation string) bool {
+	switch expectedLocation {
+	case "after-tag":
+		return info.tagLine == info.closingLine
+	case "after-props":
+		return info.lastPropLastLine == info.closingLine
+	case "props-aligned", "tag-aligned", "line-aligned":
+		col, ok := getCorrectColumn(info, expectedLocation)
+		if !ok {
+			return true
+		}
+		return col == info.closingColumn
+	default:
+		return true
+	}
+}
+
+func getCorrectColumn(info tokenInfo, expectedLocation string) (int, bool) {
+	switch expectedLocation {
+	case "props-aligned":
+		if !info.hasLastProp {
+			return 0, false
+		}
+		return info.lastPropColumn, true
+	case "tag-aligned":
+		return info.openingColumn, true
+	case "line-aligned":
+		return info.openingStartCol, true
+	default:
+		return 0, false
+	}
+}
+
+func getIndentation(text string, lineStarts []core.TextPos, info tokenInfo, expectedLocation string, correctColumn int) string {
+	var indent string
+	switch expectedLocation {
+	case "props-aligned":
+		if info.hasLastProp {
+			indent = leadingWhitespace(text, int(lineStarts[info.lastPropFirstLine]))
+		}
+	case "tag-aligned", "line-aligned":
+		indent = leadingWhitespace(text, int(lineStarts[info.openingLine]))
+	}
+	indentUTF16 := reactutil.UTF16Length(indent)
+	if indentUTF16+1 < correctColumn+1 {
+		// Non-whitespace characters precede the bracket on the reference line —
+		// pad with spaces so the column matches.
+		if correctColumn > indentUTF16 {
+			indent = indent + strings.Repeat(" ", correctColumn-indentUTF16)
+		}
+	}
+	return indent
+}
+
+func buildFix(text string, info tokenInfo, expectedLocation string, expectedNextLine bool, correctColumn int, lineStarts []core.TextPos, elemEnd int, tagNameEnd int, selfClosing bool) *rule.RuleFix {
+	closingTag := ">"
+	if selfClosing {
+		closingTag = "/>"
+	}
+
+	var start, end int
+	var newText string
+
+	switch expectedLocation {
+	case "after-tag":
+		if info.hasLastProp {
+			start = info.lastPropEnd
+			end = elemEnd
+			if expectedNextLine {
+				newText = "\n" + closingTag
+			} else {
+				newText = closingTag
+			}
+		} else {
+			start = tagNameEnd
+			end = elemEnd
+			if expectedNextLine {
+				newText = "\n" + closingTag
+			} else {
+				newText = " " + closingTag
+			}
+		}
+	case "after-props":
+		if !info.hasLastProp {
+			return nil
+		}
+		start = info.lastPropEnd
+		end = elemEnd
+		if expectedNextLine {
+			newText = "\n" + closingTag
+		} else {
+			newText = closingTag
+		}
+	case "props-aligned", "tag-aligned", "line-aligned":
+		// Upstream's `rangeStart = hasTrailingComment ? lastComment.range[1] :
+		// cachedLastAttributeEndPos`. When a trailing comment exists, rewrite
+		// from the byte AFTER the comment so the comment text stays intact.
+		if info.hasTrailingComment {
+			start = info.lastCommentEnd
+		} else if info.hasLastProp {
+			start = info.lastPropEnd
+		} else {
+			// Zero attributes AND no trailing comment — upstream's fixer
+			// returns null for this branch (the `cachedLastAttributeEndPos`
+			// it relies on is null). Mirror that: emit no fix.
+			return nil
+		}
+		end = elemEnd
+		indent := getIndentation(text, lineStarts, info, expectedLocation, correctColumn)
+		newText = "\n" + indent + closingTag
+	default:
+		return nil
+	}
+
+	return &rule.RuleFix{
+		Text:  newText,
+		Range: core.NewTextRange(start, end),
+	}
+}
+
+// findTrailingComment scans the byte range [gateEnd, closingPos) for `//` or
+// `/* ... */` comments and returns whether one was found AND the end position
+// of the LAST such comment (matching upstream's `at(-1)` selection). The scan
+// is byte-oriented because (a) the scanner skips comment tokens — they are
+// gone from the token stream by the time the rule visits the parent node, and
+// (b) the bytes between the last attribute end and the closing bracket are by
+// construction pure trivia (whitespace + comments only — no string / regex /
+// template literal content can appear between attributes in an opening tag).
+func findTrailingComment(text string, gateEnd, closingPos int) (bool, int) {
+	if gateEnd < 0 {
+		gateEnd = 0
+	}
+	if closingPos > len(text) {
+		closingPos = len(text)
+	}
+	if gateEnd >= closingPos {
+		return false, 0
+	}
+	found := false
+	lastEnd := 0
+	i := gateEnd
+	for i < closingPos {
+		c := text[i]
+		switch {
+		case c == '/' && i+1 < closingPos && text[i+1] == '/':
+			// Line comment: consume up to the next LineTerminator (LF / CR /
+			// LS / PS). The comment's end is the byte BEFORE the terminator,
+			// matching ESLint's `Comment.range[1]` (exclusive of trailing \n).
+			j := i + 2
+			for j < closingPos {
+				b := text[j]
+				if b == '\n' || b == '\r' {
+					break
+				}
+				if b == 0xE2 && j+2 < closingPos && text[j+1] == 0x80 &&
+					(text[j+2] == 0xA8 || text[j+2] == 0xA9) {
+					break
+				}
+				j++
+			}
+			found = true
+			lastEnd = j
+			i = j
+		case c == '/' && i+1 < closingPos && text[i+1] == '*':
+			// Block comment: consume up to and including `*/`.
+			j := i + 2
+			for j+1 < closingPos {
+				if text[j] == '*' && text[j+1] == '/' {
+					j += 2
+					break
+				}
+				j++
+			}
+			found = true
+			lastEnd = j
+			i = j
+		default:
+			i++
+		}
+	}
+	return found, lastEnd
+}

--- a/internal/plugins/stylistic/rules/jsx_closing_bracket_location/jsx_closing_bracket_location.md
+++ b/internal/plugins/stylistic/rules/jsx_closing_bracket_location/jsx_closing_bracket_location.md
@@ -1,0 +1,180 @@
+# jsx-closing-bracket-location
+
+Enforce closing bracket location in JSX.
+
+## Rule Details
+
+This rule checks the location of the closing bracket (`>` for opening tags, `/>` for self-closing tags) of a multiline JSX element. When the opening tag's last attribute (or, in the zero-attribute form, the tag name) is followed by a trailing comment inside the opening element, the configured `after-props` / `after-tag` location is upgraded to `line-aligned` so the fix does not move the comment onto the bracket's line.
+
+## Options
+
+This rule has a string option:
+
+- `"tag-aligned"` (default) — closing bracket aligned with the column of the opening `<`.
+- `"line-aligned"` — closing bracket aligned with the indentation of the line containing the opening tag.
+- `"props-aligned"` — closing bracket aligned with the column of the last attribute.
+- `"after-props"` — closing bracket placed immediately after the last attribute (no leading whitespace).
+
+This rule has an object option:
+
+- `"location"` — string value (any of the four above). Sets the same location for both self-closing and non-self-closing forms. When present, `nonEmpty` and `selfClosing` are ignored.
+- `"nonEmpty"` — string value or `false`. Location for non-self-closing tags (`<Foo>…</Foo>`). `false` disables the rule for this form.
+- `"selfClosing"` — string value or `false`. Location for self-closing tags (`<Foo />`). `false` disables the rule for this form.
+
+### tag-aligned
+
+Examples of **incorrect** code for this rule with the default `"tag-aligned"` option:
+
+```javascript
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+    />;
+
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+  />;
+```
+
+Examples of **correct** code for this rule with the default `"tag-aligned"` option:
+
+```javascript
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+/>;
+
+var x = <Hello firstName="John" lastName="Smith" />;
+```
+
+### line-aligned
+
+Examples of **incorrect** code for this rule with the `"line-aligned"` option:
+
+```json
+{ "@stylistic/jsx-closing-bracket-location": ["error", "line-aligned"] }
+```
+
+```javascript
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+    />;
+```
+
+Examples of **correct** code for this rule with the `"line-aligned"` option:
+
+```json
+{ "@stylistic/jsx-closing-bracket-location": ["error", "line-aligned"] }
+```
+
+```javascript
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+/>;
+```
+
+### props-aligned
+
+Examples of **incorrect** code for this rule with the `"props-aligned"` option:
+
+```json
+{ "@stylistic/jsx-closing-bracket-location": ["error", "props-aligned"] }
+```
+
+```javascript
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+/>;
+```
+
+Examples of **correct** code for this rule with the `"props-aligned"` option:
+
+```json
+{ "@stylistic/jsx-closing-bracket-location": ["error", "props-aligned"] }
+```
+
+```javascript
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+  />;
+```
+
+### after-props
+
+Examples of **incorrect** code for this rule with the `"after-props"` option:
+
+```json
+{ "@stylistic/jsx-closing-bracket-location": ["error", "after-props"] }
+```
+
+```javascript
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+/>;
+```
+
+Examples of **correct** code for this rule with the `"after-props"` option:
+
+```json
+{ "@stylistic/jsx-closing-bracket-location": ["error", "after-props"] }
+```
+
+```javascript
+var x = <Hello
+  firstName="John"
+  lastName="Smith"/>;
+```
+
+### nonEmpty
+
+Examples of **correct** code for this rule with the `{ "nonEmpty": "after-props" }` option (the closing bracket of non-self-closing tags must sit after the last prop; self-closing tags keep the default `"tag-aligned"`):
+
+```json
+{ "@stylistic/jsx-closing-bracket-location": ["error", { "nonEmpty": "after-props" }] }
+```
+
+```javascript
+<Provider
+  store>
+  <App
+    foo
+  />
+</Provider>
+```
+
+Setting `"nonEmpty": false` disables the rule for non-self-closing tags entirely:
+
+```json
+{ "@stylistic/jsx-closing-bracket-location": ["error", { "nonEmpty": false }] }
+```
+
+### selfClosing
+
+Examples of **correct** code for this rule with the `{ "selfClosing": "after-props" }` option (the closing bracket of self-closing tags must sit after the last prop; non-self-closing tags keep the default `"tag-aligned"`):
+
+```json
+{ "@stylistic/jsx-closing-bracket-location": ["error", { "selfClosing": "after-props" }] }
+```
+
+```javascript
+<Provider store>
+  <App
+    foo />
+</Provider>
+```
+
+Setting `"selfClosing": false` disables the rule for self-closing tags entirely:
+
+```json
+{ "@stylistic/jsx-closing-bracket-location": ["error", { "selfClosing": false }] }
+```
+
+## Original Documentation
+
+- [@stylistic/jsx-closing-bracket-location](https://eslint.style/rules/jsx-closing-bracket-location)

--- a/internal/plugins/stylistic/rules/jsx_closing_bracket_location/jsx_closing_bracket_location_extras_test.go
+++ b/internal/plugins/stylistic/rules/jsx_closing_bracket_location/jsx_closing_bracket_location_extras_test.go
@@ -1,0 +1,562 @@
+// TestJsxClosingBracketLocationExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Each case carries an inline
+// comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk
+// it covers, so future refactors can't silently regress them without breaking
+// a named lock-in.
+//
+// stylistic-specific delta vs. react/jsx-closing-bracket-location: the
+// trailing-comment-upgrades-after-tag/after-props-to-line-aligned branch is
+// unique to this rule. Several lock-ins below name that branch directly so
+// regressing it surfaces immediately.
+package jsx_closing_bracket_location
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxClosingBracketLocationExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxClosingBracketLocationRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: receiver / tag-name forms ----
+		// JsxMemberExpression tag (`<Foo.Bar />`) — after-tag, no props.
+		{Code: `<Foo.Bar />`, Tsx: true},
+		// JsxMemberExpression tag, multi-line — default tag-aligned.
+		{Code: "<Foo.Bar\n  foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		// JsxNamespacedName tag (`<svg:circle />`) — after-tag.
+		{Code: `<svg:circle />`, Tsx: true},
+		// TS type arguments (`<App<T> foo />`) — single line, after-props.
+		{Code: `<App<T> foo />`, Tsx: true},
+		// TS type arguments, multi-line tag-aligned.
+		{Code: "<App<T>\n  foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+
+		// ---- Dimension 4: '>' inside attribute expression must not be confused ----
+		// `x > y` inside `{}` is a valid expression; closing-detection must
+		// pick the JSX-element '>' / '/' at the end.
+		{Code: `<App foo={x > y} />`, Tsx: true},
+		// Nested JSX as attribute value — both elements are valid.
+		{Code: `<App content={<Foo />} />`, Tsx: true},
+		{Code: "<App\n  content={<Foo />}\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+
+		// ---- Dimension 4: TS-only expression wrappers in attribute values ----
+		// `as`, `satisfies`, `!`, `?.` — all may contain `>` and must not
+		// disturb closing detection.
+		{Code: `<App foo={x as T} />`, Tsx: true},
+		{Code: `<App foo={x!} />`, Tsx: true},
+		{Code: `<App foo={x?.y} />`, Tsx: true},
+		{Code: `<App foo={x satisfies T} />`, Tsx: true},
+
+		// ---- Dimension 4: spread attribute as last prop ----
+		// `{...rest}` is JsxSpreadAttribute (not JsxAttribute); the
+		// lastProp-driven column should still be the spread's column.
+		{Code: `<App {...props} />`, Tsx: true},
+		{Code: "<App\n  foo\n  {...rest}\n/>", Tsx: true},
+		// Spread is last prop, props-aligned.
+		{Code: "<App\n  foo\n  {...rest}\n  />", Tsx: true, Options: map[string]interface{}{"location": "props-aligned"}},
+
+		// ---- Dimension 4: nesting boundaries ----
+		// Multi-level nested elements — every OpeningElement processed
+		// independently, no boundary leak.
+		{Code: "<App>\n  <B>\n    <C />\n  </B>\n</App>", Tsx: true},
+		// Fragment containing inner element — fragments are NOT JsxOpening/
+		// SelfClosing kinds, so they don't fire this rule; inner element does.
+		{Code: "<>\n  <App foo />\n</>", Tsx: true},
+
+		// ---- Dimension 4: graceful degradation ----
+		// Empty attribute list. `<App></App>` non-self-closing zero attrs.
+		{Code: `<App></App>`, Tsx: true},
+		// `<App />` single-line — after-tag passes (tag.line === closing.line).
+		{Code: `<App />`, Tsx: true},
+
+		// ---- Options JSON path robustness (CLI / rule_tester / map / array shapes) ----
+		// Array-wrapped string.
+		{Code: `<App foo />`, Tsx: true, Options: []interface{}{"after-props"}},
+		// Array-wrapped map.
+		{Code: `<App foo />`, Tsx: true, Options: []interface{}{map[string]interface{}{"location": "after-props"}}},
+		// Empty array of options falls back to defaults.
+		{Code: `<App />`, Tsx: true, Options: []interface{}{}},
+		// nonEmpty:false alone — closing of `<App\n>...</App>` unchecked.
+		{Code: "<App\n  foo\n  ></App>", Tsx: true, Options: map[string]interface{}{"nonEmpty": false}},
+		// selfClosing:false alone — closing of `<App\n  foo\n  />` unchecked.
+		{Code: "<App\n  foo\n  />", Tsx: true, Options: map[string]interface{}{"selfClosing": false}},
+
+		// ---- Real-user: CRLF line terminators (Windows) ----
+		{Code: "<App\r\n  foo\r\n/>", Tsx: true},
+		// CRLF with nested provider.
+		{Code: "<Provider\r\n  store\r\n>\r\n  <App\r\n    foo\r\n  />\r\n</Provider>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+
+		// ---- Real-user: JSX expression-internal comments ----
+		// `/* */` inside attribute value expression — comment trivia inside
+		// `{}` is at JS comment level, NOT a JSX trailing comment, so it
+		// must NOT trigger the after-tag/after-props upgrade.
+		{Code: `<App foo={/* leading */ 1} />`, Tsx: true},
+		// `//` comment inside expression on its own line.
+		{Code: "<App\n  foo={\n    // line comment\n    1\n  }\n/>", Tsx: true},
+
+		// ---- Locks in `findTrailingComment` discriminator ----
+		// Comment INSIDE attribute value `{}` should NOT count as a trailing
+		// comment relative to the last attribute — it's inside the
+		// attribute's source range, not in the trivia after it.
+		{Code: "<App\n  foo={/* x */ 1}\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+
+		// ---- JSX as arrow-fn body / ternary branch / logical-AND ----
+		{Code: "var f = () => <App\n  foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		{Code: "var x = cond && <App\n  foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		{Code: "var x = cond ? <App\n  foo\n/> : null", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+
+		// ---- options nil / empty / unknown shapes degrade to defaults ----
+		// nil options → tag-aligned default applied.
+		{Code: `<App />`, Tsx: true, Options: nil},
+		// Empty map options → defaults.
+		{Code: `<App />`, Tsx: true, Options: map[string]interface{}{}},
+		// Unknown enum string → falls back to that value being used as a
+		// location key; hasCorrectLocation returns true on unknown, so no
+		// report on the simple `<App />` form.
+		{Code: `<App />`, Tsx: true, Options: "unknown-location-value"},
+		// `location` form sets both nonEmpty and selfClosing.
+		{Code: "<App\n  foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		// `location` and `nonEmpty/selfClosing` are mutually exclusive
+		// upstream-side via `'location' in config!`. When `location` is
+		// present, the per-form keys are IGNORED — even though the JSON
+		// schema rejects this mix, rslint's runtime preserves the same
+		// precedence. Here both keys say tag-aligned (selfClosing override
+		// would say props-aligned, but is ignored).
+		{Code: "<App\n  foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned", "selfClosing": "props-aligned"}},
+		{Code: "<App\n  foo\n></App>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned", "nonEmpty": "props-aligned"}},
+
+		// ---- Dimension 4: attribute value robustness ----
+		// Regex literal containing '>' in attribute expression — closing
+		// detection must not be confused.
+		{Code: `<App pattern={/>/} />`, Tsx: true},
+		// Template literal with embedded expression containing '>'.
+		{Code: "<App t={`${a > b}`} />", Tsx: true},
+		// String literal containing JSX-like text.
+		{Code: `<App title="<X>" />`, Tsx: true},
+		// Multi-line array literal as attribute value, single-line outer
+		// element — opening line != lastProp.lastLine, so 'after-props' does
+		// NOT collapse; goes to default tag-aligned.
+		{Code: "<App foo={[\n  1,\n  2,\n]}\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+
+		// ---- Dimension 4: deeply nested elements (5 levels) ----
+		// Lock-in: each opening element checked independently; no boundary
+		// leak between levels. All levels self-closing, single-line — no
+		// reports.
+		{Code: `<L1><L2><L3><L4><L5 /></L4></L3></L2></L1>`, Tsx: true},
+		// Same, multi-line at innermost; tag-aligned should match per-level.
+		{Code: "<L1>\n  <L2>\n    <L3>\n      <L4>\n        <L5\n          foo\n        />\n      </L4>\n    </L3>\n  </L2>\n</L1>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+
+		// ---- Real-user: long lastProp spanning many lines (object literal) ----
+		{
+			Code: "<App\n  config={{\n    a: 1,\n    b: 2,\n    c: {\n      nested: true,\n    },\n  }}\n/>",
+			Tsx:  true,
+		},
+		// ---- Real-user: JSX attribute name with hyphen (data-*, aria-*) ----
+		{Code: `<div data-testid="x" aria-label="y" />`, Tsx: true},
+		{Code: "<div\n  data-testid=\"x\"\n  aria-label=\"y\"\n/>", Tsx: true},
+
+		// ---- Dimension 4: TypeScript nested generic with `>>` token ----
+		// `Map<K, V>>` produces nested `>` chars. tsgo parses type-args
+		// separately; elemEnd is still after JSX closing `>`. The reverse
+		// gtPos scan must land on the JSX `>`, not a type-arg `>`.
+		{Code: `<App<Map<string, number>> foo />`, Tsx: true},
+		{Code: "<App<Map<string, number>>\n  foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		// Triple-nested generic.
+		{Code: "<App<Promise<Map<string, Array<number>>>>\n  foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+
+		// ---- Dimension 4: complex generic with object type literal ----
+		{Code: "<App<{ a: number; b: string }>\n  foo\n/>", Tsx: true},
+
+		// ---- Dimension 4: JSX as expression statement in various contexts ----
+		// throw expression — `/>` tag-aligned to `<Err` column (8).
+		{Code: "function f() {\n  throw <Err\n          code={1}\n        />;\n}", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		// yield in generator — `/>` tag-aligned to `<App` column (8).
+		{Code: "function* g() {\n  yield <App\n          foo\n        />;\n}", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		// await in async function — `/>` line-aligned to the line indent.
+		{Code: "async function f() {\n  return await Promise.resolve(<App\n    foo\n  />);\n}", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		// default parameter — `/>` line-aligned to the function-decl line indent.
+		{Code: "function f(x = <App\n  foo\n/>) { return x; }", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		// Inside template literal expression — single line element, no report.
+		{Code: "var x = `${(<App foo />)}`;", Tsx: true},
+
+		// ---- Dimension 4: multiple consecutive spreads ----
+		{Code: `<App {...a} {...b} {...c} />`, Tsx: true},
+		{Code: "<App\n  {...a}\n  {...b}\n  {...c}\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+
+		// ---- Dimension 4: HTML entities in attribute (decoded by tsgo) ----
+		{Code: `<App title="&amp;" />`, Tsx: true},
+		{Code: `<App title="&#x3E;&#x3C;" />`, Tsx: true},
+
+		// ---- Real-user: styled-components / emotion css prop ----
+		{
+			Code: "<Box\n  css={{\n    display: 'flex',\n    flexDirection: 'column',\n    padding: '1rem',\n  }}\n/>",
+			Tsx:  true,
+		},
+		// Styled component with template literal.
+		{
+			Code: "<Box\n  css={`\n    display: flex;\n    color: red;\n  `}\n/>",
+			Tsx:  true,
+		},
+
+		// ---- Real-user: redux Provider with multi-line store ----
+		{
+			Code: "<Provider\n  store={configureStore({\n    reducer,\n    middleware,\n  })}\n>\n  <App />\n</Provider>",
+			Tsx:  true,
+		},
+
+		// ---- Real-user: React Router shape ----
+		{
+			Code: "<Route\n  path=\"/users/:id\"\n  exact\n  render={({ match }) => (\n    <UserPage id={match.params.id} />\n  )}\n/>",
+			Tsx:  true,
+		},
+
+		// ---- Real-user: React.memo / forwardRef-wrapped components ----
+		{
+			Code: "<ForwardedRefComp\n  ref={ref}\n  {...props}\n/>",
+			Tsx:  true,
+		},
+
+		// ---- Real-user: conditional rendering with ternary in JSX child ----
+		{
+			Code: "<Wrapper>\n  {flag ? (\n    <On\n      foo\n    />\n  ) : (\n    <Off\n      bar\n    />\n  )}\n</Wrapper>",
+			Tsx:  true,
+		},
+
+		// ---- Comment edge cases ----
+		// Block comment containing `>` chars — must not confuse closing
+		// detection (closing scan looks at last `>` in element range).
+		{Code: "<App\n  /* >>> comment >>> */\n  foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		// Block comment spanning multiple lines, between two attrs.
+		{Code: "<App\n  foo\n  /*\n   * long\n   * comment\n   */\n  bar\n/>", Tsx: true},
+		// Multiple consecutive block comments before closing.
+		{Code: "<App\n  foo\n  /* a *//* b */\n/>", Tsx: true},
+		// Line comment with no content.
+		{Code: "<App\n  //\n  foo\n/>", Tsx: true},
+
+		// ---- Dimension 4: very long indent ----
+		// Locks in that column accounting handles 80-col indent correctly.
+		{
+			Code: "                                                                                <App\n                                                                                  foo\n                                                                                />",
+			Tsx:  true,
+		},
+
+		// ---- Dimension 4: mixed tab+space indent ----
+		// `\t ` (tab then space) is the line-indent. UTF16Length counts each
+		// as 1 unit, matching ESLint's loc.column. tag-aligned requires
+		// closing at the `<` column (which is col 0 here).
+		{Code: "<App\n\t foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+
+		// ---- Dimension 4: JSX containing a JsxFragment child ----
+		{Code: "<App>\n  <>\n    <Child />\n  </>\n</App>", Tsx: true},
+
+		// ---- Dimension 4: deeply nested mixed self-closing / paired ----
+		{Code: "<A><B><C><D><E foo /></D></C></B></A>", Tsx: true},
+
+		// ---- Dimension 4: attribute identifier in unicode ----
+		{Code: `<App データ="x" />`, Tsx: true},
+		{Code: "<App\n  データ=\"x\"\n/>", Tsx: true},
+
+		// ---- Dimension 4: TS satisfies in attribute value ----
+		{Code: `<App foo={x satisfies T} />`, Tsx: true},
+
+		// ---- Dimension 4: TS readonly assertion / const assertion ----
+		{Code: `<App foo={[1, 2] as const} />`, Tsx: true},
+
+		// ---- Real-user: large props object as last attribute ----
+		{
+			Code: "<Component\n  config={{\n    a: 1,\n    b: 2,\n    c: 3,\n    d: { nested: true },\n    e: [1, 2, 3],\n  }}\n/>",
+			Tsx:  true,
+		},
+
+		// ---- Real-user: JSX with key prop (React list pattern) ----
+		{Code: "{items.map(item =>\n  <Item\n    key={item.id}\n    {...item}\n  />\n)}", Tsx: true},
+
+		// ---- Real-user: render-prop component ----
+		{
+			Code: "<Consumer>\n  {value => (\n    <Display\n      value={value}\n    />\n  )}\n</Consumer>",
+			Tsx:  true,
+		},
+
+		// ---- Options matrix: location is "after-props" (string form) ----
+		{Code: `<App foo />`, Tsx: true, Options: "after-props"},
+		// Options matrix: nested array `[[map]]` should not crash (rslint
+		// loader collapses single-element arrays once; double-nested is
+		// non-standard input that should degrade to defaults).
+		{Code: `<App />`, Tsx: true, Options: []interface{}{[]interface{}{map[string]interface{}{"location": "props-aligned"}}}},
+		// Options matrix: array with non-string non-map first element.
+		{Code: `<App />`, Tsx: true, Options: []interface{}{42}},
+		// Options matrix: array with nil first element.
+		{Code: `<App />`, Tsx: true, Options: []interface{}{nil}},
+		// Options matrix: map with extra unknown keys alongside valid ones.
+		{Code: "<App\n  foo\n/>", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned", "extraKey": "ignored"}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Locks in upstream's findTrailingComment + upgrade branch (after-tag) ----
+		// Zero attributes, comment between tag-name and `/>`. Expected:
+		// upgrade after-tag → line-aligned, fix from comment.end. Without
+		// the upgrade, the fix would collapse `<App\n  //c\n  />` to
+		// `<App //c />`, breaking the comment.
+		// Note: with location=tag-aligned (default for `nonEmpty`/`selfClosing`)
+		// the upgrade does NOT fire (because expectedLocation is `after-tag`,
+		// not "tag-aligned"). The upgrade kicks in for `after-tag` only when
+		// hasCorrectLocation is false. Here `after-tag` is wrong (closing on
+		// line 4, tag on line 2), so it upgrades.
+		{
+			Code:   "<App\n  // comment\n  />",
+			Tsx:    true,
+			Output: []string{"<App\n  // comment\n/>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 1)",
+				Line:      3, Column: 3,
+			}},
+		},
+		// Locks in upstream getExpectedLocation() arm 2: `openingLine ===
+		// lastPropLastLine` → 'after-props'. Code: `<App foo\n  />`.
+		// Default tag-aligned, but expectedLocation collapses to after-props
+		// because the prop is on the opening line.
+		{
+			Code:   "<App foo\n  />",
+			Tsx:    true,
+			Output: []string{"<App foo/>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		// Locks in upstream getExpectedLocation() arm 3 self-closing branch:
+		// `tokens.selfClosing ? selfClosing : nonEmpty`. With selfClosing
+		// explicitly set, this routes to selfClosing's value.
+		{
+			Code:    "<App\n  foo\n  />",
+			Tsx:     true,
+			Output:  []string{"<App\n  foo\n/>"},
+			Options: map[string]interface{}{"selfClosing": "tag-aligned", "nonEmpty": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+				Line:      3, Column: 3,
+			}},
+		},
+		// Locks in upstream getExpectedLocation() arm 3 non-self-closing branch:
+		// `tokens.selfClosing ? selfClosing : nonEmpty`. With nonEmpty
+		// explicitly set, this routes to nonEmpty's value.
+		{
+			Code:    "<App\n  foo\n  ></App>",
+			Tsx:     true,
+			Output:  []string{"<App\n  foo\n></App>"},
+			Options: map[string]interface{}{"selfClosing": "line-aligned", "nonEmpty": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+				Line:      3, Column: 3,
+			}},
+		},
+		// ---- Dimension 4: JsxMemberExpression tag — column accounting uses `<` ----
+		{
+			Code:    "<Foo.Bar\n  foo />",
+			Tsx:     true,
+			Output:  []string{"<Foo.Bar\n  foo\n/>"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 1 on the next line)",
+				Line:      2, Column: 7,
+			}},
+		},
+		// ---- Dimension 4: JsxNamespacedName tag, multi-line ----
+		{
+			Code:    "<svg:circle\n  cx={1} />",
+			Tsx:     true,
+			Output:  []string{"<svg:circle\n  cx={1}\n/>"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 1 on the next line)",
+				Line:      2, Column: 10,
+			}},
+		},
+		// ---- Dimension 4: '>' inside attribute expression on a later line ----
+		// Closing detection must pick the JSX-element '>' / '/' at the end,
+		// not the comparison's `>`. tsgo's BinaryExpression `>` is part of
+		// the attribute's range and is excluded by our trimmed scan.
+		{
+			Code:   "<App foo={x > y}\n/>",
+			Tsx:    true,
+			Output: []string{`<App foo={x > y}/>`},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		// ---- Dimension 4: spread attribute as last prop ----
+		// JsxSpreadAttribute is a different node kind from JsxAttribute; the
+		// lastProp accounting must extract `{...rest}` correctly.
+		{
+			Code:    "<App\n  foo\n  {...rest}\n  />",
+			Tsx:     true,
+			Output:  []string{"<App\n  foo\n  {...rest}\n/>"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+				Line:      4, Column: 3,
+			}},
+		},
+		// ---- Locks in trailing-comment upgrade vs after-tag (zero-prop case) ----
+		// Two comments between tag-name and `/>`. expectedLocation=after-tag
+		// (no props) but trailing comment → upgrade to line-aligned. Fix
+		// rangeStart = lastComment.end (NOT tagNameEnd), so the comments stay.
+		{
+			Code:   "<input\n  // a\n  // b\n  />",
+			Tsx:    true,
+			Output: []string{"<input\n  // a\n  // b\n/>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 1)",
+				Line:      4, Column: 3,
+			}},
+		},
+		// ---- Real-user: multi-byte UTF-16 column accounting ----
+		// Opening line contains multi-byte identifier characters; the
+		// "expected column N" in the message MUST be UTF-16 (matches IDE),
+		// NOT byte offset.
+		{
+			Code:    "var x = (() => {\n  return <中文Comp\n    foo />\n})",
+			Tsx:     true,
+			Output:  []string{"var x = (() => {\n  return <中文Comp\n    foo\n  />\n})"},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				// `  return <中文Comp` is line 2; line-aligned indent = 2 spaces.
+				// Expected column is 3 (1-based UTF-16).
+				Message: "The closing bracket must be aligned with the line containing the opening tag (expected column 3 on the next line)",
+				Line:    3, Column: 9,
+			}},
+		},
+		// Tag-aligned with multi-byte chars before opening — expected column
+		// is the UTF-16 position of '<', NOT byte offset.
+		{
+			Code:    "var 中文Var = <App\n  foo />",
+			Tsx:     true,
+			Output:  []string{"var 中文Var = <App\n  foo\n            />"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				// `var 中文Var = <App` — '<' at UTF-16 col 13 (0-based 12).
+				Message: "The closing bracket must be aligned with the opening tag (expected column 13 on the next line)",
+				Line:    2, Column: 7,
+			}},
+		},
+		// ---- Real-user: after-tag with whitespace-only blank line between tag and `/>` ----
+		// Blank line is whitespace only (no comment), so the trailing-comment
+		// upgrade does NOT fire; expectedLocation stays `after-tag` and the
+		// fix collapses to single-line.
+		{
+			Code:   "<App\n\n/>",
+			Tsx:    true,
+			Output: []string{`<App />`},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the opening tag",
+			}},
+		},
+		// ---- Real-user: nested element column lock-in (3 levels) ----
+		// Three-level nesting: outer `<App>`, middle `<B foo>`, innermost
+		// `<C\n  bar\n   />`. Innermost props-aligned — column derives from
+		// `bar`, not outer elements.
+		{
+			Code:    "<App>\n  <B foo>\n    <C\n      bar\n        />\n  </B>\n</App>",
+			Tsx:     true,
+			Output:  []string{"<App>\n  <B foo>\n    <C\n      bar\n      />\n  </B>\n</App>"},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				// `bar` at UTF-16 col 7 (1-based) → "expected column 7".
+				Message: "The closing bracket must be aligned with the last prop (expected column 7)",
+				Line:    5, Column: 9,
+			}},
+		},
+		// ---- Trailing block-comment specifically ----
+		// Verifies `findTrailingComment` handles `/* ... */` and not just
+		// `// ...`. After-props upgrade fires.
+		{
+			Code:    "<input\n  foo\n  /* trailing */\n  />",
+			Tsx:     true,
+			Output:  []string{"<input\n  foo\n  /* trailing */\n/>"},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 1)",
+				Line:      4, Column: 3,
+			}},
+		},
+		// ---- Options 42 (numeric) falls back to default tag-aligned ----
+		{
+			Code:    "<App\n  foo\n  />",
+			Tsx:     true,
+			Options: 42,
+			Output:  []string{"<App\n  foo\n/>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+				Line:      3, Column: 3,
+			}},
+		},
+		// Map with unknown key — defaults apply.
+		{
+			Code:    "<App\n  foo\n  />",
+			Tsx:     true,
+			Options: map[string]interface{}{"unknownKey": "props-aligned"},
+			Output:  []string{"<App\n  foo\n/>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+				Line:      3, Column: 3,
+			}},
+		},
+		// ---- Dimension 4: regex literal in attribute value, multi-line outer ----
+		// The `>` inside `/regex/` must not be picked up as closing.
+		{
+			Code:    "<App\n  pattern={/>/}\n  />",
+			Tsx:     true,
+			Output:  []string{"<App\n  pattern={/>/}\n/>"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+				Line:      3, Column: 3,
+			}},
+		},
+		// ---- Dimension 4: template literal containing `>` ----
+		{
+			Code:    "<App\n  t={`<X>`}\n  />",
+			Tsx:     true,
+			Output:  []string{"<App\n  t={`<X>`}\n/>"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+				Line:      3, Column: 3,
+			}},
+		},
+		// ---- Locks in mutual exclusion: location with nonEmpty present ----
+		// `'location' in config!` short-circuits: nonEmpty is IGNORED when
+		// location exists. Without that short-circuit, props-aligned would
+		// apply and `</App>` at col 1 would be wrong. With the short-circuit,
+		// tag-aligned applies; `</App>` at col 1 matches `<` col 1 → would
+		// be valid. To exercise the override path being suppressed, we test
+		// an actually-misaligned closing under location=props-aligned (and
+		// nonEmpty="tag-aligned" which should NOT take effect).
+		{
+			Code:    "<App\n  foo\n  ></App>",
+			Tsx:     true,
+			Output:  []string{"<App\n  foo\n></App>"},
+			Options: map[string]interface{}{"location": "tag-aligned", "nonEmpty": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
+				Line:      3, Column: 3,
+			}},
+		},
+	})
+}

--- a/internal/plugins/stylistic/rules/jsx_closing_bracket_location/jsx_closing_bracket_location_upstream_test.go
+++ b/internal/plugins/stylistic/rules/jsx_closing_bracket_location/jsx_closing_bracket_location_upstream_test.go
@@ -1,0 +1,810 @@
+// TestJsxClosingBracketLocationUpstream migrates the full valid/invalid suite
+// from upstream packages/eslint-plugin/rules/jsx-closing-bracket-location/
+// jsx-closing-bracket-location.test.ts 1:1. Position assertions cover
+// line/column for every invalid case that upstream itself asserts them on.
+// rslint-specific lock-in cases live in
+// jsx_closing_bracket_location_extras_test.go.
+package jsx_closing_bracket_location
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxClosingBracketLocationUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxClosingBracketLocationRule, []rule_tester.ValidTestCase{
+		// ---- default tag-aligned, simple shapes ----
+		{Code: "\n        <App />\n      ", Tsx: true},
+		{Code: "\n        <App\n          // comment\n        />\n      ", Tsx: true},
+		{Code: "\n        <App /** comment */ />\n      ", Tsx: true},
+		{Code: "\n        <App foo />\n      ", Tsx: true},
+		{Code: "\n        <App\n          foo\n        />\n      ", Tsx: true},
+		{Code: "\n        <App\n          foo\n          // comment\n        />\n      ", Tsx: true},
+		{Code: "\n        <App\n          {...foo}\n        />\n      ", Tsx: true},
+		{Code: "\n        <App\n          {...foo}\n          // comment\n        />\n      ", Tsx: true},
+		// ---- string / object option equivalence for single-line forms ----
+		{Code: "\n        <App foo />\n      ", Tsx: true, Options: map[string]interface{}{"location": "after-props"}},
+		{Code: "\n        <App foo />\n      ", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		{Code: "\n        <App foo />\n      ", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		// ---- string options on multi-line shapes ----
+		{Code: "\n        <App\n          foo />\n      ", Tsx: true, Options: "after-props"},
+		{Code: "\n        <App\n          foo\n          />\n      ", Tsx: true, Options: "props-aligned"},
+		// ---- object options on multi-line shapes ----
+		{Code: "\n        <App\n          foo />\n      ", Tsx: true, Options: map[string]interface{}{"location": "after-props"}},
+		{Code: "\n        <App\n          foo\n        />\n      ", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		{Code: "\n        <App\n          foo\n        />\n      ", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		{Code: "\n        <App\n          foo\n          />\n      ", Tsx: true, Options: map[string]interface{}{"location": "props-aligned"}},
+		// ---- non-self-closing equivalents ----
+		{Code: "\n        <App foo></App>\n      ", Tsx: true},
+		{Code: "\n        <App\n          foo\n        ></App>\n      ", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		{Code: "\n        <App\n          foo\n        ></App>\n      ", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		{Code: "\n        <App\n          foo\n          ></App>\n      ", Tsx: true, Options: map[string]interface{}{"location": "props-aligned"}},
+		// ---- multi-line attribute value ----
+		{Code: "\n        <App\n          foo={function() {\n            console.log('bar');\n          }} />\n      ", Tsx: true, Options: map[string]interface{}{"location": "after-props"}},
+		{Code: "\n        <App\n          foo={function() {\n            console.log('bar');\n          }}\n          />\n      ", Tsx: true, Options: map[string]interface{}{"location": "props-aligned"}},
+		{Code: "\n        <App\n          foo={function() {\n            console.log('bar');\n          }}\n        />\n      ", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		{Code: "\n        <App\n          foo={function() {\n            console.log('bar');\n          }}\n        />\n      ", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		// ---- attribute on opening line, closing same-line collapses to after-props ----
+		{Code: "\n        <App foo={function() {\n          console.log('bar');\n        }}/>\n      ", Tsx: true, Options: map[string]interface{}{"location": "after-props"}},
+		{Code: "\n         <App foo={function() {\n                console.log('bar');\n              }}\n              />\n      ", Tsx: true, Options: map[string]interface{}{"location": "props-aligned"}},
+		{Code: "\n        <App foo={function() {\n          console.log('bar');\n        }}\n        />\n      ", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		{Code: "\n        <App foo={function() {\n          console.log('bar');\n        }}\n        />\n      ", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		// ---- selfClosing / nonEmpty per-form configuration ----
+		{Code: "\n        <Provider store>\n          <App\n            foo />\n        </Provider>\n      ", Tsx: true, Options: map[string]interface{}{"selfClosing": "after-props"}},
+		{Code: "\n        <Provider\n          store\n        >\n          <App\n            foo />\n        </Provider>\n      ", Tsx: true, Options: map[string]interface{}{"selfClosing": "after-props"}},
+		{Code: "\n        <Provider\n          store>\n          <App\n            foo\n          />\n        </Provider>\n      ", Tsx: true, Options: map[string]interface{}{"nonEmpty": "after-props"}},
+		{Code: "\n        <Provider store>\n          <App\n            foo\n            />\n        </Provider>\n      ", Tsx: true, Options: map[string]interface{}{"selfClosing": "props-aligned"}},
+		{Code: "\n        <Provider\n          store\n          >\n          <App\n            foo\n          />\n        </Provider>\n      ", Tsx: true, Options: map[string]interface{}{"nonEmpty": "props-aligned"}},
+		// ---- larger realistic shapes (function return, var assignment, etc.) ----
+		{Code: "\n        var x = function() {\n          return <App\n            foo\n                 >\n              bar\n                 </App>\n        }\n      ", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		{Code: "\n        var x = function() {\n          return <App\n            foo\n                 />\n        }\n      ", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		{Code: "\n        var x = <App\n          foo\n                />\n      ", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+		{Code: "\n        var x = function() {\n          return <App\n            foo={function() {\n              console.log('bar');\n            }}\n          />\n        }\n      ", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		{Code: "\n        var x = <App\n          foo={function() {\n            console.log('bar');\n          }}\n        />\n      ", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		{Code: "\n        <Provider\n          store\n        >\n          <App\n            foo={function() {\n              console.log('bar');\n            }}\n          />\n        </Provider>\n      ", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		{Code: "\n        <Provider\n          store\n        >\n          {baz && <App\n            foo={function() {\n              console.log('bar');\n            }}\n          />}\n        </Provider>\n      ", Tsx: true, Options: map[string]interface{}{"location": "line-aligned"}},
+		// ---- nonEmpty:false / selfClosing:false disable per-form ----
+		{Code: "\n        <App>\n          <Foo\n            bar\n          >\n          </Foo>\n          <Foo\n            bar />\n        </App>\n      ", Tsx: true, Options: map[string]interface{}{"nonEmpty": false, "selfClosing": "after-props"}},
+		{Code: "\n        <App>\n          <Foo\n            bar>\n          </Foo>\n          <Foo\n            bar\n          />\n        </App>\n      ", Tsx: true, Options: map[string]interface{}{"nonEmpty": "after-props", "selfClosing": false}},
+		// ---- multi-line attribute with array literal closing on its own line ----
+		{Code: "\n        <div className={[\n          \"some\",\n          \"stuff\",\n          2 ]}\n        >\n          Some text\n        </div>\n      ", Tsx: true, Options: map[string]interface{}{"location": "tag-aligned"}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- 1. after-tag (no props), fix collapses to single-line ----
+		{
+			Code:   "\n        <App\n        />\n      ",
+			Tsx:    true,
+			Output: []string{"\n        <App />\n      "},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the opening tag",
+			}},
+		},
+		// ---- 2. after-props default, prop on opening line, `/>` on next ----
+		{
+			Code:   "\n        <App foo\n        />\n      ",
+			Tsx:    true,
+			Output: []string{"\n        <App foo/>\n      "},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		// ---- 3. non-self-closing, after-props default ----
+		{
+			Code:   "\n        <App foo\n        ></App>\n      ",
+			Tsx:    true,
+			Output: []string{"\n        <App foo></App>\n      "},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		// ---- 4-6. multi-line prop, `/>` on same line as prop ----
+		{
+			Code:    "\n        <App\n          foo />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo\n          />\n      "},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the last prop (expected column 11 on the next line)",
+				Line:      3, Column: 15,
+			}},
+		},
+		{
+			Code:    "\n        <App\n          foo />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo\n        />\n      "},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)",
+				Line:      3, Column: 15,
+			}},
+		},
+		{
+			Code:    "\n        <App\n          foo />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo\n        />\n      "},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 9 on the next line)",
+				Line:      3, Column: 15,
+			}},
+		},
+		// ---- 7-11. multi-line prop, after-props collapses; props/tag/line aligned move bracket ----
+		{
+			Code:    "\n        <App\n          foo\n        />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo/>\n      "},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		{
+			Code:    "\n        <App\n          foo\n        />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo\n          />\n      "},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the last prop (expected column 11)",
+				Line:      4, Column: 9,
+			}},
+		},
+		{
+			Code:    "\n        <App\n          foo\n          />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo/>\n      "},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		{
+			Code:    "\n        <App\n          foo\n          />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo\n        />\n      "},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 9)",
+				Line:      4, Column: 11,
+			}},
+		},
+		{
+			Code:    "\n        <App\n          foo\n          />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo\n        />\n      "},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 9)",
+				Line:      4, Column: 11,
+			}},
+		},
+		// ---- 12-16. non-self-closing variants ----
+		{
+			Code:    "\n        <App\n          foo\n        ></App>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo></App>\n      "},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		{
+			Code:    "\n        <App\n          foo\n        ></App>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo\n          ></App>\n      "},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the last prop (expected column 11)",
+				Line:      4, Column: 9,
+			}},
+		},
+		{
+			Code:    "\n        <App\n          foo\n          ></App>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo></App>\n      "},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		{
+			Code:    "\n        <App\n          foo\n          ></App>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo\n        ></App>\n      "},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 9)",
+				Line:      4, Column: 11,
+			}},
+		},
+		{
+			Code:    "\n        <App\n          foo\n          ></App>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <App\n          foo\n        ></App>\n      "},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 9)",
+				Line:      4, Column: 11,
+			}},
+		},
+		// ---- 17. nested Provider/App, selfClosing config ----
+		{
+			Code:    "\n        <Provider\n          store>\n          <App\n            foo\n            />\n        </Provider>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <Provider\n          store\n        >\n          <App\n            foo\n            />\n        </Provider>\n      "},
+			Options: map[string]interface{}{"selfClosing": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)",
+				Line:      3, Column: 16,
+			}},
+		},
+		// ---- 18-20. very-far-right closing bracket ----
+		{
+			Code:    "\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n                                            >\n              Button Text\n            </Button>\n          );\n        };\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n              >\n              Button Text\n            </Button>\n          );\n        };\n      "},
+			Options: "props-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the last prop (expected column 15)",
+				Line:      7, Column: 45,
+			}},
+		},
+		{
+			Code:    "\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n                                            >\n              Button Text\n            </Button>\n          );\n        };\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n            >\n              Button Text\n            </Button>\n          );\n        };\n      "},
+			Options: "tag-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 13)",
+				Line:      7, Column: 45,
+			}},
+		},
+		{
+			Code:    "\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n                                            >\n              Button Text\n            </Button>\n          );\n        };\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        const Button = function(props) {\n          return (\n            <Button\n              size={size}\n              onClick={onClick}\n            >\n              Button Text\n            </Button>\n          );\n        };\n      "},
+			Options: "line-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 13)",
+				Line:      7, Column: 45,
+			}},
+		},
+		// ---- 21-23. nonEmpty / selfClosing per-form ----
+		{
+			Code:    "\n        <Provider\n          store\n          >\n          <App\n            foo\n            />\n        </Provider>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <Provider\n          store\n          >\n          <App\n            foo\n          />\n        </Provider>\n      "},
+			Options: map[string]interface{}{"nonEmpty": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 11)",
+				Line:      7, Column: 13,
+			}},
+		},
+		{
+			Code:    "\n        <Provider\n          store>\n          <App\n            foo />\n        </Provider>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <Provider\n          store\n        >\n          <App\n            foo />\n        </Provider>\n      "},
+			Options: map[string]interface{}{"selfClosing": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)",
+				Line:      3, Column: 16,
+			}},
+		},
+		{
+			Code:    "\n        <Provider\n          store>\n          <App\n            foo\n            />\n        </Provider>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <Provider\n          store>\n          <App\n            foo\n          />\n        </Provider>\n      "},
+			Options: map[string]interface{}{"nonEmpty": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 11)",
+				Line:      6, Column: 13,
+			}},
+		},
+		// ---- 24-25. function return, line-aligned ----
+		{
+			Code:    "\n        var x = function() {\n          return <App\n            foo\n                />\n        }\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        var x = function() {\n          return <App\n            foo\n          />\n        }\n      "},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 11)",
+				Line:      5, Column: 17,
+			}},
+		},
+		{
+			Code:    "\n        var x = <App\n          foo\n                />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        var x = <App\n          foo\n        />\n      "},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 9)",
+				Line:      4, Column: 17,
+			}},
+		},
+		// ---- 26-27. paren-wrapped JSX, spread / nested element ----
+		{
+			Code:    "\n        var x = (\n          <div\n            className=\"MyComponent\"\n            {...props} />\n        )\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        var x = (\n          <div\n            className=\"MyComponent\"\n            {...props}\n          />\n        )\n      "},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 11 on the next line)",
+				Line:      5, Column: 24,
+			}},
+		},
+		{
+			Code:    "\n        var x = (\n          <Something\n            content={<Foo />} />\n        )\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        var x = (\n          <Something\n            content={<Foo />}\n          />\n        )\n      "},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 11 on the next line)",
+				Line:      4, Column: 31,
+			}},
+		},
+		// ---- 28. after-tag on Something — collapse to single line ----
+		{
+			Code:    "\n        var x = (\n          <Something\n            />\n        )\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        var x = (\n          <Something />\n        )\n      "},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the opening tag",
+			}},
+		},
+		// ---- 29. div className=[...] tag-aligned ----
+		{
+			Code:    "\n        <div className={[\n          \"some\",\n          \"stuff\",\n          2 ]}>\n          Some text\n        </div>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <div className={[\n          \"some\",\n          \"stuff\",\n          2 ]}\n        >\n          Some text\n        </div>\n      "},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 9 on the next line)",
+				Line:      5, Column: 15,
+			}},
+		},
+		// ---- 30-32. tab-indented variants ----
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo />\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the last prop (expected column 6 on the next line)",
+				Line:      3, Column: 10,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo />\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)",
+				Line:      3, Column: 10,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo />\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 5 on the next line)",
+				Line:      3, Column: 10,
+			}},
+		},
+		// ---- 33-36. tab-indented existing-newline variants ----
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo/>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the last prop (expected column 6)",
+				Line:      4, Column: 5,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo/>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 5)",
+				Line:      4, Column: 6,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 5)",
+				Line:      4, Column: 6,
+			}},
+		},
+		// ---- 37-40. tab-indented non-self-closing ----
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo></App>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the last prop (expected column 6)",
+				Line:      4, Column: 5,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo></App>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 5)",
+				Line:      4, Column: 6,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t\t></App>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t></App>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 5)",
+				Line:      4, Column: 6,
+			}},
+		},
+		// ---- 41. nested Provider/App with selfClosing (tab) ----
+		{
+			Code:    "\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t"},
+			Options: map[string]interface{}{"selfClosing": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)",
+				Line:      3, Column: 11,
+			}},
+		},
+		// ---- 42-44. very-far-right (tab) ----
+		{
+			Code:    "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t"},
+			Options: "props-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the last prop (expected column 8)",
+				Line:      7, Column: 23,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t"},
+			Options: "tag-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 7)",
+				Line:      7, Column: 23,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\tconst Button = function(props) {\n\t\t\t\t\treturn (\n\t\t\t\t\t\t<Button\n\t\t\t\t\t\t\tsize={size}\n\t\t\t\t\t\t\tonClick={onClick}\n\t\t\t\t\t\t>\n\t\t\t\t\t\t\tButton Text\n\t\t\t\t\t\t</Button>\n\t\t\t\t\t);\n\t\t\t\t};\n\t\t\t"},
+			Options: "line-aligned",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 7)",
+				Line:      7, Column: 23,
+			}},
+		},
+		// ---- 45. tab Provider/App nonEmpty: props-aligned ----
+		{
+			Code:    "\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t"},
+			Options: map[string]interface{}{"nonEmpty": "props-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 6)",
+				Line:      7, Column: 7,
+			}},
+		},
+		// ---- 46-47. tab selfClosing / nonEmpty after-props ----
+		{
+			Code:    "\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo />\n\t\t\t\t</Provider>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<Provider\n\t\t\t\t\tstore\n\t\t\t\t>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo />\n\t\t\t\t</Provider>\n\t\t\t"},
+			Options: map[string]interface{}{"selfClosing": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)",
+				Line:      3, Column: 11,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<Provider\n\t\t\t\t\tstore>\n\t\t\t\t\t<App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t\t</Provider>\n\t\t\t"},
+			Options: map[string]interface{}{"nonEmpty": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 6)",
+				Line:      6, Column: 7,
+			}},
+		},
+		// ---- 48-50. line-aligned cases (var x = function / var x = <App / paren-wrapped) ----
+		{
+			Code:    "\n\t\t\t\tvar x = function() {\n\t\t\t\t\treturn <App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t\t\t\t/>\n\t\t\t\t}\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\tvar x = function() {\n\t\t\t\t\treturn <App\n\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t\t}\n\t\t\t"},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 6)",
+				Line:      5, Column: 9,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\tvar x = <App\n\t\t\t\t\tfoo\n\t\t\t\t\t\t\t\t/>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\tvar x = <App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 5)",
+				Line:      4, Column: 9,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\tvar x = (\n\t\t\t\t\t<div\n\t\t\t\t\t\tclassName=\"MyComponent\"\n\t\t\t\t\t\t{...props} />\n\t\t\t\t)\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\tvar x = (\n\t\t\t\t\t<div\n\t\t\t\t\t\tclassName=\"MyComponent\"\n\t\t\t\t\t\t{...props}\n\t\t\t\t\t/>\n\t\t\t\t)\n\t\t\t"},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 6 on the next line)",
+				Line:      5, Column: 18,
+			}},
+		},
+		// ---- 51-53. var x = ( <Something content={<Foo />} /> ) / <Something /> ----
+		{
+			Code:    "\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something\n\t\t\t\t\t\tcontent={<Foo />} />\n\t\t\t\t)\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something\n\t\t\t\t\t\tcontent={<Foo />}\n\t\t\t\t\t/>\n\t\t\t\t)\n\t\t\t"},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 6 on the next line)",
+				Line:      4, Column: 25,
+			}},
+		},
+		{
+			Code:    "\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something\n\t\t\t\t\t\t/>\n\t\t\t\t)\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\tvar x = (\n\t\t\t\t\t<Something />\n\t\t\t\t)\n\t\t\t"},
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the opening tag",
+			}},
+		},
+		// ---- 54. tab div className=[...] tag-aligned ----
+		{
+			Code:    "\n\t\t\t\t<div className={[\n\t\t\t\t\t\"some\",\n\t\t\t\t\t\"stuff\",\n\t\t\t\t\t2 ]}>\n\t\t\t\t\tSome text\n\t\t\t\t</div>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<div className={[\n\t\t\t\t\t\"some\",\n\t\t\t\t\t\"stuff\",\n\t\t\t\t\t2 ]}\n\t\t\t\t>\n\t\t\t\t\tSome text\n\t\t\t\t</div>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 5 on the next line)",
+				Line:      5, Column: 10,
+			}},
+		},
+		// ---- 55. Mixed-tab edge case (opening 6 tabs, prop 7 tabs, closing 5 tabs) ----
+		{
+			Code:    "\n\t\t\t\t\t\t\t<div\n\t\t\t\t\t\t\t\tclassName={styles}\n\t\t\t\t\t >\n\t\t\t\t\t\t\t\t{props}\n\t\t\t\t\t\t\t</div>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t\t\t\t<div\n\t\t\t\t\t\t\t\tclassName={styles}\n\t\t\t\t\t\t\t>\n\t\t\t\t\t\t\t\t{props}\n\t\t\t\t\t\t\t</div>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 8)",
+				Line:      4, Column: 7,
+			}},
+		},
+		// ---- 56. space variant: div, tag-aligned ----
+		{
+			Code:    "\n          <div\n            className={styles}\n            >\n            {props}\n          </div>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n          <div\n            className={styles}\n          >\n            {props}\n          </div>\n      "},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 11)",
+				Line:      4, Column: 13,
+			}},
+		},
+		// ---- 57. space variant: App tag-aligned ----
+		{
+			Code:    "\n          <App\n            foo\n            />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n          <App\n            foo\n          />\n      "},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 11)",
+				Line:      4, Column: 13,
+			}},
+		},
+		// ---- 58. mixed-tab opening/prop/closing (6/7/5) ----
+		{
+			Code:    "\n\t\t\t\t\t\t<App\n\t\t\t\t\t\t\tfoo\n\t\t\t\t\t/>\n\t\t\t",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t\t\t<App\n\t\t\t\t\t\t\tfoo\n\t\t\t\t\t\t/>\n\t\t\t"},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 7)",
+				Line:      4, Column: 6,
+			}},
+		},
+		// ---- 59. trailing line-comment promotes after-tag/after-props → line-aligned (tag-aligned mode) ----
+		// Upstream: location=tag-aligned mismatches → no upgrade (still tag-aligned).
+		{
+			Code:    "\n        <input\n          // comment\n          type=\"text\"\n          // comment\n          />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <input\n          // comment\n          type=\"text\"\n          // comment\n        />\n      "},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 9)",
+				Line:      6, Column: 11,
+			}},
+		},
+		// ---- 60. trailing block-comment, tag-aligned mode ----
+		{
+			Code:    "\n        <input\n          // comment\n          type=\"text\"\n          /**\n           * \n           * comment\n           * \n           */\n          />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <input\n          // comment\n          type=\"text\"\n          /**\n           * \n           * comment\n           * \n           */\n        />\n      "},
+			Options: map[string]interface{}{"location": "tag-aligned"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the opening tag (expected column 9)",
+				Line:      10, Column: 11,
+			}},
+		},
+		// ---- 61. after-props with NO trailing comment between last attr and `/>` → stays after-props ----
+		// The blank line after `type="text"` is whitespace only, not a comment, so
+		// the after-props upgrade-to-line-aligned does NOT fire.
+		{
+			Code:    "\n        <input\n          // comment\n          type=\"text\"\n\n        />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <input\n          // comment\n          type=\"text\"/>\n      "},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be placed after the last prop",
+				Line:      6, Column: 9,
+			}},
+		},
+		// ---- 62. after-props upgraded to line-aligned by trailing comment AFTER last attr ----
+		{
+			Code:    "\n        <input\n          // comment\n          type=\"text\"\n          // comment\n          />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <input\n          // comment\n          type=\"text\"\n          // comment\n        />\n      "},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 9)",
+				Line:      6, Column: 11,
+			}},
+		},
+		// ---- 63. zero-prop variant: comment between tag-name and `/>` upgrades after-tag→line-aligned ----
+		{
+			Code:    "\n        <input\n          // comment\n          // comment\n          />\n      ",
+			Tsx:     true,
+			Output:  []string{"\n        <input\n          // comment\n          // comment\n        />\n      "},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 9)",
+				Line:      5, Column: 11,
+			}},
+		},
+		// ---- 64. tab-indented after-props upgraded to line-aligned ----
+		{
+			Code:    "\n\t\t\t\t<a\n\t\t\t\t\thref=\"javascript:;\"\n\t\t\t\t\t// comment\n\t\t\t\t\t// comment\n\t\t\t\t\t>\n\t\t\t\t\ttext\n\t\t\t\t</a>\n      ",
+			Tsx:     true,
+			Output:  []string{"\n\t\t\t\t<a\n\t\t\t\t\thref=\"javascript:;\"\n\t\t\t\t\t// comment\n\t\t\t\t\t// comment\n\t\t\t\t>\n\t\t\t\t\ttext\n\t\t\t\t</a>\n      "},
+			Options: map[string]interface{}{"location": "after-props"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "bracketLocation",
+				Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 5)",
+				Line:      6, Column: 6,
+			}},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -462,6 +462,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/dot-location.test.ts',
     './tests/eslint-plugin-stylistic/rules/eol-last.test.ts',
     './tests/eslint-plugin-stylistic/rules/generator-star-spacing.test.ts',
+    './tests/eslint-plugin-stylistic/rules/jsx-closing-bracket-location.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-closing-bracket-location.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-closing-bracket-location.test.ts
@@ -1,0 +1,122 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const MESSAGE_AFTER_PROPS = 'placed after the last prop';
+const MESSAGE_AFTER_TAG = 'placed after the opening tag';
+const MESSAGE_PROPS_ALIGNED = 'aligned with the last prop';
+const MESSAGE_TAG_ALIGNED = 'aligned with the opening tag';
+const MESSAGE_LINE_ALIGNED = 'aligned with the line containing the opening tag';
+
+function details(expectedColumn: number, expectedNextLine: boolean) {
+  return ` (expected column ${expectedColumn}${expectedNextLine ? ' on the next line)' : ')'}`;
+}
+
+ruleTester.run('jsx-closing-bracket-location', null as never, {
+  valid: [
+    // default tag-aligned
+    { code: `<App />` },
+    { code: `<App foo />` },
+    { code: `<App\n  foo\n/>` },
+    { code: `<App\n  foo\n  // comment\n/>` },
+    { code: `<App\n  {...foo}\n/>` },
+    // string shortcut
+    { code: `<App\n  foo />`, options: ['after-props'] },
+    { code: `<App\n  foo\n  />`, options: ['props-aligned'] },
+    // object location form
+    { code: `<App\n  foo />`, options: [{ location: 'after-props' }] },
+    { code: `<App\n  foo\n/>`, options: [{ location: 'tag-aligned' }] },
+    { code: `<App\n  foo\n/>`, options: [{ location: 'line-aligned' }] },
+    { code: `<App\n  foo\n  />`, options: [{ location: 'props-aligned' }] },
+    // non-self-closing
+    { code: `<App foo></App>` },
+    { code: `<App\n  foo\n></App>`, options: [{ location: 'tag-aligned' }] },
+    // selfClosing / nonEmpty per-form
+    {
+      code: `<Provider store>\n  <App\n    foo />\n</Provider>`,
+      options: [{ selfClosing: 'after-props' }],
+    },
+    {
+      code: `<Provider\n  store>\n  <App\n    foo\n  />\n</Provider>`,
+      options: [{ nonEmpty: 'after-props' }],
+    },
+    // nonEmpty:false / selfClosing:false disable per-form
+    {
+      code: `<App>\n  <Foo\n    bar\n  >\n  </Foo>\n  <Foo\n    bar />\n</App>`,
+      options: [{ nonEmpty: false, selfClosing: 'after-props' }],
+    },
+  ],
+
+  invalid: [
+    // after-tag default, fix collapses to single-line
+    {
+      code: `<App\n/>`,
+      output: `<App />`,
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          message: `The closing bracket must be ${MESSAGE_AFTER_TAG}`,
+        },
+      ],
+    },
+    // after-props default, prop on opening line
+    {
+      code: `<App foo\n/>`,
+      output: `<App foo/>`,
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          message: `The closing bracket must be ${MESSAGE_AFTER_PROPS}`,
+        },
+      ],
+    },
+    // tag-aligned message + details
+    {
+      code: `<App\n  foo />`,
+      output: `<App\n  foo\n/>`,
+      options: [{ location: 'tag-aligned' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          message: `The closing bracket must be ${MESSAGE_TAG_ALIGNED}${details(1, true)}`,
+        },
+      ],
+    },
+    // props-aligned with very-far closing bracket
+    {
+      code: `<App\n  foo\n/>`,
+      output: `<App\n  foo\n  />`,
+      options: [{ location: 'props-aligned' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          message: `The closing bracket must be ${MESSAGE_PROPS_ALIGNED}${details(3, false)}`,
+        },
+      ],
+    },
+    // line-aligned, paren-wrapped JSX
+    {
+      code: `var x = (\n  <div\n    className="X"\n    {...props} />\n)`,
+      output: `var x = (\n  <div\n    className="X"\n    {...props}\n  />\n)`,
+      options: [{ location: 'line-aligned' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          message: `The closing bracket must be ${MESSAGE_LINE_ALIGNED}${details(3, true)}`,
+        },
+      ],
+    },
+    // trailing-comment upgrade after-props → line-aligned (stylistic-specific)
+    {
+      code: `<input\n  // comment\n  type="text"\n  // comment\n  />`,
+      output: `<input\n  // comment\n  type="text"\n  // comment\n/>`,
+      options: [{ location: 'after-props' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          message: `The closing bracket must be ${MESSAGE_LINE_ALIGNED}${details(1, false)}`,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/jsx-closing-bracket-location` rule from `@stylistic/eslint-plugin` to rslint.

Enforces consistent placement of the closing bracket (`>` / `/>`) for multiline JSX elements. Supports the full upstream option set:

- String shortcut: `"tag-aligned"` (default) / `"line-aligned"` / `"props-aligned"` / `"after-props"`
- Object `{ location }` form
- Object `{ nonEmpty, selfClosing }` form, each accepting a location string or `false` to disable per-form

Also handles the upstream upgrade-to-`line-aligned` branch when the `after-tag` / `after-props` location is misaligned and a trailing comment sits between the last attribute (or the tag name) and the closing bracket — preserves the comment instead of moving the bracket onto its line.

## Related Links

- Upstream rule: https://eslint.style/rules/jsx-closing-bracket-location
- Upstream source: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/jsx-closing-bracket-location/jsx-closing-bracket-location.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).