### PR TITLE
feat: enable implemented rules in javascript recommended config

### DIFF
--- a/packages/rslint/src/configs/javascript.ts
+++ b/packages/rslint/src/configs/javascript.ts
@@ -19,10 +19,10 @@ const recommended: RslintConfigEntry = {
     'no-global-assign': 'error',
     'no-import-assign': 'error',
     'no-invalid-regexp': 'error',
-    // 'no-irregular-whitespace': 'error', // not implemented
+    'no-irregular-whitespace': 'error',
     'no-misleading-character-class': 'error',
     // 'no-new-native-nonconstructor': 'error', // not implemented
-    // 'no-nonoctal-decimal-escape': 'error', // not implemented
+    'no-nonoctal-decimal-escape': 'error',
     'no-obj-calls': 'error',
     'no-octal': 'error',
     'no-prototype-builtins': 'error',
@@ -33,7 +33,7 @@ const recommended: RslintConfigEntry = {
     'no-shadow-restricted-names': 'error',
     'no-this-before-super': 'error',
     'no-undef': 'error',
-    // 'no-unexpected-multiline': 'error', // not implemented
+    'no-unexpected-multiline': 'error',
     'no-unreachable': 'error',
     'no-unsafe-finally': 'error',
     'no-unsafe-negation': 'error',
@@ -43,9 +43,9 @@ const recommended: RslintConfigEntry = {
     // 'no-unused-vars': 'error', // not implemented
     // 'no-unassigned-vars': 'error', // not implemented
     // 'no-useless-assignment': 'error', // not implemented
-    // 'no-useless-backreference': 'error', // not implemented
+    'no-useless-backreference': 'error',
     'no-useless-catch': 'error',
-    // 'no-useless-escape': 'error', // not implemented
+    'no-useless-escape': 'error',
     'no-with': 'error',
     // 'preserve-caught-error': 'error', // not implemented
     'require-yield': 'error',


### PR DESCRIPTION
## Summary

Enable 5 already-implemented rules in the `@rslint/core` JavaScript `recommended` preset (`packages/rslint/src/configs/javascript.ts`) that were previously commented out as "not implemented". All are aligned with upstream severity (`error`) from `@eslint/js` v10 `recommended`:

`no-irregular-whitespace`, `no-nonoctal-decimal-escape`, `no-unexpected-multiline`, `no-useless-backreference`, `no-useless-escape`

Nine rules stay commented out as not yet implemented (all members of `@eslint/js` v10 `recommended`): `no-empty-static-block`, `no-new-native-nonconstructor`, `no-redeclare`, `no-unused-labels`, `no-unused-private-class-members`, `no-unused-vars`, `no-unassigned-vars`, `no-useless-assignment`, `preserve-caught-error`.

### Verification
- Each enabled rule is registered in `GetAllRules()` with a matching Go `Name`.
- Diffed the preset against the full `@eslint/js` v10 `recommended` (64 rules): no missing or extra entries; severities match.
- Built the binary and linted a fixture: `no-irregular-whitespace`, `no-unexpected-multiline`, `no-useless-backreference`, `no-useless-escape` all report correctly. `no-nonoctal-decimal-escape` cannot be triggered through the tsgo parser (a `\8`/`\9` escape is a fatal TS1488 parse error before the rule runs), but its id is valid — registered and loaded with no "unknown rule".

## Related Links

## Checklist

- [x] Tests updated (or not required). <!-- config-only change; the enabled rules already have their own tests -->
- [x] Documentation updated (or not required). <!-- preset docs render dynamically and do not enumerate individual rules -->