### PR TITLE
feat: port rule promise/prefer-await-to-then

### DIFF
--- a/internal/plugins/promise/all.go
+++ b/internal/plugins/promise/all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_in_finally"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_wrap"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/param_names"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_await_to_then"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_catch"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/valid_params"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -28,6 +29,7 @@ func GetAllRules() []rule.Rule {
 		no_return_in_finally.NoReturnInFinallyRule,
 		no_return_wrap.NoReturnWrapRule,
 		param_names.ParamNamesRule,
+		prefer_await_to_then.PreferAwaitToThenRule,
 		prefer_catch.PreferCatchRule,
 		valid_params.ValidParamsRule,
 	}

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.go
@@ -28,11 +28,27 @@ var preferAwaitToCallbackMessage = rule.RuleMessage{
 	Description: "Prefer await to then()/catch()/finally().",
 }
 
-// isTopLevelScoped reports whether node is outside any function-like scope,
+// createsScope reports whether node opens a new eslint-scope scope.
+func createsScope(node *ast.Node) bool {
+	if ast.IsFunctionLike(node) {
+		return true
+	}
+	switch node.Kind {
+	case ast.KindBlock,
+		ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement,
+		ast.KindSwitchStatement, ast.KindCatchClause,
+		ast.KindClassDeclaration, ast.KindClassExpression,
+		ast.KindWithStatement, ast.KindClassStaticBlockDeclaration:
+		return true
+	}
+	return false
+}
+
+// isTopLevelScoped reports whether node is outside any scope-creating ancestor,
 // mirroring ESLint's getScope().block.type === 'Program' check.
 func isTopLevelScoped(node *ast.Node) bool {
 	for cur := node.Parent; cur != nil; cur = cur.Parent {
-		if ast.IsFunctionLike(cur) {
+		if createsScope(cur) {
 			return false
 		}
 	}
@@ -67,10 +83,19 @@ func isCypress(node *ast.Node) bool {
 		return false
 	}
 	callee := ast.SkipOuterExpressions(node.AsCallExpression().Expression, skipTransparent)
-	if callee == nil || !ast.IsPropertyAccessExpression(callee) {
+	if callee == nil {
 		return false
 	}
-	obj := ast.SkipOuterExpressions(callee.AsPropertyAccessExpression().Expression, skipTransparent)
+	var rawObj *ast.Node
+	switch {
+	case ast.IsPropertyAccessExpression(callee):
+		rawObj = callee.AsPropertyAccessExpression().Expression
+	case ast.IsElementAccessExpression(callee):
+		rawObj = callee.AsElementAccessExpression().Expression
+	default:
+		return false
+	}
+	obj := ast.SkipOuterExpressions(rawObj, skipTransparent)
 	if obj == nil {
 		return false
 	}

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.go
@@ -127,10 +127,18 @@ var PreferAwaitToThenRule = rule.Rule{
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
 				callee := ast.SkipOuterExpressions(node.AsCallExpression().Expression, skipTransparent)
-				if callee == nil || !ast.IsPropertyAccessExpression(callee) {
+				if callee == nil {
 					return
 				}
-				nameNode := callee.AsPropertyAccessExpression().Name()
+				var nameNode *ast.Node
+				switch {
+				case ast.IsPropertyAccessExpression(callee):
+					nameNode = callee.AsPropertyAccessExpression().Name()
+				case ast.IsElementAccessExpression(callee):
+					nameNode = ast.SkipOuterExpressions(callee.AsElementAccessExpression().ArgumentExpression, skipTransparent)
+				default:
+					return
+				}
 				if nameNode == nil || !ast.IsIdentifier(nameNode) {
 					return
 				}

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.go
@@ -1,0 +1,111 @@
+package prefer_await_to_then
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const skipTransparent = ast.OEKParentheses
+
+type Options struct {
+	Strict bool
+}
+
+func parseOptions(options any) Options {
+	opts := Options{}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["strict"].(bool); ok {
+			opts.Strict = v
+		}
+	}
+	return opts
+}
+
+var preferAwaitToCallbackMessage = rule.RuleMessage{
+	Id:          "preferAwaitToCallback",
+	Description: "Prefer await to then()/catch()/finally().",
+}
+
+// isTopLevelScoped reports whether node is outside any function-like scope,
+// mirroring ESLint's getScope().block.type === 'Program' check.
+func isTopLevelScoped(node *ast.Node) bool {
+	for cur := node.Parent; cur != nil; cur = cur.Parent {
+		if ast.IsFunctionLike(cur) {
+			return false
+		}
+	}
+	return true
+}
+
+// isInsideYieldOrAwait reports whether any ancestor of node is an AwaitExpression
+// or YieldExpression.
+func isInsideYieldOrAwait(node *ast.Node) bool {
+	for cur := node.Parent; cur != nil; cur = cur.Parent {
+		if cur.Kind == ast.KindAwaitExpression || cur.Kind == ast.KindYieldExpression {
+			return true
+		}
+	}
+	return false
+}
+
+// isInsideConstructor reports whether any ancestor of node is a constructor declaration.
+func isInsideConstructor(node *ast.Node) bool {
+	for cur := node.Parent; cur != nil; cur = cur.Parent {
+		if cur.Kind == ast.KindConstructor {
+			return true
+		}
+	}
+	return false
+}
+
+// isCypress reports whether callNode is part of a Cypress cy.* chain.
+// It mirrors eslint-plugin-promise's recursive isMemberCallWithObjectName('cy', node) check.
+func isCypress(node *ast.Node) bool {
+	if node == nil || !ast.IsCallExpression(node) {
+		return false
+	}
+	callee := ast.SkipOuterExpressions(node.AsCallExpression().Expression, skipTransparent)
+	if callee == nil || !ast.IsPropertyAccessExpression(callee) {
+		return false
+	}
+	obj := ast.SkipOuterExpressions(callee.AsPropertyAccessExpression().Expression, skipTransparent)
+	if obj == nil {
+		return false
+	}
+	if ast.IsIdentifier(obj) && obj.AsIdentifier().Text == "cy" {
+		return true
+	}
+	return isCypress(obj)
+}
+
+var PreferAwaitToThenRule = rule.Rule{
+	Name: "promise/prefer-await-to-then",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				callee := ast.SkipOuterExpressions(node.AsCallExpression().Expression, skipTransparent)
+				if callee == nil || !ast.IsPropertyAccessExpression(callee) {
+					return
+				}
+				nameNode := callee.AsPropertyAccessExpression().Name()
+				if nameNode == nil || !ast.IsIdentifier(nameNode) {
+					return
+				}
+				propName := nameNode.AsIdentifier().Text
+				if propName != "then" && propName != "catch" && propName != "finally" {
+					return
+				}
+				if isTopLevelScoped(node) ||
+					(!opts.Strict && isInsideYieldOrAwait(node)) ||
+					(!opts.Strict && isInsideConstructor(node)) ||
+					isCypress(node) {
+					return
+				}
+				ctx.ReportNode(nameNode, preferAwaitToCallbackMessage)
+			},
+		}
+	},
+}

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.go
@@ -34,8 +34,19 @@ func createsScope(node *ast.Node) bool {
 		return true
 	}
 	switch node.Kind {
+	case ast.KindForStatement:
+		// eslint-scope only opens a for-scope when the loop head binds with let/const/using.
+		fs := node.AsForStatement()
+		return fs != nil && fs.Initializer != nil &&
+			ast.IsVariableDeclarationList(fs.Initializer) &&
+			fs.Initializer.Flags&ast.NodeFlagsBlockScoped != 0
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		// Same rule as KindForStatement: scope only when let/const/using.
+		fs := node.AsForInOrOfStatement()
+		return fs != nil && fs.Initializer != nil &&
+			ast.IsVariableDeclarationList(fs.Initializer) &&
+			fs.Initializer.Flags&ast.NodeFlagsBlockScoped != 0
 	case ast.KindBlock,
-		ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement,
 		ast.KindSwitchStatement, ast.KindCatchClause,
 		ast.KindClassDeclaration, ast.KindClassExpression,
 		ast.KindWithStatement, ast.KindClassStaticBlockDeclaration,
@@ -51,6 +62,9 @@ func isTopLevelScoped(node *ast.Node) bool {
 	for cur := node.Parent; cur != nil; cur = cur.Parent {
 		if createsScope(cur) {
 			return false
+		}
+		if cur.Kind == ast.KindSourceFile {
+			return true
 		}
 	}
 	return true

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.go
@@ -38,7 +38,8 @@ func createsScope(node *ast.Node) bool {
 		ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement,
 		ast.KindSwitchStatement, ast.KindCatchClause,
 		ast.KindClassDeclaration, ast.KindClassExpression,
-		ast.KindWithStatement, ast.KindClassStaticBlockDeclaration:
+		ast.KindWithStatement, ast.KindClassStaticBlockDeclaration,
+		ast.KindModuleDeclaration:
 		return true
 	}
 	return false

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.md
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.md
@@ -76,10 +76,6 @@ async function foo() {
 }
 ```
 
-## Differences from ESLint
-
-- Code inside class property initializers (`class C { x = p.then() }`) and class static blocks (`class C { static { p.then() } }`) is treated as top-level and not reported, whereas ESLint reports it. This follows from rslint's simpler scope model (function-ancestor walk vs ESLint's full scope tree).
-
 ## Original Documentation
 
 https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/prefer-await-to-then.md

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.md
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then.md
@@ -1,0 +1,85 @@
+# prefer-await-to-then
+
+## Rule Details
+
+Prefer `async`/`await` over `.then()`/`.catch()`/`.finally()` for consuming Promise values.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function foo() {
+  fetchData().then((data) => {
+    process(data);
+  });
+}
+
+function bar() {
+  fetchData()
+    .then((data) => data.json())
+    .catch((err) => console.error(err));
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+async function foo() {
+  const data = await fetchData();
+  process(data);
+}
+
+async function bar() {
+  try {
+    const data = await fetchData();
+    return await data.json();
+  } catch (err) {
+    console.error(err);
+  }
+}
+```
+
+By default, `.then()`/`.catch()`/`.finally()` inside an `await` or `yield` expression, or inside a class constructor, are not reported — those positions cannot trivially be rewritten with `await`.
+
+Examples of **correct** code for this rule in default (non-strict) mode:
+
+```javascript
+async function foo() {
+  // await wraps the .then() — not reported
+  return await thing().then();
+}
+
+function* gen() {
+  // yield wraps the .then() — not reported
+  yield thing().then();
+}
+
+class Foo {
+  constructor() {
+    // inside a constructor — not reported
+    doSomething.then(cb);
+  }
+}
+```
+
+### `strict` option
+
+When `strict: true`, the rule also reports `.then()`/`.catch()`/`.finally()` inside `await`/`yield` expressions and constructors.
+
+```json
+{ "promise/prefer-await-to-then": ["error", { "strict": true }] }
+```
+
+```javascript
+// reported with strict: true
+async function foo() {
+  return await thing().then();
+}
+```
+
+## Differences from ESLint
+
+- Code inside class property initializers (`class C { x = p.then() }`) and class static blocks (`class C { static { p.then() } }`) is treated as top-level and not reported, whereas ESLint reports it. This follows from rslint's simpler scope model (function-ancestor walk vs ESLint's full scope tree).
+
+## Original Documentation
+
+https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/prefer-await-to-then.md

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_extras_test.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_extras_test.go
@@ -17,10 +17,11 @@ func TestPreferAwaitToThenExtras(t *testing.T) {
 		[]rule_tester.ValidTestCase{
 			// ---- Dimension 1: AST node types ----
 
-			// Element access is not dot notation — rule only targets PropertyAccessExpression.
-			// N/A: element-access form (`obj['then']()`) is intentionally not matched.
+			// Element access with a string/template literal key is not an identifier
+			// property, so it stays unmatched (mirrors upstream's node.property.name check).
 			{Code: `function f() { obj['then']() }`},
 			{Code: "function f() { obj[`then`]() }"},
+			// Element access with an identifier key whose name isn't then/catch/finally.
 			{Code: `function f() { obj[sym]() }`},
 
 			// Member access without call (typeof check) — not a CallExpression
@@ -86,7 +87,7 @@ func TestPreferAwaitToThenExtras(t *testing.T) {
 			{Code: `function f() { p.thenSomething() }`},
 			{Code: `function f() { p.catchError() }`},
 
-			// ---- For-loop scoping: var / no-decl heads create no scope (Comment 4 fix) ----
+			// ---- For-loop scoping: var / no-decl heads create no scope ----
 			// eslint-scope does not open a scope unless the head is let/const/using.
 			// Without a block body there is no KindBlock ancestor either, so these stay top-level.
 			{Code: `for(;;) thing.then(cb)`},
@@ -296,6 +297,22 @@ func TestPreferAwaitToThenExtras(t *testing.T) {
 				Code: `function f() { Promise.all(items.map(x => x.then(cb))) }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 45, EndLine: 1, EndColumn: 49},
+				},
+			},
+
+			// ---- Element access with an identifier key ----
+			// Upstream matches any MemberExpression.callee, including computed
+			// identifier access like obj[then](), not just dot notation.
+			{
+				Code: `function f() { obj[then]() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 20, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code: `function f() { obj[(then)]() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 21, EndLine: 1, EndColumn: 25},
 				},
 			},
 		},

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_extras_test.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_extras_test.go
@@ -85,6 +85,15 @@ func TestPreferAwaitToThenExtras(t *testing.T) {
 			{Code: `function f() { p.resolve() }`},
 			{Code: `function f() { p.thenSomething() }`},
 			{Code: `function f() { p.catchError() }`},
+
+			// ---- For-loop scoping: var / no-decl heads create no scope (Comment 4 fix) ----
+			// eslint-scope does not open a scope unless the head is let/const/using.
+			// Without a block body there is no KindBlock ancestor either, so these stay top-level.
+			{Code: `for(;;) thing.then(cb)`},
+			{Code: `for(var i=0;;) thing.then(cb)`},
+			{Code: `for(var a of xs) thing.then(cb)`},
+			{Code: `for(a of xs) thing.then(cb)`},
+			{Code: `for(var k in o) thing.then(cb)`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 1: AST node types ----
@@ -128,11 +137,30 @@ func TestPreferAwaitToThenExtras(t *testing.T) {
 					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 16, EndLine: 1, EndColumn: 20},
 				},
 			},
-			// Top-level for-of loop
+			// Top-level for-of loop (braced body — KindBlock catches it regardless)
 			{
 				Code: `for (const a of xs) { thing.then(cb) }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 29, EndLine: 1, EndColumn: 33},
+				},
+			},
+			// Top-level for-loops with let/const but no braces — scope comes from the for-head
+			{
+				Code: `for(let i=0;;) thing.then(cb)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code: `for(const a of xs) thing.then(cb)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 26, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code: `for(const k in o) thing.then(cb)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 25, EndLine: 1, EndColumn: 29},
 				},
 			},
 			// Top-level switch/case

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_extras_test.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_extras_test.go
@@ -163,6 +163,20 @@ func TestPreferAwaitToThenExtras(t *testing.T) {
 					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
 				},
 			},
+			// Top-level inside a TS namespace body
+			{
+				Code: `namespace N { Promise.resolve().then(() => {}) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 33, EndLine: 1, EndColumn: 37},
+				},
+			},
+			// Top-level inside a legacy TS module body
+			{
+				Code: `module M { Promise.resolve().then(() => {}) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 30, EndLine: 1, EndColumn: 34},
+				},
+			},
 			// Inside class method (not constructor)
 			{
 				Code: `class C { method() { hey.then(x => {}) } }`,

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_extras_test.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_extras_test.go
@@ -1,0 +1,209 @@
+package prefer_await_to_then_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_await_to_then"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferAwaitToThenExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_await_to_then.PreferAwaitToThenRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 1: AST node types ----
+
+			// Element access is not dot notation — rule only targets PropertyAccessExpression.
+			// N/A: element-access form (`obj['then']()`) is intentionally not matched.
+			{Code: `function f() { obj['then']() }`},
+			{Code: "function f() { obj[`then`]() }"},
+			{Code: `function f() { obj[sym]() }`},
+
+			// Member access without call (typeof check) — not a CallExpression
+			{Code: `function f() { return typeof obj.then === 'function' }`},
+
+			// ---- Dimension 2: Scoping & nesting ----
+
+			// Inside an async generator — yield skips by default
+			{Code: `async function * gen() { yield thing().then() }`},
+
+			// Inside a class constructor (class expression form)
+			{Code: `const C = class { constructor() { doSomething.then(cb) } }`},
+
+			// Constructor nested inside another constructor (inner class)
+			{Code: "class Outer {\n  constructor() {\n    class Inner {\n      constructor() { thing.then(cb) }\n    }\n  }\n}"},
+
+			// Deeply nested inside constructor — all levels exempt (non-strict)
+			{Code: "class Foo {\n  constructor() {\n    function inner() { thing.then(cb) }\n  }\n}"},
+
+			// ---- Dimension 3: Autofix ----
+			// N/A: this rule has no autofix.
+
+			// ---- Dimension 4: Universal edge shapes ----
+
+			// Parenthesized entire callee: (hey.then)(arg) — inside await → valid
+			{Code: `async function f() { await (hey.then)() }`},
+
+			// Non-null assertion on receiver: hey!.then() — inside await → valid
+			{Code: `async function f() { await hey!.then() }`},
+
+			// Type assertion on receiver: (hey as any).then() — inside await → valid
+			{Code: `async function f() { await (hey as any).then() }`},
+
+			// Optional chain on method: hey?.then() — inside await → valid
+			{Code: `async function f() { await hey?.then() }`},
+
+			// Optional call: hey.then?.() — inside await → valid
+			{Code: `async function f() { await hey.then?.() }`},
+
+			// Top-level: all forms are exempt from reporting
+			{Code: `thing.then(cb)`},
+			{Code: `thing.catch(cb)`},
+			{Code: `thing.finally(cb)`},
+			{Code: `(thing).then(cb)`},
+			{Code: `thing?.then(cb)`},
+
+			// ---- Branch lock-ins (Layer 3) ----
+
+			// Locks in isTopLevelScoped branch: bare call at file top level → skip
+			{Code: `somePromise.then(() => {})`},
+
+			// Locks in isCypress direct-object branch: cy.then() (base case)
+			{Code: `function f() { cy.then(cb) }`},
+
+			// Locks in isCypress deeply-nested branch: 3-level cy chain
+			{Code: `function f() { cy.get("button").click().then() }`},
+
+			// Locks in propName guard: non-then/catch/finally method call
+			{Code: `function f() { p.resolve() }`},
+			{Code: `function f() { p.thenSomething() }`},
+			{Code: `function f() { p.catchError() }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 1: AST node types ----
+
+			// Optional chain on method: hey?.then() inside a regular function IS reported.
+			// '?' shifts the start of 'then' one column right vs plain hey.then.
+			{
+				Code: `function f() { hey?.then() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 21, EndLine: 1, EndColumn: 25},
+				},
+			},
+			// .catch() on optional chain
+			{
+				Code: `function f() { hey?.catch(e => {}) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 21, EndLine: 1, EndColumn: 26},
+				},
+			},
+
+			// ---- Dimension 2: Scoping & nesting ----
+
+			// Inside arrow function (not top-level)
+			{
+				Code: `const f = () => { hey.then(x => {}) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 23, EndLine: 1, EndColumn: 27},
+				},
+			},
+			// Inside class method (not constructor)
+			{
+				Code: `class C { method() { hey.then(x => {}) } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 26, EndLine: 1, EndColumn: 30},
+				},
+			},
+			// Inside static class method
+			{
+				Code: `class C { static method() { hey.then(x => {}) } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 33, EndLine: 1, EndColumn: 37},
+				},
+			},
+			// Inside getter — 'return ' prefix shifts column further right
+			{
+				Code: `class C { get val() { return hey.then(x => x) } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 34, EndLine: 1, EndColumn: 38},
+				},
+			},
+
+			// ---- Dimension 4: Universal edge shapes ----
+
+			// Parenthesized entire callee: (hey.then)(arg) outside await.
+			// The opening '(' shifts the reported property by one column.
+			{
+				Code: `function f() { (hey.then)(x => {}) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 21, EndLine: 1, EndColumn: 25},
+				},
+			},
+			// Non-null assertion on receiver: hey!.then()
+			// The '!' shifts the column of 'then' one position right.
+			{
+				Code: `function f() { hey!.then(x => {}) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 21, EndLine: 1, EndColumn: 25},
+				},
+			},
+			// Type assertion on receiver: (hey as any).then()
+			{
+				Code: `function f() { (hey as any).then(x => {}) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 29, EndLine: 1, EndColumn: 33},
+				},
+			},
+
+			// ---- Branch lock-ins (Layer 3) ----
+
+			// Locks in strict-mode yield branch: yield with strict → reported
+			{
+				Code:    `function * f() { yield thing().then() }`,
+				Options: map[string]interface{}{"strict": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 32, EndLine: 1, EndColumn: 36},
+				},
+			},
+			// Locks in strict-mode constructor branch: constructor with strict → reported
+			{
+				Code:    `class C { constructor() { thing.then(cb) } }`,
+				Options: map[string]interface{}{"strict": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 33, EndLine: 1, EndColumn: 37},
+				},
+			},
+			// Locks in strict-mode await branch: await-wrapped .catch() with strict → reported
+			{
+				Code:    `async function f() { await thing().catch(e => {}) }`,
+				Options: map[string]interface{}{"strict": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 36, EndLine: 1, EndColumn: 41},
+				},
+			},
+
+			// ---- Real-user shapes ----
+
+			// Real-user: chained .then().catch() in a non-async function.
+			// Errors are reported outer-to-inner: catch first, then second.
+			{
+				Code: `function fetch(url) { return http.get(url).then(r => r.json()).catch(e => null) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 64, EndLine: 1, EndColumn: 69},
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 44, EndLine: 1, EndColumn: 48},
+				},
+			},
+			// Real-user: .then() nested as callback argument
+			{
+				Code: `function f() { Promise.all(items.map(x => x.then(cb))) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 45, EndLine: 1, EndColumn: 49},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_extras_test.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_extras_test.go
@@ -78,6 +78,9 @@ func TestPreferAwaitToThenExtras(t *testing.T) {
 			// Locks in isCypress deeply-nested branch: 3-level cy chain
 			{Code: `function f() { cy.get("button").click().then() }`},
 
+			// Locks in isCypress element-access branch: cy['get']() chain
+			{Code: `function f() { cy['get']('x').then(go) }`},
+
 			// Locks in propName guard: non-then/catch/finally method call
 			{Code: `function f() { p.resolve() }`},
 			{Code: `function f() { p.thenSomething() }`},
@@ -109,6 +112,55 @@ func TestPreferAwaitToThenExtras(t *testing.T) {
 				Code: `const f = () => { hey.then(x => {}) }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 23, EndLine: 1, EndColumn: 27},
+				},
+			},
+			// Top-level bare block: still a Program-level scope per eslint-scope, so reported
+			{
+				Code: `{ thing.then(cb) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 9, EndLine: 1, EndColumn: 13},
+				},
+			},
+			// Top-level if-block
+			{
+				Code: `if (x) { thing.then(cb) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 16, EndLine: 1, EndColumn: 20},
+				},
+			},
+			// Top-level for-of loop
+			{
+				Code: `for (const a of xs) { thing.then(cb) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 29, EndLine: 1, EndColumn: 33},
+				},
+			},
+			// Top-level switch/case
+			{
+				Code: `switch (x) { case 1: thing.then(cb) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 28, EndLine: 1, EndColumn: 32},
+				},
+			},
+			// Top-level try/catch
+			{
+				Code: `try { x() } catch (e) { thing.then(cb) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 31, EndLine: 1, EndColumn: 35},
+				},
+			},
+			// Class field initializer at top level
+			{
+				Code: `class C { x = p.then() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 17, EndLine: 1, EndColumn: 21},
+				},
+			},
+			// Class static block at top level
+			{
+				Code: `class C { static { p.then() } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
 				},
 			},
 			// Inside class method (not constructor)

--- a/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_upstream_test.go
+++ b/internal/plugins/promise/rules/prefer_await_to_then/prefer_await_to_then_upstream_test.go
@@ -1,0 +1,121 @@
+package prefer_await_to_then_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_await_to_then"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const msg = "Prefer await to then()/catch()/finally()."
+
+func TestPreferAwaitToThenUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_await_to_then.PreferAwaitToThenRule,
+		[]rule_tester.ValidTestCase{
+			// ---- ESLint upstream valid cases ----
+			{Code: `async function hi() { await thing() }`},
+			{Code: `async function hi() { await thing().then() }`},
+			{Code: `async function hi() { await thing().catch() }`},
+			{Code: `async function hi() { await thing().finally() }`},
+			// Cypress
+			{Code: `function hi() { cy.get(".myClass").then(go) }`},
+			{Code: `function hi() { cy.get("button").click().then() }`},
+			{Code: `function * hi() { yield thing().then() }`},
+			{Code: `a = async () => (await something())`},
+			{Code: "a = async () => {\n  try { await something() } catch (error) { somethingElse() }\n}"},
+			{Code: `something().then(async () => await somethingElse())`},
+			{Code: `function foo() { hey.somethingElse(x => {}) }`},
+			{Code: "const isThenable = (obj) => {\n  return obj && typeof obj.then === 'function';\n};"},
+			{Code: "function isThenable(obj) {\n  return obj && typeof obj.then === 'function';\n}"},
+			{Code: "class Foo {\n  constructor () {\n    doSomething.then(abc);\n  }\n}"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `function foo() { hey.then(x => {}) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
+				},
+			},
+			// Errors reported outer-to-inner (call chain traversal order)
+			{
+				Code: `function foo() { hey.then(function() { }).then() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 43, EndLine: 1, EndColumn: 47},
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code: `function foo() { hey.then(function() { }).then(x).catch() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 51, EndLine: 1, EndColumn: 56},
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 43, EndLine: 1, EndColumn: 47},
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code: `async function a() { hey.then(function() { }).then(function() { }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 47, EndLine: 1, EndColumn: 51},
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 26, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code: `function foo() { hey.catch(x => {}) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 22, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				Code: `function foo() { hey.finally(x => {}) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// strict mode: await-wrapped .then() is still reported
+			{
+				Code:    `async function hi() { await thing().then() }`,
+				Options: map[string]interface{}{"strict": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 37, EndLine: 1, EndColumn: 41},
+				},
+			},
+			// strict mode: constructor .then() is still reported
+			{
+				Code:    "class Foo {\n  constructor () {\n    doSomething.then(abc);\n  }\n}",
+				Options: map[string]interface{}{"strict": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 3, Column: 17, EndLine: 3, EndColumn: 21},
+				},
+			},
+			// strict mode: await-wrapped .catch() is still reported
+			{
+				Code:    `async function hi() { await thing().catch() }`,
+				Options: map[string]interface{}{"strict": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 37, EndLine: 1, EndColumn: 42},
+				},
+			},
+			// strict mode: await-wrapped .finally() is still reported
+			{
+				Code:    `async function hi() { await thing().finally() }`,
+				Options: map[string]interface{}{"strict": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 37, EndLine: 1, EndColumn: 44},
+				},
+			},
+			// strict mode: yield-wrapped .then() is still reported
+			{
+				Code:    `function * hi() { yield thing().then() }`,
+				Options: map[string]interface{}{"strict": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferAwaitToCallback", Message: msg, Line: 1, Column: 33, EndLine: 1, EndColumn: 37},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -514,6 +514,7 @@ export default defineConfig({
     './tests/eslint-plugin-promise/rules/no-return-in-finally.test.ts',
     './tests/eslint-plugin-promise/rules/no-return-wrap.test.ts',
     './tests/eslint-plugin-promise/rules/param-names.test.ts',
+    './tests/eslint-plugin-promise/rules/prefer-await-to-then.test.ts',
     './tests/eslint-plugin-promise/rules/prefer-catch.test.ts',
     './tests/eslint-plugin-promise/rules/valid-params.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/prefer-await-to-then.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/prefer-await-to-then.test.ts
@@ -1,0 +1,75 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const message = 'Prefer await to then()/catch()/finally().';
+
+ruleTester.run('prefer-await-to-then', {} as never, {
+  valid: [
+    { code: 'async function hi() { await thing() }' },
+    { code: 'async function hi() { await thing().then() }' },
+    { code: 'async function hi() { await thing().catch() }' },
+    { code: 'async function hi() { await thing().finally() }' },
+    // Cypress
+    { code: 'function hi() { cy.get(".myClass").then(go) }' },
+    { code: 'function hi() { cy.get("button").click().then() }' },
+    { code: 'function * hi() { yield thing().then() }' },
+    { code: 'something().then(async () => await somethingElse())' },
+    { code: 'function foo() { hey.somethingElse(x => {}) }' },
+    {
+      code: 'class Foo {\n  constructor () {\n    doSomething.then(abc);\n  }\n}',
+    },
+  ],
+
+  invalid: [
+    {
+      code: 'function foo() { hey.then(x => {}) }',
+      errors: [{ message }],
+    },
+    {
+      code: 'function foo() { hey.then(function() { }).then() }',
+      errors: [{ message }, { message }],
+    },
+    {
+      code: 'function foo() { hey.then(function() { }).then(x).catch() }',
+      errors: [{ message }, { message }, { message }],
+    },
+    {
+      code: 'async function a() { hey.then(function() { }).then(function() { }) }',
+      errors: [{ message }, { message }],
+    },
+    {
+      code: 'function foo() { hey.catch(x => {}) }',
+      errors: [{ message }],
+    },
+    {
+      code: 'function foo() { hey.finally(x => {}) }',
+      errors: [{ message }],
+    },
+    {
+      code: 'async function hi() { await thing().then() }',
+      options: [{ strict: true }],
+      errors: [{ message }],
+    },
+    {
+      code: 'class Foo {\n  constructor () {\n    doSomething.then(abc);\n  }\n}',
+      options: [{ strict: true }],
+      errors: [{ message }],
+    },
+    {
+      code: 'async function hi() { await thing().catch() }',
+      options: [{ strict: true }],
+      errors: [{ message }],
+    },
+    {
+      code: 'async function hi() { await thing().finally() }',
+      options: [{ strict: true }],
+      errors: [{ message }],
+    },
+    {
+      code: 'function * hi() { yield thing().then() }',
+      options: [{ strict: true }],
+      errors: [{ message }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Ported `promise/prefer-await-to-then` rule for #474.

## Related Links

[original docs](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/prefer-await-to-then.md)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
