### PR TITLE
ci: reduce running time by enabling higher parallel threads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
             if ($batch.Count -ge $batchSize) {
               Write-Host "Running batch of $($batch.Count) packages..."
-              go test -p 128 -count=1 $batch
+              go test -p 64 -count=1 $batch
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
               $batch = @()
             }
@@ -95,7 +95,7 @@ jobs:
           # Run remaining packages
           if ($batch.Count -gt 0) {
             Write-Host "Running final batch of $($batch.Count) packages..."
-            go test -p 128 -count=1 $batch
+            go test -p 64 -count=1 $batch
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   test-go:
     name: Test Go
+    if: false
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -77,7 +78,7 @@ jobs:
           go build ./internal/...
 
           $packages = go list ./internal/... | Where-Object { $_ -ne "" }
-          $batchSize = 32
+          $batchSize = 64
           $batch = @()
 
           foreach ($pkg in $packages) {
@@ -85,7 +86,7 @@ jobs:
 
             if ($batch.Count -ge $batchSize) {
               Write-Host "Running batch of $($batch.Count) packages..."
-              go test -p 32 -count=1 $batch
+              go test -p 64 -count=1 $batch
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
               $batch = @()
             }
@@ -94,12 +95,13 @@ jobs:
           # Run remaining packages
           if ($batch.Count -gt 0) {
             Write-Host "Running final batch of $($batch.Count) packages..."
-            go test -p 32 -count=1 $batch
+            go test -p 64 -count=1 $batch
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
   build-rslint-windows:
     name: Build rslint.exe (Windows)
+    if: false
     runs-on: rspack-windows-2022-large
     steps:
       - name: Checkout code
@@ -128,6 +130,7 @@ jobs:
 
   test-node-windows:
     name: Test npm packages (windows-latest)
+    if: false
     runs-on: windows-latest
     needs: build-rslint-windows
     steps:
@@ -172,6 +175,7 @@ jobs:
         run: pnpm run test
 
   lint:
+    if: false
     name: Lint&Check
     runs-on: rspack-ubuntu-22.04-large
     steps:
@@ -206,6 +210,7 @@ jobs:
 
   test-node:
     name: Test npm packages
+    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -272,6 +277,7 @@ jobs:
         run: pnpm run test
 
   test-wasm:
+    if: false
     name: Test WASM
     runs-on: rspack-ubuntu-22.04-large
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,7 @@ jobs:
           pnpm --filter '@rslint/wasm' build
   test-rust:
     name: Test Rust
+    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           go build ./internal/...
 
           $packages = go list ./internal/... | Where-Object { $_ -ne "" }
-          $batchSize = 64
+          $batchSize = 128
           $batch = @()
 
           foreach ($pkg in $packages) {
@@ -86,7 +86,7 @@ jobs:
 
             if ($batch.Count -ge $batchSize) {
               Write-Host "Running batch of $($batch.Count) packages..."
-              go test -p 64 -count=1 $batch
+              go test -p 128 -count=1 $batch
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
               $batch = @()
             }
@@ -95,7 +95,7 @@ jobs:
           # Run remaining packages
           if ($batch.Count -gt 0) {
             Write-Host "Running final batch of $($batch.Count) packages..."
-            go test -p 64 -count=1 $batch
+            go test -p 128 -count=1 $batch
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ concurrency:
 jobs:
   test-go:
     name: Test Go
-    if: false
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -78,7 +77,7 @@ jobs:
           go build ./internal/...
 
           $packages = go list ./internal/... | Where-Object { $_ -ne "" }
-          $batchSize = 32
+          $batchSize = 64
           $batch = @()
 
           foreach ($pkg in $packages) {
@@ -101,7 +100,6 @@ jobs:
 
   build-rslint-windows:
     name: Build rslint.exe (Windows)
-    if: false
     runs-on: rspack-windows-2022-large
     steps:
       - name: Checkout code
@@ -130,7 +128,6 @@ jobs:
 
   test-node-windows:
     name: Test npm packages (windows-latest)
-    if: false
     runs-on: windows-latest
     needs: build-rslint-windows
     steps:
@@ -175,7 +172,6 @@ jobs:
         run: pnpm run test
 
   lint:
-    if: false
     name: Lint&Check
     runs-on: rspack-ubuntu-22.04-large
     steps:
@@ -210,7 +206,6 @@ jobs:
 
   test-node:
     name: Test npm packages
-    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -277,7 +272,6 @@ jobs:
         run: pnpm run test
 
   test-wasm:
-    if: false
     name: Test WASM
     runs-on: rspack-ubuntu-22.04-large
     steps:
@@ -309,7 +303,6 @@ jobs:
           pnpm --filter '@rslint/wasm' build
   test-rust:
     name: Test Rust
-    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           go build ./internal/...
 
           $packages = go list ./internal/... | Where-Object { $_ -ne "" }
-          $batchSize = 128
+          $batchSize = 32
           $batch = @()
 
           foreach ($pkg in $packages) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
-env:
-  GOMAXPROCS: 8
-
 jobs:
   test-go:
     name: Test Go
@@ -49,7 +46,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-name: ci-test-go
       - name: Unit Test
-        run: go test -parallel 8 ./internal/...
+        run: go test -count=1 ./internal/...
 
   test-go-windows:
     name: Test Go (rspack-windows-2022-large)
@@ -80,7 +77,7 @@ jobs:
           go build ./internal/...
 
           $packages = go list ./internal/... | Where-Object { $_ -ne "" }
-          $batchSize = 100
+          $batchSize = 32
           $batch = @()
 
           foreach ($pkg in $packages) {
@@ -88,7 +85,7 @@ jobs:
 
             if ($batch.Count -ge $batchSize) {
               Write-Host "Running batch of $($batch.Count) packages..."
-              go test -parallel 4 $batch
+              go test -p 32 -count=1 $batch
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
               $batch = @()
             }
@@ -97,7 +94,7 @@ jobs:
           # Run remaining packages
           if ($batch.Count -gt 0) {
             Write-Host "Running final batch of $($batch.Count) packages..."
-            go test -parallel 4 $batch
+            go test -p 32 -count=1 $batch
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 


### PR DESCRIPTION
## Summary

Our ubuntu and windows servers have large cpu cores, we can better utilize it.

Current status:
- Test Go (ubuntu) from 9min to 4min
- Test Go (windows) from 22min to 12min

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
