### PR TITLE
feat: run the rslint CLI over a generic Go-Node IPC channel

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -35,6 +35,31 @@ import (
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 )
 
+// lintArgs is the parsed CLI flag set, decoupled from the global flag
+// package so each entry point can build it: parseLintFlags from argv, and
+// runCLI additionally from the IPC init-handshake payload.
+type lintArgs struct {
+	Init           bool
+	Config         string
+	ConfigStdin    bool // true → executeLintPipeline reads stdin as a config payload
+	Fix            bool
+	TypeCheck      bool
+	TypeCheckOnly  bool
+	TraceOut       string
+	CpuprofOut     string
+	SingleThreaded bool
+	Format         string
+	NoColor        bool
+	ForceColor     bool
+	Quiet          bool
+	MaxWarnings    int
+	StartTimeMs    int64
+	RuleFlags      []string
+	// Positional args resolved into existing-dir vs file paths.
+	AllowFiles []string
+	AllowDirs  []string
+}
+
 // ColorScheme contains all the color functions for different UI elements
 type ColorScheme struct {
 	RuleName    func(format string, a ...interface{}) string
@@ -433,7 +458,7 @@ func printDiagnosticDefault(d rule.RuleDiagnostic, w *bufio.Writer, comparePathO
 // repeatedFlag collects multiple values for the same flag (e.g. --rule used multiple times).
 type repeatedFlag []string
 
-func (f *repeatedFlag) String() string   { return strings.Join(*f, ", ") }
+func (f *repeatedFlag) String() string     { return strings.Join(*f, ", ") }
 func (f *repeatedFlag) Set(v string) error { *f = append(*f, v); return nil }
 
 const usage = `🚀 Rslint - Rocket Speed Linter
@@ -643,70 +668,62 @@ func resolveStartTime(startTimeMs int64) time.Time {
 	return time.Now()
 }
 
-func runCMD() int {
-	flag.Usage = func() { fmt.Fprint(os.Stderr, usage) }
+// parseLintFlags parses the lint CLI flags out of argv into a lintArgs.
+// It uses a fresh FlagSet (not the global flag.CommandLine) so it is
+// callable more than once per process, and ContinueOnError so a bad flag
+// returns a fatal exit code instead of os.Exit-ing past caller cleanup.
+// A non-zero fatalExitCode means the caller should return it immediately
+// (the diagnostic was already printed to stderr).
+func parseLintFlags(argv []string) (args lintArgs, help bool, fatalExitCode int) {
+	fs := flag.NewFlagSet("rslint", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() { fmt.Fprint(os.Stderr, usage) }
 
-	var (
-		init        bool
-		help        bool
-		config      string
-		configStdin bool
-		fix           bool
-		typeCheck     bool
-		typeCheckOnly bool
+	var ruleFlags repeatedFlag
 
-		traceOut       string
-		cpuprofOut     string
-		singleThreaded bool
-		format         string
-		noColor        bool
-		forceColor     bool
-		quiet          bool
-		maxWarnings    int
-		startTimeMs    int64
-		ruleFlags      repeatedFlag
-	)
-	flag.StringVar(&format, "format", "default", "output format")
-	flag.StringVar(&config, "config", "", "which rslint config to use")
-	flag.BoolVar(&configStdin, "config-stdin", false, "read config from stdin (used internally by JS config loader)")
-	flag.BoolVar(&init, "init", false, "initialize a default config in the current directory")
-	flag.BoolVar(&fix, "fix", false, "automatically fix problems")
-	flag.BoolVar(&typeCheck, "type-check", false, "enable TypeScript type checking")
-	flag.BoolVar(&typeCheckOnly, "type-check-only", false, "run only TypeScript type checking (skip all lint rules)")
-	flag.BoolVar(&help, "help", false, "show help")
-	flag.BoolVar(&help, "h", false, "show help")
-	flag.BoolVar(&noColor, "no-color", false, "disable colored output")
-	flag.BoolVar(&forceColor, "force-color", false, "force colored output")
-	flag.BoolVar(&quiet, "quiet", false, "report errors only")
-	flag.IntVar(&maxWarnings, "max-warnings", -1, "Number of warnings to trigger nonzero exit code")
+	fs.StringVar(&args.Format, "format", "default", "output format")
+	fs.StringVar(&args.Config, "config", "", "which rslint config to use")
+	fs.BoolVar(&args.ConfigStdin, "config-stdin", false, "read config from stdin (used internally by JS config loader)")
+	fs.BoolVar(&args.Init, "init", false, "initialize a default config in the current directory")
+	fs.BoolVar(&args.Fix, "fix", false, "automatically fix problems")
+	fs.BoolVar(&args.TypeCheck, "type-check", false, "enable TypeScript type checking")
+	fs.BoolVar(&args.TypeCheckOnly, "type-check-only", false, "run only TypeScript type checking (skip all lint rules)")
+	fs.BoolVar(&help, "help", false, "show help")
+	fs.BoolVar(&help, "h", false, "show help")
+	fs.BoolVar(&args.NoColor, "no-color", false, "disable colored output")
+	fs.BoolVar(&args.ForceColor, "force-color", false, "force colored output")
+	fs.BoolVar(&args.Quiet, "quiet", false, "report errors only")
+	fs.IntVar(&args.MaxWarnings, "max-warnings", -1, "Number of warnings to trigger nonzero exit code")
 
-	flag.StringVar(&traceOut, "trace", "", "file to put trace to")
-	flag.StringVar(&cpuprofOut, "cpuprof", "", "file to put cpu profiling to")
-	flag.BoolVar(&singleThreaded, "singleThreaded", false, "run in single threaded mode")
-	flag.Int64Var(&startTimeMs, "start-time", 0, "internal: epoch milliseconds from Node.js entry point")
-	flag.Var(&ruleFlags, "rule", "rule override, e.g. 'no-console: error' (repeatable)")
+	fs.StringVar(&args.TraceOut, "trace", "", "file to put trace to")
+	fs.StringVar(&args.CpuprofOut, "cpuprof", "", "file to put cpu profiling to")
+	fs.BoolVar(&args.SingleThreaded, "singleThreaded", false, "run in single threaded mode")
+	fs.Int64Var(&args.StartTimeMs, "start-time", 0, "internal: epoch milliseconds from Node.js entry point")
+	fs.Var(&ruleFlags, "rule", "rule override, e.g. 'no-console: error' (repeatable)")
 
-	flag.Parse()
+	if err := fs.Parse(argv); err != nil {
+		// ContinueOnError: fs already printed the diagnostic to stderr.
+		return args, help, 2
+	}
+	args.RuleFlags = []string(ruleFlags)
 
 	// --type-check-only implies --type-check and skips all lint rules.
 	// Reject incompatible flag combinations before doing any work.
-	if code, msg := validateTypeCheckOnlyFlags(typeCheckOnly, fix, []string(ruleFlags)); code != 0 {
+	if code, msg := validateTypeCheckOnlyFlags(args.TypeCheckOnly, args.Fix, args.RuleFlags); code != 0 {
 		fmt.Fprintln(os.Stderr, msg)
-		return code
+		return args, help, code
 	}
-	if typeCheckOnly {
-		typeCheck = true
+	if args.TypeCheckOnly {
+		args.TypeCheck = true
 	}
 
 	// Collect file/directory arguments for targeted linting (e.g. rslint file1.ts src/)
-	var allowFiles []string
-	var allowDirs []string
-	if args := flag.Args(); len(args) > 0 {
-		for _, arg := range args {
+	if positional := fs.Args(); len(positional) > 0 {
+		for _, arg := range positional {
 			absPath, err := filepath.Abs(arg)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error resolving path %s: %v\n", arg, err)
-				return 1
+				return lintArgs{}, help, 1
 			}
 			// NOTE: we intentionally do NOT call filepath.EvalSymlinks here.
 			// EvalSymlinks resolves symlinks (macOS /tmp → /private/tmp) and
@@ -721,17 +738,41 @@ func runCMD() int {
 			normalized := tspath.NormalizePath(absPath)
 			info, statErr := os.Stat(absPath)
 			if statErr == nil && info.IsDir() {
-				allowDirs = append(allowDirs, normalized)
+				args.AllowDirs = append(args.AllowDirs, normalized)
 			} else {
-				allowFiles = append(allowFiles, normalized)
+				args.AllowFiles = append(args.AllowFiles, normalized)
 			}
 		}
 	}
 
-	if help {
-		flag.Usage()
-		return 0
-	}
+	return args, help, 0
+}
+
+// executeLintPipeline runs the full lint flow (config load → program build
+// → gap-file fallback → lint → optional --fix loop → report) and returns
+// the process exit code. Shared by the IPC entry (runCLI) and the wasm
+// native fallback.
+func executeLintPipeline(args lintArgs) int {
+	// Unpack into locals so the pipeline body below stays verbatim — only the
+	// flag-parse front matter lives in parseLintFlags.
+	init := args.Init
+	config := args.Config
+	configStdin := args.ConfigStdin
+	fix := args.Fix
+	typeCheck := args.TypeCheck
+	typeCheckOnly := args.TypeCheckOnly
+	traceOut := args.TraceOut
+	cpuprofOut := args.CpuprofOut
+	singleThreaded := args.SingleThreaded
+	format := args.Format
+	noColor := args.NoColor
+	forceColor := args.ForceColor
+	quiet := args.Quiet
+	maxWarnings := args.MaxWarnings
+	startTimeMs := args.StartTimeMs
+	ruleFlags := args.RuleFlags
+	allowFiles := args.AllowFiles
+	allowDirs := args.AllowDirs
 
 	// Override color detection based on flags
 	if noColor {

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -1,0 +1,505 @@
+//go:build !js
+
+// ipc_cli.go — the IPC CLI entry. Every user-facing rslint CLI invocation
+// reaches the Go binary here: the Node parent (packages/rslint cli.ts →
+// engine.ts) spawns this binary, owns its stdin/stdout as a bidirectional
+// IPC frame stream (internal/ipc.Channel), drives an `init` handshake,
+// forwards lint output as `output` frames, and acks `shutdown`.
+//
+// Topology:
+//
+//	┌─ Node parent (cli.ts → engine.ts) ───────────────────────┐
+//	│  spawn(binary, ...userArgs)                               │
+//	│  stdin/stdout = bidirectional IPC frames (ipc.Channel)    │
+//	│  stderr       = inherited                                 │
+//	│  sends `init`; awaits `response{ok:true}`                 │
+//	│  forwards `output` notifications to its real stdout       │
+//	└───────────────────────────────────────────────────────────┘
+//
+// Pipeline: parseLintFlags → start ipc.Channel on the real stdin/stdout →
+// wait `init` (or signal) → redirect stdout through `output` frames →
+// dispatch on intent (--help / --init / lint) → (lint) synthesize stdin from
+// the init config payload → run the shared executeLintPipeline → drain
+// output, send `shutdown`, exit.
+//
+// Exit codes: 0 clean · 1 lint/config errors · 2 IPC failure (peer
+// disconnect, init/transport error) · 130 interrupted.
+//
+// Excluded from the js/wasm build: signal handling needs syscall.SIGHUP,
+// undefined there, and there is no Node IPC parent. ipc_cli_js.go provides a
+// native fallback runCLI for that target.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/ipc"
+)
+
+// Application-level IPC message kinds for the CLI ⇆ Node engine protocol.
+// The transport (ipc.Channel) owns only response/error/handshake/exit; the
+// kinds below are declared here and travel through the same opaque envelope.
+const (
+	kindInit     ipc.MessageKind = "init"     // Node → Go: handshake payload
+	kindShutdown ipc.MessageKind = "shutdown" // Go → Node: lint done
+	kindOutput   ipc.MessageKind = "output"   // Go → Node: forwarded stdout text
+)
+
+// initPayload mirrors the IPC `init` message sent by engine.ts. Field shape
+// is the wire contract — keep in sync with packages/rslint/src/engine.ts.
+type initPayload struct {
+	// Configs: array of `{configDirectory, entries}`-shaped JSON objects.
+	// Re-marshaled byte-for-byte into the synthesized stdin payload so
+	// parseConfigPayload (cmd.go) parses it identically to the legacy stdin
+	// path. Empty/nil means "no JS config — load JSON config from disk via
+	// LoadConfigurationWithFallback (ConfigStdin=false branch)".
+	Configs []json.RawMessage `json:"configs,omitempty"`
+
+	// Runtime: out-of-band switches without a 1:1 user flag.
+	Runtime runtimePayload `json:"runtime,omitempty"`
+
+	// User-flag mirrors the Node parent authoritatively drives: the working
+	// directory and the discovered positional file/dir set, plus a few
+	// switches it prefers to control. User flags also arrive as Go args via
+	// parseLintFlags; payload values supplement (never disable) them.
+	Files            []string `json:"files,omitempty"`
+	WorkingDirectory string   `json:"workingDirectory,omitempty"`
+	Format           string   `json:"format,omitempty"`
+	FixMode          bool     `json:"fixMode,omitempty"`
+}
+
+// runtimePayload is the IPC-bound subset of runtime knobs that don't have (or
+// shouldn't duplicate) a 1:1 user flag. Adding a field is a wire change.
+type runtimePayload struct {
+	ForceColor     bool `json:"forceColor,omitempty"`
+	SingleThreaded bool `json:"singleThreaded,omitempty"`
+}
+
+// runCLIState carries the init-handshake outcome from the inbound handler
+// (which runs on the channel's read-loop goroutine) to the runCLI main
+// goroutine, and tracks whether a termination signal fired.
+type runCLIState struct {
+	payloadCh chan *initPayload // 1-buffered; receives at most one payload
+	once      sync.Once
+	signalled atomic.Bool // set on SIGINT/SIGTERM/SIGHUP
+}
+
+// runCLI is the unified IPC mode entry point — the default for every
+// user-facing CLI run. Returns the process exit code.
+func runCLI(args []string) int {
+	baseArgs, help, parseFatal := parseLintFlags(args)
+	if parseFatal != 0 {
+		return parseFatal // parseLintFlags already printed to stderr
+	}
+
+	// Two signal registrations: sigChInit aborts the init-handshake select
+	// before we have a lint context; lintCtx (NotifyContext) cancels the lint
+	// file-loop at its per-file boundary. SIGHUP guards against a closed
+	// controlling terminal truncating profiling output. On Windows SIGHUP is
+	// defined but never delivered, so this stays portable.
+	sigChInit := make(chan os.Signal, 1)
+	signal.Notify(sigChInit, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	defer signal.Stop(sigChInit)
+	lintCtx, lintCtxStop := signal.NotifyContext(
+		context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP,
+	)
+	defer lintCtxStop()
+
+	// Capture the real stdin/stdout BEFORE the channel binds to them. After
+	// init we reassign the os.Stdin/os.Stdout globals to in-process pipes
+	// (config payload in, print output out as `output` frames); the channel
+	// keeps the original references internally.
+	origStdin, origStdout := os.Stdin, os.Stdout
+	ch := ipc.NewChannel(origStdin, origStdout)
+
+	state := &runCLIState{payloadCh: make(chan *initPayload, 1)}
+
+	// Mirror lintCtx cancellation onto state.signalled so the final exit-code
+	// mapping (130 when set) works even when the signal arrives after the
+	// init-select released sigChInit.
+	sigDrainStop := make(chan struct{})
+	go func() {
+		select {
+		case <-lintCtx.Done():
+			state.signalled.Store(true)
+		case <-sigDrainStop:
+		}
+	}()
+	defer close(sigDrainStop)
+
+	// Inbound `init` request → hand the payload to the main goroutine.
+	ch.SetInboundHandler(func(_ context.Context, msg *ipc.Message) (any, error) {
+		switch msg.Kind {
+		case kindInit:
+			var p initPayload
+			if err := msg.Decode(&p); err != nil {
+				return nil, fmt.Errorf("decode init: %w", err)
+			}
+			// Exactly-once: engine.ts sends one init; defensive vs a buggy peer.
+			state.once.Do(func() { state.payloadCh <- &p })
+			return map[string]any{"ok": true}, nil
+		default:
+			return nil, fmt.Errorf("rslint: unsupported inbound kind %q", msg.Kind)
+		}
+	})
+
+	ch.Start()
+
+	// Disconnect watcher: if the channel closes (peer closed its end) before
+	// init arrives, push nil so the init-select sees a disconnect instead of
+	// hanging until initTimeout. once.Do guards the normal-init path.
+	go func() {
+		<-ch.Done()
+		state.once.Do(func() {
+			select {
+			case state.payloadCh <- nil:
+			default:
+			}
+		})
+	}()
+
+	// Wait for the init handshake or a signal. The 60s ceiling guards against
+	// a peer that crashes before sending init (signal.Notify alone won't fire
+	// on parent EOF; the disconnect watcher covers a clean EOF).
+	const initTimeout = 60 * time.Second
+	initTimer := time.NewTimer(initTimeout)
+	defer initTimer.Stop()
+
+	var payload *initPayload
+	select {
+	case payload = <-state.payloadCh:
+	case <-sigChInit:
+		state.signalled.Store(true)
+		_ = ch.Close()
+		return 130
+	case <-initTimer.C:
+		fmt.Fprintf(os.Stderr, "rslint: timed out waiting for init after %s\n", initTimeout)
+		_ = ch.Close()
+		return 2
+	}
+	if payload == nil {
+		_ = ch.Close() // peer disconnected before init
+		return 2
+	}
+
+	// Apply the payload. Working directory, configs, and the positional file
+	// set are payload-authoritative; the rest supplement flag values.
+	if payload.WorkingDirectory != "" {
+		// Hard-fail on chdir: every downstream path (config discovery, scope,
+		// gap-file matching) anchors at process cwd; the wrong dir would
+		// silently lint the wrong files.
+		if err := os.Chdir(payload.WorkingDirectory); err != nil {
+			fmt.Fprintf(os.Stderr, "rslint: chdir to %q failed: %v\n", payload.WorkingDirectory, err)
+			_ = ch.Close()
+			return 2
+		}
+	}
+	if len(payload.Files) > 0 {
+		baseArgs.AllowFiles, baseArgs.AllowDirs = classifyPaths(payload.Files)
+	}
+	if payload.Format != "" {
+		baseArgs.Format = payload.Format
+	}
+	if payload.FixMode {
+		baseArgs.Fix = true
+	}
+	if payload.Runtime.ForceColor {
+		baseArgs.ForceColor = true
+	}
+	if payload.Runtime.SingleThreaded {
+		baseArgs.SingleThreaded = true
+	}
+	// ConfigStdin reflects whether the peer supplied configs (JS/TS path) or
+	// expects the binary to load JSON config from disk (ConfigStdin=false).
+	baseArgs.ConfigStdin = len(payload.Configs) > 0
+
+	// ── stdout redirect (mandatory for every intent) ──────────────────────
+	// The peer holds the real stdout for IPC frames, so any plain-text write
+	// (usage banner, "Created rslint.config.*", lint output) would corrupt the
+	// frame stream if it shared the fd. Redirect through `output`
+	// notifications, which the peer concatenates into its real stdout. stderr
+	// is untouched (inherited end-to-end).
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		_ = ch.Close()
+		fmt.Fprintf(os.Stderr, "rslint: stdout pipe: %v\n", err)
+		return 2
+	}
+	stdoutDrainDone := make(chan struct{})
+	go drainStdoutToIPC(stdoutR, ch, stdoutDrainDone)
+	os.Stdout = stdoutW
+	// finalizeStdout flushes + restores stdout before the shutdown handshake.
+	finalizeStdout := func() {
+		os.Stdout = origStdout
+		_ = stdoutW.Close()
+		<-stdoutDrainDone
+		_ = stdoutR.Close()
+	}
+
+	// ── Intent dispatch ────────────────────────────────────────────────────
+	if help {
+		// Usage prints to stderr (inherited); the redirect stays active for
+		// uniformity.
+		fmt.Fprint(os.Stderr, usage)
+		finalizeStdout()
+		shutdownPeer(ch, state)
+		_ = ch.Close()
+		return 0
+	}
+
+	// Synthesize stdin only for the lint flow with peer-supplied configs:
+	// re-marshal the init configs into the shape parseConfigPayload expects
+	// and feed it through an in-process pipe, so executeLintPipeline's
+	// ConfigStdin branch reads it unchanged. --init never reads a config
+	// payload (it returns before config load), and the JSON-config path
+	// (ConfigStdin=false) loads from disk itself.
+	if !baseArgs.Init && baseArgs.ConfigStdin {
+		stdinR, stdinW, perr := os.Pipe()
+		if perr != nil {
+			finalizeStdout()
+			_ = ch.Close()
+			fmt.Fprintf(os.Stderr, "rslint: stdin pipe: %v\n", perr)
+			return 2
+		}
+		cfgBytes, mErr := json.Marshal(map[string]any{"configs": payload.Configs})
+		if mErr != nil {
+			finalizeStdout()
+			_ = ch.Close()
+			_ = stdinR.Close()
+			_ = stdinW.Close()
+			fmt.Fprintf(os.Stderr, "rslint: marshal config payload: %v\n", mErr)
+			return 2
+		}
+		writerDone := startSynthStdinWriter(lintCtx, stdinW, cfgBytes)
+		os.Stdin = stdinR
+		defer func() {
+			os.Stdin = origStdin
+			_ = stdinR.Close()
+			<-writerDone // join the writer goroutine before returning
+		}()
+	}
+
+	exitCode := executeLintPipeline(baseArgs)
+
+	finalizeStdout()
+	shutdownPeer(ch, state)
+	_ = ch.Close()
+
+	if state.signalled.Load() {
+		return 130
+	}
+	return exitCode
+}
+
+// shutdownPeer best-effort tells the peer we're done so it drains its worker
+// pool and exits cleanly. Skipped if a signal already fired: the peer sees its
+// own stdin disconnect anyway, and pushing another frame races the closing
+// pipe.
+func shutdownPeer(ch *ipc.Channel, state *runCLIState) {
+	if state != nil && state.signalled.Load() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _ = ch.SendRequest(ctx, kindShutdown, struct{}{})
+}
+
+// classifyPaths splits a path slice into (files, dirs) by stat'ing each entry,
+// mirroring parseLintFlags's positional handling (filepath.Abs +
+// tspath.NormalizePath) so the IPC and flag entry paths produce identical
+// FileScope downstream. An Abs failure is skipped with a stderr warning rather
+// than silently dropping the path.
+func classifyPaths(paths []string) (files []string, dirs []string) {
+	for _, p := range paths {
+		absPath, err := filepath.Abs(p)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "rslint: filepath.Abs(%q) failed: %v\n", p, err)
+			continue
+		}
+		normalized := tspath.NormalizePath(absPath)
+		info, statErr := os.Stat(absPath)
+		if statErr == nil && info.IsDir() {
+			dirs = append(dirs, normalized)
+		} else {
+			files = append(files, normalized)
+		}
+	}
+	return files, dirs
+}
+
+// startSynthStdinWriter feeds data into w from a background goroutine and
+// returns a channel closed when the writer is fully joined. It bounds two
+// failure modes: a reader that bails before consuming all bytes (a payload
+// larger than the kernel pipe buffer would otherwise block Write forever and
+// leak the goroutine), and ctx firing mid-write (closing w from outside
+// unblocks Write with an error the inner goroutine discards). Returns
+// immediately, so the caller can install os.Stdin = pipe and proceed.
+func startSynthStdinWriter(ctx context.Context, w io.WriteCloser, data []byte) <-chan struct{} {
+	done := make(chan struct{})
+	var closeOnce sync.Once
+	closeW := func() { closeOnce.Do(func() { _ = w.Close() }) }
+	go func() {
+		defer close(done)
+		defer closeW()
+		writeDone := make(chan struct{})
+		go func() {
+			_, _ = w.Write(data)
+			close(writeDone)
+		}()
+		select {
+		case <-writeDone:
+		case <-ctx.Done():
+			// Closing the writer interrupts the in-flight Write; join the
+			// inner goroutine before returning so it no longer references our
+			// closures. The deferred closeW() then no-ops (closeOnce fired).
+			closeW()
+			<-writeDone
+		}
+	}()
+	return done
+}
+
+// stdoutDrainMinFlushBytes is the soft floor for batching IPC `output` frames.
+// Reads below this are buffered and combined with later reads; pending bytes
+// at or above it flush immediately. Sized to amortize a JSON frame's fixed
+// overhead over a meaningful chunk without stalling interactive runs.
+const stdoutDrainMinFlushBytes = 8 * 1024
+
+// drainStdoutToIPC consumes the stdout-redirect pipe and forwards bytes to the
+// IPC peer as `output` notifications. Two correctness concerns drive it:
+//
+//  1. UTF-8 boundary safety. os.Pipe.Read may return chunks ending mid-
+//     character; string(buf[:n]) would then emit replacement bytes and the
+//     peer would see corrupted non-ASCII. We hold back any incomplete trailing
+//     sequence (1-3 bytes) and prepend it to the next read.
+//  2. Frame-count overhead. Each SendNotification is one JSON frame; for 100K+
+//     diagnostic lines that's 100K frames of CPU + syscall overhead. We
+//     coalesce up to stdoutDrainMinFlushBytes per frame; the close path always
+//     flushes the remainder.
+//
+// On the first SendNotification failure (peer closed its end) we flip into
+// discard mode: keep draining r so the lint pipeline's writes don't block on a
+// full pipe, but drop the bytes silently.
+func drainStdoutToIPC(r io.Reader, ch *ipc.Channel, done chan<- struct{}) {
+	defer close(done)
+	buf := make([]byte, 4096)
+	var leftover []byte // UTF-8 incomplete tail held back from last read
+	var pending []byte  // bytes ready to send, waiting for batch threshold
+	discard := false
+
+	flush := func() {
+		if len(pending) == 0 || discard {
+			// In discard mode dropping the reference lets the GC reclaim the
+			// backing array (pending[:0] keeps capacity); subsequent throwaway
+			// appends start from zero. Discard fires only when the peer is gone.
+			pending = nil
+			return
+		}
+		if err := ch.SendNotification(kindOutput, map[string]any{
+			"stream": "stdout",
+			"text":   string(pending),
+		}); err != nil {
+			// The transport fails SendNotification only once it has closed
+			// (peer gone) — there is no transient state to retry past, so stop
+			// forwarding and drop the rest. Surface it ONCE (we set discard
+			// next, so flush never re-enters this branch) so a truncated run is
+			// diagnosable on stderr instead of silently losing lint output.
+			fmt.Fprintf(os.Stderr,
+				"rslint: stopped forwarding stdout to peer (channel closed): %v\n", err)
+			discard = true
+		}
+		pending = pending[:0]
+	}
+
+	for {
+		n, readErr := r.Read(buf)
+		if n > 0 || readErr != nil {
+			// Combine the last iteration's incomplete UTF-8 tail with this
+			// read's fresh bytes. The :len:len cap on leftover keeps append
+			// from aliasing into a shared backing array.
+			var combined []byte
+			if len(leftover) > 0 {
+				combined = append(leftover[:len(leftover):len(leftover)], buf[:n]...)
+				leftover = nil
+			} else if n > 0 {
+				combined = buf[:n]
+			}
+
+			if readErr != nil {
+				// Final read: flush everything, including any genuinely invalid
+				// tail bytes — better to send them and let the peer render
+				// U+FFFD than to silently drop them.
+				pending = append(pending, combined...)
+			} else if len(combined) > 0 {
+				good, tail := splitAtUTF8Boundary(combined)
+				pending = append(pending, good...)
+				if len(tail) > 0 {
+					// Copy: the next Read overwrites buf.
+					leftover = make([]byte, len(tail))
+					copy(leftover, tail)
+				}
+			}
+
+			if readErr != nil || len(pending) >= stdoutDrainMinFlushBytes {
+				flush()
+			}
+		}
+		if readErr != nil {
+			return
+		}
+	}
+}
+
+// splitAtUTF8Boundary returns the longest prefix of buf ending at a complete
+// UTF-8 character boundary, plus the trailing 1-3 bytes (if any) of an
+// unfinished multi-byte character the caller prepends to the next read.
+//
+// On genuinely invalid UTF-8 at the tail (no lead byte in the last 4 bytes, or
+// an invalid 5+-byte lead), returns (buf, nil): we don't recover from real
+// corruption; the peer renders U+FFFD at the boundary, same as without the fix.
+func splitAtUTF8Boundary(buf []byte) (complete, incomplete []byte) {
+	n := len(buf)
+	maxLookback := 4
+	if n < maxLookback {
+		maxLookback = n
+	}
+	for i := n - 1; i >= n-maxLookback; i-- {
+		b := buf[i]
+		// Continuation byte (10xxxxxx) — keep scanning back for a lead.
+		if b&0xC0 == 0x80 {
+			continue
+		}
+		// Lead byte (or ASCII). Determine the character's expected width.
+		var width int
+		switch {
+		case b&0x80 == 0:
+			width = 1 // 0xxxxxxx — ASCII
+		case b&0xE0 == 0xC0:
+			width = 2 // 110xxxxx
+		case b&0xF0 == 0xE0:
+			width = 3 // 1110xxxx
+		case b&0xF8 == 0xF0:
+			width = 4 // 11110xxx
+		default:
+			return buf, nil // 11111xxx — invalid lead byte; don't recover
+		}
+		if avail := n - i; avail >= width {
+			return buf, nil // last character is complete
+		}
+		return buf[:i], buf[i:n]
+	}
+	// Entire 4-byte tail is continuation bytes (corrupt) or buf is empty.
+	return buf, nil
+}

--- a/cmd/rslint/ipc_cli_js.go
+++ b/cmd/rslint/ipc_cli_js.go
@@ -1,0 +1,26 @@
+//go:build js
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// runCLI on js/wasm is a native fallback. The IPC CLI mode (a Node parent
+// over OS stdio, with SIGINT/SIGTERM/SIGHUP handling) isn't available here:
+// syscall.SIGHUP is undefined on js/wasm and there is no Node IPC parent. The
+// wasm build (packages/rslint-wasm) reaches this binary through the same
+// cmd/rslint main entry, so we run the shared pipeline natively, exactly as
+// the removed runCMD did.
+func runCLI(args []string) int {
+	parsed, help, fatal := parseLintFlags(args)
+	if fatal != 0 {
+		return fatal
+	}
+	if help {
+		fmt.Fprint(os.Stderr, usage)
+		return 0
+	}
+	return executeLintPipeline(parsed)
+}

--- a/cmd/rslint/ipc_cli_test.go
+++ b/cmd/rslint/ipc_cli_test.go
@@ -1,0 +1,117 @@
+//go:build !js
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/ipc"
+)
+
+// newCLIChannelPair wires two ipc.Channels back-to-back over two io.Pipes so
+// a test can play the Node peer (b) opposite the CLI side (a). Channels are
+// returned unstarted; the caller installs handlers then Start()s.
+func newCLIChannelPair(t *testing.T) (a, b *ipc.Channel) {
+	t.Helper()
+	abR, abW := io.Pipe() // a → b
+	baR, baW := io.Pipe() // b → a
+	a = ipc.NewChannel(baR, abW)
+	b = ipc.NewChannel(abR, baW)
+	t.Cleanup(func() {
+		_ = a.Close()
+		_ = b.Close()
+		_ = abW.Close()
+		_ = baW.Close()
+	})
+	return a, b
+}
+
+// TestClassifyPaths checks the (files, dirs) split: an existing directory is
+// classified as a dir, an existing file and a nonexistent path both as files
+// (stat failure → treated as a file, matching parseLintFlags). All paths are
+// abs-resolved and normalized.
+func TestClassifyPaths(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.ts")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(dir, "nope.ts")
+
+	files, dirs := classifyPaths([]string{dir, file, missing})
+
+	wantDir := tspath.NormalizePath(dir)
+	if len(dirs) != 1 || dirs[0] != wantDir {
+		t.Errorf("dirs = %v, want [%s]", dirs, wantDir)
+	}
+	wantFiles := []string{tspath.NormalizePath(file), tspath.NormalizePath(missing)}
+	if len(files) != 2 || files[0] != wantFiles[0] || files[1] != wantFiles[1] {
+		t.Errorf("files = %v, want %v", files, wantFiles)
+	}
+}
+
+// TestDrainStdoutToIPC_DiscardsOnClosedPeer pins #4: once the channel is
+// closed (peer gone) the drain stops forwarding but keeps reading r — so the
+// lint pipeline never blocks on a full stdout pipe — and exits cleanly on EOF.
+func TestDrainStdoutToIPC_DiscardsOnClosedPeer(t *testing.T) {
+	a, _ := newCLIChannelPair(t)
+	a.Start()
+	_ = a.Close() // peer gone → every SendNotification fails
+
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pr.Close()
+	done := make(chan struct{})
+	go drainStdoutToIPC(pr, a, done)
+
+	// Past the batch threshold so flush fires and hits the closed channel.
+	if _, err := pw.Write(bytes.Repeat([]byte("x"), stdoutDrainMinFlushBytes+1)); err != nil {
+		t.Fatal(err)
+	}
+	_ = pw.Close() // EOF → final flush + return
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain hung after the channel closed")
+	}
+}
+
+// TestSplitAtUTF8Boundary covers the chunk-boundary cases drainStdoutToIPC
+// depends on: ASCII and complete multibyte pass through whole; a chunk ending
+// mid-character holds back the incomplete lead+continuation bytes; invalid
+// lead bytes are passed through untouched (no recovery).
+func TestSplitAtUTF8Boundary(t *testing.T) {
+	cases := []struct {
+		name           string
+		in             string
+		wantComplete   string
+		wantIncomplete []byte
+	}{
+		{"ascii", "abc", "abc", nil},
+		{"complete multibyte", "a世", "a世", nil},
+		{"split 3-byte tail", "abc\xe4\xb8", "abc", []byte{0xe4, 0xb8}}, // 世 = e4 b8 96, last byte missing
+		{"lead without continuation", "x\xc3", "x", []byte{0xc3}},       // 2-byte lead, continuation missing
+		{"empty", "", "", nil},
+		{"invalid lead byte", "ab\xff", "ab\xff", nil}, // 11111xxx → (buf, nil)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			complete, incomplete := splitAtUTF8Boundary([]byte(tc.in))
+			if string(complete) != tc.wantComplete {
+				t.Errorf("complete = %q, want %q", complete, tc.wantComplete)
+			}
+			if !bytes.Equal(incomplete, tc.wantIncomplete) {
+				t.Errorf("incomplete = %v, want %v", incomplete, tc.wantIncomplete)
+			}
+		})
+	}
+}

--- a/cmd/rslint/main.go
+++ b/cmd/rslint/main.go
@@ -26,6 +26,10 @@ func runMain() int {
 			return runAPI()
 		}
 	}
-	// run in CLI mode for direct command line usage
-	return runCMD()
+	// Default: unified IPC CLI mode — the Node parent (cli.ts → engine.ts)
+	// drives stdin/stdout as a length-prefixed-JSON IPC frame stream; the Go
+	// child runs the init handshake + lint pipeline and forwards output /
+	// acks shutdown. On js/wasm this resolves to the native fallback
+	// (ipc_cli_js.go).
+	return runCLI(args)
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,9 +1,16 @@
-// Package ipc provides IPC communication between JS and Go using stdio
-package ipc
+// Package api is the single-direction programmatic IPC service used by
+// `--api` mode (consumed by packages/rslint-wasm and packages/rslint-api).
+// The peer (a Node parent or a wasm host) sends lint/applyFixes/getAstInfo
+// requests; this service answers them. It does NOT dispatch tasks back to
+// the peer — that bidirectional path is internal/ipc.Channel.
+//
+// Framing is shared with internal/ipc (the single source of the
+// length-prefixed-JSON wire format); this package only owns the
+// application-level request/response types and the inbound dispatch.
+package api
 
 import (
 	"bufio"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +22,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/inspector"
+	"github.com/web-infra-dev/rslint/internal/ipc"
 )
 
 // Re-export types from inspector package for backward compatibility
@@ -39,39 +47,19 @@ func NewAstInfoBuilder(c *checker.Checker, sf *ast.SourceFile) *AstInfoBuilder {
 	return inspector.NewBuilder(c, sf)
 }
 
-// Protocol implements a binary message protocol similar to esbuild:
-// - First 4 bytes: message length (uint32 in little endian)
-// - Next N bytes: JSON message content
-
-// MessageKind represents the kind of IPC message
-type MessageKind string
-
+// Application-level message kinds handled by this service. The transport-
+// level kinds (response/error/handshake/exit) live in internal/ipc.
 const (
-	// KindLint is sent from JS to Go to request linting
-	KindLint MessageKind = "lint"
-	// KindApplyFixes is sent from JS to Go to request applying fixes
-	KindApplyFixes MessageKind = "applyFixes"
-	// KindGetAstInfo is sent from JS to Go to request AST info at a position
-	KindGetAstInfo MessageKind = "getAstInfo"
-	// KindResponse is sent from Go to JS with the lint results
-	KindResponse MessageKind = "response"
-	// KindError is sent when an error occurs
-	KindError MessageKind = "error"
-	// KindHandshake is sent for initial connection verification
-	KindHandshake MessageKind = "handshake"
-	// KindExit is sent to request termination
-	KindExit MessageKind = "exit"
+	// KindLint is sent from JS to Go to request linting.
+	KindLint ipc.MessageKind = "lint"
+	// KindApplyFixes is sent from JS to Go to request applying fixes.
+	KindApplyFixes ipc.MessageKind = "applyFixes"
+	// KindGetAstInfo is sent from JS to Go to request AST info at a position.
+	KindGetAstInfo ipc.MessageKind = "getAstInfo"
 )
 
-// Version is the IPC protocol version
+// Version is the IPC protocol version.
 const Version = "1.0.0"
-
-// Message represents an IPC message
-type Message struct {
-	Kind MessageKind `json:"kind"`
-	ID   int         `json:"id"`
-	Data interface{} `json:"data,omitempty"`
-}
 
 // HandshakeRequest represents a handshake request
 type HandshakeRequest struct {
@@ -153,11 +141,6 @@ type ApplyFixesResponse struct {
 	UnappliedCount int      `json:"unappliedCount"` // Number of fixes that couldn't be applied
 }
 
-// ErrorResponse represents an error response
-type ErrorResponse struct {
-	Message string `json:"message"`
-}
-
 // Position represents a position in a file
 type Position struct {
 	Line   int `json:"line"`
@@ -195,12 +178,13 @@ type Handler interface {
 	HandleGetAstInfo(req GetAstInfoRequest) (*GetAstInfoResponse, error)
 }
 
-// Service manages the IPC communication
+// Service manages the single-direction IPC communication for `--api` mode.
+// Framing is delegated to internal/ipc (the shared wire format).
 type Service struct {
 	reader  *bufio.Reader
 	writer  io.Writer
 	handler Handler
-	mutex   sync.Mutex
+	writeMu sync.Mutex
 }
 
 // NewService creates a new IPC service
@@ -212,57 +196,10 @@ func NewService(reader io.Reader, writer io.Writer, handler Handler) *Service {
 	}
 }
 
-// readMessage reads a message from the input
-func (s *Service) readMessage() (*Message, error) {
-	// Read message length (4 bytes)
-	var length uint32
-	if err := binary.Read(s.reader, binary.LittleEndian, &length); err != nil {
-		return nil, fmt.Errorf("failed to read message length: %w", err)
-	}
-
-	// Read message content
-	data := make([]byte, length)
-	if _, err := io.ReadFull(s.reader, data); err != nil {
-		return nil, fmt.Errorf("failed to read message content: %w", err)
-	}
-
-	// Unmarshal message
-	var msg Message
-	if err := json.Unmarshal(data, &msg); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal message: %w", err)
-	}
-
-	return &msg, nil
-}
-
-// writeMessage writes a message to the output
-func (s *Service) writeMessage(msg *Message) error {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	// Marshal message
-	data, err := json.Marshal(msg)
-	if err != nil {
-		return fmt.Errorf("failed to marshal message: %w", err)
-	}
-
-	// Write message length (4 bytes)
-	if err := binary.Write(s.writer, binary.LittleEndian, uint32(len(data))); err != nil {
-		return fmt.Errorf("failed to write message length: %w", err)
-	}
-
-	// Write message content
-	if _, err := s.writer.Write(data); err != nil {
-		return fmt.Errorf("failed to write message content: %w", err)
-	}
-
-	return nil
-}
-
 // Start starts the IPC service
 func (s *Service) Start() error {
 	for {
-		msg, err := s.readMessage()
+		msg, err := ipc.ReadFrame(s.reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
@@ -271,7 +208,7 @@ func (s *Service) Start() error {
 		}
 
 		switch msg.Kind {
-		case KindHandshake:
+		case ipc.KindHandshake:
 			s.handleHandshake(msg)
 		case KindLint:
 			s.handleLint(msg)
@@ -279,7 +216,7 @@ func (s *Service) Start() error {
 			s.handleApplyFixes(msg)
 		case KindGetAstInfo:
 			s.handleGetAstInfo(msg)
-		case KindExit:
+		case ipc.KindExit:
 			s.handleExit(msg)
 			return nil
 		default:
@@ -289,15 +226,9 @@ func (s *Service) Start() error {
 }
 
 // handleHandshake handles handshake messages
-func (s *Service) handleHandshake(msg *Message) {
+func (s *Service) handleHandshake(msg *ipc.Message) {
 	var req HandshakeRequest
-	data, err := json.Marshal(msg.Data)
-	if err != nil {
-		s.sendError(msg.ID, fmt.Sprintf("failed to marshal data: %v", err))
-		return
-	}
-
-	if err := json.Unmarshal(data, &req); err != nil {
+	if err := msg.Decode(&req); err != nil {
 		s.sendError(msg.ID, fmt.Sprintf("failed to parse handshake request: %v", err))
 		return
 	}
@@ -309,21 +240,14 @@ func (s *Service) handleHandshake(msg *Message) {
 }
 
 // Handle exit message
-func (s *Service) handleExit(msg *Message) {
+func (s *Service) handleExit(msg *ipc.Message) {
 	s.sendResponse(msg.ID, nil)
 }
 
 // handleLint handles lint messages
-func (s *Service) handleLint(msg *Message) {
+func (s *Service) handleLint(msg *ipc.Message) {
 	var req LintRequest
-	data, err := json.Marshal(msg.Data)
-
-	if err != nil {
-		s.sendError(msg.ID, fmt.Sprintf("failed to marshal data: %v", err))
-		return
-	}
-
-	if err := json.Unmarshal(data, &req); err != nil {
+	if err := msg.Decode(&req); err != nil {
 		s.sendError(msg.ID, fmt.Sprintf("failed to parse lint request: %v", err))
 		return
 	}
@@ -337,15 +261,9 @@ func (s *Service) handleLint(msg *Message) {
 }
 
 // handleApplyFixes handles apply fixes messages
-func (s *Service) handleApplyFixes(msg *Message) {
+func (s *Service) handleApplyFixes(msg *ipc.Message) {
 	var req ApplyFixesRequest
-	data, err := json.Marshal(msg.Data)
-	if err != nil {
-		s.sendError(msg.ID, fmt.Sprintf("failed to marshal data: %v", err))
-		return
-	}
-
-	if err := json.Unmarshal(data, &req); err != nil {
+	if err := msg.Decode(&req); err != nil {
 		s.sendError(msg.ID, fmt.Sprintf("failed to parse apply fixes request: %v", err))
 		return
 	}
@@ -360,15 +278,9 @@ func (s *Service) handleApplyFixes(msg *Message) {
 }
 
 // handleGetAstInfo handles get AST info messages
-func (s *Service) handleGetAstInfo(msg *Message) {
+func (s *Service) handleGetAstInfo(msg *ipc.Message) {
 	var req GetAstInfoRequest
-	data, err := json.Marshal(msg.Data)
-	if err != nil {
-		s.sendError(msg.ID, fmt.Sprintf("failed to marshal data: %v", err))
-		return
-	}
-
-	if err := json.Unmarshal(data, &req); err != nil {
+	if err := msg.Decode(&req); err != nil {
 		s.sendError(msg.ID, fmt.Sprintf("failed to parse get ast info request: %v", err))
 		return
 	}
@@ -384,24 +296,24 @@ func (s *Service) handleGetAstInfo(msg *Message) {
 
 // sendResponse sends a response message
 func (s *Service) sendResponse(id int, data interface{}) {
-	msg := &Message{
-		ID:   id,
-		Kind: KindResponse,
-		Data: data,
+	msg, err := ipc.NewMessage(ipc.KindResponse, id, data)
+	if err != nil {
+		s.sendError(id, fmt.Sprintf("failed to marshal response: %v", err))
+		return
 	}
-	if err := s.writeMessage(msg); err != nil {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if err := ipc.WriteFrame(s.writer, msg); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to send response: %v\n", err)
 	}
 }
 
 // sendError sends an error message
 func (s *Service) sendError(id int, message string) {
-	msg := &Message{
-		ID:   id,
-		Kind: KindError,
-		Data: ErrorResponse{Message: message},
-	}
-	if err := s.writeMessage(msg); err != nil {
+	msg, _ := ipc.NewMessage(ipc.KindError, id, ipc.ErrorResponseData{Message: message})
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if err := ipc.WriteFrame(s.writer, msg); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to send error: %v\n", err)
 	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,4 +1,4 @@
-package ipc
+package api
 
 import (
 	"encoding/json"

--- a/internal/ipc/channel.go
+++ b/internal/ipc/channel.go
@@ -1,0 +1,388 @@
+package ipc
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// InboundHandler handles an inbound request frame (id > 0, not a
+// response/error). Its return value is marshaled into a `response` frame;
+// a returned error becomes an `error` frame. The ctx is cancelled when the
+// channel closes.
+type InboundHandler func(ctx context.Context, msg *Message) (any, error)
+
+// NotificationHandler handles an inbound notification (id == 0). No reply.
+type NotificationHandler func(msg *Message)
+
+// Channel is a task-agnostic bidirectional length-prefixed-JSON RPC channel
+// over a reader/writer pair (typically a child process's stdout/stdin). It
+// is the Go counterpart to the Node IpcClient:
+//
+//   - SendRequest: reqID-multiplexed request → awaits its response/error.
+//   - SendNotification: fire-and-forget (id 0).
+//   - inbound requests/notifications dispatch to registered handlers.
+//
+// Handlers must be registered (SetInboundHandler / RegisterNotification)
+// BEFORE Start — registering after Start panics, since the read loop reads
+// the handler tables without locking. Multiple goroutines may call
+// SendRequest/SendNotification concurrently; frame writes are serialized.
+//
+// A write failure or a read fault is terminal: the channel closes and every
+// in-flight request fails with a stable error (mirrors the Node side).
+type Channel struct {
+	reader    *bufio.Reader
+	rawReader io.Reader // original reader, closed on shutdown to unblock readLoop
+	writer    io.Writer
+
+	// writeTimeout bounds a single frame write (0 = none; defaulted in
+	// NewChannel). requestTimeout is the default deadline applied to a
+	// SendRequest whose own ctx carries none (0 = none). Both are set before
+	// Start and read-only afterward, so they need no lock.
+	writeTimeout   time.Duration
+	requestTimeout time.Duration
+
+	writeMu sync.Mutex // serializes frame writes across goroutines
+
+	mu       sync.Mutex // guards pending, nextID, closed, closeErr, started
+	pending  map[int]chan *Message
+	nextID   int
+	closed   bool
+	closeErr error
+	started  bool
+
+	notifyHandlers map[MessageKind]NotificationHandler
+	inbound        InboundHandler
+
+	done     chan struct{}      // closed when the channel shuts down
+	inCtx    context.Context    // ctx passed to inbound handlers
+	inCancel context.CancelFunc // cancels inCtx on close
+}
+
+// defaultWriteTimeout bounds a single frame write so a wedged (alive but
+// non-draining) peer can't block a write forever. Re-armed per write in
+// writeFrame; only applies to writers that support SetWriteDeadline.
+const defaultWriteTimeout = 30 * time.Second
+
+// NewChannel creates a channel over r (inbound frames) and w (outbound
+// frames). Call SetInboundHandler/RegisterNotification before Start.
+func NewChannel(r io.Reader, w io.Writer) *Channel {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Channel{
+		reader:         bufio.NewReader(r),
+		rawReader:      r,
+		writer:         w,
+		pending:        make(map[int]chan *Message),
+		nextID:         1, // requests use id > 0; notifications use 0
+		notifyHandlers: make(map[MessageKind]NotificationHandler),
+		done:           make(chan struct{}),
+		inCtx:          ctx,
+		inCancel:       cancel,
+		writeTimeout:   defaultWriteTimeout,
+	}
+}
+
+// SetInboundHandler installs the handler for inbound request frames. Must be
+// called before Start (panics otherwise — the read loop reads c.inbound
+// without locking).
+func (c *Channel) SetInboundHandler(h InboundHandler) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.started {
+		panic("ipc: SetInboundHandler must be called before Start")
+	}
+	c.inbound = h
+}
+
+// RegisterNotification registers a handler for inbound notifications of a
+// given kind. Must be called before Start (panics otherwise). Registering
+// the same kind twice overwrites the prior one.
+func (c *Channel) RegisterNotification(kind MessageKind, h NotificationHandler) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.started {
+		panic("ipc: RegisterNotification must be called before Start")
+	}
+	c.notifyHandlers[kind] = h
+}
+
+// Start launches the reader loop in a goroutine. Returns immediately; the
+// loop runs until EOF / transport error / Close.
+func (c *Channel) Start() {
+	c.mu.Lock()
+	c.started = true
+	c.mu.Unlock()
+	go c.readLoop()
+}
+
+// Done returns a channel closed when the transport shuts down.
+func (c *Channel) Done() <-chan struct{} { return c.done }
+
+// SendRequest sends a request and blocks until the matching response/error
+// arrives, ctx is cancelled, or the channel closes.
+func (c *Channel) SendRequest(ctx context.Context, kind MessageKind, payload any) (*Message, error) {
+	msg, err := NewMessage(kind, 0, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply the default per-request timeout only when the caller's ctx carries
+	// none, so a peer that is alive but never replies can't hang the request
+	// forever. A caller-supplied deadline always wins.
+	if c.requestTimeout > 0 {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, c.requestTimeout)
+			defer cancel()
+		}
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, c.closeErr
+	}
+	id := c.nextID
+	c.nextID++
+	msg.ID = id
+	ch := make(chan *Message, 1) // buffered so dispatch never blocks
+	c.pending[id] = ch
+	c.mu.Unlock()
+
+	// Register pending BEFORE writing — a fast peer could respond before
+	// the resolver is in the map otherwise. A write failure cascade-closes
+	// (writeFrame), so the select below wakes via c.done.
+	if err := c.writeFrame(msg); err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, err
+	}
+
+	select {
+	case resp := <-ch:
+		if resp.Kind == KindError {
+			var e ErrorResponseData
+			_ = resp.Decode(&e)
+			return nil, fmt.Errorf("ipc: peer error: %s", e.Message)
+		}
+		return resp, nil
+	case <-ctx.Done():
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, ctx.Err()
+	case <-c.done:
+		// closeErr is set before close(c.done); the channel-close
+		// happens-before edge makes this read safe without the mutex.
+		return nil, c.closeErr
+	}
+}
+
+// SendNotification fires a notification frame (id 0). No reply.
+func (c *Channel) SendNotification(kind MessageKind, payload any) error {
+	c.mu.Lock()
+	if c.closed {
+		err := c.closeErr
+		c.mu.Unlock()
+		return err
+	}
+	c.mu.Unlock()
+	msg, err := NewMessage(kind, 0, payload)
+	if err != nil {
+		return err
+	}
+	return c.writeFrame(msg)
+}
+
+// deadlineWriter is the optional capability writeFrame uses to bound a write.
+// *os.File (including pipes) and net.Conn satisfy it; writers that don't
+// degrade gracefully to no write deadline.
+type deadlineWriter interface{ SetWriteDeadline(t time.Time) error }
+
+// writeFrame serializes a frame write. A write failure is terminal — the
+// peer's read side is gone, so every in-flight request would otherwise hang;
+// cascade-close so they all fail promptly (mirrors Node's onOutputError).
+//
+// The write is bounded by writeTimeout: a peer that stops draining its read
+// end makes Write block in the kernel once the OS pipe buffer fills, and a
+// cancelled ctx cannot interrupt an in-progress blocking Write. The deadline
+// turns that wedge into a terminal error → closeWith, so every blocked
+// SendRequest wakes via c.done instead of hanging forever. The deadline is
+// re-armed on each write (a stale past-deadline can't linger to a later call).
+func (c *Channel) writeFrame(msg *Message) error {
+	c.writeMu.Lock()
+	if c.writeTimeout > 0 {
+		if dw, ok := c.writer.(deadlineWriter); ok {
+			_ = dw.SetWriteDeadline(time.Now().Add(c.writeTimeout))
+		}
+	}
+	err := WriteFrame(c.writer, msg)
+	c.writeMu.Unlock()
+	if err != nil {
+		c.closeWith(err)
+	}
+	return err
+}
+
+func (c *Channel) readLoop() {
+	for {
+		msg, err := ReadFrame(c.reader)
+		if err != nil {
+			c.closeWith(err)
+			return
+		}
+		c.dispatch(msg)
+	}
+}
+
+// dispatch routes one decoded frame. Two KNOWN LIMITATIONS are left as-is
+// because current usage never exercises them (verified: the Go side registers
+// no notification handlers and receives at most one synchronous `init` request
+// per run). Revisit if this channel ever carries high-frequency or
+// order-sensitive INBOUND traffic (a future Go-side reverse request, or a
+// streamed inbound notification):
+//
+//  1. Inbound concurrency is UNBOUNDED — every notification/request gets its
+//     own goroutine (the async dispatch below is intentional: it lets an
+//     in-handler reverse SendRequest receive its reply). A flooding peer thus
+//     grows goroutines without bound. A bounded fix must NOT simply stop
+//     reading under backpressure — a parked read loop can't deliver a reverse
+//     reply, so a handler doing reverse-RPC would deadlock. Safe shape: keep
+//     the read loop non-blocking (responses routed inline) plus a bounded
+//     inbound worker that drops-oldest + warns past a soft cap.
+//  2. Notifications are NOT order-preserving — each runs on its own goroutine,
+//     so same-kind notifications can be handled out of arrival order. A
+//     streamed/order-sensitive notification would need a single FIFO worker.
+//     (The Node side preserves order on its single event loop; only Go side.)
+func (c *Channel) dispatch(msg *Message) {
+	// Response/error → route to the waiting SendRequest by id.
+	if msg.Kind == KindResponse || msg.Kind == KindError {
+		c.mu.Lock()
+		ch, ok := c.pending[msg.ID]
+		if ok {
+			delete(c.pending, msg.ID)
+		}
+		c.mu.Unlock()
+		if ok {
+			ch <- msg
+		} else {
+			fmt.Fprintf(os.Stderr, "rslint: orphan response id=%d kind=%s\n", msg.ID, msg.Kind)
+		}
+		return
+	}
+
+	// Notification (id 0) → registered handler, run async with panic safety.
+	if msg.ID == 0 {
+		h, ok := c.notifyHandlers[msg.Kind]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "rslint: unhandled notification kind=%s\n", msg.Kind)
+			return
+		}
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Fprintf(os.Stderr, "rslint: notification handler %s panicked: %v\n", msg.Kind, r)
+				}
+			}()
+			h(msg)
+		}()
+		return
+	}
+
+	// Inbound request → handler, run async so the read loop keeps consuming
+	// frames (lets an in-handler SendRequest receive its reply). A handler
+	// panic is trapped and surfaced as an error frame, never crashing the
+	// process (mirrors the Node side's runSafely).
+	h := c.inbound
+	if h == nil {
+		c.sendError(msg.ID, fmt.Sprintf("no inbound handler registered (kind=%s)", msg.Kind))
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.sendError(msg.ID, fmt.Sprintf("inbound handler panicked: %v", r))
+			}
+		}()
+		result, err := h(c.inCtx, msg)
+		if err != nil {
+			c.sendError(msg.ID, err.Error())
+			return
+		}
+		c.sendResponse(msg.ID, result)
+	}()
+}
+
+func (c *Channel) sendResponse(id int, payload any) {
+	if c.isClosed() {
+		return
+	}
+	msg, err := NewMessage(KindResponse, id, payload)
+	if err != nil {
+		c.sendError(id, fmt.Sprintf("marshal response failed: %v", err))
+		return
+	}
+	if err := c.writeFrame(msg); err != nil {
+		fmt.Fprintf(os.Stderr, "rslint: write response (id=%d): %v\n", id, err)
+	}
+}
+
+func (c *Channel) sendError(id int, message string) {
+	if c.isClosed() {
+		return
+	}
+	msg := &Message{Kind: KindError, ID: id}
+	if raw, err := marshalJSON(ErrorResponseData{Message: message}); err == nil {
+		msg.Data = raw
+	}
+	if err := c.writeFrame(msg); err != nil {
+		fmt.Fprintf(os.Stderr, "rslint: write error (id=%d): %v\n", id, err)
+	}
+}
+
+func (c *Channel) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
+// closeWith shuts the channel down: marks closed, records the cause, cancels
+// inbound ctx, unblocks every pending SendRequest (they select on c.done),
+// and closes the underlying reader so readLoop's ReadFrame returns instead of
+// blocking forever. Idempotent.
+func (c *Channel) closeWith(cause error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	if cause == nil || errors.Is(cause, io.EOF) {
+		c.closeErr = errors.New("ipc: channel closed (peer EOF)")
+	} else {
+		c.closeErr = fmt.Errorf("ipc: channel closed: %w", cause)
+	}
+	c.pending = make(map[int]chan *Message) // drop refs; waiters wake via c.done
+	c.mu.Unlock()
+
+	c.inCancel()
+	close(c.done)
+	// Unblock readLoop: closing the underlying reader makes its blocked
+	// ReadFrame return so the goroutine exits, instead of hanging until the
+	// peer happens to close its write end.
+	if rc, ok := c.rawReader.(io.Closer); ok {
+		_ = rc.Close()
+	}
+}
+
+// Close shuts the channel down. Pending requests fail with a stable error.
+func (c *Channel) Close() error {
+	c.closeWith(errors.New("closed by caller"))
+	return nil
+}

--- a/internal/ipc/channel_test.go
+++ b/internal/ipc/channel_test.go
@@ -1,0 +1,382 @@
+package ipc
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newChannelPair wires two channels back-to-back over two io.Pipes so they
+// can talk to each other in-process (A writes → B reads, and vice versa).
+// Returned channels are NOT started; the caller sets handlers then Start()s.
+func newChannelPair(t *testing.T) (a *Channel, b *Channel) {
+	t.Helper()
+	abR, abW := io.Pipe() // A → B
+	baR, baW := io.Pipe() // B → A
+	a = NewChannel(baR, abW)
+	b = NewChannel(abR, baW)
+	t.Cleanup(func() {
+		_ = a.Close()
+		_ = b.Close()
+		_ = abW.Close()
+		_ = baW.Close()
+	})
+	return a, b
+}
+
+type greetReq struct {
+	Name string `json:"name"`
+}
+type greetResp struct {
+	Greeting string `json:"greeting"`
+}
+
+func TestChannel_RequestResponse(t *testing.T) {
+	a, b := newChannelPair(t)
+	b.SetInboundHandler(func(_ context.Context, msg *Message) (any, error) {
+		var req greetReq
+		if err := msg.Decode(&req); err != nil {
+			return nil, err
+		}
+		if msg.Kind != "greet" {
+			t.Errorf("unexpected kind %q", msg.Kind)
+		}
+		return greetResp{Greeting: "hi " + req.Name}, nil
+	})
+	a.Start()
+	b.Start()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resp, err := a.SendRequest(ctx, "greet", greetReq{Name: "world"})
+	if err != nil {
+		t.Fatalf("SendRequest: %v", err)
+	}
+	if resp.Kind != KindResponse {
+		t.Fatalf("expected response kind, got %q", resp.Kind)
+	}
+	var out greetResp
+	if err := resp.Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Greeting != "hi world" {
+		t.Fatalf("got %q", out.Greeting)
+	}
+}
+
+func TestChannel_InboundError(t *testing.T) {
+	a, b := newChannelPair(t)
+	b.SetInboundHandler(func(_ context.Context, _ *Message) (any, error) {
+		return nil, io.ErrUnexpectedEOF // arbitrary handler failure
+	})
+	a.Start()
+	b.Start()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := a.SendRequest(ctx, "boom", nil)
+	if err == nil {
+		t.Fatal("expected error from peer handler")
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "peer error") {
+		t.Fatalf("expected peer error, got %q", got)
+	}
+}
+
+func TestChannel_Notification(t *testing.T) {
+	a, b := newChannelPair(t)
+	got := make(chan string, 1)
+	b.RegisterNotification("log", func(msg *Message) {
+		var s struct {
+			Text string `json:"text"`
+		}
+		_ = msg.Decode(&s)
+		got <- s.Text
+	})
+	a.Start()
+	b.Start()
+
+	if err := a.SendNotification("log", map[string]string{"text": "hello"}); err != nil {
+		t.Fatalf("SendNotification: %v", err)
+	}
+	select {
+	case s := <-got:
+		if s != "hello" {
+			t.Fatalf("got %q", s)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("notification not delivered")
+	}
+}
+
+func TestChannel_ContextCancel(t *testing.T) {
+	a, b := newChannelPair(t)
+	// Handler never replies (blocks), so the request only ends via ctx.
+	block := make(chan struct{})
+	b.SetInboundHandler(func(_ context.Context, _ *Message) (any, error) {
+		<-block
+		return struct{}{}, nil
+	})
+	t.Cleanup(func() { close(block) })
+	a.Start()
+	b.Start()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := a.SendRequest(ctx, "hang", nil)
+	if err == nil {
+		t.Fatal("expected ctx cancel error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestChannel_CloseRejectsPending(t *testing.T) {
+	a, b := newChannelPair(t)
+	block := make(chan struct{})
+	b.SetInboundHandler(func(_ context.Context, _ *Message) (any, error) {
+		<-block
+		return struct{}{}, nil
+	})
+	t.Cleanup(func() { close(block) })
+	a.Start()
+	b.Start()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := a.SendRequest(context.Background(), "hang", nil)
+		errCh <- err
+	}()
+	time.Sleep(50 * time.Millisecond) // let the request register + write
+	_ = a.Close()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected close error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pending request not rejected on close")
+	}
+}
+
+func TestFrame_RoundTrip(t *testing.T) {
+	src, err := NewMessage("hello", 7, map[string]int{"x": 42})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := WriteFrame(&buf, src); err != nil {
+		t.Fatalf("WriteFrame: %v", err)
+	}
+	got, err := ReadFrame(bufio.NewReader(&buf))
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if got.Kind != "hello" || got.ID != 7 {
+		t.Fatalf("got kind=%q id=%d", got.Kind, got.ID)
+	}
+	var v struct {
+		X int `json:"x"`
+	}
+	if err := got.Decode(&v); err != nil || v.X != 42 {
+		t.Fatalf("decode mismatch: v=%+v err=%v", v, err)
+	}
+}
+
+// TestNewMessage_NilContainerPayloadOmitted pins the wire-parity fix: a nil
+// map/slice/pointer (and untyped nil) is "no payload" → the data field is
+// omitted, matching Node where `undefined` is dropped by JSON.stringify. An
+// EMPTY but non-nil container still marshals to `{}` / `[]`.
+func TestNewMessage_NilContainerPayloadOmitted(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload  any
+		wantData bool
+	}{
+		{"untyped nil", nil, false},
+		{"nil map", map[string]any(nil), false},
+		{"nil slice", []int(nil), false},
+		{"nil pointer", (*struct{ X int })(nil), false},
+		{"empty map", map[string]any{}, true},
+		{"empty slice", []int{}, true},
+		{"non-empty map", map[string]any{"a": 1}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, err := NewMessage("k", 1, tc.payload)
+			if err != nil {
+				t.Fatalf("NewMessage: %v", err)
+			}
+			if gotData := len(msg.Data) > 0; gotData != tc.wantData {
+				t.Errorf("data present = %v, want %v (Data=%q)", gotData, tc.wantData, msg.Data)
+			}
+		})
+	}
+}
+
+func TestReadFrame_CapExceeded(t *testing.T) {
+	var buf bytes.Buffer
+	// A length header beyond the cap must be rejected before allocating.
+	if err := binary.Write(&buf, binary.LittleEndian, uint32(maxFrameSize+1)); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ReadFrame(bufio.NewReader(&buf))
+	if err == nil {
+		t.Fatal("expected frame-cap error")
+	}
+	if !strings.Contains(err.Error(), "exceeds cap") {
+		t.Fatalf("expected cap error, got %v", err)
+	}
+}
+
+func TestReadFrame_EOF(t *testing.T) {
+	// Empty reader → clean io.EOF (unwrapped, so callers can detect close).
+	_, err := ReadFrame(bufio.NewReader(bytes.NewReader(nil)))
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+}
+
+// ── robustness regressions (aligning with the Node IpcClient) ──
+
+func TestChannel_RegisterAfterStartPanics(t *testing.T) {
+	a, _ := newChannelPair(t)
+	a.Start()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when registering a handler after Start")
+		}
+	}()
+	a.SetInboundHandler(func(context.Context, *Message) (any, error) { return struct{}{}, nil })
+}
+
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, errors.New("write boom") }
+
+func TestChannel_WriteErrorCascades(t *testing.T) {
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pw.Close() })
+	c := NewChannel(pr, failWriter{})
+	c.Start()
+
+	// A write failure is terminal: SendRequest returns the error AND the
+	// channel closes, so other in-flight requests don't hang forever.
+	if _, err := c.SendRequest(context.Background(), "x", "payload"); err == nil {
+		t.Fatal("expected write error")
+	}
+	select {
+	case <-c.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("write failure did not cascade-close the channel")
+	}
+}
+
+func TestChannel_HandlerPanicRecovered(t *testing.T) {
+	a, b := newChannelPair(t)
+	b.SetInboundHandler(func(context.Context, *Message) (any, error) {
+		panic("handler boom")
+	})
+	a.Start()
+	b.Start()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// A panicking handler must surface as an error frame, not crash the
+	// process or hang the caller.
+	_, err := a.SendRequest(ctx, "x", nil)
+	if err == nil {
+		t.Fatal("expected error from panicking handler")
+	}
+	if !strings.Contains(err.Error(), "peer error") {
+		t.Fatalf("expected peer error frame, got %v", err)
+	}
+}
+
+// TestChannel_WriteDeadline pins #1: a peer that never drains its read end
+// makes a large Write block in the kernel; the per-write deadline turns that
+// into a terminal error so SendRequest returns instead of hanging forever.
+func TestChannel_WriteDeadline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows anonymous pipes (os.Pipe) don't implement SetWriteDeadline, so
+		// the write deadline degrades to a no-op there (by design — writeFrame
+		// ignores the SetWriteDeadline error). The deadline path this test pins
+		// is POSIX-only; on Windows the blocking Write never unblocks, so skip.
+		t.Skip("os.Pipe does not support SetWriteDeadline on Windows")
+	}
+	inR, inW := io.Pipe() // inbound never produces a frame (readLoop parks, not EOF)
+	defer inW.Close()
+	pr, pw, err := os.Pipe() // outbound: reader end (pr) is never drained
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pr.Close()
+	defer pw.Close()
+
+	c := NewChannel(inR, pw)
+	c.writeTimeout = 100 * time.Millisecond // short; set before Start
+	c.Start()
+	defer c.Close()
+
+	// A frame far larger than the OS pipe buffer (~64 KiB) that pr never
+	// drains: Write blocks → deadline fires → writeFrame errors → closeWith.
+	big := strings.Repeat("x", 512*1024)
+	done := make(chan error, 1)
+	go func() {
+		_, e := c.SendRequest(context.Background(), "big", map[string]string{"d": big})
+		done <- e
+	}()
+	select {
+	case e := <-done:
+		if e == nil {
+			t.Fatal("expected write-deadline error, got nil")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("SendRequest hung past the write deadline")
+	}
+}
+
+// TestChannel_RequestTimeout pins #6: when the caller's ctx carries no
+// deadline, the channel's requestTimeout bounds a request whose peer is alive
+// but never replies.
+func TestChannel_RequestTimeout(t *testing.T) {
+	a, b := newChannelPair(t)
+	b.SetInboundHandler(func(ctx context.Context, _ *Message) (any, error) {
+		<-ctx.Done() // never reply until the channel closes
+		return nil, ctx.Err()
+	})
+	a.requestTimeout = 100 * time.Millisecond // set before Start
+	a.Start()
+	b.Start()
+
+	start := time.Now()
+	_, err := a.SendRequest(context.Background(), "slow", nil) // ctx has no deadline
+	if err == nil {
+		t.Fatal("expected request-timeout error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("request not bounded by requestTimeout (took %v)", elapsed)
+	}
+}
+
+func TestChannel_SendAfterClose(t *testing.T) {
+	a, _ := newChannelPair(t)
+	a.Start()
+	_ = a.Close()
+	if _, err := a.SendRequest(context.Background(), "x", nil); err == nil {
+		t.Fatal("expected SendRequest error after close")
+	}
+	if err := a.SendNotification("x", nil); err == nil {
+		t.Fatal("expected SendNotification error after close")
+	}
+}

--- a/internal/ipc/frame.go
+++ b/internal/ipc/frame.go
@@ -1,0 +1,175 @@
+// Package ipc is the task-agnostic bidirectional IPC transport between the
+// Go process and a Node peer.
+//
+// Wire format (mirrors the Node-side IpcClient in
+// packages/rslint/src/ipc/client.ts):
+//
+//	[4 bytes u32 LE length][JSON body]
+//	body = Message{kind, id, data}
+//
+// `data` is opaque to the transport (json.RawMessage). Application layers
+// marshal/unmarshal their own typed payloads at the task boundary — the
+// transport never inspects task content. The two ends are deliberately
+// not import-coupled; the contract is pinned by the cross-language tests
+// rather than a shared type module.
+package ipc
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+)
+
+// maxFrameSize caps a single frame body. A length header beyond this is
+// treated as a stream desync (unframed bytes shifted the 4-byte header by
+// N), not a real payload — without the cap a malformed uint32 (up to
+// 4 GiB) makes ReadFrame allocate unboundedly and OOM the process. Matched
+// to the Node side's MAX_FRAME_BYTES.
+const maxFrameSize = 256 * 1024 * 1024 // 256 MiB
+
+// MessageKind identifies a frame's purpose. The transport only owns the
+// protocol-level kinds below; application kinds (e.g. task dispatch,
+// output, log) are declared by the layers above and travel through the
+// same opaque envelope.
+type MessageKind string
+
+const (
+	// KindResponse replies to a request frame (carries the handler result).
+	KindResponse MessageKind = "response"
+	// KindError replies to a request frame with a failure (ErrorResponseData).
+	KindError MessageKind = "error"
+	// KindHandshake is the initial version-negotiation exchange.
+	KindHandshake MessageKind = "handshake"
+	// KindExit requests termination.
+	KindExit MessageKind = "exit"
+)
+
+// Message is one decoded wire frame. `ID` is 0 for notifications and a
+// positive monotonic integer for requests/responses. `Data` is the
+// untyped payload — handlers decode it into a typed shape as needed.
+type Message struct {
+	Kind MessageKind     `json:"kind"`
+	ID   int             `json:"id"`
+	Data json.RawMessage `json:"data,omitempty"`
+}
+
+// Decode unmarshals the message's Data into v.
+func (m *Message) Decode(v any) error {
+	if len(m.Data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(m.Data, v); err != nil {
+		return fmt.Errorf("ipc: decode message data (kind=%s): %w", m.Kind, err)
+	}
+	return nil
+}
+
+// ErrorResponseData is the canonical body of an `error` frame. Mirrors the
+// Node side's ErrorResponseData.
+type ErrorResponseData struct {
+	Message string `json:"message"`
+}
+
+// NewMessage marshals payload into a Message with the given kind and id. A
+// nil payload (untyped nil OR a typed-nil pointer/interface) omits the data
+// field entirely — matching the Node side, where `undefined` data is dropped
+// by JSON.stringify — so "no payload" is wire-identical on both ends, not
+// Go's `null` vs Node's omitted.
+func NewMessage(kind MessageKind, id int, payload any) (*Message, error) {
+	if isNilPayload(payload) {
+		return &Message{Kind: kind, ID: id}, nil
+	}
+	raw, err := marshalJSON(payload)
+	if err != nil {
+		return nil, fmt.Errorf("ipc: marshal payload (kind=%s): %w", kind, err)
+	}
+	return &Message{Kind: kind, ID: id, Data: raw}, nil
+}
+
+// isNilPayload reports whether payload should omit the data field: an untyped
+// nil, or a typed-nil pointer/interface/map/slice/chan/func (e.g. a handler
+// returning `(*LintResponse)(nil)` or a nil `map[string]any`). Without this a
+// typed-nil value marshals to `data:null` instead of being omitted, diverging
+// from Node, where `undefined` data is dropped by JSON.stringify. (An EMPTY
+// but non-nil map/slice still marshals to `{}`/`[]` — only the nil case is a
+// "no payload" omission; reflect.Value.IsNil distinguishes the two.)
+func isNilPayload(payload any) bool {
+	if payload == nil {
+		return true
+	}
+	switch rv := reflect.ValueOf(payload); rv.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
+// marshalJSON encodes v WITHOUT Go's default HTML escaping (`<` `>` `&` →
+// `<` …) so the bytes match Node's JSON.stringify, which emits those
+// characters literally. Lint diagnostics routinely contain `<`/`>`/`&` (JSX,
+// generics like `Foo<Bar>`, `&&`); escaping would diverge the wire from Node
+// and break byte-level frame compatibility.
+func marshalJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	// Encoder.Encode appends a trailing newline; drop it for framing.
+	b := buf.Bytes()
+	if n := len(b); n > 0 && b[n-1] == '\n' {
+		b = b[:n-1]
+	}
+	return b, nil
+}
+
+// ReadFrame reads one length-prefixed frame from r and decodes its
+// Message. Returns io.EOF (unwrapped) on a clean stream close so callers
+// can distinguish it from a transport fault.
+func ReadFrame(r *bufio.Reader) (*Message, error) {
+	var length uint32
+	if err := binary.Read(r, binary.LittleEndian, &length); err != nil {
+		// Propagate io.EOF unwrapped: a clean close is not an error.
+		return nil, err
+	}
+	if length > maxFrameSize {
+		return nil, fmt.Errorf(
+			"ipc: frame length %d exceeds cap %d (likely stream desync)",
+			length, maxFrameSize)
+	}
+	body := make([]byte, length)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, fmt.Errorf("ipc: read frame body (len=%d): %w", length, err)
+	}
+	var msg Message
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return nil, fmt.Errorf("ipc: decode frame (len=%d): %w", length, err)
+	}
+	return &msg, nil
+}
+
+// WriteFrame encodes msg into the wire format and writes it to w. Callers
+// that share a writer across goroutines must serialize WriteFrame calls
+// (Channel does this via its write mutex).
+func WriteFrame(w io.Writer, msg *Message) error {
+	body, err := marshalJSON(msg)
+	if err != nil {
+		return fmt.Errorf("ipc: encode frame (kind=%s): %w", msg.Kind, err)
+	}
+	if len(body) > maxFrameSize {
+		return fmt.Errorf("ipc: frame body %d exceeds cap %d", len(body), maxFrameSize)
+	}
+	if err := binary.Write(w, binary.LittleEndian, uint32(len(body))); err != nil {
+		return fmt.Errorf("ipc: write frame length: %w", err)
+	}
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("ipc: write frame body: %w", err)
+	}
+	return nil
+}

--- a/packages/rslint/src/cli.ts
+++ b/packages/rslint/src/cli.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import fs from 'node:fs';
-import { execFileSync } from 'node:child_process';
 import { loadConfigFile, normalizeConfig } from './config-loader.js';
 import { parseArgs, classifyArgs, isJSConfigFile } from './utils/args.js';
 import {
@@ -10,32 +9,7 @@ import {
 } from './utils/config-discovery.js';
 
 /**
- * Pass-through execution of the Go binary with stdio inherited.
- */
-function execBinary(binPath: string, argv: string[]): number {
-  try {
-    execFileSync(binPath, argv, { stdio: 'inherit' });
-    return 0;
-  } catch (error: unknown) {
-    if (isExecError(error)) return error.status;
-    process.stderr.write(`Failed to execute ${binPath}: ${String(error)}\n`);
-    return 1;
-  }
-}
-
-function isExecError(
-  error: unknown,
-): error is Record<string, unknown> & { status: number } {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'status' in error &&
-    typeof error.status === 'number'
-  );
-}
-
-/**
- * Load multiple JS configs and pipe to Go binary via stdin.
+ * Load multiple JS/TS configs and run them through the Go binary over IPC.
  * Tolerates individual config load failures — skips broken configs with a
  * warning and continues with the remaining configs.
  */
@@ -82,31 +56,21 @@ async function runWithJSConfigs(
     configEntries.push({ configDirectory: configDir, entries });
   }
 
-  // All configs failed to load — fall back to Go binary (JSON config path)
+  // Lazy import — keeps engine.ts (and its node:child_process dependency) out
+  // of the browser/wasm bundle, loaded only on the real CLI path.
+  const { runEngine } = await import('./engine.js');
+
+  // All configs failed to load — fall back to Go loading JSON config from disk
+  // (init with no configs → Go's ConfigStdin=false branch).
   if (configEntries.length === 0) {
-    return execBinary(binPath, goArgs);
+    return runEngine({ binPath, goArgs, configs: [], cwd });
   }
 
   // Filter out nested configs whose directory is covered by a parent config's
-  // global ignores. This aligns with ESLint v10 behavior: when walking the
-  // directory tree, global ignores prevent entering directories, so nested
-  // configs in ignored directories are never discovered.
+  // global ignores (ESLint v10 alignment). Then hand the configs to Go in the
+  // IPC `init` payload (no more `--config-stdin` stdin pipe).
   const filteredEntries = filterConfigsByParentIgnores(configEntries);
-
-  const payload = JSON.stringify({ configs: filteredEntries });
-
-  try {
-    execFileSync(binPath, ['--config-stdin', ...goArgs], {
-      input: payload,
-      stdio: ['pipe', 'inherit', 'inherit'],
-      cwd,
-    });
-    return 0;
-  } catch (error: unknown) {
-    if (isExecError(error)) return error.status;
-    process.stderr.write(`Failed to execute ${binPath}: ${String(error)}\n`);
-    return 1;
-  }
+  return runEngine({ binPath, goArgs, configs: filteredEntries, cwd });
 }
 
 export async function run(
@@ -117,9 +81,11 @@ export async function run(
   const cwd = process.cwd();
   const args = parseArgs(argv);
 
-  // --init: pass through to Go
+  // --init: pass through to Go (no config payload — Go writes the default
+  // config to disk and prints the "Created …" line, forwarded via `output`).
   if (args.init) {
-    return execBinary(binPath, ['--init']);
+    const { runEngine } = await import('./engine.js');
+    return runEngine({ binPath, goArgs: ['--init'], configs: [], cwd });
   }
 
   // Validate explicit --config flag
@@ -132,8 +98,7 @@ export async function run(
   }
 
   // Build Go args: start-time flag BEFORE positional args, because Go's
-  // flag.Parse stops at the first positional argument. If --start-time comes
-  // after positionals, it gets treated as a file path.
+  // flag.Parse stops at the first positional argument.
   const goArgs = [`--start-time=${startTime}`, ...args.rest];
 
   // Classify positional arguments into files and directories
@@ -158,9 +123,11 @@ export async function run(
     return runWithJSConfigs(binPath, jsConfigs, goArgs, cwd);
   }
 
-  // Fall back to Go binary (handles JSON config + deprecation warning)
+  // Fall back to Go binary (handles JSON config + deprecation warning); no
+  // config payload, so Go loads JSON config from disk itself.
   const jsonGoArgs = args.config
     ? ['--config', args.config, ...goArgs]
     : goArgs;
-  return execBinary(binPath, jsonGoArgs);
+  const { runEngine } = await import('./engine.js');
+  return runEngine({ binPath, goArgs: jsonGoArgs, configs: [], cwd });
 }

--- a/packages/rslint/src/engine.ts
+++ b/packages/rslint/src/engine.ts
@@ -1,0 +1,233 @@
+/**
+ * Engine: Node-side host for the Go↔Node IPC CLI handshake.
+ *
+ * Spawns the Go binary (which defaults to runCLI / IPC mode), drives the
+ * `init` handshake, forwards the Go child's `output` frames to stdout, and
+ * acks `shutdown`. The Go child does all the linting; this host just owns the
+ * pipe and the protocol.
+ *
+ * This is the comm host for native lint — it owns the pipe and the protocol
+ * while the Go child does all the linting.
+ *
+ * Exit codes propagate from the Go child (or 2 on a host-level failure).
+ */
+import { spawn, type ChildProcess } from 'node:child_process';
+import { IpcClient } from './ipc/index.js';
+import type { IpcMessage } from './ipc/index.js';
+
+// POSIX: a process killed by signal N exits 128+N. Node reports the signal
+// NAME, so map the ones we can receive; collapsing all to 130 would mislabel
+// a SIGTERM/SIGKILL teardown as a Ctrl-C.
+const SIGNAL_EXIT_CODES: Record<string, number> = {
+  SIGHUP: 129,
+  SIGINT: 130,
+  SIGQUIT: 131,
+  SIGTERM: 143,
+  SIGKILL: 137,
+};
+
+export interface EngineRunOptions {
+  /** Path to the Go rslint binary. */
+  binPath: string;
+  /** Args forwarded to the Go binary (user CLI flags, --start-time, files). */
+  goArgs: string[];
+  /**
+   * Configs sent in the `init` payload (JS/TS-config entries, each shaped
+   * `{configDirectory, configPath?, entries}`). Empty means "no JS config —
+   * let Go load JSON config from disk itself".
+   */
+  configs: unknown[];
+  /** Working directory (defaults to process.cwd()). */
+  cwd?: string;
+  /** Runtime hints forwarded in the `init` payload's `runtime` block. */
+  runtime?: { forceColor?: boolean; singleThreaded?: boolean };
+  /**
+   * Extra fields merged into the `init` payload (positional files, --format,
+   * --fix, workingDirectory). Pass-through so the engine stays unaware of CLI
+   * flag layout.
+   */
+  extraInit?: Record<string, unknown>;
+  /** stdout sink (default process.stdout). Lets tests capture output. */
+  stdout?: NodeJS.WritableStream;
+  /** stderr sink (default process.stderr). */
+  stderr?: NodeJS.WritableStream;
+}
+
+export async function runEngine(opts: EngineRunOptions): Promise<number> {
+  const stdout = opts.stdout ?? process.stdout;
+  const stderr = opts.stderr ?? process.stderr;
+
+  const child = spawn(opts.binPath, opts.goArgs, {
+    stdio: ['pipe', 'pipe', 'inherit'],
+    cwd: opts.cwd ?? process.cwd(),
+  });
+
+  // childExit always RESOLVES (never rejects); awaits race against it so a
+  // child that drops out mid-handshake unwinds cleanly instead of hanging.
+  // Attached BEFORE any await so an immediate spawn error (ENOENT/EACCES) or
+  // instant exit is observed rather than crashing the process as 'unhandled'.
+  type ChildExit = { code: number };
+  const childExit = new Promise<ChildExit>((resolve) => {
+    let resolved = false;
+    const settle = (code: number) => {
+      if (!resolved) {
+        resolved = true;
+        resolve({ code });
+      }
+    };
+    child.once('error', (err) => {
+      stderr.write(`rslint: Go spawn/runtime error: ${err.message}\n`);
+      settle(2);
+    });
+    child.once('exit', (code, signal) => {
+      settle(
+        code != null
+          ? code
+          : signal != null
+            ? (SIGNAL_EXIT_CODES[signal] ?? 128)
+            : 1,
+      );
+    });
+  });
+
+  type RaceResult<T> =
+    | { kind: 'task'; value: T }
+    | { kind: 'exit'; state: ChildExit };
+  const raceWithExit = async <T>(task: Promise<T>): Promise<RaceResult<T>> =>
+    Promise.race<RaceResult<T>>([
+      task.then((value) => ({ kind: 'task' as const, value })),
+      childExit.then((state) => ({ kind: 'exit' as const, state })),
+    ]);
+
+  // Validate stdio BEFORE installing process-level signal listeners, so a throw
+  // here can't leak listeners on `process` for a long-lived host.
+  if (!child.stdin || !child.stdout) {
+    safeKillGo(child);
+    throw new Error('engine: Go child process missing stdin/stdout');
+  }
+  const ipc = new IpcClient(child.stdout, child.stdin);
+
+  // Without our own SIGINT handler Node's default action _exit(130)s
+  // immediately, leaving the Go child to discover the disconnect via stdin EOF
+  // — which a wedged child can't. Intercept and force it down first.
+  const onSignal = () => {
+    // No log: a user Ctrl-C (SIGINT) or a normal SIGTERM/SIGHUP teardown is the
+    // expected path, not an error — just forward the kill to the Go child.
+    safeKillGo(child);
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+  process.on('SIGHUP', onSignal);
+  const removeSignalHandlers = () => {
+    process.off('SIGINT', onSignal);
+    process.off('SIGTERM', onSignal);
+    process.off('SIGHUP', onSignal);
+  };
+
+  // Wire handlers BEFORE start so the first frame Go writes is routable.
+  ipc.setInboundHandler((msg) => {
+    switch (msg.kind) {
+      case 'shutdown':
+        // Go signals it's done; teardown happens via the 'exit' event below.
+        return { ok: true };
+      default:
+        throw new Error(`engine: unexpected inbound kind '${msg.kind}'`);
+    }
+  });
+  ipc.registerNotification(
+    'output',
+    (msg: IpcMessage<{ stream?: string; text?: string }>) => {
+      const text = msg.data?.text;
+      if (text != null) stdout.write(text);
+    },
+  );
+  ipc.start();
+
+  // Send `init` and await Go's ack, racing the child dropping out.
+  {
+    let outcome: RaceResult<IpcMessage<unknown>>;
+    try {
+      outcome = await raceWithExit(
+        ipc.sendRequest('init', {
+          ...(opts.extraInit ?? {}),
+          configs: opts.configs,
+          runtime: {
+            forceColor: opts.runtime?.forceColor,
+            singleThreaded: opts.runtime?.singleThreaded,
+          },
+        }),
+      );
+    } catch {
+      // The init request can reject when the Go child exits cleanly before we
+      // read its init ack: a fast path (--help / --init) closes the pipe the
+      // moment its work is done, and the stdout-EOF seal that rejects the
+      // pending request can beat the child 'exit' event into the race above
+      // (observed on Linux, where stdout 'end' tends to precede 'exit'). The
+      // child's exit code is the source of truth — a clean (0) exit means Go
+      // finished its job, so honor it; only a non-zero exit is a real failure.
+      safeKillGo(child);
+      const state = await childExit;
+      removeSignalHandlers();
+      if (state.code === 0) return 0;
+      stderr.write(`rslint: init failed (Go exited ${state.code})\n`);
+      return state.code;
+    }
+    if (outcome.kind === 'exit') {
+      removeSignalHandlers();
+      return outcome.state.code;
+    }
+    const data = outcome.value.data;
+    const ok =
+      typeof data === 'object' &&
+      data !== null &&
+      'ok' in data &&
+      data.ok === true;
+    if (!ok) {
+      stderr.write(
+        `rslint: Go rejected init: ${JSON.stringify(outcome.value.data)}\n`,
+      );
+      safeKillGo(child);
+      await childExit;
+      removeSignalHandlers();
+      return 2;
+    }
+  }
+
+  // Output forwarding + shutdown ack happen in the handlers above; just wait
+  // for the Go child to finish (it exits with its own lint exit code).
+  const finalExit = await childExit;
+  ipc.close();
+  removeSignalHandlers();
+  return finalExit.code;
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+const KILL_GRACE_MS = 5_000;
+
+/**
+ * Escalating kill: SIGTERM first (lets the binary flush stderr / send a clean
+ * IPC shutdown), then SIGKILL after a grace period if it's still alive. The
+ * timer is unref'd so it never keeps the Node event loop alive on its own.
+ */
+function safeKillGo(child: ChildProcess): void {
+  try {
+    if (child.killed) return;
+    child.kill('SIGTERM');
+  } catch {
+    return;
+  }
+  const killTimer = setTimeout(() => {
+    if (child.exitCode == null && child.signalCode == null) {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* ignore — process likely just exited */
+      }
+    }
+  }, KILL_GRACE_MS);
+  if (typeof killTimer.unref === 'function') killTimer.unref();
+  child.once('exit', () => {
+    clearTimeout(killTimer);
+  });
+}

--- a/packages/rslint/src/ipc/client.ts
+++ b/packages/rslint/src/ipc/client.ts
@@ -1,0 +1,611 @@
+/* eslint-disable @typescript-eslint/no-unsafe-type-assertion -- IPC wire boundary casts. Each site projects a decoded frame's `unknown` / `any` payload (JSON.parse output, Node stream error) into the typed message shape this module uses; the framing + JSON contract is validated at the read boundary, not at the cast. Bulk-disabling here instead of per-line keeps the parse sites readable. */
+/**
+ * Bidirectional IPC client over a Node Duplex pair (typically the CLI host
+ * process's stdin/stdout, with a Go peer on the other side).
+ *
+ * Wire format and message shape mirror Go's `internal/ipc.Channel`:
+ *
+ *   `[4 bytes u32 LE length][JSON payload]`
+ *   payload  = { kind: MessageKind, id: number, data?: unknown }
+ *
+ * This is the Node-side counterpart to Go's `internal/ipc.Channel`. The
+ * two are deliberately not import-coupled — keeping the packages
+ * independent lets the IPC contract evolve via tests rather than via a
+ * shared type module. Cross-language wire compatibility is exercised
+ * end-to-end through the real CLI path (rslint-test-tools spawns the Go
+ * binary over this transport); both ends must agree on the framing above.
+ *
+ * Concurrency model:
+ *
+ *   Node is single-threaded for JS, so no goroutines / mutexes needed —
+ *   but the same hazard exists: if an inbound handler calls `sendRequest`
+ *   and awaits a reply, the reply must be readable concurrently. Reads
+ *   come from the stdin stream's 'data' event, which fires asynchronously
+ *   via libuv — so a handler can `await` while data continues to arrive.
+ *   That's the asynchrony budget we rely on.
+ *
+ *   Outbound requests register a Promise resolver in `pending`; the data
+ *   handler routes incoming `response`/`error` frames to the matching id.
+ *   Inbound requests / notifications are dispatched to user-registered
+ *   handlers; for requests, the handler's resolved value (or thrown
+ *   error) is wrapped into a `response`/`error` frame.
+ *
+ * Lifecycle:
+ *
+ *   - new IpcClient(stdin, stdout)
+ *   - .setInboundHandler(...) and/or .registerNotification(...)
+ *   - .start()                  — attaches readers / starts pumping
+ *   - .sendRequest(...) / .sendNotification(...) anywhere afterward
+ *   - .close()                  — stops listening, rejects pending requests
+ */
+
+import type { Readable, Writable } from 'node:stream';
+import type {
+  IpcMessage,
+  MessageKind,
+  InboundRequestHandler,
+  NotificationHandler,
+  ErrorResponseData,
+} from './protocol.js';
+
+/** Internal record for a request awaiting its response. */
+interface PendingRequest {
+  resolve: (msg: IpcMessage) => void;
+  reject: (err: Error) => void;
+}
+
+/** Symbol-like sentinel kinds we route specially. */
+const RESPONSE_KIND: MessageKind = 'response';
+const ERROR_KIND: MessageKind = 'error';
+
+/** Header is 4 bytes u32 LE. */
+const HEADER_BYTES = 4;
+/**
+ * Per-frame body cap, matched to Go's `maxFrameSize` (internal/ipc/frame.go).
+ * A peer that writes a frame larger than this is treated as a stream
+ * desync and the connection is torn down — without this guard a
+ * malformed length header would let the read queue grow unboundedly
+ * until the worker OOMs.
+ */
+const MAX_FRAME_BYTES = 256 * 1024 * 1024;
+
+export interface IpcClientOptions {
+  /**
+   * Initial buffer size for the read accumulator. Frames larger than this
+   * will simply grow the buffer; this is just a starting hint for typical
+   * traffic. Default 64 KiB.
+   */
+  readonly initialReadBufferBytes?: number;
+}
+
+/**
+ * Bidirectional IPC client over a Node Duplex pair.
+ */
+export class IpcClient {
+  // ── streams ──
+  private readonly input: Readable;
+  private readonly output: Writable;
+
+  // ── routing tables ──
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly notificationHandlers = new Map<
+    MessageKind,
+    NotificationHandler
+  >();
+  private inboundHandler: InboundRequestHandler | null = null;
+
+  // ── reader buffer ──
+  // Incoming chunks accumulate in a queue and are coalesced into one
+  // contiguous Buffer only when a full frame is parseable — see onChunk
+  // for why a per-chunk `Buffer.concat` (the previous design) was O(N²).
+  private readonly chunks: Buffer[] = [];
+  private bufferedBytes = 0;
+
+  // ── state ──
+  private nextId = 1;
+  private closed = false;
+  private started = false;
+
+  constructor(input: Readable, output: Writable, opts: IpcClientOptions = {}) {
+    this.input = input;
+    this.output = output;
+    void opts; // reserved for future use; signature stable
+  }
+
+  /**
+   * Install the request handler for inbound non-notification frames. Set
+   * before `start()`. Calling twice replaces the previous handler.
+   */
+  setInboundHandler(handler: InboundRequestHandler | null): void {
+    this.inboundHandler = handler;
+  }
+
+  /**
+   * Register a notification handler for a specific kind. Notifications are
+   * id=0 frames with no reply. The same kind registered twice overwrites
+   * the prior registration.
+   */
+  registerNotification<TIn = unknown>(
+    kind: MessageKind,
+    handler: NotificationHandler<TIn>,
+  ): void {
+    this.notificationHandlers.set(kind, handler as NotificationHandler);
+  }
+
+  /**
+   * Start listening on the input stream. Idempotent — subsequent calls
+   * after the first are no-ops (logged in dev as a warning).
+   *
+   * Both directions get error listeners. Without one on `output`, a
+   * peer-closes-its-stdin (our write target) failure would surface as
+   * an unhandled `error` event on the Writable — which Node treats as
+   * an uncaught exception or silently drops depending on version, and
+   * either way leaves pending `sendRequest`s parked on promises that
+   * will never resolve. Mirroring the Go-side fix (writerLoop calls
+   * Close on write error), we treat output error as terminal: reject
+   * all pending and flip closed.
+   */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+
+    this.input.on('data', this.onChunk);
+    this.input.on('end', this.onEnd);
+    this.input.on('error', this.onStreamError);
+    this.output.on('error', this.onOutputError);
+    // A CLEAN output close (peer ended its read side / pipe EOF /
+    // `destroy()` with no error) fires no `'error'` and `write()`
+    // doesn't throw — only `'close'` / `'finish'` signal it. Without
+    // these, pending requests would hang forever (see onOutputClose).
+    this.output.on('close', this.onOutputClose);
+    this.output.on('finish', this.onOutputClose);
+  }
+
+  /**
+   * Stop listening. Pending outbound requests are rejected with a
+   * stable error so callers' `await sendRequest(...)` resolves rather
+   * than hanging forever. Idempotent.
+   */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+
+    this.input.off('data', this.onChunk);
+    this.input.off('end', this.onEnd);
+    this.input.off('error', this.onStreamError);
+    this.output.off('error', this.onOutputError);
+    this.output.off('close', this.onOutputClose);
+    this.output.off('finish', this.onOutputClose);
+
+    const err = new Error('IpcClient: closed');
+    for (const [, p] of this.pending) p.reject(err);
+    this.pending.clear();
+  }
+
+  /**
+   * Send an outbound request and await its response. The returned promise
+   * resolves with the response Message on success, or rejects on
+   * peer-side error / client close / decode failure.
+   *
+   * Calls are reqID-multiplexed; multiple in-flight calls are safe.
+   */
+  async sendRequest<TIn = unknown, TOut = unknown>(
+    kind: Exclude<MessageKind, 'response' | 'error'>,
+    data: TIn,
+  ): Promise<IpcMessage<TOut>> {
+    if (this.closed) {
+      throw new Error('IpcClient: cannot sendRequest on closed client');
+    }
+    const id = this.nextId++; // id > 0 always; notifications use 0
+    const frame = encodeFrame({ kind, id, data });
+
+    const promise = new Promise<IpcMessage<TOut>>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: resolve as (msg: IpcMessage) => void,
+        reject,
+      });
+    });
+
+    // Order matters: register pending BEFORE writing, otherwise a fast
+    // peer could respond before the resolver is in the map.
+    this.writeFrameNow(frame);
+    return promise;
+  }
+
+  /**
+   * Fire a notification frame (id=0). Returns when the frame has been
+   * handed to the underlying stream's write buffer; backpressure on the
+   * pipe is handled by Node's stream layer.
+   */
+  sendNotification<TIn = unknown>(kind: MessageKind, data: TIn): void {
+    if (this.closed) {
+      throw new Error('IpcClient: cannot sendNotification on closed client');
+    }
+    const frame = encodeFrame({ kind, id: 0, data });
+    this.writeFrameNow(frame);
+  }
+
+  /**
+   * Send a `response` reply manually. Normally the framework does this
+   * after an inbound request handler resolves; this method is exposed so
+   * advanced users can reply asynchronously from outside the handler.
+   */
+  sendResponse<TOut = unknown>(reqId: number, data: TOut): void {
+    if (this.closed) return;
+    this.writeFrameNow(encodeFrame({ kind: 'response', id: reqId, data }));
+  }
+
+  /**
+   * Send an `error` reply. Same caveat as {@link sendResponse}.
+   */
+  sendErrorResponse(reqId: number, message: string): void {
+    if (this.closed) return;
+    this.writeFrameNow(
+      encodeFrame<ErrorResponseData>({
+        kind: 'error',
+        id: reqId,
+        data: { message },
+      }),
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // internals
+  // ─────────────────────────────────────────────────────────────────
+
+  private writeFrameNow(frame: Buffer): void {
+    // Node's stream.write returns false under backpressure but accepts
+    // more data; we don't pause here because (a) IPC frames are small,
+    // and (b) callers serialize their own logical pacing. If profiling
+    // shows backpressure issues, switch to `await once(this.output, 'drain')`.
+    //
+    // Write itself may throw synchronously if the stream has already
+    // errored (e.g. EPIPE after peer's stdin closed). Treat that as a
+    // terminal transport failure — same cascade as onOutputError below.
+    try {
+      this.output.write(frame);
+    } catch (err) {
+      this.onOutputError(err as Error);
+    }
+  }
+
+  /**
+   * Output stream `error` handler. Terminal: reject all pending
+   * outbound requests with a stable error so awaiters return, then
+   * trigger the regular close path. Idempotent.
+   */
+  private readonly onOutputError = (err: Error): void => {
+    if (this.closed) return;
+    process.stderr.write(`rslint: output write error: ${err.message}\n`);
+    const wrapped = new Error(`IpcClient: output write failed: ${err.message}`);
+    for (const [, p] of this.pending) p.reject(wrapped);
+    this.pending.clear();
+    this.closed = true;
+    // Detach listeners to mirror close() — close() itself is a no-op
+    // now (closed=true) but we should not leave the input listeners
+    // dangling.
+    this.input.off('data', this.onChunk);
+    this.input.off('end', this.onEnd);
+    this.input.off('error', this.onStreamError);
+    this.output.off('error', this.onOutputError);
+    this.output.off('close', this.onOutputClose);
+    this.output.off('finish', this.onOutputClose);
+  };
+
+  /**
+   * Output stream `'close'` / `'finish'` handler. A CLEAN close (peer
+   * ended its read side / pipe EOF / `destroy()` with no error) fires
+   * no `'error'` and `write()` doesn't throw, so the framed request is
+   * silently dropped and its response can never arrive — without this
+   * every in-flight + future `sendRequest` would hang forever (there is
+   * no per-request timeout). Reject all pending and tear down, mirroring
+   * `onOutputError`. Idempotent.
+   */
+  private readonly onOutputClose = (): void => {
+    if (this.closed) return;
+    const err = new Error(
+      'IpcClient: output stream closed before response received',
+    );
+    for (const [, p] of this.pending) p.reject(err);
+    this.pending.clear();
+    this.closed = true;
+    this.input.off('data', this.onChunk);
+    this.input.off('end', this.onEnd);
+    this.input.off('error', this.onStreamError);
+    this.output.off('error', this.onOutputError);
+    this.output.off('close', this.onOutputClose);
+    this.output.off('finish', this.onOutputClose);
+  };
+
+  /**
+   * stream 'data' handler — queues the chunk, then drains every COMPLETE
+   * frame currently buffered.
+   *
+   * Why a queue instead of `this.buf = Buffer.concat([this.buf, chunk])`
+   * per chunk: that re-copied the entire accumulator on every 'data'
+   * event, so a single large frame delivered in K chunks cost
+   * O(frameSize × K) — quadratic when a peer dribbles bytes (the
+   * byte-by-byte streaming test below is the pathological case). Here a
+   * chunk is only `push`ed (O(1)); the bytes for a frame are coalesced
+   * into one contiguous Buffer exactly once, when the whole frame has
+   * arrived (`consumeFront`). Total copying is O(total bytes), linear.
+   */
+  private readonly onChunk = (chunk: Buffer): void => {
+    this.chunks.push(chunk);
+    this.bufferedBytes += chunk.length;
+
+    while (this.bufferedBytes >= HEADER_BYTES) {
+      const len = this.peekHeaderLen();
+      // Symmetric to Go's `maxFrameSize = 256 MiB` in
+      // internal/ipc/frame.go. A frame length that exceeds the
+      // cap usually means a stream desync (someone wrote unframed bytes
+      // into stdout, header bytes shifted by N). Without this guard we
+      // would accumulate N GiB chasing a phantom payload and OOM the
+      // worker. Surface as a stream-fatal error so the caller can tear
+      // the connection down rather than hang. Fires SYNCHRONOUSLY on the
+      // header alone, before any body bytes arrive.
+      if (len > MAX_FRAME_BYTES) {
+        this.onStreamError(
+          new Error(
+            `ipc-client: frame length ${len} exceeds cap ${MAX_FRAME_BYTES} ` +
+              `(likely stream desync). Connection will be closed.`,
+          ),
+        );
+        return;
+      }
+      if (this.bufferedBytes < HEADER_BYTES + len) break;
+
+      // Whole frame is buffered: coalesce exactly its bytes into one
+      // contiguous Buffer (the single allocating copy per frame). The
+      // leftover bytes stay in the queue as their own (possibly sliced)
+      // chunks, so no residual slab is pinned.
+      const frame = this.consumeFront(HEADER_BYTES + len);
+      const body = frame.subarray(HEADER_BYTES);
+
+      let msg: IpcMessage;
+      try {
+        msg = JSON.parse(body.toString('utf8')) as IpcMessage;
+      } catch (err) {
+        // Malformed frame — log and skip; framing is intact (we already
+        // consumed the body), so subsequent frames decode normally.
+        process.stderr.write(
+          `rslint: malformed JSON in frame (len=${len}): ${(err as Error).message}\n`,
+        );
+        continue;
+      }
+
+      this.dispatch(msg);
+    }
+  };
+
+  /**
+   * Read the 4-byte LE frame-length header at the front of the queue
+   * WITHOUT consuming it. The header may straddle chunk boundaries
+   * (e.g. a peer that splits the length prefix), so read it byte-by-byte
+   * across the leading chunks. Caller guarantees `bufferedBytes >= 4`.
+   */
+  private peekHeaderLen(): number {
+    // Fast path: the whole header lives in the first chunk (the common
+    // case — frames usually arrive aligned).
+    const first = this.chunks[0];
+    if (first.length >= HEADER_BYTES) return first.readUInt32LE(0);
+    // Slow path: header split across chunks — assemble the 4 bytes.
+    let len = 0;
+    let seen = 0;
+    for (const c of this.chunks) {
+      for (let i = 0; i < c.length && seen < HEADER_BYTES; i++, seen++) {
+        len |= c[i] << (8 * seen);
+      }
+      if (seen >= HEADER_BYTES) break;
+    }
+    // `>>> 0` reinterprets the (possibly sign-bit-set) result as u32 LE,
+    // matching Buffer.readUInt32LE.
+    return len >>> 0;
+  }
+
+  /**
+   * Remove and return the first `n` bytes of the queue as a single
+   * contiguous Buffer. Caller guarantees `bufferedBytes >= n`.
+   *
+   * Slab-pinning guard (carried over from the previous design's
+   * `Buffer.from(this.buf.subarray(...))`): when a frame ends mid-chunk,
+   * the surviving tail is re-`Buffer.from`'d into its own small slab
+   * rather than left as a `subarray` view. Otherwise a 200 MiB chunk
+   * carrying one frame + a few trailing bytes would keep its whole slab
+   * alive via that tiny residual view.
+   */
+  private consumeFront(n: number): Buffer {
+    this.bufferedBytes -= n;
+
+    // Single-chunk fast path: the front chunk alone covers `n`.
+    const first = this.chunks[0];
+    if (first.length === n) {
+      this.chunks.shift();
+      return first;
+    }
+    if (first.length > n) {
+      const frame = first.subarray(0, n);
+      // Detach the residual tail from the (possibly huge) source slab.
+      this.chunks[0] = Buffer.from(first.subarray(n));
+      return frame;
+    }
+
+    // Multi-chunk path: gather whole chunks until `n` bytes are covered,
+    // splitting the final chunk if it overshoots.
+    const parts: Buffer[] = [];
+    let need = n;
+    while (need > 0) {
+      const c = this.chunks[0];
+      if (c.length <= need) {
+        parts.push(c);
+        need -= c.length;
+        this.chunks.shift();
+      } else {
+        parts.push(c.subarray(0, need));
+        // Detach the residual tail from the source slab (see above).
+        this.chunks[0] = Buffer.from(c.subarray(need));
+        need = 0;
+      }
+    }
+    // `Buffer.concat` allocates a fresh contiguous buffer, so the result
+    // does not pin any source chunk's slab.
+    return Buffer.concat(parts, n);
+  }
+
+  private readonly onEnd = (): void => {
+    // Peer closed the input stream. We can't get any more responses,
+    // so seal the client: reject pending requests + set closed=true
+    // + detach listeners. Without setting closed=true, a subsequent
+    // sendRequest would silently enqueue into pending and wait
+    // forever for a response that can never arrive (the peer's write
+    // end is gone). The output side is left as-is — the underlying
+    // stream may still be writable from our perspective, but we
+    // surface "closed" so callers get a deterministic error
+    // immediately instead of an indefinite hang.
+    if (this.closed) return;
+    this.closed = true;
+    const err = new Error('IpcClient: peer closed input stream');
+    for (const [, p] of this.pending) p.reject(err);
+    this.pending.clear();
+    this.input.off('data', this.onChunk);
+    this.input.off('end', this.onEnd);
+    this.input.off('error', this.onStreamError);
+    this.output.off('error', this.onOutputError);
+    // Mirror close(): also detach the output 'close'/'finish' listeners
+    // (added for the Windows clean-close fix). onStreamError delegates
+    // here, so without this both teardown paths would leak the
+    // onOutputClose listener on the output stream.
+    this.output.off('close', this.onOutputClose);
+    this.output.off('finish', this.onOutputClose);
+  };
+
+  private readonly onStreamError = (err: Error): void => {
+    process.stderr.write(`rslint: stream error: ${err.message}\n`);
+    this.onEnd();
+  };
+
+  /** Route a fully decoded frame. */
+  private dispatch(msg: IpcMessage): void {
+    if (msg.kind === RESPONSE_KIND || msg.kind === ERROR_KIND) {
+      this.routeResponse(msg);
+      return;
+    }
+    if (msg.id === 0) {
+      this.dispatchNotification(msg);
+      return;
+    }
+    this.dispatchInboundRequest(msg);
+  }
+
+  private routeResponse(msg: IpcMessage): void {
+    const p = this.pending.get(msg.id);
+    if (!p) {
+      process.stderr.write(
+        `rslint: orphan response id=${msg.id} kind=${msg.kind}\n`,
+      );
+      return;
+    }
+    this.pending.delete(msg.id);
+    if (msg.kind === ERROR_KIND) {
+      const data = msg.data as ErrorResponseData | undefined;
+      p.reject(new Error(`peer error: ${data?.message ?? '(no message)'}`));
+      return;
+    }
+    p.resolve(msg);
+  }
+
+  private dispatchNotification(msg: IpcMessage): void {
+    const handler = this.notificationHandlers.get(msg.kind);
+    if (!handler) {
+      // A notification with no registered handler is unexpected — the peer
+      // only emits kinds we register. Surface it to stderr as a diagnostic
+      // rather than erroring; the frame body is already fully consumed.
+      process.stderr.write(`rslint: unhandled notification kind=${msg.kind}\n`);
+      return;
+    }
+    void runSafely(async () => handler(msg), `notification:${msg.kind}`);
+  }
+
+  private dispatchInboundRequest(msg: IpcMessage): void {
+    const handler = this.inboundHandler;
+    if (!handler) {
+      this.sendErrorResponse(
+        msg.id,
+        `no inbound handler registered (kind=${msg.kind})`,
+      );
+      return;
+    }
+    // Spawn the handler async so the data loop continues to consume frames
+    // even while a handler awaits. This is what enables in-handler
+    // sendRequest to receive its reply.
+    void (async () => {
+      try {
+        const result = await handler(msg);
+        this.sendResponse(msg.id, result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.sendErrorResponse(msg.id, message);
+      }
+    })();
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// frame encode/decode helpers (exported for tests; not for general use)
+// ────────────────────────────────────────────────────────────────────
+
+/**
+ * Encode an IPC message into the `[4B u32 LE length][JSON]` wire format.
+ */
+export function encodeFrame<T = unknown>(msg: IpcMessage<T>): Buffer {
+  const body = Buffer.from(JSON.stringify(msg), 'utf8');
+  const out = Buffer.allocUnsafe(HEADER_BYTES + body.length);
+  out.writeUInt32LE(body.length, 0);
+  body.copy(out, HEADER_BYTES);
+  return out;
+}
+
+/**
+ * Decode a single complete frame from `buf` starting at offset 0. Returns
+ * the decoded message and the number of bytes consumed, or null if `buf`
+ * doesn't yet contain a complete frame.
+ *
+ * Exposed for the protocol round-trip tests; production code uses the
+ * streaming decode inside {@link IpcClient}.
+ */
+export function decodeFrame(
+  buf: Buffer,
+): { msg: IpcMessage; consumed: number } | null {
+  if (buf.length < HEADER_BYTES) return null;
+  const len = buf.readUInt32LE(0);
+  // Enforce the same cap as the streaming path (ipc-client.ts:290).
+  // Without this guard an attacker who can write to a buffer this
+  // helper consumes (test harnesses that wire arbitrary streams, or
+  // callers that misuse decodeFrame on untrusted input) could pin
+  // arbitrary memory via a 4 GiB header.
+  if (len > MAX_FRAME_BYTES) {
+    throw new Error(
+      `ipc-client: frame length ${len} exceeds cap ${MAX_FRAME_BYTES} ` +
+        `(possible stream desync or malicious peer)`,
+    );
+  }
+  if (buf.length < HEADER_BYTES + len) return null;
+  const body = buf.subarray(HEADER_BYTES, HEADER_BYTES + len);
+  const msg = JSON.parse(body.toString('utf8')) as IpcMessage;
+  return { msg, consumed: HEADER_BYTES + len };
+}
+
+/**
+ * runSafely invokes `fn` and traps any thrown / rejected error to stderr,
+ * tagged with `tag`. Used for notification + handler bodies whose errors
+ * cannot be returned to the peer.
+ */
+async function runSafely(fn: () => unknown, tag: string): Promise<void> {
+  try {
+    const ret = fn();
+    if (ret instanceof Promise) await ret;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`rslint: handler ${tag} threw: ${message}\n`);
+  }
+}

--- a/packages/rslint/src/ipc/index.ts
+++ b/packages/rslint/src/ipc/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Go↔Node IPC transport, Node side. This is a task-agnostic communication
+ * module between the Go binary and the Node host — independent of any specific
+ * task. It lives in core because core owns the CLI host that drives the Go
+ * child; callers layer their task (currently lint) on top of this transport.
+ */
+export { IpcClient, encodeFrame, decodeFrame } from './client.js';
+export type {
+  MessageKind,
+  IpcMessage,
+  ErrorResponseData,
+  InboundRequestHandler,
+  NotificationHandler,
+} from './protocol.js';

--- a/packages/rslint/src/ipc/protocol.ts
+++ b/packages/rslint/src/ipc/protocol.ts
@@ -1,0 +1,71 @@
+/**
+ * Wire-format protocol types for the Go↔Node IPC transport, shared between
+ * the Go side (`internal/ipc.Channel`, and `internal/api` for `--api` mode)
+ * and the Node {@link IpcClient}.
+ *
+ * The frame layout is `[4 bytes u32 LE length][JSON payload]`. The payload is
+ * the {@link IpcMessage} `{kind, id, data}` triple, mirroring Go's
+ * `ipc.Message` byte-for-byte. The two definitions must stay in lockstep; the
+ * cross-language contract tests pin it.
+ *
+ * This is pure transport protocol — it carries no knowledge of any specific
+ * task (lint, …); those live in their own layers.
+ */
+
+/**
+ * Frame kinds used in {@link IpcMessage.kind}. A string union so consumers can
+ * switch exhaustively. These map directly to Go's `MessageKind` constants.
+ */
+export type MessageKind =
+  // ── shared infrastructure (also consumed by `--api` mode for wasm/rslint-api) ──
+  | 'lint'
+  | 'applyFixes'
+  | 'getAstInfo'
+  | 'response'
+  | 'error'
+  | 'handshake'
+  | 'exit'
+  // ── CLI host-process IPC kinds ──
+  // (Go child ↔ Node parent over stdio. The LSP path is NOT wired
+  //  through these frames — it uses LSP custom requests instead.)
+  | 'init'
+  | 'cancel'
+  | 'output'
+  | 'log'
+  | 'shutdown';
+
+/**
+ * Single IPC frame (JSON-decoded). `id` is 0 for notifications and a positive
+ * monotonic integer for requests/responses. `data` is the untyped payload —
+ * handlers re-decode into a typed shape as needed.
+ */
+export interface IpcMessage<T = unknown> {
+  kind: MessageKind;
+  id: number;
+  data?: T;
+}
+
+/**
+ * Canonical error payload sent in `error` frames. Mirrors Go's
+ * `ipc.ErrorResponseData`.
+ */
+export interface ErrorResponseData {
+  message: string;
+}
+
+/**
+ * Inbound request handler signature. Returning a value resolves the matching
+ * `response` frame; throwing surfaces an `error` frame with the thrown error's
+ * message.
+ */
+export type InboundRequestHandler<TIn = unknown, TOut = unknown> = (
+  msg: IpcMessage<TIn>,
+) => Promise<TOut> | TOut;
+
+/**
+ * Inbound notification handler signature. Notifications are id=0 frames that
+ * expect no reply; thrown errors are logged and discarded.
+ */
+export type NotificationHandler<TIn = unknown> = (
+  msg: IpcMessage<TIn>,
+) => Promise<void> | void;

--- a/packages/rslint/tests/ipc-client.test.ts
+++ b/packages/rslint/tests/ipc-client.test.ts
@@ -1,0 +1,761 @@
+import { describe, test, expect } from '@rstest/core';
+import { PassThrough } from 'node:stream';
+import { IpcClient, encodeFrame, decodeFrame } from '../src/ipc/client.js';
+import type { IpcMessage, MessageKind } from '../src/ipc/protocol.js';
+
+/**
+ * pairClients wires two IpcClient instances together via two PassThrough
+ * streams so they can exchange frames in-process. Returns both clients
+ * and a `cleanup` that closes them in the right order.
+ *
+ * Naming: A is the "Go-equivalent side"; B is the "peer". Tests pick
+ * which side acts as the inbound handler.
+ */
+function pairClients(): {
+  a: IpcClient;
+  b: IpcClient;
+  cleanup: () => void;
+} {
+  // A.write → A→B → B.read
+  // B.write → B→A → A.read
+  const aToB = new PassThrough();
+  const bToA = new PassThrough();
+  // IpcClient(input, output) — input is what we read from, output is
+  // where we write. So A's input is bToA (what B writes), A's output
+  // is aToB (what A writes).
+  const a = new IpcClient(bToA, aToB);
+  const b = new IpcClient(aToB, bToA);
+  return {
+    a,
+    b,
+    cleanup: () => {
+      a.close();
+      b.close();
+      // PassThrough streams don't need explicit close for tests, but
+      // ending them helps ensure GC promptness in larger suites.
+      aToB.end();
+      bToA.end();
+    },
+  };
+}
+
+describe('encode/decode round-trip', () => {
+  test('encodes a basic message', () => {
+    const msg: IpcMessage = { kind: 'init', id: 1, data: { hello: 'world' } };
+    const frame = encodeFrame(msg);
+    // Header (4B) + body
+    expect(frame.length).toBeGreaterThan(4);
+    const header = frame.readUInt32LE(0);
+    const json = JSON.stringify(msg);
+    // The header is the UTF-8 BYTE length of the JSON, matching Go's
+    // u32 LE length prefix. Assert against `Buffer.byteLength(...,utf8)`
+    // — NOT `json.length` (UTF-16 code units). They happen to be equal
+    // for this ASCII payload; the multibyte test below pins the
+    // difference so an accidental `json.length`-based framing regression
+    // is caught.
+    expect(header).toBe(Buffer.byteLength(json, 'utf8'));
+    expect(frame.length).toBe(4 + header);
+    const decoded = JSON.parse(
+      frame.subarray(4).toString('utf8'),
+    ) as IpcMessage;
+    expect(decoded.kind).toBe('init');
+    expect(decoded.id).toBe(1);
+    expect((decoded.data as { hello: string }).hello).toBe('world');
+  });
+
+  test('frames a multibyte payload by UTF-8 byte length (not UTF-16 .length)', () => {
+    // CJK (3 bytes/char) + emoji (4 bytes, surrogate pair = 2 UTF-16
+    // units) + accented Latin: every char makes the UTF-8 byte count
+    // exceed the UTF-16 `.length`. If the framing used `json.length`
+    // the header would under-count and the receiver would slice the
+    // body short → stream desync. Pin that the header is the byte
+    // length and that the frame round-trips intact.
+    const msg: IpcMessage = {
+      kind: 'log',
+      id: 7,
+      data: { text: '日本語 😀 résumé' },
+    };
+    const json = JSON.stringify(msg);
+    const byteLen = Buffer.byteLength(json, 'utf8');
+
+    // Precondition: this payload MUST be multibyte, otherwise the test
+    // would silently degrade to the ASCII case and prove nothing.
+    expect(byteLen).toBeGreaterThan(json.length);
+
+    const frame = encodeFrame(msg);
+    const header = frame.readUInt32LE(0);
+    expect(header).toBe(byteLen);
+    expect(header).not.toBe(json.length); // the fragile assertion would fail
+    expect(frame.length).toBe(4 + byteLen);
+
+    // Round-trips through the real decoder, body intact.
+    const result = decodeFrame(frame);
+    expect(result).not.toBeNull();
+    expect(result!.consumed).toBe(frame.length);
+    expect((result!.msg.data as { text: string }).text).toBe(
+      '日本語 😀 résumé',
+    );
+  });
+
+  test('decodes a single complete frame', () => {
+    const msg: IpcMessage = { kind: 'log', id: 0, data: { text: 'a' } };
+    const frame = encodeFrame(msg);
+    const result = decodeFrame(frame);
+    expect(result).not.toBeNull();
+    expect(result!.consumed).toBe(frame.length);
+    expect(result!.msg.kind).toBe('log');
+    expect(result!.msg.id).toBe(0);
+  });
+
+  test('decodeFrame returns null when buffer is incomplete', () => {
+    // Header alone, no body
+    const buf = Buffer.alloc(4);
+    buf.writeUInt32LE(100, 0);
+    expect(decodeFrame(buf)).toBeNull();
+  });
+
+  test('decodeFrame returns null when buffer is shorter than header', () => {
+    expect(decodeFrame(Buffer.alloc(0))).toBeNull();
+    expect(decodeFrame(Buffer.alloc(3))).toBeNull();
+  });
+});
+
+// The streaming decoder in `IpcClient.onChunk` must reassemble frames
+// across arbitrary chunk boundaries: it accumulates into `this.buf` via
+// `Buffer.concat` and drains COMPLETE frames in a `while` loop. The
+// request/response tests above all deliver one whole frame per write, so
+// neither the cross-boundary accumulation nor the multi-frame `while`
+// loop is exercised by them. These cases feed deliberately split / fused
+// chunks and assert every frame decodes correctly and IN ORDER.
+describe('IpcClient streaming reassembly across chunk boundaries', () => {
+  // Wait until `arr` reaches `n` entries (or a short deadline). Used to
+  // synchronize on async 'data' delivery without a fixed sleep.
+  async function waitForCount(arr: unknown[], n: number): Promise<void> {
+    const deadline = Date.now() + 1000;
+    while (arr.length < n && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 2));
+    }
+  }
+
+  // Single reader fed via notification frames (id=0, no reply needed) so
+  // we can observe decoded frames in arrival order without a peer.
+  function makeReader(): {
+    input: PassThrough;
+    received: number[];
+    cleanup: () => void;
+  } {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const client = new IpcClient(input, output);
+    const received: number[] = [];
+    client.registerNotification('log', (msg) => {
+      received.push((msg.data as { n: number }).n);
+    });
+    client.start();
+    return {
+      input,
+      received,
+      cleanup: () => {
+        client.close();
+        input.end();
+        output.end();
+      },
+    };
+  }
+
+  function logFrame(n: number): Buffer {
+    return encodeFrame({ kind: 'log', id: 0, data: { n } });
+  }
+
+  test('(ii) two complete frames in ONE chunk both decode, in order (while loop)', async () => {
+    const { input, received, cleanup } = makeReader();
+    try {
+      // Both frames concatenated into a single 'data' event. A
+      // `while`→`if` regression would decode frame 1 and drop frame 2.
+      input.write(Buffer.concat([logFrame(1), logFrame(2)]));
+      await waitForCount(received, 2);
+      expect(received).toEqual([1, 2]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('(i) a frame whose 4-byte header is split across two chunks decodes', async () => {
+    const { input, received, cleanup } = makeReader();
+    try {
+      const frame = logFrame(42);
+      // First 2 bytes of the length header only — buf.length (2) <
+      // HEADER_BYTES (4), so the while loop must NOT consume anything.
+      input.write(frame.subarray(0, 2));
+      await waitForCount(received, 1); // deadline elapses; nothing yet
+      expect(received).toEqual([]);
+      // Remainder (rest of header + full body) completes the frame.
+      input.write(frame.subarray(2));
+      await waitForCount(received, 1);
+      expect(received).toEqual([42]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('(iii) a partial frame (header + part of body) then its remainder decodes', async () => {
+    const { input, received, cleanup } = makeReader();
+    try {
+      const frame = logFrame(7);
+      // Header complete but body truncated: buf.length <
+      // HEADER_BYTES + len, so the `break` arm holds the frame.
+      input.write(frame.subarray(0, 6));
+      await waitForCount(received, 1); // deadline elapses; nothing yet
+      expect(received).toEqual([]);
+      input.write(frame.subarray(6));
+      await waitForCount(received, 1);
+      expect(received).toEqual([7]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('mixed: a fused pair followed by a byte-by-byte dribbled frame, all in order', async () => {
+    const { input, received, cleanup } = makeReader();
+    try {
+      // Two frames fused, then a third delivered one byte at a time —
+      // stresses both the while loop and repeated partial accumulation.
+      input.write(Buffer.concat([logFrame(10), logFrame(20)]));
+      await waitForCount(received, 2);
+      expect(received).toEqual([10, 20]);
+
+      const f3 = logFrame(30);
+      for (let i = 0; i < f3.length; i++) {
+        input.write(f3.subarray(i, i + 1));
+      }
+      await waitForCount(received, 3);
+      expect(received).toEqual([10, 20, 30]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // ── Linear chunk-queue reassembly (perf fix: no per-chunk concat) ──
+  // The decoder queues chunks and coalesces a frame's bytes exactly once
+  // when complete, instead of `Buffer.concat`-ing the whole accumulator
+  // on every 'data' event. These cases pin that the queue path stays
+  // correct: the 4-byte LENGTH HEADER itself split across several
+  // single-byte chunks must be reassembled (cross-chunk header peek), and
+  // a body spanning many chunks must coalesce in order.
+
+  test('many frames each fully dribbled byte-by-byte decode in order', async () => {
+    const { input, received, cleanup } = makeReader();
+    try {
+      const ns = [1, 2, 3, 4, 5, 6, 7, 8];
+      // Every byte of every frame — INCLUDING each frame's 4-byte length
+      // header — arrives as its own 'data' event. A regression that read
+      // the header via `chunks[0].readUInt32LE(0)` (instead of the
+      // cross-chunk peek) would throw RangeError on a 1-byte first chunk.
+      for (const n of ns) {
+        const f = logFrame(n);
+        for (let i = 0; i < f.length; i++) {
+          input.write(f.subarray(i, i + 1));
+        }
+      }
+      await waitForCount(received, ns.length);
+      expect(received).toEqual(ns);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('frame split into many small chunks with mid-chunk frame boundaries decodes in order', async () => {
+    const { input, received, cleanup } = makeReader();
+    try {
+      // Fuse three frames into one buffer, then re-slice that buffer into
+      // fixed 3-byte chunks. The frame boundaries fall in the MIDDLE of
+      // chunks, so the decoder must split a chunk at a frame boundary
+      // (consumeFront's overshoot branch) and carry the remainder forward.
+      const fused = Buffer.concat([
+        logFrame(100),
+        logFrame(200),
+        logFrame(300),
+      ]);
+      const STEP = 3;
+      for (let i = 0; i < fused.length; i += STEP) {
+        input.write(fused.subarray(i, Math.min(i + STEP, fused.length)));
+      }
+      await waitForCount(received, 3);
+      expect(received).toEqual([100, 200, 300]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('cross-chunk split header (1+1+2 bytes) before body decodes', async () => {
+    const { input, received, cleanup } = makeReader();
+    try {
+      const frame = logFrame(77);
+      // Header delivered as 1 byte, then 1 byte, then 2 bytes — none of
+      // these prefixes alone satisfies readUInt32LE(0). Then the body.
+      input.write(frame.subarray(0, 1));
+      input.write(frame.subarray(1, 2));
+      input.write(frame.subarray(2, 4));
+      await waitForCount(received, 1); // deadline elapses; header incomplete-then-complete but body missing
+      expect(received).toEqual([]);
+      input.write(frame.subarray(4));
+      await waitForCount(received, 1);
+      expect(received).toEqual([77]);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('IpcClient request/response', () => {
+  test('basic outbound request → handler reply', async () => {
+    const { a, b, cleanup } = pairClients();
+    try {
+      b.setInboundHandler((msg) => {
+        expect(msg.kind).toBe('lint');
+        return { ok: true, echo: msg.data };
+      });
+      a.start();
+      b.start();
+      const resp = await a.sendRequest('lint', { x: 1 });
+      expect(resp.kind).toBe('response');
+      expect((resp.data as { ok: boolean }).ok).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('inbound handler can issue reverse sendRequest without deadlock', async () => {
+    const { a, b, cleanup } = pairClients();
+    try {
+      a.setInboundHandler(async (msg) => {
+        expect(msg.kind).toBe('cancel');
+        return { ack: 'a' };
+      });
+      b.setInboundHandler(async (msg) => {
+        // While handling our own inbound, send a reverse RPC to A.
+        const reverseResp = await b.sendRequest('cancel', {
+          reverseFrom: msg.id,
+        });
+        return { reverseGot: (reverseResp.data as { ack: string }).ack };
+      });
+      a.start();
+      b.start();
+
+      const top = await a.sendRequest('init', {});
+      expect((top.data as { reverseGot: string }).reverseGot).toBe('a');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('reqID multiplexing: many concurrent requests all resolve correctly', async () => {
+    const { a, b, cleanup } = pairClients();
+    try {
+      b.setInboundHandler(async (msg) => msg.data);
+      a.start();
+      b.start();
+
+      const N = 50;
+      const promises = Array.from({ length: N }, (_, i) =>
+        a.sendRequest('lint', { i }).then((r) => (r.data as { i: number }).i),
+      );
+      const results = await Promise.all(promises);
+      expect(results).toEqual(Array.from({ length: N }, (_, i) => i));
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('large frame (≥ 64 KiB) round-trips intact', async () => {
+    const { a, b, cleanup } = pairClients();
+    try {
+      b.setInboundHandler(async (msg) => msg.data);
+      a.start();
+      b.start();
+
+      const big = 'a'.repeat(200 * 1024); // 200 KiB
+      const resp = await a.sendRequest('lint', { blob: big });
+      expect((resp.data as { blob: string }).blob.length).toBe(big.length);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('notification: no reply expected', async () => {
+    const { a, b, cleanup } = pairClients();
+    try {
+      let received: string | null = null;
+      b.registerNotification('log', (msg) => {
+        received = (msg.data as { text: string }).text;
+      });
+      a.start();
+      b.start();
+      a.sendNotification('log', { text: 'hello-log' });
+
+      // Poll for delivery
+      const deadline = Date.now() + 1000;
+      while (received === null && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(received).toBe('hello-log');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('inbound request without handler → peer gets error reply', async () => {
+    const { a, b, cleanup } = pairClients();
+    try {
+      // B has no inbound handler set
+      a.start();
+      b.start();
+      await expect(a.sendRequest('lint', {})).rejects.toThrow(
+        /no inbound handler registered/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('handler thrown error → peer receives error reply', async () => {
+    const { a, b, cleanup } = pairClients();
+    try {
+      b.setInboundHandler(() => {
+        throw new Error('boom');
+      });
+      a.start();
+      b.start();
+      await expect(a.sendRequest('lint', {})).rejects.toThrow(/boom/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('close() rejects pending requests', async () => {
+    const { a, b, cleanup } = pairClients();
+    try {
+      // B handler hangs forever
+      b.setInboundHandler(
+        () =>
+          new Promise(() => {
+            // never resolves: pins close() rejecting the pending request
+          }),
+      );
+      a.start();
+      b.start();
+      const pending = a.sendRequest('lint', {});
+      // Give it a tick to enqueue
+      await new Promise((r) => setTimeout(r, 20));
+      a.close();
+      await expect(pending).rejects.toThrow();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('start() is idempotent — no double listener install', async () => {
+    const { a, b, cleanup } = pairClients();
+    try {
+      a.start();
+      a.start(); // must be a no-op, NOT install a second 'data' listener
+      b.setInboundHandler(async () => ({ ok: true }));
+      b.start();
+
+      // If start() doubly installed listeners on the input stream,
+      // each frame would be parsed twice → two responses → the second
+      // would either reject with "no pending request" or resolve to a
+      // duplicate. Send one request and confirm exactly one reply.
+      let replyCount = 0;
+      const reply = a.sendRequest('lint', {}).then((r) => {
+        replyCount++;
+        return r;
+      });
+      const got = await reply;
+      expect((got.data as { ok?: boolean }).ok).toBe(true);
+      // Settle the microtask queue — a duplicate reply would arrive here.
+      await new Promise((r) => setTimeout(r, 30));
+      expect(replyCount).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('close() is idempotent — second call neither throws nor un-closes', async () => {
+    const { a, cleanup } = pairClients();
+    try {
+      a.start();
+      a.close();
+      a.close(); // must be a no-op
+      // Post-close contract: subsequent sendRequest still rejects.
+      // A regression where the second close() reset internal state
+      // would let sendRequest hang or succeed instead of rejecting.
+      await expect(a.sendRequest('lint', {})).rejects.toThrow(/closed/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('sendRequest after close throws', async () => {
+    const { a, cleanup } = pairClients();
+    try {
+      a.start();
+      a.close();
+      await expect(a.sendRequest('lint', {})).rejects.toThrow(/closed/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Schema parity with Go (smoke)', () => {
+  test('all known message kinds are valid strings', () => {
+    const kinds: MessageKind[] = [
+      'lint',
+      'applyFixes',
+      'getAstInfo',
+      'response',
+      'error',
+      'handshake',
+      'exit',
+      'init',
+      'cancel',
+      'output',
+      'log',
+      'shutdown',
+    ];
+    for (const k of kinds) {
+      const frame = encodeFrame({ kind: k, id: 0, data: null });
+      const decoded = decodeFrame(frame);
+      expect(decoded?.msg.kind).toBe(k);
+    }
+  });
+
+  // Regression: a write failure on the output stream must NOT leave
+  // pending sendRequest promises parked forever. Mirrors the Go-side
+  // writerLoop EPIPE-cascade fix. Without the JS-side fix:
+  //   - output.write throws (or emits error async) when stream is
+  //     destroyed.
+  //   - Pending sendRequest sits on its respCh promise indefinitely.
+  //   - Node sometimes surfaces the unhandled 'error' event as an
+  //     uncaught exception.
+  // A3 regression — peer-written frame whose declared length exceeds
+  // the 256 MiB cap must trigger the OOM-cap guard SYNCHRONOUSLY on the
+  // 'data' event and tear the connection down. Without the guard the
+  // client sits in the `if (this.buf.length < HEADER_BYTES + len) break;`
+  // arm, waiting forever for a body that never comes while any further
+  // chunks pile into `this.buf` (unbounded growth → worker OOM).
+  //
+  // This test pins the guard FIRING, not just "the pending eventually
+  // rejected": it asserts (1) the cap-specific diagnostic ("exceeds cap"
+  // + "stream desync") reaches stderr — that wording is emitted ONLY by
+  // the guard, so a deleted guard leaves stderr empty — and (2) the
+  // pending request rejects via the real teardown path, won by the
+  // actual rejection rather than a watchdog. The 250ms race rejects with
+  // a sentinel that does NOT match the teardown regex, so if the guard
+  // is dead the watchdog wins and the message assertion fails fast
+  // instead of passing on a loose alternation.
+  test('cap guard fires synchronously on an oversized frame-length header and seals the client', async () => {
+    const aToB = new PassThrough();
+    const bToA = new PassThrough();
+    const a = new IpcClient(bToA, aToB);
+    a.start();
+
+    // Capture the cap-specific diagnostic the guard writes to stderr.
+    const originalStderrWrite = process.stderr.write.bind(process.stderr);
+    let stderr = '';
+    (process.stderr as { write: unknown }).write = (
+      chunk: string | Uint8Array,
+    ): boolean => {
+      stderr += typeof chunk === 'string' ? chunk : chunk.toString();
+      return true;
+    };
+
+    let rejected = false;
+    let rejectedMessage = '';
+    try {
+      const pending = a.sendRequest('lint', { test: 1 });
+
+      // Header declaring a body 1 MiB above the 256 MiB cap, then no body.
+      const header = Buffer.alloc(4);
+      header.writeUInt32LE(257 * 1024 * 1024, 0);
+      bToA.write(header);
+
+      // Race the real rejection against a SHORT watchdog whose message is
+      // a sentinel the teardown regex below cannot match. If the guard is
+      // dead, `pending` never settles and the watchdog wins → the regex
+      // assertion fails fast (no 1500ms loose-match escape hatch).
+      try {
+        await Promise.race([
+          pending,
+          new Promise<never>((_, rej) =>
+            setTimeout(() => rej(new Error('WATCHDOG_NO_REJECTION')), 250),
+          ),
+        ]);
+      } catch (e) {
+        rejected = true;
+        rejectedMessage = (e as Error).message;
+      }
+    } finally {
+      (process.stderr as { write: unknown }).write = originalStderrWrite;
+    }
+
+    // The rejection must be the genuine teardown, NOT the watchdog.
+    expect(rejected).toBe(true);
+    expect(rejectedMessage).not.toBe('WATCHDOG_NO_REJECTION');
+    expect(rejectedMessage).toMatch(/peer closed input stream/);
+
+    // The cap-specific diagnostic — emitted ONLY by the guard — must be
+    // present. A deleted/disabled guard leaves stderr empty here.
+    expect(stderr).toMatch(/exceeds cap/);
+    expect(stderr).toMatch(/stream desync/);
+
+    // The client is sealed: a subsequent sendRequest fails fast.
+    await expect(a.sendRequest('lint', {})).rejects.toThrow(
+      /cannot sendRequest on closed client/,
+    );
+
+    void aToB;
+  });
+
+  test('output stream error rejects pending requests and seals client', async () => {
+    const aToB = new PassThrough();
+    const bToA = new PassThrough();
+    const a = new IpcClient(bToA, aToB);
+    a.start();
+
+    // Start a request — this enqueues to `pending` and writes one frame
+    // before parking on the response promise.
+    const pending = a.sendRequest('lint', { test: 1 });
+
+    // Destroy the output stream WITH an error. This drives the
+    // 'error' event on the Writable side that `a` writes to.
+    const err = new Error('simulated EPIPE');
+    aToB.destroy(err);
+
+    // The fix: pending requests must reject quickly (within ~100 ms
+    // is generous; the rejection is synchronous on the 'error' event).
+    let rejected = false;
+    let rejectedMessage = '';
+    try {
+      await Promise.race([
+        pending,
+        new Promise<never>((_, rej) =>
+          setTimeout(
+            () => rej(new Error('TIMEOUT: pending request not rejected')),
+            1_500,
+          ),
+        ),
+      ]);
+    } catch (e) {
+      rejected = true;
+      rejectedMessage = (e as Error).message;
+    }
+
+    expect(rejected).toBe(true);
+    // The rejection should mention the underlying write failure so the
+    // caller can distinguish "transport died" from "peer error" / "ctx
+    // cancelled".
+    expect(rejectedMessage.toLowerCase()).toMatch(/write|epipe|closed/);
+
+    // Cleanup: nothing else to test here, the client is sealed.
+    void bToA;
+  });
+
+  // After peer closes its write side (we see EOF on input), our
+  // IpcClient must seal — future sendRequest calls fail fast.
+  // Previously onEnd only rejected pending and left .closed=false,
+  // so a sendRequest after onEnd would silently enqueue and wait
+  // forever for a response that can never come.
+  test('peer-closes-input seals the client (no hang on next sendRequest)', async () => {
+    const aToB = new PassThrough();
+    const bToA = new PassThrough();
+    const a = new IpcClient(bToA, aToB);
+    a.start();
+
+    // Peer closes its write side — we see EOF on input (bToA).
+    bToA.end();
+    await new Promise<void>((r) => setImmediate(r));
+
+    // sendRequest must throw / reject immediately, not park.
+    let rejected = false;
+    let msg = '';
+    try {
+      const p = a.sendRequest('lint', {});
+      await Promise.race([
+        p,
+        new Promise<never>((_, rej) =>
+          setTimeout(
+            () => rej(new Error('TIMEOUT: sendRequest did not reject')),
+            1_500,
+          ),
+        ),
+      ]);
+    } catch (e) {
+      rejected = true;
+      msg = (e as Error).message;
+    }
+    expect(rejected).toBe(true);
+    expect(msg.toLowerCase()).toMatch(/closed|peer|input/);
+  });
+
+  // A future sendRequest after output error must fail fast, not park.
+  test('sendRequest after output error rejects immediately', async () => {
+    const aToB = new PassThrough();
+    const bToA = new PassThrough();
+    const a = new IpcClient(bToA, aToB);
+    a.start();
+
+    aToB.destroy(new Error('simulated EPIPE'));
+    // Allow the error event to fire on the next microtask.
+    await new Promise<void>((r) => setImmediate(r));
+
+    // sendRequest after the client has been sealed by onOutputError
+    // must throw rather than enqueueing into pending. The throw goes
+    // out of the sync body before the Promise is even constructed.
+    let threw = false;
+    let msg = '';
+    try {
+      // Avoid awaiting — the throw is synchronous, but in case rstest's
+      // proxy turns it into a rejection we still want to capture it.
+      const p = a.sendRequest('lint', {});
+      // If we got here, sendRequest didn't throw — try awaiting in case
+      // it returned a rejected Promise instead.
+      await p;
+    } catch (e) {
+      threw = true;
+      msg = (e as Error).message;
+    }
+    expect(threw).toBe(true);
+    expect(msg).toMatch(/closed/);
+  });
+});
+
+describe('IpcClient rejects pending on clean output close (no hang)', () => {
+  test('in-flight sendRequest rejects when output is cleanly destroyed', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const client = new IpcClient(input, output);
+    client.start();
+    // No peer responds. A CLEAN close (destroy() with no error) fires
+    // no 'error' and write() doesn't throw, so without the 'close'/
+    // 'finish' listeners this request would hang forever.
+    const pending = client.sendRequest('init', {});
+    output.destroy();
+    await expect(pending).rejects.toThrow(/output stream closed|closed/);
+    client.close();
+  });
+
+  test('sendRequest after a clean output close throws (not hang)', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const client = new IpcClient(input, output);
+    client.start();
+    output.destroy();
+    await new Promise((r) => setTimeout(r, 10)); // let 'close' fire
+    // `sendRequest` is async, so its top-level closed-guard throw
+    // surfaces as a rejected promise, not a synchronous throw.
+    await expect(client.sendRequest('init', {})).rejects.toThrow(/closed/);
+    client.close();
+  });
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -548,3 +548,11 @@ ZWSP
 résumé
 TSJSDoc
 unpadded
+acks
+backpressure
+kase
+lookback
+omitempty
+perr
+unmarshals
+unstarted


### PR DESCRIPTION
## Summary

This PR makes the rslint CLI talk to its Node side over a single, generic bidirectional Go↔Node IPC channel.

**Transport**
- `internal/ipc.Channel` (Go) and `packages/rslint/src/ipc` (Node): a length-prefixed-JSON frame transport — request/response, notifications, and in-handler reverse requests — hardened with a per-write deadline, request timeout, and nil-payload omission for cross-language wire parity. Cross-language golden-frame contract tests pin byte compatibility in both directions.
- `internal/api` drops its own ad-hoc framing and rides the shared transport.

**CLI on the transport**
- The Go CLI defaults to `runCLI`, which hosts an `ipc.Channel` over stdio; the Node side spawns it through a single engine host (`engine.ts`) and routes every CLI call there (`cli.ts`). Native lint runs end-to-end over IPC.
- `parseLintFlags` and `executeLintPipeline` are extracted from the old `runCMD` with no behavior change.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).