### PR TITLE
fix: run config plugins in the packaged VS Code extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,10 @@ jobs:
   publish-extension-vscode:
     if: ${{ inputs.to_release == 'all' || inputs.to_release == 'extension' }}
     name: ${{ inputs.dry_run == true && 'Dry Run - VSCode Extensions' || 'Publish VSCode Extensions' }}
-    needs: [build]
+    # napi-build supplies the per-platform parser `.node` (downloaded into
+    # `binaries/native-<tuple>/`) that publish-marketplace.mjs stages into the
+    # eslint-plugin worker payload; without it the packaged plugin host can't load.
+    needs: [build, napi-build]
     runs-on: rspack-ubuntu-22.04-large
     environment: release
     steps:
@@ -137,6 +140,13 @@ jobs:
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
+
+      # publish:vsce regenerates @rslint/native's index.d.ts from the current
+      # Rust source (napi build) so the worker's build:js types are never stale.
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache: 'false'
 
       - name: Download Artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -169,7 +179,8 @@ jobs:
   publish-extension-open-vsx:
     if: ${{ inputs.to_release == 'all' || inputs.to_release == 'extension' }}
     name: ${{ inputs.dry_run == true && 'Dry Run - Open VSX Extensions' || 'Publish Open VSX Extensions' }}
-    needs: [build]
+    # Same as publish-extension-vscode: needs the per-platform parser `.node`.
+    needs: [build, napi-build]
     runs-on: ubuntu-22.04
     environment: release
     steps:
@@ -182,6 +193,13 @@ jobs:
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
+
+      # publish:ovsx regenerates @rslint/native's index.d.ts from the current
+      # Rust source (napi build) so the worker's build:js types are never stale.
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache: 'false'
 
       - name: Download Artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/packages/rslint/tests/eslint-plugin/host-cancel.test.ts
+++ b/packages/rslint/tests/eslint-plugin/host-cancel.test.ts
@@ -5,6 +5,7 @@ import { WorkerPool } from '../../src/eslint-plugin/worker-pool.js';
 import type { EslintPluginLintRequest } from '../../src/eslint-plugin/plugin/plugin-lint-protocol.js';
 
 import { LOCAL_CONFIG_DIR, localConfigs } from './worker-pool-e2e-helpers.js';
+import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
 
 /**
  * Plugin-lint host — cancellation via AbortSignal. The LSP path bridges Go's
@@ -12,10 +13,10 @@ import { LOCAL_CONFIG_DIR, localConfigs } from './worker-pool-e2e-helpers.js';
  * host.lint must cancel the dispatched worker tasks so the worker stops instead
  * of running to completion.
  *
- * Windows-skipped for the same napi-teardown reason as the other worker e2e
- * suites (they spawn + tear down real workers).
+ * win32 teardown is gated by SKIP_WIN32_NAPI_TEARDOWN (same napi-teardown
+ * reason as the other worker e2e suites); the flag is false so this runs too.
  */
-describe.skipIf(process.platform === 'win32')(
+describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
   'createPluginLintHost — cancellation via AbortSignal',
   () => {
     const req: EslintPluginLintRequest = {

--- a/packages/rslint/tests/eslint-plugin/packaged-isolation.test.ts
+++ b/packages/rslint/tests/eslint-plugin/packaged-isolation.test.ts
@@ -1,0 +1,189 @@
+import { describe, test, expect, beforeAll, afterAll } from '@rstest/core';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
+
+/**
+ * Packaged-layout isolation guard.
+ *
+ * The VS Code extension does NOT ship `@rslint/core`; instead `build.js` stages
+ * the built `dist/eslint-plugin/` worker bundle into the vsix together with a
+ * nested `node_modules/@rslint/native/` (a tiny shim loader + the platform
+ * `.node`), so the worker resolves `@rslint/native` from THERE rather than from
+ * a workspace `node_modules`. The original bug was that this worked in dev (the
+ * dev host has the workspace package) but silently produced zero diagnostics
+ * once packaged. The normal worker-pool e2e suites can't catch a regression of
+ * this because they resolve `@rslint/native` from the workspace.
+ *
+ * This test reproduces the packaged layout under `os.tmpdir()` — OFF any
+ * `@rslint/core` / workspace `node_modules` resolution path — and runs the host
+ * in a SUBPROCESS (so it neither inherits this suite's `setWorkerEntryForTests`
+ * override nor any in-process module cache). It asserts the worker loads the
+ * native parser from the nested shim and a plugin rule fires; a negative
+ * control proves the host entry (`index.js`) itself — before any worker spawns
+ * — can't fall back to a workspace `@rslint/native`.
+ *
+ * Requires `dist/eslint-plugin/` (built by `pnpm build`, the same prerequisite
+ * the worker-pool e2e suites already document) and the host `@rslint/native`
+ * `.node` (built by `pnpm --filter @rslint/native build`).
+ */
+
+const require = createRequire(import.meta.url);
+const SHIM =
+  "const binding = require('./rslint.node');\n" +
+  'module.exports = binding;\n' +
+  'module.exports.parse = binding.parse;\n';
+
+// A self-contained `.mjs` plugin + config — `.mjs` needs no `jiti`, isolating
+// this test to the native-parser resolution it is meant to guard.
+const LOCAL_PLUGIN = `export default {
+  meta: { name: 'lp', version: '1' },
+  rules: {
+    'no-null': {
+      meta: { type: 'suggestion', schema: [], messages: { e: 'no null' } },
+      create(c) {
+        return { Literal(n) { if (n.raw === 'null') c.report({ node: n, messageId: 'e' }); } };
+      },
+    },
+  },
+};
+`;
+const CONFIG = `import lp from './local-plugin.mjs';
+export default [{ plugins: { pkg: lp } }];
+`;
+
+// The runner imports the STAGED host by a path relative to its own location, so
+// Node resolves `@rslint/native` by walking up from the staged worker into the
+// staged nested node_modules — exactly the packaged resolution path.
+const RUNNER = `import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cfgDir = path.join(here, 'cfg');
+const { createPluginLintHost } = await import(
+  pathToFileURL(path.join(here, 'eslint-plugin', 'index.js')).href
+);
+const host = await createPluginLintHost([
+  { configPath: path.join(cfgDir, 'rslint.config.mjs'), configDirectory: cfgDir },
+]);
+const res = await host.lint({
+  files: [{ path: 'a.ts', text: 'const x = null;', configKey: cfgDir }],
+  rules: { 'pkg/no-null': { options: [] } },
+  fix: false,
+  suggestionsMode: 'off',
+});
+await host.shutdown();
+const d = res.results?.[0]?.diagnostics ?? [];
+if (d.length === 1 && d[0].ruleName === 'pkg/no-null') {
+  console.log('PACKAGED_OK');
+  process.exit(0);
+}
+console.error('UNEXPECTED ' + JSON.stringify(res));
+process.exit(1);
+`;
+
+/** Stage a packaged layout under `root`; omit the nested native for the negative control. */
+function stage(root: string, opts: { withNative: boolean }): void {
+  const coreEpDir = path.resolve(__dirname, '../../dist/eslint-plugin');
+  if (!fs.existsSync(path.join(coreEpDir, 'index.js'))) {
+    throw new Error(
+      `built worker bundle missing at ${coreEpDir} — run \`pnpm build\` (or ` +
+        '`pnpm --filter @rslint/core build:js`) before this test',
+    );
+  }
+  const epDest = path.join(root, 'eslint-plugin');
+  fs.cpSync(coreEpDir, epDest, { recursive: true });
+  fs.writeFileSync(
+    path.join(epDest, 'package.json'),
+    JSON.stringify({ type: 'module' }),
+  );
+
+  if (opts.withNative) {
+    const nativeDir = path.join(epDest, 'node_modules', '@rslint', 'native');
+    fs.mkdirSync(nativeDir, { recursive: true });
+    fs.writeFileSync(path.join(nativeDir, 'index.js'), SHIM);
+    fs.writeFileSync(
+      path.join(nativeDir, 'package.json'),
+      JSON.stringify({
+        name: '@rslint/native',
+        type: 'commonjs',
+        main: 'index.js',
+      }),
+    );
+    const nativeSrcDir = path.dirname(require.resolve('@rslint/native'));
+    const hostNode = fs
+      .readdirSync(nativeSrcDir)
+      .find((f) => /^rslint\..*\.node$/.test(f));
+    if (!hostNode) {
+      throw new Error(
+        `no built @rslint/native .node in ${nativeSrcDir} — run ` +
+          '`pnpm --filter @rslint/native build` before this test',
+      );
+    }
+    fs.copyFileSync(
+      path.join(nativeSrcDir, hostNode),
+      path.join(nativeDir, 'rslint.node'),
+    );
+  }
+
+  const cfgDir = path.join(root, 'cfg');
+  fs.mkdirSync(cfgDir, { recursive: true });
+  fs.writeFileSync(path.join(cfgDir, 'local-plugin.mjs'), LOCAL_PLUGIN);
+  fs.writeFileSync(path.join(cfgDir, 'rslint.config.mjs'), CONFIG);
+  fs.writeFileSync(path.join(root, 'runner.mjs'), RUNNER);
+}
+
+// Spawns a real worker that does native teardown, so it respects the same
+// win32 kill-switch as the worker-pool e2e suites (flag is false → runs on
+// win32 too, validating the napi-teardown mitigation).
+describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
+  'packaged-layout isolation (vsix eslint-plugin worker)',
+  () => {
+    let tmp: string;
+    beforeAll(() => {
+      tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rslint-pkg-'));
+    });
+    afterAll(() => {
+      if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    test('worker loads @rslint/native from the nested shim and a plugin rule fires', () => {
+      const root = path.join(tmp, 'ok');
+      fs.mkdirSync(root, { recursive: true });
+      stage(root, { withNative: true });
+      // timeout + SIGKILL so a worker wedged in native teardown (the win32
+      // abort this validates) fails loudly instead of hanging CI forever.
+      const out = execFileSync('node', ['runner.mjs'], {
+        cwd: root,
+        encoding: 'utf8',
+        timeout: 30_000,
+        killSignal: 'SIGKILL',
+      });
+      expect(out).toContain('PACKAGED_OK');
+    });
+
+    test('without the nested @rslint/native the host fails (no workspace fallback)', () => {
+      const root = path.join(tmp, 'no-native');
+      fs.mkdirSync(root, { recursive: true });
+      stage(root, { withNative: false });
+      let stderr = '';
+      let threw = false;
+      try {
+        execFileSync('node', ['runner.mjs'], {
+          cwd: root,
+          encoding: 'utf8',
+          timeout: 30_000,
+          killSignal: 'SIGKILL',
+        });
+      } catch (err) {
+        threw = true;
+        stderr = String((err as { stderr?: string }).stderr ?? '');
+      }
+      expect(threw).toBe(true);
+      expect(stderr).toContain('@rslint/native');
+      expect(stderr).toContain('ERR_MODULE_NOT_FOUND');
+    });
+  },
+);

--- a/packages/rslint/tests/eslint-plugin/win32-napi-teardown.ts
+++ b/packages/rslint/tests/eslint-plugin/win32-napi-teardown.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether to skip the real-worker teardown e2e suites on win32.
+ *
+ * Tearing down a worker that holds the napi parser addon (`@rslint/native`)
+ * used to abort below the JS layer on win32 (nodejs/node#34567), crashing the
+ * rstest child — so these suites were win32-skipped. `terminateWorker`
+ * (worker-pool.ts) now destroys the worker's stdio pipes before terminating,
+ * which should remove that race.
+ *
+ * This flag is `false` so the suites RUN on win32 in CI, validating that
+ * mitigation before the packaged VS Code extension ships the same addon in its
+ * eslint-plugin worker on the win32 vsix (a forced terminate is reachable in
+ * production via the per-task timeout / crash-respawn paths). If win32 CI shows
+ * the abort returns, flip this to `true` to restore the skip and gate
+ * eslintPlugins off on win32 in the extension's PluginLintPool.
+ */
+export const SKIP_WIN32_NAPI_TEARDOWN = false;

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-cancel.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-cancel.test.ts
@@ -8,6 +8,7 @@ import {
   localConfigs,
   task,
 } from './worker-pool-e2e-helpers.js';
+import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
 
 /**
  * WorkerPool end-to-end — cancellation: cancelTask from inside
@@ -17,12 +18,9 @@ import {
  * parseError:shutdown).
  */
 
-// Skipped on windows: tearing down a worker that has oxc (a napi addon)
-// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
-// the rstest worker running this file. These e2e tests spawn real
-// workers and tear them down, so they are windows-skipped; they still
-// run on linux/macOS.
-describe.skipIf(process.platform === 'win32')(
+// win32 teardown is gated by SKIP_WIN32_NAPI_TEARDOWN (see that file for the
+// nodejs/node#34567 rationale); the flag is false so these run on win32 too.
+describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
   'WorkerPool end-to-end with a local fixture plugin',
   () => {
     test('cancelTask inside onTaskDispatched aborts before worker runs', async () => {

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-concurrency.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-concurrency.test.ts
@@ -4,6 +4,7 @@ import { WorkerPool } from '../../src/eslint-plugin/worker-pool.js';
 import type { LintTask } from '../../src/eslint-plugin/worker-pool.js';
 
 import { localConfigs, task } from './worker-pool-e2e-helpers.js';
+import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
 
 /**
  * WorkerPool end-to-end — concurrent lintBatch (the #1050 runtime shape).
@@ -14,7 +15,8 @@ import { localConfigs, task } from './worker-pool-e2e-helpers.js';
  * partitioned to its own caller and rule — a cross-batch bleed (a result routed
  * to the wrong promise, or a doubled dispatch) would surface here.
  */
-describe.skipIf(process.platform === 'win32')(
+// win32 teardown gated by SKIP_WIN32_NAPI_TEARDOWN (flag false → runs on win32).
+describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
   'WorkerPool concurrent lintBatch (#1050 runtime shape)',
   () => {
     test('two batches in flight partition results to their own caller + rule', async () => {

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-init-errors.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-init-errors.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from '@rstest/core';
 import path from 'node:path';
 
 import { WorkerPool } from '../../src/eslint-plugin/worker-pool.js';
+import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
 
 /**
  * WorkerPool end-to-end — init-error paths: a failing config surfaces a
@@ -11,12 +12,9 @@ import { WorkerPool } from '../../src/eslint-plugin/worker-pool.js';
  * respawns before throwing (symmetric with shutdown).
  */
 
-// Skipped on windows: tearing down a worker that has oxc (a napi addon)
-// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
-// the rstest worker running this file. These e2e tests spawn real
-// workers and tear them down, so they are windows-skipped; they still
-// run on linux/macOS.
-describe.skipIf(process.platform === 'win32')(
+// win32 teardown is gated by SKIP_WIN32_NAPI_TEARDOWN (see that file for the
+// nodejs/node#34567 rationale); the flag is false so these run on win32 too.
+describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
   'WorkerPool end-to-end with a local fixture plugin',
   () => {
     test('init failure surfaces with helpful error', async () => {

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-lifecycle.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
   localConfigs,
   task,
 } from './worker-pool-e2e-helpers.js';
+import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
 
 /**
  * WorkerPool end-to-end — lifecycle: init + lintBatch + shutdown happy
@@ -22,12 +23,9 @@ import {
  * plugin (`fixtures/local-plugin.mjs`), not an external dependency.
  */
 
-// Skipped on windows: tearing down a worker that has oxc (a napi addon)
-// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
-// the rstest worker running this file. These e2e tests spawn real
-// workers and tear them down, so they are windows-skipped; they still
-// run on linux/macOS.
-describe.skipIf(process.platform === 'win32')(
+// win32 teardown is gated by SKIP_WIN32_NAPI_TEARDOWN (see that file for the
+// nodejs/node#34567 rationale); the flag is false so these run on win32 too.
+describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
   'WorkerPool end-to-end with a local fixture plugin',
   () => {
     test('init + lintBatch + shutdown happy path', async () => {

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-multiconfig.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-multiconfig.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from '@rstest/core';
 import path from 'node:path';
 
 import { WorkerPool } from '../../src/eslint-plugin/worker-pool.js';
+import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
 
 /**
  * WorkerPool end-to-end — multi-config (monorepo) dispatch: a single
@@ -12,12 +13,9 @@ import { WorkerPool } from '../../src/eslint-plugin/worker-pool.js';
  * forwarded through onLog (LSP-visible).
  */
 
-// Skipped on windows: tearing down a worker that has oxc (a napi addon)
-// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
-// the rstest worker running this file. These e2e tests spawn real
-// workers and tear them down, so they are windows-skipped; they still
-// run on linux/macOS.
-describe.skipIf(process.platform === 'win32')(
+// win32 teardown is gated by SKIP_WIN32_NAPI_TEARDOWN (see that file for the
+// nodejs/node#34567 rationale); the flag is false so these run on win32 too.
+describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
   'WorkerPool end-to-end with a local fixture plugin',
   () => {
     // Multi-config (monorepo) dispatch — a single worker holds TWO

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-queue.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-queue.test.ts
@@ -8,6 +8,7 @@ import {
   localConfigs,
   task,
 } from './worker-pool-e2e-helpers.js';
+import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
 
 /**
  * WorkerPool end-to-end — queue model: tasks wait in `pendingQueue`
@@ -19,12 +20,9 @@ import {
  * batches as parseError:'pool_degraded' instead of hanging.
  */
 
-// Skipped on windows: tearing down a worker that has oxc (a napi addon)
-// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
-// the rstest worker running this file. These e2e tests spawn real
-// workers and tear them down, so they are windows-skipped; they still
-// run on linux/macOS.
-describe.skipIf(process.platform === 'win32')(
+// win32 teardown is gated by SKIP_WIN32_NAPI_TEARDOWN (see that file for the
+// nodejs/node#34567 rationale); the flag is false so these run on win32 too.
+describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
   'WorkerPool end-to-end with a local fixture plugin',
   () => {
     // R1 (re-purposed for the queue model): the original R1 finding

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-resilience.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-resilience.test.ts
@@ -9,6 +9,7 @@ import {
   localConfigs,
   task,
 } from './worker-pool-e2e-helpers.js';
+import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
 
 /**
  * WorkerPool end-to-end — resilience: a non-cloneable task degrades to
@@ -17,12 +18,9 @@ import {
  * respawn, and a hung listener trips task_timeout → respawn → recovery.
  */
 
-// Skipped on windows: tearing down a worker that has oxc (a napi addon)
-// loaded aborts below the JS layer there (nodejs/node#34567) and crashes
-// the rstest worker running this file. These e2e tests spawn real
-// workers and tear them down, so they are windows-skipped; they still
-// run on linux/macOS.
-describe.skipIf(process.platform === 'win32')(
+// win32 teardown is gated by SKIP_WIN32_NAPI_TEARDOWN (see that file for the
+// nodejs/node#34567 rationale); the flag is false so these run on win32 too.
+describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
   'WorkerPool end-to-end with a local fixture plugin',
   () => {
     // postMessage path: a non-clonable field on the task makes

--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -13,6 +13,10 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+**/*.tsbuildinfo
+# Root-anchored on purpose: the eslint-plugin worker's nested
+# dist/eslint-plugin/node_modules/@rslint/native (loader + .node) MUST ship.
+# Do NOT rewrite to **/node_modules/** — that would strip the worker payload.
 node_modules/**
 !node_modules/vscode-languageclient/**
 !node_modules/vscode-languageserver-protocol/**

--- a/packages/vscode-extension/scripts/build.js
+++ b/packages/vscode-extension/scripts/build.js
@@ -3,6 +3,15 @@ const path = require('path');
 const fs = require('fs');
 const isWatchMode = process.argv.includes('--watch');
 
+// The eslint-plugin host is loaded at runtime via a RELATIVE dynamic import
+// `import('./eslint-plugin/index.js')` (PluginLintPool.ts). It MUST stay
+// external: it is an ESM module that spawns its sibling `lint-worker.js` via
+// `new Worker(new URL('./lint-worker.js', import.meta.url))`, so it has to keep
+// living next to that worker inside the staged `dist/eslint-plugin/`. Bundling
+// it into `dist/main.js` would break that sibling resolution. The `copy-files`
+// plugin below stages the whole worker payload (worker bundle + nested
+// `@rslint/native` loader/.node) into `dist/eslint-plugin/`. Unlike
+// `config-loader`, which IS bundled into `main.js`, the host is never bundled.
 const config = {
   entryPoints: ['src/main.ts'],
   outfile: 'dist/main.js',
@@ -11,15 +20,7 @@ const config = {
 
   sourcemap: true,
   platform: 'node',
-  // `@rslint/core/eslint-plugin` MUST stay external (esbuild matches externals
-  // by exact specifier, so the bare `@rslint/core` entry does not cover this
-  // subpath — it needs its own entry). Its WorkerPool spawns the lint worker
-  // via `new Worker(new URL('./lint-worker.js', import.meta.url))`, so the ESM
-  // `index.js` must keep living next to `lint-worker.js` inside the installed
-  // `@rslint/core/dist/eslint-plugin/`. Bundling it into `dist/main.js` would
-  // break that sibling resolution. Unlike `config-loader` below, do NOT add a
-  // bundle override for it.
-  external: ['@rslint/core', '@rslint/core/eslint-plugin', 'vscode'],
+  external: ['@rslint/core', 'vscode'],
   loader: {
     '': 'file',
   },
@@ -35,31 +36,125 @@ const config = {
       },
     },
     {
+      name: 'external-eslint-plugin-host',
+      setup(build) {
+        // Keep the relative host import verbatim (emitted as a real ESM
+        // `import("./eslint-plugin/index.js")`). Marking it external here —
+        // rather than via the top-level `external` array — keeps the exact
+        // relative specifier so it resolves against `dist/main.js` at runtime.
+        build.onResolve(
+          { filter: /^\.\/eslint-plugin\/index\.js$/ },
+          (args) => ({
+            path: args.path,
+            external: true,
+          }),
+        );
+      },
+    },
+    {
       name: 'copy-files',
       setup(build) {
         build.onStart(() => {
           console.info('start rebuild');
         });
-        build.onEnd(() => {
-          const binDir = path.resolve(
-            require.resolve('@rslint/core/package.json'),
-            '../bin',
-          );
-          fs.cpSync(binDir, path.join(__dirname, '../dist'), {
-            recursive: true,
-          });
+        build.onEnd((result) => {
+          // Don't stage a stale/partial payload on top of a failed build.
+          if (result.errors.length > 0) return;
+          stageRuntimeAssets();
           console.log('rebuild done');
         });
       },
     },
   ],
 };
+
+/**
+ * Stage everything the packaged extension needs at runtime that esbuild does
+ * not bundle into `dist/main.js`:
+ *   1. the Go LSP binary + launcher (`@rslint/core/bin`)
+ *   2. the eslint-plugin worker bundle (`@rslint/core/dist/eslint-plugin/`)
+ *   3. a nested `@rslint/native` (a tiny fixed-name shim loader + the napi
+ *      `.node`), so the worker can `import "@rslint/native"` via Node's
+ *      node_modules walk-up from the worker file.
+ *
+ * Resolution of `@rslint/native` MUST be anchored on @rslint/core's directory:
+ * the vscode-extension package doesn't declare it, so a bare `require.resolve`
+ * from here throws MODULE_NOT_FOUND.
+ */
+function stageRuntimeAssets() {
+  const distDir = path.join(__dirname, '../dist');
+  const coreDir = path.dirname(require.resolve('@rslint/core/package.json'));
+
+  // 1. Go LSP binary (`rslint`/`rslint.exe`) + launcher (`rslint.cjs`). In CI,
+  //    publish-marketplace.mjs overwrites `dist/rslint` with the per-platform
+  //    binary; locally this copy makes `pnpm build` self-sufficient for dev.
+  fs.cpSync(path.join(coreDir, 'bin'), distDir, { recursive: true });
+
+  // 2. eslint-plugin worker bundle — copy the WHOLE dir, never enumerate file
+  //    names: the Rspack runtime chunk (`<id>.js`) has a non-deterministic id
+  //    and both `index.js` and `lint-worker.js` hard-import it as a sibling.
+  const epSrc = path.join(coreDir, 'dist', 'eslint-plugin');
+  const epDest = path.join(distDir, 'eslint-plugin');
+  fs.rmSync(epDest, { recursive: true, force: true });
+  fs.cpSync(epSrc, epDest, { recursive: true });
+
+  // 3. ESM marker. The worker bundle is ESM and `@rslint/core` is
+  //    `type:module`; the copied subdir loses that ancestry, so without this
+  //    marker Node would treat the `.js` files as CommonJS and fail.
+  fs.writeFileSync(
+    path.join(epDest, 'package.json'),
+    `${JSON.stringify({ type: 'module' }, null, 2)}\n`,
+  );
+
+  // 4. Nested `@rslint/native`: a minimal shim (./native-loader-shim.cjs) that
+  //    requires a FIXED-name `./rslint.node`, replacing napi-rs's auto-generated
+  //    loader. We control exactly which per-platform `.node` ships in each vsix,
+  //    so the loader's platform/libc/universal probing is unnecessary and — in
+  //    the Electron host — a liability (see native-loader-shim.cjs for why).
+  const nativeDest = path.join(epDest, 'node_modules', '@rslint', 'native');
+  fs.mkdirSync(nativeDest, { recursive: true });
+  fs.copyFileSync(
+    path.join(__dirname, 'native-loader-shim.cjs'),
+    path.join(nativeDest, 'index.js'),
+  );
+  fs.writeFileSync(
+    path.join(nativeDest, 'package.json'),
+    `${JSON.stringify(
+      { name: '@rslint/native', type: 'commonjs', main: 'index.js' },
+      null,
+      2,
+    )}\n`,
+  );
+  // Dev: stage the current host's `.node` as the fixed `rslint.node` so a
+  // local `pnpm build` works in the dev extension host. CI overwrites this
+  // single fixed-name file with the target platform's `.node`
+  // (publish-marketplace.mjs) — one filename, so no wrong-arch leak is possible.
+  const nativeSrcDir = path.dirname(
+    require.resolve('@rslint/native', { paths: [coreDir] }),
+  );
+  const hostNode = fs
+    .readdirSync(nativeSrcDir)
+    .find((f) => /^rslint\..*\.node$/.test(f));
+  if (hostNode) {
+    fs.copyFileSync(
+      path.join(nativeSrcDir, hostNode),
+      path.join(nativeDest, 'rslint.node'),
+    );
+  } else {
+    console.warn(
+      'build.js: no local @rslint/native .node found; the eslint-plugin ' +
+        'worker will not load in the dev host until `pnpm --filter ' +
+        '@rslint/native build` is run.',
+    );
+  }
+}
+
 async function main() {
   if (isWatchMode) {
     const ctx = await esbuild.context(config);
     await ctx.watch();
   } else {
-    esbuild.build(config);
+    await esbuild.build(config);
   }
 }
 

--- a/packages/vscode-extension/scripts/native-loader-shim.cjs
+++ b/packages/vscode-extension/scripts/native-loader-shim.cjs
@@ -1,0 +1,14 @@
+// Staged by scripts/build.js into the packaged extension as
+// `dist/eslint-plugin/node_modules/@rslint/native/index.js` — a minimal,
+// deterministic replacement for napi-rs's auto-generated loader.
+//
+// The vsix is per-platform and ships exactly one binary as `./rslint.node`, so
+// none of the loader's runtime platform/libc/universal probing or version
+// checks are needed (and that probing is a liability in the Electron host — its
+// win32 branch keys on `process.config.variables.node_target_type`, and
+// Electron embeds Node as a shared library). Re-exporting `parse` explicitly
+// lets the worker's ESM `import { parse }` resolve the named export from this
+// CommonJS module.
+const binding = require('./rslint.node');
+module.exports = binding;
+module.exports.parse = binding.parse;

--- a/packages/vscode-extension/src/PluginLintPool.ts
+++ b/packages/vscode-extension/src/PluginLintPool.ts
@@ -10,14 +10,20 @@
  * (`buildPluginLintTasks` / `buildPluginLintResult`), shared with the CLI
  * engine so the two paths never drift.
  *
- * `@rslint/core/eslint-plugin` is loaded via a dynamic `import()` (not a
- * static import): it is ESM (uses `import.meta.url` to resolve its sibling
- * `lint-worker.js`) while this extension is bundled to CJS, and esbuild
- * keeps it external (see scripts/build.js) so the worker file stays next to
- * `index.js` inside the installed package. A static `require` of an ESM
- * module would fail; a dynamic `import()` loads it correctly.
+ * The host is loaded via a dynamic `import()` of the RELATIVE specifier
+ * `./eslint-plugin/index.js` (not the bare `@rslint/core/eslint-plugin`):
+ * relative to the built `dist/main.js` it resolves to the extension's OWN
+ * `dist/eslint-plugin/index.js`, which `scripts/build.js` stages into the
+ * package (worker bundle + nested `@rslint/native`). The bare
+ * specifier only resolves in dev (workspace `node_modules`); the packaged
+ * vsix ships no `@rslint/core`, so it must be the relative sibling. The host
+ * is ESM (uses `import.meta.url` to spawn its sibling `lint-worker.js`) while
+ * this extension is bundled to CJS — a static `require` of an ESM module
+ * would fail, a dynamic `import()` loads it correctly. esbuild keeps the
+ * specifier external (see scripts/build.js) so it is emitted verbatim.
  */
 
+import { window } from 'vscode';
 import type { CancellationToken } from 'vscode';
 import type { Logger } from './logger';
 import type {
@@ -38,16 +44,36 @@ interface EslintPluginModule {
 let modPromise: Promise<EslintPluginModule> | undefined;
 
 /**
- * Load the ESM `@rslint/core/eslint-plugin` entry once. esbuild preserves
- * this dynamic import verbatim in its CJS output (verified) because the
- * specifier is external — so it resolves to the installed package's ESM
- * `dist/eslint-plugin/index.js` at runtime.
+ * Load the ESM host entry once. The specifier is RELATIVE
+ * (`./eslint-plugin/index.js`): esbuild keeps it external so it survives
+ * verbatim into `dist/main.js`, where it resolves to the sibling
+ * `dist/eslint-plugin/index.js` staged by `scripts/build.js` — the same path
+ * in dev and in the packaged vsix, so the dev test exercises the packaged
+ * mechanism rather than a dev-only one.
  */
 async function loadModule(): Promise<EslintPluginModule> {
-  modPromise ??=
-    import('@rslint/core/eslint-plugin') as Promise<EslintPluginModule>;
+  // The host entry exists only in the built `dist/` (staged by build.js), never
+  // under `src/`, so it is intentionally unresolvable at compile time; its
+  // module shape is supplied by `modPromise`'s declared type (no cast needed —
+  // the suppressed import is `any`, assignable straight into the typed slot).
+  // @ts-expect-error -- runtime-only path, resolved relative to dist/main.js
+  modPromise ??= import('./eslint-plugin/index.js').catch((err: unknown) => {
+    // Don't cache a rejected load: a transient failure (e.g. a mid-rebuild
+    // dist in the dev watch window) must stay retryable on the next ensure(),
+    // which is the recovery ensure()'s catch documents.
+    modPromise = undefined;
+    throw err;
+  });
   return modPromise;
 }
+
+/**
+ * Latches the one-shot "host failed to load" warning at MODULE scope (not
+ * per-instance) so a persistent failure (e.g. a broken vsix that didn't ship
+ * the worker payload) surfaces once per session — not once per workspace folder
+ * in a multi-root window, where each folder owns its own PluginLintPool.
+ */
+let warnedOnce = false;
 
 export class PluginLintPool {
   private readonly logger: Logger;
@@ -123,12 +149,24 @@ export class PluginLintPool {
         this.host = host;
         this.fingerprint = fingerprint;
       } catch (err: unknown) {
-        // Init failed (e.g. a referenced plugin failed to import). Leave host
+        // Init failed: either the host module couldn't be loaded (a packaging
+        // regression — the vsix didn't ship `dist/eslint-plugin/` or its
+        // native `.node`), or a referenced plugin failed to import. Leave host
         // unset so we serve empty until the next config change retries, rather
         // than wedging diagnostics.
         this.host = undefined;
         this.fingerprint = undefined;
         this.logger.error('Failed to initialize ESLint-plugin host', err);
+        // Make the failure visible — but ONLY when a config actually mounted
+        // plugins (an empty-descriptor host builds no worker and failing is
+        // not a user-facing problem), and only once per session so a
+        // persistent failure doesn't re-warn on every reload.
+        if (descriptors.length > 0 && !warnedOnce) {
+          warnedOnce = true;
+          void window.showWarningMessage(
+            'Rslint: failed to load the ESLint-plugin host; rules mounted via a config’s `plugins` will report no diagnostics. See the Rslint output channel for details.',
+          );
+        }
       }
     });
   }

--- a/scripts/publish-marketplace.mjs
+++ b/scripts/publish-marketplace.mjs
@@ -40,10 +40,52 @@ async function publish_all() {
 
     await $`chmod +x ./packages/vscode-extension/dist/${targetFilename}`;
 
+    // napi parser `.node` for the eslint-plugin worker. `build.js` already
+    // staged the publish-runner's host `.node` as a fixed `rslint.node`;
+    // overwrite it with THIS platform's `.node` so the worker's
+    // `@rslint/native` shim loads the matching ABI. Source artifact comes from
+    // the `napi-build` job (`native-<tuple>`, downloaded to `binaries/`); the
+    // shim requires a constant `./rslint.node`, so one filename is overwritten
+    // per iteration — no wrong-arch leak is possible. Linux ships gnu only
+    // (musl is not a vsce target).
+    const napiTuple =
+      os === 'win32'
+        ? `win32-${arch}-msvc`
+        : os === 'linux'
+          ? `linux-${arch}-gnu`
+          : `${os}-${arch}`; // darwin-x64 / darwin-arm64
+    const nativeDir =
+      './packages/vscode-extension/dist/eslint-plugin/node_modules/@rslint/native';
+    await $`rm -f ${nativeDir}/rslint.node`;
+    await $`cp binaries/native-${napiTuple}/rslint.${napiTuple}.node ${nativeDir}/rslint.node`;
+
     await $`ls -lR ./packages/vscode-extension/dist`;
     const prereleaseFlag = prerelease ? ['--pre-release'] : [];
 
     await $`cd packages/vscode-extension && pnpm vsce package --target ${os}-${arch} ${prereleaseFlag}`;
+
+    // Smoke-check the produced vsix: the eslint-plugin worker payload + its
+    // nested native shim/.node must be present, or the packaged extension's
+    // plugin host silently dies (the dev-only blind spot this whole change
+    // fixes). `vsce ls` is unusable here (its npm dep walk breaks under pnpm),
+    // so inspect the zip directly. Cross-build arch correctness is guaranteed
+    // upstream by the `cp` from `native-${napiTuple}` (it errors if absent).
+    const vsix = `packages/vscode-extension/rslint-${os}-${arch}-${version}.vsix`;
+    const listing = (await $`unzip -Z1 ${vsix}`).stdout;
+    const requiredEntries = [
+      'extension/dist/eslint-plugin/index.js',
+      'extension/dist/eslint-plugin/lint-worker.js',
+      'extension/dist/eslint-plugin/package.json',
+      'extension/dist/eslint-plugin/node_modules/@rslint/native/index.js',
+      'extension/dist/eslint-plugin/node_modules/@rslint/native/rslint.node',
+    ];
+    const missing = requiredEntries.filter((e) => !listing.includes(e));
+    if (missing.length > 0) {
+      throw new Error(
+        `vsix smoke check failed for ${os}-${arch}: missing ${missing.join(', ')}`,
+      );
+    }
+    console.log(`vsix worker-payload smoke check passed for ${os}-${arch}`);
 
     // supports dry-run
     if (process.argv.includes('--dry-run')) {


### PR DESCRIPTION
## Summary

Rules mounted via a config's object-form `plugins` ran only in the extension dev host — in the published `.vsix` they silently produced zero diagnostics, because the package shipped neither the JS plugin-lint worker nor the native parser binary it loads. The host import failed and was swallowed, so plugin-rule diagnostics came back empty.

This change makes those rules work in the published extension:

- **Stage the worker payload into the package.** `build.js` now copies the plugin-lint worker bundle into the extension `dist/`, alongside a tiny loader + a per-platform native parser binary, and `PluginLintPool` loads the host via a path relative to the bundle — so the dev host and the packaged extension resolve it the same way (no more dev-only blind spot).
- **Ship the matching platform binary.** The marketplace publish loop copies the correct per-platform native binary into each target's `.vsix` and smoke-checks that the produced package actually contains the worker payload. The publish jobs now build the native types from source so they never go stale.
- **Fail loudly, not silently.** When the plugin host can't load, the extension surfaces a one-time warning (and logs details) instead of returning empty diagnostics.
- **Regression guards.** A new packaged-layout isolation test stages the built worker into an isolated tree (off any workspace `node_modules`) and asserts a plugin rule fires — catching exactly the dev-only blind spot that hid this bug. The real-worker teardown e2e suites now also run on win32 (behind a shared kill-switch flag) to validate native worker teardown on that platform.

## Related Links

Follow-up to #1047, which added object-form `plugins` but left this packaging gap.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
