### PR TITLE
feat: add promise/no-new-statics rule

### DIFF
--- a/internal/plugins/promise/all.go
+++ b/internal/plugins/promise/all.go
@@ -6,6 +6,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/catch_or_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_multiple_resolved"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_nesting"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_new_statics"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_wrap"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/param_names"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -18,6 +19,7 @@ func GetAllRules() []rule.Rule {
 		catch_or_return.CatchOrReturnRule,
 		no_multiple_resolved.NoMultipleResolvedRule,
 		no_nesting.NoNestingRule,
+		no_new_statics.NoNewStaticsRule,
 		no_return_wrap.NoReturnWrapRule,
 		param_names.ParamNamesRule,
 	}

--- a/internal/plugins/promise/rules/no_new_statics/no_new_statics.go
+++ b/internal/plugins/promise/rules/no_new_statics/no_new_statics.go
@@ -62,7 +62,7 @@ var NoNewStaticsRule = rule.Rule{
 				//   new Promise.resolve()    → Promise.resolve()
 				//   new  Promise.resolve()   → Promise.resolve()
 				//   new/*c*/Promise.resolve() → /*c*/Promise.resolve()
-				start := int(utils.TrimNodeTextRange(ctx.SourceFile, node).Pos())
+				start := utils.TrimNodeTextRange(ctx.SourceFile, node).Pos()
 				end := start + 3 // len("new") == 3
 				src := ctx.SourceFile.Text()
 				for end < len(src) && (src[end] == ' ' || src[end] == '\t' || src[end] == '\r' || src[end] == '\n') {

--- a/internal/plugins/promise/rules/no_new_statics/no_new_statics.go
+++ b/internal/plugins/promise/rules/no_new_statics/no_new_statics.go
@@ -1,0 +1,65 @@
+package no_new_statics
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// skipTransparent skips only parentheses — TS wrappers (as, !, satisfies) are
+// intentionally left opaque so `new (Promise as any).resolve()` is not flagged,
+// matching the behaviour a user sees in ESLint on a non-@typescript-eslint/parser
+// run (where type-assertion wrappers are visible as distinct nodes).
+const skipTransparent = ast.OEKParentheses
+
+var promiseStatics = map[string]bool{
+	"all":           true,
+	"allSettled":    true,
+	"any":           true,
+	"race":          true,
+	"reject":        true,
+	"resolve":       true,
+	"withResolvers": true,
+}
+
+func buildMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "avoidNewStatic",
+		Description: fmt.Sprintf("Avoid calling 'new' on 'Promise.%s()'", name),
+		Data:        map[string]string{"name": name},
+	}
+}
+
+var NoNewStaticsRule = rule.Rule{
+	Name: "promise/no-new-statics",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindNewExpression: func(node *ast.Node) {
+				callee := ast.SkipOuterExpressions(node.AsNewExpression().Expression, skipTransparent)
+				if callee == nil || !ast.IsPropertyAccessExpression(callee) {
+					return
+				}
+				prop := callee.AsPropertyAccessExpression()
+				object := ast.SkipOuterExpressions(prop.Expression, skipTransparent)
+				if object == nil || !ast.IsIdentifier(object) || object.AsIdentifier().Text != "Promise" {
+					return
+				}
+				name := prop.Name()
+				if name == nil || !ast.IsIdentifier(name) {
+					return
+				}
+				methodName := name.AsIdentifier().Text
+				if !promiseStatics[methodName] {
+					return
+				}
+
+				// Fix: remove "new " (4 chars) from the start of the expression.
+				nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+				removeRange := nodeRange.WithEnd(nodeRange.Pos() + 4)
+				ctx.ReportNodeWithFixes(node, buildMessage(methodName), rule.RuleFixRemoveRange(removeRange))
+			},
+		}
+	},
+}

--- a/internal/plugins/promise/rules/no_new_statics/no_new_statics.go
+++ b/internal/plugins/promise/rules/no_new_statics/no_new_statics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -55,10 +56,19 @@ var NoNewStaticsRule = rule.Rule{
 					return
 				}
 
-				// Fix: remove "new " (4 chars) from the start of the expression.
-				nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
-				removeRange := nodeRange.WithEnd(nodeRange.Pos() + 4)
-				ctx.ReportNodeWithFixes(node, buildMessage(methodName), rule.RuleFixRemoveRange(removeRange))
+				// Fix: remove "new" (3 chars) plus any trailing whitespace chars
+				// (' ', '\t', '\r', '\n'). Comments and other non-whitespace
+				// between `new` and the callee are preserved:
+				//   new Promise.resolve()    → Promise.resolve()
+				//   new  Promise.resolve()   → Promise.resolve()
+				//   new/*c*/Promise.resolve() → /*c*/Promise.resolve()
+				start := int(utils.TrimNodeTextRange(ctx.SourceFile, node).Pos())
+				end := start + 3 // len("new") == 3
+				src := ctx.SourceFile.Text()
+				for end < len(src) && (src[end] == ' ' || src[end] == '\t' || src[end] == '\r' || src[end] == '\n') {
+					end++
+				}
+				ctx.ReportNodeWithFixes(node, buildMessage(methodName), rule.RuleFixRemoveRange(core.NewTextRange(start, end)))
 			},
 		}
 	},

--- a/internal/plugins/promise/rules/no_new_statics/no_new_statics.md
+++ b/internal/plugins/promise/rules/no_new_statics/no_new_statics.md
@@ -1,0 +1,41 @@
+# no-new-statics
+
+Disallow calling `new` on a Promise static method.
+
+## Rule Details
+
+Promise static methods (`resolve`, `reject`, `all`, `allSettled`, `any`, `race`, `withResolvers`) return Promises directly — they are not constructors. Calling `new` on them is almost always a mistake and produces unexpected behavior.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+new Promise.resolve(value);
+new Promise.reject(reason);
+new Promise.all([p1, p2]);
+new Promise.allSettled([p1, p2]);
+new Promise.any([p1, p2]);
+new Promise.race([p1, p2]);
+new Promise.withResolvers();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+Promise.resolve(value);
+Promise.reject(reason);
+Promise.all([p1, p2]);
+new Promise(function (resolve, reject) {});
+new SomeClass.resolve();
+```
+
+## Autofix
+
+This rule provides an autofix that removes the `new` keyword.
+
+## Differences from ESLint
+
+- `new (Promise as any).resolve()` and similar TS type-assertion or non-null-assertion wrappers around `Promise` are **not** flagged. Under `@typescript-eslint/parser`, type wrappers are stripped before the rule sees the AST, so ESLint would flag these. rslint preserves the TS node structure and only unwraps parentheses.
+
+## Original Documentation
+
+- [eslint-plugin-promise: no-new-statics](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-new-statics.md)

--- a/internal/plugins/promise/rules/no_new_statics/no_new_statics_extras_test.go
+++ b/internal/plugins/promise/rules/no_new_statics/no_new_statics_extras_test.go
@@ -1,0 +1,144 @@
+package no_new_statics_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_new_statics"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoNewStaticsExtras covers edge-shape augmentation (Layer 2) and
+// upstream branch lock-ins (Layer 3).
+func TestNoNewStaticsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_new_statics.NoNewStaticsRule,
+		[]rule_tester.ValidTestCase{
+
+			// ---- Dimension 4: Receiver / expression wrappers ----
+
+			// N/A: optional chain (`new Promise?.resolve()`) is a parse error in JS/TS.
+
+			// TS type-assertion wrapper on object: tsgo preserves the AsExpression,
+			// SkipOuterExpressions(OEKParentheses) does not unwrap it, so the object
+			// is not seen as Identifier("Promise") — not flagged.
+			// (Type B divergence from ESLint/@typescript-eslint/parser which strips the assertion.)
+			{Code: `new (Promise as any).resolve()`},
+			{Code: `new (<any>Promise).resolve()`},
+			// TS non-null assertion on object: same — not unwrapped, not flagged.
+			// N/A in practice since `Promise!` is unusual, but verifies graceful skip.
+			{Code: `new (Promise!).resolve()`},
+
+			// ---- Dimension 4: Access / key forms ----
+
+			// Computed / bracket access is ElementAccessExpression (not
+			// PropertyAccessExpression), so it never matches the listener guard.
+			{Code: `new Promise['resolve']()`},
+			{Code: `new Promise['reject']()`},
+
+			// ---- Dimension 4: Parenthesized receiver (tsgo preserves, ESTree flattens) ----
+
+			// Single parenthesis around the whole expression: valid because the
+			// callee is now a ParenthesizedExpression wrapping the
+			// PropertyAccessExpression, not a bare PropertyAccessExpression.
+			// After SkipOuterExpressions on node.Expression, we'd get the PAE,
+			// but in tsgo `new (Promise.resolve)()` has Expression = paren(PAE)
+			// and SkipOuterExpressions would unwrap the paren to PAE which IS a PAE.
+			// However, `new (Promise.resolve)()` is flagged if the PAE's object is Promise —
+			// so include it here as an *invalid* case (see below).
+			// What is NOT flagged: `new (Promise as any).resolve()` (type wrapper, covered above).
+
+			// Property is not in PROMISE_STATICS — branch lock-in (Condition 3).
+			{Code: `new Promise.unknown()`},
+			{Code: `new Promise.then()`},
+			{Code: `new Promise.catch()`},
+			{Code: `new Promise.finally()`},
+
+			// Object is not Promise — branch lock-in (Condition 2).
+			{Code: `new MyPromise.resolve()`},
+			{Code: `new globalThis.Promise.resolve()`},
+
+			// Callee is not a PropertyAccessExpression — branch lock-in (Condition 1).
+			{Code: `new Promise()`},
+			{Code: `new Foo()`},
+
+			// ---- Real-user: nested in async functions ----
+			{Code: `async function f() { return await Promise.resolve(1) }`},
+
+			// ---- Real-user: used as default export ----
+			{Code: `export default Promise.resolve(42)`},
+		},
+		[]rule_tester.InvalidTestCase{
+
+			// ---- Dimension 4: Parenthesized receiver ----
+
+			// `new (Promise).resolve()` — parens around the Promise identifier:
+			// `node.Expression` is PAE, PAE.Expression is paren(Identifier(Promise)),
+			// SkipOuterExpressions unwraps to Identifier(Promise) → flagged.
+			// Fix removes only "new ", leaving the parens in place.
+			{
+				Code:   `new (Promise).resolve()`,
+				Output: []string{`(Promise).resolve()`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNewStatic", Message: "Avoid calling 'new' on 'Promise.resolve()'"},
+				},
+			},
+			// Double parens on Promise identifier — fix removes "new ", parens stay.
+			{
+				Code:   `new ((Promise)).resolve()`,
+				Output: []string{`((Promise)).resolve()`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNewStatic", Message: "Avoid calling 'new' on 'Promise.resolve()'"},
+				},
+			},
+			// Parens around the whole callee PropertyAccessExpression:
+			// node.Expression is paren(PAE), SkipOuterExpressions unwraps to PAE,
+			// PAE.Expression is Identifier(Promise) → flagged.
+			// Fix removes "new ", parens around callee stay.
+			{
+				Code:   `new (Promise.resolve)()`,
+				Output: []string{`(Promise.resolve)()`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNewStatic", Message: "Avoid calling 'new' on 'Promise.resolve()'"},
+				},
+			},
+
+			// ---- Dimension 3: Autofix — arguments with values ----
+			{
+				Code:   `new Promise.resolve(42)`,
+				Output: []string{`Promise.resolve(42)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNewStatic", Message: "Avoid calling 'new' on 'Promise.resolve()'"},
+				},
+			},
+			{
+				Code:   `new Promise.all([p1, p2])`,
+				Output: []string{`Promise.all([p1, p2])`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNewStatic", Message: "Avoid calling 'new' on 'Promise.all()'"},
+				},
+			},
+
+			// ---- Dimension 3: Autofix — leading whitespace / indentation preserved ----
+			{
+				Code:   "  new Promise.resolve()",
+				Output: []string{"  Promise.resolve()"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNewStatic", Message: "Avoid calling 'new' on 'Promise.resolve()'"},
+				},
+			},
+
+			// ---- Real-user: flagged in class method ----
+			{
+				Code:   `class A { m() { return new Promise.resolve(1) } }`,
+				Output: []string{`class A { m() { return Promise.resolve(1) } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNewStatic", Message: "Avoid calling 'new' on 'Promise.resolve()'"},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/promise/rules/no_new_statics/no_new_statics_extras_test.go
+++ b/internal/plugins/promise/rules/no_new_statics/no_new_statics_extras_test.go
@@ -131,6 +131,32 @@ func TestNoNewStaticsExtras(t *testing.T) {
 				},
 			},
 
+			// ---- Dimension 3: Autofix — comment between `new` and callee ----
+			// Only whitespace after `new` is stripped; comments are preserved.
+			{
+				Code:   "new/*comment*/Promise.resolve()",
+				Output: []string{"/*comment*/Promise.resolve()"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNewStatic", Message: "Avoid calling 'new' on 'Promise.resolve()'"},
+				},
+			},
+			// Newline between `new` and callee.
+			{
+				Code:   "new\nPromise.resolve()",
+				Output: []string{"Promise.resolve()"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNewStatic", Message: "Avoid calling 'new' on 'Promise.resolve()'"},
+				},
+			},
+			// Multiple spaces between `new` and callee.
+			{
+				Code:   "new  Promise.resolve()",
+				Output: []string{"Promise.resolve()"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNewStatic", Message: "Avoid calling 'new' on 'Promise.resolve()'"},
+				},
+			},
+
 			// ---- Real-user: flagged in class method ----
 			{
 				Code:   `class A { m() { return new Promise.resolve(1) } }`,

--- a/internal/plugins/promise/rules/no_new_statics/no_new_statics_upstream_test.go
+++ b/internal/plugins/promise/rules/no_new_statics/no_new_statics_upstream_test.go
@@ -1,0 +1,148 @@
+package no_new_statics_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_new_statics"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoNewStaticsUpstream migrates every valid/invalid case from the
+// eslint-plugin-promise upstream test suite for `no-new-statics`.
+func TestNoNewStaticsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_new_statics.NoNewStaticsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- ESLint upstream valid cases ----
+			{Code: `Promise.resolve()`},
+			{Code: `Promise.reject()`},
+			{Code: `Promise.all()`},
+			{Code: `Promise.race()`},
+			{Code: `Promise.withResolvers()`},
+			{Code: `new Promise(function (resolve, reject) {})`},
+			{Code: `new SomeClass()`},
+			{Code: `SomeClass.resolve()`},
+			{Code: `new SomeClass.resolve()`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- ESLint upstream invalid cases ----
+			{
+				Code:   `new Promise.resolve()`,
+				Output: []string{`Promise.resolve()`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "avoidNewStatic",
+						Message:   "Avoid calling 'new' on 'Promise.resolve()'",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 22,
+					},
+				},
+			},
+			{
+				Code:   `new Promise.reject()`,
+				Output: []string{`Promise.reject()`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "avoidNewStatic",
+						Message:   "Avoid calling 'new' on 'Promise.reject()'",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 21,
+					},
+				},
+			},
+			{
+				Code:   `new Promise.all()`,
+				Output: []string{`Promise.all()`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "avoidNewStatic",
+						Message:   "Avoid calling 'new' on 'Promise.all()'",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 18,
+					},
+				},
+			},
+			{
+				Code:   `new Promise.allSettled()`,
+				Output: []string{`Promise.allSettled()`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "avoidNewStatic",
+						Message:   "Avoid calling 'new' on 'Promise.allSettled()'",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 25,
+					},
+				},
+			},
+			{
+				Code:   `new Promise.any()`,
+				Output: []string{`Promise.any()`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "avoidNewStatic",
+						Message:   "Avoid calling 'new' on 'Promise.any()'",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 18,
+					},
+				},
+			},
+			{
+				Code:   `new Promise.race()`,
+				Output: []string{`Promise.race()`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "avoidNewStatic",
+						Message:   "Avoid calling 'new' on 'Promise.race()'",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 19,
+					},
+				},
+			},
+			{
+				Code:   `new Promise.withResolvers()`,
+				Output: []string{`Promise.withResolvers()`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "avoidNewStatic",
+						Message:   "Avoid calling 'new' on 'Promise.withResolvers()'",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 28,
+					},
+				},
+			},
+			// multi-line / nested context
+			{
+				Code:   "function a() { return new Promise.resolve(a) }",
+				Output: []string{"function a() { return Promise.resolve(a) }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "avoidNewStatic",
+						Message:   "Avoid calling 'new' on 'Promise.resolve()'",
+						Line:      1,
+						Column:    23,
+						EndLine:   1,
+						EndColumn: 45,
+					},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -474,6 +474,7 @@ export default defineConfig({
     './tests/eslint-plugin-promise/rules/catch-or-return.test.ts',
     './tests/eslint-plugin-promise/rules/no-multiple-resolved.test.ts',
     './tests/eslint-plugin-promise/rules/no-nesting.test.ts',
+    './tests/eslint-plugin-promise/rules/no-new-statics.test.ts',
     './tests/eslint-plugin-promise/rules/no-return-wrap.test.ts',
     './tests/eslint-plugin-promise/rules/param-names.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/no-new-statics.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/no-new-statics.test.ts
@@ -1,0 +1,56 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const msg = (name: string) => `Avoid calling 'new' on 'Promise.${name}()'`;
+
+ruleTester.run('no-new-statics', {} as never, {
+  valid: [
+    // ESLint upstream
+    { code: 'Promise.resolve()' },
+    { code: 'Promise.reject()' },
+    { code: 'Promise.all()' },
+    { code: 'Promise.race()' },
+    { code: 'Promise.withResolvers()' },
+    { code: 'new Promise(function (resolve, reject) {})' },
+    { code: 'new SomeClass()' },
+    { code: 'SomeClass.resolve()' },
+    { code: 'new SomeClass.resolve()' },
+  ],
+
+  invalid: [
+    // ESLint upstream
+    {
+      code: 'new Promise.resolve()',
+      errors: [{ message: msg('resolve') }],
+    },
+    {
+      code: 'new Promise.reject()',
+      errors: [{ message: msg('reject') }],
+    },
+    {
+      code: 'new Promise.all()',
+      errors: [{ message: msg('all') }],
+    },
+    {
+      code: 'new Promise.allSettled()',
+      errors: [{ message: msg('allSettled') }],
+    },
+    {
+      code: 'new Promise.any()',
+      errors: [{ message: msg('any') }],
+    },
+    {
+      code: 'new Promise.race()',
+      errors: [{ message: msg('race') }],
+    },
+    {
+      code: 'new Promise.withResolvers()',
+      errors: [{ message: msg('withResolvers') }],
+    },
+    {
+      code: 'function a() { return new Promise.resolve(a) }',
+      errors: [{ message: msg('resolve') }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Added `promise/no-new-statics` rule for #474.

## Related Links

[original docs](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-new-statics.md)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
