### PR TITLE
feat: port rule react/checked-requires-onchange-or-readonly

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -2,8 +2,9 @@ package react_plugin
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/boolean_prop_naming"
-	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/destructuring_assignment"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/button_has_type"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/checked_requires_onchange_or_readonly"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/destructuring_assignment"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/display_name"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_component_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_dom_props"
@@ -79,6 +80,7 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		boolean_prop_naming.BooleanPropNamingRule,
 		button_has_type.ButtonHasTypeRule,
+		checked_requires_onchange_or_readonly.CheckedRequiresOnchangeOrReadonlyRule,
 		destructuring_assignment.DestructuringAssignmentRule,
 		display_name.DisplayNameRule,
 		forbid_component_props.ForbidComponentPropsRule,

--- a/internal/plugins/react/reactutil/create_element.go
+++ b/internal/plugins/react/reactutil/create_element.go
@@ -101,14 +101,23 @@ func isPragmaFactoryCallCore(callee *ast.Node, pragma string, tc *checker.Checke
 	// chain terminated by the parens: ESTree freezes it into a `ChainExpression`,
 	// so upstream's `node.callee.type === 'MemberExpression'` check fails and the
 	// call is NOT recognized. tsgo keeps the explicit ParenthesizedExpression
-	// wrapper (it's lost only if we flatten it), so detect that shape first. A
+	// wrapper, so record whether the callee was parenthesized before flattening,
+	// then reject it when the flattened callee is an optional chain. A
 	// non-optional `(React.createElement)(...)` stays transparent and IS
 	// recognized; a bare `React?.createElement(...)` / `React.createElement?.(...)`
 	// has no wrapping paren and is likewise recognized — all matching upstream.
-	if callee.Kind == ast.KindParenthesizedExpression && ast.IsOptionalChain(ast.SkipParentheses(callee)) {
+	wasParenthesized := callee.Kind == ast.KindParenthesizedExpression
+	callee = ast.SkipParentheses(callee)
+	if callee == nil {
+		// Only reachable when the parenthesized inner is empty (`()`), which is
+		// itself a syntax error (such files aren't linted); guard anyway so a
+		// recovered AST can never nil-deref through `IsOptionalChain` or the
+		// `callee.Kind` checks below.
 		return false
 	}
-	callee = ast.SkipParentheses(callee)
+	if wasParenthesized && ast.IsOptionalChain(callee) {
+		return false
+	}
 
 	// Bare callee: `createElement(arg)` / `cloneElement(arg)` — recognized
 	// only when destructured from the pragma module. Mirrors upstream's

--- a/internal/plugins/react/reactutil/create_element.go
+++ b/internal/plugins/react/reactutil/create_element.go
@@ -12,12 +12,18 @@ import (
 // Pass an empty pragma to default to "React"; pass GetReactPragma(ctx.Settings)
 // to honor the user's `settings.react.pragma` configuration.
 //
-// Parentheses AND TS expression wrappers (`as` / `satisfies` / `<T>x` / `x!`)
-// are transparently skipped on both the callee itself and the pragma
-// identifier (e.g. `(React).createElement` / `(React as any).createElement`).
-// Optional-chain calls (`React?.createElement(...)`) are NOT recognized
-// (upstream's `node.callee.object.name` access fails on the OptionalCall
-// shape).
+// Parentheses are transparently skipped on both the callee and the pragma
+// identifier (e.g. `(React).createElement` / `(React.createElement)(...)`),
+// matching ESLint's paren flattening. TS expression wrappers
+// (`as` / `satisfies` / `<T>x` / `x!`) are NOT skipped, so
+// `(React as any).createElement` is NOT recognized — mirroring upstream, where
+// `node.callee.object.name` is undefined on a wrapped receiver.
+// Optional-chain pragma access (`React?.createElement(...)`, and the optional
+// call `React.createElement?.(...)`) IS recognized, matching upstream: espree
+// exposes `node.callee` as a `MemberExpression` (optional flag set). The one
+// exception is a *parenthesized* optional chain — `(React?.createElement)(...)`
+// — where the parens freeze the chain into a `ChainExpression` callee that
+// upstream does not match; this variant rejects it too.
 //
 // This non-checker variant only recognizes the member-access form. To
 // recognize bare `createElement(...)` calls (with the
@@ -39,7 +45,7 @@ func IsCreateElementCallWithChecker(callee *ast.Node, pragma string, tc *checker
 }
 
 func isCreateElementCallCore(callee *ast.Node, pragma string, tc *checker.Checker) bool {
-	return isPragmaFactoryCallCore(callee, pragma, tc, createElementOnly, false)
+	return isPragmaFactoryCallCore(callee, pragma, tc, createElementOnly)
 }
 
 // IsCreateOrCloneElementCall reports whether the callee resolves to
@@ -58,7 +64,7 @@ func isCreateElementCallCore(callee *ast.Node, pragma string, tc *checker.Checke
 // skipped — that would over-match relative to ESLint's JS-only AST and
 // is a divergence we deliberately avoid.
 func IsCreateOrCloneElementCall(callee *ast.Node, pragma string, tc *checker.Checker) bool {
-	return isPragmaFactoryCallCore(callee, pragma, tc, createOrCloneElement, true)
+	return isPragmaFactoryCallCore(callee, pragma, tc, createOrCloneElement)
 }
 
 type pragmaFactoryNames int
@@ -78,23 +84,31 @@ func (k pragmaFactoryNames) matches(name string) bool {
 	return false
 }
 
-func isPragmaFactoryCallCore(callee *ast.Node, pragma string, tc *checker.Checker, names pragmaFactoryNames, allowOptionalChain bool) bool {
+func isPragmaFactoryCallCore(callee *ast.Node, pragma string, tc *checker.Checker, names pragmaFactoryNames) bool {
 	if callee == nil {
 		return false
 	}
 	if pragma == "" {
 		pragma = DefaultReactPragma
 	}
-	// `IsCreateElementCall` (the public-named variant used by other rules)
-	// historically peels TS expression wrappers off the callee itself —
-	// keep that branch intact for backwards compatibility.
-	// `IsCreateOrCloneElementCall`, used by `no-array-index-key`, mirrors
-	// ESLint's JS-only AST and only skips parentheses on the callee.
-	if names == createElementOnly {
-		callee = SkipExpressionWrappers(callee)
-	} else {
-		callee = ast.SkipParentheses(callee)
+	// Only parentheses are transparent on the callee, matching ESLint's JS-only
+	// AST (ESTree flattens parens). TS expression wrappers
+	// (`as` / `satisfies` / `<T>x` / `x!`) are NOT peeled: upstream reads
+	// `node.callee.object.name`, which is undefined on a `TSAsExpression` /
+	// `TSNonNullExpression` receiver, so `(React as any).createElement` is not
+	// recognized — and neither is it here.
+	// A *parenthesized* optional chain — `(React?.createElement)(...)` — has its
+	// chain terminated by the parens: ESTree freezes it into a `ChainExpression`,
+	// so upstream's `node.callee.type === 'MemberExpression'` check fails and the
+	// call is NOT recognized. tsgo keeps the explicit ParenthesizedExpression
+	// wrapper (it's lost only if we flatten it), so detect that shape first. A
+	// non-optional `(React.createElement)(...)` stays transparent and IS
+	// recognized; a bare `React?.createElement(...)` / `React.createElement?.(...)`
+	// has no wrapping paren and is likewise recognized — all matching upstream.
+	if callee.Kind == ast.KindParenthesizedExpression && ast.IsOptionalChain(ast.SkipParentheses(callee)) {
+		return false
 	}
+	callee = ast.SkipParentheses(callee)
 
 	// Bare callee: `createElement(arg)` / `cloneElement(arg)` — recognized
 	// only when destructured from the pragma module. Mirrors upstream's
@@ -106,11 +120,11 @@ func isPragmaFactoryCallCore(callee *ast.Node, pragma string, tc *checker.Checke
 		return IsDestructuredFromPragmaImport(callee, pragma, tc)
 	}
 
-	// Member-access callee: `<pragma>.<name>(arg)`.
+	// Member-access callee: `<pragma>.<name>(arg)`. Optional-chain access
+	// (`React?.createElement(...)`) is accepted — upstream's `isCreateElement`
+	// / `isCreateCloneElement` see `node.callee` as a (possibly optional)
+	// MemberExpression and match it just the same.
 	if callee.Kind != ast.KindPropertyAccessExpression {
-		return false
-	}
-	if !allowOptionalChain && ast.IsOptionalChain(callee) {
 		return false
 	}
 	prop := callee.AsPropertyAccessExpression()
@@ -118,14 +132,9 @@ func isPragmaFactoryCallCore(callee *ast.Node, pragma string, tc *checker.Checke
 	if nameNode.Kind != ast.KindIdentifier || !names.matches(nameNode.AsIdentifier().Text) {
 		return false
 	}
-	// Pragma sub-expression: `IsCreateElementCall` historically peels TS
-	// wrappers; `IsCreateOrCloneElementCall` only peels parens to match
-	// ESLint's JS-only AST exactly.
-	var pragmaExpr *ast.Node
-	if names == createElementOnly {
-		pragmaExpr = SkipExpressionWrappers(prop.Expression)
-	} else {
-		pragmaExpr = ast.SkipParentheses(prop.Expression)
-	}
+	// Pragma sub-expression: only parens are transparent (see above). A TS
+	// wrapper on the receiver leaves a non-Identifier node, so it won't match —
+	// exactly like ESLint reading `.object.name` off a wrapped receiver.
+	pragmaExpr := ast.SkipParentheses(prop.Expression)
 	return pragmaExpr.Kind == ast.KindIdentifier && pragmaExpr.AsIdentifier().Text == pragma
 }

--- a/internal/plugins/react/rules/checked_requires_onchange_or_readonly/checked_requires_onchange_or_readonly.go
+++ b/internal/plugins/react/rules/checked_requires_onchange_or_readonly/checked_requires_onchange_or_readonly.go
@@ -1,0 +1,186 @@
+package checked_requires_onchange_or_readonly
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	msgMissingProperty           = "`checked` should be used with either `onChange` or `readOnly`."
+	msgExclusiveCheckedAttribute = "Use either `checked` or `defaultChecked`, but not both."
+)
+
+// targetProps mirrors upstream's `targetPropSet`. Only these four names are
+// tracked; every other attribute / property is ignored. Note the rule does
+// NOT inspect the `type` attribute — any `<input>` (or `createElement('input')`)
+// carrying `checked` is checked, regardless of `type="checkbox"` vs `"radio"`
+// vs anything else.
+var targetProps = map[string]struct{}{
+	"checked":        {},
+	"onChange":       {},
+	"readOnly":       {},
+	"defaultChecked": {},
+}
+
+type options struct {
+	ignoreMissingProperties         bool
+	ignoreExclusiveCheckedAttribute bool
+}
+
+func parseOptions(opts any) options {
+	o := options{}
+	optsMap := utils.GetOptionsMap(opts)
+	if optsMap == nil {
+		return o
+	}
+	if v, ok := optsMap["ignoreMissingProperties"].(bool); ok {
+		o.ignoreMissingProperties = v
+	}
+	if v, ok := optsMap["ignoreExclusiveCheckedAttribute"].(bool); ok {
+		o.ignoreExclusiveCheckedAttribute = v
+	}
+	return o
+}
+
+var CheckedRequiresOnchangeOrReadonlyRule = rule.Rule{
+	Name: "react/checked-requires-onchange-or-readonly",
+	Run: func(ctx rule.RuleContext, opts any) rule.RuleListeners {
+		o := parseOptions(opts)
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+
+		// checkAndReport mirrors upstream's `checkAttributesAndReport`: report
+		// only when `checked` is present, then emit the exclusive-attribute and
+		// missing-property diagnostics in that order (so a node carrying both
+		// `checked` and `defaultChecked` reports exclusiveCheckedAttribute first).
+		checkAndReport := func(node *ast.Node, propSet map[string]struct{}) {
+			if _, hasChecked := propSet["checked"]; !hasChecked {
+				return
+			}
+			if _, hasDefaultChecked := propSet["defaultChecked"]; !o.ignoreExclusiveCheckedAttribute && hasDefaultChecked {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "exclusiveCheckedAttribute",
+					Description: msgExclusiveCheckedAttribute,
+				})
+			}
+			_, hasOnChange := propSet["onChange"]
+			_, hasReadOnly := propSet["readOnly"]
+			if !o.ignoreMissingProperties && !hasOnChange && !hasReadOnly {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "missingProperty",
+					Description: msgMissingProperty,
+				})
+			}
+		}
+
+		// checkJsxElement handles the upstream `JSXOpeningElement` listener. In
+		// tsgo a self-closing `<input/>` is a JsxSelfClosingElement and a paired
+		// `<input></input>` produces a JsxOpeningElement, so both kinds route
+		// here. The element node itself is the report target, matching upstream's
+		// `report(..., { node })` on the JSXOpeningElement (whose loc is the
+		// opening tag, not the whole element).
+		checkJsxElement := func(node *ast.Node) {
+			if reactutil.GetJsxElementTypeString(node) != "input" {
+				return
+			}
+			checkAndReport(node, jsxPropSet(reactutil.GetJsxElementAttributes(node)))
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     checkJsxElement,
+			ast.KindJsxSelfClosingElement: checkJsxElement,
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if !reactutil.IsCreateElementCall(call.Expression, pragma) {
+					return
+				}
+				// Upstream requires `arguments[0]` to be a string Literal "input"
+				// and `arguments[1]` to be an ObjectExpression; anything else
+				// (missing args, non-literal tag, non-object props) bails out.
+				if call.Arguments == nil || len(call.Arguments.Nodes) < 2 {
+					return
+				}
+				firstArg := ast.SkipParentheses(call.Arguments.Nodes[0])
+				if firstArg.Kind != ast.KindStringLiteral || firstArg.AsStringLiteral().Text != "input" {
+					return
+				}
+				secondArg := ast.SkipParentheses(call.Arguments.Nodes[1])
+				if secondArg.Kind != ast.KindObjectLiteralExpression {
+					return
+				}
+				checkAndReport(node, objectPropSet(secondArg.AsObjectLiteralExpression()))
+			},
+		}
+	},
+}
+
+// jsxPropSet collects the subset of `targetProps` present as JSX attributes,
+// mirroring upstream `extractTargetProps(node.attributes, 'name')`.
+// reactutil.GetJsxPropName returns the plain attribute name for an identifier
+// attribute, "ns:name" for a namespaced one, and "spread" for a spread
+// attribute — none of which (besides a plain identifier) can land in
+// targetProps, exactly like upstream's `attr.name.name` access where a
+// spread has no `.name` and a namespaced `.name` is a node, not a string.
+func jsxPropSet(attrs []*ast.Node) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, attr := range attrs {
+		name := reactutil.GetJsxPropName(attr)
+		if _, ok := targetProps[name]; ok {
+			set[name] = struct{}{}
+		}
+	}
+	return set
+}
+
+// objectPropSet collects the subset of `targetProps` present as object keys,
+// mirroring upstream `extractTargetProps(secondArg.properties, 'key')`.
+func objectPropSet(obj *ast.ObjectLiteralExpression) map[string]struct{} {
+	set := make(map[string]struct{})
+	if obj.Properties == nil {
+		return set
+	}
+	for _, prop := range obj.Properties.Nodes {
+		name, ok := objectKeyName(prop)
+		if !ok {
+			continue
+		}
+		if _, isTarget := targetProps[name]; isTarget {
+			set[name] = struct{}{}
+		}
+	}
+	return set
+}
+
+// objectKeyName reproduces upstream's `prop.key.name` access on an object
+// property. Upstream reads `.name` without gating on `computed`, so:
+//   - `{ checked: … }`      → "checked"  (Identifier key)
+//   - `{ checked }`         → "checked"  (shorthand)
+//   - `{ [checked]: … }`    → "checked"  (computed Identifier — `.name` exists)
+//   - `{ "checked": … }`    → not matched (string Literal key has `.value`, not `.name`)
+//   - `{ ["checked"]: … }`  → not matched (computed string Literal key)
+//   - `{ ...rest }`         → not matched (SpreadAssignment has no `.key`)
+func objectKeyName(prop *ast.Node) (string, bool) {
+	var nameNode *ast.Node
+	switch prop.Kind {
+	case ast.KindPropertyAssignment:
+		nameNode = prop.AsPropertyAssignment().Name()
+	case ast.KindShorthandPropertyAssignment:
+		nameNode = prop.AsShorthandPropertyAssignment().Name()
+	default:
+		return "", false
+	}
+	if nameNode == nil {
+		return "", false
+	}
+	switch nameNode.Kind {
+	case ast.KindIdentifier:
+		return nameNode.AsIdentifier().Text, true
+	case ast.KindComputedPropertyName:
+		inner := ast.SkipParentheses(nameNode.AsComputedPropertyName().Expression)
+		if inner != nil && inner.Kind == ast.KindIdentifier {
+			return inner.AsIdentifier().Text, true
+		}
+	}
+	return "", false
+}

--- a/internal/plugins/react/rules/checked_requires_onchange_or_readonly/checked_requires_onchange_or_readonly.md
+++ b/internal/plugins/react/rules/checked_requires_onchange_or_readonly/checked_requires_onchange_or_readonly.md
@@ -1,0 +1,75 @@
+# checked-requires-onchange-or-readonly
+
+## Rule Details
+
+Enforce using `onChange` or `readOnly` attribute when `checked` is used on an `input` element (and on `React.createElement('input', ...)` calls).
+
+A controlled `<input>` whose `checked` value is fixed without an `onChange` handler can never be toggled by the user and triggers a React warning. This rule also forbids combining `checked` with `defaultChecked`, since an input is either controlled (`checked`) or uncontrolled (`defaultChecked`), never both.
+
+The check applies to every `input` element carrying `checked`, regardless of its `type`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<input type="checkbox" checked />
+<input type="radio" checked={true} />
+<input type="checkbox" checked={condition ? true : false} />
+<input type="checkbox" checked defaultChecked />
+
+React.createElement('input', { checked: false })
+React.createElement('input', { checked: true, defaultChecked: true })
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<input type="checkbox" checked onChange={() => {}} />
+<input type="checkbox" checked readOnly />
+<input type="checkbox" defaultChecked />
+
+React.createElement('input', { checked: true, onChange: noop })
+React.createElement('input', { checked: true, readOnly: true })
+```
+
+## Rule Options
+
+```json
+{ "react/checked-requires-onchange-or-readonly": ["error", { "ignoreMissingProperties": false, "ignoreExclusiveCheckedAttribute": false }] }
+```
+
+### ignoreMissingProperties
+
+Default: `false`. When `true`, an `input` with `checked` but no `onChange` / `readOnly` is allowed (the `missingProperty` diagnostic is suppressed).
+
+Examples of **correct** code for this rule with `{ "ignoreMissingProperties": true }`:
+
+```json
+{ "react/checked-requires-onchange-or-readonly": ["error", { "ignoreMissingProperties": true }] }
+```
+
+```jsx
+<input type="checkbox" checked />
+<input type="checkbox" checked={true} />
+```
+
+### ignoreExclusiveCheckedAttribute
+
+Default: `false`. When `true`, combining `checked` and `defaultChecked` is allowed (the `exclusiveCheckedAttribute` diagnostic is suppressed).
+
+Examples of **correct** code for this rule with `{ "ignoreExclusiveCheckedAttribute": true }`:
+
+```json
+{ "react/checked-requires-onchange-or-readonly": ["error", { "ignoreExclusiveCheckedAttribute": true }] }
+```
+
+```jsx
+<input type="checkbox" onChange={noop} checked defaultChecked />
+```
+
+## Limitations
+
+- Detects `<pragma>.createElement(...)` where `<pragma>` defaults to `React` and can be overridden via `settings.react.pragma` (e.g. `"Foo"` → `Foo.createElement(...)`). Destructured `createElement` (e.g. `import { createElement } from 'react'`) and `@jsx` comment pragmas are not supported.
+
+## Original Documentation
+
+- [react/checked-requires-onchange-or-readonly](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/checked-requires-onchange-or-readonly.md)

--- a/internal/plugins/react/rules/checked_requires_onchange_or_readonly/checked_requires_onchange_or_readonly_extras_test.go
+++ b/internal/plugins/react/rules/checked_requires_onchange_or_readonly/checked_requires_onchange_or_readonly_extras_test.go
@@ -1,0 +1,434 @@
+// TestCheckedRequiresOnchangeOrReadonlyExtras locks in branches and edge shapes
+// that the upstream test suite doesn't exercise. Each case carries an inline
+// comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+//
+// Dimension 4 rows that don't apply to this rule (it inspects JSX tag names,
+// attribute names, and createElement string/object arguments — never a member
+// receiver, class/function declaration, private field, or ancestor scope):
+//   - N/A: JSX tag names cannot carry paren / non-null / `as` / optional-chain wrappers.
+//   - N/A: element-access (`X['y']`) — the rule never reads dotted member access on user input.
+//   - N/A: PrivateIdentifier (`#x`) keys — illegal in object literals.
+//   - N/A: class / function declaration & container forms — the rule targets neither.
+//   - N/A: ancestor scope walks (getThisContainer / FindEnclosingScope) — none performed.
+//   - N/A: RestElement in a binding pattern — the rule never destructures (object SpreadAssignment IS covered below).
+package checked_requires_onchange_or_readonly
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestCheckedRequiresOnchangeOrReadonlyExtras(t *testing.T) {
+	ignoreMissing := map[string]interface{}{"ignoreMissingProperties": true}
+	ignoreExclusive := map[string]interface{}{"ignoreExclusiveCheckedAttribute": true}
+	pragmaFoo := map[string]interface{}{"react": map[string]interface{}{"pragma": "Foo"}}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &CheckedRequiresOnchangeOrReadonlyRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: object key forms that must NOT match ----
+		// Upstream reads `prop.key.name`; a string-literal key exposes `.value`,
+		// not `.name`, so it is invisible — even when its text is "checked".
+		{Code: `React.createElement('input', { 'checked': true })`, Tsx: true},
+		{Code: `React.createElement('input', { ['checked']: true })`, Tsx: true},
+		{Code: `React.createElement('input', { 'checked': true, 'onChange': noop })`, Tsx: true},
+		{Code: `React.createElement('input', { 0: true })`, Tsx: true},
+
+		// ---- Dimension 4: graceful degradation — no `checked` key present ----
+		{Code: `React.createElement('input', {})`, Tsx: true},
+		{Code: `React.createElement('input', { ...rest })`, Tsx: true},
+		{Code: `React.createElement('input', { onChange: noop })`, Tsx: true},
+		// JSX spread only / spread plus a non-checked target → no `checked` → ok.
+		{Code: `<input {...props} />`, Tsx: true},
+		{Code: `<input {...props} onChange={noop} />`, Tsx: true},
+
+		// ---- Branch lock-in: elementType != "input" → listener bails ----
+		{Code: `<select checked />`, Tsx: true},
+		{Code: `<Input checked />`, Tsx: true},     // capitalized → user component, not "input"
+		{Code: `<input.Foo checked />`, Tsx: true}, // member tag → "input.Foo" != "input"
+		{Code: `<INPUT checked />`, Tsx: true},     // elementType is case-sensitive
+
+		// ---- Branch lock-in: not a recognized createElement → CallExpression bails ----
+		{Code: `document.createElement('input', { checked: true })`, Tsx: true},
+		{Code: `notReact.createElement('input', { checked: true })`, Tsx: true},
+		// TS-wrapped pragma is NOT recognized (matches upstream — `.object.name`
+		// is undefined on a `TSAsExpression`). Differential-verified: 0 reports.
+		{Code: `(React as any).createElement('input', { checked: true })`, Tsx: true},
+		// A parenthesized optional chain freezes into a ChainExpression callee
+		// upstream → NOT recognized. Differential-verified: 0 reports. (Contrast
+		// the bare `React?.createElement(...)` below, which IS recognized.)
+		{Code: `(React?.createElement)('input', { checked: true })`, Tsx: true},
+		{Code: `((React?.createElement))('input', { checked: true })`, Tsx: true},
+		// Bare (destructured) createElement is not recognized by the member-form
+		// detector — documented Limitation, shared with sibling react rules.
+		{Code: `createElement('input', { checked: true })`, Tsx: true},
+
+		// ---- Branch lock-in: createElement first arg not the string "input" ----
+		{Code: `React.createElement('select', { checked: true })`, Tsx: true},
+		{Code: `React.createElement(Component, { checked: true })`, Tsx: true},
+		{Code: "React.createElement(`input`, { checked: true })", Tsx: true}, // template literal != string Literal
+		{Code: `React.createElement(42, { checked: true })`, Tsx: true},
+
+		// ---- Branch lock-in: createElement second arg not an ObjectExpression ----
+		{Code: `React.createElement('input')`, Tsx: true},
+		{Code: `React.createElement('input', null)`, Tsx: true},
+		{Code: `React.createElement('input', 'checked')`, Tsx: true},
+		{Code: `React.createElement('input', [checked])`, Tsx: true},
+
+		// ---- Dimension 4: namespaced JSX attribute name is not an Identifier → never matched ----
+		{Code: `<input ns:checked />`, Tsx: true},
+
+		// ---- Branch lock-in: no `checked` → checkAttributesAndReport returns early ----
+		{Code: `<input readOnly />`, Tsx: true},
+		{Code: `<input defaultChecked onChange={noop} />`, Tsx: true},
+		{Code: `React.createElement('input', { defaultChecked: true })`, Tsx: true},
+		{Code: `React.createElement('input', { onChange: noop, readOnly: true })`, Tsx: true},
+
+		// ---- Branch lock-in: onChange OR readOnly — either arm satisfies ----
+		{Code: `<input checked onChange={noop} readOnly />`, Tsx: true},
+
+		// ---- Branch lock-in: configured pragma — default React no longer matches ----
+		{
+			Code:     `React.createElement('input', { checked: true })`,
+			Settings: pragmaFoo,
+			Tsx:      true,
+		},
+
+		// ---- Real-user: correctly controlled inputs (the happy path the rule guards) ----
+		{Code: `<input type="checkbox" checked={isChecked} onChange={handleChange} />`, Tsx: true},
+		{Code: `<input type="radio" checked={value === 'a'} onChange={onChange} />`, Tsx: true},
+		// Real-user #3711: ignoreMissingProperties allows checked-only on the createElement path too.
+		{
+			Code:    `React.createElement('input', { checked: true })`,
+			Options: ignoreMissing,
+			Tsx:     true,
+		},
+
+		// ---- Options shape: array-wrapped config exercises GetOptionsMap's array branch ----
+		{
+			Code:    `<input type="checkbox" checked />`,
+			Options: []interface{}{map[string]interface{}{"ignoreMissingProperties": true}},
+			Tsx:     true,
+		},
+
+		// ---- Dimension 4: namespaced JSX *tag* → elementType "svg:input" != "input" ----
+		{Code: `<svg:input checked />`, Tsx: true},
+
+		// ---- Branch lock-in: createElement second arg is a variable (not an ObjectExpression) ----
+		{Code: `React.createElement('input', props)`, Tsx: true},
+
+		// ---- Dimension 4: computed key whose inner expr is NOT an Identifier → no `.name` ----
+		{Code: `React.createElement('input', { [obj.checked]: true })`, Tsx: true},
+
+		// ---- Robustness: duplicate attributes de-dupe like upstream's Set ----
+		{Code: `<input checked onChange={a} onChange={b} />`, Tsx: true},
+
+		// ---- Branch lock-in: defaultChecked without checked never reports (early return) ----
+		{Code: `<input defaultChecked readOnly />`, Tsx: true},
+
+		// ---- Real-user: a fully-wired controlled radio ----
+		{Code: `<input type="radio" name="group" value="a" checked={sel === 'a'} onChange={onSel} />`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: createElement callee / argument paren wrappers (ESTree flattens parens) ----
+		{
+			Code: `(React).createElement('input', { checked: true })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `(React.createElement)('input', { checked: true })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		// Optional-chain pragma access — recognized, matching upstream (espree
+		// callee is a MemberExpression with the optional flag). Differential-
+		// verified against eslint-plugin-react: this reports.
+		{
+			Code: `React?.createElement('input', { checked: true })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		// Optional *call* `React.createElement?.(...)` — bare (no wrapping paren),
+		// so the chain isn't frozen; recognized. Differential-verified: reports.
+		{
+			Code: `React.createElement?.('input', { checked: true })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement(('input'), { checked: true })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement('input', ({ checked: true }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 4: object key forms that DO match upstream `prop.key.name` ----
+		// Computed Identifier key: upstream reads `.name` without gating on
+		// `computed`, so `[checked]` matches exactly like `checked`.
+		{
+			Code: `React.createElement('input', { [checked]: true })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		// Shorthand property.
+		{
+			Code: `React.createElement('input', { checked })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 4: graceful degradation — spread present, `checked` still found ----
+		{
+			Code: `<input checked {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement('input', { checked: true, ...rest })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 2: nesting — listener fires on the inner input, not the container ----
+		{
+			Code: `<div><input type="checkbox" checked /></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `React.createElement('div', null, React.createElement('input', { checked: true }))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 34},
+			},
+		},
+		// Two siblings: only the one missing onChange/readOnly is reported (no bleed).
+		{
+			Code: `<div><input checked /><input checked readOnly /></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- Dimension 4: paired (non-self-closing) input drives the JsxOpeningElement
+		//      listener; the report targets the opening tag, not the whole element ----
+		{
+			Code: `<input checked></input>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+			},
+		},
+
+		// ---- Dimension 4: full position assertions (self-closing JSX + createElement) ----
+		{
+			Code: `<input type="radio" checked />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingProperty",
+					Message:   "`checked` should be used with either `onChange` or `readOnly`.",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 31,
+				},
+			},
+		},
+		{
+			Code: `React.createElement('input', { checked: true })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1, EndLine: 1, EndColumn: 48},
+			},
+		},
+
+		// ---- Dimension 4: multi-line cases (start/end span across lines) ----
+		{
+			Code: "<input\n  type=\"checkbox\"\n  checked\n/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1, EndLine: 4, EndColumn: 3},
+			},
+		},
+		{
+			Code: "React.createElement('input', {\n  checked: true\n})",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1, EndLine: 3, EndColumn: 3},
+			},
+		},
+
+		// ---- Locks in: the attribute value is ignored — only presence matters (even checked={false}) ----
+		{
+			Code: `<input checked={false} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Locks in: the `type` attribute is NOT gated — any input with `checked` is checked ----
+		{
+			Code: `<input checked />`, // no type at all
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="text" checked />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="hidden" checked />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Locks in: configured `settings.react.pragma` recognizes Foo.createElement ----
+		{
+			Code:     `Foo.createElement('input', { checked: true })`,
+			Settings: pragmaFoo,
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Real-user #3711: the two options isolate to their own diagnostic (non-inverted) ----
+		// ignoreMissingProperties suppresses ONLY missingProperty; exclusive remains.
+		{
+			Code:    `React.createElement('input', { checked: true, defaultChecked: true })`,
+			Options: ignoreMissing,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "exclusiveCheckedAttribute",
+					Message:   "Use either `checked` or `defaultChecked`, but not both.",
+					Line:      1, Column: 1,
+				},
+			},
+		},
+		// ignoreExclusiveCheckedAttribute suppresses ONLY exclusive; missing remains.
+		{
+			Code:    `React.createElement('input', { checked: true, defaultChecked: true })`,
+			Options: ignoreExclusive,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Real-user: controlled checkbox missing its onChange handler (the canonical bug) ----
+		{
+			Code: `<input type="checkbox" checked={state.checked} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Options shape: array-wrapped config exercises GetOptionsMap's array branch ----
+		{
+			Code:    `<input type="checkbox" checked defaultChecked />`,
+			Options: []interface{}{map[string]interface{}{"ignoreExclusiveCheckedAttribute": true}},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 4: multi-level parenthesized first arg (ESTree flattens all levels) ----
+		{
+			Code: `React.createElement((('input')), { checked: true })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 4: computed key wrapping a parenthesized Identifier → still `.name` "checked" ----
+		{
+			Code: `React.createElement('input', { [(checked)]: true })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Robustness: duplicate object key collapses to one `checked` (upstream Set) ----
+		{
+			Code: `React.createElement('input', { checked: true, checked: false })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 4: JSX spread BEFORE checked — order-independent, spread is opaque ----
+		{
+			Code: `<input {...props} checked />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 4: TS-only value wrappers don't affect name-presence detection ----
+		{
+			Code: `<input checked={x as boolean} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input checked={x!} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Real-user: `disabled` is not a substitute for onChange/readOnly ----
+		{
+			Code: `<input type="checkbox" checked disabled />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/checked_requires_onchange_or_readonly/checked_requires_onchange_or_readonly_upstream_test.go
+++ b/internal/plugins/react/rules/checked_requires_onchange_or_readonly/checked_requires_onchange_or_readonly_upstream_test.go
@@ -1,0 +1,151 @@
+// TestCheckedRequiresOnchangeOrReadonlyUpstream migrates the full valid/invalid
+// suite from upstream tests/lib/rules/checked-requires-onchange-or-readonly.js
+// 1:1. Position assertions cover line/column for every invalid case. rslint-
+// specific lock-in cases (edge shapes, branch lock-ins, real-user shapes) live
+// in the checked_requires_onchange_or_readonly_extras_test.go file.
+package checked_requires_onchange_or_readonly
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestCheckedRequiresOnchangeOrReadonlyUpstream(t *testing.T) {
+	ignoreMissing := map[string]interface{}{"ignoreMissingProperties": true}
+	ignoreExclusive := map[string]interface{}{"ignoreExclusiveCheckedAttribute": true}
+	bothIgnore := map[string]interface{}{"ignoreMissingProperties": true, "ignoreExclusiveCheckedAttribute": true}
+	bothFalse := map[string]interface{}{"ignoreMissingProperties": false, "ignoreExclusiveCheckedAttribute": false}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &CheckedRequiresOnchangeOrReadonlyRule, []rule_tester.ValidTestCase{
+		{Code: `<input type="checkbox" />`, Tsx: true},
+		{Code: `<input type="checkbox" onChange={noop} />`, Tsx: true},
+		{Code: `<input type="checkbox" readOnly />`, Tsx: true},
+		{Code: `<input type="checkbox" checked onChange={noop} />`, Tsx: true},
+		{Code: `<input type="checkbox" checked={true} onChange={noop} />`, Tsx: true},
+		{Code: `<input type="checkbox" checked={false} onChange={noop} />`, Tsx: true},
+		{Code: `<input type="checkbox" checked readOnly />`, Tsx: true},
+		{Code: `<input type="checkbox" checked={true} readOnly />`, Tsx: true},
+		{Code: `<input type="checkbox" checked={false} readOnly />`, Tsx: true},
+		{Code: `<input type="checkbox" defaultChecked />`, Tsx: true},
+		{Code: `React.createElement('input')`, Tsx: true},
+		{Code: `React.createElement('input', { checked: true, onChange: noop })`, Tsx: true},
+		{Code: `React.createElement('input', { checked: false, onChange: noop })`, Tsx: true},
+		{Code: `React.createElement('input', { checked: true, readOnly: true })`, Tsx: true},
+		{Code: `React.createElement('input', { checked: true, onChange: noop, readOnly: true })`, Tsx: true},
+		{Code: `React.createElement('input', { checked: foo, onChange: noop, readOnly: true })`, Tsx: true},
+		{
+			Code:    `<input type="checkbox" checked />`,
+			Options: ignoreMissing,
+			Tsx:     true,
+		},
+		{
+			Code:    `<input type="checkbox" checked={true} />`,
+			Options: ignoreMissing,
+			Tsx:     true,
+		},
+		{
+			Code:    `<input type="checkbox" onChange={noop} checked defaultChecked />`,
+			Options: ignoreExclusive,
+			Tsx:     true,
+		},
+		{
+			Code:    `<input type="checkbox" onChange={noop} checked={true} defaultChecked />`,
+			Options: ignoreExclusive,
+			Tsx:     true,
+		},
+		{
+			Code:    `<input type="checkbox" onChange={noop} checked defaultChecked />`,
+			Options: bothIgnore,
+			Tsx:     true,
+		},
+		{Code: `<span/>`, Tsx: true},
+		{Code: `React.createElement('span')`, Tsx: true},
+		{Code: `(()=>{})()`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `<input type="radio" checked />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="radio" checked={true} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="checkbox" checked />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="checkbox" checked={true} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="checkbox" checked={condition ? true : false} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<input type="checkbox" checked defaultChecked />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "exclusiveCheckedAttribute", Line: 1, Column: 1},
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("input", { checked: false })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("input", { checked: true, defaultChecked: true })`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "exclusiveCheckedAttribute", Line: 1, Column: 1},
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<input type="checkbox" checked defaultChecked />`,
+			Options: ignoreMissing,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "exclusiveCheckedAttribute", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<input type="checkbox" checked defaultChecked />`,
+			Options: ignoreExclusive,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<input type="checkbox" checked defaultChecked />`,
+			Options: bothFalse,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "exclusiveCheckedAttribute", Line: 1, Column: 1},
+				{MessageId: "missingProperty", Line: 1, Column: 1},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components_test.go
+++ b/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components_test.go
@@ -602,11 +602,22 @@ func TestNoUnstableNestedComponentsRule(t *testing.T) {
         }
       `, Tsx: true},
 
-		// ---- TS-as wrapper around createElement callee — pragma still
-		// recognized after unwrap ----
+		// ---- TS-as wrapper on a createElement callee is NOT unwrapped, matching
+		// upstream eslint-plugin-react (differential-verified: 0 reports). The
+		// receiver `(React as any)` isn't an Identifier named `React`, so the call
+		// isn't recognized as createElement — neither function below is treated as
+		// a JSX-returning component, so nothing is flagged. ----
 		{Code: `
         function ParentComponent() {
           return ((React as any).createElement)("div", null);
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          function UnstableNestedComponent() {
+            return (React as any).createElement("div", null);
+          }
+          return <UnstableNestedComponent />;
         }
       `, Tsx: true},
 
@@ -1511,23 +1522,6 @@ func TestNoUnstableNestedComponentsRule(t *testing.T) {
 		// tsgo-specific edge cases beyond the upstream test suite
 		// ============================================================
 
-		// ---- TS wrapper: `(X as any)` callee on createElement should still
-		// classify the inner arrow as JSX-returning ----
-		{
-			Code: `
-        function ParentComponent() {
-          function UnstableNestedComponent() {
-            return (React as any).createElement("div", null);
-          }
-          return <UnstableNestedComponent />;
-        }
-      `,
-			Tsx: true,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{Message: errorMessage, Line: 3, Column: 11},
-			},
-		},
-
 		// ---- TS wrapper: `<div/> satisfies JSX.Element` return ----
 		{
 			Code: `
@@ -2023,7 +2017,7 @@ func TestNoUnstableNestedComponentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Message: errorMessage,
-					Line: 3, Column: 11, EndLine: 9, EndColumn: 12,
+					Line:    3, Column: 11, EndLine: 9, EndColumn: 12,
 				},
 			},
 		},
@@ -2048,7 +2042,7 @@ func TestNoUnstableNestedComponentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Message: errorMessage,
-					Line: 3, Column: 11, EndLine: 11, EndColumn: 12,
+					Line:    3, Column: 11, EndLine: 11, EndColumn: 12,
 				},
 			},
 		},

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -88,6 +88,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/destructuring-assignment.test.ts',
     './tests/eslint-plugin-react/rules/boolean-prop-naming.test.ts',
     './tests/eslint-plugin-react/rules/button-has-type.test.ts',
+    './tests/eslint-plugin-react/rules/checked-requires-onchange-or-readonly.test.ts',
     './tests/eslint-plugin-react/rules/forbid-component-props.test.ts',
     './tests/eslint-plugin-react/rules/forbid-dom-props.test.ts',
     './tests/eslint-plugin-react/rules/forbid-elements.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/checked-requires-onchange-or-readonly.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/checked-requires-onchange-or-readonly.test.ts
@@ -1,0 +1,121 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('checked-requires-onchange-or-readonly', {} as never, {
+  valid: [
+    { code: `<input type="checkbox" />` },
+    { code: `<input type="checkbox" onChange={noop} />` },
+    { code: `<input type="checkbox" readOnly />` },
+    { code: `<input type="checkbox" checked onChange={noop} />` },
+    { code: `<input type="checkbox" checked={true} onChange={noop} />` },
+    { code: `<input type="checkbox" checked={false} onChange={noop} />` },
+    { code: `<input type="checkbox" checked readOnly />` },
+    { code: `<input type="checkbox" checked={true} readOnly />` },
+    { code: `<input type="checkbox" checked={false} readOnly />` },
+    { code: `<input type="checkbox" defaultChecked />` },
+    { code: `React.createElement('input')` },
+    { code: `React.createElement('input', { checked: true, onChange: noop })` },
+    {
+      code: `React.createElement('input', { checked: false, onChange: noop })`,
+    },
+    { code: `React.createElement('input', { checked: true, readOnly: true })` },
+    {
+      code: `React.createElement('input', { checked: true, onChange: noop, readOnly: true })`,
+    },
+    {
+      code: `React.createElement('input', { checked: foo, onChange: noop, readOnly: true })`,
+    },
+    {
+      code: `<input type="checkbox" checked />`,
+      options: [{ ignoreMissingProperties: true }],
+    },
+    {
+      code: `<input type="checkbox" checked={true} />`,
+      options: [{ ignoreMissingProperties: true }],
+    },
+    {
+      code: `<input type="checkbox" onChange={noop} checked defaultChecked />`,
+      options: [{ ignoreExclusiveCheckedAttribute: true }],
+    },
+    {
+      code: `<input type="checkbox" onChange={noop} checked={true} defaultChecked />`,
+      options: [{ ignoreExclusiveCheckedAttribute: true }],
+    },
+    {
+      code: `<input type="checkbox" onChange={noop} checked defaultChecked />`,
+      options: [
+        {
+          ignoreMissingProperties: true,
+          ignoreExclusiveCheckedAttribute: true,
+        },
+      ],
+    },
+    { code: `<span/>` },
+    { code: `React.createElement('span')` },
+    { code: `(()=>{})()` },
+  ],
+  invalid: [
+    {
+      code: `<input type="radio" checked />`,
+      errors: [{ messageId: 'missingProperty' }],
+    },
+    {
+      code: `<input type="radio" checked={true} />`,
+      errors: [{ messageId: 'missingProperty' }],
+    },
+    {
+      code: `<input type="checkbox" checked />`,
+      errors: [{ messageId: 'missingProperty' }],
+    },
+    {
+      code: `<input type="checkbox" checked={true} />`,
+      errors: [{ messageId: 'missingProperty' }],
+    },
+    {
+      code: `<input type="checkbox" checked={condition ? true : false} />`,
+      errors: [{ messageId: 'missingProperty' }],
+    },
+    {
+      code: `<input type="checkbox" checked defaultChecked />`,
+      errors: [
+        { messageId: 'exclusiveCheckedAttribute' },
+        { messageId: 'missingProperty' },
+      ],
+    },
+    {
+      code: `React.createElement("input", { checked: false })`,
+      errors: [{ messageId: 'missingProperty' }],
+    },
+    {
+      code: `React.createElement("input", { checked: true, defaultChecked: true })`,
+      errors: [
+        { messageId: 'exclusiveCheckedAttribute' },
+        { messageId: 'missingProperty' },
+      ],
+    },
+    {
+      code: `<input type="checkbox" checked defaultChecked />`,
+      options: [{ ignoreMissingProperties: true }],
+      errors: [{ messageId: 'exclusiveCheckedAttribute' }],
+    },
+    {
+      code: `<input type="checkbox" checked defaultChecked />`,
+      options: [{ ignoreExclusiveCheckedAttribute: true }],
+      errors: [{ messageId: 'missingProperty' }],
+    },
+    {
+      code: `<input type="checkbox" checked defaultChecked />`,
+      options: [
+        {
+          ignoreMissingProperties: false,
+          ignoreExclusiveCheckedAttribute: false,
+        },
+      ],
+      errors: [
+        { messageId: 'exclusiveCheckedAttribute' },
+        { messageId: 'missingProperty' },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -304,6 +304,7 @@ nunc
 objectbindingpattern
 objectliteralexpression
 onblur
+onchange
 onclick
 onfocus
 onmouseout


### PR DESCRIPTION
## Summary

Port the `react/checked-requires-onchange-or-readonly` rule from eslint-plugin-react to rslint.

It enforces that an `<input>` (or `React.createElement('input', ...)`) using `checked` also has `onChange` or `readOnly`, and forbids combining `checked` with `defaultChecked`.

Achieving full upstream parity required aligning the shared `reactutil.IsCreateElementCall` detector with eslint-plugin-react's `isCreateElement`:

- accept optional-chain pragma access (`React?.createElement(...)`);
- reject parenthesized optional chains (`(React?.createElement)(...)`) and TS-wrapped pragmas (`(React as any).createElement(...)`), which upstream does not recognize.

These were differential-verified against eslint-plugin-react. The same divergence affected `no_unstable_nested_components` (which uses the same detector), so its two TS-wrapper test cases were corrected to match upstream.

## Related Links

- Rule documentation: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/checked-requires-onchange-or-readonly.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/checked-requires-onchange-or-readonly.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).