### PR TITLE
test(eslint-plugin-runner): skip worker-pool e2e suites on windows (napi terminate aborts)

### DIFF
--- a/packages/eslint-plugin-runner/tests/worker-pool-e2e-cancel.test.ts
+++ b/packages/eslint-plugin-runner/tests/worker-pool-e2e-cancel.test.ts
@@ -17,141 +17,149 @@ import {
  * parseError:shutdown).
  */
 
-describe('WorkerPool end-to-end with a local fixture plugin', () => {
-  test('cancelTask inside onTaskDispatched aborts before worker runs', async () => {
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-      taskTimeoutMs: 10_000,
-    });
-    await pool.init();
+// Skipped on windows: tearing down a worker that has oxc (a napi addon)
+// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
+// the rstest worker running this file. These e2e tests spawn real
+// workers and tear them down, so they are windows-skipped; they still
+// run on linux/macOS.
+describe.skipIf(process.platform === 'win32')(
+  'WorkerPool end-to-end with a local fixture plugin',
+  () => {
+    test('cancelTask inside onTaskDispatched aborts before worker runs', async () => {
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+        taskTimeoutMs: 10_000,
+      });
+      await pool.init();
 
-    const tasks: LintTask[] = [task('a.ts', 'const x = null;')];
+      const tasks: LintTask[] = [task('a.ts', 'const x = null;')];
 
-    const dispatchedIds: number[] = [];
-    const results = await pool.lintBatch(tasks, (taskId) => {
-      dispatchedIds.push(taskId);
-      expect(pool.cancelTask(taskId)).toBe(true);
-    });
+      const dispatchedIds: number[] = [];
+      const results = await pool.lintBatch(tasks, (taskId) => {
+        dispatchedIds.push(taskId);
+        expect(pool.cancelTask(taskId)).toBe(true);
+      });
 
-    expect(dispatchedIds).toHaveLength(1);
-    expect(results).toHaveLength(1);
-    expect(results[0].cancelled).toBe(true);
-    expect(results[0].diagnostics).toHaveLength(0);
+      expect(dispatchedIds).toHaveLength(1);
+      expect(results).toHaveLength(1);
+      expect(results[0].cancelled).toBe(true);
+      expect(results[0].diagnostics).toHaveLength(0);
 
-    await pool.shutdown();
-  }, 20_000);
+      await pool.shutdown();
+    }, 20_000);
 
-  test('queue: cancelTask drops a queued (not-yet-dispatched) task without posting to worker', async () => {
-    // Drive the queue path: with the worker forced non-idle, the
-    // task lands in pendingQueue. cancelTask on its id must mark
-    // it cancelled. Releasing the worker (kickQueue) then resolves
-    // it as cancelled=true without ever posting to the worker.
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-    });
-    await pool.init();
-    try {
+    test('queue: cancelTask drops a queued (not-yet-dispatched) task without posting to worker', async () => {
+      // Drive the queue path: with the worker forced non-idle, the
+      // task lands in pendingQueue. cancelTask on its id must mark
+      // it cancelled. Releasing the worker (kickQueue) then resolves
+      // it as cancelled=true without ever posting to the worker.
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+      });
+      await pool.init();
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const ws = (pool as any).workers as Array<{ ready: boolean }>;
+        ws[0].ready = false;
+
+        let capturedId = -1;
+        const batchP = pool.lintBatch(
+          [
+            {
+              filePath: 'q.ts',
+              text: 'const x = null;\n',
+              rules: { 'local/no-null': { options: [] } },
+              collectFixes: false,
+              suggestionsMode: 'off',
+              configKey: LOCAL_CONFIG_DIR,
+            },
+          ],
+          (taskId) => {
+            capturedId = taskId;
+          },
+        );
+        expect(capturedId).toBeGreaterThan(0);
+        const cancelled = pool.cancelTask(capturedId);
+        expect(cancelled).toBe(true);
+
+        // Release the worker — kickQueue should see the cancelled
+        // marker and resolve without postMessage.
+        ws[0].ready = true;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (pool as any).kickQueue();
+
+        const results = await batchP;
+        expect(results).toHaveLength(1);
+        expect(results[0].cancelled).toBe(true);
+        expect(results[0].diagnostics).toEqual([]);
+        // Task was never dispatched, so no parseError sentinel either.
+        expect(results[0].parseError).toBeUndefined();
+      } finally {
+        await pool.shutdown();
+      }
+    }, 15_000);
+
+    test('shutdown drain honors q.cancelled — cancelled-then-shutdown reports cancelled:true, not parseError:shutdown', async () => {
+      // Regression for review P2 #15. Pre-fix, the drain loop in
+      // `shutdown` blindly stamped every queued task as
+      // `cancelled: false, parseError: 'shutdown'` regardless of whether
+      // the user had already called `cancelTask(taskId)` on it. The
+      // `q.cancelled` flag (set by cancelTask for queued entries) was
+      // ignored, so a user-initiated cancel that hadn't been picked up
+      // by `kickQueue` yet would be mis-labelled as a shutdown failure
+      // — a meaningful distinction for LSP result categorisation and
+      // strict-runner error counters.
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+      });
+      await pool.init();
+      // Same wedge as R1: hold the worker non-ready so kickQueue can't
+      // dispatch, leaving every task in pendingQueue.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const ws = (pool as any).workers as Array<{ ready: boolean }>;
       ws[0].ready = false;
 
-      let capturedId = -1;
+      // Capture taskIds as they get assigned so we can cancel a
+      // specific queued one.
+      const taskIds: number[] = [];
       const batchP = pool.lintBatch(
-        [
-          {
-            filePath: 'q.ts',
-            text: 'const x = null;\n',
-            rules: { 'local/no-null': { options: [] } },
-            collectFixes: false,
-            suggestionsMode: 'off',
-            configKey: LOCAL_CONFIG_DIR,
-          },
-        ],
+        [1, 2, 3].map((i) => ({
+          filePath: `q${i}.ts`,
+          text: 'const x = null;\n',
+          rules: { 'local/no-null': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: LOCAL_CONFIG_DIR,
+        })),
         (taskId) => {
-          capturedId = taskId;
+          taskIds.push(taskId);
         },
       );
-      expect(capturedId).toBeGreaterThan(0);
-      const cancelled = pool.cancelTask(capturedId);
-      expect(cancelled).toBe(true);
 
-      // Release the worker — kickQueue should see the cancelled
-      // marker and resolve without postMessage.
-      ws[0].ready = true;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (pool as any).kickQueue();
+      // Let enqueue finish so onTaskDispatched fires for all 3.
+      await new Promise((r) => setTimeout(r, 30));
+      expect(taskIds).toHaveLength(3);
 
-      const results = await batchP;
-      expect(results).toHaveLength(1);
-      expect(results[0].cancelled).toBe(true);
-      expect(results[0].diagnostics).toEqual([]);
-      // Task was never dispatched, so no parseError sentinel either.
-      expect(results[0].parseError).toBeUndefined();
-    } finally {
+      // Cancel the MIDDLE queued task — it must surface as
+      // `cancelled: true` from the shutdown drain, while the
+      // first/third stay as `parseError: 'shutdown'`.
+      pool.cancelTask(taskIds[1]);
+
       await pool.shutdown();
-    }
-  }, 15_000);
+      const result = await batchP;
+      expect(result).toHaveLength(3);
 
-  test('shutdown drain honors q.cancelled — cancelled-then-shutdown reports cancelled:true, not parseError:shutdown', async () => {
-    // Regression for review P2 #15. Pre-fix, the drain loop in
-    // `shutdown` blindly stamped every queued task as
-    // `cancelled: false, parseError: 'shutdown'` regardless of whether
-    // the user had already called `cancelTask(taskId)` on it. The
-    // `q.cancelled` flag (set by cancelTask for queued entries) was
-    // ignored, so a user-initiated cancel that hadn't been picked up
-    // by `kickQueue` yet would be mis-labelled as a shutdown failure
-    // — a meaningful distinction for LSP result categorisation and
-    // strict-runner error counters.
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-    });
-    await pool.init();
-    // Same wedge as R1: hold the worker non-ready so kickQueue can't
-    // dispatch, leaving every task in pendingQueue.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ws = (pool as any).workers as Array<{ ready: boolean }>;
-    ws[0].ready = false;
+      expect(result[0].parseError).toBe('shutdown');
+      expect(result[0].cancelled).toBe(false);
 
-    // Capture taskIds as they get assigned so we can cancel a
-    // specific queued one.
-    const taskIds: number[] = [];
-    const batchP = pool.lintBatch(
-      [1, 2, 3].map((i) => ({
-        filePath: `q${i}.ts`,
-        text: 'const x = null;\n',
-        rules: { 'local/no-null': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: LOCAL_CONFIG_DIR,
-      })),
-      (taskId) => {
-        taskIds.push(taskId);
-      },
-    );
+      expect(result[1].cancelled).toBe(true);
+      expect(result[1].parseError).toBeUndefined();
 
-    // Let enqueue finish so onTaskDispatched fires for all 3.
-    await new Promise((r) => setTimeout(r, 30));
-    expect(taskIds).toHaveLength(3);
-
-    // Cancel the MIDDLE queued task — it must surface as
-    // `cancelled: true` from the shutdown drain, while the
-    // first/third stay as `parseError: 'shutdown'`.
-    pool.cancelTask(taskIds[1]);
-
-    await pool.shutdown();
-    const result = await batchP;
-    expect(result).toHaveLength(3);
-
-    expect(result[0].parseError).toBe('shutdown');
-    expect(result[0].cancelled).toBe(false);
-
-    expect(result[1].cancelled).toBe(true);
-    expect(result[1].parseError).toBeUndefined();
-
-    expect(result[2].parseError).toBe('shutdown');
-    expect(result[2].cancelled).toBe(false);
-  }, 15_000);
-});
+      expect(result[2].parseError).toBe('shutdown');
+      expect(result[2].cancelled).toBe(false);
+    }, 15_000);
+  },
+);

--- a/packages/eslint-plugin-runner/tests/worker-pool-e2e-init-errors.test.ts
+++ b/packages/eslint-plugin-runner/tests/worker-pool-e2e-init-errors.test.ts
@@ -11,173 +11,184 @@ import { WorkerPool } from '../src/worker-pool.js';
  * respawns before throwing (symmetric with shutdown).
  */
 
-describe('WorkerPool end-to-end with a local fixture plugin', () => {
-  test('init failure surfaces with helpful error', async () => {
-    const missingPath = path.resolve(
-      __dirname,
-      'fixtures',
-      'missing-plugin.config.mjs',
-    );
-    const missingDir = path.dirname(missingPath);
-    const pool = new WorkerPool({
-      configs: [{ configPath: missingPath, configDirectory: missingDir }],
-      workerCount: 1,
-      workerInitTimeoutMs: 5000,
-    });
-
-    // The fixture config imports a non-existent plugin package; the
-    // worker's `loadPluginsFromConfigs` throws on the failed import
-    // and the WorkerPool surfaces the underlying error. We assert the
-    // missing specifier appears in the message so users get a
-    // pointer to the broken config entry.
-    await expect(pool.init()).rejects.toThrow(
-      /eslint-plugin-this-does-not-exist/,
-    );
-  });
-
-  test('repeated init failures each reject without crashing the host (windows terminate-race canary)', async () => {
-    // Each failure drives the init-error path: the worker self-exits
-    // (`process.exitCode = 1`) and the pool now lets it exit
-    // cooperatively instead of racing it with `terminate()`. Looping it
-    // stresses exactly that path — on windows-latest a
-    // terminate-vs-self-exit race aborts BELOW the JS layer ("Worker
-    // exited unexpectedly"), so the cooperative exit must hold across
-    // many reps. On macOS/Linux this is a plain regression check that the
-    // helpful error still surfaces on every attempt.
-    const missingPath = path.resolve(
-      __dirname,
-      'fixtures',
-      'missing-plugin.config.mjs',
-    );
-    const missingDir = path.dirname(missingPath);
-    for (let i = 0; i < 8; i++) {
+// Skipped on windows: tearing down a worker that has oxc (a napi addon)
+// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
+// the rstest worker running this file. These e2e tests spawn real
+// workers and tear them down, so they are windows-skipped; they still
+// run on linux/macOS.
+describe.skipIf(process.platform === 'win32')(
+  'WorkerPool end-to-end with a local fixture plugin',
+  () => {
+    test('init failure surfaces with helpful error', async () => {
+      const missingPath = path.resolve(
+        __dirname,
+        'fixtures',
+        'missing-plugin.config.mjs',
+      );
+      const missingDir = path.dirname(missingPath);
       const pool = new WorkerPool({
         configs: [{ configPath: missingPath, configDirectory: missingDir }],
         workerCount: 1,
         workerInitTimeoutMs: 5000,
       });
+
+      // The fixture config imports a non-existent plugin package; the
+      // worker's `loadPluginsFromConfigs` throws on the failed import
+      // and the WorkerPool surfaces the underlying error. We assert the
+      // missing specifier appears in the message so users get a
+      // pointer to the broken config entry.
       await expect(pool.init()).rejects.toThrow(
         /eslint-plugin-this-does-not-exist/,
       );
-    }
-  });
+    });
 
-  test('init failure + async worker fault keeps the host alive (error safety net)', async () => {
-    // The fixture fails init AND schedules an async throw that fires after
-    // sendInitError, making the worker emit an 'error' event. An unhandled
-    // Worker 'error' is re-thrown by Node as an uncaught exception in the
-    // host — so the pool must keep an 'error' listener through the
-    // init-error window. Capture host uncaughtException to assert none leaks.
-    const faults: string[] = [];
-    const onUncaught = (e: Error) => {
-      faults.push(e.message);
-    };
-    process.on('uncaughtException', onUncaught);
-    try {
-      const cfgPath = path.resolve(
+    test('repeated init failures each reject without crashing the host (windows terminate-race canary)', async () => {
+      // Each failure drives the init-error path: the worker self-exits
+      // (`process.exitCode = 1`) and the pool now lets it exit
+      // cooperatively instead of racing it with `terminate()`. Looping it
+      // stresses exactly that path — on windows-latest a
+      // terminate-vs-self-exit race aborts BELOW the JS layer ("Worker
+      // exited unexpectedly"), so the cooperative exit must hold across
+      // many reps. On macOS/Linux this is a plain regression check that the
+      // helpful error still surfaces on every attempt.
+      const missingPath = path.resolve(
         __dirname,
         'fixtures',
-        'init-error-async-fault.config.mjs',
+        'missing-plugin.config.mjs',
+      );
+      const missingDir = path.dirname(missingPath);
+      for (let i = 0; i < 8; i++) {
+        const pool = new WorkerPool({
+          configs: [{ configPath: missingPath, configDirectory: missingDir }],
+          workerCount: 1,
+          workerInitTimeoutMs: 5000,
+        });
+        await expect(pool.init()).rejects.toThrow(
+          /eslint-plugin-this-does-not-exist/,
+        );
+      }
+    });
+
+    test('init failure + async worker fault keeps the host alive (error safety net)', async () => {
+      // The fixture fails init AND schedules an async throw that fires after
+      // sendInitError, making the worker emit an 'error' event. An unhandled
+      // Worker 'error' is re-thrown by Node as an uncaught exception in the
+      // host — so the pool must keep an 'error' listener through the
+      // init-error window. Capture host uncaughtException to assert none leaks.
+      const faults: string[] = [];
+      const onUncaught = (e: Error) => {
+        faults.push(e.message);
+      };
+      process.on('uncaughtException', onUncaught);
+      try {
+        const cfgPath = path.resolve(
+          __dirname,
+          'fixtures',
+          'init-error-async-fault.config.mjs',
+        );
+        const pool = new WorkerPool({
+          configs: [
+            { configPath: cfgPath, configDirectory: path.dirname(cfgPath) },
+          ],
+          workerCount: 1,
+          workerInitTimeoutMs: 5000,
+        });
+        await expect(pool.init()).rejects.toThrow(/init eval failure/);
+        // Let the worker's scheduled async fault (20ms) fire + propagate.
+        await new Promise((r) => setTimeout(r, 200));
+        expect(faults).toEqual([]);
+      } finally {
+        process.off('uncaughtException', onUncaught);
+      }
+    });
+
+    test('init-failure path awaits in-flight respawns before throwing (symmetric with shutdown)', async () => {
+      // Regression for Fix C. `shutdown()` awaits
+      // `Promise.allSettled([...this.respawns])`; the init-failure branch
+      // did not. If a ready worker crashed during the initial spawn window
+      // (before `closed` flips), its exit handler registers an in-flight
+      // respawn in `this.respawns`; that respawn's `.then` sees
+      // `closed===true` and self-terminates the freshly-spawned worker —
+      // but `init()` would `throw` BEFORE that orphan thread was reaped.
+      // Fix: the init-failure branch mirrors shutdown and awaits the set.
+      const missingPath = path.resolve(
+        __dirname,
+        'fixtures',
+        'missing-plugin.config.mjs',
       );
       const pool = new WorkerPool({
         configs: [
-          { configPath: cfgPath, configDirectory: path.dirname(cfgPath) },
+          {
+            configPath: missingPath,
+            configDirectory: path.dirname(missingPath),
+          },
         ],
         workerCount: 1,
-        workerInitTimeoutMs: 5000,
-      });
-      await expect(pool.init()).rejects.toThrow(/init eval failure/);
-      // Let the worker's scheduled async fault (20ms) fire + propagate.
-      await new Promise((r) => setTimeout(r, 200));
-      expect(faults).toEqual([]);
-    } finally {
-      process.off('uncaughtException', onUncaught);
-    }
-  });
-
-  test('init-failure path awaits in-flight respawns before throwing (symmetric with shutdown)', async () => {
-    // Regression for Fix C. `shutdown()` awaits
-    // `Promise.allSettled([...this.respawns])`; the init-failure branch
-    // did not. If a ready worker crashed during the initial spawn window
-    // (before `closed` flips), its exit handler registers an in-flight
-    // respawn in `this.respawns`; that respawn's `.then` sees
-    // `closed===true` and self-terminates the freshly-spawned worker —
-    // but `init()` would `throw` BEFORE that orphan thread was reaped.
-    // Fix: the init-failure branch mirrors shutdown and awaits the set.
-    const missingPath = path.resolve(
-      __dirname,
-      'fixtures',
-      'missing-plugin.config.mjs',
-    );
-    const pool = new WorkerPool({
-      configs: [
-        { configPath: missingPath, configDirectory: path.dirname(missingPath) },
-      ],
-      workerCount: 1,
-      workerInitTimeoutMs: 5_000,
-    });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const internals = pool as any;
-
-    // Inject an in-flight respawn that NEVER settles on its own — only
-    // we resolve it. This makes the assertion fully deterministic with
-    // no reliance on timer ordering: with the fix, init() blocks at
-    // `await Promise.allSettled([...this.respawns])` and cannot reject
-    // until we resolve this; without the fix, init() rejects the moment
-    // the (missing-plugin) spawn fails, never awaiting this promise.
-    let resolveRespawn!: () => void;
-    let respawnSettled = false;
-    const respawnTeardown = new Promise<void>((res) => {
-      resolveRespawn = res;
-    }).then(() => {
-      respawnSettled = true;
-    });
-    internals.respawns.add(respawnTeardown);
-
-    // Kick off init() without awaiting. It will fail its spawn (the
-    // config imports a non-existent plugin) within ~tens of ms.
-    let initSettled = false;
-    let initRejected = false;
-    let settledAtInitReject = false;
-    const initP = pool
-      .init()
-      .then(
-        () => {
-          /* unexpected resolve — asserted below */
-        },
-        () => {
-          initRejected = true;
-          // Capture whether the injected respawn had ALREADY settled at
-          // the instant init() rejected. With the fix this is true (init
-          // awaited it); without the fix it is false (init threw first).
-          settledAtInitReject = respawnSettled;
-        },
-      )
-      .finally(() => {
-        initSettled = true;
+        workerInitTimeoutMs: 5_000,
       });
 
-    // Wait well beyond the measured ~32ms spawn-failure latency so the
-    // spawn has DEFINITELY failed. After this, the only thing that can
-    // keep init() pending is the fix's `await` on the injected respawn.
-    await new Promise((r) => setTimeout(r, 800));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const internals = pool as any;
 
-    // Discriminating assertion: the spawn has failed, yet init() is
-    // still pending — it is blocked awaiting the injected respawn.
-    // Without the fix init() would have rejected during this window.
-    expect(initSettled).toBe(false);
-    expect(respawnSettled).toBe(false);
+      // Inject an in-flight respawn that NEVER settles on its own — only
+      // we resolve it. This makes the assertion fully deterministic with
+      // no reliance on timer ordering: with the fix, init() blocks at
+      // `await Promise.allSettled([...this.respawns])` and cannot reject
+      // until we resolve this; without the fix, init() rejects the moment
+      // the (missing-plugin) spawn fails, never awaiting this promise.
+      let resolveRespawn!: () => void;
+      let respawnSettled = false;
+      const respawnTeardown = new Promise<void>((res) => {
+        resolveRespawn = res;
+      }).then(() => {
+        respawnSettled = true;
+      });
+      internals.respawns.add(respawnTeardown);
 
-    // Release the injected respawn; init() can now finish and throw.
-    resolveRespawn();
-    await initP;
+      // Kick off init() without awaiting. It will fail its spawn (the
+      // config imports a non-existent plugin) within ~tens of ms.
+      let initSettled = false;
+      let initRejected = false;
+      let settledAtInitReject = false;
+      const initP = pool
+        .init()
+        .then(
+          () => {
+            /* unexpected resolve — asserted below */
+          },
+          () => {
+            initRejected = true;
+            // Capture whether the injected respawn had ALREADY settled at
+            // the instant init() rejected. With the fix this is true (init
+            // awaited it); without the fix it is false (init threw first).
+            settledAtInitReject = respawnSettled;
+          },
+        )
+        .finally(() => {
+          initSettled = true;
+        });
 
-    expect(initRejected).toBe(true);
-    // init() awaited the respawn's teardown BEFORE throwing.
-    expect(settledAtInitReject).toBe(true);
-    // Post-conditions of the init-failure branch still hold.
-    expect(internals.closed).toBe(true);
-    expect(internals.workers).toHaveLength(0);
-  }, 15_000);
-});
+      // Wait well beyond the measured ~32ms spawn-failure latency so the
+      // spawn has DEFINITELY failed. After this, the only thing that can
+      // keep init() pending is the fix's `await` on the injected respawn.
+      await new Promise((r) => setTimeout(r, 800));
+
+      // Discriminating assertion: the spawn has failed, yet init() is
+      // still pending — it is blocked awaiting the injected respawn.
+      // Without the fix init() would have rejected during this window.
+      expect(initSettled).toBe(false);
+      expect(respawnSettled).toBe(false);
+
+      // Release the injected respawn; init() can now finish and throw.
+      resolveRespawn();
+      await initP;
+
+      expect(initRejected).toBe(true);
+      // init() awaited the respawn's teardown BEFORE throwing.
+      expect(settledAtInitReject).toBe(true);
+      // Post-conditions of the init-failure branch still hold.
+      expect(internals.closed).toBe(true);
+      expect(internals.workers).toHaveLength(0);
+    }, 15_000);
+  },
+);

--- a/packages/eslint-plugin-runner/tests/worker-pool-e2e-lifecycle.test.ts
+++ b/packages/eslint-plugin-runner/tests/worker-pool-e2e-lifecycle.test.ts
@@ -22,291 +22,298 @@ import {
  * plugin (`fixtures/local-plugin.mjs`), not an external dependency.
  */
 
-describe('WorkerPool end-to-end with a local fixture plugin', () => {
-  test('init + lintBatch + shutdown happy path', async () => {
-    const logs: Array<{ level: string; source: string; text: string }> = [];
+// Skipped on windows: tearing down a worker that has oxc (a napi addon)
+// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
+// the rstest worker running this file. These e2e tests spawn real
+// workers and tear them down, so they are windows-skipped; they still
+// run on linux/macOS.
+describe.skipIf(process.platform === 'win32')(
+  'WorkerPool end-to-end with a local fixture plugin',
+  () => {
+    test('init + lintBatch + shutdown happy path', async () => {
+      const logs: Array<{ level: string; source: string; text: string }> = [];
 
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 2,
-      taskTimeoutMs: 10_000,
-      onLog: (rec) => logs.push(rec),
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 2,
+        taskTimeoutMs: 10_000,
+        onLog: (rec) => logs.push(rec),
+      });
+
+      await pool.init();
+
+      const tasks: LintTask[] = [
+        task('a.ts', `const x = null;`),
+        task('b.ts', `const y = "ok"; const z = null;`),
+        task('c.ts', `// no nulls here\nconst v = 42;`),
+      ];
+
+      const results = await pool.lintBatch(tasks);
+      expect(results).toHaveLength(3);
+
+      expect(results[0].diagnostics).toHaveLength(1);
+      expect(results[0].diagnostics[0].ruleName).toBe('local/no-null');
+
+      expect(results[1].diagnostics).toHaveLength(1);
+
+      expect(results[2].diagnostics).toHaveLength(0);
+
+      await pool.shutdown();
     });
 
-    await pool.init();
+    test('--singleThreaded honors workerCount=1', async () => {
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+      });
 
-    const tasks: LintTask[] = [
-      task('a.ts', `const x = null;`),
-      task('b.ts', `const y = "ok"; const z = null;`),
-      task('c.ts', `// no nulls here\nconst v = 42;`),
-    ];
+      await pool.init();
 
-    const results = await pool.lintBatch(tasks);
-    expect(results).toHaveLength(3);
+      const tasks: LintTask[] = Array.from({ length: 5 }, (_, i) =>
+        task(`f${i}.ts`, `const v${i} = null;`),
+      );
 
-    expect(results[0].diagnostics).toHaveLength(1);
-    expect(results[0].diagnostics[0].ruleName).toBe('local/no-null');
+      const results = await pool.lintBatch(tasks);
+      expect(results).toHaveLength(5);
+      for (const r of results) {
+        expect(r.diagnostics).toHaveLength(1);
+      }
 
-    expect(results[1].diagnostics).toHaveLength(1);
-
-    expect(results[2].diagnostics).toHaveLength(0);
-
-    await pool.shutdown();
-  });
-
-  test('--singleThreaded honors workerCount=1', async () => {
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
+      await pool.shutdown();
     });
 
-    await pool.init();
+    test('--fix flag plumbs through; fixes are returned in results', async () => {
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+      });
+      await pool.init();
 
-    const tasks: LintTask[] = Array.from({ length: 5 }, (_, i) =>
-      task(`f${i}.ts`, `const v${i} = null;`),
-    );
-
-    const results = await pool.lintBatch(tasks);
-    expect(results).toHaveLength(5);
-    for (const r of results) {
-      expect(r.diagnostics).toHaveLength(1);
-    }
-
-    await pool.shutdown();
-  });
-
-  test('--fix flag plumbs through; fixes are returned in results', async () => {
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-    });
-    await pool.init();
-
-    // local/prefer-array-some HAS an autofix (replaces the entire
-    // .filter(...).length > 0 chain with .some(...)). Picking this
-    // rule rather than no-null (which is suggestion-only) is what
-    // actually exercises the collectFixes:true → result.fixes path
-    // end-to-end. A regression that silently drops collectFixes
-    // would leave result.fixes empty even though the diagnostic
-    // still fires.
-    const SRC = `const arr = [1, 2]; const r = arr.filter(x => x > 0).length > 0;`;
-    const results = await pool.lintBatch([
-      {
-        filePath: 'fix.ts',
-        text: SRC,
-        rules: { 'local/prefer-array-some': { options: [] } },
-        collectFixes: true,
-        suggestionsMode: 'off',
-        configKey: LOCAL_CONFIG_DIR,
-      },
-    ]);
-
-    expect(results[0].diagnostics).toHaveLength(1);
-    // Aggregated fixes (mirror of diagnostics[].fixes) must contain
-    // the rule's autofix bytes.
-    const fixes = results[0].fixes ?? [];
-    expect(fixes.length).toBeGreaterThanOrEqual(1);
-    // The autofix's text is the literal replacement bytes — for this
-    // rule it's the identifier `some` (rule rewrites just the
-    // `filter` member name, not the whole chain). Match on exact
-    // contents so a regression that emits empty / wrong bytes is
-    // caught.
-    expect(fixes[0].text).toBe('some');
-
-    await pool.shutdown();
-  });
-
-  test('suggestionsMode=eager produces resolved fix edges', async () => {
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-    });
-    await pool.init();
-
-    const results = await pool.lintBatch([
-      {
-        filePath: 'sug.ts',
-        text: `const x = null;`,
-        rules: { 'local/no-null': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'eager',
-        configKey: LOCAL_CONFIG_DIR,
-      },
-    ]);
-
-    expect(results[0].diagnostics).toHaveLength(1);
-    // suggestionsMode='eager' must materialize suggestion fix edges.
-    // local/no-null offers a suggestion that rewrites `null` to
-    // `undefined`. A regression that silently drops 'eager' (treating
-    // it as 'off') would leave `suggestions[*].fixes` as null/empty
-    // even though the diagnostic itself still fires. The previous
-    // version of this test only checked `suggestionsCount >= 0`, a
-    // tautology — fixed to assert the actual resolved fix bytes.
-    const suggestions = results[0].diagnostics[0].suggestions ?? [];
-    expect(suggestions.length).toBeGreaterThanOrEqual(1);
-    const fixesArr = suggestions[0].fixes ?? [];
-    expect(fixesArr.length).toBeGreaterThanOrEqual(1);
-    expect(fixesArr[0].text).toBe('undefined');
-
-    await pool.shutdown();
-  });
-
-  // pool.shutdown() posts {kind:'shutdown'} to every worker and waits
-  // up to 5 s for each to exit cooperatively before falling back to
-  // `worker.terminate()`. This invariant matters when the host (CLI
-  // parent on Ctrl-C, VS Code on extension dispose, …) tears the pool
-  // down while a plugin listener is wedged in a sync infinite loop —
-  // the worker can't even process the inbound shutdown message, so
-  // graceful exit is impossible and the pool must escalate to a forced
-  // terminate. Test fires a never-completing task, calls shutdown
-  // without a per-task timeout, and asserts the pool fully drains
-  // within grace + slack.
-  test('shutdown drains a sync-wedged worker via terminate fallback within grace', async () => {
-    const hangConfigPath = path.resolve(
-      __dirname,
-      'fixtures',
-      'hang.config.mjs',
-    );
-    const hangConfigDir = path.dirname(hangConfigPath);
-
-    const pool = new WorkerPool({
-      configs: [
+      // local/prefer-array-some HAS an autofix (replaces the entire
+      // .filter(...).length > 0 chain with .some(...)). Picking this
+      // rule rather than no-null (which is suggestion-only) is what
+      // actually exercises the collectFixes:true → result.fixes path
+      // end-to-end. A regression that silently drops collectFixes
+      // would leave result.fixes empty even though the diagnostic
+      // still fires.
+      const SRC = `const arr = [1, 2]; const r = arr.filter(x => x > 0).length > 0;`;
+      const results = await pool.lintBatch([
         {
-          configPath: hangConfigPath,
-          configDirectory: hangConfigDir,
-        },
-      ],
-      workerCount: 1,
-      // 60 s — longer than the test ceiling, so a task_timeout-driven
-      // respawn can't preempt the shutdown path we're trying to test.
-      taskTimeoutMs: 60_000,
-    });
-    await pool.init();
-
-    // Fire-and-forget: the hang listener spins forever on Program, so
-    // the task never resolves naturally. shutdown is the only force
-    // that can free the pool.
-    const wedgeP = pool.lintBatch([
-      {
-        filePath: 'wedge.ts',
-        text: 'const x = 1;\n',
-        rules: { 'hang/hang': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: hangConfigDir,
-      },
-    ]);
-
-    // Brief grace so the worker is actually inside the sync hang
-    // when shutdown lands. Without this the worker might still be
-    // sitting in its inbound queue and could process the shutdown
-    // message before entering the loop — a different (faster) path
-    // that doesn't exercise the terminate fallback we're testing.
-    await new Promise((r) => setTimeout(r, 200));
-
-    const shutdownStart = Date.now();
-    await pool.shutdown();
-    const elapsed = Date.now() - shutdownStart;
-
-    // worker-pool.ts grace = 5 s; total elapsed = grace + small
-    // overhead for terminate() to actually kill the worker thread.
-    // Lower bound 4.5 s catches a regression where shutdown returns
-    // immediately (without waiting for the worker). Upper bound 8 s
-    // catches a regression where the terminate fallback never fires.
-    expect(elapsed).toBeGreaterThanOrEqual(4_500);
-    expect(elapsed).toBeLessThan(8_000);
-
-    // In-flight tasks resolve with a sentinel parseError instead of
-    // hanging the caller forever. worker-pool.ts:539-548 maps the
-    // shutdown-kind rejection back to a result-shaped failure so
-    // callers (internal/linter) see one file as compat-failed rather
-    // than the whole batch throwing.
-    const wedgeResults = await wedgeP;
-    expect(wedgeResults).toHaveLength(1);
-    expect(wedgeResults[0].parseError).toBe('shutdown');
-
-    // Pool is fully drained — no leaked worker slot.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const finalWorkers = (pool as any).workers as Array<unknown>;
-    expect(finalWorkers.length).toBe(0);
-
-    // Idempotent: a second shutdown returns instantly without throwing.
-    const secondStart = Date.now();
-    await pool.shutdown();
-    expect(Date.now() - secondStart).toBeLessThan(50);
-  }, 15_000);
-
-  // U12: a single WorkerPool instance must support N lintBatch calls
-  // in sequence (the CLI's fix-loop and the LSP's continuous edit
-  // stream both do this). State across batches must NOT leak:
-  //   - plugin instances stay cached (no re-import per batch)
-  //   - diagnostic state is per-batch, not accumulating
-  //   - per-task timers are released after each batch
-  // The third invariant is the easiest to regress on — a leaked timer
-  // would keep the Node event loop alive past `pool.shutdown()`.
-  test('U12: WorkerPool reuse across many lintBatch invocations stays stable', async () => {
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-    });
-    await pool.init();
-
-    // Run 5 lint batches in sequence. The same worker handles all of
-    // them; no respawn / re-init expected.
-    const counts: number[] = [];
-    for (let i = 0; i < 5; i++) {
-      const r = await pool.lintBatch([
-        {
-          filePath: `iter${i}.ts`,
-          text: 'const x = null;\n',
-          rules: { 'local/no-null': { options: [] } },
-          collectFixes: false,
+          filePath: 'fix.ts',
+          text: SRC,
+          rules: { 'local/prefer-array-some': { options: [] } },
+          collectFixes: true,
           suggestionsMode: 'off',
           configKey: LOCAL_CONFIG_DIR,
         },
       ]);
-      expect(r).toHaveLength(1);
-      expect(r[0].parseError).toBeUndefined();
-      counts.push(r[0].diagnostics.length);
-    }
 
-    // Every iteration produced the SAME diagnostic count (1, for the
-    // single `null` literal). If state leaked (e.g. diagnostics
-    // accumulated across batches), counts would grow.
-    for (const c of counts) {
-      expect(c).toBe(1);
-    }
+      expect(results[0].diagnostics).toHaveLength(1);
+      // Aggregated fixes (mirror of diagnostics[].fixes) must contain
+      // the rule's autofix bytes.
+      const fixes = results[0].fixes ?? [];
+      expect(fixes.length).toBeGreaterThanOrEqual(1);
+      // The autofix's text is the literal replacement bytes — for this
+      // rule it's the identifier `some` (rule rewrites just the
+      // `filter` member name, not the whole chain). Match on exact
+      // contents so a regression that emits empty / wrong bytes is
+      // caught.
+      expect(fixes[0].text).toBe('some');
 
-    // Only one worker was used the whole time.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const workers = (pool as any).workers as Array<{ ready: boolean }>;
-    expect(workers).toHaveLength(1);
-    expect(workers[0].ready).toBe(true);
+      await pool.shutdown();
+    });
 
-    await pool.shutdown();
-  }, 30_000);
+    test('suggestionsMode=eager produces resolved fix edges', async () => {
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+      });
+      await pool.init();
 
-  // U11: a plugin that installs a `setInterval` (or any unref-able
-  // timer) during its module top-level must NOT prevent the worker
-  // from exiting on shutdown. The worker process keeps running until
-  // the event loop drains; an unref'd timer is fine, but a refed
-  // setInterval would keep the worker alive past `pool.shutdown()`,
-  // hanging the parent's Wait.
-  //
-  // The test uses a fixture plugin that creates a setInterval in its
-  // top-level, then verifies pool.shutdown completes in bounded time.
-  // If the timer kept the worker alive, shutdown would either time
-  // out (caught by Jest's per-test timeout) or rely on terminate()
-  // fallback (visible via a longer-than-expected elapsed time).
-  test('U11: plugin with a top-level setInterval — shutdown still terminates the worker', async () => {
-    const cfgDir = path.resolve(__dirname, 'fixtures');
-    const cfgPath = path.join(cfgDir, '_u11.config.mjs');
-    const pluginPath = path.join(cfgDir, '_u11-plugin.mjs');
-    await import('node:fs/promises').then((fs) =>
-      Promise.all([
-        fs.writeFile(
-          pluginPath,
-          `// Intentionally schedules a REFED interval that would
+      const results = await pool.lintBatch([
+        {
+          filePath: 'sug.ts',
+          text: `const x = null;`,
+          rules: { 'local/no-null': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'eager',
+          configKey: LOCAL_CONFIG_DIR,
+        },
+      ]);
+
+      expect(results[0].diagnostics).toHaveLength(1);
+      // suggestionsMode='eager' must materialize suggestion fix edges.
+      // local/no-null offers a suggestion that rewrites `null` to
+      // `undefined`. A regression that silently drops 'eager' (treating
+      // it as 'off') would leave `suggestions[*].fixes` as null/empty
+      // even though the diagnostic itself still fires. The previous
+      // version of this test only checked `suggestionsCount >= 0`, a
+      // tautology — fixed to assert the actual resolved fix bytes.
+      const suggestions = results[0].diagnostics[0].suggestions ?? [];
+      expect(suggestions.length).toBeGreaterThanOrEqual(1);
+      const fixesArr = suggestions[0].fixes ?? [];
+      expect(fixesArr.length).toBeGreaterThanOrEqual(1);
+      expect(fixesArr[0].text).toBe('undefined');
+
+      await pool.shutdown();
+    });
+
+    // pool.shutdown() posts {kind:'shutdown'} to every worker and waits
+    // up to 5 s for each to exit cooperatively before falling back to
+    // `worker.terminate()`. This invariant matters when the host (CLI
+    // parent on Ctrl-C, VS Code on extension dispose, …) tears the pool
+    // down while a plugin listener is wedged in a sync infinite loop —
+    // the worker can't even process the inbound shutdown message, so
+    // graceful exit is impossible and the pool must escalate to a forced
+    // terminate. Test fires a never-completing task, calls shutdown
+    // without a per-task timeout, and asserts the pool fully drains
+    // within grace + slack.
+    test('shutdown drains a sync-wedged worker via terminate fallback within grace', async () => {
+      const hangConfigPath = path.resolve(
+        __dirname,
+        'fixtures',
+        'hang.config.mjs',
+      );
+      const hangConfigDir = path.dirname(hangConfigPath);
+
+      const pool = new WorkerPool({
+        configs: [
+          {
+            configPath: hangConfigPath,
+            configDirectory: hangConfigDir,
+          },
+        ],
+        workerCount: 1,
+        // 60 s — longer than the test ceiling, so a task_timeout-driven
+        // respawn can't preempt the shutdown path we're trying to test.
+        taskTimeoutMs: 60_000,
+      });
+      await pool.init();
+
+      // Fire-and-forget: the hang listener spins forever on Program, so
+      // the task never resolves naturally. shutdown is the only force
+      // that can free the pool.
+      const wedgeP = pool.lintBatch([
+        {
+          filePath: 'wedge.ts',
+          text: 'const x = 1;\n',
+          rules: { 'hang/hang': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: hangConfigDir,
+        },
+      ]);
+
+      // Brief grace so the worker is actually inside the sync hang
+      // when shutdown lands. Without this the worker might still be
+      // sitting in its inbound queue and could process the shutdown
+      // message before entering the loop — a different (faster) path
+      // that doesn't exercise the terminate fallback we're testing.
+      await new Promise((r) => setTimeout(r, 200));
+
+      const shutdownStart = Date.now();
+      await pool.shutdown();
+      const elapsed = Date.now() - shutdownStart;
+
+      // worker-pool.ts grace = 5 s; total elapsed = grace + small
+      // overhead for terminate() to actually kill the worker thread.
+      // Lower bound 4.5 s catches a regression where shutdown returns
+      // immediately (without waiting for the worker). Upper bound 8 s
+      // catches a regression where the terminate fallback never fires.
+      expect(elapsed).toBeGreaterThanOrEqual(4_500);
+      expect(elapsed).toBeLessThan(8_000);
+
+      // In-flight tasks resolve with a sentinel parseError instead of
+      // hanging the caller forever. worker-pool.ts:539-548 maps the
+      // shutdown-kind rejection back to a result-shaped failure so
+      // callers (internal/linter) see one file as compat-failed rather
+      // than the whole batch throwing.
+      const wedgeResults = await wedgeP;
+      expect(wedgeResults).toHaveLength(1);
+      expect(wedgeResults[0].parseError).toBe('shutdown');
+
+      // Pool is fully drained — no leaked worker slot.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const finalWorkers = (pool as any).workers as Array<unknown>;
+      expect(finalWorkers.length).toBe(0);
+
+      // Idempotent: a second shutdown returns instantly without throwing.
+      const secondStart = Date.now();
+      await pool.shutdown();
+      expect(Date.now() - secondStart).toBeLessThan(50);
+    }, 15_000);
+
+    // U12: a single WorkerPool instance must support N lintBatch calls
+    // in sequence (the CLI's fix-loop and the LSP's continuous edit
+    // stream both do this). State across batches must NOT leak:
+    //   - plugin instances stay cached (no re-import per batch)
+    //   - diagnostic state is per-batch, not accumulating
+    //   - per-task timers are released after each batch
+    // The third invariant is the easiest to regress on — a leaked timer
+    // would keep the Node event loop alive past `pool.shutdown()`.
+    test('U12: WorkerPool reuse across many lintBatch invocations stays stable', async () => {
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+      });
+      await pool.init();
+
+      // Run 5 lint batches in sequence. The same worker handles all of
+      // them; no respawn / re-init expected.
+      const counts: number[] = [];
+      for (let i = 0; i < 5; i++) {
+        const r = await pool.lintBatch([
+          {
+            filePath: `iter${i}.ts`,
+            text: 'const x = null;\n',
+            rules: { 'local/no-null': { options: [] } },
+            collectFixes: false,
+            suggestionsMode: 'off',
+            configKey: LOCAL_CONFIG_DIR,
+          },
+        ]);
+        expect(r).toHaveLength(1);
+        expect(r[0].parseError).toBeUndefined();
+        counts.push(r[0].diagnostics.length);
+      }
+
+      // Every iteration produced the SAME diagnostic count (1, for the
+      // single `null` literal). If state leaked (e.g. diagnostics
+      // accumulated across batches), counts would grow.
+      for (const c of counts) {
+        expect(c).toBe(1);
+      }
+
+      // Only one worker was used the whole time.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const workers = (pool as any).workers as Array<{ ready: boolean }>;
+      expect(workers).toHaveLength(1);
+      expect(workers[0].ready).toBe(true);
+
+      await pool.shutdown();
+    }, 30_000);
+
+    // U11: a plugin that installs a `setInterval` (or any unref-able
+    // timer) during its module top-level must NOT prevent the worker
+    // from exiting on shutdown. The worker process keeps running until
+    // the event loop drains; an unref'd timer is fine, but a refed
+    // setInterval would keep the worker alive past `pool.shutdown()`,
+    // hanging the parent's Wait.
+    //
+    // The test uses a fixture plugin that creates a setInterval in its
+    // top-level, then verifies pool.shutdown completes in bounded time.
+    // If the timer kept the worker alive, shutdown would either time
+    // out (caught by Jest's per-test timeout) or rely on terminate()
+    // fallback (visible via a longer-than-expected elapsed time).
+    test('U11: plugin with a top-level setInterval — shutdown still terminates the worker', async () => {
+      const cfgDir = path.resolve(__dirname, 'fixtures');
+      const cfgPath = path.join(cfgDir, '_u11.config.mjs');
+      const pluginPath = path.join(cfgDir, '_u11-plugin.mjs');
+      await import('node:fs/promises').then((fs) =>
+        Promise.all([
+          fs.writeFile(
+            pluginPath,
+            `// Intentionally schedules a REFED interval that would
 // otherwise keep the worker alive forever. The test pins that
 // pool.shutdown() still tears the worker down within a bounded
 // elapsed window (5 s graceful + terminate fallback).
@@ -317,47 +324,48 @@ export default {
   rules: { noop: { meta: {}, create() { return {}; } } },
 };
 `,
-          'utf8',
-        ),
-        fs.writeFile(
-          cfgPath,
-          `import plugin from './_u11-plugin.mjs';
+            'utf8',
+          ),
+          fs.writeFile(
+            cfgPath,
+            `import plugin from './_u11-plugin.mjs';
 export default [{ eslintPlugins: { u11: plugin } }];
 `,
-          'utf8',
-        ),
-      ]),
-    );
-
-    try {
-      const pool = new WorkerPool({
-        configs: [{ configPath: cfgPath, configDirectory: cfgDir }],
-        workerCount: 1,
-      });
-      await pool.init();
-
-      const start = Date.now();
-      await pool.shutdown();
-      const elapsed = Date.now() - start;
-
-      // Worker pool's shutdown gives each worker up to 5s graceful
-      // before terminate(). A worker keeping its event loop alive
-      // via setInterval would hit terminate fallback — bounded by
-      // grace + small overhead. Test fails if shutdown is unbounded
-      // (i.e. hangs past 10s) or if terminate fallback itself fails
-      // (worker_threads.terminate is OS-level and very reliable).
-      expect(elapsed).toBeLessThan(8_000);
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const workers = (pool as any).workers as Array<unknown>;
-      expect(workers).toHaveLength(0);
-    } finally {
-      await import('node:fs/promises').then((fs) =>
-        Promise.all([
-          fs.rm(cfgPath, { force: true }),
-          fs.rm(pluginPath, { force: true }),
+            'utf8',
+          ),
         ]),
       );
-    }
-  }, 15_000);
-});
+
+      try {
+        const pool = new WorkerPool({
+          configs: [{ configPath: cfgPath, configDirectory: cfgDir }],
+          workerCount: 1,
+        });
+        await pool.init();
+
+        const start = Date.now();
+        await pool.shutdown();
+        const elapsed = Date.now() - start;
+
+        // Worker pool's shutdown gives each worker up to 5s graceful
+        // before terminate(). A worker keeping its event loop alive
+        // via setInterval would hit terminate fallback — bounded by
+        // grace + small overhead. Test fails if shutdown is unbounded
+        // (i.e. hangs past 10s) or if terminate fallback itself fails
+        // (worker_threads.terminate is OS-level and very reliable).
+        expect(elapsed).toBeLessThan(8_000);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const workers = (pool as any).workers as Array<unknown>;
+        expect(workers).toHaveLength(0);
+      } finally {
+        await import('node:fs/promises').then((fs) =>
+          Promise.all([
+            fs.rm(cfgPath, { force: true }),
+            fs.rm(pluginPath, { force: true }),
+          ]),
+        );
+      }
+    }, 15_000);
+  },
+);

--- a/packages/eslint-plugin-runner/tests/worker-pool-e2e-multiconfig.test.ts
+++ b/packages/eslint-plugin-runner/tests/worker-pool-e2e-multiconfig.test.ts
@@ -12,267 +12,278 @@ import { WorkerPool } from '../src/worker-pool.js';
  * forwarded through onLog (LSP-visible).
  */
 
-describe('WorkerPool end-to-end with a local fixture plugin', () => {
-  // Multi-config (monorepo) dispatch — a single worker holds TWO
-  // configs under different directories with the SAME plugin module
-  // under DIFFERENT prefixes (`pkgA` vs `pkgB`). Each task's `configKey`
-  // selects which config's `LoadedPlugins` the worker uses to resolve
-  // the rule. A bug that mixes them up would either return
-  // "rule not found" for one prefix or silently route to the wrong
-  // config's plugin instance — both visible as diagnostics that
-  // never fire on the affected file.
-  test('multi-config dispatch routes each file to its own configKey-bound plugins', async () => {
-    const cfgADir = path.resolve(__dirname, 'fixtures', 'cfgA');
-    const cfgBDir = path.resolve(__dirname, 'fixtures', 'cfgB');
+// Skipped on windows: tearing down a worker that has oxc (a napi addon)
+// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
+// the rstest worker running this file. These e2e tests spawn real
+// workers and tear them down, so they are windows-skipped; they still
+// run on linux/macOS.
+describe.skipIf(process.platform === 'win32')(
+  'WorkerPool end-to-end with a local fixture plugin',
+  () => {
+    // Multi-config (monorepo) dispatch — a single worker holds TWO
+    // configs under different directories with the SAME plugin module
+    // under DIFFERENT prefixes (`pkgA` vs `pkgB`). Each task's `configKey`
+    // selects which config's `LoadedPlugins` the worker uses to resolve
+    // the rule. A bug that mixes them up would either return
+    // "rule not found" for one prefix or silently route to the wrong
+    // config's plugin instance — both visible as diagnostics that
+    // never fire on the affected file.
+    test('multi-config dispatch routes each file to its own configKey-bound plugins', async () => {
+      const cfgADir = path.resolve(__dirname, 'fixtures', 'cfgA');
+      const cfgBDir = path.resolve(__dirname, 'fixtures', 'cfgB');
 
-    const pool = new WorkerPool({
-      configs: [
+      const pool = new WorkerPool({
+        configs: [
+          {
+            configPath: path.join(cfgADir, 'rslint.config.mjs'),
+            configDirectory: cfgADir,
+          },
+          {
+            configPath: path.join(cfgBDir, 'rslint.config.mjs'),
+            configDirectory: cfgBDir,
+          },
+        ],
+        workerCount: 1, // single worker holds both configs, exercises the per-config map
+        taskTimeoutMs: 10_000,
+      });
+      await pool.init();
+
+      // Same file source, different configKey + rule prefix:
+      //   - File under cfgA → rule `pkgA/no-null` MUST fire
+      //   - File under cfgB → rule `pkgB/no-null` MUST fire
+      const NULL_SRC = 'const x = null;';
+      const results = await pool.lintBatch([
         {
-          configPath: path.join(cfgADir, 'rslint.config.mjs'),
-          configDirectory: cfgADir,
+          filePath: 'a.ts',
+          text: NULL_SRC,
+          rules: { 'pkgA/no-null': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: cfgADir,
         },
         {
-          configPath: path.join(cfgBDir, 'rslint.config.mjs'),
-          configDirectory: cfgBDir,
+          filePath: 'b.ts',
+          text: NULL_SRC,
+          rules: { 'pkgB/no-null': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: cfgBDir,
         },
-      ],
-      workerCount: 1, // single worker holds both configs, exercises the per-config map
-      taskTimeoutMs: 10_000,
-    });
-    await pool.init();
+      ]);
 
-    // Same file source, different configKey + rule prefix:
-    //   - File under cfgA → rule `pkgA/no-null` MUST fire
-    //   - File under cfgB → rule `pkgB/no-null` MUST fire
-    const NULL_SRC = 'const x = null;';
-    const results = await pool.lintBatch([
-      {
-        filePath: 'a.ts',
-        text: NULL_SRC,
-        rules: { 'pkgA/no-null': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: cfgADir,
-      },
-      {
-        filePath: 'b.ts',
-        text: NULL_SRC,
-        rules: { 'pkgB/no-null': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: cfgBDir,
-      },
-    ]);
+      expect(results).toHaveLength(2);
+      // File a (configKey=cfgA): pkgA/no-null fires.
+      expect(results[0].parseError).toBeUndefined();
+      expect(results[0].diagnostics).toHaveLength(1);
+      expect(results[0].diagnostics[0].ruleName).toBe('pkgA/no-null');
+      // File b (configKey=cfgB): pkgB/no-null fires.
+      expect(results[1].parseError).toBeUndefined();
+      expect(results[1].diagnostics).toHaveLength(1);
+      expect(results[1].diagnostics[0].ruleName).toBe('pkgB/no-null');
 
-    expect(results).toHaveLength(2);
-    // File a (configKey=cfgA): pkgA/no-null fires.
-    expect(results[0].parseError).toBeUndefined();
-    expect(results[0].diagnostics).toHaveLength(1);
-    expect(results[0].diagnostics[0].ruleName).toBe('pkgA/no-null');
-    // File b (configKey=cfgB): pkgB/no-null fires.
-    expect(results[1].parseError).toBeUndefined();
-    expect(results[1].diagnostics).toHaveLength(1);
-    expect(results[1].diagnostics[0].ruleName).toBe('pkgB/no-null');
-
-    // Cross-confusion regression: a file under cfgA asking for
-    // `pkgB/no-null` must NOT resolve — cfgA's LoadedPlugins doesn't
-    // hold pkgB. A worker bug that "falls back" to the union of all
-    // configs would produce a hit here.
-    const cross = await pool.lintBatch([
-      {
-        filePath: 'cross.ts',
-        text: NULL_SRC,
-        rules: { 'pkgB/no-null': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: cfgADir,
-      },
-    ]);
-    expect(cross[0].parseError).toBeUndefined();
-    expect(cross[0].diagnostics).toHaveLength(0);
-    // ruleErrors is the strict signal — cfgA's plugin set doesn't
-    // know about pkgB/no-null, so resolveRule returns null and the
-    // rule resolver records it.
-    expect(cross[0].ruleErrors?.some((e) => e.rule === 'pkgB/no-null')).toBe(
-      true,
-    );
-
-    await pool.shutdown();
-  }, 20_000);
-
-  // Same monorepo-style dispatch as the cfgA/cfgB test above, but
-  // BOTH dimensions diverge: cfgX exposes only `plugin-x` (module
-  // `./plugin-x.mjs`) under prefix `px`, cfgY exposes only the
-  // disjoint `plugin-y` module under prefix `py`. The two plugins
-  // share zero identity — different module URL, different rule names,
-  // different prefix. The earlier test guards same-module/different-
-  // prefix; this one guards the harder claim that the worker's
-  // per-config `loadedPluginsByDir` keeps two ENTIRELY DIFFERENT
-  // plugin sets isolated, with no shared registry that could leak
-  // rules from one config into the other's task.
-  test('multi-config dispatch with disjoint plugin sets stays isolated', async () => {
-    const cfgXDir = path.resolve(__dirname, 'fixtures', 'cfgX');
-    const cfgYDir = path.resolve(__dirname, 'fixtures', 'cfgY');
-
-    const pool = new WorkerPool({
-      configs: [
+      // Cross-confusion regression: a file under cfgA asking for
+      // `pkgB/no-null` must NOT resolve — cfgA's LoadedPlugins doesn't
+      // hold pkgB. A worker bug that "falls back" to the union of all
+      // configs would produce a hit here.
+      const cross = await pool.lintBatch([
         {
-          configPath: path.join(cfgXDir, 'rslint.config.mjs'),
-          configDirectory: cfgXDir,
+          filePath: 'cross.ts',
+          text: NULL_SRC,
+          rules: { 'pkgB/no-null': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: cfgADir,
+        },
+      ]);
+      expect(cross[0].parseError).toBeUndefined();
+      expect(cross[0].diagnostics).toHaveLength(0);
+      // ruleErrors is the strict signal — cfgA's plugin set doesn't
+      // know about pkgB/no-null, so resolveRule returns null and the
+      // rule resolver records it.
+      expect(cross[0].ruleErrors?.some((e) => e.rule === 'pkgB/no-null')).toBe(
+        true,
+      );
+
+      await pool.shutdown();
+    }, 20_000);
+
+    // Same monorepo-style dispatch as the cfgA/cfgB test above, but
+    // BOTH dimensions diverge: cfgX exposes only `plugin-x` (module
+    // `./plugin-x.mjs`) under prefix `px`, cfgY exposes only the
+    // disjoint `plugin-y` module under prefix `py`. The two plugins
+    // share zero identity — different module URL, different rule names,
+    // different prefix. The earlier test guards same-module/different-
+    // prefix; this one guards the harder claim that the worker's
+    // per-config `loadedPluginsByDir` keeps two ENTIRELY DIFFERENT
+    // plugin sets isolated, with no shared registry that could leak
+    // rules from one config into the other's task.
+    test('multi-config dispatch with disjoint plugin sets stays isolated', async () => {
+      const cfgXDir = path.resolve(__dirname, 'fixtures', 'cfgX');
+      const cfgYDir = path.resolve(__dirname, 'fixtures', 'cfgY');
+
+      const pool = new WorkerPool({
+        configs: [
+          {
+            configPath: path.join(cfgXDir, 'rslint.config.mjs'),
+            configDirectory: cfgXDir,
+          },
+          {
+            configPath: path.join(cfgYDir, 'rslint.config.mjs'),
+            configDirectory: cfgYDir,
+          },
+        ],
+        workerCount: 1, // single worker holds both → exercises per-config map
+        taskTimeoutMs: 10_000,
+      });
+      await pool.init();
+
+      // Source mentions BOTH banned identifiers. The rule that fires
+      // is determined purely by which plugin the file's configKey
+      // routes to — `foo` should only flag under cfgX, `bar` only
+      // under cfgY.
+      const SRC = 'const foo = 1; const bar = 2;';
+
+      const results = await pool.lintBatch([
+        {
+          filePath: 'x.ts',
+          text: SRC,
+          rules: { 'px/no-foo': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: cfgXDir,
         },
         {
-          configPath: path.join(cfgYDir, 'rslint.config.mjs'),
-          configDirectory: cfgYDir,
+          filePath: 'y.ts',
+          text: SRC,
+          rules: { 'py/no-bar': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: cfgYDir,
         },
-      ],
-      workerCount: 1, // single worker holds both → exercises per-config map
-      taskTimeoutMs: 10_000,
-    });
-    await pool.init();
+      ]);
 
-    // Source mentions BOTH banned identifiers. The rule that fires
-    // is determined purely by which plugin the file's configKey
-    // routes to — `foo` should only flag under cfgX, `bar` only
-    // under cfgY.
-    const SRC = 'const foo = 1; const bar = 2;';
+      expect(results).toHaveLength(2);
 
-    const results = await pool.lintBatch([
-      {
-        filePath: 'x.ts',
-        text: SRC,
-        rules: { 'px/no-foo': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: cfgXDir,
-      },
-      {
-        filePath: 'y.ts',
-        text: SRC,
-        rules: { 'py/no-bar': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: cfgYDir,
-      },
-    ]);
+      // cfgX file: only `px/no-foo` fires, flagging `foo` exactly once.
+      expect(results[0].parseError).toBeUndefined();
+      expect(results[0].diagnostics).toHaveLength(1);
+      expect(results[0].diagnostics[0].ruleName).toBe('px/no-foo');
 
-    expect(results).toHaveLength(2);
+      // cfgY file: only `py/no-bar` fires, flagging `bar` exactly once.
+      expect(results[1].parseError).toBeUndefined();
+      expect(results[1].diagnostics).toHaveLength(1);
+      expect(results[1].diagnostics[0].ruleName).toBe('py/no-bar');
 
-    // cfgX file: only `px/no-foo` fires, flagging `foo` exactly once.
-    expect(results[0].parseError).toBeUndefined();
-    expect(results[0].diagnostics).toHaveLength(1);
-    expect(results[0].diagnostics[0].ruleName).toBe('px/no-foo');
-
-    // cfgY file: only `py/no-bar` fires, flagging `bar` exactly once.
-    expect(results[1].parseError).toBeUndefined();
-    expect(results[1].diagnostics).toHaveLength(1);
-    expect(results[1].diagnostics[0].ruleName).toBe('py/no-bar');
-
-    // Cross-confusion both directions: requesting plugin Y's rule on
-    // a cfgX file (or X's rule on a cfgY file) must NOT resolve.
-    // resolveRule returning null surfaces as a ruleErrors entry; a
-    // worker bug that merged the two LoadedPlugins would silently
-    // produce diagnostics here instead.
-    const cross = await pool.lintBatch([
-      {
-        filePath: 'cross-x-asks-y.ts',
-        text: SRC,
-        rules: { 'py/no-bar': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: cfgXDir,
-      },
-      {
-        filePath: 'cross-y-asks-x.ts',
-        text: SRC,
-        rules: { 'px/no-foo': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: cfgYDir,
-      },
-    ]);
-
-    expect(cross[0].diagnostics).toHaveLength(0);
-    expect(cross[0].ruleErrors?.some((e) => e.rule === 'py/no-bar')).toBe(true);
-    expect(cross[1].diagnostics).toHaveLength(0);
-    expect(cross[1].ruleErrors?.some((e) => e.rule === 'px/no-foo')).toBe(true);
-
-    await pool.shutdown();
-  }, 20_000);
-
-  // Unknown configKey on the wire is treated as an internal-invariant
-  // violation: the host contract guarantees every configKey was declared
-  // in WorkerPoolOptions.configs[]. Silently linting with empty rules
-  // would mask the bug — the worker emits a parseError pointing at the
-  // missing key so the host can surface it.
-  test('unknown configKey produces parseError, not silent empty-rules', async () => {
-    const cfgADir = path.resolve(__dirname, 'fixtures', 'cfgA');
-
-    const pool = new WorkerPool({
-      configs: [
+      // Cross-confusion both directions: requesting plugin Y's rule on
+      // a cfgX file (or X's rule on a cfgY file) must NOT resolve.
+      // resolveRule returning null surfaces as a ruleErrors entry; a
+      // worker bug that merged the two LoadedPlugins would silently
+      // produce diagnostics here instead.
+      const cross = await pool.lintBatch([
         {
-          configPath: path.join(cfgADir, 'rslint.config.mjs'),
-          configDirectory: cfgADir,
+          filePath: 'cross-x-asks-y.ts',
+          text: SRC,
+          rules: { 'py/no-bar': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: cfgXDir,
         },
-      ],
-      workerCount: 1,
-      taskTimeoutMs: 10_000,
-    });
-    await pool.init();
+        {
+          filePath: 'cross-y-asks-x.ts',
+          text: SRC,
+          rules: { 'px/no-foo': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: cfgYDir,
+        },
+      ]);
 
-    const bogusKey = '/not/in/worker/configs';
-    const results = await pool.lintBatch([
-      {
-        filePath: 'rogue.ts',
-        text: 'const x = null;',
-        rules: { 'pkgA/no-null': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: bogusKey,
-      },
-    ]);
+      expect(cross[0].diagnostics).toHaveLength(0);
+      expect(cross[0].ruleErrors?.some((e) => e.rule === 'py/no-bar')).toBe(
+        true,
+      );
+      expect(cross[1].diagnostics).toHaveLength(0);
+      expect(cross[1].ruleErrors?.some((e) => e.rule === 'px/no-foo')).toBe(
+        true,
+      );
 
-    expect(results).toHaveLength(1);
-    expect(results[0].diagnostics).toHaveLength(0);
-    expect(results[0].parseError).toBeDefined();
-    // The error message must name BOTH the rogue key and the set of
-    // configured directories so an operator can tell whether the host
-    // sent the wrong key or the worker was built with the wrong set.
-    expect(results[0].parseError).toMatch(/configKey/);
-    expect(results[0].parseError).toContain(bogusKey);
-    expect(results[0].parseError).toContain(cfgADir);
+      await pool.shutdown();
+    }, 20_000);
 
-    await pool.shutdown();
-  }, 20_000);
+    // Unknown configKey on the wire is treated as an internal-invariant
+    // violation: the host contract guarantees every configKey was declared
+    // in WorkerPoolOptions.configs[]. Silently linting with empty rules
+    // would mask the bug — the worker emits a parseError pointing at the
+    // missing key so the host can surface it.
+    test('unknown configKey produces parseError, not silent empty-rules', async () => {
+      const cfgADir = path.resolve(__dirname, 'fixtures', 'cfgA');
 
-  // R4: rule-side warnings (listener throw, fix() throw, suggest fix
-  // throw, invalid fix return) used to go through `process.stderr.write`
-  // directly. Under LSP that lands in VS Code's hidden "Window"
-  // channel — invisible to a user trying to debug a misbehaving
-  // plugin. After R4, the runner uses `console.error`, which
-  // `lint-worker.ts` monkey-patches into `parentPort.postMessage(
-  // { kind: 'log', level: 'error', text })`. This propagates through
-  // the WorkerPool's `onLog` callback to the host, which in turn
-  // surfaces it in the user-visible log channel.
-  //
-  // This test pins the wire path end-to-end: a fixture rule whose
-  // fix() throws → onLog sees the forwarded error string. Pre-fix,
-  // the rule's stderr never reached `onLog`.
-  test('R4: rule fix() throw is forwarded through onLog (LSP-visible)', async () => {
-    // Inline a fixture plugin that always errors in fix(). Reuse the
-    // local config dir's plugin path so config plumbing matches the
-    // pool's expectations, but override the rule resolution via the
-    // request's `rules` map. (The pool config still loads the local
-    // plugin so worker init succeeds; the task explicitly requests a
-    // non-existent rule so we exercise the no-rule path instead.)
+      const pool = new WorkerPool({
+        configs: [
+          {
+            configPath: path.join(cfgADir, 'rslint.config.mjs'),
+            configDirectory: cfgADir,
+          },
+        ],
+        workerCount: 1,
+        taskTimeoutMs: 10_000,
+      });
+      await pool.init();
+
+      const bogusKey = '/not/in/worker/configs';
+      const results = await pool.lintBatch([
+        {
+          filePath: 'rogue.ts',
+          text: 'const x = null;',
+          rules: { 'pkgA/no-null': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: bogusKey,
+        },
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].diagnostics).toHaveLength(0);
+      expect(results[0].parseError).toBeDefined();
+      // The error message must name BOTH the rogue key and the set of
+      // configured directories so an operator can tell whether the host
+      // sent the wrong key or the worker was built with the wrong set.
+      expect(results[0].parseError).toMatch(/configKey/);
+      expect(results[0].parseError).toContain(bogusKey);
+      expect(results[0].parseError).toContain(cfgADir);
+
+      await pool.shutdown();
+    }, 20_000);
+
+    // R4: rule-side warnings (listener throw, fix() throw, suggest fix
+    // throw, invalid fix return) used to go through `process.stderr.write`
+    // directly. Under LSP that lands in VS Code's hidden "Window"
+    // channel — invisible to a user trying to debug a misbehaving
+    // plugin. After R4, the runner uses `console.error`, which
+    // `lint-worker.ts` monkey-patches into `parentPort.postMessage(
+    // { kind: 'log', level: 'error', text })`. This propagates through
+    // the WorkerPool's `onLog` callback to the host, which in turn
+    // surfaces it in the user-visible log channel.
     //
-    // Cleaner: write a tiny fixture plugin + config.
-    const fs = await import('node:fs/promises');
-    const fxDir = path.resolve(__dirname, 'fixtures');
-    const pluginPath = path.join(fxDir, '_r4-bad-fix-plugin.mjs');
-    const cfgPath = path.join(fxDir, '_r4-bad-fix.config.mjs');
-    await fs.writeFile(
-      pluginPath,
-      `export default {
+    // This test pins the wire path end-to-end: a fixture rule whose
+    // fix() throws → onLog sees the forwarded error string. Pre-fix,
+    // the rule's stderr never reached `onLog`.
+    test('R4: rule fix() throw is forwarded through onLog (LSP-visible)', async () => {
+      // Inline a fixture plugin that always errors in fix(). Reuse the
+      // local config dir's plugin path so config plumbing matches the
+      // pool's expectations, but override the rule resolution via the
+      // request's `rules` map. (The pool config still loads the local
+      // plugin so worker init succeeds; the task explicitly requests a
+      // non-existent rule so we exercise the no-rule path instead.)
+      //
+      // Cleaner: write a tiny fixture plugin + config.
+      const fs = await import('node:fs/promises');
+      const fxDir = path.resolve(__dirname, 'fixtures');
+      const pluginPath = path.join(fxDir, '_r4-bad-fix-plugin.mjs');
+      const cfgPath = path.join(fxDir, '_r4-bad-fix.config.mjs');
+      await fs.writeFile(
+        pluginPath,
+        `export default {
   meta: { name: 'r4', version: '0.0.0' },
   rules: {
     'bad-fix': {
@@ -296,54 +307,55 @@ describe('WorkerPool end-to-end with a local fixture plugin', () => {
   },
 };
 `,
-      'utf8',
-    );
-    await fs.writeFile(
-      cfgPath,
-      `import p from './_r4-bad-fix-plugin.mjs';
+        'utf8',
+      );
+      await fs.writeFile(
+        cfgPath,
+        `import p from './_r4-bad-fix-plugin.mjs';
 export default [{ eslintPlugins: { r4: p } }];
 `,
-      'utf8',
-    );
-
-    const logs: Array<{ level: string; source: string; text: string }> = [];
-    const pool = new WorkerPool({
-      configs: [{ configPath: cfgPath, configDirectory: fxDir }],
-      workerCount: 1,
-      onLog: (rec) => logs.push(rec),
-    });
-
-    try {
-      await pool.init();
-      await pool.lintBatch([
-        {
-          filePath: 't.ts',
-          text: 'const trigger = 1;',
-          rules: { 'r4/bad-fix': { options: [] } },
-          collectFixes: true,
-          suggestionsMode: 'off',
-          configKey: fxDir,
-        },
-      ]);
-
-      // The forwarded log line must contain the rule name + a hint at
-      // the failure path. Pre-R4 the string went to raw stderr and
-      // logs would not contain it.
-      const errLogs = logs.filter((r) => r.level === 'error');
-      const matched = errLogs.find((r) =>
-        /r4\/bad-fix.*fix\(\) threw.*R4_FIX_BOOM/.test(r.text),
+        'utf8',
       );
-      expect(matched).toBeDefined();
-      // Source must be 'plugin' (runner-side console.error from
-      // diagnostic-builder running inside the worker, fed through the
-      // patched console).
-      expect(matched!.source).toBe('plugin');
-    } finally {
-      await pool.shutdown();
-      await Promise.all([
-        fs.rm(pluginPath, { force: true }),
-        fs.rm(cfgPath, { force: true }),
-      ]);
-    }
-  }, 15_000);
-});
+
+      const logs: Array<{ level: string; source: string; text: string }> = [];
+      const pool = new WorkerPool({
+        configs: [{ configPath: cfgPath, configDirectory: fxDir }],
+        workerCount: 1,
+        onLog: (rec) => logs.push(rec),
+      });
+
+      try {
+        await pool.init();
+        await pool.lintBatch([
+          {
+            filePath: 't.ts',
+            text: 'const trigger = 1;',
+            rules: { 'r4/bad-fix': { options: [] } },
+            collectFixes: true,
+            suggestionsMode: 'off',
+            configKey: fxDir,
+          },
+        ]);
+
+        // The forwarded log line must contain the rule name + a hint at
+        // the failure path. Pre-R4 the string went to raw stderr and
+        // logs would not contain it.
+        const errLogs = logs.filter((r) => r.level === 'error');
+        const matched = errLogs.find((r) =>
+          /r4\/bad-fix.*fix\(\) threw.*R4_FIX_BOOM/.test(r.text),
+        );
+        expect(matched).toBeDefined();
+        // Source must be 'plugin' (runner-side console.error from
+        // diagnostic-builder running inside the worker, fed through the
+        // patched console).
+        expect(matched!.source).toBe('plugin');
+      } finally {
+        await pool.shutdown();
+        await Promise.all([
+          fs.rm(pluginPath, { force: true }),
+          fs.rm(cfgPath, { force: true }),
+        ]);
+      }
+    }, 15_000);
+  },
+);

--- a/packages/eslint-plugin-runner/tests/worker-pool-e2e-queue.test.ts
+++ b/packages/eslint-plugin-runner/tests/worker-pool-e2e-queue.test.ts
@@ -19,321 +19,331 @@ import {
  * batches as parseError:'pool_degraded' instead of hanging.
  */
 
-describe('WorkerPool end-to-end with a local fixture plugin', () => {
-  // R1 (re-purposed for the queue model): the original R1 finding
-  // — `Promise.all` rejecting the whole batch when no worker was
-  // available — was eliminated by the queue refactor. Tasks now wait
-  // in `pendingQueue` for an idle worker rather than failing
-  // synchronously; transient "all workers not-ready" (mid-respawn,
-  // mid-cancel) becomes a brief backlog stall instead of a batch-
-  // wide reject.
-  //
-  // The new equivalent invariant: when the pool shuts down WHILE
-  // tasks are queued, those queued tasks must still settle (not
-  // hang) with a `parseError: 'shutdown'` marker — the same
-  // result-shaped failure inflight tasks get. This guards against
-  // a regression where the queue path drops settlement of queued
-  // promises during teardown.
-  test('R1: queued tasks resolve as parseError:shutdown when pool shuts down mid-batch', async () => {
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-    });
-    await pool.init();
-    // Force the lone worker to look busy (not idle) so freshly-
-    // enqueued tasks stay in `pendingQueue` instead of being
-    // dispatched immediately. Without this the worker would grab
-    // them before shutdown lands.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ws = (pool as any).workers as Array<{ ready: boolean }>;
-    ws[0].ready = false;
-
-    // Kick off a 5-file batch. With the worker not-ready, all 5
-    // tasks land in pendingQueue and the Promise.all stays pending.
-    const batchP = pool.lintBatch(
-      [1, 2, 3, 4, 5].map((i) => ({
-        filePath: `q${i}.ts`,
-        text: 'const x = null;\n',
-        rules: { 'local/no-null': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: LOCAL_CONFIG_DIR,
-      })),
-    );
-
-    // Let the enqueue actually happen before shutting down.
-    await new Promise((r) => setTimeout(r, 30));
-
-    // Tear down. shutdown() must drain pendingQueue and resolve
-    // every queued task with the 'shutdown' marker.
-    await pool.shutdown();
-    const result = await batchP;
-    expect(result).toHaveLength(5);
-    for (const r of result) {
-      expect(r.parseError).toBe('shutdown');
-      expect(r.diagnostics).toEqual([]);
-      expect(r.cancelled).toBe(false);
-    }
-    // No leaked worker slot.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((pool as any).workers.length).toBe(0);
-    // No leaked queue entries.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((pool as any).pendingQueue.length).toBe(0);
-  }, 15_000);
-
-  test('all workers degraded → pendingQueue drains as parseError:pool_degraded (no hang)', async () => {
-    // Regression for review P0 #2. When every worker exhausts its
-    // respawn cap (default 3), the 'exit' handler used to JUST log;
-    // `kickQueue` skips not-ready slots, so anything in
-    // `pendingQueue` waited forever — `await pool.lintBatch(tasks)`
-    // never returned and the host had no path to recover.
+// Skipped on windows: tearing down a worker that has oxc (a napi addon)
+// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
+// the rstest worker running this file. These e2e tests spawn real
+// workers and tear them down, so they are windows-skipped; they still
+// run on linux/macOS.
+describe.skipIf(process.platform === 'win32')(
+  'WorkerPool end-to-end with a local fixture plugin',
+  () => {
+    // R1 (re-purposed for the queue model): the original R1 finding
+    // — `Promise.all` rejecting the whole batch when no worker was
+    // available — was eliminated by the queue refactor. Tasks now wait
+    // in `pendingQueue` for an idle worker rather than failing
+    // synchronously; transient "all workers not-ready" (mid-respawn,
+    // mid-cancel) becomes a brief backlog stall instead of a batch-
+    // wide reject.
     //
-    // Fix: in the cap-reached branch, drain `pendingQueue` with
-    // `parseError: 'pool_degraded'` once every slot is `ready=false`.
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-      retryCap: 1,
-    });
-    await pool.init();
+    // The new equivalent invariant: when the pool shuts down WHILE
+    // tasks are queued, those queued tasks must still settle (not
+    // hang) with a `parseError: 'shutdown'` marker — the same
+    // result-shaped failure inflight tasks get. This guards against
+    // a regression where the queue path drops settlement of queued
+    // promises during teardown.
+    test('R1: queued tasks resolve as parseError:shutdown when pool shuts down mid-batch', async () => {
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+      });
+      await pool.init();
+      // Force the lone worker to look busy (not idle) so freshly-
+      // enqueued tasks stay in `pendingQueue` instead of being
+      // dispatched immediately. Without this the worker would grab
+      // them before shutdown lands.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const ws = (pool as any).workers as Array<{ ready: boolean }>;
+      ws[0].ready = false;
 
-    // Wedge: enqueue a couple of tasks but hold the worker non-ready
-    // so kickQueue can't dispatch.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const internals = pool as any;
-    internals.workers[0].ready = false;
-
-    const batchP = pool.lintBatch(
-      [1, 2].map((i) => ({
-        filePath: `q${i}.ts`,
-        text: 'const x = null;\n',
-        rules: { 'local/no-null': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: LOCAL_CONFIG_DIR,
-      })),
-    );
-    await new Promise((r) => setTimeout(r, 30));
-
-    // Simulate the terminal "all workers exhausted retryCap" state by
-    // bumping crashCount and re-running the exit handler. The exit
-    // handler is wired during `attachOngoingHandlers`; the simplest
-    // path is to terminate the worker (triggers a real 'exit') after
-    // setting crashCount to the cap.
-    internals.workers[0].crashCount = internals.opts.retryCap;
-    await internals.workers[0].worker.terminate();
-
-    const result = await batchP;
-    expect(result).toHaveLength(2);
-    for (const r of result) {
-      expect(r.parseError).toBe('pool_degraded');
-      expect(r.cancelled).toBe(false);
-      expect(r.diagnostics).toEqual([]);
-    }
-    // Pending queue fully drained.
-    expect(internals.pendingQueue.length).toBe(0);
-
-    // Tear down cleanly — the pool is in a degraded state but
-    // shutdown() should still work.
-    await pool.shutdown();
-  }, 15_000);
-
-  // Queue-model regression suite — five tests pinning the design
-  // properties that the Finding 3 refactor introduced.
-
-  test('queue: large batch on a single worker completes without queue-time timeout', async () => {
-    // 20 tasks on 1 worker × 600ms timer = 12 s total work. Pre-
-    // refactor, the timer started at lintBatch enqueue time, so
-    // tasks 2-20 raced their 600ms deadline against a 1-worker
-    // serial backlog and most would land as task_timeout. Post-
-    // refactor, each task's timer starts only when the worker
-    // actually takes it off the queue — so every task gets its
-    // full 600ms execution budget regardless of position.
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-      taskTimeoutMs: 600,
-    });
-    await pool.init();
-    try {
-      const tasks: LintTask[] = [];
-      for (let i = 0; i < 20; i++) {
-        tasks.push({
-          filePath: `f${i}.ts`,
+      // Kick off a 5-file batch. With the worker not-ready, all 5
+      // tasks land in pendingQueue and the Promise.all stays pending.
+      const batchP = pool.lintBatch(
+        [1, 2, 3, 4, 5].map((i) => ({
+          filePath: `q${i}.ts`,
           text: 'const x = null;\n',
           rules: { 'local/no-null': { options: [] } },
           collectFixes: false,
           suggestionsMode: 'off',
           configKey: LOCAL_CONFIG_DIR,
-        });
-      }
-      const results = await pool.lintBatch(tasks);
-      expect(results).toHaveLength(20);
-      // Every file has exactly ONE `null` literal → exactly ONE
-      // `local/no-null` diagnostic. `toBe(1)` (not `> 0`) proves the
-      // task ran AND catches a queue-reuse regression where a file is
-      // dispatched twice and its diagnostics merged (→ 2). None should
-      // be task_timeout: a queue-time timeout regression would land
-      // most as parseError.
-      for (const r of results) {
-        expect(r.parseError).toBeUndefined();
-        expect(r.diagnostics.length).toBe(1);
-      }
-    } finally {
+        })),
+      );
+
+      // Let the enqueue actually happen before shutting down.
+      await new Promise((r) => setTimeout(r, 30));
+
+      // Tear down. shutdown() must drain pendingQueue and resolve
+      // every queued task with the 'shutdown' marker.
       await pool.shutdown();
-    }
-  }, 30_000);
-
-  test('queue: kickQueue is idempotent + safe with empty queue', async () => {
-    // kickQueue gets called from multiple async paths (result
-    // handler, exit handler, lintBatch, postMessage_failed); a
-    // bug that double-dispatches a task or trips on an empty queue
-    // would surface as either an extra postMessage (file double-
-    // linted) or an exception. Hammer it.
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 2,
-    });
-    await pool.init();
-    try {
-      // No queued tasks — repeated kicks must be no-ops.
-      for (let i = 0; i < 20; i++) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (pool as any).kickQueue();
+      const result = await batchP;
+      expect(result).toHaveLength(5);
+      for (const r of result) {
+        expect(r.parseError).toBe('shutdown');
+        expect(r.diagnostics).toEqual([]);
+        expect(r.cancelled).toBe(false);
       }
-      // Now actually lint — pool should still work normally.
-      const r = await pool.lintBatch([
-        {
-          filePath: 'a.ts',
+      // No leaked worker slot.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((pool as any).workers.length).toBe(0);
+      // No leaked queue entries.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((pool as any).pendingQueue.length).toBe(0);
+    }, 15_000);
+
+    test('all workers degraded → pendingQueue drains as parseError:pool_degraded (no hang)', async () => {
+      // Regression for review P0 #2. When every worker exhausts its
+      // respawn cap (default 3), the 'exit' handler used to JUST log;
+      // `kickQueue` skips not-ready slots, so anything in
+      // `pendingQueue` waited forever — `await pool.lintBatch(tasks)`
+      // never returned and the host had no path to recover.
+      //
+      // Fix: in the cap-reached branch, drain `pendingQueue` with
+      // `parseError: 'pool_degraded'` once every slot is `ready=false`.
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+        retryCap: 1,
+      });
+      await pool.init();
+
+      // Wedge: enqueue a couple of tasks but hold the worker non-ready
+      // so kickQueue can't dispatch.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const internals = pool as any;
+      internals.workers[0].ready = false;
+
+      const batchP = pool.lintBatch(
+        [1, 2].map((i) => ({
+          filePath: `q${i}.ts`,
           text: 'const x = null;\n',
           rules: { 'local/no-null': { options: [] } },
           collectFixes: false,
           suggestionsMode: 'off',
           configKey: LOCAL_CONFIG_DIR,
-        },
+        })),
+      );
+      await new Promise((r) => setTimeout(r, 30));
+
+      // Simulate the terminal "all workers exhausted retryCap" state by
+      // bumping crashCount and re-running the exit handler. The exit
+      // handler is wired during `attachOngoingHandlers`; the simplest
+      // path is to terminate the worker (triggers a real 'exit') after
+      // setting crashCount to the cap.
+      internals.workers[0].crashCount = internals.opts.retryCap;
+      await internals.workers[0].worker.terminate();
+
+      const result = await batchP;
+      expect(result).toHaveLength(2);
+      for (const r of result) {
+        expect(r.parseError).toBe('pool_degraded');
+        expect(r.cancelled).toBe(false);
+        expect(r.diagnostics).toEqual([]);
+      }
+      // Pending queue fully drained.
+      expect(internals.pendingQueue.length).toBe(0);
+
+      // Tear down cleanly — the pool is in a degraded state but
+      // shutdown() should still work.
+      await pool.shutdown();
+    }, 15_000);
+
+    // Queue-model regression suite — five tests pinning the design
+    // properties that the Finding 3 refactor introduced.
+
+    test('queue: large batch on a single worker completes without queue-time timeout', async () => {
+      // 20 tasks on 1 worker × 600ms timer = 12 s total work. Pre-
+      // refactor, the timer started at lintBatch enqueue time, so
+      // tasks 2-20 raced their 600ms deadline against a 1-worker
+      // serial backlog and most would land as task_timeout. Post-
+      // refactor, each task's timer starts only when the worker
+      // actually takes it off the queue — so every task gets its
+      // full 600ms execution budget regardless of position.
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+        taskTimeoutMs: 600,
+      });
+      await pool.init();
+      try {
+        const tasks: LintTask[] = [];
+        for (let i = 0; i < 20; i++) {
+          tasks.push({
+            filePath: `f${i}.ts`,
+            text: 'const x = null;\n',
+            rules: { 'local/no-null': { options: [] } },
+            collectFixes: false,
+            suggestionsMode: 'off',
+            configKey: LOCAL_CONFIG_DIR,
+          });
+        }
+        const results = await pool.lintBatch(tasks);
+        expect(results).toHaveLength(20);
+        // Every file has exactly ONE `null` literal → exactly ONE
+        // `local/no-null` diagnostic. `toBe(1)` (not `> 0`) proves the
+        // task ran AND catches a queue-reuse regression where a file is
+        // dispatched twice and its diagnostics merged (→ 2). None should
+        // be task_timeout: a queue-time timeout regression would land
+        // most as parseError.
+        for (const r of results) {
+          expect(r.parseError).toBeUndefined();
+          expect(r.diagnostics.length).toBe(1);
+        }
+      } finally {
+        await pool.shutdown();
+      }
+    }, 30_000);
+
+    test('queue: kickQueue is idempotent + safe with empty queue', async () => {
+      // kickQueue gets called from multiple async paths (result
+      // handler, exit handler, lintBatch, postMessage_failed); a
+      // bug that double-dispatches a task or trips on an empty queue
+      // would surface as either an extra postMessage (file double-
+      // linted) or an exception. Hammer it.
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 2,
+      });
+      await pool.init();
+      try {
+        // No queued tasks — repeated kicks must be no-ops.
+        for (let i = 0; i < 20; i++) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (pool as any).kickQueue();
+        }
+        // Now actually lint — pool should still work normally.
+        const r = await pool.lintBatch([
+          {
+            filePath: 'a.ts',
+            text: 'const x = null;\n',
+            rules: { 'local/no-null': { options: [] } },
+            collectFixes: false,
+            suggestionsMode: 'off',
+            configKey: LOCAL_CONFIG_DIR,
+          },
+        ]);
+        expect(r).toHaveLength(1);
+        // Single file, single `null` literal → exactly ONE diagnostic.
+        // `toBe(1)` (not `> 0`) catches a kickQueue double-dispatch that
+        // would re-lint the file and surface duplicate diagnostics.
+        expect(r[0].diagnostics.length).toBe(1);
+      } finally {
+        await pool.shutdown();
+      }
+    }, 15_000);
+
+    test('queue: when batch size > worker count, all tasks complete (backpressure)', async () => {
+      // 30 tasks on 2 workers — only 2 inflight at a time, the
+      // remaining 28 sit in pendingQueue and get dispatched as
+      // workers complete. Pre-refactor, all 30 were postMessage'd
+      // immediately, the worker postMessage queue grew, later tasks
+      // raced their timer. This test verifies backpressure works
+      // without artificial timing assumptions.
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 2,
+      });
+      await pool.init();
+      try {
+        const tasks: LintTask[] = [];
+        for (let i = 0; i < 30; i++) {
+          tasks.push({
+            filePath: `bp${i}.ts`,
+            text: 'const x = null;\n',
+            rules: { 'local/no-null': { options: [] } },
+            collectFixes: false,
+            suggestionsMode: 'off',
+            configKey: LOCAL_CONFIG_DIR,
+          });
+        }
+        const results = await pool.lintBatch(tasks);
+        expect(results).toHaveLength(30);
+        // Every task ran successfully — no parseError, and each file's
+        // single `null` literal yields exactly ONE diagnostic. `toBe(1)`
+        // (not `> 0`) additionally catches a backpressure/queue-reuse
+        // regression that double-dispatches a file (→ 2 diagnostics).
+        for (const r of results) {
+          expect(r.parseError).toBeUndefined();
+          expect(r.diagnostics.length).toBe(1);
+        }
+      } finally {
+        await pool.shutdown();
+      }
+    }, 30_000);
+
+    test('lintBatch issued AFTER the pool settled into the terminal degraded state resolves as pool_degraded (does not hang)', async () => {
+      // Regression for Fix A. The existing "all workers degraded →
+      // pendingQueue drains as parseError:pool_degraded" test only covers
+      // tasks ALREADY in-flight when the terminal exit fires. A
+      // `lintBatch` issued AFTER the pool has settled into the degraded
+      // state was never drained: it passed the `closed` guard (pool is
+      // degraded, not closed) and the `workers.length === 0` guard, then
+      // `kickQueue` skipped the not-ready slot and NO future event would
+      // ever call the drain again → `Promise.all` never settled →
+      // permanent hang. Fix: `lintBatch` calls
+      // `drainQueueIfAllSlotsDegraded()` after the enqueue/kick so a
+      // batch handed to an already-terminal pool resolves immediately.
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+        retryCap: 1,
+      });
+      await pool.init();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const internals = pool as any;
+
+      // Drive the pool to the terminal degraded state EXACTLY the way the
+      // existing in-flight-drain test does: hold the slot non-ready,
+      // enqueue a first batch, push crashCount to the cap, and terminate
+      // the worker so its real 'exit' handler takes the cap-reached
+      // branch and drains that first batch as pool_degraded.
+      internals.workers[0].ready = false;
+      const firstBatch = pool.lintBatch([
+        task('first.ts', 'const x = null;\n'),
       ]);
-      expect(r).toHaveLength(1);
-      // Single file, single `null` literal → exactly ONE diagnostic.
-      // `toBe(1)` (not `> 0`) catches a kickQueue double-dispatch that
-      // would re-lint the file and surface duplicate diagnostics.
-      expect(r[0].diagnostics.length).toBe(1);
-    } finally {
-      await pool.shutdown();
-    }
-  }, 15_000);
+      await new Promise((r) => setTimeout(r, 30));
+      internals.workers[0].crashCount = internals.opts.retryCap;
+      await internals.workers[0].worker.terminate();
 
-  test('queue: when batch size > worker count, all tasks complete (backpressure)', async () => {
-    // 30 tasks on 2 workers — only 2 inflight at a time, the
-    // remaining 28 sit in pendingQueue and get dispatched as
-    // workers complete. Pre-refactor, all 30 were postMessage'd
-    // immediately, the worker postMessage queue grew, later tasks
-    // raced their timer. This test verifies backpressure works
-    // without artificial timing assumptions.
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 2,
-    });
-    await pool.init();
-    try {
-      const tasks: LintTask[] = [];
-      for (let i = 0; i < 30; i++) {
-        tasks.push({
-          filePath: `bp${i}.ts`,
-          text: 'const x = null;\n',
-          rules: { 'local/no-null': { options: [] } },
-          collectFixes: false,
-          suggestionsMode: 'off',
-          configKey: LOCAL_CONFIG_DIR,
-        });
+      const firstResult = await firstBatch;
+      expect(firstResult).toHaveLength(1);
+      expect(firstResult[0].parseError).toBe('pool_degraded');
+
+      // Pool is now terminal: slot is ready=false, respawning=false,
+      // EXITED (the worker thread really died — this is the discriminator
+      // that separates this from a benign not-ready-but-alive worker),
+      // crashCount>=cap, and NOT closed. Sanity-check that state so the
+      // test is exercising the intended scenario.
+      expect(internals.closed).toBe(false);
+      expect(internals.workers).toHaveLength(1);
+      expect(internals.workers[0].ready).toBe(false);
+      expect(internals.workers[0].respawning).toBe(false);
+      expect(internals.workers[0].exited).toBe(true);
+
+      // Issue a SECOND batch against the already-degraded pool. With the
+      // fix it must RESOLVE (every result pool_degraded). Without the fix
+      // it hangs forever — race it against a rejecting timer so the
+      // negative-check produces a clean, fast failure instead of wedging
+      // the whole suite on the per-test timeout.
+      const secondBatch = pool.lintBatch([
+        task('second-a.ts', 'const y = null;\n'),
+        task('second-b.ts', 'const z = null;\n'),
+      ]);
+      const guard = new Promise<never>((_, rej) =>
+        setTimeout(
+          () => rej(new Error('second lintBatch hung — Fix A regression')),
+          4_000,
+        ),
+      );
+      const secondResult = await Promise.race([secondBatch, guard]);
+      expect(secondResult).toHaveLength(2);
+      for (const r of secondResult) {
+        expect(r.parseError).toBe('pool_degraded');
+        expect(r.cancelled).toBe(false);
+        expect(r.diagnostics).toEqual([]);
       }
-      const results = await pool.lintBatch(tasks);
-      expect(results).toHaveLength(30);
-      // Every task ran successfully — no parseError, and each file's
-      // single `null` literal yields exactly ONE diagnostic. `toBe(1)`
-      // (not `> 0`) additionally catches a backpressure/queue-reuse
-      // regression that double-dispatches a file (→ 2 diagnostics).
-      for (const r of results) {
-        expect(r.parseError).toBeUndefined();
-        expect(r.diagnostics.length).toBe(1);
-      }
-    } finally {
+      expect(internals.pendingQueue.length).toBe(0);
+
       await pool.shutdown();
-    }
-  }, 30_000);
-
-  test('lintBatch issued AFTER the pool settled into the terminal degraded state resolves as pool_degraded (does not hang)', async () => {
-    // Regression for Fix A. The existing "all workers degraded →
-    // pendingQueue drains as parseError:pool_degraded" test only covers
-    // tasks ALREADY in-flight when the terminal exit fires. A
-    // `lintBatch` issued AFTER the pool has settled into the degraded
-    // state was never drained: it passed the `closed` guard (pool is
-    // degraded, not closed) and the `workers.length === 0` guard, then
-    // `kickQueue` skipped the not-ready slot and NO future event would
-    // ever call the drain again → `Promise.all` never settled →
-    // permanent hang. Fix: `lintBatch` calls
-    // `drainQueueIfAllSlotsDegraded()` after the enqueue/kick so a
-    // batch handed to an already-terminal pool resolves immediately.
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-      retryCap: 1,
-    });
-    await pool.init();
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const internals = pool as any;
-
-    // Drive the pool to the terminal degraded state EXACTLY the way the
-    // existing in-flight-drain test does: hold the slot non-ready,
-    // enqueue a first batch, push crashCount to the cap, and terminate
-    // the worker so its real 'exit' handler takes the cap-reached
-    // branch and drains that first batch as pool_degraded.
-    internals.workers[0].ready = false;
-    const firstBatch = pool.lintBatch([task('first.ts', 'const x = null;\n')]);
-    await new Promise((r) => setTimeout(r, 30));
-    internals.workers[0].crashCount = internals.opts.retryCap;
-    await internals.workers[0].worker.terminate();
-
-    const firstResult = await firstBatch;
-    expect(firstResult).toHaveLength(1);
-    expect(firstResult[0].parseError).toBe('pool_degraded');
-
-    // Pool is now terminal: slot is ready=false, respawning=false,
-    // EXITED (the worker thread really died — this is the discriminator
-    // that separates this from a benign not-ready-but-alive worker),
-    // crashCount>=cap, and NOT closed. Sanity-check that state so the
-    // test is exercising the intended scenario.
-    expect(internals.closed).toBe(false);
-    expect(internals.workers).toHaveLength(1);
-    expect(internals.workers[0].ready).toBe(false);
-    expect(internals.workers[0].respawning).toBe(false);
-    expect(internals.workers[0].exited).toBe(true);
-
-    // Issue a SECOND batch against the already-degraded pool. With the
-    // fix it must RESOLVE (every result pool_degraded). Without the fix
-    // it hangs forever — race it against a rejecting timer so the
-    // negative-check produces a clean, fast failure instead of wedging
-    // the whole suite on the per-test timeout.
-    const secondBatch = pool.lintBatch([
-      task('second-a.ts', 'const y = null;\n'),
-      task('second-b.ts', 'const z = null;\n'),
-    ]);
-    const guard = new Promise<never>((_, rej) =>
-      setTimeout(
-        () => rej(new Error('second lintBatch hung — Fix A regression')),
-        4_000,
-      ),
-    );
-    const secondResult = await Promise.race([secondBatch, guard]);
-    expect(secondResult).toHaveLength(2);
-    for (const r of secondResult) {
-      expect(r.parseError).toBe('pool_degraded');
-      expect(r.cancelled).toBe(false);
-      expect(r.diagnostics).toEqual([]);
-    }
-    expect(internals.pendingQueue.length).toBe(0);
-
-    await pool.shutdown();
-  }, 15_000);
-});
+    }, 15_000);
+  },
+);

--- a/packages/eslint-plugin-runner/tests/worker-pool-e2e-resilience.test.ts
+++ b/packages/eslint-plugin-runner/tests/worker-pool-e2e-resilience.test.ts
@@ -17,203 +17,211 @@ import {
  * respawn, and a hung listener trips task_timeout → respawn → recovery.
  */
 
-describe('WorkerPool end-to-end with a local fixture plugin', () => {
-  // postMessage path: a non-clonable field on the task makes
-  // structuredClone throw inside slot.worker.postMessage. The pool must
-  // (a) NOT leak the per-task bookkeeping (timer/cancelSlot/inflight)
-  // and (b) surface a result-shaped failure rather than poisoning the
-  // whole batch via Promise.all rejection.
-  test('postMessage failure on unserializable task yields a clean per-file error', async () => {
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 1,
-      taskTimeoutMs: 5_000,
-    });
-    await pool.init();
+// Skipped on windows: tearing down a worker that has oxc (a napi addon)
+// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
+// the rstest worker running this file. These e2e tests spawn real
+// workers and tear them down, so they are windows-skipped; they still
+// run on linux/macOS.
+describe.skipIf(process.platform === 'win32')(
+  'WorkerPool end-to-end with a local fixture plugin',
+  () => {
+    // postMessage path: a non-clonable field on the task makes
+    // structuredClone throw inside slot.worker.postMessage. The pool must
+    // (a) NOT leak the per-task bookkeeping (timer/cancelSlot/inflight)
+    // and (b) surface a result-shaped failure rather than poisoning the
+    // whole batch via Promise.all rejection.
+    test('postMessage failure on unserializable task yields a clean per-file error', async () => {
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 1,
+        taskTimeoutMs: 5_000,
+      });
+      await pool.init();
 
-    // A function on the rule meta — structuredClone refuses to clone
-    // functions (DataCloneError). This deterministically triggers the
-    // postMessage throw without depending on worker internals.
-    const badTask: LintTask = {
-      filePath: 'bad.ts',
-      text: `const x = null;`,
-      rules: {
-        'local/no-null': {
-          options: [],
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          meta: { unserializable: () => 'function' } as any,
+      // A function on the rule meta — structuredClone refuses to clone
+      // functions (DataCloneError). This deterministically triggers the
+      // postMessage throw without depending on worker internals.
+      const badTask: LintTask = {
+        filePath: 'bad.ts',
+        text: `const x = null;`,
+        rules: {
+          'local/no-null': {
+            options: [],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            meta: { unserializable: () => 'function' } as any,
+          },
         },
-      },
-      collectFixes: false,
-      suggestionsMode: 'off',
-      configKey: LOCAL_CONFIG_DIR,
-    };
+        collectFixes: false,
+        suggestionsMode: 'off',
+        configKey: LOCAL_CONFIG_DIR,
+      };
 
-    // Sibling task in the same batch — should still succeed even after
-    // the bad task's dispatch throws. This is the "Promise.all isn't
-    // poisoned" half of the contract.
-    const goodTask: LintTask = task('good.ts', `const y = null;`);
+      // Sibling task in the same batch — should still succeed even after
+      // the bad task's dispatch throws. This is the "Promise.all isn't
+      // poisoned" half of the contract.
+      const goodTask: LintTask = task('good.ts', `const y = null;`);
 
-    const results = await pool.lintBatch([badTask, goodTask]);
+      const results = await pool.lintBatch([badTask, goodTask]);
 
-    expect(results).toHaveLength(2);
-    expect(results[0].filePath).toBe('bad.ts');
-    expect(results[0].parseError).toMatch(/postMessage_failed/);
-    expect(results[0].diagnostics).toHaveLength(0);
-    expect(results[1].filePath).toBe('good.ts');
-    expect(results[1].diagnostics).toHaveLength(1);
+      expect(results).toHaveLength(2);
+      expect(results[0].filePath).toBe('bad.ts');
+      expect(results[0].parseError).toMatch(/postMessage_failed/);
+      expect(results[0].diagnostics).toHaveLength(0);
+      expect(results[1].filePath).toBe('good.ts');
+      expect(results[1].diagnostics).toHaveLength(1);
 
-    const followUp = await pool.lintBatch([goodTask]);
-    expect(followUp[0].diagnostics).toHaveLength(1);
+      const followUp = await pool.lintBatch([goodTask]);
+      expect(followUp[0].diagnostics).toHaveLength(1);
 
-    await pool.shutdown();
-  });
-
-  // #2: a batch of MANY non-cloneable (DataCloneError) tasks must each
-  // degrade to `postMessage_failed` independently — NOT overflow the stack.
-  // Pre-fix the DataCloneError catch called `kickQueue()` synchronously, so
-  // consecutive poison tasks recursed (kickQueue → dispatch → catch →
-  // kickQueue → …) and the whole batch rejected with `RangeError: Maximum
-  // call stack size exceeded` (measured overflow at a few thousand). The fix
-  // defers kickQueue via `queueMicrotask`, giving each re-dispatch a fresh
-  // stack frame so every file degrades independently.
-  test('#2: large batch of non-cloneable tasks all degrade (no stack overflow)', async () => {
-    const pool = new WorkerPool({ configs: localConfigs, workerCount: 1 });
-    await pool.init();
-
-    const poison = (i: number): LintTask => ({
-      filePath: `poison${i}.ts`,
-      text: 'const x = null;',
-      rules: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        'local/no-null': { options: [], meta: { f: () => i } as any },
-      },
-      collectFixes: false,
-      suggestionsMode: 'off',
-      configKey: LOCAL_CONFIG_DIR,
+      await pool.shutdown();
     });
 
-    // 6000 is comfortably past the pre-fix overflow threshold (~2–5k).
-    const N = 6000;
-    const results = await pool.lintBatch(
-      Array.from({ length: N }, (_, i) => poison(i)),
-    );
+    // #2: a batch of MANY non-cloneable (DataCloneError) tasks must each
+    // degrade to `postMessage_failed` independently — NOT overflow the stack.
+    // Pre-fix the DataCloneError catch called `kickQueue()` synchronously, so
+    // consecutive poison tasks recursed (kickQueue → dispatch → catch →
+    // kickQueue → …) and the whole batch rejected with `RangeError: Maximum
+    // call stack size exceeded` (measured overflow at a few thousand). The fix
+    // defers kickQueue via `queueMicrotask`, giving each re-dispatch a fresh
+    // stack frame so every file degrades independently.
+    test('#2: large batch of non-cloneable tasks all degrade (no stack overflow)', async () => {
+      const pool = new WorkerPool({ configs: localConfigs, workerCount: 1 });
+      await pool.init();
 
-    expect(results).toHaveLength(N);
-    for (const r of results) {
-      expect(r.parseError).toMatch(/postMessage_failed/);
-      expect(r.diagnostics).toHaveLength(0);
-    }
-    // Pool still healthy after the poison flood.
-    const ok = await pool.lintBatch([task('ok.ts', 'const y = null;')]);
-    expect(ok[0].diagnostics).toHaveLength(1);
+      const poison = (i: number): LintTask => ({
+        filePath: `poison${i}.ts`,
+        text: 'const x = null;',
+        rules: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          'local/no-null': { options: [], meta: { f: () => i } as any },
+        },
+        collectFixes: false,
+        suggestionsMode: 'off',
+        configKey: LOCAL_CONFIG_DIR,
+      });
 
-    await pool.shutdown();
-  }, 30_000);
+      // 6000 is comfortably past the pre-fix overflow threshold (~2–5k).
+      const N = 6000;
+      const results = await pool.lintBatch(
+        Array.from({ length: N }, (_, i) => poison(i)),
+      );
 
-  // Respawn-during-shutdown race regression — see the long jsdoc on
-  // the failing case in the previous version of this file. Same
-  // contract under configs-flow: shutdown completes promptly and the
-  // workers array stays empty after a leaked respawn settles.
-  test('worker exit racing shutdown does not leak the respawn', async () => {
-    const pool = new WorkerPool({
-      configs: localConfigs,
-      workerCount: 2,
-      taskTimeoutMs: 5_000,
+      expect(results).toHaveLength(N);
+      for (const r of results) {
+        expect(r.parseError).toMatch(/postMessage_failed/);
+        expect(r.diagnostics).toHaveLength(0);
+      }
+      // Pool still healthy after the poison flood.
+      const ok = await pool.lintBatch([task('ok.ts', 'const y = null;')]);
+      expect(ok[0].diagnostics).toHaveLength(1);
+
+      await pool.shutdown();
+    }, 30_000);
+
+    // Respawn-during-shutdown race regression — see the long jsdoc on
+    // the failing case in the previous version of this file. Same
+    // contract under configs-flow: shutdown completes promptly and the
+    // workers array stays empty after a leaked respawn settles.
+    test('worker exit racing shutdown does not leak the respawn', async () => {
+      const pool = new WorkerPool({
+        configs: localConfigs,
+        workerCount: 2,
+        taskTimeoutMs: 5_000,
+      });
+      await pool.init();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const workers = (pool as any).workers as Array<{
+        worker: { terminate(): Promise<number> };
+      }>;
+      expect(workers.length).toBeGreaterThan(0);
+      void workers[0].worker.terminate();
+
+      const shutdownStart = Date.now();
+      await pool.shutdown();
+      const shutdownElapsed = Date.now() - shutdownStart;
+      expect(shutdownElapsed).toBeLessThan(10_000);
+
+      await expect(
+        pool.lintBatch([
+          {
+            filePath: 'x.ts',
+            text: 'const x = 1;',
+            rules: {},
+            collectFixes: false,
+            suggestionsMode: 'off',
+            configKey: LOCAL_CONFIG_DIR,
+          },
+        ]),
+      ).rejects.toThrow(/closed/);
+
+      await new Promise<void>((r) => setTimeout(r, 200));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const finalWorkers = (pool as any).workers as Array<unknown>;
+      expect(finalWorkers.length).toBe(0);
     });
-    await pool.init();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const workers = (pool as any).workers as Array<{
-      worker: { terminate(): Promise<number> };
-    }>;
-    expect(workers.length).toBeGreaterThan(0);
-    void workers[0].worker.terminate();
+    test('hung listener → task_timeout → respawn → next batch succeeds', async () => {
+      const hangConfigPath = path.resolve(
+        __dirname,
+        'fixtures',
+        'hang.config.mjs',
+      );
+      const hangConfigDir = path.dirname(hangConfigPath);
 
-    const shutdownStart = Date.now();
-    await pool.shutdown();
-    const shutdownElapsed = Date.now() - shutdownStart;
-    expect(shutdownElapsed).toBeLessThan(10_000);
+      const logs: Array<{ level: string; source: string; text: string }> = [];
+      const pool = new WorkerPool({
+        configs: [
+          {
+            configPath: hangConfigPath,
+            configDirectory: hangConfigDir,
+          },
+        ],
+        workerCount: 1,
+        // Aggressive timeout so the test doesn't sit for 30 s. 600 ms
+        // is comfortably above worker startup + import latency on CI
+        // (the existing happy-path tests in this file complete in ~50–
+        // 200 ms once the worker is up), but well below the 60-s test
+        // ceiling.
+        taskTimeoutMs: 600,
+        onLog: (rec) => logs.push(rec),
+      });
+      await pool.init();
 
-    await expect(
-      pool.lintBatch([
+      const hangResult = await pool.lintBatch([
         {
-          filePath: 'x.ts',
-          text: 'const x = 1;',
-          rules: {},
+          filePath: 'wedge.ts',
+          text: 'const x = 1;\n',
+          rules: { 'hang/hang': { options: [] } },
           collectFixes: false,
           suggestionsMode: 'off',
-          configKey: LOCAL_CONFIG_DIR,
+          configKey: hangConfigDir,
         },
-      ]),
-    ).rejects.toThrow(/closed/);
+      ]);
+      expect(hangResult).toHaveLength(1);
+      expect(hangResult[0].parseError).toBe('task_timeout');
 
-    await new Promise<void>((r) => setTimeout(r, 200));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const finalWorkers = (pool as any).workers as Array<unknown>;
-    expect(finalWorkers.length).toBe(0);
-  });
+      await new Promise((r) => setTimeout(r, 500));
 
-  test('hung listener → task_timeout → respawn → next batch succeeds', async () => {
-    const hangConfigPath = path.resolve(
-      __dirname,
-      'fixtures',
-      'hang.config.mjs',
-    );
-    const hangConfigDir = path.dirname(hangConfigPath);
-
-    const logs: Array<{ level: string; source: string; text: string }> = [];
-    const pool = new WorkerPool({
-      configs: [
+      const okResult = await pool.lintBatch([
         {
-          configPath: hangConfigPath,
-          configDirectory: hangConfigDir,
+          filePath: 'ok.ts',
+          text: 'const TRIGGER = 1;\n',
+          rules: { 'hang/noop': { options: [] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+          configKey: hangConfigDir,
         },
-      ],
-      workerCount: 1,
-      // Aggressive timeout so the test doesn't sit for 30 s. 600 ms
-      // is comfortably above worker startup + import latency on CI
-      // (the existing happy-path tests in this file complete in ~50–
-      // 200 ms once the worker is up), but well below the 60-s test
-      // ceiling.
-      taskTimeoutMs: 600,
-      onLog: (rec) => logs.push(rec),
-    });
-    await pool.init();
+      ]);
+      expect(okResult).toHaveLength(1);
+      expect(okResult[0].parseError).toBeUndefined();
+      expect(okResult[0].diagnostics).toHaveLength(1);
+      expect(okResult[0].diagnostics[0].message).toBe('noop fired');
 
-    const hangResult = await pool.lintBatch([
-      {
-        filePath: 'wedge.ts',
-        text: 'const x = 1;\n',
-        rules: { 'hang/hang': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: hangConfigDir,
-      },
-    ]);
-    expect(hangResult).toHaveLength(1);
-    expect(hangResult[0].parseError).toBe('task_timeout');
+      const respawnLog = logs.find((l) => l.text.includes('respawning'));
+      expect(respawnLog).toBeDefined();
 
-    await new Promise((r) => setTimeout(r, 500));
-
-    const okResult = await pool.lintBatch([
-      {
-        filePath: 'ok.ts',
-        text: 'const TRIGGER = 1;\n',
-        rules: { 'hang/noop': { options: [] } },
-        collectFixes: false,
-        suggestionsMode: 'off',
-        configKey: hangConfigDir,
-      },
-    ]);
-    expect(okResult).toHaveLength(1);
-    expect(okResult[0].parseError).toBeUndefined();
-    expect(okResult[0].diagnostics).toHaveLength(1);
-    expect(okResult[0].diagnostics[0].message).toBe('noop fired');
-
-    const respawnLog = logs.find((l) => l.text.includes('respawning'));
-    expect(respawnLog).toBeDefined();
-
-    await pool.shutdown();
-  }, 30_000);
-});
+      await pool.shutdown();
+    }, 30_000);
+  },
+);


### PR DESCRIPTION
## Summary

The `worker-pool-e2e-*` suites flakily crash the **windows** CI job with `Worker exited unexpectedly`. Root cause: tearing down a worker thread that has **oxc-parser (a napi/Rust addon)** loaded aborts **below the JS layer** on windows — `uv_loop_close() while having open handles` / SIGABRT (nodejs/node#34567, napi-rs/napi-rs#2460). rstest's forked test child intercepts `uncaughtException` / `unhandledRejection` / `process.exit`, so the only way it can "exit unexpectedly" is this native fault.

This is **not a bug in the pool logic** — it's a known limitation of `worker_threads` + native addons. There is no reliable JS-level mitigation (any teardown ordering still races the native cleanup, below the JS layer); a real fix needs process isolation (`child_process`), tracked separately.

These six suites all spawn real workers and tear them down (shutdown / terminate / crash / wedged paths), so they are gated behind `describe.skipIf(process.platform === 'win32')`. **linux/macOS keep running them in full** — the pool logic stays covered everywhere except the windows-native-abort path it cannot survive.

> The large diff is mostly prettier re-indenting each suite body one level after the `describe.skipIf(...)` wrap; the only logical change per file is the skip guard + an explanatory comment.

## Related Links

- Failing run: https://github.com/web-infra-dev/rslint/actions/runs/26490526197/job/78007746866
- nodejs/node#34567 — worker aborts on terminate when a native addon has an open handle
- napi-rs/napi-rs#2460 — SIGABRT when a napi future resolves on a terminated worker

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
