### PR TITLE
feat: add promise/no-callback-in-promise rule

### DIFF
--- a/internal/plugins/promise/all.go
+++ b/internal/plugins/promise/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/always_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/avoid_new"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/catch_or_return"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_callback_in_promise"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_multiple_resolved"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_nesting"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_new_statics"
@@ -18,6 +19,7 @@ func GetAllRules() []rule.Rule {
 		always_return.AlwaysReturnRule,
 		avoid_new.AvoidNewRule,
 		catch_or_return.CatchOrReturnRule,
+		no_callback_in_promise.NoCallbackInPromiseRule,
 		no_multiple_resolved.NoMultipleResolvedRule,
 		no_nesting.NoNestingRule,
 		no_new_statics.NoNewStaticsRule,

--- a/internal/plugins/promise/rules/always_return/always_return.go
+++ b/internal/plugins/promise/rules/always_return/always_return.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/promiseutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -50,7 +51,7 @@ func isInlineThenFunctionExpression(node *ast.Node) bool {
 	for parent != nil && ast.IsOuterExpression(parent, skipTransparent) {
 		parent = parent.Parent
 	}
-	if parent == nil || !ast.IsCallExpression(parent) || !isMemberCall(parent, "then") {
+	if parent == nil || !ast.IsCallExpression(parent) || !promiseutil.IsMemberCall(parent, "then") {
 		return false
 	}
 	args := parent.Arguments()
@@ -73,17 +74,7 @@ func isFunctionWithBlockStatement(node *ast.Node) bool {
 	}
 }
 
-func isMemberCall(node *ast.Node, memberName string) bool {
-	if node == nil || !ast.IsCallExpression(node) {
-		return false
-	}
-	callee := ast.SkipOuterExpressions(node.AsCallExpression().Expression, skipTransparent)
-	if callee == nil || !ast.IsPropertyAccessExpression(callee) {
-		return false
-	}
-	name := callee.AsPropertyAccessExpression().Name()
-	return name != nil && ast.IsIdentifier(name) && name.AsIdentifier().Text == memberName
-}
+
 
 func isLastCallback(node *ast.Node) bool {
 	if node == nil || node.Parent == nil {
@@ -126,7 +117,7 @@ func isLastCallback(node *ast.Node) bool {
 				return false
 			}
 			call := parent.Parent
-			if call != nil && ast.IsCallExpression(call) && (isMemberCall(call, "catch") || isMemberCall(call, "finally")) {
+			if call != nil && ast.IsCallExpression(call) && (promiseutil.IsMemberCall(call, "catch") || promiseutil.IsMemberCall(call, "finally")) {
 				target = call
 				parent = target.Parent
 				continue

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.go
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.go
@@ -1,0 +1,209 @@
+package no_callback_in_promise
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const skipTransparent = ast.OEKParentheses
+
+var cbBlacklist = []string{"callback", "cb", "next", "done"}
+var timeoutWhitelist = []string{"setImmediate", "setTimeout", "requestAnimationFrame", "nextTick"}
+
+type Options struct {
+	Exceptions  []string
+	TimeoutsErr bool
+}
+
+func parseOptions(options any) Options {
+	opts := Options{}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["timeoutsErr"].(bool); ok {
+		opts.TimeoutsErr = v
+	}
+	if v, ok := optsMap["exceptions"].([]interface{}); ok {
+		for _, e := range v {
+			if s, ok := e.(string); ok {
+				opts.Exceptions = append(opts.Exceptions, s)
+			}
+		}
+	}
+	return opts
+}
+
+func buildCallbackMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "callback",
+		Description: "Avoid calling back inside of a promise.",
+	}
+}
+
+// isCallbackName returns true if name is in cbBlacklist and not in exceptions.
+func isCallbackName(name string, exceptions []string) bool {
+	for _, e := range exceptions {
+		if name == e {
+			return false
+		}
+	}
+	for _, cb := range cbBlacklist {
+		if name == cb {
+			return true
+		}
+	}
+	return false
+}
+
+// isCallbackCall returns true if node is a call expression whose callee (skipping parens) is an
+// identifier with a callback name.
+func isCallbackCall(node *ast.Node, exceptions []string) bool {
+	if !ast.IsCallExpression(node) {
+		return false
+	}
+	callee := ast.SkipOuterExpressions(node.AsCallExpression().Expression, skipTransparent)
+	return callee != nil && ast.IsIdentifier(callee) && isCallbackName(callee.AsIdentifier().Text, exceptions)
+}
+
+// getMemberCallName returns the member-property name (for a.foo()) or the direct identifier name
+// (for foo()) from a call-expression callee. Returns "" for anything else.
+func getMemberCallName(node *ast.Node) string {
+	if !ast.IsCallExpression(node) {
+		return ""
+	}
+	callee := node.AsCallExpression().Expression
+	if ast.IsPropertyAccessExpression(callee) {
+		propName := callee.AsPropertyAccessExpression().Name()
+		if propName != nil && ast.IsIdentifier(propName) {
+			return propName.AsIdentifier().Text
+		}
+		return ""
+	}
+	if ast.IsIdentifier(callee) {
+		return callee.AsIdentifier().Text
+	}
+	return ""
+}
+
+// isPromiseMemberCall returns true if node is a call expression whose callee is a
+// property-access expression with the given name — i.e. a.then(...) or a.catch(...).
+// This mirrors upstream's hasPromiseCallback which requires callee.type === 'MemberExpression'.
+func isPromiseMemberCall(node *ast.Node) bool {
+	if !ast.IsCallExpression(node) {
+		return false
+	}
+	callee := node.AsCallExpression().Expression
+	if !ast.IsPropertyAccessExpression(callee) {
+		return false
+	}
+	propName := callee.AsPropertyAccessExpression().Name()
+	if propName == nil || !ast.IsIdentifier(propName) {
+		return false
+	}
+	name := propName.AsIdentifier().Text
+	return name == "then" || name == "catch"
+}
+
+// isFunctionLike returns true for FunctionExpression and ArrowFunction nodes.
+func isFunctionLike(node *ast.Node) bool {
+	return node.Kind == ast.KindFunctionExpression || node.Kind == ast.KindArrowFunction
+}
+
+// isInsidePromise mirrors eslint-plugin-promise's lib/is-inside-promise:
+// a FunctionExpression/ArrowFunction whose parent (skipping parens) is a .then()/.catch() call.
+func isInsidePromise(node *ast.Node) bool {
+	if !isFunctionLike(node) {
+		return false
+	}
+	parent := node.Parent
+	for parent != nil && ast.IsOuterExpression(parent, skipTransparent) {
+		parent = parent.Parent
+	}
+	if parent == nil {
+		return false
+	}
+	name := getMemberCallName(parent)
+	return name == "then" || name == "catch"
+}
+
+// isInsideTimeout mirrors eslint-plugin-promise's isInsideTimeout:
+// a FunctionExpression/ArrowFunction whose parent (skipping parens) is a timeout whitelist call.
+func isInsideTimeout(node *ast.Node) bool {
+	if !isFunctionLike(node) {
+		return false
+	}
+	parent := node.Parent
+	for parent != nil && ast.IsOuterExpression(parent, skipTransparent) {
+		parent = parent.Parent
+	}
+	if parent == nil {
+		return false
+	}
+	name := getMemberCallName(parent)
+	for _, t := range timeoutWhitelist {
+		if name == t {
+			return true
+		}
+	}
+	return false
+}
+
+// ancestorSome walks up the parent chain and returns true if pred matches any ancestor.
+func ancestorSome(node *ast.Node, pred func(*ast.Node) bool) bool {
+	for cur := node.Parent; cur != nil; cur = cur.Parent {
+		if pred(cur) {
+			return true
+		}
+	}
+	return false
+}
+
+var NoCallbackInPromiseRule = rule.Rule{
+	Name: "promise/no-callback-in-promise",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				exceptions := opts.Exceptions
+
+				if !isCallbackCall(node, exceptions) {
+					// node is not itself a callback call — check if it is a promise callback
+					// call (.then/.catch) whose first arg is a callback name, or handle
+					// the timeoutsErr path.
+					callExpr := node.AsCallExpression()
+					var firstArgName string
+					if callExpr.Arguments != nil && len(callExpr.Arguments.Nodes) > 0 {
+						firstArg := ast.SkipOuterExpressions(callExpr.Arguments.Nodes[0], skipTransparent)
+						if firstArg != nil && ast.IsIdentifier(firstArg) {
+							firstArgName = firstArg.AsIdentifier().Text
+						}
+					}
+
+					if isPromiseMemberCall(node) {
+						// Scenario A: a.then(cb) — callback passed directly as argument.
+						if firstArgName != "" && isCallbackName(firstArgName, exceptions) {
+							ctx.ReportNode(callExpr.Arguments.Nodes[0], buildCallbackMessage())
+						}
+						return
+					}
+
+					if !opts.TimeoutsErr {
+						return
+					}
+					if firstArgName == "" {
+						return
+					}
+				}
+
+				// Scenario B/C/D: callback call (or named-arg call in timeoutsErr mode)
+				// inside a promise handler.
+				if ancestorSome(node, isInsidePromise) &&
+					(opts.TimeoutsErr || !ancestorSome(node, isInsideTimeout)) {
+					ctx.ReportNode(node, buildCallbackMessage())
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.go
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.go
@@ -2,6 +2,7 @@ package no_callback_in_promise
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/promiseutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -87,23 +88,8 @@ func getMemberCallName(node *ast.Node) string {
 	return ""
 }
 
-// isPromiseMemberCall returns true if node is a call expression whose callee is a
-// property-access expression with the given name — i.e. a.then(...) or a.catch(...).
-// This mirrors upstream's hasPromiseCallback which requires callee.type === 'MemberExpression'.
 func isPromiseMemberCall(node *ast.Node) bool {
-	if !ast.IsCallExpression(node) {
-		return false
-	}
-	callee := node.AsCallExpression().Expression
-	if !ast.IsPropertyAccessExpression(callee) {
-		return false
-	}
-	propName := callee.AsPropertyAccessExpression().Name()
-	if propName == nil || !ast.IsIdentifier(propName) {
-		return false
-	}
-	name := propName.AsIdentifier().Text
-	return name == "then" || name == "catch"
+	return promiseutil.IsMemberCall(node, "then") || promiseutil.IsMemberCall(node, "catch")
 }
 
 // isFunctionLike returns true for FunctionExpression and ArrowFunction nodes.

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.go
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.go
@@ -74,7 +74,7 @@ func getMemberCallName(node *ast.Node) string {
 	if !ast.IsCallExpression(node) {
 		return ""
 	}
-	callee := node.AsCallExpression().Expression
+	callee := ast.SkipOuterExpressions(node.AsCallExpression().Expression, skipTransparent)
 	if ast.IsPropertyAccessExpression(callee) {
 		propName := callee.AsPropertyAccessExpression().Name()
 		if propName != nil && ast.IsIdentifier(propName) {
@@ -155,18 +155,21 @@ var NoCallbackInPromiseRule = rule.Rule{
 					// call (.then/.catch) whose first arg is a callback name, or handle
 					// the timeoutsErr path.
 					callExpr := node.AsCallExpression()
+					var firstArg *ast.Node
 					var firstArgName string
 					if callExpr.Arguments != nil && len(callExpr.Arguments.Nodes) > 0 {
-						firstArg := ast.SkipOuterExpressions(callExpr.Arguments.Nodes[0], skipTransparent)
+						firstArg = ast.SkipOuterExpressions(callExpr.Arguments.Nodes[0], skipTransparent)
 						if firstArg != nil && ast.IsIdentifier(firstArg) {
 							firstArgName = firstArg.AsIdentifier().Text
 						}
 					}
 
 					if isPromiseMemberCall(node) {
-						// Scenario A: a.then(cb) — callback passed directly as argument.
+						// Scenario A: a.then(cb) — callback passed directly as argument. Report the
+						// unwrapped identifier (firstArg) to match upstream's node.arguments[0]; the raw
+						// Nodes[0] would span the surrounding parens, e.g. `(cb)` instead of `cb`.
 						if firstArgName != "" && isCallbackName(firstArgName, exceptions) {
-							ctx.ReportNode(callExpr.Arguments.Nodes[0], buildCallbackMessage())
+							ctx.ReportNode(firstArg, buildCallbackMessage())
 						}
 						return
 					}

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.go
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.go
@@ -121,11 +121,7 @@ func isInsidePromise(node *ast.Node) bool {
 	for parent != nil && ast.IsOuterExpression(parent, skipTransparent) {
 		parent = parent.Parent
 	}
-	if parent == nil {
-		return false
-	}
-	name := getMemberCallName(parent)
-	return name == "then" || name == "catch"
+	return parent != nil && isPromiseMemberCall(parent)
 }
 
 // isInsideTimeout mirrors eslint-plugin-promise's isInsideTimeout:

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.md
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.md
@@ -1,0 +1,65 @@
+# promise/no-callback-in-promise
+
+Disallow calling `cb()` inside of a `then()` (use `util.callbackify` instead).
+
+Mixing promise callbacks (`.then` / `.catch`) with Node.js-style error-first callbacks
+(`cb`, `callback`, `next`, `done`) makes control flow harder to reason about and is a
+common source of swallowed errors. This rule flags places where a callback is called or
+passed inside a promise handler.
+
+## Rule Details
+
+Examples of **incorrect** code:
+
+```js
+a.then(cb)
+a.then(() => cb())
+a.then(function(err) { cb(err) })
+a.catch(function(err) { callback(err) })
+```
+
+Examples of **correct** code:
+
+```js
+// callback outside a promise — fine
+function thing(cb) { cb() }
+
+// wrapped in a timeout (default: timeoutsErr is false)
+whatever.then((err) => { process.nextTick(() => cb()) })
+```
+
+## Options
+
+```json
+{
+  "promise/no-callback-in-promise": ["warn", {
+    "exceptions": [],
+    "timeoutsErr": false
+  }]
+}
+```
+
+### `exceptions`
+
+An array of callback names to exclude from the check.
+
+```js
+/* eslint promise/no-callback-in-promise: ["warn", { "exceptions": ["next"] }] */
+a.then(() => next())  // OK — "next" is excluded
+```
+
+### `timeoutsErr`
+
+When `true`, passing or calling a callback inside `setTimeout`, `setImmediate`,
+`requestAnimationFrame`, or `process.nextTick` that is itself inside a promise handler
+is also an error. Defaults to `false`.
+
+```js
+/* eslint promise/no-callback-in-promise: ["warn", { "timeoutsErr": true }] */
+whatever.then(() => { process.nextTick(() => cb()) })  // error
+whatever.then(() => process.nextTick(cb))              // error
+```
+
+## Differences from ESLint
+
+None. The rule behaves identically to the upstream `eslint-plugin-promise` implementation.

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise_extras_test.go
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise_extras_test.go
@@ -1,0 +1,223 @@
+package no_callback_in_promise_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_callback_in_promise"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoCallbackInPromiseExtras covers Layers 2 (edge-shape & real-user) and 3 (branch lock-ins).
+func TestNoCallbackInPromiseExtras(t *testing.T) {
+	e := func() rule_tester.InvalidTestCaseError {
+		return rule_tester.InvalidTestCaseError{MessageId: callbackMsgId, Message: callbackMessage}
+	}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_callback_in_promise.NoCallbackInPromiseRule,
+		[]rule_tester.ValidTestCase{
+
+			// ---- Dimension 4: Receiver / expression wrappers ----
+
+			// Parenthesized .then receiver — tsgo preserves parens as a node, upstream flattens them.
+			// isInsidePromise checks parent of the function, which is the .then() call. ✓
+			{Code: `(a).then(function() { return 1 })`},
+
+			// Computed member access — a['then'](cb) is NOT matched as a promise callback
+			// (callee is ElementAccessExpression, not PropertyAccessExpression).
+			// N/A for isInsidePromise: same structural reason.
+			{Code: `a['then'](cb)`},
+
+			// ---- Dimension 4: Parenthesized function arg ----
+
+			// tsgo represents (function(){}) as a ParenthesizedExpression wrapping FunctionExpression.
+			// isInsidePromise skips parens to reach the .then() call, so this IS flagged.
+			// (tested in invalid section)
+
+			// ---- Dimension 4: Optional chains ----
+
+			// Optional call on .then: a.then?.(cb) — QuestionDotToken on the CallExpression.
+			// getMemberCallName still returns "then" since Property name is still "then".
+			// Upstream ESTree would see the same property name.
+			{Code: `a.then?.(function() { return 1 })`},
+
+			// Optional chain on receiver: a?.then(function() {...}) still matches .then —
+			// property name is still "then". Valid because no callback is passed.
+			{Code: `a?.then(function() { return 1 })`},
+
+			// ---- Dimension 4: Callback not at first argument position ----
+
+			// cb is the second arg to .then — only first arg is checked for direct passing.
+			// Locks in upstream: name = node.arguments?.[0]?.name only looks at first arg.
+			{Code: `a.then(null, cb)`},
+
+			// ---- Dimension 4: Non-blacklist name passed to .then ----
+
+			// myHandler is not in cbBlacklist → valid.
+			// Locks in upstream Scenario A: CB_BLACKLIST.includes(name) === false path.
+			{Code: `a.then(myHandler)`},
+			{Code: `a.then(handler)`},
+			{Code: `a.then(resolve)`},
+
+			// ---- Dimension 4: Function declaration / class method boundaries ----
+
+			// Method declaration is not FunctionExpression/ArrowFunction — isInsidePromise
+			// correctly ignores it. But the outer function IS still a promise boundary:
+			// cb() inside a method inside a class inside a promise WILL be flagged because
+			// isInsidePromise checks ALL ancestors (not just the nearest function boundary).
+			// This is upstream-identical behavior. Lock in with a method that is NOT inside a
+			// promise handler to confirm non-flagging:
+			{Code: `class Foo { method() { cb() } }`},
+			{Code: `const o = { m() { cb() } }`},
+
+			// ---- Dimension 4: requestAnimationFrame in timeout whitelist ----
+
+			// requestAnimationFrame is in the whitelist — not flagged when timeoutsErr=false.
+			{Code: `whatever.then((err) => { requestAnimationFrame(() => cb()) })`},
+			{Code: `whatever.then((err) => requestAnimationFrame(cb))`},
+
+			// ---- Dimension 4: Graceful degradation — empty call, no args ----
+
+			// .then() with no args — no first argument, no report for Scenario A.
+			{Code: `a.then()`},
+
+			// ---- Dimension 4: Non-identifier first arg to .then ----
+
+			// Literal as first arg: not a callback name.
+			{Code: `a.then(42)`},
+			// Expression as first arg (not a plain identifier).
+			{Code: `a.then(arr[0])`},
+			// Arrow function as first arg — handled by isInsidePromise path, no direct-arg report.
+			{Code: `a.then(() => 1)`},
+
+			// ---- Dimension 4: timeoutsErr=false (default), non-named first arg ----
+
+			// Locks in upstream branch: !timeoutsErr → early return when NOT isPromiseMemberCall.
+			// Any call with non-callback callee inside a promise is OK without timeoutsErr.
+			{Code: `a.then(() => { foo(bar) })`},
+
+			// ---- Dimension 4: timeoutsErr=true, first arg without identifier ----
+
+			// Locks in upstream branch: !name → "Will be handled elsewhere" early return.
+			// setTimeout with a literal/expression arg inside promise should NOT be flagged.
+			{Code: `a.then(() => { foo(42) })`, Options: map[string]interface{}{"timeoutsErr": true}},
+			{Code: `a.then(() => { foo() })`, Options: map[string]interface{}{"timeoutsErr": true}},
+
+			// ---- Branch lock-ins (Layer 3) ----
+
+			// Locks in upstream isInsidePromise: function whose parent is NOT then/catch.
+			// cb() inside .map() callback — not inside a promise handler.
+			{Code: `a.map(function() { cb() })`},
+			{Code: `a.map(() => cb())`},
+			{Code: `a.finally(function() { cb() })`},
+
+			// Locks in upstream ancestor check FALSE: cb() at top level, no promise ancestor.
+			{Code: `cb()`},
+			{Code: `done()`},
+
+			// Locks in upstream: callback NOT in blacklist after applying exceptions.
+			{Code: `a.then(() => next())`, Options: map[string]interface{}{"exceptions": []interface{}{"next"}}},
+			{Code: `a.then(() => done())`, Options: map[string]interface{}{"exceptions": []interface{}{"done"}}},
+
+			// Locks in upstream valid: isCallback() = false AND isPromiseMemberCall() = false
+			// AND timeoutsErr = true AND name is defined BUT not inside any promise ancestor.
+			{Code: `setTimeout(callback)`, Options: map[string]interface{}{"timeoutsErr": true}},
+
+			// ---- Real-user: #572 — non-promise context with callback-shaped arg ----
+
+			// iterator.call(next, ...) outside a promise: not flagged.
+			{Code: `call(next, iterator)`},
+			// Same pattern inside a while loop that is NOT in a promise.
+			{Code: `while (cond) { call(next, iter) }`},
+		},
+		[]rule_tester.InvalidTestCase{
+
+			// ---- Dimension 4: Parenthesized function arg ----
+
+			// tsgo wraps (function(){}) as a ParenthesizedExpression; isInsidePromise
+			// must skip it to reach the .then() call.
+			{Code: `a.then((function(err) { cb(err) }))`,
+				Errors: []rule_tester.InvalidTestCaseError{e()}},
+
+			// ---- Dimension 4: Parenthesized callback callee ----
+
+			// (cb)() inside a promise handler — isCallbackCall must skip parens on callee.
+			{Code: `a.then(() => { (cb)() })`,
+				Errors: []rule_tester.InvalidTestCaseError{e()}},
+
+			// ---- Dimension 4: Parenthesized first arg to .then ----
+
+			// a.then((cb)) — in tsgo, Arguments.Nodes[0] is a ParenthesizedExpression.
+			// We skip outer expressions to reach the Identifier for the name check, but
+			// report the raw argument node (the ParenthesizedExpression).
+			{Code: `a.then((cb))`,
+				Errors: []rule_tester.InvalidTestCaseError{e()}},
+
+			// ---- Dimension 4: "done" and "next" as callback names ----
+
+			// Locks in cbBlacklist entries other than "cb"/"callback".
+			{Code: `a.then(done)`, Errors: []rule_tester.InvalidTestCaseError{e()}},
+			{Code: `a.then(next)`, Errors: []rule_tester.InvalidTestCaseError{e()}},
+			{Code: `a.then(() => done())`, Errors: []rule_tester.InvalidTestCaseError{e()}},
+			{Code: `a.then(() => next())`, Errors: []rule_tester.InvalidTestCaseError{e()}},
+
+			// ---- Dimension 4: .catch direct-arg case ----
+
+			{Code: `a.catch(cb)`, Errors: []rule_tester.InvalidTestCaseError{e()}},
+			{Code: `a.catch(done)`, Errors: []rule_tester.InvalidTestCaseError{e()}},
+
+			// ---- Dimension 4: Optional chain receiver, callback inside ----
+
+			// a?.then(() => cb()) — isInsidePromise still matches the arrow's parent (optional
+			// .then call), so cb() inside is still flagged.
+			{Code: `a?.then(() => cb())`,
+				Errors: []rule_tester.InvalidTestCaseError{e()}},
+
+			// ---- Dimension 4: requestAnimationFrame with timeoutsErr=true ----
+
+			// Locks in requestAnimationFrame as a whitelist entry for isInsideTimeout.
+			{Code: `whatever.then((err) => { requestAnimationFrame(() => cb()) })`,
+				Errors:  []rule_tester.InvalidTestCaseError{e()},
+				Options: map[string]interface{}{"timeoutsErr": true}},
+			{Code: `whatever.then((err) => requestAnimationFrame(cb))`,
+				Errors:  []rule_tester.InvalidTestCaseError{e()},
+				Options: map[string]interface{}{"timeoutsErr": true}},
+
+			// ---- Dimension 4: Method/class nested inside promise handler ----
+
+			// cb() inside a method declaration inside a class inside a promise handler.
+			// All ancestors are walked; the outer function expression (in .then()) triggers
+			// isInsidePromise, so cb() is flagged. (Upstream-identical behavior.)
+			{Code: `a.then(function() { class Foo { method() { cb() } } })`,
+				Errors: []rule_tester.InvalidTestCaseError{e()}},
+
+			// ---- Branch lock-ins (Layer 3) ----
+
+			// Locks in: isCallbackCall = false AND isPromiseMemberCall = false AND
+			// timeoutsErr = true AND name defined AND inside promise — ancestor check fires.
+			{Code: `a.then(() => { foo(callback) })`,
+				Errors:  []rule_tester.InvalidTestCaseError{e()},
+				Options: map[string]interface{}{"timeoutsErr": true}},
+
+			// Locks in: two different promise handlers in a chain both containing callbacks.
+			{Code: `a.then(() => cb()).catch(() => done())`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					e(),
+					e(),
+				}},
+
+			// ---- Real-user: chained promises with callback ----
+
+			// Deeper chain: a.then(...).then(() => cb()) — cb() is inside inner .then.
+			{Code: `a.then(() => 1).then(() => cb())`,
+				Errors: []rule_tester.InvalidTestCaseError{e()}},
+
+			// Real-user: passing cb as arg to inner .then while outer .then has no callback.
+			{Code: `outer.then(() => inner.then(cb))`,
+				Errors: []rule_tester.InvalidTestCaseError{e()}},
+		},
+	)
+}

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise_extras_test.go
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise_extras_test.go
@@ -132,6 +132,9 @@ func TestNoCallbackInPromiseExtras(t *testing.T) {
 			{Code: `call(next, iterator)`},
 			// Same pattern inside a while loop that is NOT in a promise.
 			{Code: `while (cond) { call(next, iter) }`},
+
+			// Top-level then should not be flagged (not a member expression)
+			{Code: `then(function() { cb() })`},
 		},
 		[]rule_tester.InvalidTestCase{
 

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise_extras_test.go
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise_extras_test.go
@@ -79,6 +79,10 @@ func TestNoCallbackInPromiseExtras(t *testing.T) {
 			{Code: `whatever.then((err) => { requestAnimationFrame(() => cb()) })`},
 			{Code: `whatever.then((err) => requestAnimationFrame(cb))`},
 
+			// Parenthesized whitelist callee — getMemberCallName must skip parens (like its
+			// sibling helpers) to still resolve "setTimeout", or the wrapped cb() is reported.
+			{Code: `promise.then(() => (setTimeout)(() => cb()))`},
+
 			// ---- Dimension 4: Graceful degradation — empty call, no args ----
 
 			// .then() with no args — no first argument, no report for Scenario A.
@@ -153,11 +157,11 @@ func TestNoCallbackInPromiseExtras(t *testing.T) {
 
 			// ---- Dimension 4: Parenthesized first arg to .then ----
 
-			// a.then((cb)) — in tsgo, Arguments.Nodes[0] is a ParenthesizedExpression.
-			// We skip outer expressions to reach the Identifier for the name check, but
-			// report the raw argument node (the ParenthesizedExpression).
+			// a.then((cb)) — in tsgo, Arguments.Nodes[0] is a ParenthesizedExpression. We
+			// skip outer expressions to reach the Identifier for both the name check and the
+			// reported node, so the report targets `cb` (column 9), not `(cb)` (column 8).
 			{Code: `a.then((cb))`,
-				Errors: []rule_tester.InvalidTestCaseError{e()}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: callbackMsgId, Message: callbackMessage, Column: 9}}},
 
 			// ---- Dimension 4: "done" and "next" as callback names ----
 

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise_upstream_test.go
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise_upstream_test.go
@@ -1,0 +1,130 @@
+package no_callback_in_promise_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_callback_in_promise"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const callbackMessage = "Avoid calling back inside of a promise."
+const callbackMsgId = "callback"
+
+func cbErr(col int) rule_tester.InvalidTestCaseError {
+	e := rule_tester.InvalidTestCaseError{MessageId: callbackMsgId, Message: callbackMessage}
+	if col > 0 {
+		e.Column = col
+	}
+	return e
+}
+
+// TestNoCallbackInPromiseUpstream migrates every valid/invalid case from the upstream
+// eslint-plugin-promise test file for no-callback-in-promise.
+func TestNoCallbackInPromiseUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_callback_in_promise.NoCallbackInPromiseRule,
+		[]rule_tester.ValidTestCase{
+			// ---- ESLint upstream valid cases ----
+			{Code: `function thing(cb) { cb() }`},
+			{Code: `doSomething(function(err) { cb(err) })`},
+			{Code: `function thing(callback) { callback() }`},
+			{Code: `doSomething(function(err) { callback(err) })`},
+
+			// Support safe callbacks (#220) — timeoutsErr defaults to false
+			{Code: `whatever.then((err) => { process.nextTick(() => cb()) })`},
+			{Code: `whatever.then((err) => { setImmediate(() => cb()) })`},
+			{Code: `whatever.then((err) => setImmediate(() => cb()))`},
+			{Code: `whatever.then((err) => process.nextTick(() => cb()))`},
+			{Code: `whatever.then((err) => process.nextTick(cb))`},
+			{Code: `whatever.then((err) => setImmediate(cb))`},
+
+			// Arrow functions and other things
+			{Code: `let thing = (cb) => cb()`},
+			{Code: `doSomething(err => cb(err))`},
+
+			// Exceptions option
+			{Code: `a.then(() => next())`, Options: map[string]interface{}{"exceptions": []interface{}{"next"}}},
+			{Code: `a.then(() => next()).catch((err) => next(err))`, Options: map[string]interface{}{"exceptions": []interface{}{"next"}}},
+			{Code: `a.then(next)`, Options: map[string]interface{}{"exceptions": []interface{}{"next"}}},
+			{Code: `a.then(next).catch(next)`, Options: map[string]interface{}{"exceptions": []interface{}{"next"}}},
+
+			// #572 — while-loop with next inside non-promise iterator call
+			{Code: `while (!(step = call(next, iterator)).done) {
+       if (result !== undefined) break;
+     }`},
+			// #572 comment — function with callback parameter used only as a regular argument
+			{Code: `function hasCallbackArg(callback) {
+       console.log(callback);
+     }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- ESLint upstream invalid cases ----
+
+			// cb directly passed to .then / .catch
+			{Code: `a.then(cb)`, Errors: []rule_tester.InvalidTestCaseError{cbErr(8)}},
+			{Code: `a.then(() => cb())`, Errors: []rule_tester.InvalidTestCaseError{cbErr(0)}},
+			{Code: `a.then(function(err) { cb(err) })`, Errors: []rule_tester.InvalidTestCaseError{cbErr(24)}},
+			{Code: `a.then(function(data) { cb(data) }, function(err) { cb(err) })`,
+				Errors: []rule_tester.InvalidTestCaseError{cbErr(25), cbErr(53)}},
+			{Code: `a.catch(function(err) { cb(err) })`, Errors: []rule_tester.InvalidTestCaseError{cbErr(0)}},
+
+			// "callback" name also flagged
+			{Code: `a.then(callback)`, Errors: []rule_tester.InvalidTestCaseError{cbErr(8)}},
+			{Code: `a.then(() => callback())`, Errors: []rule_tester.InvalidTestCaseError{cbErr(0)}},
+			{Code: `a.then(function(err) { callback(err) })`, Errors: []rule_tester.InvalidTestCaseError{cbErr(24)}},
+			{Code: `a.then(function(data) { callback(data) }, function(err) { callback(err) })`,
+				Errors: []rule_tester.InvalidTestCaseError{cbErr(0), cbErr(59)}},
+			{Code: `a.catch(function(err) { callback(err) })`, Errors: []rule_tester.InvalidTestCaseError{cbErr(0)}},
+
+			// #167 — timeoutsErr: true cases
+			{
+				Code: `
+        function wait (callback) {
+          return Promise.resolve()
+            .then(() => {
+              setTimeout(callback);
+            });
+        }
+      `,
+				Errors:  []rule_tester.InvalidTestCaseError{cbErr(0)},
+				Options: map[string]interface{}{"timeoutsErr": true},
+			},
+			{
+				Code: `
+        function wait (callback) {
+          return Promise.resolve()
+            .then(() => {
+              setTimeout(() => callback());
+            });
+        }
+      `,
+				Errors:  []rule_tester.InvalidTestCaseError{cbErr(0)},
+				Options: map[string]interface{}{"timeoutsErr": true},
+			},
+
+			// timeoutsErr: true — timeout functions inside promise handlers
+			{Code: `whatever.then((err) => { process.nextTick(() => cb()) })`,
+				Errors:  []rule_tester.InvalidTestCaseError{cbErr(0)},
+				Options: map[string]interface{}{"timeoutsErr": true}},
+			{Code: `whatever.then((err) => { setImmediate(() => cb()) })`,
+				Errors:  []rule_tester.InvalidTestCaseError{cbErr(0)},
+				Options: map[string]interface{}{"timeoutsErr": true}},
+			{Code: `whatever.then((err) => setImmediate(() => cb()))`,
+				Errors:  []rule_tester.InvalidTestCaseError{cbErr(0)},
+				Options: map[string]interface{}{"timeoutsErr": true}},
+			{Code: `whatever.then((err) => process.nextTick(() => cb()))`,
+				Errors:  []rule_tester.InvalidTestCaseError{cbErr(0)},
+				Options: map[string]interface{}{"timeoutsErr": true}},
+			{Code: `whatever.then((err) => process.nextTick(cb))`,
+				Errors:  []rule_tester.InvalidTestCaseError{cbErr(0)},
+				Options: map[string]interface{}{"timeoutsErr": true}},
+			{Code: `whatever.then((err) => setImmediate(cb))`,
+				Errors:  []rule_tester.InvalidTestCaseError{cbErr(0)},
+				Options: map[string]interface{}{"timeoutsErr": true}},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -505,6 +505,7 @@ export default defineConfig({
     './tests/eslint-plugin-promise/rules/always-return.test.ts',
     './tests/eslint-plugin-promise/rules/avoid-new.test.ts',
     './tests/eslint-plugin-promise/rules/catch-or-return.test.ts',
+    './tests/eslint-plugin-promise/rules/no-callback-in-promise.test.ts',
     './tests/eslint-plugin-promise/rules/no-multiple-resolved.test.ts',
     './tests/eslint-plugin-promise/rules/no-nesting.test.ts',
     './tests/eslint-plugin-promise/rules/no-new-statics.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/no-callback-in-promise.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/no-callback-in-promise.test.ts
@@ -1,0 +1,152 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const callbackMessage = 'Avoid calling back inside of a promise.';
+
+ruleTester.run('no-callback-in-promise', {} as never, {
+  valid: [
+    // ESLint upstream
+    { code: 'function thing(cb) { cb() }' },
+    { code: 'doSomething(function(err) { cb(err) })' },
+    { code: 'function thing(callback) { callback() }' },
+    { code: 'doSomething(function(err) { callback(err) })' },
+
+    // Support safe callbacks (#220)
+    { code: 'whatever.then((err) => { process.nextTick(() => cb()) })' },
+    { code: 'whatever.then((err) => { setImmediate(() => cb()) })' },
+    { code: 'whatever.then((err) => setImmediate(() => cb()))' },
+    { code: 'whatever.then((err) => process.nextTick(() => cb()))' },
+    { code: 'whatever.then((err) => process.nextTick(cb))' },
+    { code: 'whatever.then((err) => setImmediate(cb))' },
+
+    // Arrow functions and other things
+    { code: 'let thing = (cb) => cb()' },
+    { code: 'doSomething(err => cb(err))' },
+
+    // Exceptions option
+    { code: 'a.then(() => next())', options: [{ exceptions: ['next'] }] },
+    {
+      code: 'a.then(() => next()).catch((err) => next(err))',
+      options: [{ exceptions: ['next'] }],
+    },
+    { code: 'a.then(next)', options: [{ exceptions: ['next'] }] },
+    { code: 'a.then(next).catch(next)', options: [{ exceptions: ['next'] }] },
+
+    // #572
+    {
+      code: `while (!(step = call(next, iterator)).done) {
+       if (result !== undefined) break;
+     }`,
+    },
+    {
+      code: `function hasCallbackArg(callback) {
+       console.log(callback);
+     }`,
+    },
+  ],
+
+  invalid: [
+    // cb directly passed to .then / .catch
+    {
+      code: 'a.then(cb)',
+      errors: [{ message: callbackMessage }],
+    },
+    {
+      code: 'a.then(() => cb())',
+      errors: [{ message: callbackMessage }],
+    },
+    {
+      code: 'a.then(function(err) { cb(err) })',
+      errors: [{ message: callbackMessage }],
+    },
+    {
+      code: 'a.then(function(data) { cb(data) }, function(err) { cb(err) })',
+      errors: [{ message: callbackMessage }, { message: callbackMessage }],
+    },
+    {
+      code: 'a.catch(function(err) { cb(err) })',
+      errors: [{ message: callbackMessage }],
+    },
+
+    // "callback" name also flagged
+    {
+      code: 'a.then(callback)',
+      errors: [{ message: callbackMessage }],
+    },
+    {
+      code: 'a.then(() => callback())',
+      errors: [{ message: callbackMessage }],
+    },
+    {
+      code: 'a.then(function(err) { callback(err) })',
+      errors: [{ message: callbackMessage }],
+    },
+    {
+      code: 'a.then(function(data) { callback(data) }, function(err) { callback(err) })',
+      errors: [{ message: callbackMessage }, { message: callbackMessage }],
+    },
+    {
+      code: 'a.catch(function(err) { callback(err) })',
+      errors: [{ message: callbackMessage }],
+    },
+
+    // #167 — timeoutsErr: true cases
+    {
+      code: `
+        function wait (callback) {
+          return Promise.resolve()
+            .then(() => {
+              setTimeout(callback);
+            });
+        }
+      `,
+      errors: [{ message: callbackMessage }],
+      options: [{ timeoutsErr: true }],
+    },
+    {
+      code: `
+        function wait (callback) {
+          return Promise.resolve()
+            .then(() => {
+              setTimeout(() => callback());
+            });
+        }
+      `,
+      errors: [{ message: callbackMessage }],
+      options: [{ timeoutsErr: true }],
+    },
+
+    // timeoutsErr: true — timeout functions inside promise handlers
+    {
+      code: 'whatever.then((err) => { process.nextTick(() => cb()) })',
+      errors: [{ message: callbackMessage }],
+      options: [{ timeoutsErr: true }],
+    },
+    {
+      code: 'whatever.then((err) => { setImmediate(() => cb()) })',
+      errors: [{ message: callbackMessage }],
+      options: [{ timeoutsErr: true }],
+    },
+    {
+      code: 'whatever.then((err) => setImmediate(() => cb()))',
+      errors: [{ message: callbackMessage }],
+      options: [{ timeoutsErr: true }],
+    },
+    {
+      code: 'whatever.then((err) => process.nextTick(() => cb()))',
+      errors: [{ message: callbackMessage }],
+      options: [{ timeoutsErr: true }],
+    },
+    {
+      code: 'whatever.then((err) => process.nextTick(cb))',
+      errors: [{ message: callbackMessage }],
+      options: [{ timeoutsErr: true }],
+    },
+    {
+      code: 'whatever.then((err) => setImmediate(cb))',
+      errors: [{ message: callbackMessage }],
+      options: [{ timeoutsErr: true }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -53,6 +53,7 @@ bref
 brefs
 Buttom
 cachedvfs
+callbackify
 callees
 callsite
 callsites


### PR DESCRIPTION
## Summary

Added `promise/no-callback-in-promise` rule for #474.

This is rule is quite brute force, that only checks callback functions named as `callback`, `cb`, `next` and `done`.

## Related Links

[original docs](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-callback-in-promise.md)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
