### PR TITLE
feat: port rule @stylistic/jsx-function-call-newline

### DIFF
--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -20,6 +20,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_curly_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_equals_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_first_prop_new_line"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_function_call_newline"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -44,5 +45,6 @@ func GetAllRules() []rule.Rule {
 		jsx_curly_spacing.JsxCurlySpacingRule,
 		jsx_equals_spacing.JsxEqualsSpacingRule,
 		jsx_first_prop_new_line.JsxFirstPropNewLineRule,
+		jsx_function_call_newline.JsxFunctionCallNewlineRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/jsx_function_call_newline/jsx_function_call_newline.go
+++ b/internal/plugins/stylistic/rules/jsx_function_call_newline/jsx_function_call_newline.go
@@ -1,0 +1,165 @@
+// Package jsx_function_call_newline ports `@stylistic/jsx-function-call-newline`
+// to rslint. It enforces line breaks before and after a JSX element when the
+// element is passed as an argument to a function call or `new` expression.
+//
+// Two option values control how much is enforced:
+//
+//	multiline (default) — only JSX arguments that themselves span multiple
+//	                      lines must sit on their own line
+//	always              — every JSX argument must sit on its own line
+//
+// A JSX argument "sits on its own line" when there is a line break between it
+// and the previous token (the call's `(`, a `,`, or an opening paren) and
+// between it and the next token — except that a trailing `,` after the
+// argument is treated as already separating it, so no closing break is added.
+//
+// tsgo↔ESTree shape notes handled here:
+//   - ESTree strips parentheses, so for `fn((<div/>))` the reported argument is
+//     the bare JSXElement and getTokenBefore/After resolve to the inner parens.
+//     tsgo keeps an explicit ParenthesizedExpression, so each argument is
+//     unwrapped with ast.SkipParentheses and every position (start/end, the
+//     previous-token line, the next-token scan) is taken from the inner JSX
+//     node — landing on the same tokens ESLint walks.
+//   - ESTree's single JSXElement kind (carrying a selfClosing flag) splits in
+//     tsgo into JsxElement, JsxSelfClosingElement, and JsxFragment; isJSX here
+//     accepts all three, matching upstream's `['JSXElement','JSXFragment']`.
+package jsx_function_call_newline
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/stylisticutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const optionAlways = "always"
+
+const missingLineBreak = "missingLineBreak"
+
+var messages = map[string]string{
+	missingLineBreak: "Missing line break around JSX",
+}
+
+// parseOption resolves the string option from every shape the loader can
+// deliver: nil / empty (default 'multiline'), a bare string (single-option CLI
+// form), or a single-element array (rule-tester form). Upstream's schema is the
+// enum ['always', 'multiline'] defaulting to 'multiline'; only 'always' changes
+// behavior, so every non-'always' value (including 'multiline' and any
+// out-of-enum string the schema would have rejected) is treated as 'multiline'.
+func parseOption(options any) string {
+	raw := options
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) == 0 {
+			return "multiline"
+		}
+		raw = arr[0]
+	}
+	if s, ok := raw.(string); ok {
+		return s
+	}
+	return "multiline"
+}
+
+// isJSX mirrors upstream's `['JSXElement','JSXFragment'].includes(node.type)`.
+// ESTree's single JSXElement (carrying a selfClosing flag) splits in tsgo into
+// JsxElement (with children) and JsxSelfClosingElement, so both map to ESTree's
+// JSXElement; JsxFragment maps to JSXFragment.
+func isJSX(node *ast.Node) bool {
+	return ast.IsJsxElement(node) || ast.IsJsxSelfClosingElement(node) || ast.IsJsxFragment(node)
+}
+
+// JsxFunctionCallNewlineRule enforces line breaks around JSX arguments of
+// function calls and `new` expressions.
+var JsxFunctionCallNewlineRule = rule.Rule{
+	Name: "@stylistic/jsx-function-call-newline",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		option := parseOption(options)
+		sf := ctx.SourceFile
+		text := sf.Text()
+
+		check := func(arg *ast.Node) {
+			// ESTree's argument node is the parens-stripped expression; tsgo
+			// keeps the ParenthesizedExpression, so unwrap to the node ESLint
+			// inspects. All positions below come from this inner node, so the
+			// previous/next token scans land on the inner parens (if any) just
+			// like ESLint's getTokenBefore/After.
+			node := ast.SkipParentheses(arg)
+			if !isJSX(node) {
+				return
+			}
+
+			r := utils.TrimNodeTextRange(sf, node)
+			start, end := r.Pos(), r.End()
+			// Defensive guard against parser-recovery / synthesized JSX nodes
+			// (e.g. while editing in the LSP) whose trimmed range can be
+			// degenerate; without it the text[start:end] slice below could panic.
+			if start < 0 || end > len(text) || start >= end {
+				return
+			}
+
+			// `option === 'always' || !isSingleLine(node)`: in multiline mode a
+			// single-line JSX argument is never touched.
+			if option != optionAlways && stylisticutil.SameLineByPos(sf, start, end) {
+				return
+			}
+
+			// needsOpeningNewLine === isTokenOnSameLine(previousToken, node).
+			// node.Pos() is the full-start, which under tsgo's trivia model is
+			// exactly the previous token's end position; its line therefore
+			// equals previousToken.loc.end.line. Comparing to the JSX start line
+			// reproduces ESLint's same-line test, including the comment case
+			// (a comment in the gap belongs to the JSX's leading trivia, so
+			// node.Pos() still sits on the previous token's line).
+			needsOpening := stylisticutil.SameLineByPos(sf, node.Pos(), start)
+
+			// needsClosingNewLine: false when the next token is a `,` (the comma
+			// already separates this argument); otherwise true when the JSX end
+			// shares a line with the next token's end (i.e. no break before the
+			// `)` / inner paren that follows). The scanner starts at `end`, so
+			// the next real token always begins at/after it, satisfying
+			// upstream's `nextToken.range[0] >= node.range[1]` by construction.
+			needsClosing := false
+			s := scanner.GetScannerForSourceFile(sf, end)
+			if s.Token() != ast.KindEndOfFile && s.Token() != ast.KindCommaToken {
+				needsClosing = stylisticutil.SameLineByPos(sf, end, s.TokenEnd())
+			}
+
+			if !needsOpening && !needsClosing {
+				return
+			}
+
+			fixed := text[start:end]
+			if needsOpening {
+				fixed = "\n" + fixed
+			}
+			if needsClosing {
+				fixed = fixed + "\n"
+			}
+			ctx.ReportRangeWithFixes(
+				core.NewTextRange(start, end),
+				rule.RuleMessage{Id: missingLineBreak, Description: messages[missingLineBreak]},
+				rule.RuleFixReplaceRange(core.NewTextRange(start, end), fixed),
+			)
+		}
+
+		handleArgs := func(args *ast.NodeList) {
+			if args == nil || len(args.Nodes) == 0 {
+				return
+			}
+			for _, arg := range args.Nodes {
+				check(arg)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				handleArgs(node.AsCallExpression().Arguments)
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				handleArgs(node.AsNewExpression().Arguments)
+			},
+		}
+	},
+}

--- a/internal/plugins/stylistic/rules/jsx_function_call_newline/jsx_function_call_newline.md
+++ b/internal/plugins/stylistic/rules/jsx_function_call_newline/jsx_function_call_newline.md
@@ -1,0 +1,109 @@
+# jsx-function-call-newline
+
+Enforce line breaks before and after JSX elements when they are used as arguments to a function.
+
+## Rule Details
+
+This rule checks whether a line break is needed before and after every JSX element that serves as an argument to a function call or `new` expression. A trailing comma after the argument counts as a separator, so no line break is required between the element and that comma.
+
+## Options
+
+This rule has a string option:
+
+- `"multiline"` (default) — a line break before and after a JSX argument is required only when the element itself spans multiple lines.
+- `"always"` — a line break before and after every JSX argument is required.
+
+### multiline
+
+Examples of **incorrect** code for this rule with the default `"multiline"` option:
+
+```jsx
+fn(<div
+ />, <span>
+ foo</span>
+)
+
+fn (
+  <div />, <span>
+    bar
+  </span>
+)
+```
+
+Examples of **correct** code for this rule with the default `"multiline"` option:
+
+```jsx
+fn(<div />)
+
+fn(<span>foo</span>)
+
+fn(
+  <div
+ />,
+ <span>
+ foo</span>
+)
+
+fn (
+  <div />,
+  <span>
+    bar
+  </span>
+)
+```
+
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/jsx-function-call-newline": ["error", "always"] }
+```
+
+```jsx
+fn(<div />)
+
+fn(<span>foo</span>)
+
+fn(<span>
+bar
+</span>)
+
+fn(<div />, <div
+  style={{ color: 'red' }}
+  />, <p>baz</p>)
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```json
+{ "@stylistic/jsx-function-call-newline": ["error", "always"] }
+```
+
+```jsx
+fn(
+  <div />
+)
+
+fn(
+  <span>foo</span>
+)
+
+fn(
+  <span>
+    bar
+  </span>
+)
+
+fn(
+  <div />,
+  <div
+    style={{ color: 'red' }}
+  />,
+  <p>baz</p>
+)
+```
+
+## Original Documentation
+
+- [@stylistic/jsx-function-call-newline](https://eslint.style/rules/jsx-function-call-newline)

--- a/internal/plugins/stylistic/rules/jsx_function_call_newline/jsx_function_call_newline_extras_test.go
+++ b/internal/plugins/stylistic/rules/jsx_function_call_newline/jsx_function_call_newline_extras_test.go
@@ -1,0 +1,373 @@
+// TestJsxFunctionCallNewlineExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in. Upstream mirrors live in jsx_function_call_newline_upstream_test.go.
+//
+// The upstream suite only covers JsxSelfClosingElement arguments under `fn(...)`
+// and `new OBJ(...)`; it never exercises JSX fragments, JSX elements with
+// children, optional calls, nested calls, spreads, type-wrapped JSX, the
+// CLI/bare-string option shape, or the "next token on a later line" branch of
+// needsClosingNewLine. Those all live here.
+package jsx_function_call_newline
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxFunctionCallNewlineExtras(t *testing.T) {
+	always := []interface{}{"always"}
+	multiline := []interface{}{"multiline"}
+	const msg = "Missing line break around JSX"
+
+	// Dimension 4 rows that do not apply to this rule (the rule only inspects
+	// whole call/new arguments, never member access or declarations):
+	//   - N/A: access / key forms (`.prop`, `['x']`, `#x`, computed keys) — the
+	//     rule never reads a property name; it matches the argument node itself.
+	//   - N/A: declaration / container forms (class/function/arrow/method,
+	//     async/generator) — the rule targets call arguments, not declarations.
+	//   - N/A: optional chain ON the argument — a JSX element can't be an
+	//     optional-chain expression; the optional chain that matters is on the
+	//     call (`fn?.(...)`), covered in the invalid cases below.
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxFunctionCallNewlineRule, []rule_tester.ValidTestCase{
+		// ---- Locks in handleCallExpression() arm: arguments.length === 0 ----
+		{Code: "fn()", Tsx: true},
+		{Code: "fn()", Tsx: true, Options: always},
+		{Code: "new Foo()", Tsx: true},
+		{Code: "new Foo()", Tsx: true, Options: always},
+		// ---- Locks in NewExpression with no argument list (`new Foo`) ----
+		{Code: "new Foo", Tsx: true, Options: always},
+		// ---- Locks in check() arm: !isJSX(node) → non-JSX args never report ----
+		{Code: "fn(1, 'x', foo)", Tsx: true, Options: always},
+		{Code: "fn({\n  a: 1\n})", Tsx: true, Options: always}, // multiline object arg, not JSX
+		{Code: "fn(foo(\n))", Tsx: true, Options: always},      // multiline call arg, not JSX
+		{Code: "fn(`a\nb`)", Tsx: true, Options: always},       // multiline template arg, not JSX
+		// ---- Dimension 4: graceful degradation — spread argument ----
+		{Code: "fn(...items)", Tsx: true, Options: always},
+		// A spread's array operand is not a direct call argument, so its JSX is
+		// never inspected (the rule must not descend into it).
+		{Code: "fn(...[<div\n/>])", Tsx: true},
+		// ---- Dimension 4: TS type-expression wrapper — `as` makes the arg a
+		// TSAsExpression, not JSX (ESTree parity: arg node is TSAsExpression) ----
+		{Code: "fn((<div />) as any)", Tsx: true, Options: always},
+		{Code: "fn((<div\n/>) as any)", Tsx: true, Options: always}, // even multiline JSX inside `as` is skipped
+		// ---- multiline (default): single-line JSX is never touched ----
+		{Code: "fn(<></>)", Tsx: true},                             // single-line fragment
+		{Code: "fn(<div>x</div>)", Tsx: true},                      // single-line element with children
+		{Code: "fn(<div />)", Tsx: true, Options: multiline},       // explicit multiline, array shape
+		{Code: "fn(<div />)", Tsx: true, Options: []interface{}{}}, // empty options array → default
+		// ---- Dimension 4: parenthesized argument — newlines INSIDE the parens
+		// satisfy the rule because positions come from the inner JSX node ----
+		{Code: "fn((\n<div\n/>\n))", Tsx: true},
+		{Code: "fn(((\n<div\n/>\n)))", Tsx: true}, // multi-level parens
+		// ---- always: properly broken multi-arg call stays valid ----
+		{Code: "fn(\n<></>\n,\n<div>x</div>\n)", Tsx: true, Options: always},
+		// ---- JSX as a sub-expression is NOT the argument node, so it is never
+		// checked — even when the wrapping expression spans lines. ESTree's arg
+		// is the ConditionalExpression / BinaryExpression, not a JSXElement;
+		// SkipParentheses doesn't unwrap `?:` or `&&`/`||`, so isJSX stays false. ----
+		{Code: "fn(cond ? <div\n/> : null)", Tsx: true, Options: always},
+		{Code: "fn(a && <div\n/>)", Tsx: true, Options: always},
+		{Code: "fn(x, y || <div\n/>)", Tsx: true, Options: always},
+		// ---- Multi-byte content must not break column math or cause misfires.
+		// (The invalid `fn('日本語', <span>…)` case below pins the exact column.) ----
+		{Code: "fn(<div>{'中文テキスト'}</div>)", Tsx: true},                   // single-line → skipped
+		{Code: "fn(\n<div>{'日本語'}</div>\n)", Tsx: true, Options: always}, // properly broken
+		// ---- A JSX child of a fragment/element is not a call argument, so the
+		// inner <a/> here is never checked; only the outer fragment arg is. ----
+		{Code: "fn(\n<>\n<a />\n</>\n)", Tsx: true, Options: always},
+		// ---- Tagged template: the JSX sits in a template interpolation, not a
+		// call argument. TaggedTemplateExpression is neither Call nor New, so it
+		// is never visited (matches upstream) — multiline JSX here stays valid. ----
+		{Code: "html`${<div\n/>}`", Tsx: true, Options: always},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: JSX fragment (KindJsxFragment), multiline ----
+		{
+			Code:   "fn(<>\n</>)",
+			Tsx:    true,
+			Output: []string{"fn(\n<>\n</>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 4},
+			},
+		},
+		// ---- Dimension 4: JSX fragment, always ----
+		{
+			Code:    "fn(<></>)",
+			Tsx:     true,
+			Options: always,
+			Output:  []string{"fn(\n<></>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 1, EndColumn: 9},
+			},
+		},
+		// ---- Dimension 4: JSX element with children (KindJsxElement), multiline ----
+		{
+			Code:   "fn(<div>\n</div>)",
+			Tsx:    true,
+			Output: []string{"fn(\n<div>\n</div>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 7},
+			},
+		},
+		// ---- Dimension 4: optional call `fn?.(...)` is still a CallExpression ----
+		{
+			Code:   "fn?.(<div\n/>)",
+			Tsx:    true,
+			Output: []string{"fn?.(\n<div\n/>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 6, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Dimension 4: nested call — only the inner call's JSX arg reports;
+		// the outer call's CallExpression arg is not JSX (listener must not bleed) ----
+		{
+			Code:   "g(fn(<div\n/>))",
+			Tsx:    true,
+			Output: []string{"g(fn(\n<div\n/>\n))"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 6, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Dimension 4: parenthesized argument hugging the JSX — the inner
+		// `(` is the previous token, so a same-line open still needs a break ----
+		{
+			Code:   "fn((<div\n/>))",
+			Tsx:    true,
+			Output: []string{"fn((\n<div\n/>\n))"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 5, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Dimension 4: multi-level parens unwrap to the innermost JSX ----
+		{
+			Code:   "fn(((<div\n/>)))",
+			Tsx:    true,
+			Output: []string{"fn(((\n<div\n/>\n)))"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 6, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Dimension 4: NewExpression + hugging parens + multiline JSX ----
+		{
+			Code:   "new Foo((<div\n/>))",
+			Tsx:    true,
+			Output: []string{"new Foo((\n<div\n/>\n))"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 10, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Deep nesting: the listener descends into a JSX expression
+		// container, so a call nested inside JSX children still has its JSX arg
+		// checked. Here the outer <div> arg is already broken (no report); only
+		// the inner g(<b/>) call's multiline JSX arg reports. The two JSX nodes
+		// nest, but the outer doesn't fire, so the single fix doesn't overlap. ----
+		{
+			Code:   "fn(\n<div>{g(<b\n/>)}</div>\n)",
+			Tsx:    true,
+			Output: []string{"fn(\n<div>{g(\n<b\n/>\n)}</div>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 2, Column: 9, EndLine: 3, EndColumn: 3},
+			},
+		},
+		// ---- Deep nesting, both fire: the outer <div> arg and the inner g()'s
+		// <b/> arg are both unbroken, so both report (2 errors). Their fix ranges
+		// nest/overlap, so the fixer applies the outer fix first and defers the
+		// inner to the next pass — matching ESLint's multi-pass convergence
+		// (hence two Output steps). ----
+		{
+			Code: "fn(<div>{g(<b\n/>)}</div>)",
+			Tsx:  true,
+			Output: []string{
+				"fn(\n<div>{g(<b\n/>)}</div>\n)",
+				"fn(\n<div>{g(\n<b\n/>\n)}</div>\n)",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 11},
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 12, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Option shape: explicit "multiline" via single-element array ----
+		{
+			Code:    "fn(<div\n/>)",
+			Tsx:     true,
+			Options: multiline,
+			Output:  []string{"fn(\n<div\n/>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Option shape: bare string "always" (single-option CLI form) ----
+		{
+			Code:    "fn(<div />)",
+			Tsx:     true,
+			Options: "always",
+			Output:  []string{"fn(\n<div />\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// ---- Option shape: bare string "multiline" (single-option CLI form) ----
+		{
+			Code:    "fn(<div\n/>)",
+			Tsx:     true,
+			Options: "multiline",
+			Output:  []string{"fn(\n<div\n/>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Locks in needsClosingNewLine() arm: endWithComma → false, so only
+		// the opening break is added even though the JSX spans lines ----
+		{
+			Code:   "fn(<div\n/>, x)",
+			Tsx:    true,
+			Output: []string{"fn(\n<div\n/>, x)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Locks in needsClosingNewLine() final arm: next token (`)`) is on a
+		// LATER line and is not a comma → return false (closing already fine),
+		// so only the opening break is added ----
+		{
+			Code:   "fn(<div\n/>\n)",
+			Tsx:    true,
+			Output: []string{"fn(\n<div\n/>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Comment in the gap: getTokenBefore (node.Pos()) and getTokenAfter
+		// (scanner) skip trivia like ESLint; the leading comment stays put and
+		// only the JSX text is wrapped ----
+		{
+			Code:   "fn(/* c */ <div\n/>)",
+			Tsx:    true,
+			Output: []string{"fn(/* c */ \n<div\n/>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 12, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Real-user shape: testing-library render() with a multiline element ----
+		{
+			Code:   "render(<App\n  prop={1}\n/>)",
+			Tsx:    true,
+			Output: []string{"render(\n<App\n  prop={1}\n/>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 8, EndLine: 3, EndColumn: 3},
+			},
+		},
+		// ---- Real-user shape: createPortal(jsx, container) — only the JSX arg
+		// reports; the trailing container identifier is not JSX ----
+		{
+			Code:   "createPortal(<Modal>\n</Modal>, container)",
+			Tsx:    true,
+			Output: []string{"createPortal(\n<Modal>\n</Modal>, container)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 14, EndLine: 2, EndColumn: 9},
+			},
+		},
+		// ---- tsgo callee/type-arg shapes: a generic call carries a
+		// TypeArgumentList between the callee and `(`; node.Pos() of the first
+		// arg is still the `(`-end, so the open position stays correct ----
+		{
+			Code:   "fn<number>(<div\n/>)",
+			Tsx:    true,
+			Output: []string{"fn<number>(\n<div\n/>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 12, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Member-access callee (PropertyAccessExpression) still triggers the
+		// CallExpression listener; trailing non-JSX arg is left alone ----
+		{
+			Code:   "ReactDOM.render(<App\n/>, root)",
+			Tsx:    true,
+			Output: []string{"ReactDOM.render(\n<App\n/>, root)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 17, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- NewExpression with a qualified (member) callee ----
+		{
+			Code:   "new ns.Foo(<div\n/>)",
+			Tsx:    true,
+			Output: []string{"new ns.Foo(\n<div\n/>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 12, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Multi-byte: a CJK string arg precedes the JSX. The reported column
+		// (11) counts each CJK char as one unit, matching ESLint's UTF-16 columns
+		// (a byte-based count would land at ~18). Locks in column parity. ----
+		{
+			Code:   "fn('日本語', <span>\n</span>)",
+			Tsx:    true,
+			Output: []string{"fn('日本語', \n<span>\n</span>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 11, EndLine: 2, EndColumn: 8},
+			},
+		},
+		// ---- JSX with multiple attributes spanning lines (real component shape) ----
+		{
+			Code:   "fn(<div\n a={1}\n/>)",
+			Tsx:    true,
+			Output: []string{"fn(\n<div\n a={1}\n/>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 3, EndColumn: 3},
+			},
+		},
+		// ---- JSX with a spread attribute ({...p}) spanning lines ----
+		{
+			Code:   "fn(<div {...p}\n/>)",
+			Tsx:    true,
+			Output: []string{"fn(\n<div {...p}\n/>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Fragment with children spanning lines (the inner <a/> child is not
+		// a call argument, so only the outer fragment reports) ----
+		{
+			Code:   "fn(<>\n<a />\n</>)",
+			Tsx:    true,
+			Output: []string{"fn(\n<>\n<a />\n</>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 3, EndColumn: 4},
+			},
+		},
+		// ---- Trailing comma after a multiline JSX arg: endWithComma → no closing
+		// break, only the opening one is added ----
+		{
+			Code:   "fn(<div\n/>,)",
+			Tsx:    true,
+			Output: []string{"fn(\n<div\n/>,)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Real-user shape: JSX argument inside a chained assertion call ----
+		{
+			Code:   "expect(<C\n/>).toBe(x)",
+			Tsx:    true,
+			Output: []string{"expect(\n<C\n/>\n).toBe(x)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 8, EndLine: 2, EndColumn: 3},
+			},
+		},
+		// ---- Decorator factory `@deco(...)` is a CallExpression, so a JSX arg
+		// inside it is checked like any other call ----
+		{
+			Code:   "@deco(<div\n/>)\nclass X {}",
+			Tsx:    true,
+			Output: []string{"@deco(\n<div\n/>\n)\nclass X {}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 7, EndLine: 2, EndColumn: 3},
+			},
+		},
+	})
+}

--- a/internal/plugins/stylistic/rules/jsx_function_call_newline/jsx_function_call_newline_upstream_test.go
+++ b/internal/plugins/stylistic/rules/jsx_function_call_newline/jsx_function_call_newline_upstream_test.go
@@ -1,0 +1,116 @@
+// TestJsxFunctionCallNewlineUpstream migrates the full valid/invalid suite from
+// upstream packages/eslint-plugin/rules/jsx-function-call-newline/
+// jsx-function-call-newline.test.ts 1:1. Upstream asserts only messageId on its
+// invalid cases; the line/column/endLine/endColumn and exact message text here
+// are computed from the source each case carries (the diagnostic spans the JSX
+// argument, from its `<` to just past its closing `>`). rslint-specific lock-in
+// cases live in jsx_function_call_newline_extras_test.go.
+package jsx_function_call_newline
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxFunctionCallNewlineUpstream(t *testing.T) {
+	always := []interface{}{"always"}
+	const msg = "Missing line break around JSX"
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxFunctionCallNewlineRule, []rule_tester.ValidTestCase{
+		{Code: "fn(<div />)", Tsx: true},
+		{Code: "fn(<div />, <div />)", Tsx: true},
+		{Code: "fn(<div />,\n<div />)", Tsx: true},
+		{Code: "fn(\n<div />, <div />)", Tsx: true},
+		{Code: "fn(\n<div />, <div />\n)", Tsx: true},
+		{Code: "fn(\n<div />\n)", Tsx: true, Options: always},
+		{Code: "fn(<div />, \n<div \n style={{ color: 'red' }}\n />\n)", Tsx: true},
+		{Code: "fn(<div />, <div />, <div />)", Tsx: true},
+		{Code: "fn(<div />, <div />\n, <div />)", Tsx: true},
+		{Code: "fn(\n<div />\n,\n<div />\n,\n<div />\n)", Tsx: true},
+		{Code: "fn(\n<div />\n,\n<div />\n,\n<div />\n)", Tsx: true, Options: always},
+		{Code: "fn(\n<div />\n,\n<div ></div>)", Tsx: true},
+		{Code: "fn((<div style={{}} />), <div />, <div />)", Tsx: true},
+		{Code: "new OBJ((<div style={{}} />), <div />, <div />)", Tsx: true},
+		{Code: "new OBJ(<div />, <div />, <div />)", Tsx: true},
+		{Code: "new OBJ(<div />, <div />\n, <div />)", Tsx: true},
+		{Code: "new OBJ(\n<div />\n,\n<div />\n,\n<div />\n)", Tsx: true},
+		{Code: "new OBJ(\n<div />\n,\n<div />\n,\n<div />\n)", Tsx: true, Options: always},
+		{Code: "new OBJ(\n<div />\n,\n<div ></div>)", Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:   "fn(<div\n        />)",
+			Tsx:    true,
+			Output: []string{"fn(\n<div\n        />\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 11},
+			},
+		},
+		{
+			Code:   "new OBJ(<div\n        />)",
+			Tsx:    true,
+			Output: []string{"new OBJ(\n<div\n        />\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 9, EndLine: 2, EndColumn: 11},
+			},
+		},
+		{
+			Code:    "fn(<div />)",
+			Tsx:     true,
+			Options: always,
+			Output:  []string{"fn(\n<div />\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 1, EndColumn: 11},
+			},
+		},
+		{
+			Code:    "fn(\n<div />,<div />,\n<div />)",
+			Tsx:     true,
+			Options: always,
+			Output:  []string{"fn(\n<div />,\n<div />,\n<div />\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 2, Column: 9, EndLine: 2, EndColumn: 16},
+				{MessageId: missingLineBreak, Message: msg, Line: 3, Column: 1, EndLine: 3, EndColumn: 8},
+			},
+		},
+		{
+			Code:    "new OBJ(\n<div />,<div />,\n<div />)",
+			Tsx:     true,
+			Options: always,
+			Output:  []string{"new OBJ(\n<div />,\n<div />,\n<div />\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 2, Column: 9, EndLine: 2, EndColumn: 16},
+				{MessageId: missingLineBreak, Message: msg, Line: 3, Column: 1, EndLine: 3, EndColumn: 8},
+			},
+		},
+		{
+			Code:    "fn((\n<div />),<div />,\n<div />)",
+			Tsx:     true,
+			Options: always,
+			Output:  []string{"fn((\n<div />\n),\n<div />,\n<div />\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 2, Column: 1, EndLine: 2, EndColumn: 8},
+				{MessageId: missingLineBreak, Message: msg, Line: 2, Column: 10, EndLine: 2, EndColumn: 17},
+				{MessageId: missingLineBreak, Message: msg, Line: 3, Column: 1, EndLine: 3, EndColumn: 8},
+			},
+		},
+		{
+			Code:   "fn(<div />, <span>\n</span>)",
+			Tsx:    true,
+			Output: []string{"fn(<div />, \n<span>\n</span>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 13, EndLine: 2, EndColumn: 8},
+			},
+		},
+		{
+			Code:   "fn(<div \n />, <span>\n</span>)",
+			Tsx:    true,
+			Output: []string{"fn(\n<div \n />, \n<span>\n</span>\n)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: missingLineBreak, Message: msg, Line: 1, Column: 4, EndLine: 2, EndColumn: 4},
+				{MessageId: missingLineBreak, Message: msg, Line: 2, Column: 6, EndLine: 3, EndColumn: 8},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -470,6 +470,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/jsx-curly-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-equals-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-first-prop-new-line.test.ts',
+    './tests/eslint-plugin-stylistic/rules/jsx-function-call-newline.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-function-call-newline.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-function-call-newline.test.ts
@@ -1,0 +1,83 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const MISSING = 'Missing line break around JSX';
+
+const ALWAYS = ['always'];
+
+ruleTester.run('jsx-function-call-newline', null as never, {
+  valid: [
+    { code: `fn(<div />)` },
+    { code: `fn(<div />, <div />)` },
+    { code: `fn(<div />,\n<div />)` },
+    { code: `fn(\n<div />, <div />)` },
+    { code: `fn(\n<div />, <div />\n)` },
+    { code: `fn(\n<div />\n)`, options: ALWAYS },
+    { code: `fn(<div />, \n<div \n style={{ color: 'red' }}\n />\n)` },
+    { code: `fn(<div />, <div />, <div />)` },
+    { code: `fn(<div />, <div />\n, <div />)` },
+    { code: `fn(\n<div />\n,\n<div />\n,\n<div />\n)` },
+    { code: `fn(\n<div />\n,\n<div />\n,\n<div />\n)`, options: ALWAYS },
+    { code: `fn(\n<div />\n,\n<div ></div>)` },
+    { code: `fn((<div style={{}} />), <div />, <div />)` },
+    { code: `new OBJ((<div style={{}} />), <div />, <div />)` },
+    { code: `new OBJ(<div />, <div />, <div />)` },
+    { code: `new OBJ(<div />, <div />\n, <div />)` },
+    { code: `new OBJ(\n<div />\n,\n<div />\n,\n<div />\n)` },
+    { code: `new OBJ(\n<div />\n,\n<div />\n,\n<div />\n)`, options: ALWAYS },
+    { code: `new OBJ(\n<div />\n,\n<div ></div>)` },
+  ],
+
+  invalid: [
+    {
+      code: `fn(<div\n        />)`,
+      errors: [{ messageId: 'missingLineBreak', message: MISSING }],
+    },
+    {
+      code: `new OBJ(<div\n        />)`,
+      errors: [{ messageId: 'missingLineBreak', message: MISSING }],
+    },
+    {
+      code: `fn(<div />)`,
+      options: ALWAYS,
+      errors: [{ messageId: 'missingLineBreak', message: MISSING }],
+    },
+    {
+      code: `fn(\n<div />,<div />,\n<div />)`,
+      options: ALWAYS,
+      errors: [
+        { messageId: 'missingLineBreak', message: MISSING },
+        { messageId: 'missingLineBreak', message: MISSING },
+      ],
+    },
+    {
+      code: `new OBJ(\n<div />,<div />,\n<div />)`,
+      options: ALWAYS,
+      errors: [
+        { messageId: 'missingLineBreak', message: MISSING },
+        { messageId: 'missingLineBreak', message: MISSING },
+      ],
+    },
+    {
+      code: `fn((\n<div />),<div />,\n<div />)`,
+      options: ALWAYS,
+      errors: [
+        { messageId: 'missingLineBreak', message: MISSING },
+        { messageId: 'missingLineBreak', message: MISSING },
+        { messageId: 'missingLineBreak', message: MISSING },
+      ],
+    },
+    {
+      code: `fn(<div />, <span>\n</span>)`,
+      errors: [{ messageId: 'missingLineBreak', message: MISSING }],
+    },
+    {
+      code: `fn(<div \n />, <span>\n</span>)`,
+      errors: [
+        { messageId: 'missingLineBreak', message: MISSING },
+        { messageId: 'missingLineBreak', message: MISSING },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/jsx-function-call-newline` rule from ESLint Stylistic to rslint.

The rule enforces line breaks before and after JSX elements when they are used as arguments to a function call or `new` expression. It accepts a single string option:

- `"multiline"` (default) — a line break before and after a JSX argument is required only when the element itself spans multiple lines.
- `"always"` — every JSX argument must sit on its own line.

A trailing comma after the argument counts as a separator, so no closing line break is added before it.

## Related Links

- Rule documentation: https://eslint.style/rules/jsx-function-call-newline
- Upstream source: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/jsx-function-call-newline/jsx-function-call-newline.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).