### PR TITLE
feat: enable implemented rules in jsx-a11y recommended config

### DIFF
--- a/packages/rslint/src/configs/jsx-a11y.ts
+++ b/packages/rslint/src/configs/jsx-a11y.ts
@@ -7,7 +7,8 @@ const recommended: RslintConfigEntry = {
   plugins: ['jsx-a11y'],
   rules: {
     'jsx-a11y/alt-text': 'error',
-    // 'jsx-a11y/anchor-ambiguous-text': 'off', // not implemented (off in upstream)
+    // 'off' to match upstream recommended (upstream marks it TODO: error).
+    'jsx-a11y/anchor-ambiguous-text': 'off',
     'jsx-a11y/anchor-has-content': 'error',
     'jsx-a11y/anchor-is-valid': 'error',
     'jsx-a11y/aria-activedescendant-has-tabindex': 'error',


### PR DESCRIPTION
## Summary

Align the jsx-a11y `recommended` preset (`packages/rslint/src/configs/jsx-a11y.ts`) with upstream `eslint-plugin-jsx-a11y@6.10.2`.

Unlike the TypeScript preset, jsx-a11y `recommended` has **no commented-out rule that is both implemented and set to `error` upstream** — it is already aligned. The only adjustment:

- `jsx-a11y/anchor-ambiguous-text` is **already implemented** but was commented out as "not implemented". Upstream `recommended` sets it to `'off'` (marked `TODO: error`), so it is now declared explicitly as `'off'` to match upstream and drop the inaccurate note. No runtime behavior change (off → off).

`jsx-a11y/label-has-for` stays commented out — not yet implemented (also `'off'` upstream).

### Verification
Diffed against the full upstream `recommendedRules` (pulled from npm, 34 entries):
- Every active `error` rule matches upstream severity and options.
- The three implemented-but-unlisted rules (`no-aria-hidden-on-focusable`, `prefer-tag-over-role`, `lang`) are correctly absent — they are not part of upstream `recommended`.
- `anchor-ambiguous-text` is registered in `GetAllRules()` with matching `Name` (`jsx-a11y/anchor-ambiguous-text`).

## Related Links

## Checklist

- [x] Tests updated (or not required). <!-- config alignment; off → off, no behavior change; the rule already has its own tests -->
- [x] Documentation updated (or not required). <!-- preset docs render dynamically and do not enumerate individual rules -->