### PR TITLE
chore: bump `tsgo-client` from 0.0.2 to 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "tsgo-client"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "bitflags",
  "cbor4ii",

--- a/crates/tsgo-client/Cargo.toml
+++ b/crates/tsgo-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsgo-client"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2024"
 description = "TypeScript Go client library"
 license = "MIT"


### PR DESCRIPTION
## Summary

Currently the `tsgo-client` crate in `crate.io` is out-of-date compared to the source code in this repo.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
