### PR TITLE
feat: port rule @stylistic/jsx-first-prop-new-line

### DIFF
--- a/internal/plugins/react/rules/jsx_first_prop_new_line/jsx_first_prop_new_line.go
+++ b/internal/plugins/react/rules/jsx_first_prop_new_line/jsx_first_prop_new_line.go
@@ -1,3 +1,24 @@
+// Package jsx_first_prop_new_line implements jsx-first-prop-new-line, shared by
+// both eslint-plugin-react (`react/jsx-first-prop-new-line`) and
+// @stylistic/eslint-plugin (`@stylistic/jsx-first-prop-new-line`). The two
+// upstream rules are byte-identical — the @stylistic fork carries no behavioral
+// delta — so a single BuildRule constructs both; only the registered Name
+// differs.
+//
+// The rule enforces the position of the first prop in a JSX element. Five modes
+// select when the first prop must (or must not) sit on its own line:
+//
+//	always               first prop must always be on a new line
+//	never                first prop must never be on a new line
+//	multiline            new line required when the opening tag spans >1 line
+//	multiline-multiprop  (default) as multiline, but only when there is >1 prop
+//	multiprop            new line required when there is >1 prop; with <=1 prop
+//	                     on a multiline tag the prop must be on the same line
+//
+// Upstream listens on ESTree's JSXOpeningElement, which covers both the
+// `<App .../>` self-closing form and the `<App ...>` form. tsgo splits these
+// into KindJsxSelfClosingElement and KindJsxOpeningElement, so the rule
+// registers a listener for each.
 package jsx_first_prop_new_line
 
 import (
@@ -8,127 +29,145 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// JsxFirstPropNewLineRule enforces the position of the first property in a JSX element.
-var JsxFirstPropNewLineRule = rule.Rule{
-	Name: "react/jsx-first-prop-new-line",
-	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
-		// Default option
-		option := "multiline-multiprop"
+// JsxFirstPropNewLineRule is the eslint-plugin-react variant.
+var JsxFirstPropNewLineRule = BuildRule("react/jsx-first-prop-new-line")
 
-		// Parse options - can be a string or in an options array
-		if options != nil {
-			if optArray, ok := options.([]interface{}); ok && len(optArray) > 0 {
-				if s, ok := optArray[0].(string); ok {
+// BuildRule constructs the jsx-first-prop-new-line rule registered under name.
+// Both the react and @stylistic variants are produced from this single
+// implementation (see the package doc for why they share one body).
+func BuildRule(name string) rule.Rule {
+	return rule.Rule{
+		Name: name,
+		Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+			// Default option
+			option := "multiline-multiprop"
+
+			// Parse options. The schema is a single string enum
+			// ('always' | 'never' | 'multiline' | 'multiline-multiprop' |
+			// 'multiprop'), delivered either bare (single-option CLI form) or as
+			// a one-element array (rule-tester form). There is no object form, so
+			// no map handling is needed.
+			if options != nil {
+				if optArray, ok := options.([]interface{}); ok && len(optArray) > 0 {
+					if s, ok := optArray[0].(string); ok {
+						option = s
+					}
+				} else if s, ok := options.(string); ok {
 					option = s
 				}
-			} else if s, ok := options.(string); ok {
-				option = s
-			} else {
-				optsMap := utils.GetOptionsMap(options)
-				if optsMap != nil {
-					if s, ok := optsMap["option"].(string); ok {
-						option = s
+			}
+
+			check := func(node *ast.Node) {
+				var props []*ast.Node
+				var openingNode *ast.Node
+
+				switch node.Kind {
+				case ast.KindJsxOpeningElement:
+					opening := node.AsJsxOpeningElement()
+					openingNode = node
+					attrs := opening.Attributes.AsJsxAttributes()
+					if attrs.Properties != nil {
+						props = attrs.Properties.Nodes
+					}
+				case ast.KindJsxSelfClosingElement:
+					self := node.AsJsxSelfClosingElement()
+					openingNode = node
+					attrs := self.Attributes.AsJsxAttributes()
+					if attrs.Properties != nil {
+						props = attrs.Properties.Nodes
+					}
+				}
+
+				if len(props) == 0 {
+					return
+				}
+
+				lineMap := ctx.SourceFile.ECMALineMap()
+				text := ctx.SourceFile.Text()
+				firstProp := props[0]
+
+				// Use the trimmed position for the opening element
+				openingTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, openingNode)
+				openingLine := scanner.ComputeLineOfPosition(lineMap, openingTrimmed.Pos())
+				firstPropTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, firstProp)
+				firstPropLine := scanner.ComputeLineOfPosition(lineMap, firstPropTrimmed.Pos())
+
+				// Determine if element is multiline (opening tag start to opening tag end)
+				openingEndLine := scanner.ComputeLineOfPosition(lineMap, openingTrimmed.End())
+				isMultiline := openingLine != openingEndLine
+
+				propOnNewLineMsg := rule.RuleMessage{
+					Id:          "propOnNewLine",
+					Description: "Property should be placed on a new line",
+				}
+				propOnSameLineMsg := rule.RuleMessage{
+					Id:          "propOnSameLine",
+					Description: "Property should be placed on the same line as the component declaration",
+				}
+
+				// NOTE: Unlike ESLint — which replaces the whole range from the
+				// tag name (or type arguments) end to the first prop — both fixes
+				// below only consume the whitespace directly adjacent to the prop.
+				// A comment or type argument sitting between the tag name and the
+				// first prop is therefore preserved rather than deleted.
+				//
+				// Fix: replace whitespace before prop with newline
+				newLineFix := func() rule.RuleFix {
+					propStart := firstPropTrimmed.Pos()
+					wsStart := propStart
+					for wsStart > 0 && (text[wsStart-1] == ' ' || text[wsStart-1] == '\t') {
+						wsStart--
+					}
+					return rule.RuleFix{Text: "\n", Range: core.NewTextRange(wsStart, propStart)}
+				}
+				// Fix: replace whitespace/newlines before prop with a space.
+				// Returns nil (report without autofix) when non-whitespace — e.g.
+				// a comment — sits between the tag name and the first prop: wsStart
+				// then stops before the component-declaration line, so collapsing
+				// only the adjacent whitespace would leave the prop on a lower line
+				// and the violation would never clear (the autofix would loop).
+				sameLineFix := func() []rule.RuleFix {
+					propStart := firstPropTrimmed.Pos()
+					wsStart := propStart
+					for wsStart > 0 && (text[wsStart-1] == ' ' || text[wsStart-1] == '\t' || text[wsStart-1] == '\n' || text[wsStart-1] == '\r') {
+						wsStart--
+					}
+					if scanner.ComputeLineOfPosition(lineMap, wsStart) != openingLine {
+						return nil
+					}
+					return []rule.RuleFix{{Text: " ", Range: core.NewTextRange(wsStart, propStart)}}
+				}
+
+				switch option {
+				case "always":
+					if openingLine == firstPropLine {
+						ctx.ReportNodeWithFixes(firstProp, propOnNewLineMsg, newLineFix())
+					}
+				case "never":
+					if openingLine != firstPropLine {
+						ctx.ReportNodeWithFixes(firstProp, propOnSameLineMsg, sameLineFix()...)
+					}
+				case "multiline":
+					if isMultiline && openingLine == firstPropLine {
+						ctx.ReportNodeWithFixes(firstProp, propOnNewLineMsg, newLineFix())
+					}
+				case "multiline-multiprop":
+					if isMultiline && len(props) > 1 && openingLine == firstPropLine {
+						ctx.ReportNodeWithFixes(firstProp, propOnNewLineMsg, newLineFix())
+					}
+				case "multiprop":
+					if len(props) > 1 && openingLine == firstPropLine {
+						ctx.ReportNodeWithFixes(firstProp, propOnNewLineMsg, newLineFix())
+					} else if len(props) <= 1 && isMultiline && openingLine != firstPropLine {
+						ctx.ReportNodeWithFixes(firstProp, propOnSameLineMsg, sameLineFix()...)
 					}
 				}
 			}
-		}
 
-		check := func(node *ast.Node) {
-			var props []*ast.Node
-			var openingNode *ast.Node
-
-			switch node.Kind {
-			case ast.KindJsxOpeningElement:
-				opening := node.AsJsxOpeningElement()
-				openingNode = node
-				attrs := opening.Attributes.AsJsxAttributes()
-				if attrs.Properties != nil {
-					props = attrs.Properties.Nodes
-				}
-			case ast.KindJsxSelfClosingElement:
-				self := node.AsJsxSelfClosingElement()
-				openingNode = node
-				attrs := self.Attributes.AsJsxAttributes()
-				if attrs.Properties != nil {
-					props = attrs.Properties.Nodes
-				}
+			return rule.RuleListeners{
+				ast.KindJsxOpeningElement:     check,
+				ast.KindJsxSelfClosingElement: check,
 			}
-
-			if len(props) == 0 {
-				return
-			}
-
-			lineMap := ctx.SourceFile.ECMALineMap()
-			text := ctx.SourceFile.Text()
-			firstProp := props[0]
-
-			// Use the trimmed position for the opening element
-			openingTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, openingNode)
-			openingLine := scanner.ComputeLineOfPosition(lineMap, openingTrimmed.Pos())
-			firstPropTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, firstProp)
-			firstPropLine := scanner.ComputeLineOfPosition(lineMap, firstPropTrimmed.Pos())
-
-			// Determine if element is multiline (opening tag start to opening tag end)
-			openingEndLine := scanner.ComputeLineOfPosition(lineMap, openingTrimmed.End())
-			isMultiline := openingLine != openingEndLine
-
-			propOnNewLineMsg := rule.RuleMessage{
-				Id:          "propOnNewLine",
-				Description: "Property should be placed on a new line",
-			}
-			propOnSameLineMsg := rule.RuleMessage{
-				Id:          "propOnSameLine",
-				Description: "Property should be placed on the same line as the component declaration",
-			}
-
-			// Fix: replace whitespace before prop with newline
-			newLineFix := func() rule.RuleFix {
-				propStart := firstPropTrimmed.Pos()
-				wsStart := propStart
-				for wsStart > 0 && (text[wsStart-1] == ' ' || text[wsStart-1] == '\t') {
-					wsStart--
-				}
-				return rule.RuleFix{Text: "\n", Range: core.NewTextRange(wsStart, propStart)}
-			}
-			// Fix: replace whitespace/newlines before prop with a space
-			sameLineFix := func() rule.RuleFix {
-				propStart := firstPropTrimmed.Pos()
-				wsStart := propStart
-				for wsStart > 0 && (text[wsStart-1] == ' ' || text[wsStart-1] == '\t' || text[wsStart-1] == '\n' || text[wsStart-1] == '\r') {
-					wsStart--
-				}
-				return rule.RuleFix{Text: " ", Range: core.NewTextRange(wsStart, propStart)}
-			}
-
-			switch option {
-			case "always":
-				if openingLine == firstPropLine {
-					ctx.ReportNodeWithFixes(firstProp, propOnNewLineMsg, newLineFix())
-				}
-			case "never":
-				if openingLine != firstPropLine {
-					ctx.ReportNodeWithFixes(firstProp, propOnSameLineMsg, sameLineFix())
-				}
-			case "multiline":
-				if isMultiline && openingLine == firstPropLine {
-					ctx.ReportNodeWithFixes(firstProp, propOnNewLineMsg, newLineFix())
-				}
-			case "multiline-multiprop":
-				if isMultiline && len(props) > 1 && openingLine == firstPropLine {
-					ctx.ReportNodeWithFixes(firstProp, propOnNewLineMsg, newLineFix())
-				}
-			case "multiprop":
-				if len(props) > 1 && openingLine == firstPropLine {
-					ctx.ReportNodeWithFixes(firstProp, propOnNewLineMsg, newLineFix())
-				} else if len(props) <= 1 && isMultiline && openingLine != firstPropLine {
-					ctx.ReportNodeWithFixes(firstProp, propOnSameLineMsg, sameLineFix())
-				}
-			}
-		}
-
-		return rule.RuleListeners{
-			ast.KindJsxOpeningElement:     check,
-			ast.KindJsxSelfClosingElement: check,
-		}
-	},
+		},
+	}
 }

--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -19,6 +19,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_curly_newline"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_curly_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_equals_spacing"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_first_prop_new_line"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -42,5 +43,6 @@ func GetAllRules() []rule.Rule {
 		jsx_curly_newline.JsxCurlyNewlineRule,
 		jsx_curly_spacing.JsxCurlySpacingRule,
 		jsx_equals_spacing.JsxEqualsSpacingRule,
+		jsx_first_prop_new_line.JsxFirstPropNewLineRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/jsx_first_prop_new_line/jsx_first_prop_new_line.go
+++ b/internal/plugins/stylistic/rules/jsx_first_prop_new_line/jsx_first_prop_new_line.go
@@ -1,0 +1,15 @@
+// Package jsx_first_prop_new_line ports `@stylistic/jsx-first-prop-new-line` to
+// rslint. The @stylistic rule is a byte-identical fork of
+// `react/jsx-first-prop-new-line` (no behavioral delta), so the full
+// implementation is shared via the react rule's BuildRule; only the registered
+// name differs.
+package jsx_first_prop_new_line
+
+import (
+	reactRule "github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_first_prop_new_line"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// JsxFirstPropNewLineRule is the @stylistic/eslint-plugin variant of
+// jsx-first-prop-new-line.
+var JsxFirstPropNewLineRule rule.Rule = reactRule.BuildRule("@stylistic/jsx-first-prop-new-line")

--- a/internal/plugins/stylistic/rules/jsx_first_prop_new_line/jsx_first_prop_new_line.md
+++ b/internal/plugins/stylistic/rules/jsx_first_prop_new_line/jsx_first_prop_new_line.md
@@ -1,0 +1,69 @@
+# jsx-first-prop-new-line
+
+Enforce the position of the first prop in a JSX element.
+
+## Rule Details
+
+This rule checks whether the first prop of a JSX element sits on the same line as the element name or on its own line, according to the selected option. It is useful for enforcing consistent formatting of JSX props.
+
+Examples of **incorrect** code for this rule with the default `"multiline-multiprop"` option:
+
+```jsx
+<Hello foo="bar"
+  baz="quux"
+/>
+```
+
+Examples of **correct** code for this rule with the default `"multiline-multiprop"` option:
+
+```jsx
+<Hello foo="bar" baz="quux" />
+<Hello
+  foo="bar"
+  baz="quux"
+/>
+```
+
+## Options
+
+This rule has a string option:
+
+- `"multiline-multiprop"` (default) — the first prop must be on a new line when the JSX tag spans multiple lines and has more than one prop.
+- `"always"` — the first prop must always be on a new line.
+- `"never"` — the first prop must never be on a new line.
+- `"multiline"` — the first prop must be on a new line when the JSX tag spans multiple lines.
+- `"multiprop"` — the first prop must be on a new line when the JSX tag has more than one prop.
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/jsx-first-prop-new-line": ["error", "always"] }
+```
+
+```jsx
+<Hello personal="stuff" />
+```
+
+Examples of **incorrect** code for this rule with the `"never"` option:
+
+```json
+{ "@stylistic/jsx-first-prop-new-line": ["error", "never"] }
+```
+
+```jsx
+<Hello
+  personal="stuff"
+/>
+```
+
+## Differences from ESLint
+
+These only affect autofix in rare shapes; the reported diagnostics (positions, messages, and when they fire) match ESLint exactly.
+
+- When a comment sits between the tag name and the first prop and the fix moves the prop to a new line, rslint keeps the comment; ESLint removes it.
+- When a comment sits between the tag name and the first prop and the fix would move the prop back onto the tag's line, rslint reports the issue without an autofix (the prop cannot be moved across the comment); ESLint removes the comment and collapses the line.
+- For a generic element whose first prop is moved back onto the tag's line, rslint keeps the type arguments (`<Foo<T>`); ESLint drops them.
+
+## Original Documentation
+
+- [@stylistic/jsx-first-prop-new-line](https://eslint.style/rules/jsx-first-prop-new-line)

--- a/internal/plugins/stylistic/rules/jsx_first_prop_new_line/jsx_first_prop_new_line_extras_test.go
+++ b/internal/plugins/stylistic/rules/jsx_first_prop_new_line/jsx_first_prop_new_line_extras_test.go
@@ -1,0 +1,279 @@
+// TestJsxFirstPropNewLineExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// Dimension 4 walk (rule inspects JSX opening elements + their first attribute):
+//   - Receiver/expression wrappers (paren / non-null / as / optional chain):
+//     N/A — the rule targets JSX elements, it never reads a member-access
+//     receiver, so there is no child expression to wrap.
+//   - Access/key forms: the prop forms (identifier attr / boolean shorthand /
+//     spread / member-or-generic tag name) are covered below; computed keys do
+//     not exist on JSX attributes.
+//   - Declaration/container forms (function / class variants): N/A — the rule
+//     does not target functions or classes.
+//   - Nesting/traversal boundaries: covered (nested JSX, opening-vs-self-closing,
+//     opening tag single-line while element spans lines via children).
+//   - Graceful degradation: covered (no attributes, fragment container).
+package jsx_first_prop_new_line
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxFirstPropNewLineExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxFirstPropNewLineRule, []rule_tester.ValidTestCase{
+		// Locks in 'multiline' arm: a single-line opening tag is never checked,
+		// even with a prop on the same line.
+		{Code: `<Foo bar />`, Tsx: true, Options: []interface{}{"multiline"}},
+		// Locks in 'multiline-multiprop' arm: a single prop is not checked even
+		// when the tag spans multiple lines (the len>1 guard short-circuits).
+		{Code: `
+        <Foo bar={{
+        }} />
+      `, Tsx: true, Options: []interface{}{"multiline-multiprop"}},
+		// Locks in 'multiprop' arm: a single prop on a single-line tag is fine.
+		{Code: `<Foo bar />`, Tsx: true, Options: []interface{}{"multiprop"}},
+		// ---- Dimension 4: opening tag is single-line but the element spans
+		// lines via children — isMultiline reads the opening tag (not the whole
+		// element), so multiline-multiprop does not fire here.
+		{Code: `
+        <Foo bar baz>
+          x
+        </Foo>
+      `, Tsx: true, Options: []interface{}{"multiline-multiprop"}},
+		// ---- Dimension 4: JSX fragment container has no attributes; the inner
+		// single-line multi-prop element is valid under multiline-multiprop.
+		{Code: `
+        <>
+          <Foo bar baz />
+        </>
+      `, Tsx: true, Options: []interface{}{"multiline-multiprop"}},
+		// Default option (no options) == 'multiline-multiprop': single-line tag
+		// with multiple props is valid (locks in the default-resolution path).
+		{Code: `<Foo bar baz />`, Tsx: true},
+		// Default option: explicit empty options array resolves to the same
+		// default; a single-line multi-prop tag stays valid.
+		{Code: `<Foo bar baz />`, Tsx: true, Options: []interface{}{}},
+		// ---- Dimension 4 / nesting: JSX in an attribute value. The outer Foo
+		// has one prop (not reported under multiprop) and the inner Baz has none,
+		// so nothing is reported. Locks in that descending into attribute-value
+		// JSX does not produce a spurious report on either element.
+		{Code: `<Foo bar={<Baz />} />`, Tsx: true, Options: []interface{}{"multiprop"}},
+	}, []rule_tester.InvalidTestCase{
+		// Locks in 'always' arm: unconditional — a single prop on a single-line
+		// tag is still reported (no multiline / multi-prop requirement). Asserts
+		// the full report span (Line/Column/EndLine/EndColumn) for the prop node.
+		{
+			Code:    `<Foo bar baz />`,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output:  []string{"<Foo\nbar baz />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 6, EndLine: 1, EndColumn: 9},
+			},
+		},
+		// Locks in 'multiprop' propOnNewLine arm: >1 prop on a single-line tag is
+		// reported even though the tag is NOT multiline (distinguishes multiprop
+		// from multiline-multiprop).
+		{
+			Code:    `<Foo aaa bbb />`,
+			Tsx:     true,
+			Options: []interface{}{"multiprop"},
+			Output:  []string{"<Foo\naaa bbb />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 6},
+			},
+		},
+		// Locks in 'never' arm with a single prop (len>0, not >1): a lone prop on
+		// a new line is pulled back. Multi-line code; asserts full report span.
+		{
+			Code: `<Foo
+bar />`,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output:  []string{"<Foo bar />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnSameLine", Message: msgPropOnSameLine, Line: 2, Column: 1, EndLine: 2, EndColumn: 4},
+			},
+		},
+		// ---- Dimension 4: JsxOpeningElement with children (not self-closing) —
+		// the listener handles both element kinds.
+		{
+			Code:    `<Foo bar>x</Foo>`,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output:  []string{"<Foo\nbar>x</Foo>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 6},
+			},
+		},
+		// ---- Dimension 4: member-expression tag name (`<Foo.Bar>`).
+		// ---- Real-user: namespaced/dotted component is a common React shape.
+		{
+			Code:    `<Foo.Bar baz qux />`,
+			Tsx:     true,
+			Options: []interface{}{"multiprop"},
+			Output:  []string{"<Foo.Bar\nbaz qux />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 10},
+			},
+		},
+		// ---- Dimension 3 (autofix boundary): a comment sits between the tag name
+		// and the first prop. rslint's fix only replaces the whitespace directly
+		// before the prop, so the comment is preserved. NOTE: this diverges from
+		// ESLint, which replaces the whole name→prop range and drops the comment.
+		{
+			Code:    `<Foo /* c */ bar />`,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output:  []string{"<Foo /* c */\nbar />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 14},
+			},
+		},
+		// ---- Dimension 3 (autofix boundary): multiple spaces before the prop are
+		// all collapsed into the inserted newline.
+		{
+			Code:    `<Foo    bar />`,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output:  []string{"<Foo\nbar />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 9},
+			},
+		},
+		// ---- Nesting: each element is judged independently. Only the outer
+		// element (>1 prop, same line) is reported; the inner childless element
+		// is skipped — the listener does not bleed across the boundary.
+		{
+			Code:    `<Parent prop1 prop2><Child /></Parent>`,
+			Tsx:     true,
+			Options: []interface{}{"multiprop"},
+			Output:  []string{"<Parent\nprop1 prop2><Child /></Parent>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 9},
+			},
+		},
+		// ---- Real-user: TypeScript generic component under multiline-multiprop —
+		// the fix anchors after the type arguments (`<T>`), not after the bare name.
+		{
+			Code: `<Box<T> aaa bbb
+/>`,
+			Tsx:     true,
+			Options: []interface{}{"multiline-multiprop"},
+			Output: []string{`<Box<T>
+aaa bbb
+/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 9},
+			},
+		},
+		// ---- Dimension 3 (autofix boundary): generic component, propOnSameLine
+		// fix keeps the type arguments (`<T>`). NOTE: this diverges from ESLint,
+		// whose propOnSameLine fix replaces from the bare tag name and drops the
+		// type arguments. rslint's fix only consumes whitespace adjacent to the
+		// prop, so `<T>` survives.
+		{
+			Code: `<Foo<T>
+bar />`,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output:  []string{"<Foo<T> bar />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnSameLine", Message: msgPropOnSameLine, Line: 2, Column: 1},
+			},
+		},
+		// ---- Dimension 3 (autofix boundary): a comment between the tag name and
+		// the first prop blocks the same-line pull-back. Collapsing only the
+		// adjacent whitespace would leave the prop below the tag and the autofix
+		// would never converge, so the violation is reported WITHOUT a fix (no
+		// Output). NOTE: ESLint instead removes the comment and collapses the line.
+		{
+			Code: `<Foo
+/* c */
+bar />`,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnSameLine", Message: msgPropOnSameLine, Line: 3, Column: 1},
+			},
+		},
+		// ---- Dimension 4: spread attribute as the first prop — props[0] is a
+		// JsxSpreadAttribute (not a JsxAttribute); it is still reported/anchored.
+		{
+			Code:    `<Foo {...x} bar />`,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output: []string{`<Foo
+{...x} bar />`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 6},
+			},
+		},
+		// ---- Dimension 4 / nesting: JSX element inside an attribute value. The
+		// outer Foo has a single prop (not reported under multiprop); only the
+		// inner Baz (>1 prop, same line) is reported — the listener descends but
+		// keeps the two elements' judgments independent.
+		{
+			Code:    `<Foo bar={<Baz a b />} />`,
+			Tsx:     true,
+			Options: []interface{}{"multiprop"},
+			Output: []string{`<Foo bar={<Baz
+a b />} />`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 16},
+			},
+		},
+		// ---- Dimension 4: multibyte characters before the element. The column is
+		// counted in UTF-16 code units (`变量` = 2 units), matching ESLint — not
+		// byte offset.
+		{
+			Code:    `const 变量 = <Foo aaa bbb />`,
+			Tsx:     true,
+			Options: []interface{}{"multiprop"},
+			Output: []string{`const 变量 = <Foo
+aaa bbb />`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 17},
+			},
+		},
+		// ---- Dimension 4: CRLF line endings — the same-line fix consumes the
+		// `\r\n` pair and line numbers are computed correctly across it.
+		{
+			Code:    "<Foo\r\na />",
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output:  []string{"<Foo a />"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnSameLine", Message: msgPropOnSameLine, Line: 2, Column: 1},
+			},
+		},
+		// ---- Real-user: lowercase HTML element with multiple attributes.
+		{
+			Code:    `<div className="x" id="y" />`,
+			Tsx:     true,
+			Options: []interface{}{"multiprop"},
+			Output: []string{`<div
+className="x" id="y" />`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 6},
+			},
+		},
+		// ---- Real-user: JSX returned from an Array.map callback.
+		{
+			Code:    `items.map(i => <Item k={i} a b />)`,
+			Tsx:     true,
+			Options: []interface{}{"multiprop"},
+			Output: []string{`items.map(i => <Item
+k={i} a b />)`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 1, Column: 22},
+			},
+		},
+	})
+}

--- a/internal/plugins/stylistic/rules/jsx_first_prop_new_line/jsx_first_prop_new_line_upstream_test.go
+++ b/internal/plugins/stylistic/rules/jsx_first_prop_new_line/jsx_first_prop_new_line_upstream_test.go
@@ -1,0 +1,252 @@
+// TestJsxFirstPropNewLineUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/rules/jsx-first-prop-new-line/
+// jsx-first-prop-new-line.test.ts 1:1. Upstream asserts only messageId on its
+// invalid cases; the Line/Column here point at the first prop (the report
+// node), computed from the exact source each case carries, and Message asserts
+// the exact diagnostic text. rslint-specific lock-in cases live in
+// jsx_first_prop_new_line_extras_test.go.
+package jsx_first_prop_new_line
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	msgPropOnNewLine  = "Property should be placed on a new line"
+	msgPropOnSameLine = "Property should be placed on the same line as the component declaration"
+)
+
+func TestJsxFirstPropNewLineUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxFirstPropNewLineRule, []rule_tester.ValidTestCase{
+		// ---- 'never' ----
+		{Code: `<Foo />`, Tsx: true, Options: []interface{}{"never"}},
+		{Code: `<Foo prop="bar" />`, Tsx: true, Options: []interface{}{"never"}},
+		{Code: `<Foo {...this.props} />`, Tsx: true, Options: []interface{}{"never"}},
+		{Code: `<Foo a a a />`, Tsx: true, Options: []interface{}{"never"}},
+		{Code: `
+        <Foo a
+          b
+        />
+      `, Tsx: true, Options: []interface{}{"never"}},
+		// ---- 'multiline' ----
+		{Code: `<Foo />`, Tsx: true, Options: []interface{}{"multiline"}},
+		{Code: `<Foo prop="one" />`, Tsx: true, Options: []interface{}{"multiline"}},
+		{Code: `<Foo {...this.props} />`, Tsx: true, Options: []interface{}{"multiline"}},
+		{Code: `<Foo a a a />`, Tsx: true, Options: []interface{}{"multiline"}},
+		{Code: `
+        <Foo
+          propOne="one"
+          propTwo="two"
+        />
+      `, Tsx: true, Options: []interface{}{"multiline"}},
+		{Code: `
+        <Foo
+          {...this.props}
+          propTwo="two"
+        />
+      `, Tsx: true, Options: []interface{}{"multiline"}},
+		// ---- 'multiline-multiprop' (default) ----
+		{Code: `
+        <Foo bar />
+      `, Tsx: true, Options: []interface{}{"multiline-multiprop"}},
+		{Code: `
+        <Foo bar baz />
+      `, Tsx: true, Options: []interface{}{"multiline-multiprop"}},
+		{Code: `
+        <Foo prop={{
+        }} />
+      `, Tsx: true, Options: []interface{}{"multiline-multiprop"}},
+		{Code: `
+        <Foo
+          foo={{
+          }}
+          bar
+        />
+      `, Tsx: true, Options: []interface{}{"multiline-multiprop"}},
+		// ---- 'always' ----
+		{Code: `<Foo />`, Tsx: true, Options: []interface{}{"always"}},
+		{Code: `
+        <Foo
+          propOne="one"
+          propTwo="two"
+        />
+      `, Tsx: true, Options: []interface{}{"always"}},
+		{Code: `
+        <Foo
+          {...this.props}
+          propTwo="two"
+        />
+      `, Tsx: true, Options: []interface{}{"always"}},
+		// ---- 'multiprop' ----
+		{Code: `
+        <Foo />
+      `, Tsx: true, Options: []interface{}{"multiprop"}},
+		{Code: `
+        <Foo bar />
+      `, Tsx: true, Options: []interface{}{"multiprop"}},
+		{Code: `
+        <Foo {...this.props} />
+      `, Tsx: true, Options: []interface{}{"multiprop"}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- 'always': single-line tag, first prop on same line ----
+		{
+			Code: `
+        <Foo propOne="one" propTwo="two" />
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output: []string{`
+        <Foo
+propOne="one" propTwo="two" />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 2, Column: 14},
+			},
+		},
+		// ---- 'always': multiline tag, first prop on same line ----
+		{
+			Code: `
+        <Foo propOne="one"
+          propTwo="two"
+        />
+      `,
+			Tsx:     true,
+			Options: []interface{}{"always"},
+			Output: []string{`
+        <Foo
+propOne="one"
+          propTwo="two"
+        />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 2, Column: 14},
+			},
+		},
+		// ---- 'never': first prop on new line ----
+		{
+			Code: `
+        <Foo
+          propOne="one"
+          propTwo="two"
+        />
+      `,
+			Tsx:     true,
+			Options: []interface{}{"never"},
+			Output: []string{`
+        <Foo propOne="one"
+          propTwo="two"
+        />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnSameLine", Message: msgPropOnSameLine, Line: 3, Column: 11},
+			},
+		},
+		// ---- 'multiline': prop on same line of a multiline tag ----
+		{
+			Code: `
+        <Foo prop={{
+        }} />
+      `,
+			Tsx:     true,
+			Options: []interface{}{"multiline"},
+			Output: []string{`
+        <Foo
+prop={{
+        }} />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 2, Column: 14},
+			},
+		},
+		// ---- 'multiline-multiprop': multiline, multiple props, first on same line ----
+		{
+			Code: `
+        <Foo bar={{
+        }} baz />
+      `,
+			Tsx:     true,
+			Options: []interface{}{"multiline-multiprop"},
+			Output: []string{`
+        <Foo
+bar={{
+        }} baz />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 2, Column: 14},
+			},
+		},
+		// ---- 'multiprop': multiple props on same line ----
+		{
+			Code: `
+      <Foo propOne="one" propTwo="two" />
+      `,
+			Tsx:     true,
+			Options: []interface{}{"multiprop"},
+			Output: []string{`
+      <Foo
+propOne="one" propTwo="two" />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 2, Column: 12},
+			},
+		},
+		// ---- 'multiprop': single prop on new line in a multiline tag → same line ----
+		{
+			Code: `
+      <Foo
+bar />
+      `,
+			Tsx:     true,
+			Options: []interface{}{"multiprop"},
+			Output: []string{`
+      <Foo bar />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnSameLine", Message: msgPropOnSameLine, Line: 3, Column: 1},
+			},
+		},
+		// ---- 'multiprop': single spread prop on new line → same line ----
+		{
+			Code: `
+      <Foo
+{...this.props} />
+      `,
+			Tsx:     true,
+			Options: []interface{}{"multiprop"},
+			Output: []string{`
+      <Foo {...this.props} />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnSameLine", Message: msgPropOnSameLine, Line: 3, Column: 1},
+			},
+		},
+		// ---- 'multiline': TypeScript generic component (typeArguments fix anchor) ----
+		{
+			Code: `
+        <DataTable<Items> fullscreen keyField="id" items={items}
+          activeSortableColumn={sorting}
+          onSortClick={handleSortedClick}
+          rowActions={[
+          ]}
+        />
+      `,
+			Tsx:     true,
+			Options: []interface{}{"multiline"},
+			Output: []string{`
+        <DataTable<Items>
+fullscreen keyField="id" items={items}
+          activeSortableColumn={sorting}
+          onSortClick={handleSortedClick}
+          rowActions={[
+          ]}
+        />
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "propOnNewLine", Message: msgPropOnNewLine, Line: 2, Column: 27},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -469,6 +469,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/jsx-curly-newline.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-curly-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-equals-spacing.test.ts',
+    './tests/eslint-plugin-stylistic/rules/jsx-first-prop-new-line.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-first-prop-new-line.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-first-prop-new-line.test.ts
@@ -1,0 +1,254 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const PROP_ON_NEW_LINE = 'Property should be placed on a new line';
+const PROP_ON_SAME_LINE =
+  'Property should be placed on the same line as the component declaration';
+
+// Mirrors upstream packages/eslint-plugin/rules/jsx-first-prop-new-line/
+// jsx-first-prop-new-line.test.ts (Layer 1). This JS suite verifies binary
+// registration + wire protocol + ESLint-compatible diagnostics; edge-shape and
+// branch lock-in cases live in the Go _extras_test.go.
+ruleTester.run('jsx-first-prop-new-line', null as never, {
+  valid: [
+    // never
+    { code: `<Foo />`, options: ['never'] },
+    { code: `<Foo prop="bar" />`, options: ['never'] },
+    { code: `<Foo {...this.props} />`, options: ['never'] },
+    { code: `<Foo a a a />`, options: ['never'] },
+    {
+      code: `
+        <Foo a
+          b
+        />
+      `,
+      options: ['never'],
+    },
+    // multiline
+    { code: `<Foo />`, options: ['multiline'] },
+    { code: `<Foo prop="one" />`, options: ['multiline'] },
+    { code: `<Foo {...this.props} />`, options: ['multiline'] },
+    { code: `<Foo a a a />`, options: ['multiline'] },
+    {
+      code: `
+        <Foo
+          propOne="one"
+          propTwo="two"
+        />
+      `,
+      options: ['multiline'],
+    },
+    {
+      code: `
+        <Foo
+          {...this.props}
+          propTwo="two"
+        />
+      `,
+      options: ['multiline'],
+    },
+    // multiline-multiprop (default)
+    {
+      code: `
+        <Foo bar />
+      `,
+      options: ['multiline-multiprop'],
+    },
+    {
+      code: `
+        <Foo bar baz />
+      `,
+      options: ['multiline-multiprop'],
+    },
+    {
+      code: `
+        <Foo prop={{
+        }} />
+      `,
+      options: ['multiline-multiprop'],
+    },
+    {
+      code: `
+        <Foo
+          foo={{
+          }}
+          bar
+        />
+      `,
+      options: ['multiline-multiprop'],
+    },
+    // always
+    { code: `<Foo />`, options: ['always'] },
+    {
+      code: `
+        <Foo
+          propOne="one"
+          propTwo="two"
+        />
+      `,
+      options: ['always'],
+    },
+    {
+      code: `
+        <Foo
+          {...this.props}
+          propTwo="two"
+        />
+      `,
+      options: ['always'],
+    },
+    // multiprop
+    {
+      code: `
+        <Foo />
+      `,
+      options: ['multiprop'],
+    },
+    {
+      code: `
+        <Foo bar />
+      `,
+      options: ['multiprop'],
+    },
+    {
+      code: `
+        <Foo {...this.props} />
+      `,
+      options: ['multiprop'],
+    },
+  ],
+
+  invalid: [
+    // always: single-line tag, first prop on same line
+    {
+      code: `
+        <Foo propOne="one" propTwo="two" />
+      `,
+      output: `
+        <Foo
+propOne="one" propTwo="two" />
+      `,
+      options: ['always'],
+      errors: [{ messageId: 'propOnNewLine', message: PROP_ON_NEW_LINE }],
+    },
+    // always: multiline tag, first prop on same line
+    {
+      code: `
+        <Foo propOne="one"
+          propTwo="two"
+        />
+      `,
+      output: `
+        <Foo
+propOne="one"
+          propTwo="two"
+        />
+      `,
+      options: ['always'],
+      errors: [{ messageId: 'propOnNewLine', message: PROP_ON_NEW_LINE }],
+    },
+    // never: first prop on new line
+    {
+      code: `
+        <Foo
+          propOne="one"
+          propTwo="two"
+        />
+      `,
+      output: `
+        <Foo propOne="one"
+          propTwo="two"
+        />
+      `,
+      options: ['never'],
+      errors: [{ messageId: 'propOnSameLine', message: PROP_ON_SAME_LINE }],
+    },
+    // multiline: prop on same line of a multiline tag
+    {
+      code: `
+        <Foo prop={{
+        }} />
+      `,
+      output: `
+        <Foo
+prop={{
+        }} />
+      `,
+      options: ['multiline'],
+      errors: [{ messageId: 'propOnNewLine', message: PROP_ON_NEW_LINE }],
+    },
+    // multiline-multiprop: multiline, multiple props, first on same line
+    {
+      code: `
+        <Foo bar={{
+        }} baz />
+      `,
+      output: `
+        <Foo
+bar={{
+        }} baz />
+      `,
+      options: ['multiline-multiprop'],
+      errors: [{ messageId: 'propOnNewLine', message: PROP_ON_NEW_LINE }],
+    },
+    // multiprop: multiple props on same line
+    {
+      code: `
+      <Foo propOne="one" propTwo="two" />
+      `,
+      output: `
+      <Foo
+propOne="one" propTwo="two" />
+      `,
+      options: ['multiprop'],
+      errors: [{ messageId: 'propOnNewLine', message: PROP_ON_NEW_LINE }],
+    },
+    // multiprop: single prop on new line in a multiline tag -> same line
+    {
+      code: `
+      <Foo
+bar />
+      `,
+      output: `
+      <Foo bar />
+      `,
+      options: ['multiprop'],
+      errors: [{ messageId: 'propOnSameLine', message: PROP_ON_SAME_LINE }],
+    },
+    // multiprop: single spread prop on new line -> same line
+    {
+      code: `
+      <Foo
+{...this.props} />
+      `,
+      output: `
+      <Foo {...this.props} />
+      `,
+      options: ['multiprop'],
+      errors: [{ messageId: 'propOnSameLine', message: PROP_ON_SAME_LINE }],
+    },
+    // multiline: TypeScript generic component (typeArguments fix anchor)
+    {
+      code: `
+        <DataTable<Items> fullscreen keyField="id" items={items}
+          activeSortableColumn={sorting}
+          onSortClick={handleSortedClick}
+          rowActions={[
+          ]}
+        />
+      `,
+      output: `
+        <DataTable<Items>
+fullscreen keyField="id" items={items}
+          activeSortableColumn={sorting}
+          onSortClick={handleSortedClick}
+          rowActions={[
+          ]}
+        />
+      `,
+      options: ['multiline'],
+      errors: [{ messageId: 'propOnNewLine', message: PROP_ON_NEW_LINE }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/jsx-first-prop-new-line` rule to rslint.

It enforces the position of the first prop in a JSX element via five modes (`always` / `never` / `multiline` / `multiline-multiprop` (default) / `multiprop`). `@stylistic/jsx-first-prop-new-line` is a byte-identical fork of `react/jsx-first-prop-new-line`, so the implementation is shared by refactoring the react rule into a `BuildRule(name)` and reusing it — matching the existing `jsx-equals-spacing` / `jsx-curly-brace-presence` pattern.

Diagnostics, report positions, messages, and options are fully aligned with ESLint. Two rare autofix corners (a comment, or type arguments, sitting between the tag name and the first prop) intentionally preserve user code instead of deleting it — documented under "Differences from ESLint" in the rule doc.

## Related Links

- Rule documentation: https://eslint.style/rules/jsx-first-prop-new-line
- Source code: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/jsx-first-prop-new-line/jsx-first-prop-new-line.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).