### PR TITLE
perf: dispatch eslint-plugin batches concurrently to saturate the worker pool

### DIFF
--- a/cmd/rslint/eslint_plugin.go
+++ b/cmd/rslint/eslint_plugin.go
@@ -100,19 +100,22 @@ func dispatchPluginLintAsync(
 ) <-chan []rule.RuleDiagnostic {
 	ch := make(chan []rule.RuleDiagnostic, 1)
 	go func() {
-		// onDiagnostic is invoked synchronously (DispatchEslintPluginRules runs
-		// no goroutines), so the local slice needs no lock.
+		// onDiagnostic is invoked serially (DispatchEslintPluginRules fans batches
+		// out to goroutines but emits diagnostics single-threaded after Wait), so
+		// the local slice needs no lock.
 		var diags []rule.RuleDiagnostic
 		if dispatch != nil && len(inputs) > 0 {
 			err := linter.DispatchEslintPluginRules(ctx, dispatch, inputs, fix, suggestionsMode,
 				func(d rule.RuleDiagnostic) { diags = append(diags, d) })
 			if err != nil && !errors.Is(err, context.Canceled) {
 				fmt.Fprintf(os.Stderr, "rslint: eslint-plugin lint error: %v\n", err)
-				// A total dispatch failure means NONE of these files ran their
-				// plugin rules. Surface it as an error diagnostic so the exit
-				// code reflects the failure instead of a stderr-only false green
-				// (per-file worker failures already surface inside Dispatch-
-				// EslintPluginRules; this covers the whole-batch dispatch error).
+				// A dispatch error means one or more batches failed to run their
+				// plugin rules (concurrent batches no longer abort each other, so
+				// the rest may have succeeded and already emitted). Surface it as
+				// an error diagnostic so the exit code reflects the failure instead
+				// of a stderr-only false green (per-file worker failures already
+				// surface inside DispatchEslintPluginRules; this covers a batch
+				// dispatch error).
 				diags = append(diags, linter.NewEslintPluginErrorDiagnostic(
 					dispatchFailurePath(inputs), "rslint/plugin-lint-error",
 					"ESLint plugin lint dispatch failed: "+err.Error()))
@@ -123,9 +126,10 @@ func dispatchPluginLintAsync(
 	return ch
 }
 
-// dispatchFailurePath anchors a whole-batch dispatch-failure diagnostic to a
-// real file so it renders with a location. The failure is batch-wide; the first
-// input is representative.
+// dispatchFailurePath anchors a dispatch-failure diagnostic to a real file so it
+// renders with a location. One representative input suffices: the diagnostic
+// exists to surface the failure and non-zero the exit code, not to attribute it
+// to a specific file.
 func dispatchFailurePath(inputs []linter.EslintPluginFileInput) string {
 	if len(inputs) > 0 {
 		return inputs[0].Path

--- a/internal/linter/eslint_plugin.go
+++ b/internal/linter/eslint_plugin.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"golang.org/x/sync/errgroup"
 )
 
 // ─── wire types — mirror packages/rslint/src/eslint-plugin/plugin/plugin-lint-protocol.ts ───
@@ -154,16 +156,77 @@ func BuildEslintPluginFileInput(filePath, configKey string, rules []ConfiguredRu
 // configKey miss) that must surface.
 const eslintPluginShutdownSentinel = "shutdown"
 
-// DispatchEslintPluginRules groups files by their rule-config signature,
-// sends each homogeneous batch to the Node host, and feeds the rebuilt
-// diagnostics through onDiagnostic — the SAME sink as native rules, so they
-// merge into the unified output / --fix pipeline. Intended to be called
-// from a goroutine running in parallel with native linting; a panic is
-// trapped and returned as an error so it can't crash the process.
+// DispatchEslintPluginRules groups files by their rule-config signature and
+// dispatches each homogeneous batch to the Node host as an independent reverse
+// IPC request, feeding the rebuilt diagnostics through onDiagnostic — the SAME
+// sink as native rules, so they merge into the unified output / --fix pipeline.
+// Intended to be called from a goroutine running in parallel with native
+// linting.
+//
+// Batches are dispatched CONCURRENTLY (bounded by dispatchConcurrency). A serial
+// loop leaves the Node worker pool idle between batches whenever the file set
+// fragments into many small batches (monorepo multi-config / per-rule option
+// splits) — it only saturates the pool within a single batch. Dispatching
+// batches concurrently lets every batch's files share the one pool, keeping it
+// saturated across batches. `dispatch` is therefore invoked from multiple
+// goroutines and MUST be safe for concurrent use (the CLI IPC channel and the
+// LSP reverse-request sender both are; LSP also only ever has one batch).
+// Per-batch diagnostics are collected into index-keyed slots and emitted in
+// batch order AFTER all batches finish, so onDiagnostic stays single-threaded
+// (callers keep their lock-free collectors) and output ordering is
+// deterministic. A batch failure no longer aborts the others; the first error
+// in batch order is returned, preserving the previous serial error semantics
+// for callers.
 func DispatchEslintPluginRules(
 	ctx context.Context,
 	dispatch EslintPluginDispatcher,
 	files []EslintPluginFileInput,
+	fix bool,
+	suggestionsMode string,
+	onDiagnostic DiagnosticHandler,
+) error {
+	if len(files) == 0 || dispatch == nil {
+		return nil
+	}
+
+	batches := groupEslintPluginFiles(files)
+	batchDiags := make([][]rule.RuleDiagnostic, len(batches))
+	batchErrs := make([]error, len(batches))
+
+	var g errgroup.Group
+	g.SetLimit(dispatchConcurrency())
+	for i, batch := range batches {
+		g.Go(func() error {
+			// Each batch writes only its own slot, so concurrent batches share
+			// no state; diagnostics are emitted serially after Wait.
+			batchErrs[i] = dispatchOneBatch(ctx, dispatch, batch, fix, suggestionsMode,
+				func(d rule.RuleDiagnostic) { batchDiags[i] = append(batchDiags[i], d) })
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	for _, diags := range batchDiags {
+		for _, d := range diags {
+			onDiagnostic(d)
+		}
+	}
+	for _, batchErr := range batchErrs {
+		if batchErr != nil {
+			return batchErr
+		}
+	}
+	return nil
+}
+
+// dispatchOneBatch sends one batch's reverse request and rebuilds its
+// diagnostics through onDiagnostic. A panic is trapped and returned as an error
+// so a worker-side failure can't crash the driver process (each batch runs in
+// its own goroutine, so a panic must be trapped here rather than escaping).
+func dispatchOneBatch(
+	ctx context.Context,
+	dispatch EslintPluginDispatcher,
+	batch []EslintPluginFileInput,
 	fix bool,
 	suggestionsMode string,
 	onDiagnostic DiagnosticHandler,
@@ -173,33 +236,43 @@ func DispatchEslintPluginRules(
 			err = fmt.Errorf("eslint-plugin dispatch panicked: %v", r)
 		}
 	}()
-
-	if len(files) == 0 || dispatch == nil {
+	req := buildEslintPluginRequest(batch, fix, suggestionsMode)
+	res, dispatchErr := dispatch(ctx, req)
+	if dispatchErr != nil {
+		return dispatchErr
+	}
+	if res == nil {
 		return nil
 	}
+	return applyEslintPluginResults(batch, res, onDiagnostic)
+}
 
-	for _, batch := range groupEslintPluginFiles(files) {
-		req := buildEslintPluginRequest(batch, fix, suggestionsMode)
-		res, dispatchErr := dispatch(ctx, req)
-		if dispatchErr != nil {
-			return dispatchErr
-		}
-		if res == nil {
-			continue
-		}
-		if applyErr := applyEslintPluginResults(batch, res, onDiagnostic); applyErr != nil {
-			return applyErr
-		}
+// dispatchConcurrency bounds how many plugin-lint batches are dispatched
+// concurrently. The Node worker pool has up to 8 workers (capped at the core
+// count; see worker-pool.ts), so to keep it saturated the in-flight batch count
+// must at least match that worker count; a small buffer on top lets a freed
+// worker pick up the next batch's tasks from the shared queue without idling
+// during the Go↔Node round trip between batches. Capping it keeps a heavily
+// fragmented file set from dispatching every batch's reverse request at once —
+// note this bounds concurrent batches, NOT the tasks inside one batch (a single
+// huge batch still enqueues all its tasks together, bounded by the batch itself).
+func dispatchConcurrency() int {
+	const poolWorkers = 8 // mirrors the Node worker pool cap (worker-pool.ts)
+	const roundTripBuffer = 2
+	n := runtime.NumCPU()
+	if n > poolWorkers {
+		n = poolWorkers
 	}
-	return nil
+	return n + roundTripBuffer
 }
 
 // groupEslintPluginFiles buckets files by (configKey + rule-config
-// signature). A batch shares a single `rules` map on the wire, so every
-// file in it must agree on the configured rules — including each rule's
-// options AND severity (severity is reattached from the matching rule, so
-// two files configuring the same rule at different severities must not
-// share a batch).
+// signature). A batch shares a single `rules` map on the wire, so every file
+// in it must agree on the configured rules' names AND options. Severity is
+// deliberately NOT part of the key: it never travels on the wire (only options
+// do) and is reattached per-file in applyEslintPluginResults, so two files
+// configuring the same rule at different severities produce a byte-identical
+// request and SHOULD share a batch rather than needlessly fragment the pool.
 func groupEslintPluginFiles(files []EslintPluginFileInput) [][]EslintPluginFileInput {
 	order := []string{}
 	groups := map[string][]EslintPluginFileInput{}
@@ -219,13 +292,12 @@ func groupEslintPluginFiles(files []EslintPluginFileInput) [][]EslintPluginFileI
 
 func eslintPluginBatchKey(f EslintPluginFileInput) string {
 	type sigRule struct {
-		Name     string `json:"name"`
-		Options  any    `json:"options"`
-		Severity int    `json:"severity"`
+		Name    string `json:"name"`
+		Options any    `json:"options"`
 	}
 	sig := make([]sigRule, 0, len(f.Rules))
 	for _, r := range f.Rules {
-		sig = append(sig, sigRule{Name: r.Name, Options: r.Options, Severity: r.Severity.Int()})
+		sig = append(sig, sigRule{Name: r.Name, Options: r.Options})
 	}
 	sort.Slice(sig, func(i, j int) bool { return sig[i].Name < sig[j].Name })
 	b, err := json.Marshal(struct {

--- a/internal/linter/eslint_plugin_test.go
+++ b/internal/linter/eslint_plugin_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/core"
@@ -39,9 +41,16 @@ func TestDispatchEslintPlugin_GroupsBySignature(t *testing.T) {
 		{Path: "/c.ts", ConfigKey: "/cfg", Rules: []ConfiguredRule{pluginRule("uc/x", []any{"o2"}, rule.SeverityError)}},
 		{Path: "/d.ts", ConfigKey: "/other", Rules: []ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityError)}},
 	}
-	var batches []EslintPluginLintRequest
+	var (
+		mu      sync.Mutex
+		batches []EslintPluginLintRequest
+	)
 	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
+		// dispatch is now invoked concurrently (one goroutine per batch), so the
+		// shared slice needs a lock.
+		mu.Lock()
 		batches = append(batches, req)
+		mu.Unlock()
 		results := make([]EslintPluginFileResult, 0, len(req.Files))
 		for _, f := range req.Files {
 			results = append(results, EslintPluginFileResult{FilePath: f.Path})
@@ -65,6 +74,179 @@ func TestDispatchEslintPlugin_GroupsBySignature(t *testing.T) {
 	}
 	if twoFileBatches != 1 {
 		t.Errorf("expected exactly one 2-file batch (A+B), got %d", twoFileBatches)
+	}
+}
+
+func TestDispatchEslintPlugin_SeverityDoesNotFragmentBatches(t *testing.T) {
+	// Same configKey + rule + options, differing ONLY in severity. Severity is
+	// not part of the batch key (it never goes on the wire, reattached per-file),
+	// so these must share exactly ONE batch — yet each file keeps its severity.
+	ta, tb := "a\n", "b\n"
+	files := []EslintPluginFileInput{
+		{Path: "/a.ts", ConfigKey: "/cfg", Text: &ta, Rules: []ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityError)}},
+		{Path: "/b.ts", ConfigKey: "/cfg", Text: &tb, Rules: []ConfiguredRule{pluginRule("uc/x", []any{"o1"}, rule.SeverityWarning)}},
+	}
+	var (
+		mu         sync.Mutex
+		batchCount int
+	)
+	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
+		mu.Lock()
+		batchCount++
+		mu.Unlock()
+		results := make([]EslintPluginFileResult, 0, len(req.Files))
+		for _, f := range req.Files {
+			results = append(results, EslintPluginFileResult{
+				FilePath:    f.Path,
+				Diagnostics: []EslintPluginDiagnostic{{RuleName: "uc/x", Message: "m", StartPos: 0, EndPos: 1}},
+			})
+		}
+		return &EslintPluginLintResult{Results: results}, nil
+	}
+	sevByPath := map[string]rule.DiagnosticSeverity{}
+	if err := DispatchEslintPluginRules(context.Background(), dispatch, files, false, "off", func(d rule.RuleDiagnostic) {
+		sevByPath[d.FilePath] = d.Severity
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if batchCount != 1 {
+		t.Fatalf("severity must not fragment batches: expected 1 batch, got %d", batchCount)
+	}
+	if sevByPath["/a.ts"] != rule.SeverityError {
+		t.Errorf("/a.ts severity = %v, want Error", sevByPath["/a.ts"])
+	}
+	if sevByPath["/b.ts"] != rule.SeverityWarning {
+		t.Errorf("/b.ts severity = %v, want Warning", sevByPath["/b.ts"])
+	}
+}
+
+func TestDispatchEslintPlugin_ConcurrentBatchesAllEmitted(t *testing.T) {
+	// Many distinct batches (each a different option → its own batch) are
+	// dispatched concurrently. Every batch's diagnostic must be emitted exactly
+	// once. The `seen` map is written from onDiagnostic WITHOUT a lock on purpose:
+	// onDiagnostic must stay single-threaded (emitted after Wait), so -race would
+	// catch a regression that emits concurrently.
+	const n = 20
+	files := make([]EslintPluginFileInput, n)
+	texts := make([]string, n)
+	for i := range files {
+		texts[i] = "x\n"
+		files[i] = EslintPluginFileInput{
+			Path:      fmt.Sprintf("/f%d.ts", i),
+			ConfigKey: "/cfg",
+			Text:      &texts[i],
+			Rules:     []ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)}, // distinct options → distinct batch
+		}
+	}
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		results := make([]EslintPluginFileResult, 0, len(req.Files))
+		for _, f := range req.Files {
+			results = append(results, EslintPluginFileResult{
+				FilePath:    f.Path,
+				Diagnostics: []EslintPluginDiagnostic{{RuleName: "uc/x", Message: "m", StartPos: 0, EndPos: 1}},
+			})
+		}
+		return &EslintPluginLintResult{Results: results}, nil
+	}
+	seen := map[string]int{}
+	if err := DispatchEslintPluginRules(context.Background(), dispatch, files, false, "off", func(d rule.RuleDiagnostic) {
+		seen[d.FilePath]++
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != n {
+		t.Fatalf("expected %d batches dispatched, got %d", n, calls)
+	}
+	if len(seen) != n {
+		t.Fatalf("expected diagnostics for all %d files, got %d distinct", n, len(seen))
+	}
+	for p, c := range seen {
+		if c != 1 {
+			t.Errorf("%s emitted %d times, want exactly 1", p, c)
+		}
+	}
+}
+
+func TestDispatchEslintPlugin_BatchFailureDoesNotAbortOthers(t *testing.T) {
+	// One batch's dispatch fails; the others must still run and emit their
+	// diagnostics (concurrent dispatch no longer aborts on the first failure),
+	// and the error must still surface to the caller.
+	const n = 10
+	const failOn = "/f3.ts"
+	files := make([]EslintPluginFileInput, n)
+	texts := make([]string, n)
+	for i := range files {
+		texts[i] = "x\n"
+		files[i] = EslintPluginFileInput{
+			Path:      fmt.Sprintf("/f%d.ts", i),
+			ConfigKey: "/cfg",
+			Text:      &texts[i],
+			Rules:     []ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)},
+		}
+	}
+	wantErr := errors.New("boom")
+	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
+		if req.Files[0].Path == failOn {
+			return nil, wantErr
+		}
+		return &EslintPluginLintResult{Results: []EslintPluginFileResult{{
+			FilePath:    req.Files[0].Path,
+			Diagnostics: []EslintPluginDiagnostic{{RuleName: "uc/x", Message: "m", StartPos: 0, EndPos: 1}},
+		}}}, nil
+	}
+	seen := map[string]int{}
+	err := DispatchEslintPluginRules(context.Background(), dispatch, files, false, "off", func(d rule.RuleDiagnostic) {
+		seen[d.FilePath]++
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected the failing batch's error to surface, got %v", err)
+	}
+	if len(seen) != n-1 {
+		t.Errorf("expected all %d non-failing files emitted, got %d", n-1, len(seen))
+	}
+	if _, ok := seen[failOn]; ok {
+		t.Errorf("failing file %s must have no diagnostic", failOn)
+	}
+}
+
+func TestDispatchEslintPlugin_FirstBatchErrorWins(t *testing.T) {
+	// Multiple batches fail; the returned error must be the first in batch order
+	// (groupEslintPluginFiles keeps first-seen order), matching the previous
+	// serial "stop at the first failure" error semantics regardless of which
+	// batch's goroutine finished first.
+	errEarly := errors.New("early")
+	errLate := errors.New("late")
+	texts := make([]string, 6)
+	files := make([]EslintPluginFileInput, 6)
+	for i := range files {
+		texts[i] = "x\n"
+		files[i] = EslintPluginFileInput{
+			Path:      fmt.Sprintf("/f%d.ts", i),
+			ConfigKey: "/cfg",
+			Text:      &texts[i],
+			Rules:     []ConfiguredRule{pluginRule("uc/x", []any{i}, rule.SeverityError)}, // distinct options → own batch, order f0..f5
+		}
+	}
+	dispatch := func(ctx context.Context, req EslintPluginLintRequest) (*EslintPluginLintResult, error) {
+		switch req.Files[0].Path {
+		case "/f2.ts":
+			return nil, errEarly
+		case "/f4.ts":
+			return nil, errLate
+		default:
+			return &EslintPluginLintResult{Results: []EslintPluginFileResult{{FilePath: req.Files[0].Path}}}, nil
+		}
+	}
+	err := DispatchEslintPluginRules(context.Background(), dispatch, files, false, "off", func(rule.RuleDiagnostic) {})
+	if !errors.Is(err, errEarly) {
+		t.Fatalf("expected the first-in-batch-order error (f2's), got %v", err)
 	}
 }
 

--- a/internal/lsp/eslint_plugin.go
+++ b/internal/lsp/eslint_plugin.go
@@ -154,8 +154,9 @@ func (s *Server) dispatchPluginLint(uri lsproto.DocumentUri, generation uint64) 
 	ctx := s.backgroundCtx
 
 	go func() {
-		// onDiagnostic is invoked synchronously (DispatchEslintPluginRules runs
-		// no goroutines), so the local slice needs no lock.
+		// onDiagnostic is invoked serially (DispatchEslintPluginRules emits
+		// diagnostics single-threaded after its batches complete; here there is
+		// only ever one batch), so the local slice needs no lock.
 		var diags []rule.RuleDiagnostic
 		err := linter.DispatchEslintPluginRules(
 			ctx,
@@ -228,8 +229,9 @@ func (s *Server) mergePluginDiagnostics(r pluginLintResult) {
 // reverse-request response is routed by readLoop (server.go pendingServer-
 // Requests), never by the dispatch loop, so awaiting our own request cannot
 // deadlock — the same reason the native fixAll pass may block on the language
-// service. onDiagnostic is invoked synchronously (DispatchEslintPluginRules
-// runs no goroutines), so the local slice needs no lock. Returns nil when the
+// service. onDiagnostic is invoked serially (DispatchEslintPluginRules emits
+// diagnostics single-threaded after its batches complete; this path has only
+// one batch), so the local slice needs no lock. Returns nil when the
 // file has no plugin rules.
 //
 // The caller (computeFixAllContent) passes a ctx already bounded by a deadline


### PR DESCRIPTION
## Summary

Plugin-lint reverse dispatch sent each `(configKey + rule-signature)` batch to the Node worker pool **serially** — awaiting one batch's full result before sending the next. A single config is one batch and costs nothing, but a fragmented file set (monorepo multi-config, or the same rule configured at different options) splits into many small batches and leaves the worker pool **idle between them**: it only ever saturates within a single batch.

This PR dispatches batches **concurrently** so the pool stays saturated across batches. It targets the `feat/eslint-plugins-20260603` branch (#1047) so the change is isolated and easy to review.

## Changes

- **Concurrent batch dispatch** (`internal/linter/eslint_plugin.go`): `DispatchEslintPluginRules` now fans batches out via `errgroup`, bounded by `min(cpus,8)+2` — at least the Node pool's worker count, plus a small buffer so a freed worker picks up the next batch's tasks from the shared queue without idling during the Go↔Node round trip, while capping how many reverse requests a heavily fragmented set enqueues at once. Multiple in-flight batches share the one worker pool's `pendingQueue`, keeping all workers busy.
  - Per-batch diagnostics are collected into index-keyed slots and emitted in batch order **after** all batches finish, so `onDiagnostic` stays single-threaded (callers keep their lock-free collectors) and output ordering is deterministic.
  - A batch failure **no longer aborts the others** (the serial loop stopped at the first failure); the first error in batch order is still returned, preserving caller semantics.
  - `dispatch` is now invoked concurrently and must be concurrency-safe — the CLI IPC channel already is (`SendRequest` multiplexes by request id), and LSP only ever dispatches one batch.
- **Drop severity from the batch key**: severity never travels on the wire (only options do) and is reattached per-file in `applyEslintPluginResults`, so two files differing only in severity produced byte-identical requests yet fragmented into separate batches. Merging them reduces fragmentation at zero correctness cost.

## Benefit

Scheduling benchmark on an 8-worker pool (real `worker_threads`, modeling the exact serial-vs-concurrent dispatch; the speedup depends only on worker count and batch distribution, not on the per-file cost):

| Scenario | Serial (old) | Concurrent (this PR) | Ideal | Speedup | Pool util (this PR) |
|---|---|---|---|---|---|
| Single config (1 batch × 1000 files) | 528ms | 530ms | 527ms | 1.00× | 94% |
| Fragmented monorepo (100 cfg × 5, uniform) | 408ms | 267ms | 267ms | 1.53× | 94% |
| Fragmented monorepo (skewed file sizes) | 963ms | 260ms | 266ms | **3.71×** | 92% |
| Extreme fragmentation (500 × 1) | 2017ms | 289ms | 295ms | **6.98×** | 85% |

The concurrent column lands at the ideal upper bound — pool utilization goes from 12–61% (idle between batches) to 85–95%. **Single-config CLI runs and LSP (single-file dispatch) are unchanged** (1.00×); the win is entirely in fragmented monorepo plugin-lint.

## Correctness

- Behavior is bit-for-bit equivalent to the serial version (diagnostic set, batch-order emission, first-error return semantics); the only intentional difference is that a failed batch no longer aborts the others — a strict improvement, and no caller depends on the old abort.
- New tests: severity-does-not-fragment-batches, all-concurrent-batches-emitted (asserts single-threaded emit via a deliberately lock-free map under `-race`), batch-failure-does-not-abort-others, first-batch-error-wins.
- `go test -race`, `gofmt`, `go vet`, `golangci-lint` all clean.

## Checklist

- [x] Tests updated.
- [x] Documentation updated (or not required).
