### PR TITLE
fix(website): convert @stylistic registry entry to presets format

### DIFF
--- a/website/theme/plugin-registry.ts
+++ b/website/theme/plugin-registry.ts
@@ -150,8 +150,12 @@ export const PLUGIN_REGISTRY: PluginMeta[] = [
     prefix: '@stylistic',
     group: '@stylistic/eslint-plugin',
     importName: 'stylisticPlugin',
-    presetName: 'stylisticPlugin.configs.recommended',
-    description: 'Stylistic / formatting rules',
+    presets: [
+      {
+        name: 'stylisticPlugin.configs.recommended',
+        description: 'Stylistic / formatting rules',
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
## Summary

#985 reworked the website `PluginMeta` model from `presetName: string | null` to `presets: PluginPresetMeta[]`, but it branched before #983 introduced the `@stylistic` entry, which still used the old `presetName` field.

After both landed on `main`, the `@stylistic` entry was left with `presetName` / `description` and **no `presets`**, so `expandPluginPresets()` and `plugin-rule-manifest.ts` call `.map` on `undefined`:

```
TypeError: Cannot read properties of undefined (reading 'map')
    at website/plugin-rule-manifest.ts:43
```

This crashes both `rspress dev` and `pnpm build:website`. The bad merge produced **no conflict markers** (the two edits don't textually overlap), which is why CI on the stale PR branch stayed green.

This converts the `@stylistic` entry to the `presets: [...]` shape used by every other plugin.

## Verification

- `pnpm --filter @rslint/core run build:js && pnpm --filter @rslint/website run dev` now boots cleanly (previously crashed at config load).
- `@stylistic` preset is back in the generated manifest and the preset table.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
