### PR TITLE
feat: port rule @stylistic/jsx-indent-props

### DIFF
--- a/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props.go
+++ b/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props.go
@@ -7,7 +7,14 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// JsxIndentPropsRule enforces JSX prop indentation.
+// JsxIndentPropsRule is the eslint-plugin-react variant of jsx-indent-props.
+var JsxIndentPropsRule = BuildRule("react/jsx-indent-props")
+
+// BuildRule constructs the jsx-indent-props rule registered under name. Both
+// the react (`react/jsx-indent-props`) and @stylistic
+// (`@stylistic/jsx-indent-props`) variants are produced from this single
+// implementation — the two upstream rules are byte-identical (the @stylistic
+// fork carries no behavioral delta), so only the registered Name differs.
 //
 // Ported from eslint-plugin-react's `jsx-indent-props` rule. The rule walks
 // every JsxOpeningElement / JsxSelfClosingElement, computes the expected
@@ -24,146 +31,159 @@ import (
 //     ECMA line map via `scanner.ComputeLineOfPosition`.
 //
 // Ternary operator handling: upstream maintains a `line.isUsingOperator`
-// flag that is set when the line containing the JSX `<` starts with `?` or
-// `:` after whitespace. When that flag is on (and `'first'` mode is off and
-// `ignoreTernaryOperator` is off), the FIRST prop that sits first-in-line
-// receives an extra `indentSize` bump, after which the flag is cleared.
-// We replicate that behaviour with a per-element `bumpApplied` boolean and
-// a per-prop bracket reset (mirrors upstream's `useBracket` reset inside
-// `getNodeIndent` — any prop whose first source line contains `<` cancels
-// the pending bump, exactly the same way upstream's per-call side effect
-// would).
-var JsxIndentPropsRule = rule.Rule{
-	Name: "react/jsx-indent-props",
-	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
-		indentType, indentSize, indentChar, indentIsFirst, ignoreTernaryOperator := parseOptions(options)
+// flag, updated by `getNodeIndent` from each scanned line, that grants the
+// next first-in-line prop an extra `indentSize` bump (when `'first'` mode and
+// `ignoreTernaryOperator` are both off). We replicate `getNodeIndent`'s
+// per-prop side effect with the exact same precedence: a line starting with
+// `?`/`:` after whitespace (useOperator) sets the flag and PRECEDES the
+// `<`-contains reset (useBracket). That precedence is load-bearing for the
+// shape where the first prop shares the opening tag's `?`/`:` line — the line
+// both starts with the operator and contains `<`, and upstream keeps the flag
+// set so the bump carries to the following props.
+func BuildRule(name string) rule.Rule {
+	return rule.Rule{
+		Name: name,
+		Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+			indentType, indentSize, indentChar, indentIsFirst, ignoreTernaryOperator := parseOptions(options)
 
-		text := ctx.SourceFile.Text()
-		lineMap := ctx.SourceFile.ECMALineMap()
+			text := ctx.SourceFile.Text()
+			lineMap := ctx.SourceFile.ECMALineMap()
 
-		// firstNonWhitespaceCharOnLine returns the first non space / tab
-		// character on the line containing pos, or 0 if none.
-		firstNonWhitespaceCharOnLine := func(pos int) byte {
-			start := reactutil.IndentLineStart(lineMap, pos)
-			for i := start; i < len(text); i++ {
-				c := text[i]
-				if c == ' ' || c == '\t' {
-					continue
+			// firstNonWhitespaceCharOnLine returns the first non space / tab
+			// character on the line containing pos, or 0 if none.
+			firstNonWhitespaceCharOnLine := func(pos int) byte {
+				start := reactutil.IndentLineStart(lineMap, pos)
+				for i := start; i < len(text); i++ {
+					c := text[i]
+					if c == ' ' || c == '\t' {
+						continue
+					}
+					if c == '\n' || c == '\r' {
+						return 0
+					}
+					return c
 				}
-				if c == '\n' || c == '\r' {
-					return 0
-				}
-				return c
+				return 0
 			}
-			return 0
-		}
 
-		// firstLineContainsBracket reports whether the first source line
-		// of node (from line-start of trimmed start to the next newline
-		// or the trimmed end, whichever comes first) contains a `<`.
-		// Mirrors upstream's `useBracket` check inside `getNodeIndent`,
-		// which resets `isUsingOperator` whenever the scanned line
-		// includes a `<` (i.e. the prop is on the same line as the
-		// element's opening `<`, or carries an inline JSX-literal value).
-		firstLineContainsBracket := func(node *ast.Node) bool {
-			trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
-			lineStart := reactutil.IndentLineStart(lineMap, trimmed.Pos())
-			end := trimmed.End()
-			for i := lineStart; i < end && i < len(text); i++ {
-				c := text[i]
-				if c == '\n' {
-					break
-				}
-				if c == '<' {
-					return true
-				}
-			}
-			return false
-		}
-
-		check := func(node *ast.Node) {
-			var props []*ast.Node
-			switch node.Kind {
-			case ast.KindJsxOpeningElement:
-				opening := node.AsJsxOpeningElement()
-				if opening.Attributes != nil {
-					attrs := opening.Attributes.AsJsxAttributes()
-					if attrs != nil && attrs.Properties != nil {
-						props = attrs.Properties.Nodes
+			// firstLineContainsBracket reports whether the first source line
+			// of node (from line-start of trimmed start to the next newline
+			// or the trimmed end, whichever comes first) contains a `<`.
+			// Mirrors upstream's `useBracket` check inside `getNodeIndent`,
+			// which resets `isUsingOperator` whenever the scanned line
+			// includes a `<` (i.e. the prop is on the same line as the
+			// element's opening `<`, or carries an inline JSX-literal value).
+			firstLineContainsBracket := func(node *ast.Node) bool {
+				trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+				lineStart := reactutil.IndentLineStart(lineMap, trimmed.Pos())
+				end := trimmed.End()
+				for i := lineStart; i < end && i < len(text); i++ {
+					c := text[i]
+					if c == '\n' {
+						break
+					}
+					if c == '<' {
+						return true
 					}
 				}
-			case ast.KindJsxSelfClosingElement:
-				self := node.AsJsxSelfClosingElement()
-				if self.Attributes != nil {
-					attrs := self.Attributes.AsJsxAttributes()
-					if attrs != nil && attrs.Properties != nil {
-						props = attrs.Properties.Nodes
+				return false
+			}
+
+			check := func(node *ast.Node) {
+				var props []*ast.Node
+				switch node.Kind {
+				case ast.KindJsxOpeningElement:
+					opening := node.AsJsxOpeningElement()
+					if opening.Attributes != nil {
+						attrs := opening.Attributes.AsJsxAttributes()
+						if attrs != nil && attrs.Properties != nil {
+							props = attrs.Properties.Nodes
+						}
+					}
+				case ast.KindJsxSelfClosingElement:
+					self := node.AsJsxSelfClosingElement()
+					if self.Attributes != nil {
+						attrs := self.Attributes.AsJsxAttributes()
+						if attrs != nil && attrs.Properties != nil {
+							props = attrs.Properties.Nodes
+						}
+					}
+				}
+				if len(props) == 0 {
+					return
+				}
+
+				openingTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+				openingStart := openingTrimmed.Pos()
+
+				// isUsingOperator: line containing the opening `<` starts
+				// with `?` or `:` after whitespace.
+				leadChar := firstNonWhitespaceCharOnLine(openingStart)
+				isUsingOperator := leadChar == '?' || leadChar == ':'
+
+				elementIndent := reactutil.IndentLeading(text, lineMap, openingStart, indentChar)
+
+				var propIndent int
+				if indentIsFirst {
+					// 'first' mode aligns to the visual column of the
+					// first prop. Use UTF-16 character column (matches
+					// ESLint's `loc.start.column`) instead of byte
+					// offset so multi-byte characters preceding the
+					// first prop don't inflate the expected indent.
+					propIndent = reactutil.NodeStartUTF16Column(ctx.SourceFile, props[0])
+				} else {
+					propIndent = elementIndent + indentSize
+				}
+
+				nestedIndent := propIndent
+
+				for _, prop := range props {
+					// Mirror upstream's getNodeIndent side effect, which runs
+					// for EVERY prop (before the first-in-line report gate). It
+					// updates the ternary-operator state from the prop's first
+					// source line, with useOperator (line starts with `?`/`:`
+					// after whitespace) taking PRIORITY over useBracket (line
+					// contains `<`) — exactly upstream's if/else ordering. The
+					// priority matters when the first prop shares the opening
+					// tag's `?`/`:` line: that line both starts with the
+					// operator and contains `<`, and upstream keeps
+					// isUsingOperator set so the bump carries to the next prop.
+					propLead := firstNonWhitespaceCharOnLine(utils.TrimNodeTextRange(ctx.SourceFile, prop).Pos())
+					currentOperator := false
+					if propLead == '?' || propLead == ':' {
+						isUsingOperator = true
+						currentOperator = true
+					} else if firstLineContainsBracket(prop) {
+						isUsingOperator = false
+					}
+
+					// Bump decision, also run for every prop. A prop whose own
+					// line starts with the operator (currentOperator) does not
+					// consume the bump; the first following prop that doesn't
+					// re-arm the operator does. Applying it clears
+					// isUsingOperator so the bump fires at most once.
+					if isUsingOperator && !currentOperator && !indentIsFirst && !ignoreTernaryOperator {
+						nestedIndent += indentSize
+						isUsingOperator = false
+					}
+
+					if !reactutil.IsNodeFirstInLine(ctx.SourceFile, prop) {
+						continue
+					}
+
+					actualIndent := reactutil.NodeStartIndent(ctx.SourceFile, prop, indentChar)
+					if actualIndent != nestedIndent {
+						reactutil.ReportIndentReplaceLeading(ctx, prop, nestedIndent, actualIndent, indentChar, indentType)
 					}
 				}
 			}
-			if len(props) == 0 {
-				return
+
+			return rule.RuleListeners{
+				ast.KindJsxOpeningElement:     check,
+				ast.KindJsxSelfClosingElement: check,
 			}
-
-			openingTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
-			openingStart := openingTrimmed.Pos()
-
-			// isUsingOperator: line containing the opening `<` starts
-			// with `?` or `:` after whitespace.
-			leadChar := firstNonWhitespaceCharOnLine(openingStart)
-			isUsingOperator := leadChar == '?' || leadChar == ':'
-
-			elementIndent := reactutil.IndentLeading(text, lineMap, openingStart, indentChar)
-
-			var propIndent int
-			if indentIsFirst {
-				// 'first' mode aligns to the visual column of the
-				// first prop. Use UTF-16 character column (matches
-				// ESLint's `loc.start.column`) instead of byte
-				// offset so multi-byte characters preceding the
-				// first prop don't inflate the expected indent.
-				propIndent = reactutil.NodeStartUTF16Column(ctx.SourceFile, props[0])
-			} else {
-				propIndent = elementIndent + indentSize
-			}
-
-			nestedIndent := propIndent
-			bumpApplied := false
-
-			for _, prop := range props {
-				// Mirror upstream: `getNodeIndent(node)` is called per
-				// prop regardless of first-in-line status, and resets
-				// `isUsingOperator` when the scanned line contains a
-				// `<`. Apply the same reset here so a prop whose first
-				// source line includes `<` (e.g. on the element's own
-				// `<` line, or carrying an inline JSX-literal value)
-				// cancels the bump.
-				if firstLineContainsBracket(prop) {
-					isUsingOperator = false
-				}
-
-				if !reactutil.IsNodeFirstInLine(ctx.SourceFile, prop) {
-					continue
-				}
-
-				if !bumpApplied && isUsingOperator && !indentIsFirst && !ignoreTernaryOperator {
-					nestedIndent += indentSize
-					bumpApplied = true
-					isUsingOperator = false
-				}
-
-				actualIndent := reactutil.NodeStartIndent(ctx.SourceFile, prop, indentChar)
-				if actualIndent != nestedIndent {
-					reactutil.ReportIndentReplaceLeading(ctx, prop, nestedIndent, actualIndent, indentChar, indentType)
-				}
-			}
-		}
-
-		return rule.RuleListeners{
-			ast.KindJsxOpeningElement:     check,
-			ast.KindJsxSelfClosingElement: check,
-		}
-	},
+		},
+	}
 }
 
 // parseOptions parses the rule options. The first positional option may be:

--- a/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props_test.go
+++ b/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props_test.go
@@ -406,6 +406,31 @@ func TestJsxIndentPropsRule(t *testing.T) {
 			Tsx:     true,
 			Options: []interface{}{map[string]interface{}{"indentMode": "spaces"}},
 		},
+
+		// First prop sharing the opening tag's `?`/`:` line: upstream's
+		// getNodeIndent gives useOperator (line starts with the operator)
+		// priority over useBracket (line contains `<`), so the operator state
+		// survives the `<` and the bump carries to the new-line props.
+		// Confirmed valid via ESLint differential. (Regression guard: an
+		// earlier port reset the state on `<` unconditionally and reported
+		// false positives on these.)
+		{
+			Code:    "\n        const x = cond\n          ? <App foo\n              bar\n            />\n          : null\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// `:` alternate is symmetric.
+		{
+			Code:    "\n        const x = cond\n          ? null\n          : <App foo\n              bar\n            />\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
+		// Multiple new-line props after the operator-line first prop — all bumped.
+		{
+			Code:    "\n        const y = cond\n          ? <App foo\n              bar\n              baz\n            />\n          : null\n      ",
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+		},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Default 4-space indent — child at 10 must be 12. ----
 		{
@@ -808,6 +833,20 @@ func TestJsxIndentPropsRule(t *testing.T) {
 					EndLine:   5,
 					EndColumn: 12,
 				},
+			},
+		},
+
+		// First prop on the `?`/`:` line, new-line prop at the UN-bumped column
+		// (12) — must report needs 14 (propIndent 12 + bump 2), proving the
+		// ternary bump is applied. Direct regression guard for useOperator
+		// preceding useBracket in the per-prop side effect.
+		{
+			Code:    "\n        const x = cond\n          ? <App foo\n            bar\n            />\n          : null\n      ",
+			Output:  []string{"\n        const x = cond\n          ? <App foo\n              bar\n            />\n          : null\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 12.", Line: 4, Column: 13},
 			},
 		},
 	})

--- a/internal/plugins/stylistic/all.go
+++ b/internal/plugins/stylistic/all.go
@@ -21,6 +21,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_equals_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_first_prop_new_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_function_call_newline"
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/rules/jsx_indent_props"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -46,5 +47,6 @@ func GetAllRules() []rule.Rule {
 		jsx_equals_spacing.JsxEqualsSpacingRule,
 		jsx_first_prop_new_line.JsxFirstPropNewLineRule,
 		jsx_function_call_newline.JsxFunctionCallNewlineRule,
+		jsx_indent_props.JsxIndentPropsRule,
 	}
 }

--- a/internal/plugins/stylistic/rules/jsx_indent_props/jsx_indent_props.go
+++ b/internal/plugins/stylistic/rules/jsx_indent_props/jsx_indent_props.go
@@ -1,0 +1,19 @@
+// Package jsx_indent_props ports `@stylistic/jsx-indent-props` to rslint. It
+// enforces a consistent indentation style for the props of a JSX element:
+// either N spaces / one tab relative to the element's own indent, or visual
+// alignment with the column of the first prop (`'first'` mode).
+//
+// The @stylistic rule is a byte-identical fork of `react/jsx-indent-props` (no
+// behavioral delta — their test suites match case-for-case), so the full
+// implementation is shared via the react rule's BuildRule; only the registered
+// name differs.
+package jsx_indent_props
+
+import (
+	reactRule "github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_indent_props"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// JsxIndentPropsRule is the @stylistic/eslint-plugin variant of
+// jsx-indent-props.
+var JsxIndentPropsRule rule.Rule = reactRule.BuildRule("@stylistic/jsx-indent-props")

--- a/internal/plugins/stylistic/rules/jsx_indent_props/jsx_indent_props.md
+++ b/internal/plugins/stylistic/rules/jsx_indent_props/jsx_indent_props.md
@@ -1,0 +1,138 @@
+# jsx-indent-props
+
+Enforce props indentation in JSX.
+
+## Rule Details
+
+This rule enforces a consistent indentation style for JSX props. The default style is `4 spaces`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<Hello
+  firstName="John"
+/>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<Hello
+    firstName="John"
+/>
+```
+
+## Options
+
+The first option accepts:
+
+- `"tab"` — tab-based indentation.
+- a non-negative integer — N-space indentation.
+- `"first"` — align each prop with the column of the first prop.
+- an object with these keys:
+  - `indentMode` — same value space as the positional option above (`"tab"`, `"first"`, or an integer).
+  - `ignoreTernaryOperator` — boolean (default `false`). When `true`, props inside a JSX element nested in a `?:` consequent / alternate are NOT given an extra `indentMode` bump.
+
+Examples of **incorrect** code for this rule with `["error", 2]`:
+
+```json
+{ "@stylistic/jsx-indent-props": ["error", 2] }
+```
+
+```jsx
+<Hello
+    firstName="John"
+/>
+```
+
+Examples of **correct** code for this rule with `["error", 2]`:
+
+```json
+{ "@stylistic/jsx-indent-props": ["error", 2] }
+```
+
+```jsx
+<Hello
+  firstName="John"
+/>
+```
+
+Examples of **correct** code for this rule with `["error", "tab"]`:
+
+```json
+{ "@stylistic/jsx-indent-props": ["error", "tab"] }
+```
+
+```jsx
+<Hello
+	firstName="John"
+/>
+```
+
+Examples of **correct** code for this rule with `["error", 0]`:
+
+```json
+{ "@stylistic/jsx-indent-props": ["error", 0] }
+```
+
+```jsx
+<Hello
+firstName="John"
+/>
+```
+
+Examples of **incorrect** code for this rule with `["error", "first"]`:
+
+```json
+{ "@stylistic/jsx-indent-props": ["error", "first"] }
+```
+
+```jsx
+<Hello firstName="John"
+  lastName="Doe"
+/>
+```
+
+Examples of **correct** code for this rule with `["error", "first"]`:
+
+```json
+{ "@stylistic/jsx-indent-props": ["error", "first"] }
+```
+
+```jsx
+<Hello firstName="John"
+       lastName="Doe"
+/>
+```
+
+Examples of **correct** code for this rule with `["error", { "indentMode": 2, "ignoreTernaryOperator": false }]` (default — props inside a `?:` branch receive an extra `indentMode` bump):
+
+```json
+{ "@stylistic/jsx-indent-props": ["error", { "indentMode": 2, "ignoreTernaryOperator": false }] }
+```
+
+```jsx
+{condition
+  ? <Hello
+      firstName="John"
+    />
+  : null}
+```
+
+Examples of **correct** code for this rule with `["error", { "indentMode": 2, "ignoreTernaryOperator": true }]` (no extra bump inside `?:`):
+
+```json
+{ "@stylistic/jsx-indent-props": ["error", { "indentMode": 2, "ignoreTernaryOperator": true }] }
+```
+
+```jsx
+{condition
+  ? <Hello
+    firstName="John"
+  />
+  : null}
+```
+
+## Original Documentation
+
+- [@stylistic/jsx-indent-props](https://eslint.style/rules/jsx-indent-props)

--- a/internal/plugins/stylistic/rules/jsx_indent_props/jsx_indent_props_extras_test.go
+++ b/internal/plugins/stylistic/rules/jsx_indent_props/jsx_indent_props_extras_test.go
@@ -1,0 +1,312 @@
+// TestJsxIndentPropsExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+//
+// The implementation is shared with react/jsx-indent-props via BuildRule, so
+// these cases double as guards for both registered variants.
+package jsx_indent_props
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxIndentPropsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxIndentPropsRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: access/key form — JsxSpreadAttribute as first prop
+		// (default 4-space). `{...rest}` must obey the same indent contract as
+		// a plain JsxAttribute. ----
+		{Code: "\n        <App\n            {...rest}\n            foo\n        />\n      ", Tsx: true},
+
+		// ---- Dimension 4: spread as first prop under 'first' — the column
+		// anchor is the leading `{` of `{...rest}`, not any inner identifier. ----
+		{Code: "\n        <App {...rest}\n             foo\n        />\n      ", Tsx: true, Options: []interface{}{"first"}},
+		{Code: "\n        <App {...rest}\n             id=\"x\"\n             onClick={fn}\n        />\n      ", Tsx: true, Options: []interface{}{"first"}},
+
+		// ---- Dimension 4: boolean attribute as first prop under 'first' —
+		// anchor comes from the boolean's identifier start. ----
+		{Code: "\n        <App disabled\n             onClick={fn}\n             id=\"x\"\n        />\n      ", Tsx: true, Options: []interface{}{"first"}},
+
+		// ---- Dimension 4: container forms — generic tag `<Foo<T>>` type
+		// arguments don't appear in Attributes.Properties.Nodes, so prop
+		// processing ignores them. ----
+		{Code: "\n        <Foo<string>\n            a\n            b\n        />\n      ", Tsx: true},
+
+		// ---- Dimension 4: member-expression tag `<Foo.Bar>` — the dotted name
+		// must be transparent to prop processing. ----
+		{Code: "\n        <Foo.Bar\n            a\n            b\n        />\n      ", Tsx: true},
+
+		// ---- Dimension 4: namespaced tag `<svg:rect>` — same shape as member,
+		// transparent to prop processing. ----
+		{Code: "\n        <svg:rect\n            a\n            b\n        />\n      ", Tsx: true},
+
+		// ---- Dimension 4: graceful degradation — single-line JSX inside a
+		// ternary must NOT trigger the bump (the `?` sits on the same line as
+		// `<` but the line does not START with `?`/`:` after whitespace). ----
+		{Code: "\n        const x = cond ? <App foo bar /> : null\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Dimension 4: nesting boundary — adjacent ternary JSX + non-ternary
+		// JSX. The per-element state reset must keep `isUsingOperator` from
+		// leaking from the first element to the second. ----
+		{Code: "\n        const a = c1\n          ? <X\n              a\n            /> : null;\n        const b = <App\n          foo\n        />;\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Dimension 4: multi-line JSX literal as an attr value — first line
+		// of `foo={` does NOT contain `<`, so upstream's `useBracket` reset does
+		// NOT fire and the ternary bump still applies to subsequent props. ----
+		{Code: "\n        c\n          ? <App\n              foo={\n                <Inner/>\n              }\n              bar\n            />\n          : null\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Dimension 4: single-line attr value containing a JSX literal —
+		// `foo={<Inner/>}`'s first line contains `<`, which cancels the ternary
+		// bump (upstream's `useBracket` reset). Both props align WITHOUT it. ----
+		{Code: "\n        c\n          ? <App\n            foo={<Inner/>}\n            bar\n          />\n          : null\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Dimension 4: TS type-expression wrapper around the ternary side
+		// (`as`). The `useOperator` check is line-content-based, so the wrapper
+		// doesn't move which line `?` sits on and the bump still applies. ----
+		{Code: "\n        const x = c\n          ? (<App\n              foo\n            />) as React.ReactElement\n          : null\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// N/A: optional-chain / non-null receiver wrappers — the rule inspects
+		// JSX attribute positions, never an arbitrary member/call receiver, so
+		// `?.` / `!` receiver shapes don't reach this rule's child accesses.
+
+		// ---- Real-user: inline arrow event handler with a multi-line body. The
+		// first source line of `onClick` ends with `={() => {` (no `<`), so the
+		// bracket-reset is a no-op and there is no ternary. ----
+		{Code: "\n        <button\n          onClick={() => {\n            setX(true);\n            log();\n          }}\n          disabled\n        />\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Real-user: className template literal whose interpolation itself
+		// contains a `?:` — the `?` is inside `${ ... }`, not at line start, so
+		// it must NOT trigger the operator bump. ----
+		{Code: "\n        <div\n          className={`foo ${cond ? 'a' : 'b'} bar`}\n          id=\"x\"\n        />\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Real-user: spread + named override (`<Input {...props} value={x} />`). ----
+		{Code: "\n        <Input\n          {...props}\n          value={localValue}\n        />\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Real-user: multiple consecutive spread attributes followed by named. ----
+		{Code: "\n        <Input\n          {...props1}\n          {...props2}\n          value={x}\n        />\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Real-user: render-prop / children-as-function — JSX nested inside
+		// a JSX expression container that itself sits in JSX children. ----
+		{Code: "\n        <Query>\n          {(data) => <Result\n            value={data}\n            onClick={handler}\n          />}\n        </Query>\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Real-user: conditional rendering with `&&` wrapping multi-line JSX.
+		// The line of `<Modal` is not led by `?`/`:`, so no bump. ----
+		{Code: "\n        {isOpen && (\n          <Modal\n            onClose={close}\n            title=\"Welcome\"\n          />\n        )}\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Real-user: `.map(...)` render with a multi-line JSX body. ----
+		{Code: "\n        {items.map((item) => (\n          <Item\n            key={item.id}\n            value={item.value}\n          />\n        ))}\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Real-user: hyphenated and dotted attribute names exercising the
+		// JSX identifier parser; `ref` is just an attribute. ----
+		{Code: "\n        <input\n          ref={inputRef}\n          type=\"text\"\n          aria-label=\"name\"\n          data-testid=\"input\"\n        />\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Real-user: full-form component — function declaration, return,
+		// multi-line opening tag, hyphenated and template-literal props. ----
+		{Code: "\n        function Form({ submit }) {\n          return (\n            <form\n              onSubmit={submit}\n              noValidate\n              autoComplete=\"off\"\n              className={`form ${variant}`}\n            >\n              <input\n                ref={inputRef}\n                type=\"text\"\n              />\n            </form>\n          );\n        }\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Real-user: comment between attributes — leading trivia on `b`;
+		// the trimmed start must skip the comment so the indent reading lands on
+		// `b`'s line, not the comment's. ----
+		{Code: "\n        <App\n          a={1}\n          // separator\n          b={2}\n        />\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Branch lock-in: parseOptions object form with ONLY
+		// `ignoreTernaryOperator` (no indentMode) falls back to default 4-space,
+		// and the flag still suppresses the bump. ----
+		{Code: "\n        {cond\n          ? <App\n              foo\n            />\n          : null}\n      ", Tsx: true, Options: []interface{}{map[string]interface{}{"ignoreTernaryOperator": true}}},
+
+		// ---- Branch lock-in: parseOptions object form with `indentMode: 'first'`
+		// — string value inside the object form behaves as the bare `'first'`. ----
+		{Code: "\n        <App aaa\n             b\n             cc\n        />\n      ", Tsx: true, Options: []interface{}{map[string]interface{}{"indentMode": "first"}}},
+
+		// ---- Branch lock-in: large indent (8-space) — option size only feeds
+		// arithmetic and the string repeat. ----
+		{Code: "\n        <App\n                foo\n                bar\n        />\n      ", Tsx: true, Options: []interface{}{float64(8)}},
+
+		// ---- Branch lock-in: empty options array — equivalent to default 4-space. ----
+		{Code: "\n        <App\n            foo\n        />\n      ", Tsx: true, Options: []interface{}{}},
+
+		// ---- Branch lock-in: unrecognised string in object form
+		// (`indentMode: 'spaces'`) silently falls through to default 4-space. ----
+		{Code: "\n        <App\n            foo\n        />\n      ", Tsx: true, Options: []interface{}{map[string]interface{}{"indentMode": "spaces"}}},
+
+		// ---- Branch lock-in: ternary bump when the FIRST prop shares the
+		// opening tag's `?`/`:` line. Upstream's getNodeIndent gives useOperator
+		// (line starts with the operator) priority over useBracket (line
+		// contains `<`), so the operator state survives the `<` on that line and
+		// the bump carries to the new-line props. Confirmed valid via ESLint
+		// differential against @stylistic 5.10.0. (Regression guard: an earlier
+		// port reset the state on `<` unconditionally and reported false positives here.) ----
+		{Code: "\n        const x = cond\n          ? <App foo\n              bar\n            />\n          : null\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+		// `:` alternate is symmetric.
+		{Code: "\n        const x = cond\n          ? null\n          : <App foo\n              bar\n            />\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+		// Multiple new-line props after the operator-line first prop — all bumped.
+		{Code: "\n        const y = cond\n          ? <App foo\n              bar\n              baz\n            />\n          : null\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// N/A: ArrayExpression / ObjectExpression node-type skip — upstream's
+		// `node.type !== 'ArrayExpression' && node.type !== 'ObjectExpression'`
+		// guard is vestigial in the JSX context: JSX attributes are always
+		// JsxAttribute / JsxSpreadAttribute, never those kinds, so the guard is
+		// unreachable here (inherited from the generic indent rule it forked).
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: spread + named prop both at wrong indent — both must
+		// report. ----
+		{
+			Code:   "\n        <App\n          {...rest}\n          foo\n        />\n      ",
+			Output: []string{"\n        <App\n            {...rest}\n            foo\n        />\n      "},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Branch lock-in: bracket-reset cancels the ternary bump. The props
+		// are indented as if the bump applied, but the first prop's first source
+		// line contains `<` (`foo={<Inner/>}`), so upstream's `useBracket` reset
+		// fires and the expected indent is propIndent (NOT propIndent+indentSize).
+		// Without the reset this would silently accept props at indent 10. ----
+		{
+			Code:    "\n        c\n          ? <App\n              foo={<Inner/>}\n              bar\n            />\n          : null\n      ",
+			Output:  []string{"\n        c\n          ? <App\n            foo={<Inner/>}\n            bar\n            />\n          : null\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Branch lock-in: ternary state must NOT leak to the next JSX. The
+		// first element's `?` line sets `isUsingOperator`, but the second
+		// element's own `<` line isn't led by `?`/`:` — it must fall back to the
+		// non-bumped expected indent. ----
+		{
+			Code:    "\n        const a = c1 ? <X\n          a\n        /> : null;\n        <Y\n            foo\n        />\n      ",
+			Output:  []string{"\n        const a = c1 ? <X\n          a\n        /> : null;\n        <Y\n          foo\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent"},
+			},
+		},
+
+		// ---- Diagnostic contract: default 4-space, full diagnostic shape —
+		// messageId, exact message text, and 1-based Line/Column/EndLine/
+		// EndColumn anchored at the JsxAttribute's trimmed range. ----
+		{
+			Code:   "\n        <App\n          foo\n        />\n      ",
+			Output: []string{"\n        <App\n            foo\n        />\n      "},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10.", Line: 3, Column: 11, EndLine: 3, EndColumn: 14},
+			},
+		},
+
+		// ---- Diagnostic contract: tab option, zero leading tabs — needed=1 must
+		// use the SINGULAR "character"; locks in the pluralization branch. ----
+		{
+			Code:    "\n        <App1\n            foo\n        />\n      ",
+			Output:  []string{"\n        <App1\n\tfoo\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 1 tab character but found 0.", Line: 3, Column: 13, EndLine: 3, EndColumn: 16},
+			},
+		},
+
+		// ---- Diagnostic contract: 'first' alignment mismatch — expected indent
+		// is the first prop's column (`a` at column 13). ----
+		{
+			Code:    "\n        <App a\n          b\n        />\n      ",
+			Output:  []string{"\n        <App a\n             b\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 13 space characters but found 10.", Line: 3, Column: 11, EndLine: 3, EndColumn: 12},
+			},
+		},
+
+		// ---- Diagnostic contract: multi-error sequencing — two mis-indented
+		// props on different lines each report on their OWN line. ----
+		{
+			Code:   "\n        <App\n          foo\n          bar\n        />\n      ",
+			Output: []string{"\n        <App\n            foo\n            bar\n        />\n      "},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10.", Line: 3, Column: 11},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10.", Line: 4, Column: 11},
+			},
+		},
+
+		// ---- Branch lock-in: 'first' with three mismatched props — Line
+		// increments stay in source order (iteration follows
+		// Attributes.Properties.Nodes order). ----
+		{
+			Code:    "\n        <App\n          a\n         b\n           c\n        />\n      ",
+			Output:  []string{"\n        <App\n          a\n          b\n          c\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Line: 4, Column: 10},
+				{MessageId: "wrongIndent", Line: 5, Column: 12},
+			},
+		},
+
+		// ---- Branch lock-in: negative indent option `[-2]` makes propIndent < 0.
+		// (1) The rule MUST NOT panic on the negative repeat count (omitted
+		// Output asserts no fix was applied — matching ESLint, whose repeat()
+		// throws and is silently dropped). (2) The message preserves the
+		// negative `needed` verbatim. ----
+		{
+			Code:    "<App\nfoo\n/>",
+			Tsx:     true,
+			Options: []interface{}{float64(-2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of -2 space characters but found 0.", Line: 2, Column: 1, EndLine: 2, EndColumn: 4},
+			},
+		},
+
+		// ---- Dimension 4: multi-byte tag name in 'first' mode — `<中Foo>` adds
+		// 1 UTF-16 code unit but 3 UTF-8 bytes. propIndent must use the UTF-16
+		// character column (matches ESLint's loc.start.column), not byte offset;
+		// otherwise this would expect indent 16 instead of 14. ----
+		{
+			Code:    "\n        <中Foo a=\"x\"\n           b=\"y\"\n        />\n      ",
+			Output:  []string{"\n        <中Foo a=\"x\"\n              b=\"y\"\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 11.", Line: 3, Column: 12, EndLine: 3, EndColumn: 17},
+			},
+		},
+
+		// ---- Diagnostic contract: multi-line attribute value — the `beforeNav`
+		// attribute spans 4 lines; the diagnostic's end-of-range must land on the
+		// CLOSING line/column of the JsxAttribute, not on its first line. ----
+		{
+			Code:   "\n        <BaseLayout\n          beforeNav={\n            <Banner />\n          }\n        />\n      ",
+			Output: []string{"\n        <BaseLayout\n            beforeNav={\n            <Banner />\n          }\n        />\n      "},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10.", Line: 3, Column: 11, EndLine: 5, EndColumn: 12},
+			},
+		},
+
+		// ---- Branch lock-in: same operator-line-first-prop shape, but the
+		// new-line prop sits at the UN-bumped column (12). Must report needs 14
+		// (propIndent 12 + bump 2), proving the ternary bump IS applied — the
+		// direct regression guard for useOperator preceding useBracket. ----
+		{
+			Code:    "\n        const x = cond\n          ? <App foo\n            bar\n            />\n          : null\n      ",
+			Output:  []string{"\n        const x = cond\n          ? <App foo\n              bar\n            />\n          : null\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 12.", Line: 4, Column: 13},
+			},
+		},
+	})
+}

--- a/internal/plugins/stylistic/rules/jsx_indent_props/jsx_indent_props_upstream_test.go
+++ b/internal/plugins/stylistic/rules/jsx_indent_props/jsx_indent_props_upstream_test.go
@@ -1,0 +1,265 @@
+// TestJsxIndentPropsUpstream migrates the full valid/invalid suite from upstream
+// packages/eslint-plugin/rules/jsx-indent-props/jsx-indent-props.test.ts 1:1.
+// Upstream asserts messageId + data on its invalid cases; the Message here
+// reproduces upstream's exact rendered text (from the needed/type/gotten data),
+// and Line/Column point at the reported attribute, computed from the exact
+// source each case carries. rslint-specific edge-shape and branch lock-in cases
+// live in jsx_indent_props_extras_test.go.
+package jsx_indent_props
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/stylistic/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxIndentPropsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxIndentPropsRule, []rule_tester.ValidTestCase{
+		// ---- Default 4-space indent (no options) ----
+		{Code: "\n        <App foo\n        />\n      ", Tsx: true},
+
+		// ---- 2-space indent ----
+		{Code: "\n        <App\n          foo\n        />\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- Complex multi-element array literal (options: [2]) ----
+		{Code: "\n        const Test = () => ([\n          (x\n            ? <div key=\"1\" />\n            : <div key=\"2\" />),\n          <div\n            key=\"3\"\n            align=\"left\"\n          />,\n          <div\n            key=\"4\"\n            align=\"left\"\n          />,\n        ]);\n      ", Tsx: true, Options: []interface{}{float64(2)}},
+
+		// ---- 0-indent (props flush to column 0) ----
+		{Code: "\n        <App\n        foo\n        />\n      ", Tsx: true, Options: []interface{}{float64(0)}},
+
+		// ---- Negative indent (props two cols LEFT of `<App`) ----
+		{Code: "\n          <App\n        foo\n          />\n      ", Tsx: true, Options: []interface{}{float64(-2)}},
+
+		// ---- Tab indentation ----
+		{Code: "\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t", Tsx: true, Options: []interface{}{"tab"}},
+
+		// ---- 'first' option, no props ----
+		{Code: "\n        <App/>\n      ", Tsx: true, Options: []interface{}{"first"}},
+
+		// ---- 'first' option, props aligned with first prop's column ----
+		{Code: "\n        <App aaa\n             b\n             cc\n        />\n      ", Tsx: true, Options: []interface{}{"first"}},
+		{Code: "\n        <App   aaa\n               b\n               cc\n        />\n      ", Tsx: true, Options: []interface{}{"first"}},
+		{Code: "\n        const test = <App aaa\n                          b\n                          cc\n                     />\n      ", Tsx: true, Options: []interface{}{"first"}},
+		{Code: "\n        <App aaa x\n             b y\n             cc\n        />\n      ", Tsx: true, Options: []interface{}{"first"}},
+		{Code: "\n        const test = <App aaa x\n                          b y\n                          cc\n                     />\n      ", Tsx: true, Options: []interface{}{"first"}},
+		{Code: "\n        <App aaa\n             b\n        >\n            <Child c\n                   d/>\n        </App>\n      ", Tsx: true, Options: []interface{}{"first"}},
+		{Code: "\n        <Fragment>\n          <App aaa\n               b\n               cc\n          />\n          <OtherApp a\n                    bbb\n                    c\n          />\n        </Fragment>\n      ", Tsx: true, Options: []interface{}{"first"}},
+
+		// ---- 'first' with all props on new lines: each prop must match the
+		// first prop's column. ----
+		{Code: "\n        <App\n          a\n          b\n        />\n      ", Tsx: true, Options: []interface{}{"first"}},
+
+		// ---- ignoreTernaryOperator: false (default), input already bumped. ----
+		{Code: "\n        {this.props.ignoreTernaryOperatorFalse\n          ? <span\n              className=\"value\"\n              some={{aaa}}\n            />\n          : null}\n      ", Tsx: true, Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": false}}},
+
+		// ---- Function returning JSX in conditional, default indentMode=2. ----
+		{Code: "\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n            id=\"id\"\n          >\n            test\n          </div>\n        }\n      ", Tsx: true, Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": false}}},
+		{Code: "\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n            id=\"id\"\n          >\n            test\n          </div>\n        }\n      ", Tsx: true, Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": true}}},
+
+		// ---- Tab indent with conditional + return JSX ----
+		{Code: "\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n", Tsx: true, Options: []interface{}{map[string]interface{}{"indentMode": "tab", "ignoreTernaryOperator": false}}},
+		{Code: "\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n", Tsx: true, Options: []interface{}{map[string]interface{}{"indentMode": "tab", "ignoreTernaryOperator": true}}},
+
+		// ---- ignoreTernaryOperator: true — props inside ternary side do NOT
+		// receive the extra bump. ----
+		{Code: "\n        {this.props.ignoreTernaryOperatorTrue\n          ? <span\n            className=\"value\"\n            some={{aaa}}\n            />\n          : null}\n      ", Tsx: true, Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": true}}},
+
+		// ---- Realistic anchor element (object form with only indentMode). ----
+		{Code: "\n        <a\n          role={'button'}\n          className={`navbar-burger ${open ? 'is-active' : ''}`}\n          href={'#'}\n          aria-label={'menu'}\n          aria-expanded={false}\n          onClick={openMenu}>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n        </a>\n      ", Tsx: true, Options: []interface{}{map[string]interface{}{"indentMode": float64(2)}}},
+
+		// ---- Same realistic element under 'first' alignment ----
+		{Code: "\n        <a role={'button'}\n           className={`navbar-burger ${open ? 'is-active' : ''}`}\n           href={'#'}\n           aria-label={'menu'}\n           aria-expanded={false}\n           onClick={openMenu}>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n        </a>\n      ", Tsx: true, Options: []interface{}{"first"}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Default 4-space — child at 10 must be 12. ----
+		{
+			Code:   "\n        <App\n          foo\n        />\n      ",
+			Output: []string{"\n        <App\n            foo\n        />\n      "},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 10.", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- 2-space — child at 12 must be 10. ----
+		{
+			Code:    "\n        <App\n            foo\n        />\n      ",
+			Output:  []string{"\n        <App\n          foo\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 12.", Line: 3, Column: 13},
+			},
+		},
+
+		// ---- Conditional with JSX in both branches — bump applies on each
+		// ternary side. ----
+		{
+			Code:    "\n        const test = true\n          ? <span\n            attr=\"value\"\n            />\n          : <span\n            attr=\"otherValue\"\n            />\n      ",
+			Output:  []string{"\n        const test = true\n          ? <span\n              attr=\"value\"\n            />\n          : <span\n              attr=\"otherValue\"\n            />\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 12.", Line: 4, Column: 13},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 12.", Line: 7, Column: 13},
+			},
+		},
+
+		// ---- Alternate wrapped in its own parens — no ternary bump. ----
+		{
+			Code:    "\n        const test = true\n          ? <span attr=\"value\" />\n          : (\n            <span\n                attr=\"otherValue\"\n            />\n          )\n      ",
+			Output:  []string{"\n        const test = true\n          ? <span attr=\"value\" />\n          : (\n            <span\n              attr=\"otherValue\"\n            />\n          )\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 16.", Line: 6, Column: 17},
+			},
+		},
+
+		// ---- Ternary alternate: one prop. ----
+		{
+			Code:    "\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n            some={aaa}/>\n        }\n      ",
+			Output:  []string{"\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n              some={aaa}/>\n        }\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 12.", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Ternary alternate: two props, both bumped. ----
+		{
+			Code:    "\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n            some={aaa}\n            other={bbb}/>\n        }\n      ",
+			Output:  []string{"\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n              some={aaa}\n              other={bbb}/>\n        }\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 12.", Line: 5, Column: 13},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 12.", Line: 6, Column: 13},
+			},
+		},
+
+		// ---- Ternary consequent inside JSXExpressionContainer: bump applies. ----
+		{
+			Code:    "\n        {this.props.test\n          ? <span\n            className=\"value\"\n            some={{aaa}}\n            />\n          : null}\n      ",
+			Output:  []string{"\n        {this.props.test\n          ? <span\n              className=\"value\"\n              some={{aaa}}\n            />\n          : null}\n      "},
+			Tsx:     true,
+			Options: []interface{}{float64(2)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 12.", Line: 4, Column: 13},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 12.", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Tab option, prop has no leading tab — needed=1 (singular). ----
+		{
+			Code:    "\n        <App1\n            foo\n        />\n      ",
+			Output:  []string{"\n        <App1\n\tfoo\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 1 tab character but found 0.", Line: 3, Column: 13},
+			},
+		},
+
+		// ---- Tab option, too many tabs — needed=5. ----
+		{
+			Code:    "\n\t\t\t\t<App\n\t\t\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t",
+			Output:  []string{"\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t"},
+			Tsx:     true,
+			Options: []interface{}{"tab"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 5 tab characters but found 7.", Line: 3, Column: 8},
+			},
+		},
+
+		// ---- 'first': prop at col 10 must match firstPropCol=13. ----
+		{
+			Code:    "\n        <App a\n          b\n        />\n      ",
+			Output:  []string{"\n        <App a\n             b\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 13 space characters but found 10.", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- 'first': prop at col 11 must match firstPropCol=14. ----
+		{
+			Code:    "\n        <App  a\n           b\n        />\n      ",
+			Output:  []string{"\n        <App  a\n              b\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 11.", Line: 3, Column: 12},
+			},
+		},
+
+		// ---- 'first', first prop on new line: subsequent props match the
+		// FIRST prop's column. ----
+		{
+			Code:    "\n        <App\n              a\n           b\n        />\n      ",
+			Output:  []string{"\n        <App\n              a\n              b\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 14 space characters but found 11.", Line: 4, Column: 12},
+			},
+		},
+
+		// ---- 'first', three props with two mis-aligned. ----
+		{
+			Code:    "\n        <App\n          a\n         b\n           c\n        />\n      ",
+			Output:  []string{"\n        <App\n          a\n          b\n          c\n        />\n      "},
+			Tsx:     true,
+			Options: []interface{}{"first"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 9.", Line: 4, Column: 10},
+				{MessageId: "wrongIndent", Message: "Expected indentation of 10 space characters but found 11.", Line: 5, Column: 12},
+			},
+		},
+
+		// ---- ignoreTernaryOperator:false, return JSX one indent off. ----
+		{
+			Code:    "\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n              id=\"id\"\n          >\n            test\n          </div>\n        }\n      ",
+			Output:  []string{"\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n            id=\"id\"\n          >\n            test\n          </div>\n        }\n      "},
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": false}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 14.", Line: 8, Column: 15},
+			},
+		},
+
+		// ---- Same shape, ignoreTernaryOperator:true (return JSX not in a
+		// ternary, so behaviour is identical). ----
+		{
+			Code:    "\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n              id=\"id\"\n          >\n            test\n          </div>\n        }\n      ",
+			Output:  []string{"\n        const F = () => {\n          const foo = true\n            ? <div id=\"id\">test</div>\n            : false;\n\n          return <div\n            id=\"id\"\n          >\n            test\n          </div>\n        }\n      "},
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": float64(2), "ignoreTernaryOperator": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 12 space characters but found 14.", Line: 8, Column: 15},
+			},
+		},
+
+		// ---- Tab indent + return JSX off by one tab. ----
+		{
+			Code:    "\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n",
+			Output:  []string{"\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n"},
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": "tab", "ignoreTernaryOperator": false}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 6 tab characters but found 7.", Line: 8, Column: 8},
+			},
+		},
+		{
+			Code:    "\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n",
+			Output:  []string{"\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id=\"id\">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid=\"id\"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n"},
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"indentMode": "tab", "ignoreTernaryOperator": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "wrongIndent", Message: "Expected indentation of 6 tab characters but found 7.", Line: 8, Column: 8},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -472,6 +472,7 @@ export default defineConfig({
     './tests/eslint-plugin-stylistic/rules/jsx-equals-spacing.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-first-prop-new-line.test.ts',
     './tests/eslint-plugin-stylistic/rules/jsx-function-call-newline.test.ts',
+    './tests/eslint-plugin-stylistic/rules/jsx-indent-props.test.ts',
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-indent-props.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-stylistic/rules/jsx-indent-props.test.ts
@@ -1,0 +1,256 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// Mirrors upstream packages/eslint-plugin/rules/jsx-indent-props/
+// jsx-indent-props.test.ts (Layer 1). This JS suite verifies binary
+// registration + wire protocol + ESLint-compatible diagnostics; edge-shape and
+// branch lock-in cases live in the Go jsx_indent_props_extras_test.go.
+ruleTester.run('jsx-indent-props', null as never, {
+  valid: [
+    // ---- Default 4-space indent ----
+    { code: `\n        <App foo\n        />\n      ` },
+
+    // ---- 2-space indent ----
+    {
+      code: `\n        <App\n          foo\n        />\n      `,
+      options: [2],
+    },
+
+    // ---- Complex array literal with multiple JSX elements ----
+    {
+      code: `\n        const Test = () => ([\n          (x\n            ? <div key="1" />\n            : <div key="2" />),\n          <div\n            key="3"\n            align="left"\n          />,\n          <div\n            key="4"\n            align="left"\n          />,\n        ]);\n      `,
+      options: [2],
+    },
+
+    // ---- 0-indent ----
+    {
+      code: `\n        <App\n        foo\n        />\n      `,
+      options: [0],
+    },
+
+    // ---- Negative indent ----
+    {
+      code: `\n          <App\n        foo\n          />\n      `,
+      options: [-2],
+    },
+
+    // ---- Tab indent ----
+    {
+      code: `\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t`,
+      options: ['tab'],
+    },
+
+    // ---- 'first' option, no props ----
+    {
+      code: `\n        <App/>\n      `,
+      options: ['first'],
+    },
+
+    // ---- 'first' option, props aligned with first prop's column ----
+    {
+      code: `\n        <App aaa\n             b\n             cc\n        />\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        <App   aaa\n               b\n               cc\n        />\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        const test = <App aaa\n                          b\n                          cc\n                     />\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        <App aaa x\n             b y\n             cc\n        />\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        const test = <App aaa x\n                          b y\n                          cc\n                     />\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        <App aaa\n             b\n        >\n            <Child c\n                   d/>\n        </App>\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        <Fragment>\n          <App aaa\n               b\n               cc\n          />\n          <OtherApp a\n                    bbb\n                    c\n          />\n        </Fragment>\n      `,
+      options: ['first'],
+    },
+    {
+      code: `\n        <App\n          a\n          b\n        />\n      `,
+      options: ['first'],
+    },
+
+    // ---- ignoreTernaryOperator: false (default) — props inside the ternary
+    // side already have the bump applied. ----
+    {
+      code: `\n        {this.props.ignoreTernaryOperatorFalse\n          ? <span\n              className="value"\n              some={{aaa}}\n            />\n          : null}\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: false }],
+    },
+
+    // ---- Function returning JSX in conditional, both flag values. ----
+    {
+      code: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n            id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: false }],
+    },
+    {
+      code: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n            id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: true }],
+    },
+
+    // ---- Tab indent with conditional + return JSX ----
+    {
+      code: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      options: [{ indentMode: 'tab', ignoreTernaryOperator: false }],
+    },
+    {
+      code: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      options: [{ indentMode: 'tab', ignoreTernaryOperator: true }],
+    },
+
+    // ---- ignoreTernaryOperator:true — no bump applied. ----
+    {
+      code: `\n        {this.props.ignoreTernaryOperatorTrue\n          ? <span\n            className="value"\n            some={{aaa}}\n            />\n          : null}\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: true }],
+    },
+
+    // ---- Realistic anchor element, indentMode-only object form ----
+    {
+      code: `\n        <a\n          role={'button'}\n          className={\`navbar-burger \${open ? 'is-active' : ''}\`}\n          href={'#'}\n          aria-label={'menu'}\n          aria-expanded={false}\n          onClick={openMenu}>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n        </a>\n      `,
+      options: [{ indentMode: 2 }],
+    },
+
+    // ---- Same realistic element, 'first' alignment ----
+    {
+      code: `\n        <a role={'button'}\n           className={\`navbar-burger \${open ? 'is-active' : ''}\`}\n           href={'#'}\n           aria-label={'menu'}\n           aria-expanded={false}\n           onClick={openMenu}>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n          <span aria-hidden={'true'}/>\n        </a>\n      `,
+      options: ['first'],
+    },
+  ],
+  invalid: [
+    // ---- Default 4-space indent — child at 10 must be 12. ----
+    {
+      code: `\n        <App\n          foo\n        />\n      `,
+      output: `\n        <App\n            foo\n        />\n      `,
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- 2-space indent — child at 12 must be 10. ----
+    {
+      code: `\n        <App\n            foo\n        />\n      `,
+      output: `\n        <App\n          foo\n        />\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- Conditional with JSX in both branches — bump applies. ----
+    {
+      code: `\n        const test = true\n          ? <span\n            attr="value"\n            />\n          : <span\n            attr="otherValue"\n            />\n      `,
+      output: `\n        const test = true\n          ? <span\n              attr="value"\n            />\n          : <span\n              attr="otherValue"\n            />\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }, { messageId: 'wrongIndent' }],
+    },
+
+    // ---- Alternate wrapped in its own parens — no ternary bump. ----
+    {
+      code: `\n        const test = true\n          ? <span attr="value" />\n          : (\n            <span\n                attr="otherValue"\n            />\n          )\n      `,
+      output: `\n        const test = true\n          ? <span attr="value" />\n          : (\n            <span\n              attr="otherValue"\n            />\n          )\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- Ternary alternate, single prop. ----
+    {
+      code: `\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n            some={aaa}/>\n        }\n      `,
+      output: `\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n              some={aaa}/>\n        }\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- Ternary alternate, two props bumped. ----
+    {
+      code: `\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n            some={aaa}\n            other={bbb}/>\n        }\n      `,
+      output: `\n        {test.isLoading\n          ? <Value/>\n          : <OtherValue\n              some={aaa}\n              other={bbb}/>\n        }\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }, { messageId: 'wrongIndent' }],
+    },
+
+    // ---- Ternary consequent inside JSXExpressionContainer. ----
+    {
+      code: `\n        {this.props.test\n          ? <span\n            className="value"\n            some={{aaa}}\n            />\n          : null}\n      `,
+      output: `\n        {this.props.test\n          ? <span\n              className="value"\n              some={{aaa}}\n            />\n          : null}\n      `,
+      options: [2],
+      errors: [{ messageId: 'wrongIndent' }, { messageId: 'wrongIndent' }],
+    },
+
+    // ---- Tab option, prop has no leading tab. ----
+    {
+      code: `\n        <App1\n            foo\n        />\n      `,
+      output: `\n        <App1\n\tfoo\n        />\n      `,
+      options: ['tab'],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- Tab option, too many tabs. ----
+    {
+      code: `\n\t\t\t\t<App\n\t\t\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t`,
+      output: `\n\t\t\t\t<App\n\t\t\t\t\tfoo\n\t\t\t\t/>\n\t\t\t`,
+      options: ['tab'],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- 'first' alignment failures. ----
+    {
+      code: `\n        <App a\n          b\n        />\n      `,
+      output: `\n        <App a\n             b\n        />\n      `,
+      options: ['first'],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+    {
+      code: `\n        <App  a\n           b\n        />\n      `,
+      output: `\n        <App  a\n              b\n        />\n      `,
+      options: ['first'],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+    {
+      code: `\n        <App\n              a\n           b\n        />\n      `,
+      output: `\n        <App\n              a\n              b\n        />\n      `,
+      options: ['first'],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+    {
+      code: `\n        <App\n          a\n         b\n           c\n        />\n      `,
+      output: `\n        <App\n          a\n          b\n          c\n        />\n      `,
+      options: ['first'],
+      errors: [{ messageId: 'wrongIndent' }, { messageId: 'wrongIndent' }],
+    },
+
+    // ---- Return JSX off by one indent unit, both ignoreTernaryOperator
+    // values (return JSX is not in a ternary so behaviour matches). ----
+    {
+      code: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n              id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      output: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n            id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: false }],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+    {
+      code: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n              id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      output: `\n        const F = () => {\n          const foo = true\n            ? <div id="id">test</div>\n            : false;\n\n          return <div\n            id="id"\n          >\n            test\n          </div>\n        }\n      `,
+      options: [{ indentMode: 2, ignoreTernaryOperator: true }],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+
+    // ---- Tab indent + return JSX off by one. ----
+    {
+      code: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      output: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      options: [{ indentMode: 'tab', ignoreTernaryOperator: false }],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+    {
+      code: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      output: `\n\t\t\t\tconst F = () => {\n\t\t\t\t\tconst foo = true\n\t\t\t\t\t\t? <div id="id">test</div>\n\t\t\t\t\t\t: false;\n\n\t\t\t\t\treturn <div\n\t\t\t\t\t\tid="id"\n\t\t\t\t\t>\n\t\t\t\t\t\ttest\n\t\t\t\t\t</div>\n\t\t\t\t}\n`,
+      options: [{ indentMode: 'tab', ignoreTernaryOperator: true }],
+      errors: [{ messageId: 'wrongIndent' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `@stylistic/jsx-indent-props` rule to rslint. It enforces a consistent indentation style for the props of a JSX element — N spaces, a tab, or alignment with the first prop's column (`"first"`), with an optional `ignoreTernaryOperator`.

The `@stylistic` rule is byte-identical to `react/jsx-indent-props`, so the implementation is shared via `BuildRule`; only the registered name differs. This change also aligns a ternary-bump edge case in the shared implementation: when the first prop sits on the opening tag's `?`/`:` line, upstream's `getNodeIndent` gives `useOperator` priority over `useBracket`, so the indent bump carries to the new-line props. Verified by a differential against `@stylistic/eslint-plugin@5.10.0`, including real-code runs over rsbuild/rspack (93 diagnostics, 0 divergence).

## Related Links

- Rule docs: https://eslint.style/rules/jsx-indent-props
- Source: https://github.com/eslint-stylistic/eslint-stylistic/blob/main/packages/eslint-plugin/rules/jsx-indent-props/jsx-indent-props.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).