### PR TITLE
feat: add globalIgnores config helper

### DIFF
--- a/packages/rslint/src/define-config.ts
+++ b/packages/rslint/src/define-config.ts
@@ -126,3 +126,27 @@ export type RslintConfig = RslintConfigEntry[];
 export function defineConfig(config: RslintConfig): RslintConfig {
   return config;
 }
+
+/**
+ * Define a global-ignores config entry.
+ *
+ * Mirrors ESLint's `globalIgnores` helper: returns a config entry that contains
+ * only `ignores`. Because the entry has no `files` (and no rules/plugins/etc.),
+ * the patterns are treated as *global* ignores — applied across every other
+ * config entry — instead of being scoped to a single entry's `files`.
+ *
+ * @example
+ * export default defineConfig([
+ *   globalIgnores(['dist/**', 'coverage/**']),
+ *   { files: ['src/**'], rules: { 'no-console': 'error' } },
+ * ]);
+ */
+export function globalIgnores(ignorePatterns: string[]): RslintConfigEntry {
+  if (!Array.isArray(ignorePatterns)) {
+    throw new TypeError('ignorePatterns must be an array');
+  }
+  if (ignorePatterns.length === 0) {
+    throw new TypeError('ignorePatterns must contain at least one pattern');
+  }
+  return { ignores: ignorePatterns };
+}

--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -9,7 +9,7 @@ import {
   GetAstInfoResponse,
 } from './service.js';
 
-export { defineConfig } from './define-config.js';
+export { defineConfig, globalIgnores } from './define-config.js';
 export type { RslintConfigEntry } from './define-config.js';
 export {
   ts,

--- a/packages/rslint/tests/define-config.test.ts
+++ b/packages/rslint/tests/define-config.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from '@rstest/core';
+import { globalIgnores } from '../src/define-config.js';
+
+describe('globalIgnores', () => {
+  test('returns a config entry containing only the ignores', () => {
+    expect(globalIgnores(['dist/**', 'node_modules/**'])).toEqual({
+      ignores: ['dist/**', 'node_modules/**'],
+    });
+  });
+
+  test('produces an entry with no keys other than `ignores`', () => {
+    // The global-ignore semantics rely on the entry having ONLY `ignores`
+    // (no files/rules/plugins/settings/languageOptions). Lock that in so the
+    // go-side `isGlobalIgnoreEntry` keeps recognizing it as a global ignore.
+    expect(Object.keys(globalIgnores(['dist/**']))).toEqual(['ignores']);
+  });
+
+  test('returns the same patterns array reference', () => {
+    const patterns = ['dist/**'];
+    expect(globalIgnores(patterns).ignores).toBe(patterns);
+  });
+
+  test('throws TypeError when patterns is not an array', () => {
+    // @ts-expect-error testing the runtime guard against non-array input
+    expect(() => globalIgnores('dist/**')).toThrow(TypeError);
+    // @ts-expect-error testing the runtime guard against non-array input
+    expect(() => globalIgnores('dist/**')).toThrow(
+      'ignorePatterns must be an array',
+    );
+  });
+
+  test('throws TypeError when patterns is empty', () => {
+    expect(() => globalIgnores([])).toThrow(TypeError);
+    expect(() => globalIgnores([])).toThrow(
+      'ignorePatterns must contain at least one pattern',
+    );
+  });
+});

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -1,30 +1,28 @@
-import { defineConfig, ts } from '@rslint/core';
+import { defineConfig, globalIgnores, ts } from '@rslint/core';
 
 export default defineConfig([
-  {
-    ignores: [
-      'node_modules/**',
-      '**/dist/**',
-      'typescript-go/**',
+  globalIgnores([
+    'node_modules/**',
+    '**/dist/**',
+    'typescript-go/**',
 
-      // Test fixtures — not real source code
-      '**/fixtures/**',
-      'packages/rslint-test-tools/tests/**',
-      'packages/rslint/tests/eslint-plugin/**',
+    // Test fixtures — not real source code
+    '**/fixtures/**',
+    'packages/rslint-test-tools/tests/**',
+    'packages/rslint/tests/eslint-plugin/**',
 
-      // VSCode extension test artifacts
-      'packages/vscode-extension/__tests__/**',
-      'packages/vscode-extension/.vscode-test/**',
+    // VSCode extension test artifacts
+    'packages/vscode-extension/__tests__/**',
+    'packages/vscode-extension/.vscode-test/**',
 
-      // Generated / build artifacts
-      'website/doc_build/**',
-      'website/generated/**',
+    // Generated / build artifacts
+    'website/doc_build/**',
+    'website/generated/**',
 
-      // Files that need special handling
-      'packages/rslint-wasm/src/worker.ts',
-      'packages/rule-tester/src/index.ts',
-    ],
-  },
+    // Files that need special handling
+    'packages/rslint-wasm/src/worker.ts',
+    'packages/rule-tester/src/index.ts',
+  ]),
   // Start from recommended preset, then override rules and parserOptions
   ts.configs.recommended,
   {

--- a/website/docs/en/config/ignoring-files.md
+++ b/website/docs/en/config/ignoring-files.md
@@ -20,6 +20,29 @@ Glob patterns for files to exclude. An entry with **only** `ignores` (no other f
 }
 ```
 
+### The `globalIgnores` helper
+
+Writing an entry with only `ignores` is common enough that `@rslint/core` exports a `globalIgnores` helper, mirroring ESLint v10. It returns a config entry containing just the given patterns, so the global-ignore intent is explicit:
+
+```ts
+import { defineConfig, globalIgnores } from '@rslint/core';
+
+export default defineConfig([
+  globalIgnores(['**/dist/**', '**/fixtures/**']),
+  // ... other entries
+]);
+```
+
+This is exactly equivalent to writing the entry by hand:
+
+```ts
+{
+  ignores: ['**/dist/**', '**/fixtures/**'],
+}
+```
+
+`globalIgnores` throws a `TypeError` if it receives a non-array or an empty array.
+
 ### Pattern types in global ignores
 
 Global ignore patterns affect both file matching and directory traversal (including config discovery in monorepos):

--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -71,13 +71,11 @@ rslint --init
 A typical TypeScript project configuration:
 
 ```ts
-import { defineConfig, ts } from '@rslint/core';
+import { defineConfig, globalIgnores, ts } from '@rslint/core';
 
 export default defineConfig([
   // Global ignores — files excluded from all rules
-  {
-    ignores: ['**/dist/**', '**/fixtures/**'],
-  },
+  globalIgnores(['**/dist/**', '**/fixtures/**']),
   // Preset with recommended rules
   ts.configs.recommended,
   // Custom rule overrides


### PR DESCRIPTION
## Summary

Add a `globalIgnores` helper to `@rslint/core`, mirroring ESLint v10's `globalIgnores`. It returns a config entry containing only `ignores`, so the patterns are treated as **global** ignores (applied across every entry) rather than scoped to a single entry's `files`.

- `globalIgnores(patterns)` returns `{ ignores: patterns }` and validates input — throws `TypeError` on a non-array or empty array, matching ESLint's messages.
- No go-side change needed: the existing `isGlobalIgnoreEntry` (`internal/config/config.go`) already recognizes an entry that has only `ignores` as a global ignore.
- ESLint's second arg `name` is intentionally **not** supported — rslint's config entries carry no `name` field on either the TS or go side.

Documented under `config/ignoring-files` (plus the basic-config example) and adopted in the repo's own `rslint.config.ts`.

Verified equivalence end-to-end: running the repo lint before vs. after switching `rslint.config.ts` to `globalIgnores` produces **identical** results — 0 errors / 108 warnings / 139 files / 89 rules, with position and rule+message fingerprints matching exactly.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
