### PR TITLE
fix: enable promise catch-or-return preset

### DIFF
--- a/packages/rslint/src/configs/promise.ts
+++ b/packages/rslint/src/configs/promise.ts
@@ -8,7 +8,7 @@ const recommended: RslintConfigEntry = {
     // 'promise/always-return': 'error', // not implemented
     'promise/no-return-wrap': 'error',
     'promise/param-names': 'error',
-    // 'promise/catch-or-return': 'error', // not implemented
+    'promise/catch-or-return': 'error',
     // 'promise/no-native': 'off', // not implemented
     // 'promise/no-nesting': 'warn', // not implemented
     // 'promise/no-promise-in-callback': 'warn', // not implemented


### PR DESCRIPTION
## Summary

enable the ported rule in `packages/rslint/src/configs/promise.ts`