### PR TITLE
fix: align promise/always-return ignored assignment and control flow with ESLint

### DIFF
--- a/internal/plugins/promise/rules/always_return/always_return.go
+++ b/internal/plugins/promise/rules/always_return/always_return.go
@@ -171,7 +171,7 @@ func isIgnoredAssignment(stmt *ast.Node, ignoredVars []string) bool {
 		return false
 	}
 	bin := expr.AsBinaryExpression()
-	if bin == nil || bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindEqualsToken {
+	if bin == nil || bin.OperatorToken == nil || !ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
 		return false
 	}
 	rootName := rootObjectName(bin.Left)

--- a/internal/plugins/promise/rules/always_return/always_return_test.go
+++ b/internal/plugins/promise/rules/always_return/always_return_test.go
@@ -111,6 +111,45 @@ func TestAlwaysReturn(t *testing.T) {
 			{Code: `hey.then(function() { do {} while (true) })`},
 			{Code: `hey.then(function() { while (1) { return 1; } })`},
 			{Code: `hey.then(function() { while ('truthy') { return 1; } })`},
+
+			// ---- coverage gaps surfaced in review: for / labeled / do-while(false) ----
+			{Code: `hey.then(function() { for (;;) { return 1; } })`},
+			{Code: `hey.then(function() { outer: { return 1; } })`},
+			{Code: `hey.then(function() { do { return 1; } while (false) })`},
+
+			// ---- switch: a conditional break must not be masked, yet these still terminate ----
+			{Code: `hey.then(function(x) { switch (x) { case 1: { return 1; } default: return 2; } })`},
+			{Code: `hey.then(function(x) { switch (x) { case 1: if (y) return 1; else return 2; default: return 3; } })`},
+			{Code: `hey.then(function(x) { switch (x) { case 1: if (y) return 1; default: return 2; } })`},
+			{Code: `hey.then(function(x) { switch (x) { case 1: while (true) { break; } return 'a'; default: return 'b'; } })`},
+
+			// ---- ignoreAssignmentVariable: compound assignment to an ignored var (default globalThis) ----
+			{Code: `hey.then(x => { globalThis.a += x })`},
+			{Code: `hey.then(x => { globalThis.a ||= x })`},
+			{Code: `hey.then(x => { globalThis.a ??= x })`},
+			{Code: `hey.then(x => { globalThis[x] -= 1 })`},
+			{Code: `hey.then(x => { window.a += x })`, Options: map[string]interface{}{"ignoreAssignmentVariable": []interface{}{"window"}}},
+
+			// ---- try/catch: catch unreachable because the try block cannot throw ----
+			{Code: `hey.then(function() { try { return 1 } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { return -1 } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { return {a: 1} } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { return [1, 2] } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { return true ? 1 : 2 } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { return } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { return 1; foo() } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { let a = 1; return 1 } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { return "x" } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { return void 0 } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { return 1 + 2 } catch (e) { log(e) } })`},
+			{Code: "hey.then(function() { try { return `a${1}` } catch (e) { log(e) } })"},
+			{Code: `hey.then(function() { try { ; return 1 } catch (e) { log(e) } })`},
+			{Code: `hey.then(function() { try { 1; return 2 } catch (e) { log(e) } })`},
+
+			// ---- switch: break reachability inside a clause ----
+			{Code: `hey.then(function(x) { switch (x) { case 1: { return 1; break; } default: return 2; } })`},
+			{Code: `hey.then(function(x) { switch (x) { case 1: ; return 1; default: return 2; } })`},
+			{Code: `hey.then(function() { try { return 'a' in {} } catch (e) { log(e) } })`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- ESLint upstream invalid cases ----
@@ -177,6 +216,31 @@ func TestAlwaysReturn(t *testing.T) {
 			{Code: `hey.then(function(x) { switch (x) { case 1: return 'a'; case 2: break; default: return 'c'; } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
 			// switch where default case body doesn't terminate
 			{Code: `hey.then(function(x) { switch (x) { case 1: return 'a'; default: console.log('nope'); } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			// switch where a case conditionally breaks out before its return (review fix)
+			{Code: `hey.then(function(x) { switch (x) { case 1: if (y) break; return 'a'; default: return 'b'; } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			// same, with the conditional break nested inside a block
+			{Code: `hey.then(function(x) { switch (x) { case 1: { if (y) break; } return 'a'; default: return 'b'; } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			// compound assignment to a non-ignored variable is still reported
+			{Code: `hey.then(x => { notGlobal.a += x })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+
+			// ---- try/catch: catch reachable because the try block may throw ----
+			{Code: `hey.then(function() { try { return foo() } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function() { try { return x } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function() { try { return {[k]: 1} } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function() { try { foo(); return 1 } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function() { try { return x.y } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function() { try { return [...x] } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function() { try { return {...x} } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: "hey.then(function() { try { return `a${x}` } catch (e) { log(e) } })", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function() { try { let a = foo(); return 1 } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function() { try { let {a} = x; return 1 } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+
+			// ---- switch: break (else-branch / labeled) exits the switch, not terminal ----
+			{Code: `hey.then(function(x) { switch (x) { case 1: if (y) return 1; else break; default: return 2; } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function(x) { outer: switch (x) { case 1: if (y) break outer; return 1; default: return 2; } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function(x) { switch (x) { case 1: lbl: if (y) break; return 1; default: return 2; } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function() { try { return x instanceof Object } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
+			{Code: `hey.then(function() { try { throw new Error() } catch (e) { log(e) } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thenShouldReturnOrThrow", Message: message}}},
 		},
 	)
 }

--- a/internal/utils/flow.go
+++ b/internal/utils/flow.go
@@ -214,6 +214,9 @@ func StatementCompletion(stmt *ast.Node) Completion {
 		if catchBlock != nil && StatementListCompletion(catchBlock.Statements()) == CompletionTerminates {
 			return CompletionTerminates
 		}
+		if tryBlockCannotReachCatch(tryStmt.TryBlock) {
+			return CompletionTerminates
+		}
 		return CompletionFallsThrough
 	case ast.KindSwitchStatement:
 		if switchTerminatesAll(stmt) {
@@ -279,14 +282,14 @@ func switchTerminatesAll(stmt *ast.Node) bool {
 		return false
 	}
 	for i := range clauses {
-		if !clausesTerminateFrom(clauses, i) {
+		if !clausesTerminateFrom(clauses, i, stmt) {
 			return false
 		}
 	}
 	return true
 }
 
-func clausesTerminateFrom(clauses []*ast.Node, start int) bool {
+func clausesTerminateFrom(clauses []*ast.Node, start int, switchNode *ast.Node) bool {
 	for i := start; i < len(clauses); i++ {
 		clause := clauses[i]
 		if clause == nil {
@@ -296,7 +299,7 @@ func clausesTerminateFrom(clauses []*ast.Node, start int) bool {
 		if caseOrDefault == nil || caseOrDefault.Statements == nil {
 			continue
 		}
-		switch StatementListCompletion(caseOrDefault.Statements.Nodes) {
+		switch caseClauseCompletion(caseOrDefault.Statements.Nodes, switchNode) {
 		case CompletionTerminates:
 			return true
 		case CompletionStops:
@@ -304,6 +307,68 @@ func clausesTerminateFrom(clauses []*ast.Node, start int) bool {
 		}
 	}
 	return false
+}
+
+// caseClauseCompletion is StatementListCompletion specialized for switch clause
+// bodies: a break that exits switchNode along a reachable path counts as
+// CompletionStops (the clause leaves the switch rather than terminating the
+// function). This catches a conditional break such as `if (c) break;` that a
+// later `return` would otherwise mask.
+func caseClauseCompletion(statements []*ast.Node, switchNode *ast.Node) Completion {
+	for _, stmt := range statements {
+		if stmtCanBreakOutOfSwitch(stmt, switchNode) {
+			return CompletionStops
+		}
+		switch StatementCompletion(stmt) {
+		case CompletionTerminates:
+			return CompletionTerminates
+		case CompletionStops:
+			return CompletionStops
+		}
+	}
+	return CompletionFallsThrough
+}
+
+// stmtCanBreakOutOfSwitch reports whether executing stmt can reach a break that
+// exits switchNode without first terminating. It descends into blocks and if
+// branches (tracking reachability) but not into nested loops/switches, whose
+// unlabeled breaks target themselves.
+func stmtCanBreakOutOfSwitch(stmt *ast.Node, switchNode *ast.Node) bool {
+	if stmt == nil {
+		return false
+	}
+	switch stmt.Kind {
+	case ast.KindBreakStatement:
+		return breakExitsTarget(stmt, switchNode)
+	case ast.KindBlock:
+		for _, s := range stmt.Statements() {
+			if stmtCanBreakOutOfSwitch(s, switchNode) {
+				return true
+			}
+			switch StatementCompletion(s) {
+			case CompletionTerminates, CompletionStops:
+				return false
+			}
+		}
+		return false
+	case ast.KindIfStatement:
+		ifStmt := stmt.AsIfStatement()
+		if ifStmt == nil {
+			return false
+		}
+		if stmtCanBreakOutOfSwitch(ifStmt.ThenStatement, switchNode) {
+			return true
+		}
+		return ifStmt.ElseStatement != nil && stmtCanBreakOutOfSwitch(ifStmt.ElseStatement, switchNode)
+	case ast.KindLabeledStatement:
+		labeledStmt := stmt.AsLabeledStatement()
+		if labeledStmt == nil {
+			return false
+		}
+		return stmtCanBreakOutOfSwitch(labeledStmt.Statement, switchNode)
+	default:
+		return false
+	}
 }
 
 func isTruthyLiteral(expr *ast.Node) bool {
@@ -342,7 +407,7 @@ func containsBreakExitingLoop(loop *ast.Node, body *ast.Node) bool {
 		if node != body && IsFunctionLikeContainer(node) {
 			return false
 		}
-		if node.Kind == ast.KindBreakStatement && breakExitsLoop(node, loop) {
+		if node.Kind == ast.KindBreakStatement && breakExitsTarget(node, loop) {
 			found = true
 			return true
 		}
@@ -353,13 +418,15 @@ func containsBreakExitingLoop(loop *ast.Node, body *ast.Node) bool {
 	return found
 }
 
-func breakExitsLoop(breakStmt *ast.Node, loop *ast.Node) bool {
+// breakExitsTarget reports whether breakStmt exits target, which may be a loop
+// or a switch statement.
+func breakExitsTarget(breakStmt *ast.Node, target *ast.Node) bool {
 	stmt := breakStmt.AsBreakStatement()
 	if stmt == nil {
 		return false
 	}
 	if stmt.Label == nil {
-		return nearestUnlabeledBreakTarget(breakStmt) == loop
+		return nearestUnlabeledBreakTarget(breakStmt) == target
 	}
 	labelName := stmt.Label.Text()
 	for parent := breakStmt.Parent; parent != nil; parent = parent.Parent {
@@ -371,7 +438,7 @@ func breakExitsLoop(breakStmt *ast.Node, loop *ast.Node) bool {
 		}
 		labeledStmt := parent.AsLabeledStatement()
 		if labeledStmt != nil && labeledStmt.Label != nil && labeledStmt.Label.Text() == labelName {
-			return isAncestorOrSelf(parent, loop)
+			return isAncestorOrSelf(parent, target)
 		}
 	}
 	return false
@@ -416,4 +483,124 @@ func isProcessExitOrAbortCall(expr *ast.Node) bool {
 	}
 	object := ast.SkipOuterExpressions(prop.Expression, skipOEKParentheses)
 	return object != nil && ast.IsIdentifier(object) && object.AsIdentifier().Text == "process"
+}
+
+// tryBlockCannotReachCatch reports whether the try block reaches a return whose
+// argument cannot throw, with every preceding statement also unable to throw, so
+// the catch clause is unreachable. In that case a non-terminating catch does not
+// stop the function from always returning. Mirrors ESLint's code-path analysis,
+// which only routes to catch when a statement may throw.
+func tryBlockCannotReachCatch(tryBlock *ast.Node) bool {
+	if tryBlock == nil {
+		return false
+	}
+	for _, s := range tryBlock.Statements() {
+		if s == nil {
+			return false
+		}
+		switch s.Kind {
+		case ast.KindReturnStatement:
+			arg := s.AsReturnStatement().Expression
+			return arg == nil || expressionCannotThrow(arg)
+		case ast.KindThrowStatement:
+			return false
+		default:
+			if !statementCannotThrow(s) {
+				return false
+			}
+		}
+	}
+	return false
+}
+
+// statementCannotThrow reports whether a non-terminating statement preceding a
+// return in a try block cannot throw. Only simple side-effect-free forms qualify;
+// anything else is treated conservatively as possibly throwing.
+func statementCannotThrow(stmt *ast.Node) bool {
+	switch stmt.Kind {
+	case ast.KindEmptyStatement:
+		return true
+	case ast.KindExpressionStatement:
+		return expressionCannotThrow(stmt.AsExpressionStatement().Expression)
+	case ast.KindVariableStatement:
+		list := stmt.AsVariableStatement().DeclarationList
+		if list == nil {
+			return false
+		}
+		for _, d := range list.AsVariableDeclarationList().Declarations.Nodes {
+			if d == nil {
+				return false
+			}
+			decl := d.AsVariableDeclaration()
+			if name := decl.Name(); name == nil || !ast.IsIdentifier(name) {
+				return false
+			}
+			if decl.Initializer != nil && !expressionCannotThrow(decl.Initializer) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// expressionCannotThrow reports whether evaluating expr cannot throw. It is a
+// conservative whitelist mirroring ESLint: literals and operations whose
+// operands all cannot throw. Anything that dereferences a binding (identifier,
+// member access, call, new, spread, computed key, or a template/expression with
+// a variable) may throw and returns false.
+func expressionCannotThrow(expr *ast.Node) bool {
+	expr = ast.SkipOuterExpressions(expr, skipOEKParentheses)
+	if expr == nil {
+		return false
+	}
+	switch expr.Kind {
+	case ast.KindNumericLiteral, ast.KindStringLiteral, ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral, ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindTrueKeyword, ast.KindFalseKeyword, ast.KindNullKeyword:
+		return true
+	case ast.KindPrefixUnaryExpression:
+		return expressionCannotThrow(expr.AsPrefixUnaryExpression().Operand)
+	case ast.KindVoidExpression:
+		return expressionCannotThrow(expr.AsVoidExpression().Expression)
+	case ast.KindBinaryExpression:
+		bin := expr.AsBinaryExpression()
+		return expressionCannotThrow(bin.Left) && expressionCannotThrow(bin.Right)
+	case ast.KindConditionalExpression:
+		cond := expr.AsConditionalExpression()
+		return expressionCannotThrow(cond.Condition) &&
+			expressionCannotThrow(cond.WhenTrue) &&
+			expressionCannotThrow(cond.WhenFalse)
+	case ast.KindObjectLiteralExpression:
+		for _, prop := range expr.AsObjectLiteralExpression().Properties.Nodes {
+			if prop == nil || prop.Kind != ast.KindPropertyAssignment {
+				return false
+			}
+			pa := prop.AsPropertyAssignment()
+			if name := pa.Name(); name != nil && ast.IsComputedPropertyName(name) {
+				return false
+			}
+			if !expressionCannotThrow(pa.Initializer) {
+				return false
+			}
+		}
+		return true
+	case ast.KindArrayLiteralExpression:
+		for _, el := range expr.AsArrayLiteralExpression().Elements.Nodes {
+			if el == nil || el.Kind == ast.KindSpreadElement || !expressionCannotThrow(el) {
+				return false
+			}
+		}
+		return true
+	case ast.KindTemplateExpression:
+		for _, span := range expr.AsTemplateExpression().TemplateSpans.Nodes {
+			if span == nil || !expressionCannotThrow(span.AsTemplateSpan().Expression) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
 }

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/always-return.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/always-return.test.ts
@@ -135,6 +135,43 @@ ruleTester.run('always-return', {} as never, {
     { code: 'hey.then(function() { do {} while (true) })' },
     { code: 'hey.then(function() { while (1) { return 1; } })' },
     { code: "hey.then(function() { while ('truthy') { return 1; } })" },
+
+    // coverage gaps surfaced in review: for / labeled / do-while(false)
+    { code: 'hey.then(function() { for (;;) { return 1; } })' },
+    { code: 'hey.then(function() { outer: { return 1; } })' },
+    { code: 'hey.then(function() { do { return 1; } while (false) })' },
+
+    // switch: a conditional break must not be masked, yet these still terminate
+    {
+      code: 'hey.then(function(x) { switch (x) { case 1: { return 1; } default: return 2; } })',
+    },
+    {
+      code: 'hey.then(function(x) { switch (x) { case 1: if (y) return 1; else return 2; default: return 3; } })',
+    },
+    {
+      code: 'hey.then(function(x) { switch (x) { case 1: if (y) return 1; default: return 2; } })',
+    },
+    {
+      code: 'hey.then(function(x) { switch (x) { case 1: while (true) { break; } return "a"; default: return "b"; } })',
+    },
+
+    // ignoreAssignmentVariable: compound assignment to an ignored var (default globalThis)
+    { code: 'hey.then(x => { globalThis.a += x })' },
+    { code: 'hey.then(x => { globalThis.a ||= x })' },
+    { code: 'hey.then(x => { globalThis.a ??= x })' },
+    {
+      code: 'hey.then(x => { window.a += x })',
+      options: [{ ignoreAssignmentVariable: ['window'] }],
+    },
+
+    // try/catch: catch unreachable because the try block cannot throw
+    { code: 'hey.then(function() { try { return 1 } catch (e) { log(e) } })' },
+    {
+      code: 'hey.then(function() { try { return {a: 1} } catch (e) { log(e) } })',
+    },
+    {
+      code: 'hey.then(function() { try { return 1; foo() } catch (e) { log(e) } })',
+    },
   ],
 
   invalid: [
@@ -268,6 +305,28 @@ ruleTester.run('always-return', {} as never, {
     },
     {
       code: 'hey.then(x => { process.exitCode = 1 })',
+      errors: [{ message }],
+    },
+
+    // switch where a case conditionally breaks out before its return (review fix)
+    {
+      code: 'hey.then(function(x) { switch (x) { case 1: if (y) break; return "a"; default: return "b"; } })',
+      errors: [{ message }],
+    },
+    {
+      code: 'hey.then(function(x) { switch (x) { case 1: { if (y) break; } return "a"; default: return "b"; } })',
+      errors: [{ message }],
+    },
+    // compound assignment to a non-ignored variable is still reported
+    { code: 'hey.then(x => { notGlobal.a += x })', errors: [{ message }] },
+
+    // try/catch: catch reachable because the try block may throw
+    {
+      code: 'hey.then(function() { try { return foo() } catch (e) { log(e) } })',
+      errors: [{ message }],
+    },
+    {
+      code: 'hey.then(function() { try { foo(); return 1 } catch (e) { log(e) } })',
       errors: [{ message }],
     },
   ],


### PR DESCRIPTION
## Summary

Follow-up to #938. Fixes three places where `promise/always-return` diverged from `eslint-plugin-promise`, each verified against `eslint-plugin-promise@7.3.0` as an oracle:

- **Ignored compound assignment (false positive):** `isIgnoredAssignment` only accepted `=`, so `globalThis.x += v` / `||=` / `??=` were reported even though upstream ignores the operator kind.
- **Conditional break in a switch clause (false negative):** a reachable `break` inside a case (e.g. `case 1: if (c) break; return x`) was masked by a later `return`, so the switch was wrongly treated as terminating.
- **Unreachable catch (false positive):** when a `try` block cannot throw, the `catch` no longer has to terminate, mirroring ESLint's code-path reachability. `expressionCannotThrow` recursively models which expressions can throw.

Control-flow helpers live in `internal/utils/flow.go` (consumed only by this rule). Regression tests added on the Go and differential (`.test.ts`) sides, with branch coverage for the new helpers.

## Related Links

- Follow-up to #938

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).