### PR TITLE
feat: port rule @stylistic/jsx-curly-newline

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -16,6 +16,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_closing_bracket_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_closing_tag_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_curly_brace_presence"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_curly_newline"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -36,5 +37,6 @@ func GetAllRules() []rule.Rule {
 		jsx_closing_bracket_location.JsxClosingBracketLocationRule,
 		jsx_closing_tag_location.JsxClosingTagLocationRule,
 		jsx_curly_brace_presence.JsxCurlyBracePresenceRule,
+		jsx_curly_newline.JsxCurlyNewlineRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/jsx_curly_newline/jsx_curly_newline.go
+++ b/internal/plugins/stylistic/rules/jsx_curly_newline/jsx_curly_newline.go
@@ -1,0 +1,206 @@
+// Package jsx_curly_newline ports `@stylistic/jsx-curly-newline` to rslint. It
+// enforces consistent linebreaks immediately inside the curly braces of a JSX
+// expression container (`{ ... }` in attribute values and children).
+//
+// For each container the rule looks at two boundaries: between `{` and the
+// first token, and between the last token and `}`. Whether a newline is
+// required there is decided per option (`singleline` / `multiline`, each
+// `consistent` | `require` | `forbid`; the string forms `'consistent'` and
+// `'never'` are shorthands), selected by whether the contained expression is
+// single- or multi-line.
+//
+// Two tsgo↔ESTree shape differences are handled here:
+//   - Spread children (`{...x}`) are JSXSpreadChild in ESTree and not visited by
+//     this rule; tsgo folds them into JsxExpression with a DotDotDotToken, so
+//     those are skipped.
+//   - ESTree's `node.expression` unwraps parentheses, while tsgo keeps an
+//     explicit ParenthesizedExpression. The single-/multi-line decision uses the
+//     unwrapped expression, but the brace-adjacent token positions use the raw
+//     (possibly parenthesized) expression — matching ESLint's token walk.
+package jsx_curly_newline
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	modeConsistent = "consistent"
+	modeRequire    = "require"
+	modeForbid     = "forbid"
+)
+
+var messages = map[string]string{
+	"expectedBefore":   "Expected newline before '}'.",
+	"expectedAfter":    "Expected newline after '{'.",
+	"unexpectedBefore": "Unexpected newline before '}'.",
+	"unexpectedAfter":  "Unexpected newline after '{'.",
+}
+
+// parseOptions resolves the (singleline, multiline) modes from every shape the
+// loader can deliver for upstream's `string | { singleline?, multiline? }`
+// schema: nil, a bare value (single-option CLI form), or a single-element array
+// (rule-tester form). It mirrors upstream's destructuring exactly —
+//
+//	'never'      => { singleline: 'forbid',  multiline: 'forbid' }
+//	'consistent' => { singleline: 'consistent', multiline: 'consistent' }
+//	object       => fields with each side defaulting to 'consistent'
+//
+// Any value outside the enum is rejected by upstream's JSON schema before the
+// rule runs; the `default` arm of the mode switch treats unknown strings as
+// `consistent`, so hand-written rslint configs degrade the same way.
+func parseOptions(options any) (singleline, multiline string) {
+	singleline, multiline = modeConsistent, modeConsistent
+	raw := options
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) == 0 {
+			return
+		}
+		raw = arr[0]
+	}
+	switch v := raw.(type) {
+	case string:
+		if v == "never" {
+			return modeForbid, modeForbid
+		}
+		// 'consistent' (the only other enum value) sets both sides; upstream:
+		// `typeof options === 'string' ? { multiline: options, singleline: options }`.
+		return v, v
+	case map[string]interface{}:
+		if s, ok := v["singleline"].(string); ok {
+			singleline = s
+		}
+		if m, ok := v["multiline"].(string); ok {
+			multiline = m
+		}
+	}
+	return
+}
+
+// JsxCurlyNewlineRule enforces linebreaks inside JSX expression-container braces.
+var JsxCurlyNewlineRule = rule.Rule{
+	Name: "@stylistic/jsx-curly-newline",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		singleline, multiline := parseOptions(options)
+		text := ctx.SourceFile.Text()
+		lineStarts := ctx.SourceFile.ECMALineMap()
+		lineOf := func(pos int) int {
+			return scanner.ComputeLineOfPosition(lineStarts, pos)
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxExpression: func(node *ast.Node) {
+				jsxExpr := node.AsJsxExpression()
+				// Spread children ({...x}) map to ESTree JSXSpreadChild, which
+				// this rule does not handle (it only visits
+				// JSXExpressionContainer).
+				if jsxExpr.DotDotDotToken != nil {
+					return
+				}
+
+				openBrace := utils.TrimNodeTextRange(ctx.SourceFile, node).Pos()
+				closeBrace := node.End() - 1
+				// Guard parser-recovery shapes (unterminated container,
+				// synthesized nodes) where the braces aren't where we expect.
+				if openBrace < 0 || closeBrace <= openBrace || closeBrace >= len(text) ||
+					text[openBrace] != '{' || text[closeBrace] != '}' {
+					return
+				}
+
+				openLine := lineOf(openBrace)
+				closeLine := lineOf(closeBrace)
+
+				// afterStart / beforeEnd are the positions of the first token
+				// after `{` and the last token before `}`, mirroring ESLint's
+				// getTokenAfter(leftCurly) / getTokenBefore(rightCurly) (both
+				// skip comments). For a non-empty container these are the raw
+				// expression's trimmed bounds, whose token scan already skips
+				// leading/trailing comment trivia. For an empty container ({},
+				// {/* c */}) the token after `{` is `}` and the token before
+				// `}` is `{`, exactly where ESLint's walk lands.
+				var afterStart, beforeEnd int
+				var singleLine bool
+				if jsxExpr.Expression != nil {
+					exprRange := utils.TrimNodeTextRange(ctx.SourceFile, jsxExpr.Expression)
+					afterStart = exprRange.Pos()
+					beforeEnd = exprRange.End()
+					// isSingleLine inspects ESTree's node.expression, which has
+					// no node for parentheses; tsgo keeps an explicit
+					// ParenthesizedExpression. Judge single-/multi-line by the
+					// unwrapped expression so `{(\nfoo\n)}` is multiline by its
+					// inner node — matching ESLint.
+					inner := utils.TrimNodeTextRange(ctx.SourceFile, ast.SkipParentheses(jsxExpr.Expression))
+					singleLine = lineOf(inner.Pos()) == lineOf(inner.End())
+				} else {
+					afterStart = closeBrace
+					beforeEnd = openBrace + 1
+					singleLine = openLine == closeLine
+				}
+
+				hasLeftNewline := openLine != lineOf(afterStart)
+				hasRightNewline := lineOf(beforeEnd) != closeLine
+
+				mode := multiline
+				if singleLine {
+					mode = singleline
+				}
+				var needsNewlines bool
+				switch mode {
+				case modeForbid:
+					needsNewlines = false
+				case modeRequire:
+					needsNewlines = true
+				default: // 'consistent' and any non-enum value
+					needsNewlines = hasLeftNewline
+				}
+
+				// Left brace: the gap between `{` and the first token.
+				switch {
+				case hasLeftNewline && !needsNewlines:
+					reportToken(ctx, openBrace, "unexpectedAfter",
+						removalFix(ctx.SourceFile, openBrace+1, afterStart))
+				case !hasLeftNewline && needsNewlines:
+					reportToken(ctx, openBrace, "expectedAfter",
+						&rule.RuleFix{Text: "\n", Range: core.NewTextRange(openBrace+1, openBrace+1)})
+				}
+
+				// Right brace: the gap between the last token and `}`.
+				switch {
+				case hasRightNewline && !needsNewlines:
+					reportToken(ctx, closeBrace, "unexpectedBefore",
+						removalFix(ctx.SourceFile, beforeEnd, closeBrace))
+				case !hasRightNewline && needsNewlines:
+					reportToken(ctx, closeBrace, "expectedBefore",
+						&rule.RuleFix{Text: "\n", Range: core.NewTextRange(closeBrace, closeBrace)})
+				}
+			},
+		}
+	},
+}
+
+// reportToken reports a diagnostic anchored at the single-character brace token
+// at pos. A nil fix emits the diagnostic without an autofix (upstream's
+// `output: null`, used when a comment sits in the gap).
+func reportToken(ctx rule.RuleContext, pos int, id string, fix *rule.RuleFix) {
+	msg := rule.RuleMessage{Id: id, Description: messages[id]}
+	tokenRange := core.NewTextRange(pos, pos+1)
+	if fix != nil {
+		ctx.ReportRangeWithFixes(tokenRange, msg, *fix)
+	} else {
+		ctx.ReportRange(tokenRange, msg)
+	}
+}
+
+// removalFix builds a fix that deletes the [start, end) gap between a brace and
+// the adjacent token, but returns nil when a comment sits in that gap — mirroring
+// upstream's safeReplaceTextBetween, which refuses to delete comments.
+// utils.HasCommentsInRange is rslint's commentsExistBetween equivalent.
+func removalFix(sf *ast.SourceFile, start, end int) *rule.RuleFix {
+	if utils.HasCommentsInRange(sf, core.NewTextRange(start, end)) {
+		return nil
+	}
+	return &rule.RuleFix{Text: "", Range: core.NewTextRange(start, end)}
+}

--- a/internal/plugins/stylistic/rules/jsx_curly_newline/jsx_curly_newline.md
+++ b/internal/plugins/stylistic/rules/jsx_curly_newline/jsx_curly_newline.md
@@ -1,0 +1,110 @@
+# jsx-curly-newline
+
+Enforce consistent linebreaks inside the curly braces of JSX expression containers (`{ ... }` in attribute values and children).
+
+## Rule Details
+
+For each JSX expression container the rule checks two positions: right after the opening `{` and right before the closing `}`. Whether a newline is required at those positions is controlled by the option, chosen by whether the contained expression spans a single line or multiple lines.
+
+The rule only manages the linebreaks themselves; it does not adjust indentation (that is the job of an indentation rule).
+
+## Options
+
+This rule accepts either a string or an object.
+
+- `"consistent"` (default) — the closing brace's linebreak must match the opening brace's: if there is a newline after `{`, there must be one before `}`, and vice versa.
+- `"never"` — no linebreaks are allowed after `{` or before `}`.
+- An object `{ "singleline": ..., "multiline": ... }`, where each property is one of:
+  - `"consistent"` (default for each property) — match the opening brace, as above.
+  - `"require"` — a newline is required after `{` and before `}`.
+  - `"forbid"` — newlines after `{` and before `}` are not allowed.
+
+  `singleline` applies when the expression is on a single line; `multiline` applies when it spans multiple lines.
+
+Examples of **incorrect** code for this rule with the default `"consistent"` option:
+
+```javascript
+<div>
+  { foo
+  }
+</div>
+```
+
+Examples of **correct** code for this rule with the default `"consistent"` option:
+
+```javascript
+<div>{foo}</div>;
+
+<div>
+  {
+    foo
+  }
+</div>;
+
+<div foo={
+  bar
+} />;
+```
+
+Examples of **incorrect** code for this rule with the `"never"` option:
+
+```json
+{ "@stylistic/jsx-curly-newline": ["error", "never"] }
+```
+
+```javascript
+<div>
+  {
+    foo
+  }
+</div>
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```json
+{ "@stylistic/jsx-curly-newline": ["error", "never"] }
+```
+
+```javascript
+<div>{foo}</div>;
+
+<div>
+  { foo &&
+    foo.bar }
+</div>;
+```
+
+Examples of **incorrect** code for this rule with the `{ "singleline": "consistent", "multiline": "require" }` option:
+
+```json
+{ "@stylistic/jsx-curly-newline": ["error", { "singleline": "consistent", "multiline": "require" }] }
+```
+
+```javascript
+<div>
+  { foo &&
+    bar }
+</div>
+```
+
+Examples of **correct** code for this rule with the `{ "singleline": "consistent", "multiline": "require" }` option:
+
+```json
+{ "@stylistic/jsx-curly-newline": ["error", { "singleline": "consistent", "multiline": "require" }] }
+```
+
+```javascript
+<div>{foo}</div>;
+
+<div>
+  {
+    foo &&
+    bar
+  }
+</div>;
+```
+
+## Original Documentation
+
+- [@stylistic/jsx-curly-newline](https://eslint.style/rules/jsx-curly-newline)

--- a/internal/plugins/stylistic/rules/jsx_curly_newline/jsx_curly_newline_extras_test.go
+++ b/internal/plugins/stylistic/rules/jsx_curly_newline/jsx_curly_newline_extras_test.go
@@ -1,0 +1,224 @@
+// TestJsxCurlyNewlineExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+package jsx_curly_newline
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxCurlyNewlineExtras(t *testing.T) {
+	const (
+		expectedAfter    = "Expected newline after '{'."
+		expectedBefore   = "Expected newline before '}'."
+		unexpectedAfter  = "Unexpected newline after '{'."
+		unexpectedBefore = "Unexpected newline before '}'."
+	)
+	singleForbid := []interface{}{map[string]interface{}{"singleline": "forbid"}}
+	singleRequire := []interface{}{map[string]interface{}{"singleline": "require"}}
+	multiForbid := []interface{}{map[string]interface{}{"multiline": "forbid"}}
+	// Discriminator option: singleline and multiline disagree, so the
+	// single-/multi-line decision (which the paren-unwrap affects) is observable.
+	singleReqMultiForbid := []interface{}{map[string]interface{}{"singleline": "require", "multiline": "forbid"}}
+	multilineRequire := []interface{}{map[string]interface{}{"singleline": "consistent", "multiline": "require"}}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxCurlyNewlineRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: parenthesized expression (single line, no newlines) ----
+		{Code: "<div>{(foo)}</div>", Tsx: true},
+		// ---- Dimension 4: TS type-expression wrappers (as / non-null) ----
+		{Code: "<div>{foo as string}</div>", Tsx: true},
+		{Code: "<div>{foo!}</div>", Tsx: true},
+		// ---- Dimension 4: optional chain (no ChainExpression wrapper in tsgo) ----
+		{Code: "<div>{foo?.bar}</div>", Tsx: true},
+		// ---- Dimension 4: element access ----
+		{Code: "<div>{foo['bar']}</div>", Tsx: true},
+		// ---- Dimension 4: object literal — outer container braces, not the object's ----
+		{Code: "<div style={{ color: 'red' }} />", Tsx: true},
+		{Code: "<div style={{\n  color: 'red'\n}} />", Tsx: true},
+		// ---- Dimension 4: nested JSX containers — listener fires per container, no bleed ----
+		{Code: "<div>{cond && <span>{foo}</span>}</div>", Tsx: true},
+		// ---- Dimension 4: deep nesting (3 container levels), all single-line ----
+		{Code: "<div>{a && <span>{b && <i>{c}</i>}</span>}</div>", Tsx: true},
+		// ---- Dimension 4: fragment children ----
+		{Code: "<>{foo}</>", Tsx: true},
+		{Code: "<>{\nfoo\n}</>", Tsx: true},
+		// ---- Dimension 4: attribute container holding an element with its own container ----
+		{Code: "<Foo bar={<Baz qux={x} />} />", Tsx: true},
+		// ---- Real-user: the canonical multiline `.map` child — must NOT false-positive
+		// under the default `consistent` (braces hug the call, content broke inside). ----
+		{Code: "<ul>{items.map((i) =>\n<li>{i}</li>\n)}</ul>", Tsx: true},
+		// ---- Dimension 4: empty container / graceful degradation ----
+		{Code: "<div>{}</div>", Tsx: true},
+		{Code: "<div>{}</div>", Tsx: true, Options: []interface{}{"never"}},
+		{Code: "<div>{\n}</div>", Tsx: true},
+		{Code: "<div>{/* comment */}</div>", Tsx: true},
+		// ---- Dimension 4: spread child — JSXSpreadChild in ESTree, not visited ----
+		{Code: "<div>{...children}</div>", Tsx: true, Options: []interface{}{"never"}},
+		// ---- Dimension 4: spread attribute — JsxSpreadAttribute, not a JsxExpression ----
+		{Code: "<div {...props} />", Tsx: true, Options: []interface{}{"never"}},
+		// Locks in shouldHaveNewlines(): multiline:'require' leaves singleline at
+		// its 'consistent' default — a single-line expr without newlines is fine.
+		{Code: "<div>{foo}</div>", Tsx: true, Options: multiForbid},
+		// Exercises the bare-object options path (CLI single-option shape).
+		{Code: "<div>{foo}</div>", Tsx: true, Options: map[string]interface{}{"multiline": "require"}},
+	}, []rule_tester.InvalidTestCase{
+		// Locks in shouldHaveNewlines() singleline='forbid' arm: single-line expr
+		// with newlines on both sides is rejected.
+		{
+			Code:    "<div>{\nfoo\n}</div>",
+			Tsx:     true,
+			Options: singleForbid,
+			Output:  []string{"<div>{foo}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedAfter", Message: unexpectedAfter, Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 3, Column: 1, EndLine: 3, EndColumn: 2},
+			},
+		},
+		// Locks in shouldHaveNewlines() singleline='require' arm: single-line expr
+		// missing newlines on both sides.
+		{
+			Code:    "<div>{foo}</div>",
+			Tsx:     true,
+			Options: singleRequire,
+			Output:  []string{"<div>{\nfoo\n}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "expectedAfter", Message: expectedAfter, Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "expectedBefore", Message: expectedBefore, Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// Locks in shouldHaveNewlines() multiline='forbid' arm via the OBJECT
+		// form (a distinct code path from the 'never' string shorthand).
+		{
+			Code:    "<div>{\nfoo &&\nbar\n}</div>",
+			Tsx:     true,
+			Options: multiForbid,
+			Output:  []string{"<div>{foo &&\nbar}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedAfter", Message: unexpectedAfter, Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 4, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// Locks in parseOptions() default arm: no options => 'consistent'.
+		{
+			Code:   "<div>{\nfoo}</div>",
+			Tsx:    true,
+			Output: []string{"<div>{\nfoo\n}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "expectedBefore", Message: expectedBefore, Line: 2, Column: 4, EndLine: 2, EndColumn: 5},
+			},
+		},
+		// ---- Dimension 4: empty container — isSingleLine of the JSXEmptyExpression
+		// is decided by whether the braces share a line. A single-line `{ }` under
+		// singleline='require' must report both sides (multiline defaults to
+		// 'consistent', which would yield 0 errors if the braces were misjudged). ----
+		{
+			Code:    "<div>{ }</div>",
+			Tsx:     true,
+			Options: singleRequire,
+			Output:  []string{"<div>{\n \n}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "expectedAfter", Message: expectedAfter, Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "expectedBefore", Message: expectedBefore, Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+			},
+		},
+		// ---- Dimension 4: nested containers fixed independently — the inner
+		// container violates 'never' while the outer is already compliant. ----
+		{
+			Code:    "<div>{<span>{\nfoo\n}</span>}</div>",
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output:  []string{"<div>{<span>{foo}</span>}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedAfter", Message: unexpectedAfter, Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 3, Column: 1, EndLine: 3, EndColumn: 2},
+			},
+		},
+		// ---- Dimension 4: multi-byte content — tsgo positions are byte offsets, so
+		// the fix ranges must slice on byte boundaries (UTF-16 offsets would corrupt
+		// the CJK identifier or trip the brace guard). ----
+		{
+			Code:    "<div>{\n你好\n}</div>",
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output:  []string{"<div>{你好}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedAfter", Message: unexpectedAfter, Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 3, Column: 1, EndLine: 3, EndColumn: 2},
+			},
+		},
+		// ---- Dimension 4: U+2028 LINE SEPARATOR counts as a line break (tsgo's
+		// ECMALineMap and ESLint's LINEBREAK_MATCHER agree), so `}` is on a new line. ----
+		{
+			Code:    "<div>{foo\u2028}</div>",
+			Tsx:     true,
+			Options: []interface{}{"consistent"},
+			Output:  []string{"<div>{foo}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+			},
+		},
+		// ---- Dimension 4: comment-only empty container spanning lines — both sides
+		// report under 'never', and neither is fixed (the gap is the comment). ----
+		{
+			Code:    "<div>{/* a\nb */}</div>",
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedAfter", Message: unexpectedAfter, Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 2, Column: 5, EndLine: 2, EndColumn: 6},
+			},
+		},
+		// Locks in parseOptions() bare-string path ('never' not array-wrapped).
+		{
+			Code:    "<div>{\nfoo\n}</div>",
+			Tsx:     true,
+			Options: "never",
+			Output:  []string{"<div>{foo}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedAfter", Message: unexpectedAfter, Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 3, Column: 1, EndLine: 3, EndColumn: 2},
+			},
+		},
+		// ---- Dimension 4: parenthesized expression — isSingleLine uses the
+		// UNWRAPPED inner node. Here the parens span lines but `foo` is single-
+		// line, so singleline='require' applies (multiline='forbid' would give 0
+		// errors if we wrongly judged by the ParenthesizedExpression's own span).
+		{
+			Code:    "<div>{(\nfoo\n)}</div>",
+			Tsx:     true,
+			Options: singleReqMultiForbid,
+			Output:  []string{"<div>{\n(\nfoo\n)\n}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "expectedAfter", Message: expectedAfter, Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "expectedBefore", Message: expectedBefore, Line: 3, Column: 2, EndLine: 3, EndColumn: 3},
+			},
+		},
+		// ---- Real-user: eslint-plugin-react#3097 — multiline ternary gets
+		// newlines added after { and before }, with NO indentation adjustment. ----
+		{
+			Code:    "<div>{cond\n? a\n: b}</div>",
+			Tsx:     true,
+			Options: multilineRequire,
+			Output:  []string{"<div>{\ncond\n? a\n: b\n}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "expectedAfter", Message: expectedAfter, Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "expectedBefore", Message: expectedBefore, Line: 3, Column: 4, EndLine: 3, EndColumn: 5},
+			},
+		},
+		// ---- Real-user: eslint-stylistic#292 — closing brace moved to its own
+		// line (indentation untouched) when content already broke after {. ----
+		{
+			Code:    "<div>{\ntrue && (\n<p/>\n)}</div>",
+			Tsx:     true,
+			Options: []interface{}{"consistent"},
+			Output:  []string{"<div>{\ntrue && (\n<p/>\n)\n}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "expectedBefore", Message: expectedBefore, Line: 4, Column: 2, EndLine: 4, EndColumn: 3},
+			},
+		},
+	})
+}

--- a/internal/plugins/stylistic/rules/jsx_curly_newline/jsx_curly_newline_upstream_test.go
+++ b/internal/plugins/stylistic/rules/jsx_curly_newline/jsx_curly_newline_upstream_test.go
@@ -1,0 +1,159 @@
+// TestJsxCurlyNewlineUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/rules/jsx-curly-newline/
+// jsx-curly-newline.test.ts 1:1. Upstream asserts only messageId on its invalid
+// cases; the line/column/endLine/endColumn and exact message text here are
+// computed from the source each case carries. rslint-specific lock-in cases
+// live in jsx_curly_newline_extras_test.go.
+package jsx_curly_newline
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxCurlyNewlineUpstream(t *testing.T) {
+	consistent := []interface{}{"consistent"}
+	never := []interface{}{"never"}
+	multilineRequire := []interface{}{map[string]interface{}{"singleline": "consistent", "multiline": "require"}}
+
+	const (
+		expectedAfter    = "Expected newline after '{'."
+		expectedBefore   = "Expected newline before '}'."
+		unexpectedAfter  = "Unexpected newline after '{'."
+		unexpectedBefore = "Unexpected newline before '}'."
+	)
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxCurlyNewlineRule, []rule_tester.ValidTestCase{
+		// ---- consistent (default) ----
+		{Code: "<div>{foo}</div>", Tsx: true, Options: consistent},
+		{Code: "<div>\n          {\n            foo\n          }\n        </div>", Tsx: true, Options: consistent},
+		{Code: "<div>\n          { foo &&\n            foo.bar }\n        </div>", Tsx: true, Options: consistent},
+		{Code: "<div>\n          {\n            foo &&\n            foo.bar\n          }\n        </div>", Tsx: true, Options: consistent},
+		{Code: "<div foo={\n          bar\n        } />", Tsx: true, Options: consistent},
+		// ---- { singleline: consistent, multiline: require } ----
+		{Code: "<div>{foo}</div>", Tsx: true, Options: multilineRequire},
+		{Code: "<div foo={bar} />", Tsx: true, Options: multilineRequire},
+		{Code: "<div>\n          {\n            foo &&\n            foo.bar\n          }\n        </div>", Tsx: true, Options: multilineRequire},
+		{Code: "<div>\n          {\n            foo\n          }\n        </div>", Tsx: true, Options: multilineRequire},
+		// ---- never ----
+		{Code: "<div>{foo}</div>", Tsx: true, Options: never},
+		{Code: "<div foo={bar} />", Tsx: true, Options: never},
+		{Code: "<div>\n          { foo &&\n            foo.bar }\n        </div>", Tsx: true, Options: never},
+	}, []rule_tester.InvalidTestCase{
+		// ---- consistent: newline before } but not after { ----
+		{
+			Code:    "<div>\n          { foo \n}\n        </div>",
+			Tsx:     true,
+			Options: consistent,
+			Output:  []string{"<div>\n          { foo}\n        </div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 3, Column: 1, EndLine: 3, EndColumn: 2},
+			},
+		},
+		{
+			Code:    "<div>\n          { foo &&\n            foo.bar \n}\n        </div>",
+			Tsx:     true,
+			Options: consistent,
+			Output:  []string{"<div>\n          { foo &&\n            foo.bar}\n        </div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 4, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		{
+			Code:    "<div>\n          { foo &&\n            bar\n          }\n        </div>",
+			Tsx:     true,
+			Options: consistent,
+			Output:  []string{"<div>\n          { foo &&\n            bar}\n        </div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 4, Column: 11, EndLine: 4, EndColumn: 12},
+			},
+		},
+		// ---- { multiline: require }: newline before } unexpected on single-line expr ----
+		{
+			Code:    "<div>{foo\n}</div>",
+			Tsx:     true,
+			Options: multilineRequire,
+			Output:  []string{"<div>{foo}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+			},
+		},
+		{
+			Code:    "<div>{\nfoo}</div>",
+			Tsx:     true,
+			Options: multilineRequire,
+			Output:  []string{"<div>{\nfoo\n}</div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "expectedBefore", Message: expectedBefore, Line: 2, Column: 4, EndLine: 2, EndColumn: 5},
+			},
+		},
+		{
+			Code:    "<div>\n          { foo &&\n            bar }\n        </div>",
+			Tsx:     true,
+			Options: multilineRequire,
+			Output:  []string{"<div>\n          {\n foo &&\n            bar \n}\n        </div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "expectedAfter", Message: expectedAfter, Line: 2, Column: 11, EndLine: 2, EndColumn: 12},
+				{MessageId: "expectedBefore", Message: expectedBefore, Line: 3, Column: 17, EndLine: 3, EndColumn: 18},
+			},
+		},
+		{
+			Code:    "<div style={foo &&\n          foo.bar\n        } />",
+			Tsx:     true,
+			Options: multilineRequire,
+			Output:  []string{"<div style={\nfoo &&\n          foo.bar\n        } />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "expectedAfter", Message: expectedAfter, Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+			},
+		},
+		// ---- never: newlines on both sides unexpected ----
+		{
+			Code:    "<div>\n          {\nfoo\n}\n        </div>",
+			Tsx:     true,
+			Options: never,
+			Output:  []string{"<div>\n          {foo}\n        </div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedAfter", Message: unexpectedAfter, Line: 2, Column: 11, EndLine: 2, EndColumn: 12},
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 4, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		{
+			Code:    "<div>\n          {\n            foo &&\n            foo.bar\n          }\n        </div>",
+			Tsx:     true,
+			Options: never,
+			Output:  []string{"<div>\n          {foo &&\n            foo.bar}\n        </div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedAfter", Message: unexpectedAfter, Line: 2, Column: 11, EndLine: 2, EndColumn: 12},
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 5, Column: 11, EndLine: 5, EndColumn: 12},
+			},
+		},
+		{
+			Code:    "<div>\n          { foo &&\n            foo.bar\n          }\n        </div>",
+			Tsx:     true,
+			Options: never,
+			Output:  []string{"<div>\n          { foo &&\n            foo.bar}\n        </div>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 4, Column: 11, EndLine: 4, EndColumn: 12},
+			},
+		},
+		// ---- never: comment in the gap suppresses the fix (output unchanged) ----
+		{
+			Code:    "<div>\n          { /* not fixed due to comment */\n            foo }\n        </div>",
+			Tsx:     true,
+			Options: never,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedAfter", Message: unexpectedAfter, Line: 2, Column: 11, EndLine: 2, EndColumn: 12},
+			},
+		},
+		{
+			Code:    "<div>\n          { foo\n            /* not fixed due to comment */}\n        </div>",
+			Tsx:     true,
+			Options: never,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpectedBefore", Message: unexpectedBefore, Line: 3, Column: 43, EndLine: 3, EndColumn: 44},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -466,6 +466,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/jsx-closing-bracket-location.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-curly-brace-presence.test.ts',
+    './tests/eslint-plugin-stylistic/rules/jsx-curly-newline.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-curly-newline.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-curly-newline.test.ts
@@ -1,0 +1,126 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const EXPECTED_AFTER = "Expected newline after '{'.";
+const EXPECTED_BEFORE = "Expected newline before '}'.";
+const UNEXPECTED_AFTER = "Unexpected newline after '{'.";
+const UNEXPECTED_BEFORE = "Unexpected newline before '}'.";
+
+const CONSISTENT = ['consistent'];
+const NEVER = ['never'];
+const MULTILINE_REQUIRE = [{ singleline: 'consistent', multiline: 'require' }];
+
+ruleTester.run('jsx-curly-newline', null as never, {
+  valid: [
+    // consistent (default)
+    { code: `<div>{foo}</div>`, options: CONSISTENT },
+    {
+      code: `<div>\n          {\n            foo\n          }\n        </div>`,
+      options: CONSISTENT,
+    },
+    {
+      code: `<div>\n          { foo &&\n            foo.bar }\n        </div>`,
+      options: CONSISTENT,
+    },
+    {
+      code: `<div>\n          {\n            foo &&\n            foo.bar\n          }\n        </div>`,
+      options: CONSISTENT,
+    },
+    { code: `<div foo={\n          bar\n        } />`, options: CONSISTENT },
+    // { singleline: consistent, multiline: require }
+    { code: `<div>{foo}</div>`, options: MULTILINE_REQUIRE },
+    { code: `<div foo={bar} />`, options: MULTILINE_REQUIRE },
+    {
+      code: `<div>\n          {\n            foo &&\n            foo.bar\n          }\n        </div>`,
+      options: MULTILINE_REQUIRE,
+    },
+    {
+      code: `<div>\n          {\n            foo\n          }\n        </div>`,
+      options: MULTILINE_REQUIRE,
+    },
+    // never
+    { code: `<div>{foo}</div>`, options: NEVER },
+    { code: `<div foo={bar} />`, options: NEVER },
+    {
+      code: `<div>\n          { foo &&\n            foo.bar }\n        </div>`,
+      options: NEVER,
+    },
+  ],
+
+  invalid: [
+    // consistent: newline before } but not after {
+    {
+      code: `<div>\n          { foo \n}\n        </div>`,
+      options: CONSISTENT,
+      errors: [{ messageId: 'unexpectedBefore', message: UNEXPECTED_BEFORE }],
+    },
+    {
+      code: `<div>\n          { foo &&\n            foo.bar \n}\n        </div>`,
+      options: CONSISTENT,
+      errors: [{ messageId: 'unexpectedBefore', message: UNEXPECTED_BEFORE }],
+    },
+    {
+      code: `<div>\n          { foo &&\n            bar\n          }\n        </div>`,
+      options: CONSISTENT,
+      errors: [{ messageId: 'unexpectedBefore', message: UNEXPECTED_BEFORE }],
+    },
+    // { multiline: require }: newline before } unexpected on single-line expr
+    {
+      code: `<div>{foo\n}</div>`,
+      options: MULTILINE_REQUIRE,
+      errors: [{ messageId: 'unexpectedBefore', message: UNEXPECTED_BEFORE }],
+    },
+    {
+      code: `<div>{\nfoo}</div>`,
+      options: MULTILINE_REQUIRE,
+      errors: [{ messageId: 'expectedBefore', message: EXPECTED_BEFORE }],
+    },
+    {
+      code: `<div>\n          { foo &&\n            bar }\n        </div>`,
+      options: MULTILINE_REQUIRE,
+      errors: [
+        { messageId: 'expectedAfter', message: EXPECTED_AFTER },
+        { messageId: 'expectedBefore', message: EXPECTED_BEFORE },
+      ],
+    },
+    {
+      code: `<div style={foo &&\n          foo.bar\n        } />`,
+      options: MULTILINE_REQUIRE,
+      errors: [{ messageId: 'expectedAfter', message: EXPECTED_AFTER }],
+    },
+    // never: newlines on both sides unexpected
+    {
+      code: `<div>\n          {\nfoo\n}\n        </div>`,
+      options: NEVER,
+      errors: [
+        { messageId: 'unexpectedAfter', message: UNEXPECTED_AFTER },
+        { messageId: 'unexpectedBefore', message: UNEXPECTED_BEFORE },
+      ],
+    },
+    {
+      code: `<div>\n          {\n            foo &&\n            foo.bar\n          }\n        </div>`,
+      options: NEVER,
+      errors: [
+        { messageId: 'unexpectedAfter', message: UNEXPECTED_AFTER },
+        { messageId: 'unexpectedBefore', message: UNEXPECTED_BEFORE },
+      ],
+    },
+    {
+      code: `<div>\n          { foo &&\n            foo.bar\n          }\n        </div>`,
+      options: NEVER,
+      errors: [{ messageId: 'unexpectedBefore', message: UNEXPECTED_BEFORE }],
+    },
+    // never: comment in the gap suppresses the fix
+    {
+      code: `<div>\n          { /* not fixed due to comment */\n            foo }\n        </div>`,
+      options: NEVER,
+      errors: [{ messageId: 'unexpectedAfter', message: UNEXPECTED_AFTER }],
+    },
+    {
+      code: `<div>\n          { foo\n            /* not fixed due to comment */}\n        </div>`,
+      options: NEVER,
+      errors: [{ messageId: 'unexpectedBefore', message: UNEXPECTED_BEFORE }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/jsx-curly-newline` rule from ESLint Stylistic to rslint.

It enforces consistent linebreaks inside the curly braces of JSX expression containers (`{ ... }` in attribute values and children). Options: the `consistent` (default) / `never` string shorthands, or a `{ singleline, multiline }` object where each side is `consistent` | `require` | `forbid`.

## Related Links

- Rule docs: https://eslint.style/rules/jsx-curly-newline
- Source: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/jsx-curly-newline/jsx-curly-newline.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).