### PR TITLE
feat(eslint-plugin-jest): add `max-nested-describe` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -2,6 +2,7 @@ package jest
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/expect_expect"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/max_nested_describe"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_alias_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_commented_out_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_deprecated_functions"
@@ -33,6 +34,7 @@ import (
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		expect_expect.ExpectExpectRule,
+		max_nested_describe.MaxNestedDescribeRule,
 		no_alias_methods.NoAliasMethodsRule,
 		no_commented_out_tests.NoCommentedOutTestsRule,
 		no_deprecated_functions.NoDeprecatedFunctionsRule,

--- a/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.go
+++ b/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.go
@@ -1,0 +1,87 @@
+package max_nested_describe
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const defaultMax = 5
+
+type options struct {
+	Max int
+}
+
+func parseOptions(raw any) options {
+	opts := options{Max: defaultMax}
+	if raw == nil {
+		return opts
+	}
+
+	optArray, ok := raw.([]interface{})
+	if !ok || len(optArray) == 0 {
+		return opts
+	}
+
+	optsMap, ok := optArray[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+
+	switch v := optsMap["max"].(type) {
+	case float64:
+		opts.Max = int(v)
+	case int:
+		opts.Max = v
+	case int64:
+		opts.Max = int(v)
+	}
+
+	return opts
+}
+
+func buildErrorExceededMaxDepthMessage(depth, maxAllowed int) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "exceededMaxDepth",
+		Description: fmt.Sprintf("Too many nested describe calls (%d) - maximum allowed is %d", depth, maxAllowed),
+		Data: map[string]string{
+			"depth": strconv.Itoa(depth),
+			"max":   strconv.Itoa(maxAllowed),
+		},
+	}
+}
+
+var MaxNestedDescribeRule = rule.Rule{
+	Name: "jest/max-nested-describe",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		describes := make([]*ast.Node, 0, 8)
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				if !utils.IsTypeOfJestFnCall(node, ctx, utils.JestFnTypeDescribe) {
+					return
+				}
+
+				describes = append(describes, node)
+				if len(describes) > opts.Max {
+					ctx.ReportNode(node, buildErrorExceededMaxDepthMessage(len(describes), opts.Max))
+				}
+			},
+			rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
+				if !utils.IsTypeOfJestFnCall(node, ctx, utils.JestFnTypeDescribe) {
+					return
+				}
+				if len(describes) == 0 {
+					return
+				}
+				if describes[len(describes)-1] == node {
+					describes = describes[:len(describes)-1]
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.md
+++ b/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.md
@@ -1,0 +1,116 @@
+# max-nested-describe
+
+## Rule Details
+
+Enforce a maximum depth for nested `describe()` calls. Grouping tests with `describe` is useful, but too many nested levels make suites harder to read and navigate.
+
+This rule counts every Jest suite call as a nesting level, including `fdescribe`, `xdescribe`, `describe.only`, `describe.skip`, and `describe.each`.
+
+Examples of **incorrect** code for this rule (with the default `{ "max": 5 }`):
+
+```javascript
+describe('foo', () => {
+  describe('bar', () => {
+    describe('baz', () => {
+      describe('qux', () => {
+        describe('quxx', () => {
+          describe('too many', () => {
+            it('should get something', () => {
+              expect(getSomething()).toBe('Something');
+            });
+          });
+        });
+      });
+    });
+  });
+});
+
+describe('foo', function () {
+  describe('bar', function () {
+    describe('baz', function () {
+      describe('qux', function () {
+        describe('quxx', function () {
+          describe('too many', function () {
+            it('should get something', () => {
+              expect(getSomething()).toBe('Something');
+            });
+          });
+        });
+      });
+    });
+  });
+});
+```
+
+Examples of **correct** code for this rule (with the default `{ "max": 5 }`):
+
+```javascript
+describe('foo', () => {
+  describe('bar', () => {
+    it('should get something', () => {
+      expect(getSomething()).toBe('Something');
+    });
+  });
+
+  describe('qux', () => {
+    it('should get something', () => {
+      expect(getSomething()).toBe('Something');
+    });
+  });
+});
+
+describe('foo2', function () {
+  it('should get something', () => {
+    expect(getSomething()).toBe('Something');
+  });
+});
+
+describe('foo', function () {
+  describe('bar', function () {
+    describe('baz', function () {
+      describe('qux', function () {
+        describe('this is the limit', function () {
+          it('should get something', () => {
+            expect(getSomething()).toBe('Something');
+          });
+        });
+      });
+    });
+  });
+});
+```
+
+## Options
+
+- First argument (optional): object with `max`
+  - `max`: maximum allowed nesting depth for `describe()` calls. Default is `5`. A value of `0` disallows any `describe` block.
+
+Examples of **correct** code with `{ "max": 2 }`:
+
+```javascript
+describe('foo', () => {
+  describe('bar', () => {
+    it('should get something', () => {
+      expect(getSomething()).toBe('Something');
+    });
+  });
+});
+```
+
+Examples of **incorrect** code with `{ "max": 2 }`:
+
+```javascript
+fdescribe('foo', () => {
+  describe.only('bar', () => {
+    describe.skip('baz', () => {
+      it('should get something', () => {
+        expect(getSomething()).toBe('Something');
+      });
+    });
+  });
+});
+```
+
+## Original Documentation
+
+- [jest/max-nested-describe](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/max-nested-describe.md)

--- a/internal/plugins/jest/rules/max_nested_describe/max_nested_describe_test.go
+++ b/internal/plugins/jest/rules/max_nested_describe/max_nested_describe_test.go
@@ -1,0 +1,216 @@
+package max_nested_describe_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/max_nested_describe"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestMaxNestedDescribeRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&max_nested_describe.MaxNestedDescribeRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `
+      describe('foo', function() {
+        describe('bar', function () {
+          describe('baz', function () {
+            describe('qux', function () {
+              describe('qux', function () {
+                it('should get something', () => {
+                  expect(getSomething()).toBe('Something');
+                });
+              })
+            })
+          })
+        })
+      });
+    `},
+			{Code: `
+      describe('foo', function() {
+        describe('bar', function () {
+          describe('baz', function () {
+            describe('qux', function () {
+              describe('qux', function () {
+                it('should get something', () => {
+                  expect(getSomething()).toBe('Something');
+                });
+              });
+
+              fdescribe('qux', () => {
+                it('something', async () => {
+                  expect('something').toBe('something');
+                });
+              });
+            })
+          })
+        })
+      });
+    `},
+			{
+				Code: `
+        describe('foo', () => {
+          describe.only('bar', () => {
+            describe.skip('baz', () => {
+              it('something', async () => {
+                expect('something').toBe('something');
+              });
+            });
+          });
+        });
+    `,
+				Options: []interface{}{
+					map[string]interface{}{"max": 3},
+				},
+			},
+			{
+				Code: `
+        it('something', async () => {
+          expect('something').toBe('something');
+        });
+    `,
+				Options: []interface{}{
+					map[string]interface{}{"max": 0},
+				},
+			},
+			{Code: `
+      describe('foo', () => {
+        describe.each(['hello', 'world'])("%s", (a) => {});
+      });
+    `},
+			{Code: "describe('foo', () => {\n  describe.each`\n  foo  | bar\n  ${'1'} | ${'2'}\n  `('$foo $bar', ({ foo, bar }) => {});\n});"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `
+        describe('foo', function() {
+          describe('bar', function () {
+            describe('baz', function () {
+              describe('qux', function () {
+                describe('quxx', function () {
+                  describe('over limit', function () {
+                    it('should get something', () => {
+                      expect(getSomething()).toBe('Something');
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceededMaxDepth", Line: 7, Column: 19},
+				},
+			},
+			{
+				Code: `
+        describe('foo', () => {
+          describe('bar', () => {
+            describe('baz', () => {
+              describe('baz1', () => {
+                describe('baz2', () => {
+                  describe('baz3', () => {
+                    it('should get something', () => {
+                      expect(getSomething()).toBe('Something');
+                    });
+                  });
+
+                  describe('baz4', () => {
+                    it('should get something', () => {
+                      expect(getSomething()).toBe('Something');
+                    });
+                  });
+                });
+              });
+            });
+
+            describe('qux', function () {
+              it('should get something', () => {
+                expect(getSomething()).toBe('Something');
+              });
+            });
+          })
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceededMaxDepth", Line: 7, Column: 19},
+					{MessageId: "exceededMaxDepth", Line: 13, Column: 19},
+				},
+			},
+			{
+				Code: `
+        fdescribe('foo', () => {
+          describe.only('bar', () => {
+            describe.skip('baz', () => {
+              it('should get something', () => {
+                expect(getSomething()).toBe('Something');
+              });
+            });
+
+            describe('baz', () => {
+              it('should get something', () => {
+                expect(getSomething()).toBe('Something');
+              });
+            });
+          });
+        });
+
+        xdescribe('qux', () => {
+          it('should get something', () => {
+            expect(getSomething()).toBe('Something');
+          });
+        });
+      `,
+				Options: []interface{}{
+					map[string]interface{}{"max": 2},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceededMaxDepth", Line: 4, Column: 13},
+					{MessageId: "exceededMaxDepth", Line: 10, Column: 13},
+				},
+			},
+			{
+				Code: `
+        describe('qux', () => {
+          it('should get something', () => {
+            expect(getSomething()).toBe('Something');
+          });
+        });
+      `,
+				Options: []interface{}{
+					map[string]interface{}{"max": 0},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceededMaxDepth", Line: 2, Column: 9},
+				},
+			},
+			{
+				Code: `
+        describe('foo', () => {
+          describe.each(['hello', 'world'])("%s", (a) => {});
+        });
+      `,
+				Options: []interface{}{
+					map[string]interface{}{"max": 1},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceededMaxDepth", Line: 3, Column: 11},
+				},
+			},
+			{
+				Code: "describe('foo', () => {\n  describe.each`\n  foo  | bar\n  ${'1'} | ${'2'}\n  `('$foo $bar', ({ foo, bar }) => {});\n});",
+				Options: []interface{}{
+					map[string]interface{}{"max": 1},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceededMaxDepth", Line: 2, Column: 3},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -432,6 +432,7 @@ export default defineConfig({
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/expect-expect.test.ts',
+    './tests/eslint-plugin-jest/rules/max-nested-describe.test.ts',
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',
     './tests/eslint-plugin-jest/rules/no-commented-out-tests.test.ts',
     './tests/eslint-plugin-jest/rules/no-deprecated-functions.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/max-nested-describe.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/max-nested-describe.test.ts
@@ -1,0 +1,206 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('max-nested-describe', {} as never, {
+  valid: [
+    {
+      code: `
+      describe('foo', function() {
+        describe('bar', function () {
+          describe('baz', function () {
+            describe('qux', function () {
+              describe('qux', function () {
+                it('should get something', () => {
+                  expect(getSomething()).toBe('Something');
+                });
+              })
+            })
+          })
+        })
+      });
+    `,
+    },
+    {
+      code: `
+      describe('foo', function() {
+        describe('bar', function () {
+          describe('baz', function () {
+            describe('qux', function () {
+              describe('qux', function () {
+                it('should get something', () => {
+                  expect(getSomething()).toBe('Something');
+                });
+              });
+
+              fdescribe('qux', () => {
+                it('something', async () => {
+                  expect('something').toBe('something');
+                });
+              });
+            })
+          })
+        })
+      });
+    `,
+    },
+    {
+      code: `
+        describe('foo', () => {
+          describe.only('bar', () => {
+            describe.skip('baz', () => {
+              it('something', async () => {
+                expect('something').toBe('something');
+              });
+            });
+          });
+        });
+    `,
+      options: [{ max: 3 }],
+    },
+    {
+      code: `
+        it('something', async () => {
+          expect('something').toBe('something');
+        });
+    `,
+      options: [{ max: 0 }],
+    },
+    {
+      code: `
+      describe('foo', () => {
+        describe.each(['hello', 'world'])("%s", (a) => {});
+      });
+    `,
+    },
+    {
+      code: `
+      describe('foo', () => {
+        describe.each\`
+        foo  | bar
+        ${'1'} | ${'2'}
+        \`('$foo $bar', ({ foo, bar }) => {});
+      });
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        describe('foo', function() {
+          describe('bar', function () {
+            describe('baz', function () {
+              describe('qux', function () {
+                describe('quxx', function () {
+                  describe('over limit', function () {
+                    it('should get something', () => {
+                      expect(getSomething()).toBe('Something');
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      `,
+      errors: [{ messageId: 'exceededMaxDepth', line: 6, column: 11 }],
+    },
+    {
+      code: `
+        describe('foo', () => {
+          describe('bar', () => {
+            describe('baz', () => {
+              describe('baz1', () => {
+                describe('baz2', () => {
+                  describe('baz3', () => {
+                    it('should get something', () => {
+                      expect(getSomething()).toBe('Something');
+                    });
+                  });
+
+                  describe('baz4', () => {
+                    it('should get something', () => {
+                      expect(getSomething()).toBe('Something');
+                    });
+                  });
+                });
+              });
+            });
+
+            describe('qux', function () {
+              it('should get something', () => {
+                expect(getSomething()).toBe('Something');
+              });
+            });
+          })
+        });
+      `,
+      errors: [
+        { messageId: 'exceededMaxDepth', line: 6, column: 11 },
+        { messageId: 'exceededMaxDepth', line: 12, column: 11 },
+      ],
+    },
+    {
+      code: `
+        fdescribe('foo', () => {
+          describe.only('bar', () => {
+            describe.skip('baz', () => {
+              it('should get something', () => {
+                expect(getSomething()).toBe('Something');
+              });
+            });
+
+            describe('baz', () => {
+              it('should get something', () => {
+                expect(getSomething()).toBe('Something');
+              });
+            });
+          });
+        });
+
+        xdescribe('qux', () => {
+          it('should get something', () => {
+            expect(getSomething()).toBe('Something');
+          });
+        });
+      `,
+      options: [{ max: 2 }],
+      errors: [
+        { messageId: 'exceededMaxDepth', line: 3, column: 5 },
+        { messageId: 'exceededMaxDepth', line: 9, column: 5 },
+      ],
+    },
+    {
+      code: `
+        describe('qux', () => {
+          it('should get something', () => {
+            expect(getSomething()).toBe('Something');
+          });
+        });
+      `,
+      options: [{ max: 0 }],
+      errors: [{ messageId: 'exceededMaxDepth', line: 1, column: 1 }],
+    },
+    {
+      code: `
+        describe('foo', () => {
+          describe.each(['hello', 'world'])("%s", (a) => {});
+        });
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'exceededMaxDepth', line: 2, column: 3 }],
+    },
+    {
+      code: `
+        describe('foo', () => {
+          describe.each\`
+          foo  | bar
+          ${'1'} | ${'2'}
+          \`('$foo $bar', ({ foo, bar }) => {});
+        });
+      `,
+      options: [{ max: 1 }],
+      errors: [{ messageId: 'exceededMaxDepth', line: 2, column: 3 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

* Port `max-nested-describe` from eslint-plugin-jest to rslint

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/max-nested-describe [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/max-nested-describe.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/max-nested-describe.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
