### PR TITLE
feat: port rule promise/prefer-catch

### DIFF
--- a/internal/plugins/promise/all.go
+++ b/internal/plugins/promise/all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_in_finally"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_wrap"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/param_names"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_catch"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/valid_params"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -27,6 +28,7 @@ func GetAllRules() []rule.Rule {
 		no_return_in_finally.NoReturnInFinallyRule,
 		no_return_wrap.NoReturnWrapRule,
 		param_names.ParamNamesRule,
+		prefer_catch.PreferCatchRule,
 		valid_params.ValidParamsRule,
 	}
 }

--- a/internal/plugins/promise/rules/prefer_catch/prefer_catch.go
+++ b/internal/plugins/promise/rules/prefer_catch/prefer_catch.go
@@ -3,6 +3,7 @@ package prefer_catch
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -58,8 +59,10 @@ var PreferCatchRule = rule.Rule{
 					// Get text of arg1 stripping outer parens to match ESLint's getText behavior
 					innerArg1 := ast.SkipOuterExpressions(args[1], skipTransparent)
 					catcherText := utils.TrimmedNodeText(sf, innerArg1)
-					// Remove from end of arg0 (comma position) to end of arg1
-					removeRange := core.NewTextRange(args[0].End(), args[1].End())
+					// Remove from the comma after arg0 to end of arg1, so trivia
+					// between arg0 and the comma (e.g. a trailing comment) is kept.
+					commaStart := scanner.GetRangeOfTokenAtPosition(sf, args[0].End()).Pos()
+					removeRange := core.NewTextRange(commaStart, args[1].End())
 					ctx.ReportNodeWithFixes(thenName, msg,
 						rule.RuleFixRemoveRange(removeRange),
 						rule.RuleFixInsertBefore(sf, thenName, "catch("+catcherText+")."),

--- a/internal/plugins/promise/rules/prefer_catch/prefer_catch.go
+++ b/internal/plugins/promise/rules/prefer_catch/prefer_catch.go
@@ -1,0 +1,71 @@
+package prefer_catch
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const skipTransparent = ast.OEKParentheses
+
+func buildPreferCatchToThenMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferCatchToThen",
+		Description: "Prefer `catch` to `then(a, b)`/`then(null, b)`.",
+	}
+}
+
+var PreferCatchRule = rule.Rule{
+	Name: "promise/prefer-catch",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				callExpr := node.AsCallExpression()
+				callee := ast.SkipOuterExpressions(callExpr.Expression, skipTransparent)
+				if callee == nil || !ast.IsPropertyAccessExpression(callee) {
+					return
+				}
+				prop := callee.AsPropertyAccessExpression()
+				thenName := prop.Name()
+				if thenName == nil || !ast.IsIdentifier(thenName) || thenName.AsIdentifier().Text != "then" {
+					return
+				}
+
+				args := node.Arguments()
+				if len(args) < 2 {
+					return
+				}
+
+				sf := ctx.SourceFile
+				msg := buildPreferCatchToThenMessage()
+
+				firstArg := ast.SkipOuterExpressions(args[0], skipTransparent)
+				isNullOrUndef := firstArg.Kind == ast.KindNullKeyword ||
+					(ast.IsIdentifier(firstArg) && firstArg.AsIdentifier().Text == "undefined")
+
+				if isNullOrUndef {
+					// hey.then(null, fn2) → hey.catch(fn2)
+					// Remove from start of arg0 to start of arg1 (removes "null, " with trailing whitespace)
+					removeStart := utils.TrimNodeTextRange(sf, args[0]).Pos()
+					removeEnd := utils.TrimNodeTextRange(sf, args[1]).Pos()
+					ctx.ReportNodeWithFixes(thenName, msg,
+						rule.RuleFixRemoveRange(core.NewTextRange(removeStart, removeEnd)),
+						rule.RuleFixReplace(sf, thenName, "catch"),
+					)
+				} else {
+					// hey.then(fn1, fn2) → hey.catch(fn2).then(fn1)
+					// Get text of arg1 stripping outer parens to match ESLint's getText behavior
+					innerArg1 := ast.SkipOuterExpressions(args[1], skipTransparent)
+					catcherText := utils.TrimmedNodeText(sf, innerArg1)
+					// Remove from end of arg0 (comma position) to end of arg1
+					removeRange := core.NewTextRange(args[0].End(), args[1].End())
+					ctx.ReportNodeWithFixes(thenName, msg,
+						rule.RuleFixRemoveRange(removeRange),
+						rule.RuleFixInsertBefore(sf, thenName, "catch("+catcherText+")."),
+					)
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/promise/rules/prefer_catch/prefer_catch.md
+++ b/internal/plugins/promise/rules/prefer_catch/prefer_catch.md
@@ -26,9 +26,7 @@ prom.catch(handleErr)
 
 ## Differences from ESLint
 
-For the (unusual) 3-argument form `x.then(a, b, c)`, upstream's autofix produces
-invalid output (`x.catch(b).then(ac)`); this port produces valid output
-(`x.catch(b).then(a, c)`).
+Fixed an upstream autofix bug: `x.then(a, b, c)` now fixes to `x.catch(b).then(a, c)` instead of `x.catch(b).then(ac)`.
 
 ## Original Documentation
 

--- a/internal/plugins/promise/rules/prefer_catch/prefer_catch.md
+++ b/internal/plugins/promise/rules/prefer_catch/prefer_catch.md
@@ -1,0 +1,33 @@
+# prefer-catch
+
+Prefer `.catch()` over `.then(null, fn)` or `.then(a, b)` for error handling.
+
+## Rule Details
+
+A `.then()` call with two arguments can obscure that an error handler is present.
+The second argument also only catches rejections from earlier in the chain — not
+from the first argument — so `.catch()` is both clearer and semantically preferred.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+hey.then(fn1, fn2)
+hey.then(null, fn2)
+hey.then(undefined, fn2)
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+prom.then(fn)
+prom.catch(handleErr).then(handle)
+prom.catch(handleErr)
+```
+
+## Differences from ESLint
+
+None known.
+
+## Original Documentation
+
+- [eslint-plugin-promise: prefer-catch](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/prefer-catch.md)

--- a/internal/plugins/promise/rules/prefer_catch/prefer_catch.md
+++ b/internal/plugins/promise/rules/prefer_catch/prefer_catch.md
@@ -26,7 +26,9 @@ prom.catch(handleErr)
 
 ## Differences from ESLint
 
-None known.
+For the (unusual) 3-argument form `x.then(a, b, c)`, upstream's autofix produces
+invalid output (`x.catch(b).then(ac)`); this port produces valid output
+(`x.catch(b).then(a, c)`).
 
 ## Original Documentation
 

--- a/internal/plugins/promise/rules/prefer_catch/prefer_catch_extras_test.go
+++ b/internal/plugins/promise/rules/prefer_catch/prefer_catch_extras_test.go
@@ -1,7 +1,7 @@
 // TestPreferCatchExtras locks in branches and edge shapes that the upstream test
-// suite doesn't exercise. Each case carries an inline comment pointing at the
-// specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
-// refactors can't silently regress them without breaking a named lock-in.
+// suite doesn't exercise. Each case carries an inline comment explaining the
+// specific branch it covers, so future refactors can't silently regress them
+// without breaking a named lock-in.
 package prefer_catch_test
 
 import (
@@ -19,33 +19,35 @@ func TestPreferCatchExtras(t *testing.T) {
 		t,
 		&prefer_catch.PreferCatchRule,
 		[]rule_tester.ValidTestCase{
-			// ---- Dimension 4: element-access form is not a PropertyAccessExpression ----
+			// ---- element-access form is not a PropertyAccessExpression ----
 			// N/A: ElementAccessExpression is never matched (callee must be PAE)
 			{Code: `prom['then'](fn1, fn2)`},
 
-			// ---- Dimension 4: wrong method name does not report ----
+			// ---- wrong method name does not report ----
 			// Locks in upstream name === 'then' check: .catch/.finally with 2 args must not fire
 			{Code: `prom.catch(fn1, fn2)`},
 			{Code: `prom.finally(fn1, fn2)`},
 
-			// ---- Dimension 4: single argument is valid ----
+			// ---- single argument is valid ----
 			// Locks in upstream arguments.length >= 2 check
 			{Code: `prom.then(fn)`},
 			{Code: `prom.then(null)`},
 			{Code: `prom.then(undefined)`},
 
-			// ---- Dimension 4: parenthesized callee is unwrapped ----
-			// (prom.then) is a ParenthesizedExpression wrapping the PAE; after
-			// SkipOuterExpressions the callee becomes the PAE and matches.
-			// This tests that calling (prom.then)(fn1, fn2) still is fine with no report
-			// since after skip it IS a PAE with name 'then' — actually this SHOULD report.
-			// N/A: there's no case where a parenthesized PAE callee should be excluded.
-
 			// ---- Real-user: computed-then is not dotted access ----
 			{Code: `promise[methodName](fn1, fn2)`},
 		},
 		[]rule_tester.InvalidTestCase{
-			// ---- Dimension 4: parenthesized receiver object ----
+			// ---- parenthesized callee is unwrapped ----
+			// (prom.then) is a ParenthesizedExpression wrapping the PAE; after
+			// SkipOuterExpressions the callee becomes the PAE and matches.
+			{
+				Code:   `(prom.then)(fn1, fn2)`,
+				Output: []string{`(prom.catch(fn2).then)(fn1)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 7}},
+			},
+
+			// ---- parenthesized receiver object ----
 			// (prom).then(fn1, fn2): callee is PAE (name=then) on a paren-wrapped object.
 			// The rule listens on the PAE itself (not its Expression), so this matches.
 			{
@@ -54,7 +56,7 @@ func TestPreferCatchExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 8}},
 			},
 
-			// ---- Dimension 4: optional-chain .then ----
+			// ---- optional-chain .then ----
 			// prom?.then(fn1, fn2): upstream doesn't exclude optional chains.
 			{
 				Code:   `prom?.then(fn1, fn2)`,
@@ -62,7 +64,7 @@ func TestPreferCatchExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 7}},
 			},
 
-			// ---- Dimension 4: TS non-null assertion on receiver ----
+			// ---- TS non-null assertion on receiver ----
 			// prom!.then(fn1, fn2): callee is PAE on NonNullExpression — still matches.
 			{
 				Code:   `prom!.then(fn1, fn2)`,
@@ -70,14 +72,14 @@ func TestPreferCatchExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 7}},
 			},
 
-			// ---- Dimension 4: TS type-cast wrapper on receiver ----
+			// ---- TS type-cast wrapper on receiver ----
 			{
 				Code:   `(prom as any).then(fn1, fn2)`,
 				Output: []string{`(prom as any).catch(fn2).then(fn1)`},
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 15}},
 			},
 
-			// ---- Dimension 4: parenthesized first arg (null) ----
+			// ---- parenthesized first arg (null) ----
 			// Locks in upstream isNullOrUndef check with paren-wrapped null.
 			{
 				Code:   `hey.then((null), fn2)`,
@@ -85,7 +87,7 @@ func TestPreferCatchExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 5}},
 			},
 
-			// ---- Dimension 4: parenthesized first arg (undefined) ----
+			// ---- parenthesized first arg (undefined) ----
 			{
 				Code:   `hey.then((undefined), fn2)`,
 				Output: []string{`hey.catch(fn2)`},

--- a/internal/plugins/promise/rules/prefer_catch/prefer_catch_extras_test.go
+++ b/internal/plugins/promise/rules/prefer_catch/prefer_catch_extras_test.go
@@ -1,0 +1,119 @@
+// TestPreferCatchExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the
+// specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+package prefer_catch_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_catch"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferCatchExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_catch.PreferCatchRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: element-access form is not a PropertyAccessExpression ----
+			// N/A: ElementAccessExpression is never matched (callee must be PAE)
+			{Code: `prom['then'](fn1, fn2)`},
+
+			// ---- Dimension 4: wrong method name does not report ----
+			// Locks in upstream name === 'then' check: .catch/.finally with 2 args must not fire
+			{Code: `prom.catch(fn1, fn2)`},
+			{Code: `prom.finally(fn1, fn2)`},
+
+			// ---- Dimension 4: single argument is valid ----
+			// Locks in upstream arguments.length >= 2 check
+			{Code: `prom.then(fn)`},
+			{Code: `prom.then(null)`},
+			{Code: `prom.then(undefined)`},
+
+			// ---- Dimension 4: parenthesized callee is unwrapped ----
+			// (prom.then) is a ParenthesizedExpression wrapping the PAE; after
+			// SkipOuterExpressions the callee becomes the PAE and matches.
+			// This tests that calling (prom.then)(fn1, fn2) still is fine with no report
+			// since after skip it IS a PAE with name 'then' — actually this SHOULD report.
+			// N/A: there's no case where a parenthesized PAE callee should be excluded.
+
+			// ---- Real-user: computed-then is not dotted access ----
+			{Code: `promise[methodName](fn1, fn2)`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized receiver object ----
+			// (prom).then(fn1, fn2): callee is PAE (name=then) on a paren-wrapped object.
+			// The rule listens on the PAE itself (not its Expression), so this matches.
+			{
+				Code:   `(prom).then(fn1, fn2)`,
+				Output: []string{`(prom).catch(fn2).then(fn1)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 8}},
+			},
+
+			// ---- Dimension 4: optional-chain .then ----
+			// prom?.then(fn1, fn2): upstream doesn't exclude optional chains.
+			{
+				Code:   `prom?.then(fn1, fn2)`,
+				Output: []string{`prom?.catch(fn2).then(fn1)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 7}},
+			},
+
+			// ---- Dimension 4: TS non-null assertion on receiver ----
+			// prom!.then(fn1, fn2): callee is PAE on NonNullExpression — still matches.
+			{
+				Code:   `prom!.then(fn1, fn2)`,
+				Output: []string{`prom!.catch(fn2).then(fn1)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 7}},
+			},
+
+			// ---- Dimension 4: TS type-cast wrapper on receiver ----
+			{
+				Code:   `(prom as any).then(fn1, fn2)`,
+				Output: []string{`(prom as any).catch(fn2).then(fn1)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 15}},
+			},
+
+			// ---- Dimension 4: parenthesized first arg (null) ----
+			// Locks in upstream isNullOrUndef check with paren-wrapped null.
+			{
+				Code:   `hey.then((null), fn2)`,
+				Output: []string{`hey.catch(fn2)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 5}},
+			},
+
+			// ---- Dimension 4: parenthesized first arg (undefined) ----
+			{
+				Code:   `hey.then((undefined), fn2)`,
+				Output: []string{`hey.catch(fn2)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 5}},
+			},
+
+			// ---- Locks in upstream arguments.length >= 2: exactly 2 args triggers, 3 also triggers ----
+			// 3 args: arg[1] removed first → hey.catch(fn2).then(fn1, fn3); then rule fires again
+			// on the resulting .then(fn1, fn3) which still has 2 args.
+			{
+				Code:   `hey.then(fn1, fn2, fn3)`,
+				Output: []string{`hey.catch(fn2).then(fn1, fn3)`, `hey.catch(fn2).catch(fn3).then(fn1)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 5}},
+			},
+
+			// ---- Real-user: typical async/fetch error handler pattern ----
+			{
+				Code:   `fetch('/api').then(res => res.json(), err => console.error(err))`,
+				Output: []string{`fetch('/api').catch(err => console.error(err)).then(res => res.json())`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 15}},
+			},
+
+			// ---- Real-user: null error handler in promise chain ----
+			{
+				Code:   `loadData().then(null, onError)`,
+				Output: []string{`loadData().catch(onError)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Line: 1, Column: 12}},
+			},
+		},
+	)
+}

--- a/internal/plugins/promise/rules/prefer_catch/prefer_catch_upstream_test.go
+++ b/internal/plugins/promise/rules/prefer_catch/prefer_catch_upstream_test.go
@@ -1,0 +1,78 @@
+// TestPreferCatchUpstream migrates the full valid/invalid suite from upstream
+// __tests__/prefer-catch.js 1:1. Position assertions cover line/column for
+// every invalid case. rslint-specific lock-in cases live in prefer_catch_extras_test.go.
+package prefer_catch_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_catch"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const preferCatchMessage = "Prefer `catch` to `then(a, b)`/`then(null, b)`."
+
+func TestPreferCatchUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_catch.PreferCatchRule,
+		[]rule_tester.ValidTestCase{
+			// ---- upstream valid cases ----
+			{Code: `prom.then()`},
+			{Code: `prom.then(fn)`},
+			{Code: `prom.then(fn1).then(fn2)`},
+			{Code: `prom.then(() => {})`},
+			{Code: `prom.then(function () {})`},
+			{Code: `prom.catch()`},
+			{Code: `prom.catch(handleErr).then(handle)`},
+			{Code: `prom.catch(handleErr)`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- upstream invalid cases ----
+			{
+				Code:   `hey.then(fn1, fn2)`,
+				Output: []string{`hey.catch(fn2).then(fn1)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Message: preferCatchMessage, Line: 1, Column: 5, EndLine: 1, EndColumn: 9}},
+			},
+			{
+				Code:   `hey.then(fn1, (fn2))`,
+				Output: []string{`hey.catch(fn2).then(fn1)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Message: preferCatchMessage, Line: 1, Column: 5}},
+			},
+			{
+				Code:   `hey.then(null, fn2)`,
+				Output: []string{`hey.catch(fn2)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Message: preferCatchMessage, Line: 1, Column: 5}},
+			},
+			{
+				Code:   `hey.then(undefined, fn2)`,
+				Output: []string{`hey.catch(fn2)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Message: preferCatchMessage, Line: 1, Column: 5}},
+			},
+			{
+				Code:   `function foo() { hey.then(x => {}, () => {}) }`,
+				Output: []string{`function foo() { hey.catch(() => {}).then(x => {}) }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferCatchToThen", Message: preferCatchMessage, Line: 1, Column: 22}},
+			},
+			{
+				Code: `
+function foo() {
+  hey.then(function a() { }, function b() {}).then(fn1, fn2)
+}
+`,
+				Output: []string{`
+function foo() {
+  hey.catch(function b() {}).then(function a() { }).catch(fn2).then(fn1)
+}
+`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferCatchToThen", Message: preferCatchMessage, Line: 3, Column: 47},
+					{MessageId: "preferCatchToThen", Message: preferCatchMessage, Line: 3, Column: 7},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -512,6 +512,7 @@ export default defineConfig({
     './tests/eslint-plugin-promise/rules/no-return-in-finally.test.ts',
     './tests/eslint-plugin-promise/rules/no-return-wrap.test.ts',
     './tests/eslint-plugin-promise/rules/param-names.test.ts',
+    './tests/eslint-plugin-promise/rules/prefer-catch.test.ts',
     './tests/eslint-plugin-promise/rules/valid-params.test.ts',
 
     // eslint-plugin-unicorn

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/prefer-catch.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/prefer-catch.test.ts
@@ -1,0 +1,61 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const message = 'Prefer `catch` to `then(a, b)`/`then(null, b)`.';
+
+ruleTester.run('prefer-catch', {} as never, {
+  valid: [
+    // ESLint upstream
+    { code: 'prom.then()' },
+    { code: 'prom.then(fn)' },
+    { code: 'prom.then(fn1).then(fn2)' },
+    { code: 'prom.then(() => {})' },
+    { code: 'prom.then(function () {})' },
+    { code: 'prom.catch()' },
+    { code: 'prom.catch(handleErr).then(handle)' },
+    { code: 'prom.catch(handleErr)' },
+  ],
+
+  invalid: [
+    // ESLint upstream
+    {
+      code: 'hey.then(fn1, fn2)',
+      errors: [{ message }],
+      output: 'hey.catch(fn2).then(fn1)',
+    },
+    {
+      code: 'hey.then(fn1, (fn2))',
+      errors: [{ message }],
+      output: 'hey.catch(fn2).then(fn1)',
+    },
+    {
+      code: 'hey.then(null, fn2)',
+      errors: [{ message }],
+      output: 'hey.catch(fn2)',
+    },
+    {
+      code: 'hey.then(undefined, fn2)',
+      errors: [{ message }],
+      output: 'hey.catch(fn2)',
+    },
+    {
+      code: 'function foo() { hey.then(x => {}, () => {}) }',
+      errors: [{ message }],
+      output: 'function foo() { hey.catch(() => {}).then(x => {}) }',
+    },
+    {
+      code: `
+function foo() {
+  hey.then(function a() { }, function b() {}).then(fn1, fn2)
+}
+`,
+      errors: [{ message }, { message }],
+      output: `
+function foo() {
+  hey.catch(function b() {}).then(function a() { }).catch(fn2).then(fn1)
+}
+`,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Ported `promise/prefer-catch` rule for #474.

## Related Links

[original docs](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/prefer-catch.md)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
