### PR TITLE
feat(eslint-plugin-jest): add `prefer-to-have-been-called-times` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -21,6 +21,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_be"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_contain"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_have_been_called"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_have_been_called_times"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_have_length"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_todo"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/valid_describe_callback"
@@ -50,6 +51,7 @@ func GetAllRules() []rule.Rule {
 		prefer_strict_equal.PreferStrictEqualRule,
 		prefer_to_be.PreferToBeRule,
 		prefer_to_contain.PreferToContainRule,
+		prefer_to_have_been_called_times.PreferToHaveBeenCalledTimesRule,
 		prefer_to_have_been_called.PreferToHaveBeenCalledRule,
 		prefer_to_have_length.PreferToHaveLengthRule,
 		prefer_todo.PreferTodoRule,

--- a/internal/plugins/jest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/jest/rules/prefer_to_contain/prefer_to_contain.go
@@ -27,8 +27,7 @@ func getIncludesCalleeName(callee *ast.Node) (receiver *ast.Node, ok bool) {
 	switch callee.Kind {
 	case ast.KindPropertyAccessExpression:
 		prop := callee.AsPropertyAccessExpression()
-		name := prop.Name()
-		if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "includes" {
+		if !jestUtils.IsNamedMember(prop.Name(), "includes") {
 			return nil, false
 		}
 
@@ -39,39 +38,13 @@ func getIncludesCalleeName(callee *ast.Node) (receiver *ast.Node, ok bool) {
 		if arg == nil {
 			return nil, false
 		}
-
-		switch arg.Kind {
-		case ast.KindStringLiteral:
-			if arg.AsStringLiteral().Text != "includes" {
-				return nil, false
-			}
-		case ast.KindNoSubstitutionTemplateLiteral:
-			if arg.AsNoSubstitutionTemplateLiteral().Text != "includes" {
-				return nil, false
-			}
-		default:
+		if !jestUtils.IsNamedMember(arg, "includes") {
 			return nil, false
 		}
 		return el.Expression, true
 	}
 
 	return nil, false
-}
-
-func receiverBeforeInvocation(matcherCall *ast.Node) *ast.Node {
-	if matcherCall == nil || matcherCall.Kind != ast.KindCallExpression {
-		return nil
-	}
-
-	expr := matcherCall.AsCallExpression().Expression
-	switch expr.Kind {
-	case ast.KindPropertyAccessExpression:
-		return expr.AsPropertyAccessExpression().Expression
-	case ast.KindElementAccessExpression:
-		return expr.AsElementAccessExpression().Expression
-	}
-
-	return nil
 }
 
 var PreferToContainRule = rule.Rule{
@@ -141,7 +114,7 @@ var PreferToContainRule = rule.Rule{
 
 				hasNotModifier := slices.Contains(jestFnCall.Modifiers, "not")
 				shouldNegate := isTrueLiteral == hasNotModifier
-				if receiverBeforeInvocation(node) == nil {
+				if jestUtils.ReceiverBeforeInvocation(node) == nil {
 					return
 				}
 

--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.go
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.go
@@ -1,0 +1,130 @@
+package prefer_to_have_been_called_times
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func buildPreferMatcherMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferMatcher",
+		Description: "Use `toHaveBeenCalledTimes()`",
+	}
+}
+
+func unwrapMockProperty(mockExpr *ast.Node) *ast.Node {
+	if mockExpr == nil {
+		return nil
+	}
+	mockExpr = ast.SkipParentheses(mockExpr)
+	switch mockExpr.Kind {
+	case ast.KindPropertyAccessExpression:
+		if ast.IsOptionalChain(mockExpr) {
+			return nil
+		}
+		pa := mockExpr.AsPropertyAccessExpression()
+		if !jestUtils.IsNamedMember(pa.Name(), "mock") {
+			return nil
+		}
+		return pa.Expression
+	case ast.KindElementAccessExpression:
+		if ast.IsOptionalChain(mockExpr) {
+			return nil
+		}
+		el := mockExpr.AsElementAccessExpression()
+		if !jestUtils.IsNamedMember(ast.SkipParentheses(el.ArgumentExpression), "mock") {
+			return nil
+		}
+		return el.Expression
+	default:
+		return nil
+	}
+}
+
+// unwrapMockCallsAccessProperty returns the mock function expression when arg is
+// exactly `*.mock.calls` or `*["mock"].calls` (no indexing after `.calls`).
+func unwrapMockCallsAccessProperty(arg *ast.Node) *ast.Node {
+	if arg == nil {
+		return nil
+	}
+	switch arg.Kind {
+	case ast.KindPropertyAccessExpression:
+		if ast.IsOptionalChain(arg) {
+			return nil
+		}
+		pa := arg.AsPropertyAccessExpression()
+		if !jestUtils.IsNamedMember(pa.Name(), "calls") {
+			return nil
+		}
+		return unwrapMockProperty(pa.Expression)
+	case ast.KindElementAccessExpression:
+		if ast.IsOptionalChain(arg) {
+			return nil
+		}
+		el := arg.AsElementAccessExpression()
+		if !jestUtils.IsNamedMember(ast.SkipParentheses(el.ArgumentExpression), "calls") {
+			return nil
+		}
+		return unwrapMockProperty(el.Expression)
+	default:
+		return nil
+	}
+}
+
+var PreferToHaveBeenCalledTimesRule = rule.Rule{
+	Name: "jest/prefer-to-have-been-called-times",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				jestFnCall := jestUtils.ParseJestFnCall(node, ctx)
+				if jestFnCall == nil ||
+					jestFnCall.Kind != jestUtils.JestFnTypeExpect ||
+					jestFnCall.Matcher != "toHaveLength" {
+					return
+				}
+
+				expectCall := jestFnCall.Head.Local.Node.Parent
+				if expectCall == nil || expectCall.Kind != ast.KindCallExpression {
+					return
+				}
+
+				args := expectCall.Arguments()
+				if len(args) == 0 {
+					return
+				}
+
+				inner := unwrapMockCallsAccessProperty(args[0])
+				if inner == nil {
+					return
+				}
+
+				matcherCall := node.AsCallExpression()
+				if matcherCall == nil || matcherCall.Arguments == nil {
+					return
+				}
+
+				matcherReceiver, matcherParent := jestUtils.GetAccessorReceiverAndParent(jestFnCall.MatcherEntry)
+				if matcherReceiver == nil || matcherParent == nil {
+					return
+				}
+
+				reportNode := node
+				if jestFnCall.MatcherEntry != nil && jestFnCall.MatcherEntry.Node != nil {
+					reportNode = jestFnCall.MatcherEntry.Node
+				}
+
+				ctx.ReportNodeWithFixes(
+					reportNode,
+					buildPreferMatcherMessage(),
+					rule.RuleFixRemoveRange(core.NewTextRange(inner.End(), args[0].End())),
+					rule.RuleFixReplaceRange(
+						core.NewTextRange(matcherReceiver.End(), matcherParent.End()),
+						".toHaveBeenCalledTimes",
+					),
+				)
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.go
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.go
@@ -5,13 +5,12 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	rslintUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func buildPreferMatcherMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "preferMatcher",
-		Description: "Use `toHaveBeenCalledTimes()`",
+		Description: "Prefer `toHaveBeenCalledTimes`",
 	}
 }
 
@@ -97,23 +96,14 @@ var PreferToHaveBeenCalledTimesRule = rule.Rule{
 					return
 				}
 
-				inner := unwrapMockCallsAccessProperty(args[0])
+				unwrappedArg := ast.SkipParentheses(args[0])
+				inner := unwrapMockCallsAccessProperty(unwrappedArg)
 				if inner == nil {
-					return
-				}
-
-				matcherCall := node.AsCallExpression()
-				if matcherCall == nil || matcherCall.Arguments == nil {
 					return
 				}
 
 				matcherReceiver, matcherParent := jestUtils.GetAccessorReceiverAndParent(jestFnCall.MatcherEntry)
 				if matcherReceiver == nil || matcherParent == nil {
-					return
-				}
-
-				sourceFile := ast.GetSourceFileOfNode(node)
-				if sourceFile == nil {
 					return
 				}
 
@@ -125,10 +115,7 @@ var PreferToHaveBeenCalledTimesRule = rule.Rule{
 				ctx.ReportNodeWithFixes(
 					reportNode,
 					buildPreferMatcherMessage(),
-					rule.RuleFixReplaceRange(
-						rslintUtils.TrimNodeTextRange(sourceFile, args[0]),
-						rslintUtils.TrimmedNodeText(sourceFile, inner),
-					),
+					rule.RuleFixRemoveRange(core.NewTextRange(inner.End(), unwrappedArg.End())),
 					rule.RuleFixReplaceRange(
 						core.NewTextRange(matcherReceiver.End(), matcherParent.End()),
 						".toHaveBeenCalledTimes",

--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.go
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.go
@@ -5,6 +5,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	rslintUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func buildPreferMatcherMessage() rule.RuleMessage {
@@ -49,6 +50,7 @@ func unwrapMockCallsAccessProperty(arg *ast.Node) *ast.Node {
 	if arg == nil {
 		return nil
 	}
+	arg = ast.SkipParentheses(arg)
 	switch arg.Kind {
 	case ast.KindPropertyAccessExpression:
 		if ast.IsOptionalChain(arg) {
@@ -110,6 +112,11 @@ var PreferToHaveBeenCalledTimesRule = rule.Rule{
 					return
 				}
 
+				sourceFile := ast.GetSourceFileOfNode(node)
+				if sourceFile == nil {
+					return
+				}
+
 				reportNode := node
 				if jestFnCall.MatcherEntry != nil && jestFnCall.MatcherEntry.Node != nil {
 					reportNode = jestFnCall.MatcherEntry.Node
@@ -118,7 +125,10 @@ var PreferToHaveBeenCalledTimesRule = rule.Rule{
 				ctx.ReportNodeWithFixes(
 					reportNode,
 					buildPreferMatcherMessage(),
-					rule.RuleFixRemoveRange(core.NewTextRange(inner.End(), args[0].End())),
+					rule.RuleFixReplaceRange(
+						rslintUtils.TrimNodeTextRange(sourceFile, args[0]),
+						rslintUtils.TrimmedNodeText(sourceFile, inner),
+					),
 					rule.RuleFixReplaceRange(
 						core.NewTextRange(matcherReceiver.End(), matcherParent.End()),
 						".toHaveBeenCalledTimes",

--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.md
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.md
@@ -1,0 +1,38 @@
+# prefer-to-have-been-called-times
+
+## Rule Details
+
+In order to have a better failure message, `toHaveBeenCalledTimes()` should be
+used instead of directly checking the length of `mock.calls`.
+
+This rule triggers a warning if `toHaveLength` is used to assert the number of
+times a mock has been called.
+
+This rule is often used together with
+[`prefer-to-have-length`](./prefer_to_have_length.md).
+
+Examples of **incorrect** code for this rule:
+
+```js
+expect(someFunction.mock.calls).toHaveLength(1);
+expect(someFunction.mock.calls).toHaveLength(0);
+
+expect(someFunction.mock.calls).not.toHaveLength(1);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+expect(someFunction).toHaveBeenCalledTimes(1);
+expect(someFunction).toHaveBeenCalledTimes(0);
+
+expect(someFunction).not.toHaveBeenCalledTimes(0);
+
+expect(uncalledFunction).not.toBeCalled();
+
+expect(method.mock.calls[0][0]).toStrictEqual(value);
+```
+
+## Original Documentation
+
+- [jest/prefer-to-have-been-called-times](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-have-been-called-times.md)

--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times_test.go
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times_test.go
@@ -1,0 +1,84 @@
+package prefer_to_have_been_called_times_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_have_been_called_times"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferToHaveBeenCalledTimesRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_to_have_been_called_times.PreferToHaveBeenCalledTimesRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect.assertions(1)`},
+			{Code: `expect(fn).toHaveBeenCalledTimes`},
+			{Code: `expect(fn.mock.calls).toHaveLength`},
+			{Code: `expect(fn.mock.values).toHaveLength(0)`},
+			{Code: `expect(fn.values.calls).toHaveLength(0)`},
+			{Code: `expect(fn).toHaveBeenCalledTimes(0)`},
+			{Code: `expect(fn).resolves.toHaveBeenCalledTimes(10)`},
+			{Code: `expect(fn).not.toHaveBeenCalledTimes(10)`},
+			{Code: `expect(fn).toHaveBeenCalledTimes(1)`},
+			{Code: `expect(fn).toBeCalledTimes(0);`},
+			{Code: `expect(fn).toHaveBeenCalledTimes(0);`},
+			{Code: `expect(fn);`},
+			{Code: `expect(method.mock.calls[0][0]).toStrictEqual(value);`},
+			{Code: `expect(fn.mock.length).toEqual(1);`},
+			{Code: `expect(fn.mock.calls).toEqual([]);`},
+			{Code: `expect(fn.mock.calls).toContain(1, 2, 3);`},
+			{Code: `expect((fn.mock.calls)).toHaveLength(1);`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `expect(method.mock.calls).toHaveLength(1);`,
+				Output: []string{
+					`expect(method).toHaveBeenCalledTimes(1);`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferMatcher", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `expect(method.mock.calls).resolves.toHaveLength(x);`,
+				Output: []string{
+					`expect(method).resolves.toHaveBeenCalledTimes(x);`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferMatcher", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code: `expect(method["mock"].calls).toHaveLength(0);`,
+				Output: []string{
+					`expect(method).toHaveBeenCalledTimes(0);`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferMatcher", Line: 1, Column: 30},
+				},
+			},
+			{
+				Code: `expect(my.method.mock.calls).not.toHaveLength(0);`,
+				Output: []string{
+					`expect(my.method).not.toHaveBeenCalledTimes(0);`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferMatcher", Line: 1, Column: 34},
+				},
+			},
+			{
+				Code: `expect(method.mock.calls).toHaveLength(1, 2);`,
+				Output: []string{
+					`expect(method).toHaveBeenCalledTimes(1, 2);`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferMatcher", Line: 1, Column: 27},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times_test.go
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times_test.go
@@ -82,7 +82,7 @@ func TestPreferToHaveBeenCalledTimesRule(t *testing.T) {
 			{
 				Code: `expect((method.mock.calls)).toHaveLength(1);`,
 				Output: []string{
-					`expect(method).toHaveBeenCalledTimes(1);`,
+					`expect((method)).toHaveBeenCalledTimes(1);`,
 				},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "preferMatcher", Line: 1, Column: 29},

--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times_test.go
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times_test.go
@@ -31,7 +31,7 @@ func TestPreferToHaveBeenCalledTimesRule(t *testing.T) {
 			{Code: `expect(fn.mock.length).toEqual(1);`},
 			{Code: `expect(fn.mock.calls).toEqual([]);`},
 			{Code: `expect(fn.mock.calls).toContain(1, 2, 3);`},
-			{Code: `expect((fn.mock.calls)).toHaveLength(1);`},
+			{Code: `expect((fn.mock.calls)).toEqual([]);`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
@@ -77,6 +77,15 @@ func TestPreferToHaveBeenCalledTimesRule(t *testing.T) {
 				},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "preferMatcher", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `expect((method.mock.calls)).toHaveLength(1);`,
+				Output: []string{
+					`expect(method).toHaveBeenCalledTimes(1);`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferMatcher", Line: 1, Column: 29},
 				},
 			},
 		},

--- a/internal/plugins/jest/rules/prefer_to_have_length/prefer_to_have_length.go
+++ b/internal/plugins/jest/rules/prefer_to_have_length/prefer_to_have_length.go
@@ -26,24 +26,6 @@ func checkIsEqualityMethod(members []string) bool {
 	return false
 }
 
-func isLengthPropertyName(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindIdentifier:
-		return node.AsIdentifier().Text == "length"
-	case ast.KindStringLiteral:
-		return node.AsStringLiteral().Text == "length"
-	case ast.KindNoSubstitutionTemplateLiteral:
-		return node.AsNoSubstitutionTemplateLiteral().Text == "length"
-	case ast.KindPrivateIdentifier:
-		return node.AsPrivateIdentifier().Text == "length"
-	default:
-		return false
-	}
-}
-
 func unwrapLengthAccessProperty(arg *ast.Node) *ast.Node {
 	if arg == nil {
 		return nil
@@ -55,7 +37,7 @@ func unwrapLengthAccessProperty(arg *ast.Node) *ast.Node {
 			return nil
 		}
 		el := arg.AsElementAccessExpression()
-		if !isLengthPropertyName(ast.SkipParentheses(el.ArgumentExpression)) {
+		if !jestUtils.IsNamedMember(ast.SkipParentheses(el.ArgumentExpression), "length") {
 			return nil
 		}
 		return el.Expression
@@ -64,26 +46,10 @@ func unwrapLengthAccessProperty(arg *ast.Node) *ast.Node {
 			return nil
 		}
 		pa := arg.AsPropertyAccessExpression()
-		if !isLengthPropertyName(pa.Name()) {
+		if !jestUtils.IsNamedMember(pa.Name(), "length") {
 			return nil
 		}
 		return pa.Expression
-	default:
-		return nil
-	}
-}
-
-// receiverBeforeInvocation returns the expression before .m() or ["m"]() on a call (e.g. expect(x).not before .toBe).
-func receiverBeforeInvocation(matcherCall *ast.Node) *ast.Node {
-	if matcherCall == nil || matcherCall.Kind != ast.KindCallExpression {
-		return nil
-	}
-	expr := matcherCall.AsCallExpression().Expression
-	switch expr.Kind {
-	case ast.KindPropertyAccessExpression:
-		return expr.AsPropertyAccessExpression().Expression
-	case ast.KindElementAccessExpression:
-		return expr.AsElementAccessExpression().Expression
 	default:
 		return nil
 	}
@@ -133,7 +99,7 @@ var PreferToHaveLengthRule = rule.Rule{
 					return
 				}
 
-				beforeMatcher := receiverBeforeInvocation(node)
+				beforeMatcher := jestUtils.ReceiverBeforeInvocation(node)
 				if beforeMatcher == nil {
 					return
 				}

--- a/internal/plugins/jest/utils/parse_jest_fn.go
+++ b/internal/plugins/jest/utils/parse_jest_fn.go
@@ -403,3 +403,40 @@ func GetAccessorReceiverAndParent(entry *ParsedJestFnMemberEntry) (*ast.Node, *a
 		return nil, nil
 	}
 }
+
+func IsNamedMember(node *ast.Node, name string) bool {
+	if node == nil {
+		return false
+	}
+
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text == name
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text == name
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text == name
+	case ast.KindPrivateIdentifier:
+		return node.AsPrivateIdentifier().Text == name
+	default:
+		return false
+	}
+}
+
+// ReceiverBeforeInvocation returns the expression before .m() or ["m"]() on a
+// call, such as `expect(x).not` before `.toBe()`.
+func ReceiverBeforeInvocation(matcherCall *ast.Node) *ast.Node {
+	if matcherCall == nil || matcherCall.Kind != ast.KindCallExpression {
+		return nil
+	}
+
+	expr := matcherCall.AsCallExpression().Expression
+	switch expr.Kind {
+	case ast.KindPropertyAccessExpression:
+		return expr.AsPropertyAccessExpression().Expression
+	case ast.KindElementAccessExpression:
+		return expr.AsElementAccessExpression().Expression
+	default:
+		return nil
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -445,6 +445,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/prefer-strict-equal.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-be.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-contain.test.ts',
+    './tests/eslint-plugin-jest/rules/prefer-to-have-been-called-times.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-have-been-called.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-have-length.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-todo.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-to-have-been-call-times.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-to-have-been-call-times.test.ts
@@ -1,0 +1,70 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-to-have-been-called-times', {} as never, {
+  valid: [
+    { code: 'expect.assertions(1)' },
+    { code: 'expect(fn).toHaveBeenCalledTimes' },
+    { code: 'expect(fn.mock.calls).toHaveLength' },
+    { code: 'expect(fn.mock.values).toHaveLength(0)' },
+    { code: 'expect(fn.values.calls).toHaveLength(0)' },
+    { code: 'expect(fn).toHaveBeenCalledTimes(0)' },
+    { code: 'expect(fn).resolves.toHaveBeenCalledTimes(10)' },
+    { code: 'expect(fn).not.toHaveBeenCalledTimes(10)' },
+    { code: 'expect(fn).toHaveBeenCalledTimes(1)' },
+    { code: 'expect(fn).toBeCalledTimes(0);' },
+    { code: 'expect(fn).toHaveBeenCalledTimes(0);' },
+    { code: 'expect(fn);' },
+    { code: 'expect(method.mock.calls[0][0]).toStrictEqual(value);' },
+    { code: 'expect(fn.mock.length).toEqual(1);' },
+    { code: 'expect(fn.mock.calls).toEqual([]);' },
+    { code: 'expect(fn.mock.calls).toContain(1, 2, 3);' },
+  ],
+  invalid: [
+    {
+      code: 'expect(method.mock.calls).toHaveLength(1);',
+      output: 'expect(method).toHaveBeenCalledTimes(1);',
+      errors: [
+        {
+          messageId: 'preferMatcher',
+          column: 27,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(method.mock.calls).resolves.toHaveLength(x);',
+      output: 'expect(method).resolves.toHaveBeenCalledTimes(x);',
+      errors: [
+        {
+          messageId: 'preferMatcher',
+          column: 36,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(method["mock"].calls).toHaveLength(0);',
+      output: 'expect(method).toHaveBeenCalledTimes(0);',
+      errors: [
+        {
+          messageId: 'preferMatcher',
+          column: 30,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(my.method.mock.calls).not.toHaveLength(0);',
+      output: 'expect(my.method).not.toHaveBeenCalledTimes(0);',
+      errors: [
+        {
+          messageId: 'preferMatcher',
+          column: 34,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-to-have-been-called-times.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-to-have-been-called-times.test.ts
@@ -69,7 +69,7 @@ ruleTester.run('prefer-to-have-been-called-times', {} as never, {
     },
     {
       code: 'expect((method.mock.calls)).toHaveLength(1);',
-      output: 'expect(method).toHaveBeenCalledTimes(1);',
+      output: 'expect((method)).toHaveBeenCalledTimes(1);',
       errors: [
         {
           messageId: 'preferMatcher',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-to-have-been-called-times.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-to-have-been-called-times.test.ts
@@ -20,6 +20,7 @@ ruleTester.run('prefer-to-have-been-called-times', {} as never, {
     { code: 'expect(fn.mock.length).toEqual(1);' },
     { code: 'expect(fn.mock.calls).toEqual([]);' },
     { code: 'expect(fn.mock.calls).toContain(1, 2, 3);' },
+    { code: 'expect((fn.mock.calls)).toEqual([]);' },
   ],
   invalid: [
     {
@@ -62,6 +63,17 @@ ruleTester.run('prefer-to-have-been-called-times', {} as never, {
         {
           messageId: 'preferMatcher',
           column: 34,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect((method.mock.calls)).toHaveLength(1);',
+      output: 'expect(method).toHaveBeenCalledTimes(1);',
+      errors: [
+        {
+          messageId: 'preferMatcher',
+          column: 29,
           line: 1,
         },
       ],


### PR DESCRIPTION
## Summary

* Port `prefer-to-have-been-called-times` from `eslint-plugin-jest` to `rslint`

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/prefer-to-have-been-called-times [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-have-been-called-times.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/prefer-to-have-been-called-times.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
