### PR TITLE
feat: port rule @stylistic/jsx-closing-tag-location

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -14,6 +14,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/eol_last"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/generator_star_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_closing_bracket_location"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_closing_tag_location"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -32,5 +33,6 @@ func GetAllRules() []rule.Rule {
 		eol_last.EolLastRule,
 		generator_star_spacing.GeneratorStarSpacingRule,
 		jsx_closing_bracket_location.JsxClosingBracketLocationRule,
+		jsx_closing_tag_location.JsxClosingTagLocationRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/jsx_closing_tag_location/jsx_closing_tag_location.go
+++ b/internal/plugins/stylistic/rules/jsx_closing_tag_location/jsx_closing_tag_location.go
@@ -1,0 +1,176 @@
+// Package jsx_closing_tag_location ports `@stylistic/jsx-closing-tag-location`
+// to rslint. It enforces the closing tag location for multiline JSX elements
+// and fragments: under `tag-aligned` (default) the closing tag must sit in the
+// same column as the opening tag, and under `line-aligned` it must sit in the
+// column where the line containing the opening tag begins.
+//
+// The rule originated as `react/jsx-closing-tag-location` and was adopted into
+// eslint-stylistic. Two upstream-stylistic specifics are mirrored here: the
+// autofix indent is always emitted as spaces (never the opening line's literal
+// indentation, so tab indents collapse to spaces), and the "move the tag to
+// its own line" fix is a pure insertion that does NOT strip whitespace already
+// preceding the tag (upstream's `insertTextBefore`).
+package jsx_closing_tag_location
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const defaultLocation = "tag-aligned"
+
+var messages = map[string]string{
+	"onOwnLine":        "Closing tag of a multiline JSX expression must be on its own line.",
+	"matchIndent":      "Expected closing tag to match indentation of opening.",
+	"alignWithOpening": "Expected closing tag to be aligned with the line containing the opening tag",
+}
+
+// messageLocation maps the option to the messageId emitted when the closing
+// tag is alone on its line (upstream's MESSAGE_LOCATION table). When the
+// closing tag shares its line with preceding content the rule always emits
+// `onOwnLine` instead.
+var messageLocation = map[string]string{
+	"tag-aligned":  "matchIndent",
+	"line-aligned": "alignWithOpening",
+}
+
+// parseOption accepts every shape rslint's loader can deliver for upstream's
+// single-string schema (`enum: ['tag-aligned', 'line-aligned']`, default
+// `tag-aligned`): nil, a bare string (single-option CLI form), or a
+// single-element array (rule-tester form). Any value outside the enum falls
+// back to the default — upstream's JSON schema rejects those before the rule
+// runs, so this branch is only reachable through hand-written rslint configs.
+func parseOption(options any) string {
+	raw := options
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) == 0 {
+			return defaultLocation
+		}
+		raw = arr[0]
+	}
+	if s, ok := raw.(string); ok && (s == "tag-aligned" || s == "line-aligned") {
+		return s
+	}
+	return defaultLocation
+}
+
+// JsxClosingTagLocationRule enforces closing tag location for multiline JSX.
+var JsxClosingTagLocationRule = rule.Rule{
+	Name: "@stylistic/jsx-closing-tag-location",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		location := parseOption(options)
+
+		checkClosing := func(node *ast.Node) {
+			// Resolve the matching opening tag from the parent element /
+			// fragment (mirrors upstream's `node.parent.openingElement` /
+			// `openingFragment`). A closing tag always has a parent, but guard
+			// defensively against parser recovery shapes.
+			var openingNode *ast.Node
+			switch node.Kind {
+			case ast.KindJsxClosingElement:
+				parent := node.Parent
+				if parent == nil || !ast.IsJsxElement(parent) {
+					return
+				}
+				openingNode = parent.AsJsxElement().OpeningElement
+			case ast.KindJsxClosingFragment:
+				parent := node.Parent
+				if parent == nil || !ast.IsJsxFragment(parent) {
+					return
+				}
+				openingNode = parent.AsJsxFragment().OpeningFragment
+			default:
+				return
+			}
+			if openingNode == nil {
+				return
+			}
+
+			text := ctx.SourceFile.Text()
+			lineStarts := ctx.SourceFile.ECMALineMap()
+
+			openingTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, openingNode)
+			openingPos := openingTrimmed.Pos()
+			openingLine := scanner.ComputeLineOfPosition(lineStarts, openingPos)
+			openingLineStart := int(lineStarts[openingLine])
+
+			closingTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			closingPos := closingTrimmed.Pos()
+			closingLine := scanner.ComputeLineOfPosition(lineStarts, closingPos)
+			closingLineStart := int(lineStarts[closingLine])
+
+			// Single-line element (opening and closing tags share a line) —
+			// nothing to enforce.
+			if openingLine == closingLine {
+				return
+			}
+
+			// Columns are UTF-16 code-unit offsets to match ESLint's
+			// `loc.column`; a multi-byte character before either tag would
+			// otherwise shift the comparison off ESLint's.
+			closingColumn := reactutil.UTF16Length(text[closingLineStart:closingPos])
+
+			// targetColumn is upstream's getIndentation(): the opening tag's
+			// own column under `tag-aligned`, or the indentation of the line
+			// containing the opening tag under `line-aligned`. It doubles as
+			// both the column the closing tag is checked against and the width
+			// of the autofix indent.
+			var targetColumn int
+			if location == "line-aligned" {
+				targetColumn = reactutil.UTF16Length(reactutil.HorizontalWhitespacePrefix(text[openingLineStart:]))
+			} else {
+				targetColumn = reactutil.UTF16Length(text[openingLineStart:openingPos])
+			}
+
+			if closingColumn == targetColumn {
+				return
+			}
+
+			indent := strings.Repeat(" ", targetColumn)
+
+			// First-in-line iff only whitespace precedes the closing tag back
+			// to its line start. Equivalent to upstream's
+			// `isNodeFirstInLine`, which walks back over whitespace-only JSXText
+			// and reports whether the preceding token lands on an earlier line.
+			leadingWS := reactutil.HorizontalWhitespacePrefix(text[closingLineStart:closingPos])
+			if len(leadingWS) == closingPos-closingLineStart {
+				// Closing tag is alone on its line — only its indentation is
+				// wrong. Replace the leading whitespace of the closing line
+				// with `indent` (upstream's replaceTextRange over
+				// [lineStart, node.start]).
+				msgID := messageLocation[location]
+				ctx.ReportNodeWithFixes(node, rule.RuleMessage{
+					Id:          msgID,
+					Description: messages[msgID],
+				}, rule.RuleFix{
+					Text:  indent,
+					Range: core.NewTextRange(closingLineStart, closingPos),
+				})
+				return
+			}
+
+			// Closing tag shares its line with preceding content — move it to
+			// its own line. Upstream uses insertTextBefore(node, "\n"+indent),
+			// a pure insertion that leaves any whitespace already before the
+			// tag in place.
+			ctx.ReportNodeWithFixes(node, rule.RuleMessage{
+				Id:          "onOwnLine",
+				Description: messages["onOwnLine"],
+			}, rule.RuleFix{
+				Text:  "\n" + indent,
+				Range: core.NewTextRange(closingPos, closingPos),
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxClosingElement:  checkClosing,
+			ast.KindJsxClosingFragment: checkClosing,
+		}
+	},
+}

--- a/internal/plugins/stylistic/rules/jsx_closing_tag_location/jsx_closing_tag_location.md
+++ b/internal/plugins/stylistic/rules/jsx_closing_tag_location/jsx_closing_tag_location.md
@@ -1,0 +1,66 @@
+# jsx-closing-tag-location
+
+Enforce closing tag location for multiline JSX.
+
+## Rule Details
+
+This rule checks the location of the closing tag (`</Foo>`, or `</>` for fragments) of a multiline JSX element. A single-line element — whose opening and closing tags share a line — is always allowed. When the element spans multiple lines, the closing tag must be on its own line and aligned according to the chosen option; otherwise the rule reports it and the autofix re-indents the closing tag (or moves it onto its own line).
+
+## Options
+
+This rule has a string option:
+
+- `"tag-aligned"` (default) — closing tag aligned with the column of the opening `<`.
+- `"line-aligned"` — closing tag aligned with the indentation of the line containing the opening tag (useful when the opening tag does not start its line, e.g. `const App = <Bar>`).
+
+### tag-aligned
+
+Examples of **incorrect** code for this rule with the default `"tag-aligned"` option:
+
+```javascript
+<Say
+  firstName="John"
+  lastName="Smith">
+  Hello
+    </Say>;
+```
+
+Examples of **correct** code for this rule with the default `"tag-aligned"` option:
+
+```javascript
+<Say
+  firstName="John"
+  lastName="Smith">
+  Hello
+</Say>;
+```
+
+### line-aligned
+
+Examples of **incorrect** code for this rule with the `"line-aligned"` option:
+
+```json
+{ "@stylistic/jsx-closing-tag-location": ["error", "line-aligned"] }
+```
+
+```javascript
+const App = <Bar>
+  Foo
+                </Bar>;
+```
+
+Examples of **correct** code for this rule with the `"line-aligned"` option:
+
+```json
+{ "@stylistic/jsx-closing-tag-location": ["error", "line-aligned"] }
+```
+
+```javascript
+const App = <Bar>
+  Foo
+</Bar>;
+```
+
+## Original Documentation
+
+- [@stylistic/jsx-closing-tag-location](https://eslint.style/rules/jsx-closing-tag-location)

--- a/internal/plugins/stylistic/rules/jsx_closing_tag_location/jsx_closing_tag_location_extras_test.go
+++ b/internal/plugins/stylistic/rules/jsx_closing_tag_location/jsx_closing_tag_location_extras_test.go
@@ -1,0 +1,433 @@
+// TestJsxClosingTagLocationExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// stylistic-specific deltas vs. react/jsx-closing-tag-location, locked in here:
+//   - the autofix indent is always SPACES, even when the reference line is
+//     tab-indented (react preserves the literal indentation under line-aligned);
+//   - the "move to its own line" fix is a pure insertion that leaves any
+//     whitespace already before the tag in place (react strips it);
+//   - the option is string-only — a `{ location }` object is NOT honored
+//     (react accepts it).
+package jsx_closing_tag_location
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxClosingTagLocationExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxClosingTagLocationRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4 rows that do NOT apply to this rule ----
+		// N/A: receiver / expression wrappers (paren, non-null `!`, `as`,
+		//   `satisfies`, optional chain). The rule inspects only the opening /
+		//   closing TAG positions, never a member-access receiver, so no child
+		//   node that could be wrapped is ever read.
+		// N/A: access / key forms (string / numeric / computed / private keys).
+		//   The rule reads no property keys.
+		// N/A: async / generator / declaration-vs-expression container variants.
+		//   These are function/class shapes; the rule only sees JSX elements and
+		//   fragments (their element-vs-fragment split IS covered below).
+
+		// ---- Dimension 4: graceful degradation ----
+		// Self-closing element has no closing tag — never visited, never reported.
+		{Code: "<App\n  foo\n/>", Tsx: true},
+		// Single-line element with an expression child — opening/closing share a
+		// line. Locks in upstream `opening.line === node.line` early return.
+		{Code: "<App>{cond ? a : b}</App>", Tsx: true},
+		// Single-line fragment.
+		{Code: "<>{x}</>", Tsx: true},
+		// Empty multiline body, closing aligned with opening.
+		{Code: "<App>\n</App>", Tsx: true},
+
+		// ---- Dimension 4: container forms ----
+		// JsxMemberExpression tag name — only the `<` position matters.
+		{Code: "<Foo.Bar>\n  x\n</Foo.Bar>", Tsx: true},
+
+		// ---- Real-user: multiline opening tag with attributes (docs example) ----
+		{Code: "<Say\n  firstName=\"John\"\n  lastName=\"Smith\">\n  Hello\n</Say>", Tsx: true},
+		// ---- Real-user: conditional render, paren-wrapped, properly aligned ----
+		{Code: "<App>\n  {cond && (\n    <Foo>\n      bar\n    </Foo>\n  )}\n</App>", Tsx: true},
+
+		// Locks in upstream column-match arm: when the closing tag shares its
+		// line with content BUT lands on the target column, it is valid — the
+		// column check returns before the first-in-line / messageId logic.
+		// (upstream only tests this for line-aligned; this is the tag-aligned twin.)
+		{Code: "  <App>\nab</App>", Tsx: true},
+
+		// Locks in getIndentation() option branch: same source is VALID under
+		// line-aligned (closing column 0 == opening line indent 0) but INVALID
+		// under tag-aligned (see the matching invalid case below). Exercises the
+		// bare-string option parse path.
+		{Code: "var x = <App>\n  foo\n</App>", Tsx: true, Options: "line-aligned"},
+
+		// ---- Real-user: list rendering via a .map() callback, all aligned ----
+		{Code: "<ul>\n  {items.map(i => (\n    <li>\n      {i}\n    </li>\n  ))}\n</ul>", Tsx: true},
+		// ---- Real-user: ternary rendering, both branches aligned ----
+		{Code: "<div>\n  {cond ? (\n    <A>\n      x\n    </A>\n  ) : (\n    <B>\n      y\n    </B>\n  )}\n</div>", Tsx: true},
+		// ---- Real-user: multi-line opening tag with several props; tag-aligned
+		// closing aligns to the opening `<` column, not the `>` line. ----
+		{Code: "const el = (\n  <Button\n    type=\"submit\"\n  >\n    Submit\n  </Button>\n)", Tsx: true},
+		// ---- tsgo/UTF-16: multi-byte chars before the opening tag do NOT shift
+		// line-aligned (which keys off the opening LINE indent, here 0). ----
+		{Code: "const 名字 = <App>\n  foo\n</App>", Tsx: true, Options: "line-aligned"},
+		// ---- Doc example (line-aligned, correct): closing aligns with the
+		// opening LINE indent (0) even though the opening `<` is at column 12. ----
+		{Code: "const App = <Bar>\n  Foo\n</Bar>", Tsx: true, Options: "line-aligned"},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Layer 3: getIndentation() option branch (tag-aligned twin of the
+		// line-aligned valid case above) — opening tag not at line start, so
+		// tag-aligned (opening column 8) and line-aligned (line indent 0) diverge.
+		{
+			Code:   "var x = <App>\n  foo\n</App>",
+			Tsx:    true,
+			Output: []string{"var x = <App>\n  foo\n        </App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      3,
+				Column:    1,
+				EndLine:   3,
+				EndColumn: 7,
+			}},
+		},
+
+		// ---- Layer 3 (stylistic-specific): pure-insert fix preserves the
+		// whitespace already before the tag. react strips the two spaces after
+		// "foo"; stylistic's insertTextBefore leaves them. ----
+		{
+			Code:   "<App>\n  foo  </App>",
+			Tsx:    true,
+			Output: []string{"<App>\n  foo  \n</App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "onOwnLine",
+				Line:      2,
+				Column:    8,
+				EndLine:   2,
+				EndColumn: 14,
+			}},
+		},
+
+		// ---- Layer 3 (stylistic-specific): tab-indented reference line, the
+		// fix emits SPACES (one per leading whitespace char), not tabs. Under
+		// line-aligned react would re-use the literal "\t". ----
+		{
+			Code:    "\t<App>\n\t\tfoo\n\t\t\t</App>",
+			Tsx:     true,
+			Options: []interface{}{"line-aligned"},
+			Output:  []string{"\t<App>\n\t\tfoo\n </App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "alignWithOpening",
+				Line:      3,
+				Column:    4,
+				EndLine:   3,
+				EndColumn: 10,
+			}},
+		},
+
+		// ---- Dimension 4: nesting boundary — only the misaligned INNER element
+		// reports; the correctly-aligned outer element must not bleed in. ----
+		{
+			Code:   "<App>\n  <Inner>\n    x\n      </Inner>\n</App>",
+			Tsx:    true,
+			Output: []string{"<App>\n  <Inner>\n    x\n  </Inner>\n</App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      4,
+				Column:    7,
+				EndLine:   4,
+				EndColumn: 15,
+			}},
+		},
+
+		// ---- Dimension 4: element nested in a fragment — fragment closing is
+		// aligned (valid), only the inner element reports. ----
+		{
+			Code:   "<>\n  <App>\n    x\n      </App>\n</>",
+			Tsx:    true,
+			Output: []string{"<>\n  <App>\n    x\n  </App>\n</>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      4,
+				Column:    7,
+				EndLine:   4,
+				EndColumn: 13,
+			}},
+		},
+
+		// ---- Dimension 4: container form — JsxMemberExpression tag name. ----
+		{
+			Code:   "<Foo.Bar>\n  x\n    </Foo.Bar>",
+			Tsx:    true,
+			Output: []string{"<Foo.Bar>\n  x\n</Foo.Bar>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      3,
+				Column:    5,
+				EndLine:   3,
+				EndColumn: 15,
+			}},
+		},
+
+		// ---- Real-user: multiline opening tag with attributes (docs example,
+		// tag-aligned). ----
+		{
+			Code:   "<Say\n  firstName=\"John\"\n  lastName=\"Smith\">\n  Hello\n    </Say>",
+			Tsx:    true,
+			Output: []string{"<Say\n  firstName=\"John\"\n  lastName=\"Smith\">\n  Hello\n</Say>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      5,
+				Column:    5,
+				EndLine:   5,
+				EndColumn: 11,
+			}},
+		},
+
+		// ---- Real-user: paren-wrapped assignment, line-aligned (opening tag
+		// indented 2, closing over-indented). ----
+		{
+			Code:    "var x = (\n  <App>\n    foo\n      </App>\n)",
+			Tsx:     true,
+			Options: []interface{}{"line-aligned"},
+			Output:  []string{"var x = (\n  <App>\n    foo\n  </App>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "alignWithOpening",
+				Line:      4,
+				Column:    7,
+				EndLine:   4,
+				EndColumn: 13,
+			}},
+		},
+
+		// ---- Dimension 4: graceful — unknown option string falls back to the
+		// default (tag-aligned). Upstream's JSON schema rejects this value
+		// before the rule runs; rslint has no schema validation, so the rule
+		// must degrade rather than emit an empty messageId. ----
+		{
+			Code:    "<App>\n  foo\n    </App>",
+			Tsx:     true,
+			Options: "tag-align", // typo → not in enum → default
+			Output:  []string{"<App>\n  foo\n</App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      3,
+				Column:    5,
+				EndLine:   3,
+				EndColumn: 11,
+			}},
+		},
+
+		// ---- Dimension 4: graceful — the `{ location }` object form is NOT in
+		// stylistic's string-only schema, so it is ignored and the rule uses the
+		// default tag-aligned (here flagging what line-aligned would have
+		// accepted). This is the key option-shape divergence from the react rule,
+		// which DOES honor `{ location }`. ----
+		{
+			Code:    "var x = <App>\n  foo\n</App>",
+			Tsx:     true,
+			Options: map[string]interface{}{"location": "line-aligned"},
+			Output:  []string{"var x = <App>\n  foo\n        </App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      3,
+				Column:    1,
+				EndLine:   3,
+				EndColumn: 7,
+			}},
+		},
+
+		// ---- Layer 3 (faithfulness lock-in): a leading comma is CONTENT, not
+		// whitespace, so the close is NOT first-in-line → onOwnLine, and the
+		// pure-insert fix must leave the comma intact. reactutil.IsNodeFirstInLine
+		// skips commas and would (a) mis-pick matchIndent and (b) DELETE the comma
+		// via replaceTextRange — which is exactly why this rule computes
+		// first-in-line itself instead of reusing that helper. ----
+		{
+			Code:   "<App>\n  ,</App>",
+			Tsx:    true,
+			Output: []string{"<App>\n  ,\n</App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "onOwnLine",
+				Line:      2,
+				Column:    4,
+				EndLine:   2,
+				EndColumn: 10,
+			}},
+		},
+
+		// ---- Dimension 4: fragment nested in a fragment — only the misaligned
+		// inner fragment reports; the aligned outer fragment must not bleed in. ----
+		{
+			Code:   "<>\n  <>\n    x\n      </>\n</>",
+			Tsx:    true,
+			Output: []string{"<>\n  <>\n    x\n  </>\n</>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      4,
+				Column:    7,
+				EndLine:   4,
+				EndColumn: 10,
+			}},
+		},
+
+		// ---- Dimension 4: 3-level deep nesting — only the innermost element is
+		// misaligned; both correctly-aligned ancestors must stay silent. ----
+		{
+			Code:   "<A>\n  <B>\n    <C>\n      x\n        </C>\n  </B>\n</A>",
+			Tsx:    true,
+			Output: []string{"<A>\n  <B>\n    <C>\n      x\n    </C>\n  </B>\n</A>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      5,
+				Column:    9,
+				EndLine:   5,
+				EndColumn: 13,
+			}},
+		},
+
+		// ---- Dimension 4: container form — JsxNamespacedName tag (`<a:b>`).
+		// The rule reads only the `<` position, so the tag-name shape is
+		// irrelevant; this locks that in. ----
+		{
+			Code:   "<a:b>\n  x\n    </a:b>",
+			Tsx:    true,
+			Output: []string{"<a:b>\n  x\n</a:b>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      3,
+				Column:    5,
+				EndLine:   3,
+				EndColumn: 11,
+			}},
+		},
+
+		// ---- tsgo/UTF-16 lock-in: multi-byte chars on the opening line. The
+		// tag-aligned target column AND the fix indent width are UTF-16 columns
+		// (10 = "const 名 = "), not byte offsets (12). A byte-based impl would
+		// emit 12 spaces and diverge from ESLint. ----
+		{
+			Code:   "const 名 = <App>\n  foo\n</App>",
+			Tsx:    true,
+			Output: []string{"const 名 = <App>\n  foo\n          </App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      3,
+				Column:    1,
+				EndLine:   3,
+				EndColumn: 7,
+			}},
+		},
+
+		// ---- tsgo/UTF-16 lock-in: multi-byte content on the closing line before
+		// the tag — the reported column is UTF-16 (7), not the byte offset (9). ----
+		{
+			Code:   "<App>\n  名foo</App>",
+			Tsx:    true,
+			Output: []string{"<App>\n  名foo\n</App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "onOwnLine",
+				Line:      2,
+				Column:    7,
+				EndLine:   2,
+				EndColumn: 13,
+			}},
+		},
+
+		// ---- Dimension 4 (line-ending lock-in): CRLF terminators must produce
+		// the same line/column/fix as LF. ----
+		{
+			Code:   "<App>\r\n  foo\r\n      </App>",
+			Tsx:    true,
+			Output: []string{"<App>\r\n  foo\r\n</App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      3,
+				Column:    7,
+				EndLine:   3,
+				EndColumn: 13,
+			}},
+		},
+
+		// ---- Dimension 4: container form — TS generic component tag `<App<T>>`.
+		// The opening `<` is the element start, not the `<` of the type args. ----
+		{
+			Code:   "<App<T>>\n  x\n    </App>",
+			Tsx:    true,
+			Output: []string{"<App<T>>\n  x\n</App>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      3,
+				Column:    5,
+				EndLine:   3,
+				EndColumn: 11,
+			}},
+		},
+
+		// ---- Real-user: JSX returned from a .map() callback, closing misaligned;
+		// the outer <ul> stays aligned and silent. ----
+		{
+			Code:   "<ul>\n  {items.map(i =>\n    <li>\n      {i}\n      </li>\n  )}\n</ul>",
+			Tsx:    true,
+			Output: []string{"<ul>\n  {items.map(i =>\n    <li>\n      {i}\n    </li>\n  )}\n</ul>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      5,
+				Column:    7,
+				EndLine:   5,
+				EndColumn: 12,
+			}},
+		},
+
+		// ---- Real-user: JSX as an array element — the closing tag is followed by
+		// a comma, which (being after the tag) must not affect first-in-line. ----
+		{
+			Code:   "[\n  <App>\n    x\n      </App>,\n]",
+			Tsx:    true,
+			Output: []string{"[\n  <App>\n    x\n  </App>,\n]"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      4,
+				Column:    7,
+				EndLine:   4,
+				EndColumn: 13,
+			}},
+		},
+
+		// ---- Real-user: multi-line opening tag, line-aligned. The closing keys
+		// off the opening LINE indent (2), proving the `<` is taken from the
+		// opening tag's line, not the `>` line. ----
+		{
+			Code:    "const el = (\n  <Button\n    type=\"submit\"\n    onClick={fn}\n  >\n    Submit\n      </Button>\n)",
+			Tsx:     true,
+			Options: []interface{}{"line-aligned"},
+			Output:  []string{"const el = (\n  <Button\n    type=\"submit\"\n    onClick={fn}\n  >\n    Submit\n  </Button>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "alignWithOpening",
+				Line:      7,
+				Column:    7,
+				EndLine:   7,
+				EndColumn: 16,
+			}},
+		},
+
+		// ---- Doc example (line-aligned, incorrect): mirrors the `.md` example;
+		// the over-indented closing tag is re-aligned to the opening line indent. ----
+		{
+			Code:    "const App = <Bar>\n  Foo\n                </Bar>",
+			Tsx:     true,
+			Options: []interface{}{"line-aligned"},
+			Output:  []string{"const App = <Bar>\n  Foo\n</Bar>"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "alignWithOpening",
+				Line:      3,
+				Column:    17,
+				EndLine:   3,
+				EndColumn: 23,
+			}},
+		},
+	})
+}

--- a/internal/plugins/stylistic/rules/jsx_closing_tag_location/jsx_closing_tag_location_upstream_test.go
+++ b/internal/plugins/stylistic/rules/jsx_closing_tag_location/jsx_closing_tag_location_upstream_test.go
@@ -1,0 +1,116 @@
+// TestJsxClosingTagLocationUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/rules/jsx-closing-tag-location/
+// jsx-closing-tag-location.test.ts 1:1. Upstream asserts only messageId on its
+// invalid cases; line/column/endLine/endColumn here are computed from the exact
+// source the case carries. rslint-specific lock-in cases live in
+// jsx_closing_tag_location_extras_test.go.
+package jsx_closing_tag_location
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxClosingTagLocationUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxClosingTagLocationRule, []rule_tester.ValidTestCase{
+		// ---- default tag-aligned ----
+		{Code: "\n    <App>\n      foo\n    </App>\n  ", Tsx: true},
+		{Code: "\n    <App>foo</App>\n  ", Tsx: true},
+		// ---- fragment (features: ['fragment']) ----
+		{Code: "\n    <>\n      foo\n    </>\n  ", Tsx: true},
+		{Code: "\n    <>foo</>\n  ", Tsx: true},
+		// ---- line-aligned ----
+		{Code: "\n    const foo = () => {\n      return <App>\n   bar</App>\n    }\n  ", Tsx: true, Options: []interface{}{"line-aligned"}},
+		{Code: "\n    const foo = () => {\n      return <App>\n          bar</App>\n    }\n  ", Tsx: true},
+		{Code: "\n    const foo = () => {\n      return <App>\n          bar\n      </App>\n    }\n  ", Tsx: true, Options: []interface{}{"line-aligned"}},
+		{Code: "\n    const foo = <App>\n          bar\n    </App>\n  ", Tsx: true, Options: []interface{}{"line-aligned"}},
+		{Code: "\n    const x = <App>\n          foo\n              </App>\n  ", Tsx: true},
+		{Code: "\n    const foo =\n      <App>\n          bar\n      </App>\n  ", Tsx: true, Options: []interface{}{"line-aligned"}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- default tag-aligned: closing tag alone on its line, wrong indent ----
+		{
+			Code:   "\n    <App>\n      foo\n      </App>\n  ",
+			Tsx:    true,
+			Output: []string{"\n    <App>\n      foo\n    </App>\n  "},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Message:   "Expected closing tag to match indentation of opening.",
+				Line:      4,
+				Column:    7,
+				EndLine:   4,
+				EndColumn: 13,
+			}},
+		},
+		// ---- default tag-aligned: closing tag shares line with content ----
+		{
+			Code:   "\n    <App>\n      foo</App>\n  ",
+			Tsx:    true,
+			Output: []string{"\n    <App>\n      foo\n    </App>\n  "},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "onOwnLine",
+				Message:   "Closing tag of a multiline JSX expression must be on its own line.",
+				Line:      3,
+				Column:    10,
+				EndLine:   3,
+				EndColumn: 16,
+			}},
+		},
+		// ---- fragment, alone on its line, wrong indent (features: ['fragment', 'no-ts-old']) ----
+		{
+			Code:   "\n    <>\n      foo\n      </>\n  ",
+			Tsx:    true,
+			Output: []string{"\n    <>\n      foo\n    </>\n  "},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "matchIndent",
+				Line:      4,
+				Column:    7,
+				EndLine:   4,
+				EndColumn: 10,
+			}},
+		},
+		// ---- fragment, shares line with content (features: ['fragment', 'no-ts-old']) ----
+		{
+			Code:   "\n    <>\n      foo</>\n  ",
+			Tsx:    true,
+			Output: []string{"\n    <>\n      foo\n    </>\n  "},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "onOwnLine",
+				Line:      3,
+				Column:    10,
+				EndLine:   3,
+				EndColumn: 13,
+			}},
+		},
+		// ---- line-aligned: closing tag shares line with content ----
+		{
+			Code:    "\n    const x = () => {\n      return <App>\n          foo</App>\n    }\n  ",
+			Tsx:     true,
+			Options: []interface{}{"line-aligned"},
+			Output:  []string{"\n    const x = () => {\n      return <App>\n          foo\n      </App>\n    }\n  "},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "onOwnLine",
+				Line:      4,
+				Column:    14,
+				EndLine:   4,
+				EndColumn: 20,
+			}},
+		},
+		// ---- line-aligned: closing tag alone on its line, over-indented ----
+		{
+			Code:    "\n    const x = <App>\n          foo\n              </App>\n  ",
+			Tsx:     true,
+			Options: []interface{}{"line-aligned"},
+			Output:  []string{"\n    const x = <App>\n          foo\n    </App>\n  "},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "alignWithOpening",
+				Message:   "Expected closing tag to be aligned with the line containing the opening tag",
+				Line:      4,
+				Column:    15,
+				EndLine:   4,
+				EndColumn: 21,
+			}},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -464,6 +464,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/eol-last.test.ts',
     './tests/eslint-plugin-stylistic/rules/generator-star-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-closing-bracket-location.test.ts',
+    './tests/eslint-plugin-stylistic/rules/jsx-closing-tag-location.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-closing-tag-location.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-closing-tag-location.test.ts
@@ -1,0 +1,87 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const MESSAGE_ON_OWN_LINE =
+  'Closing tag of a multiline JSX expression must be on its own line.';
+const MESSAGE_MATCH_INDENT =
+  'Expected closing tag to match indentation of opening.';
+const MESSAGE_ALIGN_WITH_OPENING =
+  'Expected closing tag to be aligned with the line containing the opening tag';
+
+ruleTester.run('jsx-closing-tag-location', null as never, {
+  valid: [
+    // default tag-aligned
+    { code: `\n    <App>\n      foo\n    </App>\n  ` },
+    { code: `\n    <App>foo</App>\n  ` },
+    // fragment
+    { code: `\n    <>\n      foo\n    </>\n  ` },
+    { code: `\n    <>foo</>\n  ` },
+    // line-aligned
+    {
+      code: `\n    const foo = () => {\n      return <App>\n   bar</App>\n    }\n  `,
+      options: ['line-aligned'],
+    },
+    {
+      code: `\n    const foo = () => {\n      return <App>\n          bar</App>\n    }\n  `,
+    },
+    {
+      code: `\n    const foo = () => {\n      return <App>\n          bar\n      </App>\n    }\n  `,
+      options: ['line-aligned'],
+    },
+    {
+      code: `\n    const foo = <App>\n          bar\n    </App>\n  `,
+      options: ['line-aligned'],
+    },
+    {
+      code: `\n    const x = <App>\n          foo\n              </App>\n  `,
+    },
+    {
+      code: `\n    const foo =\n      <App>\n          bar\n      </App>\n  `,
+      options: ['line-aligned'],
+    },
+  ],
+
+  invalid: [
+    // default tag-aligned: closing tag alone on its line, wrong indent
+    {
+      code: `\n    <App>\n      foo\n      </App>\n  `,
+      output: `\n    <App>\n      foo\n    </App>\n  `,
+      errors: [{ messageId: 'matchIndent', message: MESSAGE_MATCH_INDENT }],
+    },
+    // default tag-aligned: closing tag shares line with content
+    {
+      code: `\n    <App>\n      foo</App>\n  `,
+      output: `\n    <App>\n      foo\n    </App>\n  `,
+      errors: [{ messageId: 'onOwnLine', message: MESSAGE_ON_OWN_LINE }],
+    },
+    // fragment, alone on its line, wrong indent
+    {
+      code: `\n    <>\n      foo\n      </>\n  `,
+      output: `\n    <>\n      foo\n    </>\n  `,
+      errors: [{ messageId: 'matchIndent', message: MESSAGE_MATCH_INDENT }],
+    },
+    // fragment, shares line with content
+    {
+      code: `\n    <>\n      foo</>\n  `,
+      output: `\n    <>\n      foo\n    </>\n  `,
+      errors: [{ messageId: 'onOwnLine', message: MESSAGE_ON_OWN_LINE }],
+    },
+    // line-aligned: closing tag shares line with content
+    {
+      code: `\n    const x = () => {\n      return <App>\n          foo</App>\n    }\n  `,
+      output: `\n    const x = () => {\n      return <App>\n          foo\n      </App>\n    }\n  `,
+      options: ['line-aligned'],
+      errors: [{ messageId: 'onOwnLine', message: MESSAGE_ON_OWN_LINE }],
+    },
+    // line-aligned: closing tag alone on its line, over-indented
+    {
+      code: `\n    const x = <App>\n          foo\n              </App>\n  `,
+      output: `\n    const x = <App>\n          foo\n    </App>\n  `,
+      options: ['line-aligned'],
+      errors: [
+        { messageId: 'alignWithOpening', message: MESSAGE_ALIGN_WITH_OPENING },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/jsx-closing-tag-location` rule from ESLint Stylistic to rslint.

Enforces the closing tag location for multiline JSX elements and fragments. A single-line element is always allowed; when the element spans multiple lines, the closing tag must sit on its own line and be aligned according to the option:

- `"tag-aligned"` (default) — aligned with the column of the opening `<`.
- `"line-aligned"` — aligned with the indentation of the line containing the opening tag.

The port mirrors the upstream behavior exactly (UTF-16 columns, spaces-only autofix indent, pure-insert "move to own line" fix, string-only option). It supports both `JsxClosingElement` and `JsxClosingFragment`, and was differentially validated against ESLint Stylistic on the rsbuild and rspack codebases plus a violation corpus (tag-aligned and line-aligned), with byte-for-byte agreement.

## Related Links

- Rule documentation: https://eslint.style/rules/jsx-closing-tag-location
- Upstream source: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/jsx-closing-tag-location/jsx-closing-tag-location.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).