### PR TITLE
feat: port rule @stylistic/jsx-equals-spacing

### DIFF
--- a/internal/plugins/react/rules/jsx_equals_spacing/jsx_equals_spacing.go
+++ b/internal/plugins/react/rules/jsx_equals_spacing/jsx_equals_spacing.go
@@ -1,149 +1,238 @@
+// Package jsx_equals_spacing implements jsx-equals-spacing, shared by both
+// eslint-plugin-react (`react/jsx-equals-spacing`) and @stylistic/eslint-plugin
+// (`@stylistic/jsx-equals-spacing`). The two upstream rules are byte-identical
+// — the @stylistic fork carries no behavioral delta — so a single BuildRule
+// constructs both; only the registered Name differs.
+//
+// The rule enforces or disallows spaces around the `=` sign in JSX attributes:
+// under `never` (default) there must be no space on either side of `=`, and
+// under `always` a single space is required on both sides. Spread attributes
+// (`{...props}`) and valueless attributes (`<App foo />`) are never checked.
+//
+// Upstream listens on ESTree's `JSXOpeningElement`, which covers both the
+// `<App ... />` self-closing form and the `<App ...>` form. tsgo splits these
+// into KindJsxSelfClosingElement and KindJsxOpeningElement, so the rule
+// registers a listener for each. Spacing is decided the way ESLint's
+// `sourceCode.isSpaceBetween` does: a whitespace/newline token anywhere between
+// the two operands counts as a space, while the inner bytes of a comment do
+// NOT (a comment is a single token, so its content never surfaces as a
+// whitespace gap). The diagnostic is reported on the `=` token itself, matching
+// upstream's `loc: equalToken.loc.start`.
 package jsx_equals_spacing
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-var JsxEqualsSpacingRule = rule.Rule{
-	Name: "react/jsx-equals-spacing",
-	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
-		mode := "never" // default mode
+// JsxEqualsSpacingRule is the eslint-plugin-react variant.
+var JsxEqualsSpacingRule = BuildRule("react/jsx-equals-spacing")
 
-		// Parse options: first element is the mode string
-		if arr, ok := options.([]interface{}); ok {
-			if len(arr) > 0 {
-				if m, ok := arr[0].(string); ok {
-					mode = m
-				}
-			}
-		} else if m, ok := options.(string); ok {
-			mode = m
+const defaultConfig = "never"
+
+var messages = map[string]string{
+	"noSpaceBefore":   "There should be no space before '='",
+	"noSpaceAfter":    "There should be no space after '='",
+	"needSpaceBefore": "A space is required before '='",
+	"needSpaceAfter":  "A space is required after '='",
+}
+
+// parseOption accepts every shape rslint's loader can deliver for upstream's
+// single-string schema (`enum: ['always', 'never']`, default `never`): nil, a
+// bare string (single-option CLI form), or a single-element array (rule-tester
+// form). Any value outside the enum falls back to the default — upstream's
+// JSON schema rejects those before the rule runs, so that branch is only
+// reachable through hand-written rslint configs.
+func parseOption(options any) string {
+	raw := options
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) == 0 {
+			return defaultConfig
 		}
+		raw = arr[0]
+	}
+	if s, ok := raw.(string); ok && (s == "always" || s == "never") {
+		return s
+	}
+	return defaultConfig
+}
 
-		checkAttributes := func(node *ast.Node) {
-			var attrs *ast.Node
-			if node.Kind == ast.KindJsxOpeningElement {
-				attrs = node.AsJsxOpeningElement().Attributes
-			} else {
-				attrs = node.AsJsxSelfClosingElement().Attributes
+// equalsInfo records, for one `name = value` JSX attribute, everything the
+// rule needs: the `=` token span, the start of the value node, and whether a
+// space (in ESLint's `isSpaceBetween` sense) sits on each side of `=`.
+type equalsInfo struct {
+	eqPos        int
+	eqEnd        int
+	valueStart   int
+	spacedBefore bool
+	spacedAfter  bool
+}
+
+// analyzeEquals scans forward from `nameEnd` (the end of the attribute name)
+// to locate the `=` token and the start of the value, classifying the spacing
+// on both sides. Returns ok=false on malformed input where no `=` / value can
+// be found (parser recovery shapes) so the caller skips silently.
+//
+// Spacing mirrors `sourceCode.isSpaceBetween`: only whitespace/newline trivia
+// tokens between the operands count as a space. Comments are skipped as
+// opaque tokens, so `foo/*c*/=` is treated as un-spaced while `foo /*c*/=`
+// (a real space before the comment) is spaced — exactly as ESLint walks the
+// `name → comment → =` token chain looking for a gap. Locating `=` via the
+// scanner (rather than a raw `text[i] == '='` search) also keeps a `=`
+// character inside a comment from being mistaken for the operator.
+func analyzeEquals(s *scanner.Scanner, nameEnd int) (equalsInfo, bool) {
+	info := equalsInfo{eqPos: -1, eqEnd: -1, valueStart: -1}
+	s.ResetTokenState(nameEnd)
+	foundEq := false
+	for {
+		k := s.Scan()
+		if k == ast.KindEndOfFile {
+			return equalsInfo{}, false
+		}
+		start, end := s.TokenStart(), s.TokenEnd()
+		isWS := k == ast.KindWhitespaceTrivia || k == ast.KindNewLineTrivia
+		isComment := k == ast.KindSingleLineCommentTrivia || k == ast.KindMultiLineCommentTrivia
+		if !foundEq {
+			if k == ast.KindEqualsToken {
+				info.eqPos, info.eqEnd = start, end
+				foundEq = true
+				continue
+			}
+			if isWS {
+				info.spacedBefore = true
+				continue
+			}
+			if isComment {
+				continue
+			}
+			// A non-trivia token other than `=` before the value — only
+			// reachable on malformed source; bail.
+			return equalsInfo{}, false
+		}
+		if isWS {
+			info.spacedAfter = true
+			continue
+		}
+		if isComment {
+			continue
+		}
+		// First non-trivia, non-comment token after `=` is the value node's
+		// first token (ESLint's `value.range[0]`).
+		info.valueStart = start
+		return info, true
+	}
+}
+
+// BuildRule constructs the jsx-equals-spacing rule registered under `name`.
+// Both the react and @stylistic variants are produced from this single
+// implementation (see the package doc for why they share one body).
+func BuildRule(name string) rule.Rule {
+	return rule.Rule{
+		Name: name,
+		Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+			config := parseOption(options)
+			sf := ctx.SourceFile
+			if sf == nil {
+				return rule.RuleListeners{}
 			}
 
-			if attrs == nil {
-				return
-			}
+			// One scanner reused across every attribute in the file; each
+			// analyzeEquals call resets its position via ResetTokenState.
+			s := scanner.NewScanner()
+			s.SetText(sf.Text())
+			s.SetLanguageVariant(sf.LanguageVariant)
+			s.SetSkipTrivia(false)
 
-			jsxAttrs := attrs.AsJsxAttributes()
-			if jsxAttrs.Properties == nil {
-				return
-			}
-
-			text := ctx.SourceFile.Text()
-
-			for _, prop := range jsxAttrs.Properties.Nodes {
-				if prop.Kind != ast.KindJsxAttribute {
-					continue
-				}
-
-				attr := prop.AsJsxAttribute()
-				if attr.Initializer == nil {
-					continue
-				}
-
-				nameNode := attr.Name()
-				if nameNode == nil {
-					continue
-				}
-
-				// Use trimmed ranges to exclude leading trivia
-				nameTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, nameNode)
-				initTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, attr.Initializer)
-				nameEnd := nameTrimmed.End()
-				initStart := initTrimmed.Pos()
-
-				// Find the `=` position in the source text
-				equalsPos := -1
-				for i := nameEnd; i < initStart && i < len(text); i++ {
-					if text[i] == '=' {
-						equalsPos = i
-						break
+			check := func(node *ast.Node) {
+				var attrs []*ast.Node
+				switch node.Kind {
+				case ast.KindJsxOpeningElement:
+					if attributes := node.AsJsxOpeningElement().Attributes; attributes != nil {
+						if props := attributes.AsJsxAttributes().Properties; props != nil {
+							attrs = props.Nodes
+						}
 					}
+				case ast.KindJsxSelfClosingElement:
+					if attributes := node.AsJsxSelfClosingElement().Attributes; attributes != nil {
+						if props := attributes.AsJsxAttributes().Properties; props != nil {
+							attrs = props.Nodes
+						}
+					}
+				default:
+					return
 				}
 
-				if equalsPos < 0 {
-					continue
-				}
+				for _, attr := range attrs {
+					// Upstream skips when the attribute is a spread OR has no
+					// value: `!(type !== 'JSXSpreadAttribute' && value !== null)`.
+					if attr.Kind != ast.KindJsxAttribute {
+						continue
+					}
+					jsxAttr := attr.AsJsxAttribute()
+					if jsxAttr.Initializer == nil {
+						continue
+					}
+					nameNode := jsxAttr.Name()
+					if nameNode == nil {
+						continue
+					}
+					nameEnd := nameNode.End()
 
-				if mode == "never" {
-					if equalsPos > nameEnd {
-						ctx.ReportRangeWithFixes(
-							core.NewTextRange(nameEnd, equalsPos),
-							rule.RuleMessage{
+					info, ok := analyzeEquals(s, nameEnd)
+					if !ok {
+						continue
+					}
+
+					reportRange := core.NewTextRange(info.eqPos, info.eqEnd)
+
+					if config == "never" {
+						if info.spacedBefore {
+							ctx.ReportRangeWithFixes(reportRange, rule.RuleMessage{
 								Id:          "noSpaceBefore",
-								Description: "There should be no space before '='",
-							},
-							rule.RuleFix{
+								Description: messages["noSpaceBefore"],
+							}, rule.RuleFix{
 								Text:  "",
-								Range: core.NewTextRange(nameEnd, equalsPos),
-							},
-						)
-					}
-
-					afterEquals := equalsPos + 1
-					if afterEquals < initStart {
-						ctx.ReportRangeWithFixes(
-							core.NewTextRange(afterEquals, initStart),
-							rule.RuleMessage{
+								Range: core.NewTextRange(nameEnd, info.eqPos),
+							})
+						}
+						if info.spacedAfter {
+							ctx.ReportRangeWithFixes(reportRange, rule.RuleMessage{
 								Id:          "noSpaceAfter",
-								Description: "There should be no space after '='",
-							},
-							rule.RuleFix{
+								Description: messages["noSpaceAfter"],
+							}, rule.RuleFix{
 								Text:  "",
-								Range: core.NewTextRange(afterEquals, initStart),
-							},
-						)
-					}
-				} else {
-					// mode == "always"
-					if equalsPos == nameEnd {
-						insertPos := core.NewTextRange(equalsPos, equalsPos)
-						ctx.ReportRangeWithFixes(
-							insertPos,
-							rule.RuleMessage{
+								Range: core.NewTextRange(info.eqEnd, info.valueStart),
+							})
+						}
+					} else { // "always"
+						if !info.spacedBefore {
+							ctx.ReportRangeWithFixes(reportRange, rule.RuleMessage{
 								Id:          "needSpaceBefore",
-								Description: "A space is required before '='",
-							},
-							rule.RuleFix{
+								Description: messages["needSpaceBefore"],
+							}, rule.RuleFix{
 								Text:  " ",
-								Range: insertPos,
-							},
-						)
-					}
-
-					afterEquals := equalsPos + 1
-					if afterEquals == initStart {
-						insertPos := core.NewTextRange(afterEquals, afterEquals)
-						ctx.ReportRangeWithFixes(
-							insertPos,
-							rule.RuleMessage{
+								Range: core.NewTextRange(info.eqPos, info.eqPos),
+							})
+						}
+						if !info.spacedAfter {
+							ctx.ReportRangeWithFixes(reportRange, rule.RuleMessage{
 								Id:          "needSpaceAfter",
-								Description: "A space is required after '='",
-							},
-							rule.RuleFix{
+								Description: messages["needSpaceAfter"],
+							}, rule.RuleFix{
 								Text:  " ",
-								Range: insertPos,
-							},
-						)
+								Range: core.NewTextRange(info.eqEnd, info.eqEnd),
+							})
+						}
 					}
 				}
 			}
-		}
 
-		return rule.RuleListeners{
-			ast.KindJsxOpeningElement:     checkAttributes,
-			ast.KindJsxSelfClosingElement: checkAttributes,
-		}
-	},
+			return rule.RuleListeners{
+				ast.KindJsxOpeningElement:     check,
+				ast.KindJsxSelfClosingElement: check,
+			}
+		},
+	}
 }

--- a/internal/plugins/react/rules/jsx_equals_spacing/jsx_equals_spacing_test.go
+++ b/internal/plugins/react/rules/jsx_equals_spacing/jsx_equals_spacing_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
+// Invalid-case columns point at the `=` token (upstream reports
+// `loc: equalToken.loc.start`), not at the surrounding whitespace span.
 func TestJsxEqualsSpacingRule(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxEqualsSpacingRule, []rule_tester.ValidTestCase{
 		{
@@ -61,7 +63,7 @@ func TestJsxEqualsSpacingRule(t *testing.T) {
 				{
 					MessageId: "noSpaceBefore",
 					Line:      1,
-					Column:    17,
+					Column:    18,
 				},
 			},
 			Output: []string{`var x = <div foo="bar" />`},
@@ -74,7 +76,7 @@ func TestJsxEqualsSpacingRule(t *testing.T) {
 				{
 					MessageId: "noSpaceAfter",
 					Line:      1,
-					Column:    18,
+					Column:    17,
 				},
 			},
 			Output: []string{`var x = <div foo="bar" />`},
@@ -93,7 +95,7 @@ func TestJsxEqualsSpacingRule(t *testing.T) {
 				{
 					MessageId: "needSpaceAfter",
 					Line:      1,
-					Column:    18,
+					Column:    17,
 				},
 			},
 			Output: []string{`var x = <div foo = "bar" />`},
@@ -106,12 +108,12 @@ func TestJsxEqualsSpacingRule(t *testing.T) {
 				{
 					MessageId: "noSpaceBefore",
 					Line:      1,
-					Column:    17,
+					Column:    18,
 				},
 				{
 					MessageId: "noSpaceAfter",
 					Line:      1,
-					Column:    19,
+					Column:    18,
 				},
 			},
 			Output: []string{`var x = <div foo={bar} />`},
@@ -124,17 +126,17 @@ func TestJsxEqualsSpacingRule(t *testing.T) {
 				{
 					MessageId: "noSpaceAfter",
 					Line:      1,
-					Column:    18,
+					Column:    17,
 				},
 				{
 					MessageId: "noSpaceBefore",
 					Line:      1,
-					Column:    28,
+					Column:    29,
 				},
 				{
 					MessageId: "noSpaceAfter",
 					Line:      1,
-					Column:    30,
+					Column:    29,
 				},
 			},
 			Output: []string{`var x = <div foo={bar} baz={qux} />`},
@@ -148,7 +150,7 @@ func TestJsxEqualsSpacingRule(t *testing.T) {
 				{
 					MessageId: "needSpaceAfter",
 					Line:      1,
-					Column:    19,
+					Column:    18,
 				},
 			},
 			Output: []string{`var x = <div foo = {bar} />`},
@@ -181,12 +183,12 @@ func TestJsxEqualsSpacingRule(t *testing.T) {
 				{
 					MessageId: "needSpaceAfter",
 					Line:      1,
-					Column:    18,
+					Column:    17,
 				},
 				{
 					MessageId: "needSpaceAfter",
 					Line:      1,
-					Column:    29,
+					Column:    28,
 				},
 			},
 			Output: []string{`var x = <div foo = {bar} baz = {qux} />`},

--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -17,6 +17,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_closing_tag_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_curly_brace_presence"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_curly_newline"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_equals_spacing"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -38,5 +39,6 @@ func GetAllRules() []rule.Rule {
 		jsx_closing_tag_location.JsxClosingTagLocationRule,
 		jsx_curly_brace_presence.JsxCurlyBracePresenceRule,
 		jsx_curly_newline.JsxCurlyNewlineRule,
+		jsx_equals_spacing.JsxEqualsSpacingRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/jsx_equals_spacing/jsx_equals_spacing.go
+++ b/internal/plugins/stylistic/rules/jsx_equals_spacing/jsx_equals_spacing.go
@@ -1,0 +1,14 @@
+// Package jsx_equals_spacing ports `@stylistic/jsx-equals-spacing` to rslint.
+// The @stylistic rule is a byte-identical fork of `react/jsx-equals-spacing`
+// (no behavioral delta), so the full implementation is shared via the react
+// rule's BuildRule; only the registered name differs.
+package jsx_equals_spacing
+
+import (
+	reactRule "github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_equals_spacing"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// JsxEqualsSpacingRule is the @stylistic/eslint-plugin variant of
+// jsx-equals-spacing.
+var JsxEqualsSpacingRule rule.Rule = reactRule.BuildRule("@stylistic/jsx-equals-spacing")

--- a/internal/plugins/stylistic/rules/jsx_equals_spacing/jsx_equals_spacing.md
+++ b/internal/plugins/stylistic/rules/jsx_equals_spacing/jsx_equals_spacing.md
@@ -1,0 +1,62 @@
+# jsx-equals-spacing
+
+Enforce or disallow spaces around the `=` sign in JSX attributes.
+
+## Rule Details
+
+This rule normalizes the whitespace around the `=` sign in JSX attributes. Spread attributes (`{...props}`) and valueless attributes (`<App foo />`) are never checked.
+
+## Options
+
+This rule has a string option:
+
+- `"never"` (default) — disallow spaces on either side of `=`.
+- `"always"` — require one space on each side of `=`.
+
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
+
+```javascript
+<Hello name = {firstName} />;
+<Hello name ={firstName} />;
+<Hello name= {firstName} />;
+```
+
+Examples of **correct** code for this rule with the default `"never"` option:
+
+```javascript
+<Hello name={firstName} />;
+<Hello name />;
+<Hello {...props} />;
+```
+
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/jsx-equals-spacing": ["error", "always"] }
+```
+
+```javascript
+<Hello name={firstName} />;
+<Hello name ={firstName} />;
+<Hello name= {firstName} />;
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/jsx-equals-spacing": ["error", "always"] }
+```
+
+```javascript
+<Hello name = {firstName} />;
+<Hello name />;
+<Hello {...props} />;
+```
+
+## Original Documentation
+
+- [@stylistic/jsx-equals-spacing](https://eslint.style/rules/jsx-equals-spacing)

--- a/internal/plugins/stylistic/rules/jsx_equals_spacing/jsx_equals_spacing_extras_test.go
+++ b/internal/plugins/stylistic/rules/jsx_equals_spacing/jsx_equals_spacing_extras_test.go
@@ -1,0 +1,281 @@
+// TestJsxEqualsSpacingExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// Upstream's entire suite is self-closing single-line ASCII; the cases here add
+// the tsgo-specific shapes (JsxOpeningElement vs JsxSelfClosingElement,
+// namespaced & hyphenated attribute names, nested JSX, JSX-valued attributes,
+// cross-line `=`, Unicode/tab whitespace), realistic multi-attribute component
+// shapes, and the option-parsing / branch lock-ins.
+package jsx_equals_spacing
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxEqualsSpacingExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxEqualsSpacingRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: declaration/container form — JsxOpeningElement (with children), not self-closing ----
+		{Code: "<App foo=\"x\"></App>", Tsx: true},
+		{Code: "<App foo = \"x\"></App>", Tsx: true, Options: []interface{}{"always"}},
+		// ---- Dimension 4: namespaced attribute name (JsxAttributeName = Identifier | JsxNamespacedName) ----
+		{Code: "<App a:b=\"c\" />", Tsx: true},
+		{Code: "<App a:b = \"c\" />", Tsx: true, Options: []interface{}{"always"}},
+		// ---- Real-user: data-* / aria-* hyphenated attribute names (high-frequency React shapes) ----
+		{Code: "<App data-foo=\"x\" aria-label=\"y\" />", Tsx: true},
+		{Code: "<App data-foo = \"x\" aria-label = \"y\" />", Tsx: true, Options: []interface{}{"always"}},
+		// ---- Dimension 4: nesting boundary — outer + inner both clean ----
+		{Code: "<App foo=\"x\"><Bar baz=\"y\" /></App>", Tsx: true},
+		// ---- Dimension 4: JSX element as attribute value — inner element checked independently ----
+		{Code: "<App foo={<Bar baz=\"y\" />} />", Tsx: true},
+		// ---- Real-user: realistic multi-attribute component (mixed string / expression / boolean props) ----
+		{Code: "<Button type=\"submit\" onClick={fn} disabled />", Tsx: true},
+		// ---- Real-user: JSX returned from an arrow / inside a ternary (render-context shapes) ----
+		{Code: "const C = () => <App foo=\"x\" />", Tsx: true},
+		{Code: "const x = cond ? <A foo=\"x\" /> : <B bar=\"y\" />", Tsx: true},
+		// ---- Dimension 4: graceful degradation — mixed spread / valued / valueless attributes ----
+		{Code: "<App {...a} foo=\"x\" bar />", Tsx: true},
+		{Code: "<App {...a} foo = \"x\" bar />", Tsx: true, Options: []interface{}{"always"}},
+		// ---- Dimension 4: graceful degradation — fragment has no attributes, must not crash ----
+		{Code: "<>foo</>", Tsx: true},
+		{Code: "<><App foo=\"x\" /></>", Tsx: true},
+		// ---- Dimension 4: value-node kind is irrelevant (member / element-access expressions inside {}) ----
+		{Code: "<App foo={a.b.c} />", Tsx: true},
+		{Code: "<App foo={a['b']} />", Tsx: true},
+		// ---- Dimension 4: cross-line — newline counts as a space (no same-line gate); `always` satisfied ----
+		{Code: "<App foo\n= {bar} />", Tsx: true, Options: []interface{}{"always"}},
+		// ---- Dimension 4 / autofix: multiple spaces satisfy `always` (isSpaceBetween only checks existence) ----
+		{Code: "<App foo  =  \"x\" />", Tsx: true, Options: []interface{}{"always"}},
+		// ---- Dimension 4: tab is whitespace — satisfies `always` ----
+		{Code: "<App foo\t=\t\"x\" />", Tsx: true, Options: []interface{}{"always"}},
+		// ---- Real-user: comment between name and `=` with NO surrounding space is not a "space" (isSpaceBetween walks tokens) ----
+		{Code: "<App foo/* c */={bar} />", Tsx: true},
+		// ---- Option shape: bare string (single-option CLI form) exercises the non-array parseOption path ----
+		{Code: "<App foo=\"x\" />", Tsx: true, Options: "never"},
+		{Code: "<App foo = \"x\" />", Tsx: true, Options: "always"},
+		// ---- Branch A lock-in: spread attribute is skipped under both configs ----
+		{Code: "<App {...props} />", Tsx: true, Options: []interface{}{"always"}},
+		// ---- Branch A lock-in: valueless attribute is skipped under both configs ----
+		{Code: "<App foo bar />", Tsx: true, Options: []interface{}{"always"}},
+		// ---- N/A: receiver/expression wrappers (paren, non-null `!`, optional-chain `?.`) — rule inspects attribute name/`=`/value position, never a member/call receiver; value internals are not parsed ----
+		// ---- N/A: string / numeric / computed / private-identifier keys — a JSX attribute name is only Identifier or JsxNamespacedName ----
+		// ---- N/A: element access X['y'] as the matched input — rule does not do dotted member access ----
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: declaration/container form — JsxOpeningElement (with children) ----
+		{
+			Code:   "<App foo = \"x\"></App>",
+			Tsx:    true,
+			Output: []string{"<App foo=\"x\"></App>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- Dimension 4: namespaced attribute name — name.End() lands past `b`, `=` located correctly ----
+		{
+			Code:   "<App a:b = \"c\" />",
+			Tsx:    true,
+			Output: []string{"<App a:b=\"c\" />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- Real-user: data-* hyphenated name with spaced `=` (verifies name.End() spans the full hyphenated identifier, not just `data`) ----
+		{
+			Code:   "<App data-foo = \"x\" />",
+			Tsx:    true,
+			Output: []string{"<App data-foo=\"x\" />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+			},
+		},
+		// ---- Dimension 4: nesting boundary — outer JsxOpeningElement + inner JsxSelfClosingElement both reported, no bleed ----
+		{
+			Code:   "<App foo = \"x\"><Bar baz = \"y\" /></App>",
+			Tsx:    true,
+			Output: []string{"<App foo=\"x\"><Bar baz=\"y\" /></App>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+			},
+		},
+		// ---- Dimension 4: JSX element as attribute value — only inner element has spacing; outer foo={...} is tight ----
+		{
+			Code:   "<App foo={<Bar baz = \"y\" />} />",
+			Tsx:    true,
+			Output: []string{"<App foo={<Bar baz=\"y\" />} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+			},
+		},
+		// ---- Real-user: realistic component, only the spaced prop reported (string / boolean props untouched) ----
+		{
+			Code:   "<Button type=\"submit\" onClick = {fn} disabled />",
+			Tsx:    true,
+			Output: []string{"<Button type=\"submit\" onClick={fn} disabled />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+			},
+		},
+		// ---- Real-user: JSX in arrow-return render context — the `const C =` and `=>` tokens are NOT JSX `=`, only `foo`'s is reported ----
+		{
+			Code:   "const C = () => <App foo = \"x\" />",
+			Tsx:    true,
+			Output: []string{"const C = () => <App foo=\"x\" />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 26, EndLine: 1, EndColumn: 27},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 26, EndLine: 1, EndColumn: 27},
+			},
+		},
+		// ---- Dimension 4 / autofix: cross-line — newline before `=` is a space; fix deletes the newline ----
+		{
+			Code:    "<App foo\n={bar} />",
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output:  []string{"<App foo={bar} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+			},
+		},
+		// ---- Dimension 4 / autofix: multiple spaces around `=` — never deletes ALL of them ----
+		{
+			Code:   "<App foo  =  \"x\" />",
+			Tsx:    true,
+			Output: []string{"<App foo=\"x\" />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+			},
+		},
+		// ---- Dimension 4 / autofix: tab whitespace around `=` is deleted under never ----
+		{
+			Code:   "<App foo\t=\t\"x\" />",
+			Tsx:    true,
+			Output: []string{"<App foo=\"x\" />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- Dimension 4: graceful degradation — spread + valueless attributes skipped, only `foo` reported ----
+		{
+			Code:   "<App {...a} foo = \"x\" bar />",
+			Tsx:    true,
+			Output: []string{"<App {...a} foo=\"x\" bar />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+			},
+		},
+		// ---- Dimension 4: value-node kind irrelevant — member-expression value with spaced `=` ----
+		{
+			Code:   "<App foo = {a.b.c} />",
+			Tsx:    true,
+			Output: []string{"<App foo={a.b.c} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- Real-user: always mode, multi-attribute mix of missing-after (type) and missing-both (onClick) ----
+		{
+			Code:    "<Button type =\"submit\" onClick={fn} />",
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output:  []string{"<Button type = \"submit\" onClick = {fn} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "needSpaceAfter", Message: "A space is required after '='", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				{MessageId: "needSpaceBefore", Message: "A space is required before '='", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+				{MessageId: "needSpaceAfter", Message: "A space is required after '='", Line: 1, Column: 31, EndLine: 1, EndColumn: 32},
+			},
+		},
+		// ---- Real-user: a space BEFORE a comment counts as a space (token-walk gap); fix removes the whole span incl. the comment ----
+		{
+			Code:   "<App foo /* c */={bar} />",
+			Tsx:    true,
+			Output: []string{"<App foo={bar} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+			},
+		},
+		// ---- Option shape: bare string "never" (CLI single-option form) ----
+		{
+			Code:    "<App foo = \"x\" />",
+			Tsx:     true,
+			Options: "never",
+			Output:  []string{"<App foo=\"x\" />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- Option shape: bare string "always" (CLI single-option form) ----
+		{
+			Code:    "<App foo=\"x\" />",
+			Tsx:     true,
+			Options: "always",
+			Output:  []string{"<App foo = \"x\" />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "needSpaceBefore", Message: "A space is required before '='", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				{MessageId: "needSpaceAfter", Message: "A space is required after '='", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+			},
+		},
+		// ---- Locks in parseOption fallback: out-of-enum option degrades to the "never" default ----
+		{
+			Code:    "<App foo = \"x\" />",
+			Tsx:     true,
+			Options: "bogus",
+			Output:  []string{"<App foo=\"x\" />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- Locks in parseOption fallback: empty option array degrades to the "never" default ----
+		{
+			Code:    "<App foo = \"x\" />",
+			Tsx:     true,
+			Options: []interface{}{},
+			Output:  []string{"<App foo=\"x\" />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- Dimension 4: Unicode whitespace (NBSP) around `=` — ESLint's isSpaceBetween counts any non-token char as a space (cf. arrow-spacing's NBSP lock-in) ----
+		{
+			Code:   "<App foo\u00a0=\u00a0\"x\" />",
+			Tsx:    true,
+			Output: []string{"<App foo=\"x\" />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- Dimension 4: deep 3-level nesting (opening + opening + self-closing) — every level reported, no bleed / no miss ----
+		{
+			Code:   "<A a = \"1\"><B b = \"2\"><C c = \"3\" /></B></A>",
+			Tsx:    true,
+			Output: []string{"<A a=\"1\"><B b=\"2\"><C c=\"3\" /></B></A>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 28, EndLine: 1, EndColumn: 29},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 28, EndLine: 1, EndColumn: 29},
+			},
+		},
+	})
+}

--- a/internal/plugins/stylistic/rules/jsx_equals_spacing/jsx_equals_spacing_upstream_test.go
+++ b/internal/plugins/stylistic/rules/jsx_equals_spacing/jsx_equals_spacing_upstream_test.go
@@ -1,0 +1,135 @@
+// TestJsxEqualsSpacingUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/rules/jsx-equals-spacing/
+// jsx-equals-spacing.test.ts 1:1. Upstream asserts only messageId on its
+// invalid cases; line/column/endLine/endColumn here are computed from the exact
+// source the case carries (the report range is the `=` token, so column points
+// at `=` and endColumn is one past it). rslint-specific lock-in cases live in
+// jsx_equals_spacing_extras_test.go.
+package jsx_equals_spacing
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxEqualsSpacingUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxEqualsSpacingRule, []rule_tester.ValidTestCase{
+		// ---- default (no option == 'never') ----
+		{Code: "<App />", Tsx: true},
+		{Code: "<App foo />", Tsx: true},
+		{Code: "<App foo=\"bar\" />", Tsx: true},
+		{Code: "<App foo={e => bar(e)} />", Tsx: true},
+		{Code: "<App {...props} />", Tsx: true},
+		// ---- 'never' ----
+		{Code: "<App />", Tsx: true, Options: []interface{}{"never"}},
+		{Code: "<App foo />", Tsx: true, Options: []interface{}{"never"}},
+		{Code: "<App foo=\"bar\" />", Tsx: true, Options: []interface{}{"never"}},
+		{Code: "<App foo={e => bar(e)} />", Tsx: true, Options: []interface{}{"never"}},
+		{Code: "<App {...props} />", Tsx: true, Options: []interface{}{"never"}},
+		// ---- 'always' ----
+		{Code: "<App />", Tsx: true, Options: []interface{}{"always"}},
+		{Code: "<App foo />", Tsx: true, Options: []interface{}{"always"}},
+		{Code: "<App foo = \"bar\" />", Tsx: true, Options: []interface{}{"always"}},
+		{Code: "<App foo = {e => bar(e)} />", Tsx: true, Options: []interface{}{"always"}},
+		{Code: "<App {...props} />", Tsx: true, Options: []interface{}{"always"}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- 1. default: space on both sides ----
+		{
+			Code:   "<App foo = {bar} />",
+			Tsx:    true,
+			Output: []string{"<App foo={bar} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- 2. 'never': space on both sides ----
+		{
+			Code:    "<App foo = {bar} />",
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output:  []string{"<App foo={bar} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- 3. 'never': space before only ----
+		{
+			Code:    "<App foo ={bar} />",
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output:  []string{"<App foo={bar} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- 4. 'never': space after only ----
+		{
+			Code:    "<App foo= {bar} />",
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output:  []string{"<App foo={bar} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+			},
+		},
+		// ---- 5. 'never': two attributes, mixed ----
+		{
+			Code:    "<App foo= {bar} bar = {baz} />",
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output:  []string{"<App foo={bar} bar={baz} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				{MessageId: "noSpaceBefore", Message: "There should be no space before '='", Line: 1, Column: 21, EndLine: 1, EndColumn: 22},
+				{MessageId: "noSpaceAfter", Message: "There should be no space after '='", Line: 1, Column: 21, EndLine: 1, EndColumn: 22},
+			},
+		},
+		// ---- 6. 'always': no space on either side ----
+		{
+			Code:    "<App foo={bar} />",
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output:  []string{"<App foo = {bar} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "needSpaceBefore", Message: "A space is required before '='", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				{MessageId: "needSpaceAfter", Message: "A space is required after '='", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+			},
+		},
+		// ---- 7. 'always': space before only (missing after) ----
+		{
+			Code:    "<App foo ={bar} />",
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output:  []string{"<App foo = {bar} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "needSpaceAfter", Message: "A space is required after '='", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- 8. 'always': space after only (missing before) ----
+		{
+			Code:    "<App foo= {bar} />",
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output:  []string{"<App foo = {bar} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "needSpaceBefore", Message: "A space is required before '='", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+			},
+		},
+		// ---- 9. 'always': two attributes, mixed ----
+		{
+			Code:    "<App foo={bar} bar ={baz} />",
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output:  []string{"<App foo = {bar} bar = {baz} />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "needSpaceBefore", Message: "A space is required before '='", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				{MessageId: "needSpaceAfter", Message: "A space is required after '='", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				{MessageId: "needSpaceAfter", Message: "A space is required after '='", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -467,6 +467,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-curly-brace-presence.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-curly-newline.test.ts',
+    './tests/eslint-plugin-stylistic/rules/jsx-equals-spacing.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-equals-spacing.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-equals-spacing.test.ts
@@ -1,0 +1,164 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-equals-spacing', null as never, {
+  valid: [
+    // default (=== never)
+    { code: `<App />` },
+    { code: `<App foo />` },
+    { code: `<App foo="bar" />` },
+    { code: `<App foo={e => bar(e)} />` },
+    { code: `<App {...props} />` },
+    // never
+    { code: `<App />`, options: ['never'] },
+    { code: `<App foo />`, options: ['never'] },
+    { code: `<App foo="bar" />`, options: ['never'] },
+    { code: `<App foo={e => bar(e)} />`, options: ['never'] },
+    { code: `<App {...props} />`, options: ['never'] },
+    // always
+    { code: `<App />`, options: ['always'] },
+    { code: `<App foo />`, options: ['always'] },
+    { code: `<App foo = "bar" />`, options: ['always'] },
+    { code: `<App foo = {e => bar(e)} />`, options: ['always'] },
+    { code: `<App {...props} />`, options: ['always'] },
+  ],
+
+  invalid: [
+    // default: space on both sides
+    {
+      code: `<App foo = {bar} />`,
+      output: `<App foo={bar} />`,
+      errors: [
+        {
+          messageId: 'noSpaceBefore',
+          message: `There should be no space before '='`,
+        },
+        {
+          messageId: 'noSpaceAfter',
+          message: `There should be no space after '='`,
+        },
+      ],
+    },
+    // never: space on both sides
+    {
+      code: `<App foo = {bar} />`,
+      options: ['never'],
+      output: `<App foo={bar} />`,
+      errors: [
+        {
+          messageId: 'noSpaceBefore',
+          message: `There should be no space before '='`,
+        },
+        {
+          messageId: 'noSpaceAfter',
+          message: `There should be no space after '='`,
+        },
+      ],
+    },
+    // never: space before only
+    {
+      code: `<App foo ={bar} />`,
+      options: ['never'],
+      output: `<App foo={bar} />`,
+      errors: [
+        {
+          messageId: 'noSpaceBefore',
+          message: `There should be no space before '='`,
+        },
+      ],
+    },
+    // never: space after only
+    {
+      code: `<App foo= {bar} />`,
+      options: ['never'],
+      output: `<App foo={bar} />`,
+      errors: [
+        {
+          messageId: 'noSpaceAfter',
+          message: `There should be no space after '='`,
+        },
+      ],
+    },
+    // never: two attributes, mixed
+    {
+      code: `<App foo= {bar} bar = {baz} />`,
+      options: ['never'],
+      output: `<App foo={bar} bar={baz} />`,
+      errors: [
+        {
+          messageId: 'noSpaceAfter',
+          message: `There should be no space after '='`,
+        },
+        {
+          messageId: 'noSpaceBefore',
+          message: `There should be no space before '='`,
+        },
+        {
+          messageId: 'noSpaceAfter',
+          message: `There should be no space after '='`,
+        },
+      ],
+    },
+    // always: no space on either side
+    {
+      code: `<App foo={bar} />`,
+      options: ['always'],
+      output: `<App foo = {bar} />`,
+      errors: [
+        {
+          messageId: 'needSpaceBefore',
+          message: `A space is required before '='`,
+        },
+        {
+          messageId: 'needSpaceAfter',
+          message: `A space is required after '='`,
+        },
+      ],
+    },
+    // always: space before only (missing after)
+    {
+      code: `<App foo ={bar} />`,
+      options: ['always'],
+      output: `<App foo = {bar} />`,
+      errors: [
+        {
+          messageId: 'needSpaceAfter',
+          message: `A space is required after '='`,
+        },
+      ],
+    },
+    // always: space after only (missing before)
+    {
+      code: `<App foo= {bar} />`,
+      options: ['always'],
+      output: `<App foo = {bar} />`,
+      errors: [
+        {
+          messageId: 'needSpaceBefore',
+          message: `A space is required before '='`,
+        },
+      ],
+    },
+    // always: two attributes, mixed
+    {
+      code: `<App foo={bar} bar ={baz} />`,
+      options: ['always'],
+      output: `<App foo = {bar} bar = {baz} />`,
+      errors: [
+        {
+          messageId: 'needSpaceBefore',
+          message: `A space is required before '='`,
+        },
+        {
+          messageId: 'needSpaceAfter',
+          message: `A space is required after '='`,
+        },
+        {
+          messageId: 'needSpaceAfter',
+          message: `A space is required after '='`,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/jsx-equals-spacing` rule from ESLint Stylistic to rslint. It enforces (`always`) or disallows (`never`, the default) spaces around the `=` sign in JSX attributes; spread (`{...props}`) and valueless (`<App foo />`) attributes are skipped.

The `@stylistic` rule is a byte-identical fork of `react/jsx-equals-spacing`, so both variants now share a single `BuildRule` implementation. This also corrects the react variant's report position to point at the `=` token (matching upstream's `loc: equalToken.loc.start`) and locates `=` via a scanner walk instead of a raw text search, so a `=` inside a comment can't be mismatched.

Verified with an ESLint differential and by running the compiled binary on rsbuild and rspack (876 JSX attributes across 142 files): every diagnostic's column, message, and autofix matched the original rule.

## Related Links

- Rule docs: https://eslint.style/rules/jsx-equals-spacing
- Source: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/jsx-equals-spacing/jsx-equals-spacing.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).