### PR TITLE
feat: add promise/avoid-new rule

### DIFF
--- a/internal/plugins/promise/all.go
+++ b/internal/plugins/promise/all.go
@@ -2,6 +2,7 @@ package promise_plugin
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/always_return"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/avoid_new"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/catch_or_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_wrap"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/param_names"
@@ -11,6 +12,7 @@ import (
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		always_return.AlwaysReturnRule,
+		avoid_new.AvoidNewRule,
 		catch_or_return.CatchOrReturnRule,
 		no_return_wrap.NoReturnWrapRule,
 		param_names.ParamNamesRule,

--- a/internal/plugins/promise/rules/avoid_new/avoid_new.go
+++ b/internal/plugins/promise/rules/avoid_new/avoid_new.go
@@ -1,0 +1,33 @@
+package avoid_new
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// skipTransparent only unwraps parens — ESLint's ESTree parser drops
+// parentheses, so `new (Promise)(...)` already has the identifier visible at
+// the ESLint level. TS-only wrappers (non-null, as, satisfies) are
+// intentionally NOT unwrapped: the original rule treats them as not-a-Promise-
+// constructor and skips silently, and we mirror that.
+const skipTransparent = ast.OEKParentheses
+
+var AvoidNewRule = rule.Rule{
+	Name: "promise/avoid-new",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindNewExpression: func(node *ast.Node) {
+				callee := ast.SkipOuterExpressions(node.AsNewExpression().Expression, skipTransparent)
+				if callee == nil || callee.Kind != ast.KindIdentifier {
+					return
+				}
+				if callee.AsIdentifier().Text == "Promise" {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "avoidNew",
+						Description: "Avoid creating new promises.",
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/promise/rules/avoid_new/avoid_new.md
+++ b/internal/plugins/promise/rules/avoid_new/avoid_new.md
@@ -1,0 +1,30 @@
+# promise/avoid-new
+
+Disallow creating `new` promises outside of utility libs (use `util.promisify` instead).
+
+## Rule Details
+
+This rule discourages using the `new Promise` constructor directly. When promisifying callback-based functions, prefer Node's `util.promisify`. When wrapping a plain value or error, prefer `Promise.resolve()` or `Promise.reject()`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var x = new Promise(function (resolve, reject) {});
+new Promise();
+Thing(new Promise(() => {}));
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+Promise.resolve();
+Promise.reject();
+Promise.all();
+new Horse();
+new PromiseLikeThing();
+new Promise.resolve();
+```
+
+## Original Documentation
+
+https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/avoid-new.md

--- a/internal/plugins/promise/rules/avoid_new/avoid_new.md
+++ b/internal/plugins/promise/rules/avoid_new/avoid_new.md
@@ -1,4 +1,4 @@
-# promise/avoid-new
+# avoid-new
 
 Disallow creating `new` promises outside of utility libs (use `util.promisify` instead).
 

--- a/internal/plugins/promise/rules/avoid_new/avoid_new.md
+++ b/internal/plugins/promise/rules/avoid_new/avoid_new.md
@@ -27,4 +27,4 @@ new Promise.resolve();
 
 ## Original Documentation
 
-https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/avoid-new.md
+- [eslint-plugin-promise: avoid-new](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/avoid-new.md)

--- a/internal/plugins/promise/rules/avoid_new/avoid_new_extras_test.go
+++ b/internal/plugins/promise/rules/avoid_new/avoid_new_extras_test.go
@@ -1,0 +1,105 @@
+// TestAvoidNewExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the
+// specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+
+package avoid_new_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/avoid_new"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestAvoidNewExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&avoid_new.AvoidNewRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: TS type assertion (as) on callee ----
+			// ESLint: TSAsExpression callee → callee.name undefined → no report.
+			// tsgo: AsExpression not unwrapped (only parens are) → no report. Matches ESLint.
+			{Code: `new (Promise as any)()`},
+
+			// ---- Dimension 4: element-access callee ----
+			// Locks in the "callee is not an Identifier" branch: ElementAccessExpression
+			// is not an Identifier → no report.
+			{Code: `new Promise['resolve']()`},
+
+			// ---- Dimension 4: non-Promise class names ----
+			// Locks in the name-inequality branch: callee.Text !== "Promise" → no report.
+			{Code: `new MyPromise()`},
+			{Code: `new PromiseFactory()`},
+
+			// ---- Real-user: namespace-scoped constructor ----
+			// `new Bluebird.Promise()` — callee is PropertyAccessExpression, not Identifier.
+			{Code: `new Bluebird.Promise(() => {})`},
+
+			// ---- Real-user: util.promisify alternative ----
+			// Static Promise methods are the encouraged replacement; make sure they
+			// are not flagged.
+			{Code: `Promise.resolve(someCallbackFn())`},
+			{Code: `Promise.reject(new Error('oops'))`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized callee ----
+			// ESLint's ESTree parser drops parens, so `(Promise)` is seen as Identifier.
+			// tsgo preserves ParenthesizedExpression; SkipOuterExpressions unwraps it
+			// so behavior matches ESLint.
+			{
+				Code:   `new (Promise)()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 1}},
+			},
+			// Double-parenthesized callee — SkipOuterExpressions peels all layers.
+			{
+				Code:   `new ((Promise))()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 1}},
+			},
+
+			// ---- Dimension 4: new Promise with type arguments ----
+			// TypeArguments live on the NewExpression node, not the callee, so the
+			// callee remains a plain Identifier "Promise" → should report.
+			{
+				Code:   `new Promise<string>((resolve) => { resolve('x') })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 1}},
+			},
+
+			// ---- Dimension 4: new Promise deeply nested ----
+			// The listener fires on every NewExpression regardless of nesting depth.
+			{
+				Code:   `foo(bar(new Promise(() => {})))`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 9}},
+			},
+
+			// Locks in upstream NewExpression arm: callee is Identifier "Promise" → report.
+			// Arm: non-Promise name (e.g. 'Horse') → no report, covered by valid cases.
+			{
+				Code:   `new Promise(function(resolve) {})`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 1}},
+			},
+
+			// ---- Real-user: new Promise inside arrow function ----
+			{
+				Code:   `const fn = () => new Promise((resolve) => setTimeout(resolve, 0))`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 18}},
+			},
+
+			// ---- Real-user: new Promise exported from a module ----
+			{
+				Code:   `export const p = new Promise((resolve, reject) => { reject(new Error('fail')) })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 18}},
+			},
+
+			// Locks in: shadowing Promise does not suppress the report — the rule
+			// only checks the callee's text, not whether the binding is the global Promise.
+			{
+				Code:   `const Promise = class {}; const p = new Promise()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 37}},
+			},
+		},
+	)
+}

--- a/internal/plugins/promise/rules/avoid_new/avoid_new_upstream_test.go
+++ b/internal/plugins/promise/rules/avoid_new/avoid_new_upstream_test.go
@@ -1,0 +1,47 @@
+// TestAvoidNewUpstream migrates the full valid/invalid suite from upstream
+// __tests__/avoid-new.js 1:1. Position assertions cover line/column for every
+// invalid case. rslint-specific lock-in cases live in avoid_new_extras_test.go.
+
+package avoid_new_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/avoid_new"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const avoidNewMessage = "Avoid creating new promises."
+
+func TestAvoidNewUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&avoid_new.AvoidNewRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `Promise.resolve()`},
+			{Code: `Promise.reject()`},
+			{Code: `Promise.all()`},
+			{Code: `new Horse()`},
+			{Code: `new PromiseLikeThing()`},
+			// callee is a member expression — not a plain identifier named "Promise"
+			{Code: `new Promise.resolve()`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `var x = new Promise(function (x, y) {})`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 9}},
+			},
+			{
+				Code:   `new Promise()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 1}},
+			},
+			{
+				Code:   `Thing(new Promise(() => {}))`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNew", Message: avoidNewMessage, Line: 1, Column: 7}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -462,6 +462,7 @@ export default defineConfig({
 
     // eslint-plugin-promise
     './tests/eslint-plugin-promise/rules/always-return.test.ts',
+    './tests/eslint-plugin-promise/rules/avoid-new.test.ts',
     './tests/eslint-plugin-promise/rules/catch-or-return.test.ts',
     './tests/eslint-plugin-promise/rules/no-return-wrap.test.ts',
     './tests/eslint-plugin-promise/rules/param-names.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/avoid-new.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/avoid-new.test.ts
@@ -1,0 +1,31 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const errorMessage = 'Avoid creating new promises.';
+
+ruleTester.run('avoid-new', {} as never, {
+  valid: [
+    { code: 'Promise.resolve()' },
+    { code: 'Promise.reject()' },
+    { code: 'Promise.all()' },
+    { code: 'new Horse()' },
+    { code: 'new PromiseLikeThing()' },
+    { code: 'new Promise.resolve()' },
+  ],
+
+  invalid: [
+    {
+      code: 'var x = new Promise(function (x, y) {})',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'new Promise()',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'Thing(new Promise(() => {}))',
+      errors: [{ message: errorMessage }],
+    },
+  ],
+});

--- a/packages/rslint/src/configs/promise.ts
+++ b/packages/rslint/src/configs/promise.ts
@@ -13,7 +13,7 @@ const recommended: RslintConfigEntry = {
     // 'promise/no-nesting': 'warn', // not implemented
     // 'promise/no-promise-in-callback': 'warn', // not implemented
     // 'promise/no-callback-in-promise': 'warn', // not implemented
-    // 'promise/avoid-new': 'off', // not implemented
+    'promise/avoid-new': 'off',
     // 'promise/no-new-statics': 'error', // not implemented
     // 'promise/no-return-in-finally': 'warn', // not implemented
     // 'promise/valid-params': 'warn', // not implemented

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -325,6 +325,8 @@ preresolved
 Prettier
 prioritises
 progressbar
+promisify
+promisifying
 promiseutil
 propertyassignment
 proptypes


### PR DESCRIPTION
## Summary

Added `promise/avoid-new` rule for #474.

## Related Links

[original docs](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/avoid-new.md)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
