### PR TITLE
feat: add promise/no-return-in-finally rule

### DIFF
--- a/internal/plugins/promise/all.go
+++ b/internal/plugins/promise/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_multiple_resolved"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_nesting"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_new_statics"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_in_finally"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_wrap"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/param_names"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/valid_params"
@@ -21,6 +22,7 @@ func GetAllRules() []rule.Rule {
 		no_multiple_resolved.NoMultipleResolvedRule,
 		no_nesting.NoNestingRule,
 		no_new_statics.NoNewStaticsRule,
+		no_return_in_finally.NoReturnInFinallyRule,
 		no_return_wrap.NoReturnWrapRule,
 		param_names.ParamNamesRule,
 		valid_params.ValidParamsRule,

--- a/internal/plugins/promise/promiseutil/promiseutil.go
+++ b/internal/plugins/promise/promiseutil/promiseutil.go
@@ -55,26 +55,6 @@ func IsPromiseStatic(name string) bool {
 	}
 }
 
-// NearestFunctionBoundary returns the closest ancestor of node that is a
-// function-like declaration or expression, or nil if none exists. It stops at
-// function expressions, arrow functions, method declarations, getters, setters,
-// and constructors — the same boundaries used by eslint-plugin-promise rules.
-func NearestFunctionBoundary(node *ast.Node) *ast.Node {
-	for cur := node.Parent; cur != nil; cur = cur.Parent {
-		switch cur.Kind {
-		case ast.KindFunctionExpression,
-			ast.KindFunctionDeclaration,
-			ast.KindArrowFunction,
-			ast.KindMethodDeclaration,
-			ast.KindGetAccessor,
-			ast.KindSetAccessor,
-			ast.KindConstructor:
-			return cur
-		}
-	}
-	return nil
-}
-
 // IsMemberCallWithObjectName mirrors eslint-plugin-promise's lib/is-member-call-with-object-name.
 // It reports whether node is a call expression whose callee's root object is an identifier
 // named objectName, following the member chain recursively.

--- a/internal/plugins/promise/promiseutil/promiseutil.go
+++ b/internal/plugins/promise/promiseutil/promiseutil.go
@@ -63,6 +63,7 @@ func NearestFunctionBoundary(node *ast.Node) *ast.Node {
 	for cur := node.Parent; cur != nil; cur = cur.Parent {
 		switch cur.Kind {
 		case ast.KindFunctionExpression,
+			ast.KindFunctionDeclaration,
 			ast.KindArrowFunction,
 			ast.KindMethodDeclaration,
 			ast.KindGetAccessor,

--- a/internal/plugins/promise/promiseutil/promiseutil.go
+++ b/internal/plugins/promise/promiseutil/promiseutil.go
@@ -55,6 +55,25 @@ func IsPromiseStatic(name string) bool {
 	}
 }
 
+// NearestFunctionBoundary returns the closest ancestor of node that is a
+// function-like declaration or expression, or nil if none exists. It stops at
+// function expressions, arrow functions, method declarations, getters, setters,
+// and constructors — the same boundaries used by eslint-plugin-promise rules.
+func NearestFunctionBoundary(node *ast.Node) *ast.Node {
+	for cur := node.Parent; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindFunctionExpression,
+			ast.KindArrowFunction,
+			ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor,
+			ast.KindConstructor:
+			return cur
+		}
+	}
+	return nil
+}
+
 // IsMemberCallWithObjectName mirrors eslint-plugin-promise's lib/is-member-call-with-object-name.
 // It reports whether node is a call expression whose callee's root object is an identifier
 // named objectName, following the member chain recursively.

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.go
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.go
@@ -1,0 +1,43 @@
+package no_return_in_finally
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/promiseutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const skipTransparent = ast.OEKParentheses
+
+func buildMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noReturnInFinally",
+		Description: "No return in finally",
+	}
+}
+
+// isFinallyCallback reports whether fn is directly passed as a callback to a
+// .finally() call. Parentheses around fn are skipped.
+func isFinallyCallback(fn *ast.Node) bool {
+	parent := fn.Parent
+	for parent != nil && ast.IsOuterExpression(parent, skipTransparent) {
+		parent = parent.Parent
+	}
+	return parent != nil && promiseutil.IsMemberCall(parent, "finally")
+}
+
+var NoReturnInFinallyRule = rule.Rule{
+	Name: "promise/no-return-in-finally",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindReturnStatement: func(node *ast.Node) {
+				fn := promiseutil.NearestFunctionBoundary(node)
+				if fn == nil {
+					return
+				}
+				if isFinallyCallback(fn) {
+					ctx.ReportNode(node, buildMessage())
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.go
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.go
@@ -15,60 +15,45 @@ func buildMessage() rule.RuleMessage {
 	}
 }
 
-// isFinallyCallback reports whether fn is directly passed as a callback to a
-// .finally() call. Parentheses around fn are skipped.
-func isFinallyCallback(fn *ast.Node) bool {
-	parent := fn.Parent
-	for parent != nil && ast.IsOuterExpression(parent, skipTransparent) {
-		parent = parent.Parent
+// callbackBody returns the block body of a .finally() callback, or nil if fn
+// isn't a function/arrow expression with a block body. Upstream only ever
+// sees FunctionExpression/ArrowFunctionExpression here, since fn comes
+// straight from the call's first argument.
+func callbackBody(fn *ast.Node) *ast.Node {
+	switch fn.Kind {
+	case ast.KindFunctionExpression:
+		return fn.AsFunctionExpression().Body
+	case ast.KindArrowFunction:
+		return fn.AsArrowFunction().Body
+	default:
+		return nil
 	}
-	if parent == nil || !promiseutil.IsMemberCall(parent, "finally") {
-		return false
-	}
-	callExpr := parent.AsCallExpression()
-	if callExpr.Arguments == nil || len(callExpr.Arguments.Nodes) == 0 {
-		return false
-	}
-	firstArg := ast.SkipOuterExpressions(callExpr.Arguments.Nodes[0], skipTransparent)
-	unwrappedFn := ast.SkipOuterExpressions(fn, skipTransparent)
-	return unwrappedFn == firstArg
 }
 
 var NoReturnInFinallyRule = rule.Rule{
 	Name: "promise/no-return-in-finally",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		return rule.RuleListeners{
-			ast.KindReturnStatement: func(node *ast.Node) {
-				fn := promiseutil.NearestFunctionBoundary(node)
-				if fn == nil {
+			ast.KindCallExpression: func(node *ast.Node) {
+				if !promiseutil.IsMemberCall(node, "finally") {
 					return
 				}
-				if isFinallyCallback(fn) {
-					var body *ast.Node
-					switch fn.Kind {
-					case ast.KindFunctionExpression:
-						body = fn.AsFunctionExpression().Body
-					case ast.KindFunctionDeclaration:
-						body = fn.AsFunctionDeclaration().Body
-					case ast.KindMethodDeclaration:
-						body = fn.AsMethodDeclaration().Body
-					case ast.KindGetAccessor:
-						body = fn.AsGetAccessorDeclaration().Body
-					case ast.KindSetAccessor:
-						body = fn.AsSetAccessorDeclaration().Body
-					case ast.KindConstructor:
-						body = fn.AsConstructorDeclaration().Body
-					case ast.KindArrowFunction:
-						body = fn.AsArrowFunction().Body
-					}
-					
-					// ESLint's promise/no-return-in-finally rule only checks top-level statements
-					// in the function's block body. It ignores nested returns.
-					if body != nil && body.Kind == ast.KindBlock {
-						if node.Parent != body {
-							return
-						}
-						ctx.ReportNode(node, buildMessage())
+				call := node.AsCallExpression()
+				if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+					return
+				}
+				fn := ast.SkipOuterExpressions(call.Arguments.Nodes[0], skipTransparent)
+				body := callbackBody(fn)
+				if body == nil || body.Kind != ast.KindBlock {
+					return
+				}
+				// Mirrors upstream's body.body.some(...): only the callback's
+				// direct top-level statements count; nested returns don't.
+				for _, stmt := range body.AsBlock().Statements.Nodes {
+					if stmt.Kind == ast.KindReturnStatement {
+						callee := ast.SkipOuterExpressions(call.Expression, skipTransparent)
+						ctx.ReportNode(callee.AsPropertyAccessExpression().Name(), buildMessage())
+						return
 					}
 				}
 			},

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.go
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.go
@@ -22,7 +22,16 @@ func isFinallyCallback(fn *ast.Node) bool {
 	for parent != nil && ast.IsOuterExpression(parent, skipTransparent) {
 		parent = parent.Parent
 	}
-	return parent != nil && promiseutil.IsMemberCall(parent, "finally")
+	if parent == nil || !promiseutil.IsMemberCall(parent, "finally") {
+		return false
+	}
+	callExpr := parent.AsCallExpression()
+	if callExpr.Arguments == nil || len(callExpr.Arguments.Nodes) == 0 {
+		return false
+	}
+	firstArg := ast.SkipOuterExpressions(callExpr.Arguments.Nodes[0], skipTransparent)
+	unwrappedFn := ast.SkipOuterExpressions(fn, skipTransparent)
+	return unwrappedFn == firstArg
 }
 
 var NoReturnInFinallyRule = rule.Rule{
@@ -35,7 +44,32 @@ var NoReturnInFinallyRule = rule.Rule{
 					return
 				}
 				if isFinallyCallback(fn) {
-					ctx.ReportNode(node, buildMessage())
+					var body *ast.Node
+					switch fn.Kind {
+					case ast.KindFunctionExpression:
+						body = fn.AsFunctionExpression().Body
+					case ast.KindFunctionDeclaration:
+						body = fn.AsFunctionDeclaration().Body
+					case ast.KindMethodDeclaration:
+						body = fn.AsMethodDeclaration().Body
+					case ast.KindGetAccessor:
+						body = fn.AsGetAccessorDeclaration().Body
+					case ast.KindSetAccessor:
+						body = fn.AsSetAccessorDeclaration().Body
+					case ast.KindConstructor:
+						body = fn.AsConstructorDeclaration().Body
+					case ast.KindArrowFunction:
+						body = fn.AsArrowFunction().Body
+					}
+					
+					// ESLint's promise/no-return-in-finally rule only checks top-level statements
+					// in the function's block body. It ignores nested returns.
+					if body != nil && body.Kind == ast.KindBlock {
+						if node.Parent != body {
+							return
+						}
+						ctx.ReportNode(node, buildMessage())
+					}
 				}
 			},
 		}

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.md
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.md
@@ -1,0 +1,31 @@
+# promise/no-return-in-finally
+
+Disallow return statements inside a callback passed to `.finally()`, since nothing would consume what's returned.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+myPromise.finally(function (val) {
+  return val
+})
+
+myPromise.finally(() => {
+  return 2
+})
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+myPromise.finally(function (val) {
+  console.log('value:', val)
+})
+
+myPromise.finally(() => {})
+```
+
+## Original Documentation
+
+https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-return-in-finally.md

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.md
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.md
@@ -29,3 +29,11 @@ myPromise.finally(() => {})
 ## Original Documentation
 
 https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-return-in-finally.md
+
+## ESLint Parity and Compatibility
+
+To align with the behavior of `eslint-plugin-promise`'s `no-return-in-finally` rule, the following behaviors are intentionally preserved:
+
+1. **Nested Return Statements**: ESLint's rule only checks top-level statements directly inside the finally callback's block body. It ignores nested return statements (e.g., inside an `if` statement block, a `try/catch` block, or any nested block). rslint mirrors this behavior and only flags top-level returns directly under the main function body block.
+2. **Implicit Arrow Returns**: ESLint does not flag implicit returns in arrow functions without a block body (e.g., `promise.finally(() => 2)`). rslint also does not flag these implicit returns.
+

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally_extras_test.go
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally_extras_test.go
@@ -1,0 +1,131 @@
+// TestNoReturnInFinallyExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+package no_return_in_finally_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_in_finally"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoReturnInFinallyExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_return_in_finally.NoReturnInFinallyRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: nesting / traversal boundary ----
+			// Return inside a nested function inside finally callback: only the
+			// directly passed function is checked; inner function is a separate
+			// function boundary.
+			{Code: `myPromise.finally(function() { var f = function() { return 2; }; f(); })`},
+			// Return inside a method inside finally callback: method creates
+			// its own function boundary, not attributed to finally callback.
+			{Code: `myPromise.finally(function() { class C { m() { return 2; } } })`},
+			// Return inside getter inside finally callback.
+			{Code: `myPromise.finally(function() { class C { get x() { return 2; } } })`},
+			// Return inside setter inside finally callback.
+			{Code: `myPromise.finally(function() { class C { set x(v) { return v; } } })`},
+			// Return inside constructor inside finally callback.
+			{Code: `myPromise.finally(function() { class C { constructor() { return; } } })`},
+			// Arrow function with expression body (no explicit return): valid.
+			// N/A for return-statement analysis since expression body has no ReturnStatement.
+			{Code: `myPromise.finally(() => 2)`},
+
+			// ---- Dimension 4: access / key forms ----
+			// Computed access: promise['finally'](fn) is NOT matched by IsMemberCall.
+			// N/A: IsMemberCall only checks PropertyAccessExpression (dotted access).
+			{Code: `myPromise['finally'](() => { return 2 })`},
+
+			// ---- Dimension 4: receiver / expression wrappers ----
+			// No function boundary above return: return at top level is not inside
+			// any function → no report. N/A: ReturnStatement at module level is a
+			// parse error; covered implicitly since no listener fires.
+
+			// ---- Locks in upstream isFinallyCallback() arm: no function boundary ----
+			// A return not inside any function produces no error.
+			// (The rule listener fires only on ReturnStatement nodes; if
+			// NearestFunctionBoundary returns nil the check exits early.)
+			{Code: `var x = 1`},
+
+			// ---- Locks in upstream isFinallyCallback() arm: non-finally callee ----
+			// Return inside a .then() callback is not a finally callback.
+			{Code: `myPromise.then(function() { return 2; })`},
+			// Return inside a .catch() callback is not a finally callback.
+			{Code: `myPromise.catch(function() { return 2; })`},
+			// Return inside a plain function call is not a finally callback.
+			{Code: `doThing(function() { return 2; })`},
+			// Return inside a function declaration is not inside any finally callback.
+			{Code: `function foo() { return 2; }`},
+
+			// ---- Real-user: cleanup without returning ----
+			// Common pattern: side-effect only in finally, no return.
+			{Code: `fetch('/api').finally(function() { cleanup(); })`},
+			// Chained promise with finally doing side-effects only.
+			{Code: `Promise.resolve(1).then(fn).finally(() => { console.log('done'); })`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: receiver / expression wrappers (invalid) ----
+			// Parenthesized callback must still be flagged (SkipOuterExpressions).
+			{
+				Code:   `myPromise.finally((function() { return 2; }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 33}},
+			},
+			// Double parens around callback.
+			{
+				Code:   `myPromise.finally(((function() { return 2; })))`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 34}},
+			},
+			// Parenthesized arrow function.
+			{
+				Code:   `myPromise.finally((() => { return 2; }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 28}},
+			},
+
+			// ---- Dimension 4: optional chain on the callee ----
+			// Optional-chain finally: promise?.finally(fn). tsgo represents ?. as
+			// a QuestionDotToken flag on the CallExpression; IsMemberCall checks
+			// PropertyAccessExpression name which still matches.
+			{
+				Code:   `myPromise?.finally(() => { return 2 })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 28}},
+			},
+
+			// ---- Dimension 4: declaration / container forms ----
+			// Async function expression callback.
+			{
+				Code:   `myPromise.finally(async function() { return 2; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 38}},
+			},
+			// Named function expression callback.
+			{
+				Code:   `myPromise.finally(function cleanup() { return 2; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 40}},
+			},
+
+			// ---- Dimension 4: nesting / traversal boundary ----
+			// Return in outer function is flagged; inner function's return is not.
+			{
+				Code:   `myPromise.finally(function() { var f = function() { return 2; }; return 3; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 66}},
+			},
+
+			// ---- Real-user: return in multiline finally callback ----
+			{
+				Code: `
+fetch('/api')
+  .then(process)
+  .finally(function() {
+    return cleanup();
+  });`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 5}},
+			},
+		},
+	)
+}

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally_extras_test.go
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally_extras_test.go
@@ -38,6 +38,16 @@ func TestNoReturnInFinallyExtras(t *testing.T) {
 			// N/A for return-statement analysis since expression body has no ReturnStatement.
 			{Code: `myPromise.finally(() => 2)`},
 
+			// Nested FunctionDeclaration creates its own function boundary;
+			// returns inside the declaration are ignored by the rule.
+
+			// Ensure the callback is only checked when it is the first argument of finally()
+			{Code: `Promise.finally(arg1, () => { return 1; })`},
+
+			// Ensure only top-level returns in the function's block are checked (ESLint parity).
+			{Code: `Promise.finally(() => { if (true) { return 1; } })`},
+			{Code: `Promise.finally(() => { try { return 1; } catch(e) {} })`},
+
 			// ---- Dimension 4: access / key forms ----
 			// Computed access: promise['finally'](fn) is NOT matched by IsMemberCall.
 			// N/A: IsMemberCall only checks PropertyAccessExpression (dotted access).
@@ -114,6 +124,16 @@ func TestNoReturnInFinallyExtras(t *testing.T) {
 			{
 				Code:   `myPromise.finally(function() { var f = function() { return 2; }; return 3; })`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 66}},
+			},
+			// FunctionDeclaration boundary: outer return is flagged, inner return is ignored.
+			{
+				Code:   `myPromise.finally(() => { function a() { return 1; } return a(); })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg}},
+			},
+			// Empty returns at the top level should still be caught.
+			{
+				Code:   `Promise.finally(() => { return; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg}},
 			},
 
 			// ---- Real-user: return in multiline finally callback ----

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally_extras_test.go
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally_extras_test.go
@@ -22,11 +22,11 @@ func TestNoReturnInFinallyExtras(t *testing.T) {
 		[]rule_tester.ValidTestCase{
 			// ---- Dimension 4: nesting / traversal boundary ----
 			// Return inside a nested function inside finally callback: only the
-			// directly passed function is checked; inner function is a separate
-			// function boundary.
+			// callback's own direct top-level statements are scanned, so the
+			// inner function's return is not seen.
 			{Code: `myPromise.finally(function() { var f = function() { return 2; }; f(); })`},
-			// Return inside a method inside finally callback: method creates
-			// its own function boundary, not attributed to finally callback.
+			// Return inside a method inside finally callback: the callback's
+			// direct statement is a class declaration, not a return.
 			{Code: `myPromise.finally(function() { class C { m() { return 2; } } })`},
 			// Return inside getter inside finally callback.
 			{Code: `myPromise.finally(function() { class C { get x() { return 2; } } })`},
@@ -37,9 +37,6 @@ func TestNoReturnInFinallyExtras(t *testing.T) {
 			// Arrow function with expression body (no explicit return): valid.
 			// N/A for return-statement analysis since expression body has no ReturnStatement.
 			{Code: `myPromise.finally(() => 2)`},
-
-			// Nested FunctionDeclaration creates its own function boundary;
-			// returns inside the declaration are ignored by the rule.
 
 			// Ensure the callback is only checked when it is the first argument of finally()
 			{Code: `Promise.finally(arg1, () => { return 1; })`},
@@ -54,17 +51,17 @@ func TestNoReturnInFinallyExtras(t *testing.T) {
 			{Code: `myPromise['finally'](() => { return 2 })`},
 
 			// ---- Dimension 4: receiver / expression wrappers ----
-			// No function boundary above return: return at top level is not inside
+			// No `.finally()` call at all: return at top level is not inside
 			// any function → no report. N/A: ReturnStatement at module level is a
 			// parse error; covered implicitly since no listener fires.
 
-			// ---- Locks in upstream isFinallyCallback() arm: no function boundary ----
-			// A return not inside any function produces no error.
-			// (The rule listener fires only on ReturnStatement nodes; if
-			// NearestFunctionBoundary returns nil the check exits early.)
+			// ---- Locks in IsMemberCall(node, "finally") gate: no .finally() call ----
+			// A return not inside any .finally() callback produces no error.
+			// (The rule listener fires on CallExpression and exits early unless
+			// IsMemberCall(node, "finally") matches.)
 			{Code: `var x = 1`},
 
-			// ---- Locks in upstream isFinallyCallback() arm: non-finally callee ----
+			// ---- Locks in IsMemberCall(node, "finally") gate: non-finally callee ----
 			// Return inside a .then() callback is not a finally callback.
 			{Code: `myPromise.then(function() { return 2; })`},
 			// Return inside a .catch() callback is not a finally callback.
@@ -85,17 +82,17 @@ func TestNoReturnInFinallyExtras(t *testing.T) {
 			// Parenthesized callback must still be flagged (SkipOuterExpressions).
 			{
 				Code:   `myPromise.finally((function() { return 2; }))`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 33}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 11}},
 			},
 			// Double parens around callback.
 			{
 				Code:   `myPromise.finally(((function() { return 2; })))`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 34}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 11}},
 			},
 			// Parenthesized arrow function.
 			{
 				Code:   `myPromise.finally((() => { return 2; }))`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 28}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 11}},
 			},
 
 			// ---- Dimension 4: optional chain on the callee ----
@@ -104,36 +101,46 @@ func TestNoReturnInFinallyExtras(t *testing.T) {
 			// PropertyAccessExpression name which still matches.
 			{
 				Code:   `myPromise?.finally(() => { return 2 })`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 28}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 12}},
 			},
 
 			// ---- Dimension 4: declaration / container forms ----
 			// Async function expression callback.
 			{
 				Code:   `myPromise.finally(async function() { return 2; })`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 38}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 11}},
 			},
 			// Named function expression callback.
 			{
 				Code:   `myPromise.finally(function cleanup() { return 2; })`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 40}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 11}},
 			},
 
 			// ---- Dimension 4: nesting / traversal boundary ----
-			// Return in outer function is flagged; inner function's return is not.
+			// Outer return is a direct top-level statement and is flagged;
+			// the inner function's return is not a top-level statement of the
+			// callback, so it's ignored. Reports once on `.finally`, not on
+			// either return.
 			{
 				Code:   `myPromise.finally(function() { var f = function() { return 2; }; return 3; })`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 66}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 11}},
 			},
-			// FunctionDeclaration boundary: outer return is flagged, inner return is ignored.
+			// FunctionDeclaration's return isn't a top-level statement of the
+			// callback either; the outer return still flags the call once.
 			{
 				Code:   `myPromise.finally(() => { function a() { return 1; } return a(); })`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 11}},
 			},
 			// Empty returns at the top level should still be caught.
 			{
 				Code:   `Promise.finally(() => { return; })`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 9}},
+			},
+			// Multiple top-level returns still produce a single report (upstream
+			// uses .some(), not .forEach()).
+			{
+				Code:   `myPromise.finally(() => { return 1; return 2; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 11}},
 			},
 
 			// ---- Real-user: return in multiline finally callback ----
@@ -144,7 +151,7 @@ fetch('/api')
   .finally(function() {
     return cleanup();
   });`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 5}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 4, Column: 4}},
 			},
 		},
 	)

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally_upstream_test.go
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally_upstream_test.go
@@ -32,19 +32,19 @@ func TestNoReturnInFinallyUpstream(t *testing.T) {
 			// ---- invalid: return inside finally callback ----
 			{
 				Code:   `Promise.resolve(1).finally(() => { return 2 })`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 36}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 20}},
 			},
 			{
 				Code:   `Promise.reject(0).finally(() => { return 2 })`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 35}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 19}},
 			},
 			{
 				Code:   `myPromise.finally(() => { return 2 });`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 27}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 11}},
 			},
 			{
 				Code:   `Promise.resolve(1).finally(function () { return 2 })`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 42}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 20}},
 			},
 		},
 	)

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally_upstream_test.go
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally_upstream_test.go
@@ -1,0 +1,51 @@
+// TestNoReturnInFinallyUpstream migrates the full valid/invalid suite from
+// upstream __tests__/no-return-in-finally.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// the no_return_in_finally_extras_test.go file.
+package no_return_in_finally_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_in_finally"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const noReturnMsg = "No return in finally"
+
+func TestNoReturnInFinallyUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_return_in_finally.NoReturnInFinallyRule,
+		[]rule_tester.ValidTestCase{
+			// ---- valid: no return in finally callback ----
+			{Code: `Promise.resolve(1).finally(() => { console.log(2) })`},
+			{Code: `Promise.reject(4).finally(() => { console.log(2) })`},
+			{Code: `Promise.reject(4).finally(() => {})`},
+			{Code: `myPromise.finally(() => {});`},
+			{Code: `Promise.resolve(1).finally(function () { })`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- invalid: return inside finally callback ----
+			{
+				Code:   `Promise.resolve(1).finally(() => { return 2 })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 36}},
+			},
+			{
+				Code:   `Promise.reject(0).finally(() => { return 2 })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 35}},
+			},
+			{
+				Code:   `myPromise.finally(() => { return 2 });`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 27}},
+			},
+			{
+				Code:   `Promise.resolve(1).finally(function () { return 2 })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReturnInFinally", Message: noReturnMsg, Line: 1, Column: 42}},
+			},
+		},
+	)
+}

--- a/internal/plugins/promise/rules/no_return_wrap/no_return_wrap.go
+++ b/internal/plugins/promise/rules/no_return_wrap/no_return_wrap.go
@@ -74,7 +74,7 @@ func checkCallExpression(ctx rule.RuleContext, opts Options, callNode *ast.Node,
 }
 
 func isInPromise(node *ast.Node) bool {
-	functionNode := promiseutil.NearestFunctionBoundary(node)
+	functionNode := nearestFunctionBoundary(node)
 	if functionNode == nil {
 		return false
 	}
@@ -108,6 +108,26 @@ func isInPromise(node *ast.Node) bool {
 		cur = cur.Parent
 	}
 	return cur != nil && promiseutil.IsPromiseLikeCall(cur)
+}
+
+// nearestFunctionBoundary mirrors eslint-plugin-promise's no-return-wrap,
+// which only considers ArrowFunctionExpression/FunctionExpression ancestors
+// (filtering out FunctionDeclaration) when locating the enclosing function.
+// This differs from promiseutil.NearestFunctionBoundary, which is shared with
+// no-return-in-finally and does include FunctionDeclaration.
+func nearestFunctionBoundary(node *ast.Node) *ast.Node {
+	for cur := node.Parent; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindFunctionExpression,
+			ast.KindArrowFunction,
+			ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor,
+			ast.KindConstructor:
+			return cur
+		}
+	}
+	return nil
 }
 
 func isExpressionBodyArrowCall(node *ast.Node) bool {

--- a/internal/plugins/promise/rules/no_return_wrap/no_return_wrap.go
+++ b/internal/plugins/promise/rules/no_return_wrap/no_return_wrap.go
@@ -74,7 +74,7 @@ func checkCallExpression(ctx rule.RuleContext, opts Options, callNode *ast.Node,
 }
 
 func isInPromise(node *ast.Node) bool {
-	functionNode := nearestFunctionBoundary(node)
+	functionNode := promiseutil.NearestFunctionBoundary(node)
 	if functionNode == nil {
 		return false
 	}
@@ -108,21 +108,6 @@ func isInPromise(node *ast.Node) bool {
 		cur = cur.Parent
 	}
 	return cur != nil && promiseutil.IsPromiseLikeCall(cur)
-}
-
-func nearestFunctionBoundary(node *ast.Node) *ast.Node {
-	for cur := node.Parent; cur != nil; cur = cur.Parent {
-		switch cur.Kind {
-		case ast.KindFunctionExpression,
-			ast.KindArrowFunction,
-			ast.KindMethodDeclaration,
-			ast.KindGetAccessor,
-			ast.KindSetAccessor,
-			ast.KindConstructor:
-			return cur
-		}
-	}
-	return nil
 }
 
 func isExpressionBodyArrowCall(node *ast.Node) bool {

--- a/internal/plugins/promise/rules/no_return_wrap/no_return_wrap.go
+++ b/internal/plugins/promise/rules/no_return_wrap/no_return_wrap.go
@@ -113,8 +113,6 @@ func isInPromise(node *ast.Node) bool {
 // nearestFunctionBoundary mirrors eslint-plugin-promise's no-return-wrap,
 // which only considers ArrowFunctionExpression/FunctionExpression ancestors
 // (filtering out FunctionDeclaration) when locating the enclosing function.
-// This differs from promiseutil.NearestFunctionBoundary, which is shared with
-// no-return-in-finally and does include FunctionDeclaration.
 func nearestFunctionBoundary(node *ast.Node) *ast.Node {
 	for cur := node.Parent; cur != nil; cur = cur.Parent {
 		switch cur.Kind {

--- a/internal/plugins/promise/rules/no_return_wrap/no_return_wrap_test.go
+++ b/internal/plugins/promise/rules/no_return_wrap/no_return_wrap_test.go
@@ -189,6 +189,18 @@ func TestNoReturnWrap(t *testing.T) {
 			{Code: `doThing().catch((function() { return Promise.reject(4) }))`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "reject", Message: rejectMessage}}},
 			// Chained bind + outer parens.
 			{Code: `doThing().then(((function() { return Promise.resolve(4) }).bind(this).bind(this)))`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "resolve", Message: resolveMessage}}},
+
+			// ---- Regression: nested FunctionDeclaration must not be treated as the
+			// boundary; upstream filters ancestors to arrow/function expressions only,
+			// so this still resolves to the promise callback and reports. ----
+			{Code: `
+      Promise.resolve().then(function () {
+        function helper() {
+          return Promise.resolve(4);
+        }
+        return helper();
+      });
+      `, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "resolve", Message: resolveMessage, Line: 4}}},
 		},
 	)
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -508,6 +508,7 @@ export default defineConfig({
     './tests/eslint-plugin-promise/rules/no-multiple-resolved.test.ts',
     './tests/eslint-plugin-promise/rules/no-nesting.test.ts',
     './tests/eslint-plugin-promise/rules/no-new-statics.test.ts',
+    './tests/eslint-plugin-promise/rules/no-return-in-finally.test.ts',
     './tests/eslint-plugin-promise/rules/no-return-wrap.test.ts',
     './tests/eslint-plugin-promise/rules/param-names.test.ts',
     './tests/eslint-plugin-promise/rules/valid-params.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/no-return-in-finally.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/no-return-in-finally.test.ts
@@ -1,0 +1,36 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const noReturnMsg = 'No return in finally';
+
+ruleTester.run('no-return-in-finally', {} as never, {
+  valid: [
+    // ESLint upstream
+    { code: 'Promise.resolve(1).finally(() => { console.log(2) })' },
+    { code: 'Promise.reject(4).finally(() => { console.log(2) })' },
+    { code: 'Promise.reject(4).finally(() => {})' },
+    { code: 'myPromise.finally(() => {});' },
+    { code: 'Promise.resolve(1).finally(function () { })' },
+  ],
+
+  invalid: [
+    // ESLint upstream
+    {
+      code: 'Promise.resolve(1).finally(() => { return 2 })',
+      errors: [{ message: noReturnMsg }],
+    },
+    {
+      code: 'Promise.reject(0).finally(() => { return 2 })',
+      errors: [{ message: noReturnMsg }],
+    },
+    {
+      code: 'myPromise.finally(() => { return 2 });',
+      errors: [{ message: noReturnMsg }],
+    },
+    {
+      code: 'Promise.resolve(1).finally(function () { return 2 })',
+      errors: [{ message: noReturnMsg }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Ported `promise/no-return-in-finally` rule for #474, clean. good.

## Related Links

[original docs](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-return-in-finally.md)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
