### PR TITLE
feat(eslint-plugin-jest): add `prefer-expect-resolves` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -17,6 +17,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_test_prefixes"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_called_with"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_each"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_expect_resolves"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_strict_equal"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_be"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_contain"
@@ -48,6 +49,7 @@ func GetAllRules() []rule.Rule {
 		no_test_prefixes.NoTestPrefixesRule,
 		prefer_called_with.PreferCalledWithRule,
 		prefer_each.PreferEachRule,
+		prefer_expect_resolves.PreferExpectResolvesRule,
 		prefer_strict_equal.PreferStrictEqualRule,
 		prefer_to_be.PreferToBeRule,
 		prefer_to_contain.PreferToContainRule,

--- a/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves.go
+++ b/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves.go
@@ -1,0 +1,66 @@
+package prefer_expect_resolves
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	rslintUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildExpectResolvesErrorMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "expectResolves",
+		Description: "Use `await expect(...).resolves instead",
+	}
+}
+
+var PreferExpectResolvesRule = rule.Rule{
+	Name: "jest/prefer-expect-resolves",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				jestFnCall := jestUtils.ParseJestFnCall(node, ctx)
+				if jestFnCall == nil || jestFnCall.Kind != jestUtils.JestFnTypeExpect {
+					return
+				}
+
+				expectCall := jestFnCall.Head.Local.Node.Parent
+				if expectCall == nil || expectCall.Kind != ast.KindCallExpression {
+					return
+				}
+
+				args := expectCall.Arguments()
+				if len(args) == 0 {
+					return
+				}
+
+				awaitNode := ast.SkipParentheses(args[0])
+				if awaitNode == nil || awaitNode.Kind != ast.KindAwaitExpression {
+					return
+				}
+
+				awaitExpr := awaitNode.AsAwaitExpression()
+				if awaitExpr == nil || awaitExpr.Expression == nil {
+					return
+				}
+
+				sourceFile := ctx.SourceFile
+				awaitRange := rslintUtils.TrimNodeTextRange(sourceFile, awaitNode)
+				argumentRange := rslintUtils.TrimNodeTextRange(sourceFile, awaitExpr.Expression)
+
+				fixes := []rule.RuleFix{
+					rule.RuleFixInsertBefore(sourceFile, expectCall, "await "),
+					rule.RuleFixRemoveRange(core.NewTextRange(awaitRange.Pos(), argumentRange.Pos())),
+				}
+				if !slices.Contains(jestFnCall.Modifiers, "resolves") && !slices.Contains(jestFnCall.Modifiers, "rejects") {
+					fixes = append(fixes, rule.RuleFixInsertAfter(expectCall, ".resolves"))
+				}
+
+				ctx.ReportNodeWithFixes(awaitNode, buildExpectResolvesErrorMessage(), fixes...)
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves.md
+++ b/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves.md
@@ -1,0 +1,58 @@
+# prefer-expect-resolves
+
+## Rule Details
+
+Prefer `await expect(promise).resolves.<matcher>` over
+`expect(await promise).<matcher>` when asserting on a resolved promise value.
+
+If the promise rejects, `expect(await promise)` throws before Jest can run the
+matcher, so the failure looks like an unhandled rejection rather than a test
+assertion. The `.resolves` modifier keeps failures inside Jest's matcher
+pipeline and mirrors `.rejects`, which has no equivalent `await`-inside-`expect`
+form.
+
+This rule reports `await` used as an argument to `expect()` (including renamed
+`expect` bindings from `@jest/globals`). It is fixable.
+
+Examples of **incorrect** code for this rule:
+
+```js
+it('passes', async () => {
+  expect(await someValue()).toBe(true);
+});
+
+it('is true', async () => {
+  const myPromise = Promise.resolve(true);
+
+  expect(await myPromise).toBe(true);
+});
+
+import { expect as pleaseExpect } from '@jest/globals';
+
+pleaseExpect(await myPromise).toBe(true);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it('passes', async () => {
+  await expect(someValue()).resolves.toBe(true);
+});
+
+it('is true', async () => {
+  const myPromise = Promise.resolve(true);
+
+  await expect(myPromise).resolves.toBe(true);
+});
+
+// rejections use `.rejects` — not in scope for this rule
+it('errors', async () => {
+  await expect(Promise.reject(new Error('oh noes!'))).rejects.toThrowError(
+    'oh noes!',
+  );
+});
+```
+
+## Original Documentation
+
+- [jest/prefer-expect-resolves](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-expect-resolves.md)

--- a/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves_test.go
+++ b/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves_test.go
@@ -1,0 +1,175 @@
+package prefer_expect_resolves_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_expect_resolves"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferExpectResolvesRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_expect_resolves.PreferExpectResolvesRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect.hasAssertions()`},
+			{Code: `
+      it('passes', async () => {
+        await expect(someValue()).resolves.toBe(true);
+      });
+    `},
+			{Code: `
+      it('is true', async () => {
+        const myPromise = Promise.resolve(true);
+
+        await expect(myPromise).resolves.toBe(true);
+      });
+    `},
+			{Code: `
+      it('errors', async () => {
+        await expect(Promise.reject(new Error('oh noes!'))).rejects.toThrowError(
+          'oh noes!',
+        );
+      });
+    `},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `
+        it('passes', async () => {
+          expect(await someValue(),).toBe(true);
+        });
+      `,
+				Output: []string{`
+        it('passes', async () => {
+          await expect(someValue(),).resolves.toBe(true);
+        });
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectResolves", Line: 3, Column: 18, EndColumn: 35},
+				},
+			},
+			{
+				Code: `
+        it('is true', async () => {
+          const myPromise = Promise.resolve(true);
+
+          expect(await myPromise).toBe(true);
+        });
+      `,
+				Output: []string{`
+        it('is true', async () => {
+          const myPromise = Promise.resolve(true);
+
+          await expect(myPromise).resolves.toBe(true);
+        });
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectResolves", Line: 5, Column: 18, EndColumn: 33},
+				},
+			},
+			{
+				Code: `
+        import { expect as pleaseExpect } from '@jest/globals';
+
+        it('is true', async () => {
+          const myPromise = Promise.resolve(true);
+
+          pleaseExpect(await myPromise).toBe(true);
+        });
+      `,
+				Output: []string{`
+        import { expect as pleaseExpect } from '@jest/globals';
+
+        it('is true', async () => {
+          const myPromise = Promise.resolve(true);
+
+          await pleaseExpect(myPromise).resolves.toBe(true);
+        });
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectResolves", Line: 7, Column: 24, EndColumn: 39},
+				},
+			},
+			{
+				Code: `
+        it('keeps parens around awaited argument', async () => {
+          const myPromise = Promise.resolve(true);
+
+          expect(await (myPromise)).toBe(true);
+        });
+      `,
+				Output: []string{`
+        it('keeps parens around awaited argument', async () => {
+          const myPromise = Promise.resolve(true);
+
+          await expect((myPromise)).resolves.toBe(true);
+        });
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectResolves", Line: 5, Column: 18, EndColumn: 35},
+				},
+			},
+			{
+				Code: `
+        it('unwraps extra parens around await expression', async () => {
+          const myPromise = Promise.resolve(true);
+
+          expect((await myPromise)).toBe(true);
+        });
+      `,
+				Output: []string{`
+        it('unwraps extra parens around await expression', async () => {
+          const myPromise = Promise.resolve(true);
+
+          await expect((myPromise)).resolves.toBe(true);
+        });
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectResolves", Line: 5, Column: 19, EndColumn: 34},
+				},
+			},
+			{
+				Code: `
+        it('prefers moving await before expect rejects', async () => {
+          const myPromise = Promise.reject(new Error('oh noes!'));
+
+          expect(await myPromise).rejects.toThrow('oh noes!');
+        });
+      `,
+				Output: []string{`
+        it('prefers moving await before expect rejects', async () => {
+          const myPromise = Promise.reject(new Error('oh noes!'));
+
+          await expect(myPromise).rejects.toThrow('oh noes!');
+        });
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectResolves", Line: 5, Column: 18, EndColumn: 33},
+				},
+			},
+			{
+				Code: `
+        it('does not duplicate resolves modifier', async () => {
+          const myPromise = Promise.resolve(true);
+
+          expect(await myPromise).resolves.toBe(true);
+        });
+      `,
+				Output: []string{`
+        it('does not duplicate resolves modifier', async () => {
+          const myPromise = Promise.resolve(true);
+
+          await expect(myPromise).resolves.toBe(true);
+        });
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectResolves", Line: 5, Column: 18, EndColumn: 33},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -447,6 +447,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/no-duplicate-hooks.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-called-with.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-each.test.ts',
+    './tests/eslint-plugin-jest/rules/prefer-expect-resolves.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-strict-equal.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-be.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-contain.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-expect-resolves.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-expect-resolves.test.ts
@@ -1,0 +1,87 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-expect-resolves', {} as never, {
+  valid: [
+    { code: 'expect.hasAssertions()' },
+    {
+      code: `
+      it('passes', async () => {
+        await expect(someValue()).resolves.toBe(true);
+      });
+    `,
+    },
+    {
+      code: `
+      it('is true', async () => {
+        const myPromise = Promise.resolve(true);
+
+        await expect(myPromise).resolves.toBe(true);
+      });
+    `,
+    },
+    {
+      code: `
+      it('errors', async () => {
+        await expect(Promise.reject(new Error('oh noes!'))).rejects.toThrowError(
+          'oh noes!',
+        );
+      });
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        it('passes', async () => {
+          expect(await someValue(),).toBe(true);
+        });
+      `,
+      output: `
+        it('passes', async () => {
+          await expect(someValue(),).resolves.toBe(true);
+        });
+      `,
+      errors: [{ endColumn: 27, column: 10, messageId: 'expectResolves' }],
+    },
+    {
+      code: `
+        it('is true', async () => {
+          const myPromise = Promise.resolve(true);
+
+          expect(await myPromise).toBe(true);
+        });
+      `,
+      output: `
+        it('is true', async () => {
+          const myPromise = Promise.resolve(true);
+
+          await expect(myPromise).resolves.toBe(true);
+        });
+      `,
+      errors: [{ endColumn: 25, column: 10, messageId: 'expectResolves' }],
+    },
+    {
+      code: `
+        import { expect as pleaseExpect } from '@jest/globals';
+
+        it('is true', async () => {
+          const myPromise = Promise.resolve(true);
+
+          pleaseExpect(await myPromise).toBe(true);
+        });
+      `,
+      output: `
+        import { expect as pleaseExpect } from '@jest/globals';
+
+        it('is true', async () => {
+          const myPromise = Promise.resolve(true);
+
+          await pleaseExpect(myPromise).resolves.toBe(true);
+        });
+      `,
+      errors: [{ endColumn: 31, column: 16, messageId: 'expectResolves' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

* Port `prefer-expect-resolves` from eslint-plugin-jest to rslint

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/prefer-expect-resolves [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-expect-resolves.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/prefer-expect-resolves.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
