### PR TITLE
feat: redesign homepage with side-by-side hero and animated lint demo

### DIFF
--- a/website/theme/components/Hero.module.scss
+++ b/website/theme/components/Hero.module.scss
@@ -1,8 +1,124 @@
-:global {
-  .rs-oval {
-    width: 70% !important;
-    height: 70% !important;
-    top: calc(50% + 20px) !important;
-    left: calc(50% + 5px) !important;
+/* Custom hero styles — faithfully replicate the shared @rstack-dev/doc-ui
+   <Hero> visuals (279deg orange→red gradient title, button shapes, GitHub
+   link, light/dark colours pulled from doc-ui's own values) but scaled down
+   and left-aligned to sit beside the lint demo. These are OUR module classes
+   (referenced via styles.* in Hero.tsx), so the build-hashed names are
+   resolved automatically — no fragile coupling to doc-ui internals.
+
+   rspress marks dark mode with `.dark` on <html> (theme/index.scss). */
+.hero {
+  --hero-title-color: #0b0c0e;
+  --hero-desc-color: #6b7075;
+  --hero-gradient: linear-gradient(279deg, #ff8b00 35.21%, #f93920 63.34%);
+  --hero-btn-border: #ff8b00;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  text-align: left;
+
+  :global(html.dark) & {
+    --hero-title-color: #ffffff;
+    --hero-desc-color: #c6cacd;
+  }
+}
+
+.logo {
+  height: 130px;
+  width: auto;
+  user-select: none;
+}
+
+.title {
+  margin: 0;
+  font-size: 56px;
+  font-weight: 700;
+  line-height: 1.1;
+  background: var(--hero-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 38px;
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--hero-title-color);
+}
+
+.description {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--hero-desc-color);
+}
+
+.buttons {
+  display: flex;
+  justify-content: flex-start;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+/* Shared button shape — copied from doc-ui's .button (radius/padding/weight/
+   capitalize + hover lift). */
+.button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  min-width: 120px;
+  padding: 12px 28px;
+  border-radius: 25px;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 150%;
+  text-align: center;
+  text-transform: capitalize;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+
+  &:hover {
+    opacity: 0.75;
+    transform: translate3d(0, -2px, 0);
+  }
+  &:active {
+    opacity: 0.5;
+  }
+}
+
+.buttonPrimary {
+  border: none;
+  color: #ffffff;
+  background: var(--hero-gradient);
+}
+
+.buttonSecondary {
+  border: 1.5px solid var(--hero-btn-border);
+  color: var(--hero-title-color);
+  background: none;
+}
+
+.githubIcon {
+  width: 22px;
+  height: 22px;
+  margin-right: 8px;
+  color: currentColor;
+}
+
+/* When the hero/demo row stacks (<=1024px, see pages/index.module.scss),
+   re-center the copy. */
+@media (max-width: 1024px) {
+  .hero {
+    align-items: center;
+    text-align: center;
+  }
+  .buttons {
+    justify-content: center;
   }
 }

--- a/website/theme/components/Hero.tsx
+++ b/website/theme/components/Hero.tsx
@@ -1,8 +1,20 @@
 import { useI18n, useNavigate } from '@rspress/core/runtime';
-import { Hero as BaseHero } from '@rstack-dev/doc-ui/hero';
+// import { Hero as BaseHero } from '@rstack-dev/doc-ui/hero';
 import { useI18nUrl } from './utils';
-import './Hero.module.scss';
+import styles from './Hero.module.scss';
 
+const GITHUB_URL = 'https://github.com/web-infra-dev/rslint';
+const LOGO_URL = 'https://assets.rspack.rs/rslint/rslint-logo.svg';
+
+/**
+ * Custom hero. Replaces the shared `@rstack-dev/doc-ui` <Hero> (commented
+ * below): that component exposes no props/CSS-vars for size, alignment or
+ * height, and its class names are build-hashed (not an API), so fitting it
+ * into the side-by-side layout would have meant fragile selector overrides.
+ * This owns its markup + module styles, faithfully replicating doc-ui's
+ * visuals (gradient title, button styles, GitHub link, theme colours) and
+ * only adjusting size + alignment for the hero/demo row. See Hero.module.scss.
+ */
 export function Hero() {
   const navigate = useNavigate();
   const tUrl = useI18nUrl();
@@ -10,16 +22,59 @@ export function Hero() {
   const onClickGetStarted = () => {
     navigate(tUrl('/guide'));
   };
+
   return (
-    <BaseHero
-      showStars
-      onClickGetStarted={onClickGetStarted}
-      title="Rslint"
-      subTitle={t('subtitle')}
-      description={t('slogan')}
-      logoUrl="https://assets.rspack.rs/rslint/rslint-logo.svg"
-      getStartedButtonText={t('quickStart')}
-      githubURL="https://github.com/web-infra-dev/rslint"
-    />
+    <div className={styles.hero}>
+      <img className={styles.logo} src={LOGO_URL} alt="Rslint" />
+      <h1 className={styles.title}>Rslint</h1>
+      <p className={styles.subtitle}>{t('subtitle')}</p>
+      <p className={styles.description}>{t('slogan')}</p>
+      <div className={styles.buttons}>
+        <button
+          type="button"
+          className={`${styles.button} ${styles.buttonPrimary}`}
+          onClick={onClickGetStarted}
+        >
+          {t('quickStart')}
+        </button>
+        <a
+          className={`${styles.button} ${styles.buttonSecondary}`}
+          href={GITHUB_URL}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <svg
+            className={styles.githubIcon}
+            xmlns="http://www.w3.org/2000/svg"
+            width="100%"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M12 .297c-6.63 0-12 5.373-12 12c0 5.303 3.438 9.8 8.205 11.385c.6.113.82-.258.82-.577c0-.285-.01-1.04-.015-2.04c-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729c1.205.084 1.838 1.236 1.838 1.236c1.07 1.835 2.809 1.305 3.495.998c.108-.776.417-1.305.76-1.605c-2.665-.3-5.466-1.332-5.466-5.93c0-1.31.465-2.38 1.235-3.22c-.135-.303-.54-1.523.105-3.176c0 0 1.005-.322 3.3 1.23c.96-.267 1.98-.399 3-.405c1.02.006 2.04.138 3 .405c2.28-1.552 3.285-1.23 3.285-1.23c.645 1.653.24 2.873.12 3.176c.765.84 1.23 1.91 1.23 3.22c0 4.61-2.805 5.625-5.475 5.92c.42.36.81 1.096.81 2.22c0 1.606-.015 2.896-.015 3.286c0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+            />
+          </svg>
+          GitHub
+        </a>
+      </div>
+    </div>
   );
 }
+
+/* Previous shared-component implementation (kept for reference):
+ *
+ * import { Hero as BaseHero } from '@rstack-dev/doc-ui/hero';
+ *
+ * <BaseHero
+ *   showStars={false}
+ *   showOvalBg={false}
+ *   onClickGetStarted={onClickGetStarted}
+ *   title="Rslint"
+ *   subTitle={t('subtitle')}
+ *   description={t('slogan')}
+ *   logoUrl={LOGO_URL}
+ *   getStartedButtonText={t('quickStart')}
+ *   githubURL={GITHUB_URL}
+ * />
+ */

--- a/website/theme/components/LintDemo/Starfield.tsx
+++ b/website/theme/components/LintDemo/Starfield.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useRef } from 'react';
+import styles from './styles.module.scss';
+
+/**
+ * Parallax star field — ambient full-page background canvas.
+ *
+ * Ported near-verbatim from the d-glitch-decode prototype's `starfield`
+ * IIFE. Three depth layers drift leftward at their own speed; per-star
+ * twinkle modulates alpha + luminance so the field gently breathes, and a
+ * very low-amplitude mouse force field leaves a soft wake.
+ *
+ * Theme detection is inverted vs the prototype: it used
+ * `classList.contains('theme-light')`, but rspress marks DARK mode with
+ * `.dark` on <html> (theme/index.scss:11). So light == NO `.dark` class.
+ * A MutationObserver on <html>'s class reflects rspress theme switches in
+ * real time (the prototype polled / toggled a class directly).
+ */
+export function Starfield() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !canvas.getContext) {
+      return;
+    }
+    const ctx = canvas.getContext('2d', { alpha: true });
+    if (!ctx) {
+      return;
+    }
+
+    const MAX_DPR = 1.75;
+
+    type LayerSpec = {
+      count: number;
+      speed: number;
+      sizeMin: number;
+      sizeMax: number;
+      alphaMin: number;
+      alphaMax: number;
+      twinkle: number;
+    };
+
+    const LAYERS_DARK: LayerSpec[] = [
+      {
+        count: 90,
+        speed: 18,
+        sizeMin: 1.1,
+        sizeMax: 2.4,
+        alphaMin: 0.55,
+        alphaMax: 1.0,
+        twinkle: 0.4,
+      },
+      {
+        count: 160,
+        speed: 10,
+        sizeMin: 0.7,
+        sizeMax: 1.5,
+        alphaMin: 0.35,
+        alphaMax: 0.75,
+        twinkle: 0.3,
+      },
+      {
+        count: 240,
+        speed: 4,
+        sizeMin: 0.4,
+        sizeMax: 0.9,
+        alphaMin: 0.18,
+        alphaMax: 0.45,
+        twinkle: 0.18,
+      },
+    ];
+    const LAYERS_LIGHT: LayerSpec[] = [
+      {
+        count: 70,
+        speed: 16,
+        sizeMin: 0.9,
+        sizeMax: 2.0,
+        alphaMin: 0.35,
+        alphaMax: 0.7,
+        twinkle: 0.28,
+      },
+      {
+        count: 130,
+        speed: 9,
+        sizeMin: 0.6,
+        sizeMax: 1.3,
+        alphaMin: 0.22,
+        alphaMax: 0.5,
+        twinkle: 0.2,
+      },
+      {
+        count: 200,
+        speed: 3,
+        sizeMin: 0.3,
+        sizeMax: 0.8,
+        alphaMin: 0.12,
+        alphaMax: 0.32,
+        twinkle: 0.12,
+      },
+    ];
+
+    // [r, g, b, pick-weight]
+    const TINTS_DARK: number[][] = [
+      [255, 245, 232, 0.45],
+      [192, 150, 255, 0.25],
+      [255, 158, 84, 0.18],
+      [142, 200, 255, 0.12],
+    ];
+    const TINTS_LIGHT: number[][] = [
+      [144, 144, 152, 0.5],
+      [196, 168, 120, 0.28],
+      [168, 144, 196, 0.14],
+      [196, 86, 32, 0.08],
+    ];
+
+    let W = 0;
+    let H = 0;
+    let DPR = 1;
+
+    function resize() {
+      DPR = Math.min(MAX_DPR, window.devicePixelRatio || 1);
+      W = window.innerWidth;
+      H = window.innerHeight;
+      canvas!.style.width = W + 'px';
+      canvas!.style.height = H + 'px';
+      canvas!.width = Math.floor(W * DPR);
+      canvas!.height = Math.floor(H * DPR);
+      ctx!.setTransform(DPR, 0, 0, DPR, 0, 0);
+    }
+
+    type Layer = {
+      specDark: LayerSpec;
+      specLight: LayerSpec;
+      capacity: number;
+      x: Float32Array;
+      y: Float32Array;
+      size: Float32Array;
+      baseAlpha: Float32Array;
+      twinklePhase: Float32Array;
+      tintIdx: Uint8Array;
+    };
+
+    let layers: Layer[] = [];
+
+    function pickWeightedTint(list: number[][]) {
+      const r = Math.random();
+      let acc = 0;
+      for (let i = 0; i < list.length; i++) {
+        acc += list[i][3];
+        if (r < acc) {
+          return i;
+        }
+      }
+      return list.length - 1;
+    }
+
+    function seed() {
+      layers = [];
+      for (let li = 0; li < LAYERS_DARK.length; li++) {
+        const d = LAYERS_DARK[li];
+        const l = LAYERS_LIGHT[li];
+        const N = Math.max(d.count, l.count);
+        const x = new Float32Array(N);
+        const y = new Float32Array(N);
+        const sz = new Float32Array(N);
+        const a0 = new Float32Array(N);
+        const tp = new Float32Array(N);
+        const ti = new Uint8Array(N);
+        for (let i = 0; i < N; i++) {
+          x[i] = Math.random() * W;
+          y[i] = Math.random() * H;
+          sz[i] = d.sizeMin + Math.random() * (d.sizeMax - d.sizeMin);
+          a0[i] = d.alphaMin + Math.random() * (d.alphaMax - d.alphaMin);
+          tp[i] = Math.random() * Math.PI * 2;
+          ti[i] = pickWeightedTint(TINTS_DARK);
+        }
+        layers.push({
+          specDark: d,
+          specLight: l,
+          capacity: N,
+          x,
+          y,
+          size: sz,
+          baseAlpha: a0,
+          twinklePhase: tp,
+          tintIdx: ti,
+        });
+      }
+    }
+
+    resize();
+    seed();
+
+    const onResize = () => {
+      resize();
+      seed();
+    };
+    window.addEventListener('resize', onResize);
+
+    // Mouse — very subtle wake.
+    const MOUSE_FORCE = 220;
+    let mx = -9999;
+    let my = -9999;
+    let hasMouse = false;
+    const onMouseMove = (e: MouseEvent) => {
+      mx = e.clientX;
+      my = e.clientY;
+      hasMouse = true;
+    };
+    const onMouseLeave = () => {
+      hasMouse = false;
+    };
+    window.addEventListener('mousemove', onMouseMove, { passive: true });
+    window.addEventListener('mouseleave', onMouseLeave);
+
+    // rspress: dark mode == html.dark; light == no .dark class.
+    const isLight = () => !document.documentElement.classList.contains('dark');
+
+    let raf = 0;
+    let prev = performance.now();
+    function render(now: number) {
+      const dt = Math.min(0.08, (now - prev) / 1000);
+      prev = now;
+
+      const light = isLight();
+      const layerSpecs = light ? LAYERS_LIGHT : LAYERS_DARK;
+      const tintList = light ? TINTS_LIGHT : TINTS_DARK;
+
+      ctx!.clearRect(0, 0, W, H);
+      ctx!.globalCompositeOperation = light ? 'source-over' : 'lighter';
+
+      for (let li = 0; li < layers.length; li++) {
+        const L = layers[li];
+        const spec = layerSpecs[li];
+        const N = Math.min(L.capacity, spec.count);
+        const speed = spec.speed;
+        const twinkleAmp = spec.twinkle;
+
+        for (let i = 0; i < N; i++) {
+          let x = L.x[i] - speed * dt;
+          let y = L.y[i] + speed * dt * 0.08;
+
+          if (x < -4) {
+            x = W + 4;
+          }
+          if (y > H + 4) {
+            y = -4;
+          }
+
+          if (hasMouse) {
+            const dx = x - mx;
+            const dy = y - my;
+            const d2 = dx * dx + dy * dy + 60;
+            if (d2 < 30000) {
+              const f = MOUSE_FORCE / d2;
+              x += dx * f * dt;
+              y += dy * f * dt;
+            }
+          }
+
+          L.x[i] = x;
+          L.y[i] = y;
+
+          const tw = Math.sin(now * 0.0014 + L.twinklePhase[i]);
+          const a = Math.max(0.04, L.baseAlpha[i] + tw * twinkleAmp * 0.5);
+          const lumMult = 1 + tw * 0.15;
+          const tint = tintList[L.tintIdx[i]];
+          const r = Math.min(255, Math.round(tint[0] * lumMult));
+          const g = Math.min(255, Math.round(tint[1] * lumMult));
+          const b = Math.min(255, Math.round(tint[2] * lumMult));
+
+          ctx!.fillStyle =
+            'rgba(' + r + ',' + g + ',' + b + ',' + a.toFixed(3) + ')';
+          ctx!.beginPath();
+          ctx!.arc(x, y, L.size[i], 0, Math.PI * 2);
+          ctx!.fill();
+        }
+      }
+
+      raf = requestAnimationFrame(render);
+    }
+    raf = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseleave', onMouseLeave);
+    };
+  }, []);
+
+  return (
+    <canvas ref={canvasRef} className={styles.starfield} aria-hidden="true" />
+  );
+}

--- a/website/theme/components/LintDemo/index.tsx
+++ b/website/theme/components/LintDemo/index.tsx
@@ -1,0 +1,769 @@
+import { useEffect, useRef } from 'react';
+import './keyframes.scss';
+import styles from './styles.module.scss';
+
+/**
+ * Live lint-scan demo pane — ported from the d-glitch-decode prototype's
+ * `.decode-pane`. Shows a fake but faithful rslint run: a scanner band
+ * sweeps a TS snippet decoding each char, a CLI-style console types the
+ * `$ rslint ./demo.ts` command, a spinner+bar progress line fills, two
+ * diagnostics (no-explicit-any + eqeqeq) render in the real rslint default
+ * printer format, and VS Code MarkerHover tooltips appear on squiggle
+ * hover. Clicking "Quick Fix..." on the eqeqeq tooltip rewrites the source
+ * (`==` -> `===`) and reruns the cycle with one fewer diagnostic; the
+ * "rerun" button replays the full 2-violation cycle.
+ *
+ * The original was vanilla DOM + rAF. We keep that imperative model: the
+ * static shell is rendered as JSX, and the whole animation engine runs in
+ * a single useEffect against a ref-scoped container (getElementById ->
+ * root.querySelector). All rAF / setInterval / listeners are torn down on
+ * unmount. No theme branching is needed here — every colour comes from CSS
+ * vars that flip on rspress's `html.dark` class (see styles.module.scss).
+ */
+export function LintDemo() {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) {
+      return;
+    }
+    const $ = <T extends HTMLElement = HTMLElement>(sel: string) =>
+      root.querySelector(sel) as T | null;
+
+    // ---------- source code shown in the pane ----------
+    const ORIGINAL_SOURCE = `export function hello(name: any) {
+  if (name == 'Rslint') {
+    return 'Welcome back!';
+  }
+  return \`Hello, \${name}\`;
+}`;
+    let SOURCE = ORIGINAL_SOURCE;
+
+    function classify(src: string): (string | null)[] {
+      const out: (string | null)[] = new Array(src.length).fill(null);
+      const tag = (s: number, e: number, k: string) => {
+        for (let i = s; i < e; i++) {
+          out[i] = k;
+        }
+      };
+      let re = /'[^']*'|"[^"]*"/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src))) {
+        tag(m.index, m.index + m[0].length, 's');
+      }
+      re = /\b\d+\b/g;
+      while ((m = re.exec(src))) {
+        tag(m.index, m.index + m[0].length, 'n');
+      }
+      re = /\/\/[^\n]*/g;
+      while ((m = re.exec(src))) {
+        tag(m.index, m.index + m[0].length, 'c');
+      }
+      re =
+        /\b(import|from|export|default|const|let|function|return|if|else|new|await|async|true|false|null|undefined|while)\b/g;
+      while ((m = re.exec(src))) {
+        if (out[m.index] === null) {
+          tag(m.index, m.index + m[0].length, 'k');
+        }
+      }
+      re = /\b([A-Za-z_$][\w$]*)\s*\(/g;
+      while ((m = re.exec(src))) {
+        if (out[m.index] === null) {
+          tag(m.index, m.index + m[1].length, 'p');
+        }
+      }
+      return out;
+    }
+    let KINDS = classify(SOURCE);
+
+    // ---------- build char nodes ----------
+    const codeEl = $('#ld-code');
+    const decodeBody = $('#ld-decodeBody');
+    if (!codeEl || !decodeBody) {
+      return;
+    }
+    let lines = SOURCE.split('\n');
+    type CharNode = {
+      node: HTMLSpanElement;
+      char: string;
+      y: number;
+      kind: string | null;
+      state: string;
+    };
+    const charNodes: CharNode[] = [];
+    const LINE_H = 22;
+    const TOP_PAD = 14;
+
+    const lineCharSpans: HTMLSpanElement[][] = [];
+
+    function buildCharNodes() {
+      codeEl!.innerHTML = '';
+      lines = SOURCE.split('\n');
+      KINDS = classify(SOURCE);
+      charNodes.length = 0;
+      lineCharSpans.length = 0;
+      let abs = 0;
+      lines.forEach((line, ly) => {
+        const lineDiv = document.createElement('div');
+        lineDiv.className = 'cl';
+        const lineArr: HTMLSpanElement[] = [];
+        if (line.length === 0) {
+          lineDiv.innerHTML = '&nbsp;';
+        } else {
+          for (let cx = 0; cx < line.length; cx++) {
+            const s = document.createElement('span');
+            s.className = 'ch enc';
+            s.textContent = line[cx];
+            lineDiv.appendChild(s);
+            lineArr.push(s);
+            charNodes.push({
+              node: s,
+              char: line[cx],
+              y: ly * LINE_H + LINE_H / 2 + TOP_PAD,
+              kind: KINDS[abs],
+              state: 'enc',
+            });
+            abs++;
+          }
+        }
+        lineCharSpans.push(lineArr);
+        codeEl!.appendChild(lineDiv);
+        abs++;
+      });
+    }
+    buildCharNodes();
+
+    // ---------- violations ----------
+    type Violation = {
+      line: number;
+      col: number;
+      len: number;
+      severity: 'error' | 'warning';
+      rule: string;
+      message: string;
+      quickFix: boolean;
+      fix: { replace: string } | null;
+      codeLines: { n: number; text: string; hl: [number, number] | null }[];
+    };
+    const ORIGINAL_VIOLATIONS: Violation[] = [
+      {
+        line: 1,
+        col: 29,
+        len: 3,
+        severity: 'error',
+        rule: '@typescript-eslint/no-explicit-any',
+        message: 'Unexpected any. Specify a different type.',
+        quickFix: false,
+        fix: null,
+        codeLines: [
+          { n: 1, text: `export function hello(name: any) {`, hl: [28, 31] },
+          { n: 2, text: `  if (name == 'Rslint') {`, hl: null },
+        ],
+      },
+      {
+        line: 2,
+        col: 12,
+        len: 2,
+        severity: 'error',
+        rule: 'eqeqeq',
+        message: "Expected '===' and instead saw '=='.",
+        quickFix: true,
+        fix: { replace: '===' },
+        codeLines: [
+          { n: 1, text: `export function hello(name: any) {`, hl: null },
+          { n: 2, text: `  if (name == 'Rslint') {`, hl: [11, 13] },
+          { n: 3, text: `    return 'Welcome back!';`, hl: null },
+        ],
+      },
+    ];
+    let VIOLATIONS: Violation[] = ORIGINAL_VIOLATIONS.slice();
+
+    // ---------- DOM refs ----------
+    const scanner = $('#ld-scanner');
+    const decodePane = $('#ld-decodePane');
+    const consoleEl = $('#ld-console');
+    const replayBtn = $('#ld-replayBtn');
+    const paneFile = $('#ld-paneFile');
+    if (!scanner || !decodePane || !consoleEl || !replayBtn || !paneFile) {
+      return;
+    }
+
+    // ---------- console log (rslint default printer style) ----------
+    function pushLog(html: string, extraClass?: string | null) {
+      const div = document.createElement('div');
+      div.className = 'log ' + (extraClass || 'info');
+      div.innerHTML = html;
+      consoleEl!.appendChild(div);
+    }
+    function clearLog() {
+      consoleEl!.innerHTML = '';
+    }
+    function esc(s: string) {
+      return s.replace(
+        /[&<>]/g,
+        (c) =>
+          (
+            ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }) as Record<
+              string,
+              string
+            >
+          )[c],
+      );
+    }
+
+    function pushDiagnostic(
+      v: Violation,
+      file: string,
+      firstWithRise?: boolean,
+    ) {
+      const sevClass = v.severity === 'error' ? 'sev-err' : 'sev-warn';
+      const sevLabel = v.severity === 'error' ? 'error' : 'warning';
+
+      pushLog(
+        ` <span class="rname"> ${esc(v.rule)} </span>` +
+          ` — <span class="${sevClass}">[${sevLabel}]</span> ` +
+          esc(v.message),
+        firstWithRise ? 'diag-in' : null,
+      );
+
+      pushLog(
+        `  <span class="border">╭─┴──────────(</span> ` +
+          `<span class="file">${esc(file)}:${v.line}:${v.col}</span> ` +
+          `<span class="border">)─────</span>`,
+      );
+
+      const lastN = v.codeLines[v.codeLines.length - 1].n;
+      const numW = String(lastN).length;
+      for (const cl of v.codeLines) {
+        let body: string;
+        if (cl.hl) {
+          const [a, b] = cl.hl;
+          body =
+            esc(cl.text.slice(0, a)) +
+            `<span class="under">${esc(cl.text.slice(a, b))}</span>` +
+            esc(cl.text.slice(b));
+        } else {
+          body = esc(cl.text);
+        }
+        const nStr = String(cl.n).padStart(numW, ' ');
+        pushLog(
+          `  <span class="border">│ </span><span class="gutter">${nStr}</span><span class="border"> │</span>  ${body}`,
+        );
+      }
+
+      pushLog(
+        `  <span class="border">╰────────────────────────────────</span>`,
+      );
+    }
+
+    // ---------- VS Code MarkerHover popover ----------
+    type Tooltip = {
+      tip: HTMLDivElement;
+      spans: HTMLSpanElement[];
+      show: () => void;
+      hide: () => void;
+      isFixed: () => boolean;
+    };
+    const tooltipNodes: Tooltip[] = [];
+    function spawnTooltip(v: Violation): Tooltip | null {
+      const lineIdx = v.line - 1;
+      const colIdx = v.col - 1;
+      const spans = lineCharSpans[lineIdx] || [];
+      const anchor = spans[colIdx];
+      if (!anchor) {
+        return null;
+      }
+
+      const tokenSpans: HTMLSpanElement[] = [];
+      for (let i = colIdx; i < colIdx + v.len && i < spans.length; i++) {
+        spans[i].classList.add('violation');
+        tokenSpans.push(spans[i]);
+      }
+
+      const tip = document.createElement('div');
+      tip.className = 'vsc-tip';
+
+      const statusBar = v.quickFix
+        ? `<div class="status-bar"><a class="action quick-fix" href="#">Quick Fix...</a></div>`
+        : '';
+
+      const lspMessage = `[${v.rule}] ${v.message}`;
+
+      tip.innerHTML = `
+        <div class="vsc-body">
+          <span class="msg">${esc(lspMessage)}</span>
+          <span class="details">rslint</span>
+        </div>
+        ${statusBar}
+      `;
+
+      decodeBody!.appendChild(tip);
+
+      const bodyRect = decodeBody!.getBoundingClientRect();
+      const anchorRect = anchor.getBoundingClientRect();
+
+      const tipWidth = 340;
+      const padding = 8;
+      const anchorLeftRel = anchorRect.left - bodyRect.left;
+      const anchorTopRel = anchorRect.top - bodyRect.top;
+
+      let tipLeft = anchorLeftRel - 14;
+      const maxLeft = decodeBody!.clientWidth - tipWidth - padding;
+      if (tipLeft > maxLeft) {
+        tipLeft = maxLeft;
+      }
+      if (tipLeft < padding) {
+        tipLeft = padding;
+      }
+
+      const tipHeight = tip.offsetHeight;
+      const tipGap = 22;
+      let tipTop = anchorTopRel - tipHeight - tipGap;
+      if (tipTop < padding) {
+        tipTop = anchorTopRel + tipGap + 6;
+      }
+
+      tip.style.left = tipLeft + 'px';
+      tip.style.top = tipTop + 'px';
+
+      let hideTimer: ReturnType<typeof setTimeout> | null = null;
+      let fixed = false;
+      const show = () => {
+        if (fixed) {
+          return;
+        }
+        if (hideTimer) {
+          clearTimeout(hideTimer);
+          hideTimer = null;
+        }
+        tip.classList.add('visible');
+        tokenSpans.forEach((s) => s.classList.add('hovered'));
+      };
+      const hide = () => {
+        if (hideTimer) {
+          clearTimeout(hideTimer);
+        }
+        hideTimer = setTimeout(() => {
+          tip.classList.remove('visible');
+          tokenSpans.forEach((s) => s.classList.remove('hovered'));
+        }, 120);
+      };
+      tokenSpans.forEach((s) => {
+        s.addEventListener('mouseenter', show);
+        s.addEventListener('mouseleave', hide);
+      });
+      tip.addEventListener('mouseenter', show);
+      tip.addEventListener('mouseleave', hide);
+
+      const fixLink = tip.querySelector('.quick-fix');
+      const applyFix = () => {
+        if (fixed) {
+          return;
+        }
+        if (!v.quickFix || !v.fix) {
+          return;
+        }
+        fixed = true;
+        tip.classList.remove('visible');
+        triggerRelint(v);
+      };
+      if (fixLink) {
+        fixLink.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          applyFix();
+        });
+      }
+
+      return {
+        tip,
+        spans: tokenSpans,
+        show,
+        hide,
+        isFixed() {
+          return fixed;
+        },
+      };
+    }
+
+    function clearTooltips() {
+      tooltipNodes.forEach((t) => {
+        if (t.spans && t.show && t.hide) {
+          t.spans.forEach((s) => {
+            s.removeEventListener('mouseenter', t.show);
+            s.removeEventListener('mouseleave', t.hide);
+          });
+        }
+        if (t.tip) {
+          t.tip.classList.remove('visible');
+          t.tip.remove();
+        }
+        if (t.spans) {
+          t.spans.forEach((s) =>
+            s.classList.remove('violation', 'visible', 'hovered'),
+          );
+        }
+      });
+      tooltipNodes.length = 0;
+    }
+
+    // ---------- cycle ----------
+    const SCAN_MS = 1100;
+    const SCAN_TOP = -40;
+    const SCAN_BOT = lines.length * LINE_H + TOP_PAD + 40;
+
+    // ---------- live "rslint is running" progress line ----------
+    const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+    const SPIN_INTERVAL = 80;
+    const BAR_CELLS = 10;
+    const BAR_FILLED = '▰';
+    const BAR_EMPTY = '▱';
+    let progressEl: HTMLElement | null = null;
+
+    function renderProgress(t: number, done: boolean) {
+      if (!progressEl) {
+        return;
+      }
+      if (done) {
+        const errs = VIOLATIONS.length;
+        const errCls = errs === 0 ? 'ok' : 'bad';
+        const errLbl = errs === 1 ? 'error' : 'errors';
+        progressEl.innerHTML =
+          ` <span class="ok">✓</span> ` +
+          `<span class="rname">rslint completed</span>  ` +
+          `<span class="meta">·</span>  ` +
+          `<span class="${errCls}">${errs} ${errLbl}</span>  ` +
+          `<span class="meta">in</span>  ` +
+          `<span class="bold">${currentRunMs}ms</span>`;
+        return;
+      }
+      const ratio = Math.max(0, Math.min(1, t / SCAN_MS));
+      const filled = Math.round(ratio * BAR_CELLS);
+      const bar =
+        `<span class="rname">${BAR_FILLED.repeat(filled)}</span>` +
+        `<span class="meta">${BAR_EMPTY.repeat(BAR_CELLS - filled)}</span>`;
+      const pct = String(Math.round(ratio * 100)).padStart(3, ' ');
+      const ms = Math.floor(ratio * currentRunMs);
+      const spinIdx = Math.floor(t / SPIN_INTERVAL) % SPINNER_FRAMES.length;
+      progressEl.innerHTML =
+        `<span class="rname">${SPINNER_FRAMES[spinIdx]}</span>  ` +
+        `${bar}  ` +
+        `<span class="bold">${pct}%</span>  ` +
+        `<span class="meta">·</span>  ` +
+        `<span class="bold">${ms}ms</span>`;
+    }
+
+    const FILE = './demo.ts';
+    const TYPE_MS = 32;
+    const CMD_TEXT = `$ rslint ${FILE}`;
+    // The border fill spans the WHOLE run — from the first typed char through
+    // to the summary beat (typing + scan + the SCAN_MS+840 summary offset) —
+    // so the ring completes exactly as the lint result lands, instead of
+    // finishing early at scan-end and sitting full while diagnostics render.
+    const FILL_END_MS = CMD_TEXT.length * TYPE_MS + SCAN_MS + 840;
+    // Once the ring is fully drawn the shine dot keeps looping, but at this
+    // calmer pace (one lap / 4s — the original idle speed) instead of the
+    // faster draw speed, otherwise the post-fill loop feels too fast.
+    const SHINE_CYCLE_MS = 4000;
+    const randRunMs = () => 8 + Math.floor(Math.random() * 38);
+    let currentRunMs = randRunMs();
+
+    let firedFlags: Record<number, boolean> = {};
+    let cycleStart = performance.now();
+    // True cycle start (when the command begins typing). Drives the border
+    // fill across the whole animation, independent of `cycleStart` which gets
+    // offset far into the future during the typing phase.
+    let animStart = performance.now();
+    let stopped = false;
+
+    // Track timers/rAF so the cleanup can cancel everything.
+    let raf = 0;
+    let typer: ReturnType<typeof setInterval> | null = null;
+
+    function buildSummaryHTML() {
+      const errors = VIOLATIONS.length;
+      const errClass = errors === 0 ? 'ok' : 'bad';
+      const errLabel = errors === 1 ? 'error' : 'errors';
+      const tail =
+        `<span class="meta">(linted <span class="bold">1</span> file ` +
+        `with <span class="bold">${VIOLATIONS.length}</span> rules ` +
+        `in <span class="bold">${currentRunMs}ms</span> ` +
+        `using <span class="bold">8</span> threads)</span>`;
+      return (
+        `Found <span class="${errClass}">${errors} ${errLabel}</span> and ` +
+        `<span class="ok">0</span> warnings ` +
+        tail
+      );
+    }
+
+    function armTooltip(v: Violation) {
+      const t = spawnTooltip(v);
+      if (!t) {
+        return;
+      }
+      tooltipNodes.push(t);
+      const beatDelay = (tooltipNodes.length - 1) * 0.7;
+      t.spans.forEach((s) => {
+        s.style.animationDelay = beatDelay + 's';
+        s.classList.add('visible');
+      });
+    }
+
+    const SCHEDULE: { at: number; fn: () => void }[] = [
+      {
+        at: 0,
+        fn: () => {
+          // Sync the border-fill clock to the moment the command line (and
+          // its typing cursor) actually appears, so the ring starts drawing
+          // in lockstep with the cursor instead of a frame ahead.
+          animStart = performance.now();
+          pushLog(
+            `<span class="cmd-group">` +
+              `<span class="cmd cmd-typed"></span>` +
+              `<span class="cmd type-caret">▌</span>` +
+              `</span>` +
+              `<span class="prog-right"></span>`,
+            'cmdline',
+          );
+          const lastLog = consoleEl!.lastElementChild;
+          const cmdEl =
+            lastLog &&
+            (lastLog.querySelector('.cmd-typed') as HTMLElement | null);
+          const caretEl =
+            lastLog &&
+            (lastLog.querySelector('.type-caret') as HTMLElement | null);
+          const progSpan =
+            lastLog &&
+            (lastLog.querySelector('.prog-right') as HTMLElement | null);
+
+          cycleStart = performance.now() + 1e7;
+
+          const text = CMD_TEXT;
+          let i = 0;
+          typer = setInterval(() => {
+            if (!cmdEl || !cmdEl.parentNode) {
+              if (typer) {
+                clearInterval(typer);
+              }
+              return;
+            }
+            if (i >= text.length) {
+              if (typer) {
+                clearInterval(typer);
+              }
+              if (caretEl && caretEl.parentNode) {
+                caretEl.remove();
+              }
+              progressEl = progSpan;
+              cycleStart = performance.now();
+              renderProgress(0, false);
+              return;
+            }
+            cmdEl.textContent = text.slice(0, ++i);
+          }, TYPE_MS);
+        },
+      },
+      {
+        at: SCAN_MS,
+        fn: () => {
+          if (progressEl) {
+            progressEl.classList.add('fading');
+            progressEl = null;
+          }
+        },
+      },
+      {
+        at: SCAN_MS + 100,
+        fn: () => VIOLATIONS[0] && armTooltip(VIOLATIONS[0]),
+      },
+      {
+        at: SCAN_MS + 240,
+        fn: () => VIOLATIONS[1] && armTooltip(VIOLATIONS[1]),
+      },
+      {
+        at: SCAN_MS + 200,
+        fn: () => VIOLATIONS[0] && pushDiagnostic(VIOLATIONS[0], FILE, true),
+      },
+      {
+        at: SCAN_MS + 520,
+        fn: () => VIOLATIONS[1] && pushDiagnostic(VIOLATIONS[1], FILE, true),
+      },
+      {
+        at: SCAN_MS + 840,
+        fn: () => {
+          pushLog(buildSummaryHTML(), 'diag-in');
+          replayBtn!.classList.add('ready');
+          paneFile!.textContent = `done · ${FILE}`;
+          stopped = true;
+        },
+      },
+    ];
+
+    function resetCycle(now: number) {
+      cycleStart = now;
+      animStart = now;
+      currentRunMs = randRunMs();
+      firedFlags = {};
+      stopped = false;
+      progressEl = null;
+      decodePane!.style.setProperty('--ld-border-fill', '0');
+      replayBtn!.classList.remove('ready');
+      paneFile!.textContent = `linting ${FILE}`;
+      clearLog();
+      clearTooltips();
+      buildCharNodes();
+    }
+
+    function resetForReplay(now: number) {
+      SOURCE = ORIGINAL_SOURCE;
+      VIOLATIONS = ORIGINAL_VIOLATIONS.slice();
+      resetCycle(now);
+    }
+
+    function triggerRelint(v: Violation) {
+      if (!v || !v.fix) {
+        return;
+      }
+      const srcLines = SOURCE.split('\n');
+      const lineIdx0 = v.line - 1;
+      const colIdx0 = v.col - 1;
+      if (srcLines[lineIdx0]) {
+        const ln = srcLines[lineIdx0];
+        srcLines[lineIdx0] =
+          ln.slice(0, colIdx0) + v.fix.replace + ln.slice(colIdx0 + v.len);
+        SOURCE = srcLines.join('\n');
+      }
+      VIOLATIONS = VIOLATIONS.filter(
+        (x) => !(x.rule === v.rule && x.line === v.line && x.col === v.col),
+      );
+      resetCycle(performance.now());
+    }
+
+    const onReplayClick = () => {
+      resetForReplay(performance.now());
+    };
+    replayBtn.addEventListener('click', onReplayClick);
+
+    function frame(now: number) {
+      const t = now - cycleStart;
+
+      // The border fill grows from the first frame to the summary beat, and the
+      // shine dot rides exactly at its leading edge (conic starts at -90deg /
+      // top, clockwise) — the dot "draws" the ring as it grows (one lap over
+      // FILL_END_MS). Once the ring is full, fill clamps at 1 and the dot keeps
+      // looping from the 270deg seam, but at the calmer SHINE_CYCLE_MS pace.
+      const elapsed = Math.max(0, now - animStart);
+      const fillRaw = elapsed / FILL_END_MS;
+      decodePane!.style.setProperty(
+        '--ld-border-fill',
+        String(Math.min(1, fillRaw)),
+      );
+      // Start at -52deg (top-left corner) to match the fill conic's `from` in
+      // styles.module.scss; 308 = -52 + 360 is the seam after one full lap.
+      const shineDeg =
+        elapsed < FILL_END_MS
+          ? -52 + fillRaw * 360
+          : 308 + ((elapsed - FILL_END_MS) / SHINE_CYCLE_MS) * 360;
+      decodePane!.style.setProperty('--ld-shine-angle', `${shineDeg}deg`);
+
+      let scanY: number;
+      if (t < SCAN_MS) {
+        scanY = SCAN_TOP + (t / SCAN_MS) * (SCAN_BOT - SCAN_TOP);
+      } else {
+        scanY = SCAN_BOT;
+      }
+      scanner!.style.transform = `translateY(${scanY - 35}px)`;
+
+      for (const cn of charNodes) {
+        let newState: string;
+        if (cn.y < scanY - 32) {
+          newState = 'dec';
+        } else if (cn.y < scanY + 12) {
+          newState = 'scr';
+        } else {
+          newState = 'enc';
+        }
+
+        if (newState !== cn.state) {
+          cn.state = newState;
+          const keep: string[] = [];
+          const cls0 = cn.node.classList;
+          if (cls0.contains('violation')) {
+            keep.push('violation');
+          }
+          if (cls0.contains('visible')) {
+            keep.push('visible');
+          }
+          if (cls0.contains('hovered')) {
+            keep.push('hovered');
+          }
+          let cls = `ch ${newState}`;
+          if (newState === 'dec' && cn.kind) {
+            cls += ` t-${cn.kind}`;
+          }
+          if (keep.length) {
+            cls += ' ' + keep.join(' ');
+          }
+          cn.node.className = cls;
+        }
+      }
+
+      if (!stopped) {
+        for (let i = 0; i < SCHEDULE.length; i++) {
+          if (!firedFlags[i] && t >= SCHEDULE[i].at) {
+            SCHEDULE[i].fn();
+            firedFlags[i] = true;
+          }
+        }
+      }
+
+      if (progressEl && t < SCAN_MS) {
+        renderProgress(t, false);
+      }
+
+      raf = requestAnimationFrame(frame);
+    }
+    raf = requestAnimationFrame(frame);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      if (typer) {
+        clearInterval(typer);
+      }
+      replayBtn.removeEventListener('click', onReplayClick);
+      clearTooltips();
+    };
+  }, []);
+
+  return (
+    <div className={styles.lintDemo} ref={rootRef}>
+      <div className="stage-col">
+        <div className="decode-pane" id="ld-decodePane">
+          <div className="ld-frame" aria-hidden="true" />
+          <div className="pane-head">
+            <span className="live" />
+            <span>rslint</span>
+            <span className="right">
+              <span id="ld-paneFile">linting ./demo.ts</span>
+              <button
+                className="replay"
+                id="ld-replayBtn"
+                type="button"
+                aria-label="Rerun lint"
+              >
+                <span className="icon">{'↻'}</span>
+                <span>rerun</span>
+              </button>
+            </span>
+          </div>
+          <div className="decode-body" id="ld-decodeBody">
+            <div className="scanner" id="ld-scanner" />
+            <div className="code-text" id="ld-code" />
+          </div>
+          <div className="console" id="ld-console" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/website/theme/components/LintDemo/keyframes.scss
+++ b/website/theme/components/LintDemo/keyframes.scss
@@ -1,0 +1,89 @@
+/* Lint-demo keyframes — kept in a PLAIN (non-module) stylesheet on purpose.
+   Inside styles.module.scss, dart-sass hoists every @keyframes to the top
+   level and strips the surrounding :global marker, so the CSS-Modules pass
+   hashes the keyframe names (ld-spin -> ld-spin-PRrU1x) while the bare
+   `animation: ld-spin` references inside the :global selector blocks are
+   left untouched — name mismatch, every animation silently dies. A plain
+   .scss is never module-hashed, so these names stay literal and match the
+   references. The ld- prefix keeps them out of the global namespace's way.
+
+   They animate elements inside `.lintDemo`; the referenced CSS custom
+   properties (--ld-*) resolve on those target elements, not here. */
+
+@keyframes ld-blink {
+  50% {
+    opacity: 0.3;
+  }
+}
+
+@keyframes ld-replay-spin {
+  from {
+    transform: translateY(0.5px) rotate(0);
+  }
+  to {
+    transform: translateY(0.5px) rotate(-360deg);
+  }
+}
+
+@keyframes ld-lockin {
+  0% {
+    color: var(--ld-code-lockin-flash);
+    text-shadow: 0 0 10px var(--ld-code-lockin-glow);
+    transform: scale(1.35);
+  }
+  100% {
+    color: var(--ld-code-text);
+    text-shadow: none;
+    transform: scale(1);
+  }
+}
+
+@keyframes ld-token-tint {
+  0%,
+  100% {
+    color: var(--ld-code-text);
+  }
+  50% {
+    color: var(--ld-token-violation-tint);
+  }
+}
+
+@keyframes ld-log-in {
+  from {
+    opacity: 0;
+    transform: translateX(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes ld-log-out {
+  to {
+    opacity: 0;
+    transform: translateX(6px);
+  }
+}
+
+@keyframes ld-caret-blink {
+  0%,
+  49.99% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes ld-diag-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/website/theme/components/LintDemo/styles.module.scss
+++ b/website/theme/components/LintDemo/styles.module.scss
@@ -1,0 +1,644 @@
+/* Live-lint demo pane + parallax starfield background.
+   Ported from the d-glitch-decode prototype. All demo-internal element
+   classes are kept as :global kebab-case names (the imperative useEffect
+   logic builds DOM with innerHTML / classList using these literal strings),
+   scoped under the module-hashed `.lintDemo` / `.starfield` roots so they
+   don't leak globally.
+
+   Theme: rspress puts `.dark` on <html> in dark mode and removes it in
+   light mode (verified theme/index.scss:11). The prototype's light palette
+   (originally `:root.theme-light`) is therefore bound to html:not(.dark),
+   and the dark palette to html.dark. Brand orange is shared across both. */
+
+.starfield {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  /* Below all rspress content (nav, hero, tool-stack) and the page
+     background image, above the solid page fill. rspress home content is
+     statically positioned, so a low positive z-index here would paint the
+     canvas ABOVE block-level siblings; -1 puts it in the negative-z
+     stacking step so every positioned/static module reliably covers it. */
+  z-index: 0;
+  display: block;
+
+  /* Light mode (html without .dark) — dots are darker on cream, so dial
+     opacity down a touch to avoid a stippled look. */
+  :global(html:not(.dark)) & {
+    opacity: 0.85;
+  }
+}
+
+.lintDemo {
+  /* ---- Theme tokens (dark default) ---- */
+  --ld-orange: #ff5e00;
+  --ld-orange-soft: #ff7524;
+  --ld-text: #e8eaf0;
+  --ld-muted: #7c8294;
+
+  /* Decode pane shell */
+  --ld-pane-bg: linear-gradient(180deg, #0b0e16, #090c14);
+  --ld-pane-shadow: 0 30px 80px -30px rgba(255, 94, 0, 0.5);
+  --ld-pane-head-bg: rgba(255, 255, 255, 0.02);
+  --ld-pane-head-border: rgba(255, 255, 255, 0.05);
+  --ld-pane-head-right: rgba(255, 255, 255, 0.4);
+  --ld-replay-bg: rgba(255, 255, 255, 0.04);
+  --ld-replay-bg-hov: rgba(255, 94, 0, 0.08);
+  --ld-replay-border: rgba(255, 255, 255, 0.1);
+  --ld-replay-border-hov: rgba(255, 94, 0, 0.5);
+  --ld-replay-color: rgba(255, 255, 255, 0.62);
+  --ld-replay-color-hov: var(--ld-orange-soft);
+  --ld-shine-bright: rgba(255, 200, 150, 1);
+  --ld-shine-mid: rgba(255, 94, 0, 0.85);
+  --ld-border-on: rgba(255, 94, 0, 0.6);
+  --ld-border-off: rgba(255, 94, 0, 0.1);
+
+  /* Source code syntax tokens (Material Palenight) */
+  --ld-code-text: #d4d4d4;
+  --ld-code-lockin-flash: #ffffff;
+  --ld-code-lockin-glow: rgba(255, 255, 255, 0.8);
+  --ld-code-gutter: rgba(255, 255, 255, 0.15);
+  --ld-code-enc: rgba(220, 224, 235, 0.18);
+  --ld-code-scr: rgba(255, 200, 150, 0.82);
+  --ld-code-scr-glow: rgba(255, 94, 0, 0.55);
+  --ld-code-kw: #c792ea;
+  --ld-code-str: #c3e88d;
+  --ld-code-num: #ffcb6b;
+  --ld-code-com: #5a5f73;
+  --ld-code-fn: #82aaff;
+
+  /* Scanner band */
+  --ld-scanner-orange: #ff5e00;
+  --ld-scanner-fade-faint: rgba(255, 94, 0, 0.04);
+  --ld-scanner-fade-mid: rgba(255, 94, 0, 0.18);
+  --ld-scanner-flare-white: white;
+  --ld-scanner-trail: rgba(255, 94, 0, 0.3);
+
+  /* VS Code squiggle (error red) */
+  --ld-squiggle-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 6 4' width='6' height='4' preserveAspectRatio='none'><path d='M0 3 Q1.5 0.6 3 3 T6 3' fill='none' stroke='%23f48771' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  --ld-token-violation-tint: #f48771;
+
+  /* VS Code MarkerHover tooltip (Default Dark+) */
+  --ld-vsc-bg: #252526;
+  --ld-vsc-border: #454545;
+  --ld-vsc-keyline: #3e3e42;
+  --ld-vsc-text: #cccccc;
+  --ld-vsc-link: #3794ff;
+  --ld-vsc-err-red: #f48771;
+  --ld-vsc-shadow: rgba(0, 0, 0, 0.5);
+
+  /* Console (rslint default printer ANSI palette) */
+  --ld-console-bg: rgba(0, 0, 0, 0.32);
+  --ld-console-border: rgba(255, 255, 255, 0.05);
+  --ld-console-rname: #5fff5f;
+  --ld-console-file: #5fd7d7;
+  --ld-console-err: #ff5f5f;
+  --ld-console-warn: #ffd75f;
+  --ld-console-faint: rgba(255, 255, 255, 0.42);
+  --ld-console-cmd: rgba(255, 255, 255, 0.7);
+  --ld-console-bold: #ffffff;
+  --ld-console-caret: rgba(255, 255, 255, 0.85);
+
+  /* Monospace stack: JetBrains Mono is not loaded by the site
+     (rspress controls <head>), so fall through to platform mono fonts. */
+  --ld-mono:
+    'JetBrains Mono', ui-monospace, 'SF Mono', 'Menlo', 'Consolas', monospace;
+
+  /* Placement (width, centering, gutters) is owned by the page's
+     `.heroRow` grid — see theme/pages/index.module.scss. Here the root only
+     carries the theme tokens + a stacking context for the pane. */
+  position: relative;
+  z-index: 4;
+
+  /* ---- Light palette: rspress light mode = html WITHOUT .dark ----
+     Nested as `:global(html:not(.dark)) &` so `.lintDemo` stays the local
+     (module-hashed) anchor and only the `html:not(.dark)` ancestor is
+     global. Compiles to `:global(html:not(.dark)) .lintDemo { ... }`. */
+  :global(html:not(.dark)) & {
+    --ld-text: #1d1f24;
+    --ld-muted: #5b6172;
+
+    --ld-pane-bg: linear-gradient(180deg, #ffffff, #fafbfd);
+    --ld-pane-shadow:
+      0 22px 56px -28px rgba(20, 22, 28, 0.22), 0 1px 0 rgba(20, 22, 28, 0.04);
+    --ld-pane-head-bg: rgba(20, 22, 28, 0.03);
+    --ld-pane-head-border: rgba(20, 22, 28, 0.08);
+    --ld-pane-head-right: rgba(20, 22, 28, 0.5);
+    --ld-replay-bg: rgba(20, 22, 28, 0.04);
+    --ld-replay-bg-hov: rgba(255, 94, 0, 0.1);
+    --ld-replay-border: rgba(20, 22, 28, 0.1);
+    --ld-replay-border-hov: rgba(255, 94, 0, 0.55);
+    --ld-replay-color: rgba(20, 22, 28, 0.62);
+    --ld-shine-bright: rgba(255, 174, 110, 1);
+    --ld-shine-mid: rgba(255, 94, 0, 0.95);
+    --ld-border-on: rgba(255, 94, 0, 0.7);
+    --ld-border-off: rgba(255, 94, 0, 0.12);
+
+    --ld-code-text: #1f1f1f;
+    --ld-code-lockin-flash: #000000;
+    --ld-code-lockin-glow: rgba(0, 0, 0, 0.55);
+    --ld-code-gutter: rgba(20, 22, 28, 0.3);
+    --ld-code-enc: rgba(20, 22, 28, 0.28);
+    --ld-code-scr: rgba(160, 60, 0, 0.85);
+    --ld-code-scr-glow: rgba(255, 94, 0, 0.42);
+    --ld-code-kw: #0000ff;
+    --ld-code-str: #a31515;
+    --ld-code-num: #098658;
+    --ld-code-com: #008000;
+    --ld-code-fn: #795e26;
+
+    --ld-scanner-fade-faint: rgba(255, 94, 0, 0.06);
+    --ld-scanner-fade-mid: rgba(255, 94, 0, 0.22);
+    --ld-scanner-flare-white: #ffcf99;
+    --ld-scanner-trail: rgba(255, 94, 0, 0.32);
+
+    --ld-squiggle-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 6 4' width='6' height='4' preserveAspectRatio='none'><path d='M0 3 Q1.5 0.6 3 3 T6 3' fill='none' stroke='%23cd3131' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    --ld-token-violation-tint: #cd3131;
+
+    --ld-vsc-bg: #f3f3f3;
+    --ld-vsc-border: #c8c8c8;
+    --ld-vsc-keyline: #d4d4d4;
+    --ld-vsc-text: #1f1f1f;
+    --ld-vsc-link: #006ab1;
+    --ld-vsc-err-red: #cd3131;
+    --ld-vsc-shadow: rgba(20, 22, 28, 0.18);
+
+    --ld-console-bg: rgba(245, 245, 247, 0.85);
+    --ld-console-border: rgba(20, 22, 28, 0.08);
+    --ld-console-rname: #267f00;
+    --ld-console-file: #007acc;
+    --ld-console-err: #cd3131;
+    --ld-console-warn: #949800;
+    --ld-console-faint: rgba(20, 22, 28, 0.55);
+    --ld-console-cmd: rgba(20, 22, 28, 0.78);
+    --ld-console-bold: #000000;
+    --ld-console-caret: rgba(20, 22, 28, 0.85);
+  }
+}
+
+/* ===========================================================
+   Demo-internal element styles. Kept as :global kebab classes
+   (the imperative JS references them as literal strings), but
+   nested under the hashed `.lintDemo` root so they stay scoped.
+   =========================================================== */
+.lintDemo :global {
+  .stage-col {
+    display: flex;
+    flex-direction: column;
+    width: 590px;
+    max-width: 100%;
+  }
+
+  .decode-pane {
+    position: relative;
+    width: 590px;
+    max-width: 100%;
+    background: var(--ld-pane-bg);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--ld-pane-shadow);
+    isolation: isolate;
+  }
+
+  /* Animated frame border, drawn ON TOP of the content as a 1.5px ring (so
+     no inner background can ever cover it — that's also why the content
+     needs no inset). Two stacked rings via the mask-composite border trick:
+       ::before — progress fill that draws around the perimeter in sync with
+         the lint run (--ld-border-fill, 0→1, set by the engine each frame);
+       ::after  — the bright shine arc that keeps travelling on top. */
+  .ld-frame,
+  .ld-frame::before,
+  .ld-frame::after {
+    position: absolute;
+    inset: 0;
+    border-radius: 12px;
+    pointer-events: none;
+  }
+  .ld-frame {
+    z-index: 6;
+  }
+  .ld-frame::before,
+  .ld-frame::after {
+    content: '';
+    padding: 1.5px;
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    mask-composite: exclude;
+  }
+  .ld-frame::before {
+    /* Starts at -52deg — the actual top-left corner direction for this pane's
+       aspect (a generic -45deg lands part-way along the top edge, leaving the
+       corner unfilled). Draws clockwise from there. Must match the shine start
+       angle in index.tsx. */
+    background: conic-gradient(
+      from -52deg,
+      var(--ld-border-on) 0deg,
+      var(--ld-border-on) calc(var(--ld-border-fill, 0) * 360deg),
+      var(--ld-border-off) calc(var(--ld-border-fill, 0) * 360deg)
+    );
+  }
+  .ld-frame::after {
+    /* Shine dot rides at the fill's leading edge (its angle --ld-shine-angle
+       is driven by the engine each frame, see index.tsx), so it "draws" the
+       ring as it grows, then keeps looping once the ring is full. The bright
+       highlight starts at the conic's start angle (the fill front) and only
+       glows forward (clockwise, into the about-to-be-filled side). It must NOT
+       glow backward: at the very start that backward side is the ring's
+       "tail" (filled last, a whole lap later), so lighting it would make a
+       streak flash on then vanish as the dot moves off. */
+    background: conic-gradient(
+      from var(--ld-shine-angle, -52deg),
+      var(--ld-shine-bright) 0deg,
+      var(--ld-shine-mid) 13deg,
+      transparent 34deg 360deg
+    );
+  }
+
+  .pane-head {
+    position: relative;
+    z-index: 1;
+    min-height: 44px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--ld-pane-head-border);
+    font-family: var(--ld-mono);
+    font-size: 11px;
+    color: var(--ld-muted);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--ld-pane-head-bg);
+  }
+  .pane-head .live {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--ld-orange);
+    box-shadow: 0 0 6px var(--ld-orange);
+    animation: ld-blink 1.4s infinite;
+  }
+  .pane-head .right {
+    margin-left: auto;
+    color: var(--ld-pane-head-right);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  /* Always laid out (display:inline-flex from the start) so it never pops in
+     with a reflow that shoves paneFile sideways (which read as the module
+     "jumping"). Shown dimmed + non-interactive while the run is in progress —
+     so paneFile's right edge isn't an odd blank gap — then brightens to fully
+     enabled when ready. */
+  .pane-head .replay {
+    display: inline-flex;
+    opacity: 0.4;
+    pointer-events: none;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 9px;
+    border-radius: 5px;
+    border: 1px solid var(--ld-replay-border);
+    background: var(--ld-replay-bg);
+    color: var(--ld-replay-color);
+    font-family: var(--ld-mono);
+    font-size: 10.5px;
+    cursor: pointer;
+    transition:
+      color 0.15s,
+      border-color 0.15s,
+      background 0.15s,
+      opacity 0.35s ease;
+  }
+  .pane-head .replay.ready {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .pane-head .replay:hover {
+    color: var(--ld-replay-color-hov);
+    border-color: var(--ld-replay-border-hov);
+    background: var(--ld-replay-bg-hov);
+  }
+  .pane-head .replay .icon {
+    display: inline-block;
+    font-size: 12px;
+    line-height: 1;
+    transform: translateY(0.5px);
+  }
+  .pane-head .replay:hover .icon {
+    animation: ld-replay-spin 0.5s ease;
+  }
+
+  .decode-body {
+    position: relative;
+    z-index: 1;
+    padding: 10px 14px 6px;
+    height: 165px;
+    overflow: hidden;
+  }
+  .scanner {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 70px;
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      var(--ld-scanner-fade-faint) 25%,
+      var(--ld-scanner-fade-mid) 48%,
+      var(--ld-scanner-fade-faint) 75%,
+      transparent 100%
+    );
+    pointer-events: none;
+    z-index: 5;
+    transform: translateY(-70px);
+  }
+  .scanner::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--ld-scanner-orange) 15%,
+      var(--ld-scanner-flare-white) 50%,
+      var(--ld-scanner-orange) 85%,
+      transparent
+    );
+    box-shadow:
+      0 0 12px var(--ld-scanner-orange),
+      0 0 24px var(--ld-scanner-orange),
+      0 0 48px var(--ld-scanner-orange);
+  }
+  .scanner::after {
+    content: '';
+    position: absolute;
+    top: calc(50% + 2px);
+    left: 0;
+    right: 0;
+    height: 18px;
+    background: linear-gradient(180deg, var(--ld-scanner-trail), transparent);
+  }
+
+  .code-text {
+    font-family: var(--ld-mono);
+    font-size: 12px;
+    line-height: 22px;
+    color: var(--ld-text);
+    white-space: pre;
+    counter-reset: line;
+    position: relative;
+  }
+  .cl {
+    display: block;
+    position: relative;
+    padding-left: 28px;
+    min-height: 18px;
+  }
+  .cl::before {
+    counter-increment: line;
+    content: counter(line);
+    position: absolute;
+    left: 0;
+    width: 20px;
+    text-align: right;
+    color: var(--ld-code-gutter);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch {
+    display: inline-block;
+    transform-origin: center;
+    transition:
+      color 0.28s ease,
+      text-shadow 0.28s ease;
+  }
+  .ch.enc {
+    color: var(--ld-code-enc);
+  }
+  .ch.scr {
+    color: var(--ld-code-scr);
+    text-shadow: 0 0 6px var(--ld-code-scr-glow);
+  }
+  .ch.dec {
+    color: var(--ld-code-text);
+    animation: ld-lockin 0.32s ease-out;
+  }
+  .ch.dec.t-k {
+    color: var(--ld-code-kw);
+  }
+  .ch.dec.t-s {
+    color: var(--ld-code-str);
+  }
+  .ch.dec.t-n {
+    color: var(--ld-code-num);
+  }
+  .ch.dec.t-c {
+    color: var(--ld-code-com);
+    font-style: italic;
+  }
+  .ch.dec.t-p {
+    color: var(--ld-code-fn);
+  }
+
+  .ch.violation {
+    position: relative;
+    cursor: help;
+  }
+  .ch.violation::after {
+    content: '';
+    position: absolute;
+    left: -0.5px;
+    right: -0.5px;
+    bottom: -1px;
+    height: 4px;
+    background-image: var(--ld-squiggle-url);
+    background-repeat: repeat-x;
+    background-size: 6px 4px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.25s ease;
+  }
+  .ch.violation.visible::after {
+    opacity: 0.92;
+  }
+  .ch.violation.visible {
+    animation: ld-token-tint 1.8s ease-in-out infinite;
+  }
+  .ch.violation.visible.hovered {
+    animation: none;
+    color: var(--ld-token-violation-tint);
+  }
+  .ch.violation.visible.hovered::after {
+    opacity: 1;
+  }
+
+  /* VS Code MarkerHover popover */
+  .vsc-tip {
+    position: absolute;
+    z-index: 8;
+    width: 340px;
+    background: var(--ld-vsc-bg);
+    color: var(--ld-vsc-text);
+    border: 1px solid var(--ld-vsc-border);
+    border-radius: 3px;
+    box-shadow: 0 2px 8px var(--ld-vsc-shadow);
+    font-family:
+      -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI',
+      'Helvetica Neue', system-ui, sans-serif;
+    font-size: 13px;
+    line-height: 1.4;
+    opacity: 0;
+    transform: translateY(-4px);
+    transition:
+      opacity 0.18s ease,
+      transform 0.18s ease;
+    pointer-events: none;
+  }
+  .vsc-tip.visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+  .vsc-tip .vsc-body {
+    padding: 8px 12px 8px 12px;
+  }
+  .vsc-tip .msg {
+    display: block;
+    white-space: pre-wrap;
+    color: var(--ld-vsc-text);
+    word-wrap: break-word;
+  }
+  .vsc-tip .details {
+    display: block;
+    margin-top: 4px;
+    opacity: 0.6;
+    color: var(--ld-vsc-text);
+  }
+  .vsc-tip .status-bar {
+    border-top: 1px solid var(--ld-vsc-keyline);
+    padding: 5px 12px 7px 12px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    font-size: 12px;
+  }
+  .vsc-tip .status-bar .action {
+    color: var(--ld-vsc-link);
+    cursor: pointer;
+    text-decoration: none;
+  }
+  .vsc-tip .status-bar .action:hover {
+    text-decoration: underline;
+  }
+
+  .console {
+    position: relative;
+    z-index: 1;
+    padding: 6px 14px 10px;
+    height: 250px;
+    overflow: hidden;
+    border-top: 1px solid var(--ld-console-border);
+    background: var(--ld-console-bg);
+    font-family: var(--ld-mono);
+    font-size: 10.5px;
+    line-height: 1.6;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+  .console .log {
+    display: block;
+    color: var(--ld-text);
+    white-space: pre;
+    overflow-x: auto;
+    overflow-y: hidden;
+    max-width: 100%;
+    min-width: 0;
+    scrollbar-width: none;
+    animation: ld-log-in 0.32s ease-out;
+  }
+  .console .log::-webkit-scrollbar {
+    display: none;
+  }
+  .console .log.fade {
+    animation: ld-log-out 0.2s ease forwards;
+  }
+  .console .log .rname {
+    color: var(--ld-console-rname);
+  }
+  .console .log .file {
+    color: var(--ld-console-file);
+    font-style: italic;
+  }
+  .console .log .sev-err {
+    color: var(--ld-console-err);
+    font-weight: 700;
+  }
+  .console .log .sev-warn {
+    color: var(--ld-console-warn);
+  }
+  .console .log .border {
+    color: var(--ld-console-faint);
+  }
+  .console .log .gutter {
+    color: var(--ld-console-faint);
+  }
+  .console .log .under {
+    color: var(--ld-console-err);
+    font-weight: 700;
+  }
+  .console .log .cmd {
+    color: var(--ld-console-cmd);
+  }
+  .console .log .ok {
+    color: var(--ld-console-rname);
+    font-weight: 700;
+  }
+  .console .log .bad {
+    color: var(--ld-console-err);
+    font-weight: 700;
+  }
+  .console .log .bold {
+    color: var(--ld-console-bold);
+    font-weight: 700;
+  }
+  .console .log .meta {
+    color: var(--ld-console-faint);
+  }
+  .console .log.cmdline {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 16px;
+  }
+  .console .log.cmdline .cmd-group {
+    white-space: nowrap;
+  }
+  .console .log.cmdline .type-caret {
+    display: inline-block;
+    margin-left: 0;
+    color: var(--ld-console-caret);
+    animation: ld-caret-blink 1s linear infinite;
+  }
+  .console .log.cmdline .prog-right {
+    white-space: nowrap;
+    transition: opacity 0.32s ease-out;
+  }
+  .console .log.cmdline .prog-right.fading {
+    opacity: 0;
+  }
+  .console .log.diag-in {
+    animation: ld-diag-rise 0.32s ease-out;
+  }
+}

--- a/website/theme/pages/index.module.scss
+++ b/website/theme/pages/index.module.scss
@@ -1,0 +1,28 @@
+/* Hero row — custom hero (left) beside the lint demo (right). It lives INSIDE
+   the shared doc-ui `containerStyle` section (the same wrapper Rstack/ToolStack
+   uses, applied in pages/index.tsx), so the horizontal gutters and 1296px
+   max-width — and how they respond to window size — are identical to Rstack's,
+   keeping the two stacked sections edge-aligned at every breakpoint. The
+   container's vertical padding also restores the hero height (~96px top/bottom
+   + the ~460px demo ≈ the old single-hero block). This element only owns the
+   inner two-column grid. */
+.heroRow {
+  width: 100%;
+  max-width: 1296px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 590px;
+  align-items: center;
+  gap: 48px;
+}
+
+/* Stack only on tablet/narrow widths. Above this the columns stay side-by-side
+   (1024–1280 is a touch tight because doc-ui's gutter eats width, but it keeps
+   common laptop widths side-by-side). Hero.module.scss re-centers at the same
+   breakpoint. */
+@media (max-width: 1024px) {
+  .heroRow {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    gap: 40px;
+  }
+}

--- a/website/theme/pages/index.tsx
+++ b/website/theme/pages/index.tsx
@@ -1,13 +1,26 @@
 import { BackgroundImage } from '@rstack-dev/doc-ui/background-image';
+import { containerStyle } from '@rstack-dev/doc-ui/section-style';
 import { CopyRight } from '../components/Copyright';
 import { Hero } from '../components/Hero';
+import { LintDemo } from '../components/LintDemo';
+import { Starfield } from '../components/LintDemo/Starfield';
 import { ToolStack } from '../components/ToolStack';
+import styles from './index.module.scss';
 
 export function HomeLayout() {
   return (
     <div style={{ position: 'relative' }}>
+      <Starfield />
       <BackgroundImage />
-      <Hero />
+      {/* Same doc-ui section wrapper ToolStack uses, so the hero's gutters +
+          max-width track Rstack's at every window size and the two sections
+          line up. Its vertical padding also restores the hero's height. */}
+      <section className={containerStyle}>
+        <div className={styles.heroRow}>
+          <Hero />
+          <LintDemo />
+        </div>
+      </section>
       <ToolStack />
       <CopyRight />
     </div>


### PR DESCRIPTION
## Summary

Redesign the website homepage hero into a side-by-side layout with a live, animated "lint scan" demo.

- **Custom hero** replacing the shared doc-ui `<Hero>` — faithfully replicates its gradient title, button styles, GitHub link and light/dark colours, but scaled down and left-aligned to sit beside the demo (decorative stars/oval off, since we have our own background).
- **`LintDemo`** pane: a scanner sweeps a TS snippet, the console types `$ rslint ./demo.ts`, two diagnostics render in rslint's real default-printer format with VS Code hover tooltips + a working Quick Fix → re-lint, and an animated frame border draws clockwise from the top-left in sync with the run (a shine dot leads the fill, then loops).
- **`Starfield`** parallax canvas background.
- Hero + demo share doc-ui's `containerStyle`, so their gutters align with the Rstack section at every window size; the row stacks below 1024px.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).