### PR TITLE
feat: add no-type-alias rule

### DIFF
--- a/internal/plugins/typescript/all.go
+++ b/internal/plugins/typescript/all.go
@@ -66,6 +66,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_restricted_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_shadow"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_this_alias"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_type_alias"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_condition"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment"
@@ -196,6 +197,7 @@ func GetAllRules() []rule.Rule {
 		no_redeclare.NoRedeclareRule,
 		no_redundant_type_constituents.NoRedundantTypeConstituentsRule,
 		no_this_alias.NoThisAliasRule,
+		no_type_alias.NoTypeAliasRule,
 		no_require_imports.NoRequireImportsRule,
 		no_restricted_imports.NoRestrictedImportsRule,
 		no_restricted_types.NoRestrictedTypesRule,

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias.go
@@ -335,7 +335,7 @@ var NoTypeAliasRule = rule.CreateRule(rule.Rule{
 			if node.Kind == ast.KindTypeOperator {
 				typeOp := node.AsTypeOperatorNode()
 				if typeOp != nil {
-					if typeOp.Operator == ast.KindKeyOfKeyword || typeOp.Operator == ast.KindUniqueKeyword {
+					if typeOp.Operator == ast.KindKeyOfKeyword {
 						checkAndReport(opts.AllowAliases, isTopLevel, t, "Aliases")
 						return
 					}

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias.go
@@ -36,6 +36,21 @@ type NoTypeAliasOptions struct {
 	AllowTupleTypes       optionValue `json:"allowTupleTypes"`
 }
 
+func parseSimpleOption(val string) optionValue {
+	if val == string(optionAlways) || val == string(optionNever) {
+		return optionValue(val)
+	}
+	return optionNever
+}
+
+func parseCompositionOption(val string) optionValue {
+	switch optionValue(val) {
+	case optionAlways, optionNever, optionInUnions, optionInIntersections, optionInUnionsAndIntersections:
+		return optionValue(val)
+	}
+	return optionNever
+}
+
 func parseOptions(options any) NoTypeAliasOptions {
 	opts := NoTypeAliasOptions{
 		AllowAliases:          optionNever,
@@ -60,28 +75,28 @@ func parseOptions(options any) NoTypeAliasOptions {
 		return opts
 	}
 	if v, ok := optsMap["allowAliases"].(string); ok {
-		opts.AllowAliases = optionValue(v)
+		opts.AllowAliases = parseCompositionOption(v)
 	}
 	if v, ok := optsMap["allowCallbacks"].(string); ok {
-		opts.AllowCallbacks = optionValue(v)
+		opts.AllowCallbacks = parseSimpleOption(v)
 	}
 	if v, ok := optsMap["allowConditionalTypes"].(string); ok {
-		opts.AllowConditionalTypes = optionValue(v)
+		opts.AllowConditionalTypes = parseSimpleOption(v)
 	}
 	if v, ok := optsMap["allowConstructors"].(string); ok {
-		opts.AllowConstructors = optionValue(v)
+		opts.AllowConstructors = parseSimpleOption(v)
 	}
 	if v, ok := optsMap["allowGenerics"].(string); ok {
-		opts.AllowGenerics = optionValue(v)
+		opts.AllowGenerics = parseSimpleOption(v)
 	}
 	if v, ok := optsMap["allowLiterals"].(string); ok {
-		opts.AllowLiterals = optionValue(v)
+		opts.AllowLiterals = parseCompositionOption(v)
 	}
 	if v, ok := optsMap["allowMappedTypes"].(string); ok {
-		opts.AllowMappedTypes = optionValue(v)
+		opts.AllowMappedTypes = parseCompositionOption(v)
 	}
 	if v, ok := optsMap["allowTupleTypes"].(string); ok {
-		opts.AllowTupleTypes = optionValue(v)
+		opts.AllowTupleTypes = parseCompositionOption(v)
 	}
 	return opts
 }

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias.go
@@ -1,0 +1,341 @@
+package no_type_alias
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type optionValue string
+
+const (
+	optionAlways                   optionValue = "always"
+	optionNever                    optionValue = "never"
+	optionInUnions                 optionValue = "in-unions"
+	optionInIntersections          optionValue = "in-intersections"
+	optionInUnionsAndIntersections optionValue = "in-unions-and-intersections"
+)
+
+type compositionType int
+
+const (
+	compositionNone compositionType = iota
+	compositionUnion
+	compositionIntersection
+)
+
+type NoTypeAliasOptions struct {
+	AllowAliases          optionValue `json:"allowAliases"`
+	AllowCallbacks        optionValue `json:"allowCallbacks"`
+	AllowConditionalTypes optionValue `json:"allowConditionalTypes"`
+	AllowConstructors     optionValue `json:"allowConstructors"`
+	AllowGenerics         optionValue `json:"allowGenerics"`
+	AllowLiterals         optionValue `json:"allowLiterals"`
+	AllowMappedTypes      optionValue `json:"allowMappedTypes"`
+	AllowTupleTypes       optionValue `json:"allowTupleTypes"`
+}
+
+func parseOptions(options any) NoTypeAliasOptions {
+	opts := NoTypeAliasOptions{
+		AllowAliases:          optionNever,
+		AllowCallbacks:        optionNever,
+		AllowConditionalTypes: optionNever,
+		AllowConstructors:     optionNever,
+		AllowGenerics:         optionNever,
+		AllowLiterals:         optionNever,
+		AllowMappedTypes:      optionNever,
+		AllowTupleTypes:       optionNever,
+	}
+	if options == nil {
+		return opts
+	}
+	var optsMap map[string]interface{}
+	if arr, ok := options.([]interface{}); ok && len(arr) > 0 {
+		optsMap, _ = arr[0].(map[string]interface{})
+	} else {
+		optsMap, _ = options.(map[string]interface{})
+	}
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowAliases"].(string); ok {
+		opts.AllowAliases = optionValue(v)
+	}
+	if v, ok := optsMap["allowCallbacks"].(string); ok {
+		opts.AllowCallbacks = optionValue(v)
+	}
+	if v, ok := optsMap["allowConditionalTypes"].(string); ok {
+		opts.AllowConditionalTypes = optionValue(v)
+	}
+	if v, ok := optsMap["allowConstructors"].(string); ok {
+		opts.AllowConstructors = optionValue(v)
+	}
+	if v, ok := optsMap["allowGenerics"].(string); ok {
+		opts.AllowGenerics = optionValue(v)
+	}
+	if v, ok := optsMap["allowLiterals"].(string); ok {
+		opts.AllowLiterals = optionValue(v)
+	}
+	if v, ok := optsMap["allowMappedTypes"].(string); ok {
+		opts.AllowMappedTypes = optionValue(v)
+	}
+	if v, ok := optsMap["allowTupleTypes"].(string); ok {
+		opts.AllowTupleTypes = optionValue(v)
+	}
+	return opts
+}
+
+func buildNoTypeAliasMessage(alias string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noTypeAlias",
+		Description: "Type " + strings.ToLower(alias) + " are not allowed.",
+	}
+}
+
+func buildNoCompositionAliasMessage(typeName string, composition compositionType) rule.RuleMessage {
+	compositionName := "intersection"
+	if composition == compositionUnion {
+		compositionName = "union"
+	}
+
+	return rule.RuleMessage{
+		Id:          "noCompositionAlias",
+		Description: typeName + " in " + compositionName + " types are not allowed.",
+	}
+}
+
+var NoTypeAliasRule = rule.CreateRule(rule.Rule{
+	Name: "no-type-alias",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		isSupportedComposition := func(isTopLevel bool, composition compositionType, allowed optionValue) bool {
+			if allowed != optionInUnions && allowed != optionInIntersections && allowed != optionInUnionsAndIntersections {
+				return true
+			}
+			if isTopLevel {
+				return false
+			}
+			if composition == compositionUnion {
+				return allowed == optionInUnions || allowed == optionInUnionsAndIntersections
+			}
+			if composition == compositionIntersection {
+				return allowed == optionInIntersections || allowed == optionInUnionsAndIntersections
+			}
+			return false
+		}
+
+		reportError := func(node *ast.Node, composition compositionType, isTopLevel bool, aliasLabel string) {
+			if node == nil {
+				return
+			}
+			if isTopLevel {
+				ctx.ReportNode(node, buildNoTypeAliasMessage(aliasLabel))
+				return
+			}
+			ctx.ReportNode(node, buildNoCompositionAliasMessage(aliasLabel, composition))
+		}
+
+		type typeWithComposition struct {
+			node        *ast.Node
+			composition compositionType
+		}
+
+		var getTypes func(node *ast.Node, composition compositionType) []typeWithComposition
+		getTypes = func(node *ast.Node, composition compositionType) []typeWithComposition {
+			if node == nil {
+				return nil
+			}
+			if node.Kind == ast.KindParenthesizedType {
+				parenthesized := node.AsParenthesizedTypeNode()
+				if parenthesized == nil {
+					return nil
+				}
+				return getTypes(parenthesized.Type, composition)
+			}
+			switch node.Kind {
+			case ast.KindUnionType:
+				union := node.AsUnionTypeNode()
+				if union == nil || union.Types == nil {
+					return nil
+				}
+				var out []typeWithComposition
+				for _, t := range union.Types.Nodes {
+					out = append(out, getTypes(t, compositionUnion)...)
+				}
+				return out
+			case ast.KindIntersectionType:
+				intersection := node.AsIntersectionTypeNode()
+				if intersection == nil || intersection.Types == nil {
+					return nil
+				}
+				var out []typeWithComposition
+				for _, t := range intersection.Types.Nodes {
+					out = append(out, getTypes(t, compositionIntersection)...)
+				}
+				return out
+			default:
+				return []typeWithComposition{{node: node, composition: composition}}
+			}
+		}
+
+		isAliasKind := func(node *ast.Node) bool {
+			if node == nil {
+				return false
+			}
+			switch node.Kind {
+			case ast.KindArrayType,
+				ast.KindImportType,
+				ast.KindIndexedAccessType,
+				ast.KindLiteralType,
+				ast.KindTemplateLiteralType,
+				ast.KindTypeQuery,
+				ast.KindTypeReference:
+				return true
+			default:
+				return false
+			}
+		}
+
+		isKeywordType := func(node *ast.Node) bool {
+			if node == nil {
+				return false
+			}
+			switch node.Kind {
+			case ast.KindAnyKeyword,
+				ast.KindBigIntKeyword,
+				ast.KindBooleanKeyword,
+				ast.KindIntrinsicKeyword,
+				ast.KindNeverKeyword,
+				ast.KindNullKeyword,
+				ast.KindNumberKeyword,
+				ast.KindObjectKeyword,
+				ast.KindStringKeyword,
+				ast.KindSymbolKeyword,
+				ast.KindUndefinedKeyword,
+				ast.KindUnknownKeyword,
+				ast.KindVoidKeyword:
+				return true
+			default:
+				return false
+			}
+		}
+
+		isValidTupleType := func(t typeWithComposition) bool {
+			if t.node == nil {
+				return false
+			}
+			if t.node.Kind == ast.KindTupleType {
+				return true
+			}
+			if t.node.Kind != ast.KindTypeOperator {
+				return false
+			}
+			typeOp := t.node.AsTypeOperatorNode()
+			if typeOp == nil || typeOp.Type == nil {
+				return false
+			}
+			if typeOp.Operator != ast.KindKeyOfKeyword && typeOp.Operator != ast.KindReadonlyKeyword {
+				return false
+			}
+			return typeOp.Type.Kind == ast.KindTupleType
+		}
+
+		isValidGeneric := func(t typeWithComposition) bool {
+			if t.node == nil || t.node.Kind != ast.KindTypeReference {
+				return false
+			}
+			typeRef := t.node.AsTypeReferenceNode()
+			return typeRef != nil && typeRef.TypeArguments != nil && len(typeRef.TypeArguments.Nodes) > 0
+		}
+
+		checkAndReport := func(option optionValue, isTopLevel bool, t typeWithComposition, label string) {
+			if option == optionNever || !isSupportedComposition(isTopLevel, t.composition, option) {
+				reportError(t.node, t.composition, isTopLevel, label)
+			}
+		}
+
+		validateTypeAlias := func(t typeWithComposition, isTopLevel bool) {
+			if t.node == nil {
+				return
+			}
+			switch t.node.Kind {
+			case ast.KindFunctionType:
+				if opts.AllowCallbacks == optionNever {
+					reportError(t.node, t.composition, isTopLevel, "Callbacks")
+				}
+				return
+			case ast.KindConditionalType:
+				if opts.AllowConditionalTypes == optionNever {
+					reportError(t.node, t.composition, isTopLevel, "Conditional types")
+				}
+				return
+			case ast.KindConstructorType:
+				if opts.AllowConstructors == optionNever {
+					reportError(t.node, t.composition, isTopLevel, "Constructors")
+				}
+				return
+			case ast.KindTypeLiteral:
+				checkAndReport(opts.AllowLiterals, isTopLevel, t, "Literals")
+				return
+			case ast.KindMappedType:
+				checkAndReport(opts.AllowMappedTypes, isTopLevel, t, "Mapped types")
+				return
+			}
+
+			if isValidTupleType(t) {
+				checkAndReport(opts.AllowTupleTypes, isTopLevel, t, "Tuple Types")
+				return
+			}
+
+			if isValidGeneric(t) {
+				if opts.AllowGenerics == optionNever {
+					reportError(t.node, t.composition, isTopLevel, "Generics")
+				}
+				return
+			}
+
+			if isKeywordType(t.node) || isAliasKind(t.node) {
+				checkAndReport(opts.AllowAliases, isTopLevel, t, "Aliases")
+				return
+			}
+
+			if t.node.Kind == ast.KindTypeOperator {
+				typeOp := t.node.AsTypeOperatorNode()
+				if typeOp != nil {
+					if typeOp.Operator == ast.KindKeyOfKeyword {
+						checkAndReport(opts.AllowAliases, isTopLevel, t, "Aliases")
+						return
+					}
+					if typeOp.Operator == ast.KindReadonlyKeyword && typeOp.Type != nil && isAliasKind(typeOp.Type) {
+						checkAndReport(opts.AllowAliases, isTopLevel, t, "Aliases")
+						return
+					}
+				}
+			}
+
+			reportError(t.node, t.composition, isTopLevel, "Unhandled")
+		}
+
+		return rule.RuleListeners{
+			ast.KindTypeAliasDeclaration: func(node *ast.Node) {
+				decl := node.AsTypeAliasDeclaration()
+				if decl == nil || decl.Type == nil {
+					return
+				}
+				types := getTypes(decl.Type, compositionNone)
+				if len(types) == 0 {
+					return
+				}
+				if len(types) == 1 {
+					validateTypeAlias(types[0], true)
+					return
+				}
+				for _, t := range types {
+					validateTypeAlias(t, false)
+				}
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias.go
@@ -120,6 +120,17 @@ func buildNoCompositionAliasMessage(typeName string, composition compositionType
 	}
 }
 
+func unwrapParenthesized(node *ast.Node) *ast.Node {
+	for node != nil && node.Kind == ast.KindParenthesizedType {
+		parenthesized := node.AsParenthesizedTypeNode()
+		if parenthesized == nil {
+			break
+		}
+		node = parenthesized.Type
+	}
+	return node
+}
+
 var NoTypeAliasRule = rule.CreateRule(rule.Rule{
 	Name: "no-type-alias",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
@@ -163,11 +174,7 @@ var NoTypeAliasRule = rule.CreateRule(rule.Rule{
 				return nil
 			}
 			if node.Kind == ast.KindParenthesizedType {
-				parenthesized := node.AsParenthesizedTypeNode()
-				if parenthesized == nil {
-					return nil
-				}
-				return getTypes(parenthesized.Type, composition)
+				return getTypes(unwrapParenthesized(node), composition)
 			}
 			switch node.Kind {
 			case ast.KindUnionType:
@@ -196,6 +203,7 @@ var NoTypeAliasRule = rule.CreateRule(rule.Rule{
 		}
 
 		isAliasKind := func(node *ast.Node) bool {
+			node = unwrapParenthesized(node)
 			if node == nil {
 				return false
 			}
@@ -214,6 +222,7 @@ var NoTypeAliasRule = rule.CreateRule(rule.Rule{
 		}
 
 		isKeywordType := func(node *ast.Node) bool {
+			node = unwrapParenthesized(node)
 			if node == nil {
 				return false
 			}
@@ -238,30 +247,33 @@ var NoTypeAliasRule = rule.CreateRule(rule.Rule{
 		}
 
 		isValidTupleType := func(t typeWithComposition) bool {
-			if t.node == nil {
+			node := unwrapParenthesized(t.node)
+			if node == nil {
 				return false
 			}
-			if t.node.Kind == ast.KindTupleType {
+			if node.Kind == ast.KindTupleType {
 				return true
 			}
-			if t.node.Kind != ast.KindTypeOperator {
+			if node.Kind != ast.KindTypeOperator {
 				return false
 			}
-			typeOp := t.node.AsTypeOperatorNode()
+			typeOp := node.AsTypeOperatorNode()
 			if typeOp == nil || typeOp.Type == nil {
 				return false
 			}
 			if typeOp.Operator != ast.KindKeyOfKeyword && typeOp.Operator != ast.KindReadonlyKeyword {
 				return false
 			}
-			return typeOp.Type.Kind == ast.KindTupleType
+			unwrappedType := unwrapParenthesized(typeOp.Type)
+			return unwrappedType != nil && unwrappedType.Kind == ast.KindTupleType
 		}
 
 		isValidGeneric := func(t typeWithComposition) bool {
-			if t.node == nil || t.node.Kind != ast.KindTypeReference {
+			node := unwrapParenthesized(t.node)
+			if node == nil || node.Kind != ast.KindTypeReference {
 				return false
 			}
-			typeRef := t.node.AsTypeReferenceNode()
+			typeRef := node.AsTypeReferenceNode()
 			return typeRef != nil && typeRef.TypeArguments != nil && len(typeRef.TypeArguments.Nodes) > 0
 		}
 
@@ -275,7 +287,11 @@ var NoTypeAliasRule = rule.CreateRule(rule.Rule{
 			if t.node == nil {
 				return
 			}
-			switch t.node.Kind {
+			node := unwrapParenthesized(t.node)
+			if node == nil {
+				return
+			}
+			switch node.Kind {
 			case ast.KindFunctionType:
 				if opts.AllowCallbacks == optionNever {
 					reportError(t.node, t.composition, isTopLevel, "Callbacks")
@@ -311,21 +327,24 @@ var NoTypeAliasRule = rule.CreateRule(rule.Rule{
 				return
 			}
 
-			if isKeywordType(t.node) || isAliasKind(t.node) {
+			if isKeywordType(node) || isAliasKind(node) {
 				checkAndReport(opts.AllowAliases, isTopLevel, t, "Aliases")
 				return
 			}
 
-			if t.node.Kind == ast.KindTypeOperator {
-				typeOp := t.node.AsTypeOperatorNode()
+			if node.Kind == ast.KindTypeOperator {
+				typeOp := node.AsTypeOperatorNode()
 				if typeOp != nil {
-					if typeOp.Operator == ast.KindKeyOfKeyword {
+					if typeOp.Operator == ast.KindKeyOfKeyword || typeOp.Operator == ast.KindUniqueKeyword {
 						checkAndReport(opts.AllowAliases, isTopLevel, t, "Aliases")
 						return
 					}
-					if typeOp.Operator == ast.KindReadonlyKeyword && typeOp.Type != nil && isAliasKind(typeOp.Type) {
-						checkAndReport(opts.AllowAliases, isTopLevel, t, "Aliases")
-						return
+					if typeOp.Operator == ast.KindReadonlyKeyword && typeOp.Type != nil {
+						unwrappedOperand := unwrapParenthesized(typeOp.Type)
+						if isAliasKind(unwrappedOperand) || isKeywordType(unwrappedOperand) {
+							checkAndReport(opts.AllowAliases, isTopLevel, t, "Aliases")
+							return
+						}
 					}
 				}
 			}

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias.md
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias.md
@@ -1,0 +1,23 @@
+# no-type-alias
+
+## Rule Details
+
+Disallow type aliases.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+type Name = string;
+```
+
+Examples of **correct** code:
+
+```ts
+interface Name {
+  value: string;
+}
+```
+
+## Original Documentation
+
+- https://typescript-eslint.io/rules/no-type-alias

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
@@ -1,0 +1,32 @@
+package no_type_alias
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoTypeAliasRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoTypeAliasRule, []rule_tester.ValidTestCase{
+		{Code: `interface Foo { bar: string }`},
+		{Code: `type Foo = string`, Options: map[string]interface{}{"allowAliases": "always"}},
+		{
+			Code:    `type Foo = 'a' | 'b'`,
+			Options: map[string]interface{}{"allowAliases": "in-unions"},
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:   `type Foo = string`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = string | number`,
+			Options: map[string]interface{}{"allowAliases": "never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 21},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
@@ -9,24 +9,391 @@ import (
 
 func TestNoTypeAliasRule(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoTypeAliasRule, []rule_tester.ValidTestCase{
+		// Baseline: interface declarations are always fine
 		{Code: `interface Foo { bar: string }`},
+
+		// allowAliases: always (top-level alias allowed)
 		{Code: `type Foo = string`, Options: map[string]interface{}{"allowAliases": "always"}},
+		{Code: `type Foo = 'a'`, Options: map[string]interface{}{"allowAliases": "always"}},
+		{Code: `type Foo = typeof bar`, Options: map[string]interface{}{"allowAliases": "always"}},
+		{Code: `type Foo = typeof import('foo')`, Options: map[string]interface{}{"allowAliases": "always"}},
+
+		// allowAliases: in-unions
+		{Code: `type Foo = 'a' | 'b'`, Options: map[string]interface{}{"allowAliases": "in-unions"}},
+		{Code: `type Foo = 'a' | 'b' | 'c'`, Options: map[string]interface{}{"allowAliases": "in-unions"}},
+		{Code: `type Foo = typeof bar | typeof baz`, Options: map[string]interface{}{"allowAliases": "in-unions"}},
+
+		// allowAliases: in-intersections
+		{Code: `type Foo = 'a' & 'b'`, Options: map[string]interface{}{"allowAliases": "in-intersections"}},
+		{Code: `type Foo = 'a' & 'b' & 'c'`, Options: map[string]interface{}{"allowAliases": "in-intersections"}},
+
+		// allowAliases: in-unions-and-intersections
+		{Code: `type Foo = 'a' | 'b'`, Options: map[string]interface{}{"allowAliases": "in-unions-and-intersections"}},
+		{Code: `type Foo = 'a' & 'b'`, Options: map[string]interface{}{"allowAliases": "in-unions-and-intersections"}},
+		{Code: `type Foo = 'a' | ('b' & 'c')`, Options: map[string]interface{}{"allowAliases": "in-unions-and-intersections"}},
+
+		// allowCallbacks
+		{Code: `type Foo = () => void`, Options: map[string]interface{}{"allowCallbacks": "always"}},
+		{Code: `type Foo = () => void | string`, Options: map[string]interface{}{"allowCallbacks": "always"}},
+
+		// allowLiterals
+		{Code: `type Foo = {}`, Options: map[string]interface{}{"allowLiterals": "always"}},
+		{Code: `type Foo = {} | {}`, Options: map[string]interface{}{"allowLiterals": "in-unions"}},
+		{Code: `type Foo = {} | {}`, Options: map[string]interface{}{"allowLiterals": "in-unions-and-intersections"}},
+		{Code: `type Foo = {} & {}`, Options: map[string]interface{}{"allowLiterals": "in-intersections"}},
+		{Code: `type Foo = {} & {}`, Options: map[string]interface{}{"allowLiterals": "in-unions-and-intersections"}},
+
+		// allowMappedTypes
+		{Code: `type Foo<T> = { readonly [P in keyof T]: T[P] }`, Options: map[string]interface{}{"allowMappedTypes": "always"}},
+		{Code: `type Foo<T> = { readonly [P in keyof T]: T[P] } | { readonly [P in keyof T]: T[P] }`, Options: map[string]interface{}{"allowMappedTypes": "in-unions"}},
+		{Code: `type Foo<T> = { readonly [P in keyof T]: T[P] } & { readonly [P in keyof T]: T[P] }`, Options: map[string]interface{}{"allowMappedTypes": "in-intersections"}},
+		{Code: `type Foo<T> = { readonly [P in keyof T]: T[P] } | { readonly [P in keyof T]: T[P] }`, Options: map[string]interface{}{"allowMappedTypes": "in-unions-and-intersections"}},
+
+		// allowTupleTypes
+		{Code: `type Foo = [string]`, Options: map[string]interface{}{"allowTupleTypes": "always"}},
+		{Code: `type Foo = [string] | [number, number]`, Options: map[string]interface{}{"allowTupleTypes": "in-unions"}},
+		{Code: `type Foo = [string] & [number, number]`, Options: map[string]interface{}{"allowTupleTypes": "in-intersections"}},
+		{Code: `type Foo = ([string] & [number, number]) | [number, number, number]`, Options: map[string]interface{}{"allowTupleTypes": "in-unions-and-intersections"}},
+		{Code: `type Foo = readonly [string] | [number, number]`, Options: map[string]interface{}{"allowTupleTypes": "always"}},
+		{Code: `type Foo = readonly [string] | readonly [number, number]`, Options: map[string]interface{}{"allowTupleTypes": "always"}},
+		{Code: `type Foo = keyof [string]`, Options: map[string]interface{}{"allowTupleTypes": "always"}},
+		{Code: `type Foo = keyof [string] | [number, number]`, Options: map[string]interface{}{"allowTupleTypes": "always"}},
+		{Code: `type Foo = keyof [string] | [number, number]`, Options: map[string]interface{}{"allowTupleTypes": "in-unions"}},
+
+		// allowConditionalTypes
+		{Code: `type Foo<T> = T extends number ? number : null`, Options: map[string]interface{}{"allowConditionalTypes": "always"}},
+
+		// allowConstructors
+		{Code: `type Foo = new (bar: number) => string | null`, Options: map[string]interface{}{"allowConstructors": "always"}},
+
+		// allowGenerics
+		{Code: `type Foo = Record<string, number>`, Options: map[string]interface{}{"allowGenerics": "always"}},
+
+		// Mixed options (real-world style)
 		{
-			Code:    `type Foo = 'a' | 'b'`,
-			Options: map[string]interface{}{"allowAliases": "in-unions"},
+			Code: `type ClassValue = string | number | undefined | null | false`,
+			Options: map[string]interface{}{
+				"allowAliases":       "in-unions-and-intersections",
+				"allowCallbacks":       "always",
+				"allowLiterals":        "in-unions-and-intersections",
+				"allowMappedTypes":     "in-unions-and-intersections",
+				"allowTupleTypes":      "in-unions-and-intersections",
+				"allowGenerics":        "always",
+				"allowConditionalTypes": "always",
+				"allowConstructors":    "always",
+			},
 		},
 	}, []rule_tester.InvalidTestCase{
+		// Default: no aliases allowed
 		{
 			Code:   `type Foo = string`,
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
 		},
 		{
-			Code:    `type Foo = string | number`,
+			Code:   `type Foo = 'a'`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:   `type Foo = typeof import('foo')`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+
+		// Union aliases with default / never
+		{
+			Code: `type Foo = 'a' | 'b'`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:    `type Foo = 'a' | 'b'`,
 			Options: map[string]interface{}{"allowAliases": "never"},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
-				{MessageId: "noCompositionAlias", Line: 1, Column: 21},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
 			},
+		},
+		{
+			Code: `type Foo = 'a' | 'b' | 'c'`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 24},
+			},
+		},
+		{
+			Code:    `type Foo = 'a' | 'b' | 'c'`,
+			Options: map[string]interface{}{"allowAliases": "never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 24},
+			},
+		},
+
+		// Intersection aliases with default / never
+		{
+			Code: `type Foo = 'a' & 'b'`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:    `type Foo = 'a' & 'b'`,
+			Options: map[string]interface{}{"allowAliases": "never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code: `type Foo = 'a' & 'b' & 'c'`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 24},
+			},
+		},
+
+		// Composition mismatches for allowAliases
+		{
+			Code:    `type Foo = 'a' | 'b'`,
+			Options: map[string]interface{}{"allowAliases": "in-intersections"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:    `type Foo = 'a' & 'b'`,
+			Options: map[string]interface{}{"allowAliases": "in-unions"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:    `type Foo = 'a' | 'b' | 'c'`,
+			Options: map[string]interface{}{"allowAliases": "in-intersections"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 24},
+			},
+		},
+		{
+			Code:    `type Foo = 'a' | 'b'`,
+			Options: map[string]interface{}{"allowAliases": "in-intersections", "allowLiterals": "in-unions"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 18},
+			},
+		},
+
+		// allowCallbacks: never (default)
+		{
+			Code:    `type Foo = () => void`,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = () => void`,
+			Options: map[string]interface{}{"allowCallbacks": "never"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+
+		// allowLiterals: never (default)
+		{
+			Code:   `type Foo = {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = {}`,
+			Options: map[string]interface{}{"allowLiterals": "never"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = {}`,
+			Options: map[string]interface{}{"allowLiterals": "in-unions"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = {}`,
+			Options: map[string]interface{}{"allowLiterals": "in-intersections"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = {}`,
+			Options: map[string]interface{}{"allowLiterals": "in-unions-and-intersections"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+
+		// Literal unions / intersections
+		{
+			Code: `type Foo = {} | {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 17},
+			},
+		},
+		{
+			Code:    `type Foo = {} | {}`,
+			Options: map[string]interface{}{"allowLiterals": "never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 17},
+			},
+		},
+		{
+			Code:    `type Foo = {} | {}`,
+			Options: map[string]interface{}{"allowLiterals": "in-intersections"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 17},
+			},
+		},
+		{
+			Code: `type Foo = {} & {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 17},
+			},
+		},
+		{
+			Code:    `type Foo = {} & {}`,
+			Options: map[string]interface{}{"allowLiterals": "never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 17},
+			},
+		},
+		{
+			Code:    `type Foo = {} & {}`,
+			Options: map[string]interface{}{"allowLiterals": "in-unions"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 17},
+			},
+		},
+
+		// allowMappedTypes: never (default)
+		{
+			Code:    `type Foo<T> = { readonly [P in keyof T]: T[P] }`,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
+		},
+		{
+			Code:    `type Foo<T> = { readonly [P in keyof T]: T[P] }`,
+			Options: map[string]interface{}{"allowMappedTypes": "never"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
+		},
+		{
+			Code:    `type Foo<T> = { readonly [P in keyof T]: T[P] } | { readonly [P in keyof T]: T[P] }`,
+			Options: map[string]interface{}{"allowMappedTypes": "in-intersections"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 15},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 51},
+			},
+		},
+		{
+			Code:    `type Foo<T> = { readonly [P in keyof T]: T[P] } & { readonly [P in keyof T]: T[P] }`,
+			Options: map[string]interface{}{"allowMappedTypes": "in-unions"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 15},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 51},
+			},
+		},
+
+		// allowTupleTypes: never (default)
+		{
+			Code:    `type Foo = [string]`,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = [string]`,
+			Options: map[string]interface{}{"allowTupleTypes": "never"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = [string] | [number, number]`,
+			Options: map[string]interface{}{"allowTupleTypes": "in-intersections"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 23},
+			},
+		},
+		{
+			Code:    `type Foo = [string] & [number, number]`,
+			Options: map[string]interface{}{"allowTupleTypes": "in-unions"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 23},
+			},
+		},
+		{
+			Code:    `type Foo = readonly [string] | [number, number]`,
+			Options: map[string]interface{}{"allowTupleTypes": "in-intersections"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 32},
+			},
+		},
+		{
+			Code:    `type Foo = readonly [string] & [number, number]`,
+			Options: map[string]interface{}{"allowTupleTypes": "in-unions"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 32},
+			},
+		},
+		{
+			Code:    `type Foo = [string] & readonly [number, number]`,
+			Options: map[string]interface{}{"allowTupleTypes": "in-unions"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 23},
+			},
+		},
+		{
+			Code:    `type Foo = keyof [string] | [number, number]`,
+			Options: map[string]interface{}{"allowTupleTypes": "in-intersections"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noCompositionAlias", Line: 1, Column: 12},
+				{MessageId: "noCompositionAlias", Line: 1, Column: 29},
+			},
+		},
+
+		// allowConditionalTypes: never (default)
+		{
+			Code:    `type Foo<T> = T extends number ? number : null`,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
+		},
+		{
+			Code:    `type Foo<T> = T extends number ? number : null`,
+			Options: map[string]interface{}{"allowConditionalTypes": "never"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
+		},
+
+		// allowConstructors: never (default)
+		{
+			Code:    `type Foo = new (bar: number) => string | null`,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = new (bar: number) => string | null`,
+			Options: map[string]interface{}{"allowConstructors": "never"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+
+		// allowGenerics: never (default)
+		{
+			Code:    `type Foo = Record<string, number>`,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = Record<string, number>`,
+			Options: map[string]interface{}{"allowGenerics": "never"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
 		},
 	})
 }

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
@@ -19,7 +19,6 @@ func TestNoTypeAliasRule(t *testing.T) {
 		{Code: `type Foo = typeof import('foo')`, Options: map[string]interface{}{"allowAliases": "always"}},
 		{Code: `type Foo = (string)`, Options: map[string]interface{}{"allowAliases": "always"}},
 		{Code: `type Foo = readonly (string[])`, Options: map[string]interface{}{"allowAliases": "always"}},
-		{Code: `type Foo = unique symbol`, Options: map[string]interface{}{"allowAliases": "always"}},
 
 		// allowAliases: in-unions
 		{Code: `type Foo = 'a' | 'b'`, Options: map[string]interface{}{"allowAliases": "in-unions"}},
@@ -110,6 +109,11 @@ func TestNoTypeAliasRule(t *testing.T) {
 		{
 			Code:   `type Foo = unique symbol`,
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = unique symbol`,
+			Options: map[string]interface{}{"allowAliases": "always"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
 		},
 
 		// Union aliases with default / never

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
@@ -17,6 +17,9 @@ func TestNoTypeAliasRule(t *testing.T) {
 		{Code: `type Foo = 'a'`, Options: map[string]interface{}{"allowAliases": "always"}},
 		{Code: `type Foo = typeof bar`, Options: map[string]interface{}{"allowAliases": "always"}},
 		{Code: `type Foo = typeof import('foo')`, Options: map[string]interface{}{"allowAliases": "always"}},
+		{Code: `type Foo = (string)`, Options: map[string]interface{}{"allowAliases": "always"}},
+		{Code: `type Foo = readonly (string[])`, Options: map[string]interface{}{"allowAliases": "always"}},
+		{Code: `type Foo = unique symbol`, Options: map[string]interface{}{"allowAliases": "always"}},
 
 		// allowAliases: in-unions
 		{Code: `type Foo = 'a' | 'b'`, Options: map[string]interface{}{"allowAliases": "in-unions"}},
@@ -59,6 +62,8 @@ func TestNoTypeAliasRule(t *testing.T) {
 		{Code: `type Foo = keyof [string]`, Options: map[string]interface{}{"allowTupleTypes": "always"}},
 		{Code: `type Foo = keyof [string] | [number, number]`, Options: map[string]interface{}{"allowTupleTypes": "always"}},
 		{Code: `type Foo = keyof [string] | [number, number]`, Options: map[string]interface{}{"allowTupleTypes": "in-unions"}},
+		{Code: `type Foo = readonly ([string])`, Options: map[string]interface{}{"allowTupleTypes": "always"}},
+		{Code: `type Foo = keyof ([string])`, Options: map[string]interface{}{"allowTupleTypes": "always"}},
 
 		// allowConditionalTypes
 		{Code: `type Foo<T> = T extends number ? number : null`, Options: map[string]interface{}{"allowConditionalTypes": "always"}},
@@ -68,6 +73,7 @@ func TestNoTypeAliasRule(t *testing.T) {
 
 		// allowGenerics
 		{Code: `type Foo = Record<string, number>`, Options: map[string]interface{}{"allowGenerics": "always"}},
+		{Code: `type Foo = (Record<string, number>)`, Options: map[string]interface{}{"allowGenerics": "always"}},
 
 		// Mixed options (real-world style)
 		{
@@ -95,6 +101,14 @@ func TestNoTypeAliasRule(t *testing.T) {
 		},
 		{
 			Code:   `type Foo = typeof import('foo')`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:   `type Foo = (string)`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 13}},
+		},
+		{
+			Code:   `type Foo = unique symbol`,
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
 		},
 

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
@@ -73,14 +73,14 @@ func TestNoTypeAliasRule(t *testing.T) {
 		{
 			Code: `type ClassValue = string | number | undefined | null | false`,
 			Options: map[string]interface{}{
-				"allowAliases":       "in-unions-and-intersections",
-				"allowCallbacks":       "always",
-				"allowLiterals":        "in-unions-and-intersections",
-				"allowMappedTypes":     "in-unions-and-intersections",
-				"allowTupleTypes":      "in-unions-and-intersections",
-				"allowGenerics":        "always",
+				"allowAliases":          "in-unions-and-intersections",
+				"allowCallbacks":        "always",
+				"allowLiterals":         "in-unions-and-intersections",
+				"allowMappedTypes":      "in-unions-and-intersections",
+				"allowTupleTypes":       "in-unions-and-intersections",
+				"allowGenerics":         "always",
 				"allowConditionalTypes": "always",
-				"allowConstructors":    "always",
+				"allowConstructors":     "always",
 			},
 		},
 	}, []rule_tester.InvalidTestCase{
@@ -194,8 +194,8 @@ func TestNoTypeAliasRule(t *testing.T) {
 
 		// allowCallbacks: never (default)
 		{
-			Code:    `type Foo = () => void`,
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+			Code:   `type Foo = () => void`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
 		},
 		{
 			Code:    `type Foo = () => void`,
@@ -279,8 +279,8 @@ func TestNoTypeAliasRule(t *testing.T) {
 
 		// allowMappedTypes: never (default)
 		{
-			Code:    `type Foo<T> = { readonly [P in keyof T]: T[P] }`,
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
+			Code:   `type Foo<T> = { readonly [P in keyof T]: T[P] }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
 		},
 		{
 			Code:    `type Foo<T> = { readonly [P in keyof T]: T[P] }`,
@@ -306,8 +306,8 @@ func TestNoTypeAliasRule(t *testing.T) {
 
 		// allowTupleTypes: never (default)
 		{
-			Code:    `type Foo = [string]`,
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+			Code:   `type Foo = [string]`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
 		},
 		{
 			Code:    `type Foo = [string]`,
@@ -365,8 +365,8 @@ func TestNoTypeAliasRule(t *testing.T) {
 
 		// allowConditionalTypes: never (default)
 		{
-			Code:    `type Foo<T> = T extends number ? number : null`,
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
+			Code:   `type Foo<T> = T extends number ? number : null`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
 		},
 		{
 			Code:    `type Foo<T> = T extends number ? number : null`,
@@ -376,8 +376,8 @@ func TestNoTypeAliasRule(t *testing.T) {
 
 		// allowConstructors: never (default)
 		{
-			Code:    `type Foo = new (bar: number) => string | null`,
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+			Code:   `type Foo = new (bar: number) => string | null`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
 		},
 		{
 			Code:    `type Foo = new (bar: number) => string | null`,
@@ -387,12 +387,66 @@ func TestNoTypeAliasRule(t *testing.T) {
 
 		// allowGenerics: never (default)
 		{
-			Code:    `type Foo = Record<string, number>`,
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+			Code:   `type Foo = Record<string, number>`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
 		},
 		{
 			Code:    `type Foo = Record<string, number>`,
 			Options: map[string]interface{}{"allowGenerics": "never"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+
+		// Invalid option values: simple options should fall back to "never" when given composition-only values
+		{
+			Code:    `type Foo = () => void`,
+			Options: map[string]interface{}{"allowCallbacks": "in-unions"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = () => void`,
+			Options: map[string]interface{}{"allowCallbacks": "in-intersections"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = () => void`,
+			Options: map[string]interface{}{"allowCallbacks": "in-unions-and-intersections"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo<T> = T extends number ? number : null`,
+			Options: map[string]interface{}{"allowConditionalTypes": "in-unions"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
+		},
+		{
+			Code:    `type Foo = new (bar: number) => string | null`,
+			Options: map[string]interface{}{"allowConstructors": "in-unions"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = Record<string, number>`,
+			Options: map[string]interface{}{"allowGenerics": "in-unions"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+
+		// Invalid option values: composition options should fall back to "never" when given invalid values
+		{
+			Code:    `type Foo = string`,
+			Options: map[string]interface{}{"allowAliases": "invalid"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo = {}`,
+			Options: map[string]interface{}{"allowLiterals": "invalid"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
+		},
+		{
+			Code:    `type Foo<T> = { readonly [P in keyof T]: T[P] }`,
+			Options: map[string]interface{}{"allowMappedTypes": "invalid"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
+		},
+		{
+			Code:    `type Foo = [string]`,
+			Options: map[string]interface{}{"allowTupleTypes": "invalid"},
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
 		},
 	})

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -286,7 +286,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/no-shadow/no-shadow-eslint.test.ts',
     './tests/typescript-eslint/rules/no-shadow/no-shadow.test.ts',
     './tests/typescript-eslint/rules/no-this-alias.test.ts',
-    // './tests/typescript-eslint/rules/no-type-alias.test.ts',
+    './tests/typescript-eslint/rules/no-type-alias.test.ts',
     './tests/typescript-eslint/rules/no-use-before-define.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-boolean-literal-compare.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-condition.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-type-alias.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-type-alias.test.ts.snap
@@ -4814,7 +4814,7 @@ exports[`no-type-alias > invalid 123`] = `
       "ruleName": "@typescript-eslint/no-type-alias",
     },
     {
-      "message": "Unhandled in union types are not allowed.",
+      "message": "Aliases in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-type-alias.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-type-alias.test.ts.snap
@@ -1,0 +1,4970 @@
+// Rstest Snapshot v1
+
+exports[`no-type-alias > invalid 1`] = `
+{
+  "code": "type Foo = 'a';",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 2`] = `
+{
+  "code": "type Foo = 'a';",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 3`] = `
+{
+  "code": "type Foo = typeof import('foo');",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 4`] = `
+{
+  "code": "type Foo = 'a' | 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 5`] = `
+{
+  "code": "type Foo = 'a' | typeof import('foo');",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 6`] = `
+{
+  "code": "type Foo = 'a' | 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 7`] = `
+{
+  "code": "type Foo = 'a' | 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 8`] = `
+{
+  "code": "type Foo = 'a' | 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 9`] = `
+{
+  "code": "type Foo = 'a' | 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 10`] = `
+{
+  "code": "type Foo = 'a' | 'b' | 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 11`] = `
+{
+  "code": "type Foo = 'a' | 'b' | 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 12`] = `
+{
+  "code": "type Foo = 'a' | 'b' | 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 13`] = `
+{
+  "code": "type Foo = 'a' | 'b' | 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 14`] = `
+{
+  "code": "type Foo = 'a' | 'b' | 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 15`] = `
+{
+  "code": "type Foo = 'a' | 'b' | 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 16`] = `
+{
+  "code": "type Foo = 'a' & 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 17`] = `
+{
+  "code": "type Foo = 'a' & 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 18`] = `
+{
+  "code": "type Foo = 'a' & 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 19`] = `
+{
+  "code": "type Foo = 'a' & 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 20`] = `
+{
+  "code": "type Foo = 'a' & 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 21`] = `
+{
+  "code": "type Foo = 'a' & 'b';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 22`] = `
+{
+  "code": "type Foo = 'a' & 'b' & 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 23`] = `
+{
+  "code": "type Foo = 'a' & 'b' & 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 24`] = `
+{
+  "code": "type Foo = 'a' & 'b' & 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 25`] = `
+{
+  "code": "type Foo = 'a' & 'b' & 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 26`] = `
+{
+  "code": "type Foo = 'a' & 'b' & 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 27`] = `
+{
+  "code": "type Foo = 'a' & 'b' & 'c';",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 28`] = `
+{
+  "code": "type Foo = 'a' | ('b' & 'c');",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 29`] = `
+{
+  "code": "type Foo = 'a' | ('b' & 'c');",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 30`] = `
+{
+  "code": "type Foo = 'a' | ('b' & 'c');",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 31`] = `
+{
+  "code": "type Foo = 'a' | ('b' & 'c');",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 32`] = `
+{
+  "code": "type Foo = 'a' | ('b' & 'c');",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 33`] = `
+{
+  "code": "type Foo = 'a' | ('b' & 'c');",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 34`] = `
+{
+  "code": "type Foo = 'a' | ('b' & 'c');",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 35`] = `
+{
+  "code": "type Foo = 'a' | ('b' & 'c');",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 36`] = `
+{
+  "code": "type Foo = string;",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 37`] = `
+{
+  "code": "type Foo = string;",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 38`] = `
+{
+  "code": "type Foo = string;",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 39`] = `
+{
+  "code": "type Foo = string;",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 40`] = `
+{
+  "code": "type Foo = string;",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 41`] = `
+{
+  "code": "type Foo = string | string[];",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 42`] = `
+{
+  "code": "type Foo = string | string[];",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 43`] = `
+{
+  "code": "type Foo = string | string[];",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 44`] = `
+{
+  "code": "type Foo = string | string[];",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 45`] = `
+{
+  "code": "type Foo = string | string[];",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 46`] = `
+{
+  "code": "type Foo = string | string[];",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 47`] = `
+{
+  "code": "type Foo = string | string[] | number;",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 48`] = `
+{
+  "code": "type Foo = string | string[] | number;",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 49`] = `
+{
+  "code": "type Foo = string | string[] | number;",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 50`] = `
+{
+  "code": "type Foo = string | string[] | number;",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 51`] = `
+{
+  "code": "type Foo = string | string[] | number;",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 52`] = `
+{
+  "code": "type Foo = string | string[] | number;",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 53`] = `
+{
+  "code": "type Foo = string | (string[] & number);",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 54`] = `
+{
+  "code": "type Foo = string | (string[] & number);",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 55`] = `
+{
+  "code": "type Foo = string | (string[] & number);",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 56`] = `
+{
+  "code": "type Foo = string | (string[] & number);",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 57`] = `
+{
+  "code": "type Foo = string | (string[] & number);",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 58`] = `
+{
+  "code": "type Foo = string | (string[] & number);",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 59`] = `
+{
+  "code": "type Foo = string | (string[] & number);",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 60`] = `
+{
+  "code": "type Foo = string | (string[] & number);",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 61`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 62`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 63`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 64`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 65`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar;
+      ",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 66`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar | {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 67`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar | {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 68`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar | {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 69`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar | {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 70`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar | {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 71`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar & {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 72`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar & {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 73`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar & {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 74`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar & {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 75`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar & {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 76`] = `
+{
+  "code": "type Foo = () => void;",
+  "diagnostics": [
+    {
+      "message": "Type callbacks are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 77`] = `
+{
+  "code": "type Foo = () => void;",
+  "diagnostics": [
+    {
+      "message": "Type callbacks are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 78`] = `
+{
+  "code": "type Foo = {};",
+  "diagnostics": [
+    {
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 79`] = `
+{
+  "code": "type Foo = {};",
+  "diagnostics": [
+    {
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 80`] = `
+{
+  "code": "type Foo = {};",
+  "diagnostics": [
+    {
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 81`] = `
+{
+  "code": "type Foo = {};",
+  "diagnostics": [
+    {
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 82`] = `
+{
+  "code": "type Foo = {};",
+  "diagnostics": [
+    {
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 83`] = `
+{
+  "code": "type Foo = {};",
+  "diagnostics": [
+    {
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 84`] = `
+{
+  "code": "type Foo = {};",
+  "diagnostics": [
+    {
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 85`] = `
+{
+  "code": "type Foo = {};",
+  "diagnostics": [
+    {
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 86`] = `
+{
+  "code": "type Foo = {};",
+  "diagnostics": [
+    {
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 87`] = `
+{
+  "code": "type Foo = {};",
+  "diagnostics": [
+    {
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 88`] = `
+{
+  "code": "type Foo = {} | {};",
+  "diagnostics": [
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 89`] = `
+{
+  "code": "type Foo = {} | {};",
+  "diagnostics": [
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 90`] = `
+{
+  "code": "type Foo = {} | {};",
+  "diagnostics": [
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 91`] = `
+{
+  "code": "type Foo = {} & {};",
+  "diagnostics": [
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 92`] = `
+{
+  "code": "type Foo = {} & {};",
+  "diagnostics": [
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 93`] = `
+{
+  "code": "type Foo = {} & {};",
+  "diagnostics": [
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 94`] = `
+{
+  "code": "type Foo = (string & {}) | 'a' | 1;",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 95`] = `
+{
+  "code": "type Foo = (string & {}) | 'a' | 1;",
+  "diagnostics": [
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 96`] = `
+{
+  "code": "
+type Foo<T> = {
+  readonly [P in keyof T]: T[P];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Type mapped types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 97`] = `
+{
+  "code": "
+type Foo<T> = {
+  readonly [P in keyof T]: T[P];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Type mapped types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 98`] = `
+{
+  "code": "
+type Foo<T> = {
+  readonly [P in keyof T]: T[P];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Type mapped types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 99`] = `
+{
+  "code": "
+type Foo<T> = {
+  readonly [P in keyof T]: T[P];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Type mapped types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 100`] = `
+{
+  "code": "
+type Foo<T> = {
+  readonly [P in keyof T]: T[P];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Type mapped types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 101`] = `
+{
+  "code": "
+type Foo<T> =
+  | {
+      readonly [P in keyof T]: T[P];
+    }
+  | {
+      readonly [P in keyof T]: T[P];
+    };
+      ",
+  "diagnostics": [
+    {
+      "message": "Mapped types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Mapped types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 8,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 102`] = `
+{
+  "code": "
+type Foo<T> =
+  | {
+      readonly [P in keyof T]: T[P];
+    }
+  | {
+      readonly [P in keyof T]: T[P];
+    };
+      ",
+  "diagnostics": [
+    {
+      "message": "Mapped types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Mapped types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 8,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 103`] = `
+{
+  "code": "
+type Foo<T> =
+  | {
+      readonly [P in keyof T]: T[P];
+    }
+  | {
+      readonly [P in keyof T]: T[P];
+    };
+      ",
+  "diagnostics": [
+    {
+      "message": "Mapped types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Mapped types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 8,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 104`] = `
+{
+  "code": "
+type Foo<T> = {
+  readonly [P in keyof T]: T[P];
+} & {
+  readonly [P in keyof T]: T[P];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Mapped types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Mapped types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 105`] = `
+{
+  "code": "
+type Foo<T> = {
+  readonly [P in keyof T]: T[P];
+} & {
+  readonly [P in keyof T]: T[P];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Mapped types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Mapped types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 106`] = `
+{
+  "code": "
+type Foo<T> = {
+  readonly [P in keyof T]: T[P];
+} & {
+  readonly [P in keyof T]: T[P];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Mapped types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Mapped types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 107`] = `
+{
+  "code": "export type ButtonProps = JSX.IntrinsicElements['button'];",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 108`] = `
+{
+  "code": "type Foo = [number] | [number, number];",
+  "diagnostics": [
+    {
+      "message": "Tuple Types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Tuple Types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 109`] = `
+{
+  "code": "type Foo = [number] & [number, number];",
+  "diagnostics": [
+    {
+      "message": "Tuple Types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Tuple Types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 110`] = `
+{
+  "code": "type Foo = [number] | [number, number];",
+  "diagnostics": [
+    {
+      "message": "Tuple Types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Tuple Types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 111`] = `
+{
+  "code": "type Foo = [number];",
+  "diagnostics": [
+    {
+      "message": "Type tuple types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 112`] = `
+{
+  "code": "type Foo = [number];",
+  "diagnostics": [
+    {
+      "message": "Type tuple types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 113`] = `
+{
+  "code": "type Foo = [number];",
+  "diagnostics": [
+    {
+      "message": "Type tuple types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 114`] = `
+{
+  "code": "type Foo = readonly [number] | keyof [number, number];",
+  "diagnostics": [
+    {
+      "message": "Tuple Types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Tuple Types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 115`] = `
+{
+  "code": "type Foo = keyof [number] & [number, number];",
+  "diagnostics": [
+    {
+      "message": "Tuple Types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Tuple Types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 116`] = `
+{
+  "code": "type Foo = [number] | readonly [number, number];",
+  "diagnostics": [
+    {
+      "message": "Tuple Types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Tuple Types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 117`] = `
+{
+  "code": "type Foo = readonly [number];",
+  "diagnostics": [
+    {
+      "message": "Type tuple types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 118`] = `
+{
+  "code": "type Foo = keyof [number];",
+  "diagnostics": [
+    {
+      "message": "Type tuple types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 119`] = `
+{
+  "code": "type Foo = readonly [number];",
+  "diagnostics": [
+    {
+      "message": "Type tuple types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 120`] = `
+{
+  "code": "type Foo = new (bar: number) => string | null;",
+  "diagnostics": [
+    {
+      "message": "Type constructors are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 121`] = `
+{
+  "code": "type MyType<T> = T extends number ? number : null;",
+  "diagnostics": [
+    {
+      "message": "Type conditional types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 122`] = `
+{
+  "code": "type MyType<T> = T extends number ? number : null;",
+  "diagnostics": [
+    {
+      "message": "Type conditional types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 123`] = `
+{
+  "code": "type Foo = keyof [string] | unique symbol;",
+  "diagnostics": [
+    {
+      "message": "Tuple Types in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Unhandled in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 124`] = `
+{
+  "code": "type Foo = Record<string, number>;",
+  "diagnostics": [
+    {
+      "message": "Type generics are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 125`] = `
+{
+  "code": "type Foo = \`foo-\${number}\`;",
+  "diagnostics": [
+    {
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 126`] = `
+{
+  "code": "type Foo = \`a-\${number}\` | \`b-\${number}\`;",
+  "diagnostics": [
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 127`] = `
+{
+  "code": "type Foo = \`a-\${number}\` & \`b-\${number}\`;",
+  "diagnostics": [
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-type-alias.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-type-alias.test.ts.snap
@@ -80,6 +80,32 @@ exports[`no-type-alias > invalid 3`] = `
 
 exports[`no-type-alias > invalid 4`] = `
 {
+  "code": "type Foo = unique symbol;",
+  "diagnostics": [
+    {
+      "message": "Type unhandled are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 5`] = `
+{
   "code": "type Foo = 'a' | 'b';",
   "diagnostics": [
     {
@@ -119,7 +145,7 @@ exports[`no-type-alias > invalid 4`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 5`] = `
+exports[`no-type-alias > invalid 6`] = `
 {
   "code": "type Foo = 'a' | typeof import('foo');",
   "diagnostics": [
@@ -144,47 +170,6 @@ exports[`no-type-alias > invalid 5`] = `
       "range": {
         "end": {
           "column": 38,
-          "line": 1,
-        },
-        "start": {
-          "column": 18,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
-  ],
-  "errorCount": 2,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-type-alias > invalid 6`] = `
-{
-  "code": "type Foo = 'a' | 'b';",
-  "diagnostics": [
-    {
-      "message": "Aliases in union types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 15,
-          "line": 1,
-        },
-        "start": {
-          "column": 12,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
-    {
-      "message": "Aliases in union types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 21,
           "line": 1,
         },
         "start": {
@@ -326,7 +311,7 @@ exports[`no-type-alias > invalid 9`] = `
 
 exports[`no-type-alias > invalid 10`] = `
 {
-  "code": "type Foo = 'a' | 'b' | 'c';",
+  "code": "type Foo = 'a' | 'b';",
   "diagnostics": [
     {
       "message": "Aliases in union types are not allowed.",
@@ -358,23 +343,8 @@ exports[`no-type-alias > invalid 10`] = `
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
-    {
-      "message": "Aliases in union types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 27,
-          "line": 1,
-        },
-        "start": {
-          "column": 24,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
   ],
-  "errorCount": 3,
+  "errorCount": 2,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -662,10 +632,10 @@ exports[`no-type-alias > invalid 15`] = `
 
 exports[`no-type-alias > invalid 16`] = `
 {
-  "code": "type Foo = 'a' & 'b';",
+  "code": "type Foo = 'a' | 'b' | 'c';",
   "diagnostics": [
     {
-      "message": "Aliases in intersection types are not allowed.",
+      "message": "Aliases in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
@@ -680,7 +650,7 @@ exports[`no-type-alias > invalid 16`] = `
       "ruleName": "@typescript-eslint/no-type-alias",
     },
     {
-      "message": "Aliases in intersection types are not allowed.",
+      "message": "Aliases in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
@@ -694,8 +664,23 @@ exports[`no-type-alias > invalid 16`] = `
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
+    {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
   ],
-  "errorCount": 2,
+  "errorCount": 3,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -908,7 +893,7 @@ exports[`no-type-alias > invalid 21`] = `
 
 exports[`no-type-alias > invalid 22`] = `
 {
-  "code": "type Foo = 'a' & 'b' & 'c';",
+  "code": "type Foo = 'a' & 'b';",
   "diagnostics": [
     {
       "message": "Aliases in intersection types are not allowed.",
@@ -940,23 +925,8 @@ exports[`no-type-alias > invalid 22`] = `
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
-    {
-      "message": "Aliases in intersection types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 27,
-          "line": 1,
-        },
-        "start": {
-          "column": 24,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
   ],
-  "errorCount": 3,
+  "errorCount": 2,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -1244,10 +1214,10 @@ exports[`no-type-alias > invalid 27`] = `
 
 exports[`no-type-alias > invalid 28`] = `
 {
-  "code": "type Foo = 'a' | ('b' & 'c');",
+  "code": "type Foo = 'a' & 'b' & 'c';",
   "diagnostics": [
     {
-      "message": "Aliases in union types are not allowed.",
+      "message": "Aliases in intersection types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
@@ -1266,11 +1236,11 @@ exports[`no-type-alias > invalid 28`] = `
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 22,
+          "column": 21,
           "line": 1,
         },
         "start": {
-          "column": 19,
+          "column": 18,
           "line": 1,
         },
       },
@@ -1281,11 +1251,11 @@ exports[`no-type-alias > invalid 28`] = `
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 28,
+          "column": 27,
           "line": 1,
         },
         "start": {
-          "column": 25,
+          "column": 24,
           "line": 1,
         },
       },
@@ -1471,6 +1441,21 @@ exports[`no-type-alias > invalid 32`] = `
   "code": "type Foo = 'a' | ('b' & 'c');",
   "diagnostics": [
     {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
       "message": "Aliases in intersection types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
@@ -1501,7 +1486,7 @@ exports[`no-type-alias > invalid 32`] = `
       "ruleName": "@typescript-eslint/no-type-alias",
     },
   ],
-  "errorCount": 2,
+  "errorCount": 3,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -1553,22 +1538,37 @@ exports[`no-type-alias > invalid 34`] = `
   "code": "type Foo = 'a' | ('b' & 'c');",
   "diagnostics": [
     {
-      "message": "Aliases in union types are not allowed.",
+      "message": "Aliases in intersection types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 15,
+          "column": 22,
           "line": 1,
         },
         "start": {
-          "column": 12,
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
           "line": 1,
         },
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
   ],
-  "errorCount": 1,
+  "errorCount": 2,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -1602,14 +1602,14 @@ exports[`no-type-alias > invalid 35`] = `
 
 exports[`no-type-alias > invalid 36`] = `
 {
-  "code": "type Foo = string;",
+  "code": "type Foo = 'a' | ('b' & 'c');",
   "diagnostics": [
     {
-      "message": "Type aliases are not allowed.",
-      "messageId": "noTypeAlias",
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 18,
+          "column": 15,
           "line": 1,
         },
         "start": {
@@ -1732,11 +1732,11 @@ exports[`no-type-alias > invalid 40`] = `
 
 exports[`no-type-alias > invalid 41`] = `
 {
-  "code": "type Foo = string | string[];",
+  "code": "type Foo = string;",
   "diagnostics": [
     {
-      "message": "Aliases in union types are not allowed.",
-      "messageId": "noCompositionAlias",
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
       "range": {
         "end": {
           "column": 18,
@@ -1749,23 +1749,8 @@ exports[`no-type-alias > invalid 41`] = `
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
-    {
-      "message": "Aliases in union types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 29,
-          "line": 1,
-        },
-        "start": {
-          "column": 21,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
   ],
-  "errorCount": 2,
+  "errorCount": 1,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -1978,7 +1963,7 @@ exports[`no-type-alias > invalid 46`] = `
 
 exports[`no-type-alias > invalid 47`] = `
 {
-  "code": "type Foo = string | string[] | number;",
+  "code": "type Foo = string | string[];",
   "diagnostics": [
     {
       "message": "Aliases in union types are not allowed.",
@@ -2010,23 +1995,8 @@ exports[`no-type-alias > invalid 47`] = `
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
-    {
-      "message": "Aliases in union types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 38,
-          "line": 1,
-        },
-        "start": {
-          "column": 32,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
   ],
-  "errorCount": 3,
+  "errorCount": 2,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -2314,7 +2284,7 @@ exports[`no-type-alias > invalid 52`] = `
 
 exports[`no-type-alias > invalid 53`] = `
 {
-  "code": "type Foo = string | (string[] & number);",
+  "code": "type Foo = string | string[] | number;",
   "diagnostics": [
     {
       "message": "Aliases in union types are not allowed.",
@@ -2332,30 +2302,30 @@ exports[`no-type-alias > invalid 53`] = `
       "ruleName": "@typescript-eslint/no-type-alias",
     },
     {
-      "message": "Aliases in intersection types are not allowed.",
+      "message": "Aliases in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 30,
+          "column": 29,
           "line": 1,
         },
         "start": {
-          "column": 22,
+          "column": 21,
           "line": 1,
         },
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
     {
-      "message": "Aliases in intersection types are not allowed.",
+      "message": "Aliases in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 39,
+          "column": 38,
           "line": 1,
         },
         "start": {
-          "column": 33,
+          "column": 32,
           "line": 1,
         },
       },
@@ -2541,6 +2511,21 @@ exports[`no-type-alias > invalid 57`] = `
   "code": "type Foo = string | (string[] & number);",
   "diagnostics": [
     {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
       "message": "Aliases in intersection types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
@@ -2571,7 +2556,7 @@ exports[`no-type-alias > invalid 57`] = `
       "ruleName": "@typescript-eslint/no-type-alias",
     },
   ],
-  "errorCount": 2,
+  "errorCount": 3,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -2623,22 +2608,37 @@ exports[`no-type-alias > invalid 59`] = `
   "code": "type Foo = string | (string[] & number);",
   "diagnostics": [
     {
-      "message": "Aliases in union types are not allowed.",
+      "message": "Aliases in intersection types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 18,
+          "column": 30,
           "line": 1,
         },
         "start": {
-          "column": 12,
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
           "line": 1,
         },
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
   ],
-  "errorCount": 1,
+  "errorCount": 2,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -2672,22 +2672,19 @@ exports[`no-type-alias > invalid 60`] = `
 
 exports[`no-type-alias > invalid 61`] = `
 {
-  "code": "
-interface Bar {}
-type Foo = Bar;
-      ",
+  "code": "type Foo = string | (string[] & number);",
   "diagnostics": [
     {
-      "message": "Type aliases are not allowed.",
-      "messageId": "noTypeAlias",
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 15,
-          "line": 3,
+          "column": 18,
+          "line": 1,
         },
         "start": {
           "column": 12,
-          "line": 3,
+          "line": 1,
         },
       },
       "ruleName": "@typescript-eslint/no-type-alias",
@@ -2819,12 +2816,12 @@ exports[`no-type-alias > invalid 66`] = `
 {
   "code": "
 interface Bar {}
-type Foo = Bar | {};
+type Foo = Bar;
       ",
   "diagnostics": [
     {
-      "message": "Aliases in union types are not allowed.",
-      "messageId": "noCompositionAlias",
+      "message": "Type aliases are not allowed.",
+      "messageId": "noTypeAlias",
       "range": {
         "end": {
           "column": 15,
@@ -2837,23 +2834,8 @@ type Foo = Bar | {};
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
-    {
-      "message": "Literals in union types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 20,
-          "line": 3,
-        },
-        "start": {
-          "column": 18,
-          "line": 3,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
   ],
-  "errorCount": 2,
+  "errorCount": 1,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -2911,6 +2893,50 @@ type Foo = Bar | {};
       ",
   "diagnostics": [
     {
+      "message": "Aliases in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in union types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 69`] = `
+{
+  "code": "
+interface Bar {}
+type Foo = Bar | {};
+      ",
+  "diagnostics": [
+    {
       "message": "Literals in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
@@ -2932,7 +2958,7 @@ type Foo = Bar | {};
 }
 `;
 
-exports[`no-type-alias > invalid 69`] = `
+exports[`no-type-alias > invalid 70`] = `
 {
   "code": "
 interface Bar {}
@@ -2976,7 +3002,7 @@ type Foo = Bar | {};
 }
 `;
 
-exports[`no-type-alias > invalid 70`] = `
+exports[`no-type-alias > invalid 71`] = `
 {
   "code": "
 interface Bar {}
@@ -3000,50 +3026,6 @@ type Foo = Bar | {};
     },
   ],
   "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-type-alias > invalid 71`] = `
-{
-  "code": "
-interface Bar {}
-type Foo = Bar & {};
-      ",
-  "diagnostics": [
-    {
-      "message": "Aliases in intersection types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 15,
-          "line": 3,
-        },
-        "start": {
-          "column": 12,
-          "line": 3,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
-    {
-      "message": "Literals in intersection types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 20,
-          "line": 3,
-        },
-        "start": {
-          "column": 18,
-          "line": 3,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
-  ],
-  "errorCount": 2,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -3145,6 +3127,21 @@ type Foo = Bar & {};
       ",
   "diagnostics": [
     {
+      "message": "Aliases in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
       "message": "Literals in intersection types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
@@ -3160,7 +3157,7 @@ type Foo = Bar & {};
       "ruleName": "@typescript-eslint/no-type-alias",
     },
   ],
-  "errorCount": 1,
+  "errorCount": 2,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -3197,19 +3194,22 @@ type Foo = Bar & {};
 
 exports[`no-type-alias > invalid 76`] = `
 {
-  "code": "type Foo = () => void;",
+  "code": "
+interface Bar {}
+type Foo = Bar & {};
+      ",
   "diagnostics": [
     {
-      "message": "Type callbacks are not allowed.",
-      "messageId": "noTypeAlias",
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 22,
-          "line": 1,
+          "column": 20,
+          "line": 3,
         },
         "start": {
-          "column": 12,
-          "line": 1,
+          "column": 18,
+          "line": 3,
         },
       },
       "ruleName": "@typescript-eslint/no-type-alias",
@@ -3249,14 +3249,14 @@ exports[`no-type-alias > invalid 77`] = `
 
 exports[`no-type-alias > invalid 78`] = `
 {
-  "code": "type Foo = {};",
+  "code": "type Foo = () => void;",
   "diagnostics": [
     {
-      "message": "Type literals are not allowed.",
+      "message": "Type callbacks are not allowed.",
       "messageId": "noTypeAlias",
       "range": {
         "end": {
-          "column": 14,
+          "column": 22,
           "line": 1,
         },
         "start": {
@@ -3509,11 +3509,11 @@ exports[`no-type-alias > invalid 87`] = `
 
 exports[`no-type-alias > invalid 88`] = `
 {
-  "code": "type Foo = {} | {};",
+  "code": "type Foo = {};",
   "diagnostics": [
     {
-      "message": "Literals in union types are not allowed.",
-      "messageId": "noCompositionAlias",
+      "message": "Type literals are not allowed.",
+      "messageId": "noTypeAlias",
       "range": {
         "end": {
           "column": 14,
@@ -3526,23 +3526,8 @@ exports[`no-type-alias > invalid 88`] = `
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
-    {
-      "message": "Literals in union types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 19,
-          "line": 1,
-        },
-        "start": {
-          "column": 17,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
   ],
-  "errorCount": 2,
+  "errorCount": 1,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -3632,10 +3617,10 @@ exports[`no-type-alias > invalid 90`] = `
 
 exports[`no-type-alias > invalid 91`] = `
 {
-  "code": "type Foo = {} & {};",
+  "code": "type Foo = {} | {};",
   "diagnostics": [
     {
-      "message": "Literals in intersection types are not allowed.",
+      "message": "Literals in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
@@ -3650,7 +3635,7 @@ exports[`no-type-alias > invalid 91`] = `
       "ruleName": "@typescript-eslint/no-type-alias",
     },
     {
-      "message": "Literals in intersection types are not allowed.",
+      "message": "Literals in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
@@ -3755,6 +3740,47 @@ exports[`no-type-alias > invalid 93`] = `
 
 exports[`no-type-alias > invalid 94`] = `
 {
+  "code": "type Foo = {} & {};",
+  "diagnostics": [
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Literals in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 95`] = `
+{
   "code": "type Foo = (string & {}) | 'a' | 1;",
   "diagnostics": [
     {
@@ -3794,7 +3820,7 @@ exports[`no-type-alias > invalid 94`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 95`] = `
+exports[`no-type-alias > invalid 96`] = `
 {
   "code": "type Foo = (string & {}) | 'a' | 1;",
   "diagnostics": [
@@ -3845,36 +3871,6 @@ exports[`no-type-alias > invalid 95`] = `
     },
   ],
   "errorCount": 3,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-type-alias > invalid 96`] = `
-{
-  "code": "
-type Foo<T> = {
-  readonly [P in keyof T]: T[P];
-};
-      ",
-  "diagnostics": [
-    {
-      "message": "Type mapped types are not allowed.",
-      "messageId": "noTypeAlias",
-      "range": {
-        "end": {
-          "column": 2,
-          "line": 4,
-        },
-        "start": {
-          "column": 15,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
-  ],
-  "errorCount": 1,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -4003,47 +3999,28 @@ type Foo<T> = {
 exports[`no-type-alias > invalid 101`] = `
 {
   "code": "
-type Foo<T> =
-  | {
-      readonly [P in keyof T]: T[P];
-    }
-  | {
-      readonly [P in keyof T]: T[P];
-    };
+type Foo<T> = {
+  readonly [P in keyof T]: T[P];
+};
       ",
   "diagnostics": [
     {
-      "message": "Mapped types in union types are not allowed.",
-      "messageId": "noCompositionAlias",
+      "message": "Type mapped types are not allowed.",
+      "messageId": "noTypeAlias",
       "range": {
         "end": {
-          "column": 6,
-          "line": 5,
+          "column": 2,
+          "line": 4,
         },
         "start": {
-          "column": 5,
-          "line": 3,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
-    {
-      "message": "Mapped types in union types are not allowed.",
-      "messageId": "noCompositionAlias",
-      "range": {
-        "end": {
-          "column": 6,
-          "line": 8,
-        },
-        "start": {
-          "column": 5,
-          "line": 6,
+          "column": 15,
+          "line": 2,
         },
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
   ],
-  "errorCount": 2,
+  "errorCount": 1,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -4150,39 +4127,41 @@ type Foo<T> =
 exports[`no-type-alias > invalid 104`] = `
 {
   "code": "
-type Foo<T> = {
-  readonly [P in keyof T]: T[P];
-} & {
-  readonly [P in keyof T]: T[P];
-};
+type Foo<T> =
+  | {
+      readonly [P in keyof T]: T[P];
+    }
+  | {
+      readonly [P in keyof T]: T[P];
+    };
       ",
   "diagnostics": [
     {
-      "message": "Mapped types in intersection types are not allowed.",
+      "message": "Mapped types in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 2,
-          "line": 4,
+          "column": 6,
+          "line": 5,
         },
         "start": {
-          "column": 15,
-          "line": 2,
+          "column": 5,
+          "line": 3,
         },
       },
       "ruleName": "@typescript-eslint/no-type-alias",
     },
     {
-      "message": "Mapped types in intersection types are not allowed.",
+      "message": "Mapped types in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
-          "column": 2,
-          "line": 6,
+          "column": 6,
+          "line": 8,
         },
         "start": {
           "column": 5,
-          "line": 4,
+          "line": 6,
         },
       },
       "ruleName": "@typescript-eslint/no-type-alias",
@@ -4290,6 +4269,53 @@ type Foo<T> = {
 
 exports[`no-type-alias > invalid 107`] = `
 {
+  "code": "
+type Foo<T> = {
+  readonly [P in keyof T]: T[P];
+} & {
+  readonly [P in keyof T]: T[P];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Mapped types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+    {
+      "message": "Mapped types in intersection types are not allowed.",
+      "messageId": "noCompositionAlias",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 108`] = `
+{
   "code": "export type ButtonProps = JSX.IntrinsicElements['button'];",
   "diagnostics": [
     {
@@ -4314,7 +4340,7 @@ exports[`no-type-alias > invalid 107`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 108`] = `
+exports[`no-type-alias > invalid 109`] = `
 {
   "code": "type Foo = [number] | [number, number];",
   "diagnostics": [
@@ -4355,7 +4381,7 @@ exports[`no-type-alias > invalid 108`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 109`] = `
+exports[`no-type-alias > invalid 110`] = `
 {
   "code": "type Foo = [number] & [number, number];",
   "diagnostics": [
@@ -4396,7 +4422,7 @@ exports[`no-type-alias > invalid 109`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 110`] = `
+exports[`no-type-alias > invalid 111`] = `
 {
   "code": "type Foo = [number] | [number, number];",
   "diagnostics": [
@@ -4432,32 +4458,6 @@ exports[`no-type-alias > invalid 110`] = `
     },
   ],
   "errorCount": 2,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-type-alias > invalid 111`] = `
-{
-  "code": "type Foo = [number];",
-  "diagnostics": [
-    {
-      "message": "Type tuple types are not allowed.",
-      "messageId": "noTypeAlias",
-      "range": {
-        "end": {
-          "column": 20,
-          "line": 1,
-        },
-        "start": {
-          "column": 12,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
-  ],
-  "errorCount": 1,
   "fileCount": 1,
   "ruleCount": 1,
 }
@@ -4517,6 +4517,32 @@ exports[`no-type-alias > invalid 113`] = `
 
 exports[`no-type-alias > invalid 114`] = `
 {
+  "code": "type Foo = [number];",
+  "diagnostics": [
+    {
+      "message": "Type tuple types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 115`] = `
+{
   "code": "type Foo = readonly [number] | keyof [number, number];",
   "diagnostics": [
     {
@@ -4556,7 +4582,7 @@ exports[`no-type-alias > invalid 114`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 115`] = `
+exports[`no-type-alias > invalid 116`] = `
 {
   "code": "type Foo = keyof [number] & [number, number];",
   "diagnostics": [
@@ -4597,7 +4623,7 @@ exports[`no-type-alias > invalid 115`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 116`] = `
+exports[`no-type-alias > invalid 117`] = `
 {
   "code": "type Foo = [number] | readonly [number, number];",
   "diagnostics": [
@@ -4638,7 +4664,7 @@ exports[`no-type-alias > invalid 116`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 117`] = `
+exports[`no-type-alias > invalid 118`] = `
 {
   "code": "type Foo = readonly [number];",
   "diagnostics": [
@@ -4664,7 +4690,7 @@ exports[`no-type-alias > invalid 117`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 118`] = `
+exports[`no-type-alias > invalid 119`] = `
 {
   "code": "type Foo = keyof [number];",
   "diagnostics": [
@@ -4690,7 +4716,7 @@ exports[`no-type-alias > invalid 118`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 119`] = `
+exports[`no-type-alias > invalid 120`] = `
 {
   "code": "type Foo = readonly [number];",
   "diagnostics": [
@@ -4716,7 +4742,7 @@ exports[`no-type-alias > invalid 119`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 120`] = `
+exports[`no-type-alias > invalid 121`] = `
 {
   "code": "type Foo = new (bar: number) => string | null;",
   "diagnostics": [
@@ -4730,32 +4756,6 @@ exports[`no-type-alias > invalid 120`] = `
         },
         "start": {
           "column": 12,
-          "line": 1,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-type-alias",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-type-alias > invalid 121`] = `
-{
-  "code": "type MyType<T> = T extends number ? number : null;",
-  "diagnostics": [
-    {
-      "message": "Type conditional types are not allowed.",
-      "messageId": "noTypeAlias",
-      "range": {
-        "end": {
-          "column": 50,
-          "line": 1,
-        },
-        "start": {
-          "column": 18,
           "line": 1,
         },
       },
@@ -4796,6 +4796,32 @@ exports[`no-type-alias > invalid 122`] = `
 
 exports[`no-type-alias > invalid 123`] = `
 {
+  "code": "type MyType<T> = T extends number ? number : null;",
+  "diagnostics": [
+    {
+      "message": "Type conditional types are not allowed.",
+      "messageId": "noTypeAlias",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-type-alias",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-type-alias > invalid 124`] = `
+{
   "code": "type Foo = keyof [string] | unique symbol;",
   "diagnostics": [
     {
@@ -4814,7 +4840,7 @@ exports[`no-type-alias > invalid 123`] = `
       "ruleName": "@typescript-eslint/no-type-alias",
     },
     {
-      "message": "Aliases in union types are not allowed.",
+      "message": "Unhandled in union types are not allowed.",
       "messageId": "noCompositionAlias",
       "range": {
         "end": {
@@ -4835,7 +4861,7 @@ exports[`no-type-alias > invalid 123`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 124`] = `
+exports[`no-type-alias > invalid 125`] = `
 {
   "code": "type Foo = Record<string, number>;",
   "diagnostics": [
@@ -4861,7 +4887,7 @@ exports[`no-type-alias > invalid 124`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 125`] = `
+exports[`no-type-alias > invalid 126`] = `
 {
   "code": "type Foo = \`foo-\${number}\`;",
   "diagnostics": [
@@ -4887,7 +4913,7 @@ exports[`no-type-alias > invalid 125`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 126`] = `
+exports[`no-type-alias > invalid 127`] = `
 {
   "code": "type Foo = \`a-\${number}\` | \`b-\${number}\`;",
   "diagnostics": [
@@ -4928,7 +4954,7 @@ exports[`no-type-alias > invalid 126`] = `
 }
 `;
 
-exports[`no-type-alias > invalid 127`] = `
+exports[`no-type-alias > invalid 128`] = `
 {
   "code": "type Foo = \`a-\${number}\` & \`b-\${number}\`;",
   "diagnostics": [

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-type-alias.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-type-alias.test.ts
@@ -585,6 +585,20 @@ type KeyNames = keyof typeof SCALARS;
       options: [{ allowAliases: 'never' }],
     },
     {
+      code: 'type Foo = unique symbol;',
+      errors: [
+        {
+          column: 12,
+          data: {
+            alias: 'unhandled',
+          },
+          line: 1,
+          messageId: 'noTypeAlias',
+        },
+      ],
+      options: [{ allowAliases: 'always' }],
+    },
+    {
       code: "type Foo = 'a' | 'b';",
       errors: [
         {


### PR DESCRIPTION
## Summary
- add the `@typescript-eslint/no-type-alias` rule implementation and docs
- register the rule in the TypeScript plugin registry
- expand Go coverage for options and edge cases
- enable the rstest fixture and generated snapshots

## Validation
- `act` Linux `test-go` job passed: `go test -parallel 8 ./internal/...`
- `act` Linux `lint` job passed: `golangci-lint`, `npm run lint:go`, `npm run format:go`, `pnpm check-spell`
- `act` Linux `test-node` job passed with pnpm store isolated outside the workspace (`PNPM_HOME=/tmp/pnpm-home`, `npm_config_store_dir=/tmp/pnpm-store`)
  - `packages/rslint-test-tools`: 383 test files passed, 1155 passed / 30 skipped
  - VSCode extension tests passed
- `act` Linux `test-wasm` job passed; wasm build and JS wrapper completed

## Notes
- macOS and Windows jobs were intentionally not run locally; Docker/act cannot faithfully emulate those runners.
- The branch was prepared directly on upstream `web-infra-dev/rslint`, not the fork.
