### PR TITLE
fix: declaration references to use definition source file ids

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -184,7 +184,12 @@ func runMain() int {
 
 	initPrimitiveTypes(tc, &checkResult.Semantic)
 	fileMap := make(map[string]int32)
-	for sourcefileId, file := range program.GetSourceFiles() {
+	sourceFiles := program.GetSourceFiles()
+	sourceFileIds := make(map[*ast.SourceFile]SourceFileId, len(sourceFiles))
+	for sourcefileId, file := range sourceFiles {
+		sourceFileIds[file] = SourceFileId(sourcefileId)
+	}
+	for sourcefileId, file := range sourceFiles {
 		fileMap[file.FileName()] = int32(sourcefileId)
 		checkResult.ModuleList = append(checkResult.ModuleList, file.FileName())
 		sourceFile := file.AsSourceFile()
@@ -200,7 +205,7 @@ func runMain() int {
 		})
 		checkResult.SourceFiles = append(checkResult.SourceFiles, encodedSourceFile)
 
-		CollectSemanticInFile(tc, file, &checkResult.Semantic, sourcefileId)
+		CollectSemanticInFile(tc, file, &checkResult.Semantic, sourcefileId, sourceFileIds)
 	}
 	checkResult.Diagnostics = getDiagnostics(diagnostics, &fileMap)
 

--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -187,7 +187,7 @@ func runMain() int {
 	sourceFiles := program.GetSourceFiles()
 	sourceFileIds := make(map[*ast.SourceFile]SourceFileId, len(sourceFiles))
 	for sourcefileId, file := range sourceFiles {
-		sourceFileIds[file] = SourceFileId(sourcefileId)
+		sourceFileIds[file] = sourcefileId
 	}
 	for sourcefileId, file := range sourceFiles {
 		fileMap[file.FileName()] = int32(sourcefileId)

--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -175,7 +175,6 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 			End:          nodePositionMap.UTF8ToUTF16(node.End()),
 		}
 	}
-	}
 
 	recordType := func(ty *checker.Type) checker.TypeId {
 		if ty == nil {

--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -70,7 +70,7 @@ func CollectSemantic(program *compiler.Program) Semantic {
 	sourceFiles := program.GetSourceFiles()
 	sourceFileIds := make(map[*ast.SourceFile]SourceFileId, len(sourceFiles))
 	for id, sourceFile := range sourceFiles {
-		sourceFileIds[sourceFile] = SourceFileId(id)
+		sourceFileIds[sourceFile] = id
 	}
 
 	for id, sourceFile := range sourceFiles {

--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -67,8 +67,14 @@ func CollectSemantic(program *compiler.Program) Semantic {
 	tc, done := program.GetTypeChecker(context.Background())
 	defer done()
 
-	for id, sourceFile := range program.GetSourceFiles() {
-		CollectSemanticInFile(tc, sourceFile, &semantic, id)
+	sourceFiles := program.GetSourceFiles()
+	sourceFileIds := make(map[*ast.SourceFile]SourceFileId, len(sourceFiles))
+	for id, sourceFile := range sourceFiles {
+		sourceFileIds[sourceFile] = SourceFileId(id)
+	}
+
+	for id, sourceFile := range sourceFiles {
+		CollectSemanticInFile(tc, sourceFile, &semantic, id, sourceFileIds)
 	}
 	return semantic
 }
@@ -137,7 +143,7 @@ func initPrimitiveTypes(tc *checker.Checker, semantic *Semantic) {
 		Never:     tc.GetNeverType().Id(),
 	}
 }
-func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *Semantic, sourceFileId int) {
+func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *Semantic, sourceFileId int, sourceFileIds map[*ast.SourceFile]SourceFileId) {
 	if tc == nil || file == nil {
 		return
 	}
@@ -147,6 +153,19 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 	positionMap := file.GetPositionMap()
 	utf16 := func(pos int) int {
 		return positionMap.UTF8ToUTF16(pos)
+	}
+	nodeReference := func(node *ast.Node) *NodeReference {
+		if node == nil || node.Pos() < 0 || node.End() < 0 {
+			return nil
+		}
+
+		nodeSourceFile := ast.GetSourceFileOfNode(node)
+		nodePositionMap := nodeSourceFile.GetPositionMap()
+		return &NodeReference{
+			SourceFileId: sourceFileIds[nodeSourceFile],
+			Start:        nodePositionMap.UTF8ToUTF16(node.Pos()),
+			End:          nodePositionMap.UTF8ToUTF16(node.End()),
+		}
 	}
 
 	recordType := func(ty *checker.Type) checker.TypeId {
@@ -208,15 +227,7 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 					typeID := recordType(ty)
 					sym_id := ast.GetSymbolId(symbol)
 
-					// Get declaration position if available
-					var declRef *NodeReference
-					if symbol.ValueDeclaration != nil && symbol.ValueDeclaration.Pos() >= 0 && symbol.ValueDeclaration.End() >= 0 {
-						declRef = &NodeReference{
-							SourceFileId: sourceFileId,
-							Start:        utf16(symbol.ValueDeclaration.Pos()),
-							End:          utf16(symbol.ValueDeclaration.End()),
-						}
-					}
+					declRef := nodeReference(symbol.ValueDeclaration)
 
 					semantic.Symtab[sym_id] = SymbolInfo{
 						Id:         sym_id,
@@ -253,15 +264,7 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 					if ty := tc.GetTypeOfSymbol(valueSymbol); ty != nil {
 						typeID := recordType(ty)
 
-						// Get declaration position if available
-						var declRef *NodeReference
-						if valueSymbol.ValueDeclaration != nil && valueSymbol.ValueDeclaration.Pos() >= 0 && valueSymbol.ValueDeclaration.End() >= 0 {
-							declRef = &NodeReference{
-								SourceFileId: sourceFileId,
-								Start:        utf16(valueSymbol.ValueDeclaration.Pos()),
-								End:          utf16(valueSymbol.ValueDeclaration.End()),
-							}
-						}
+						declRef := nodeReference(valueSymbol.ValueDeclaration)
 
 						semantic.Symtab[value_sym_id] = SymbolInfo{
 							Id:         value_sym_id,

--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -160,12 +160,21 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 		}
 
 		nodeSourceFile := ast.GetSourceFileOfNode(node)
+		if nodeSourceFile == nil {
+			return nil
+		}
+		nodeSourceFileId, ok := sourceFileIds[nodeSourceFile]
+		if !ok {
+			return nil
+		}
+
 		nodePositionMap := nodeSourceFile.GetPositionMap()
 		return &NodeReference{
-			SourceFileId: sourceFileIds[nodeSourceFile],
+			SourceFileId: nodeSourceFileId,
 			Start:        nodePositionMap.UTF8ToUTF16(node.Pos()),
 			End:          nodePositionMap.UTF8ToUTF16(node.End()),
 		}
+	}
 	}
 
 	recordType := func(ty *checker.Type) checker.TypeId {


### PR DESCRIPTION
## Summary

Fixes semantic declaration references so decl.sourcefile_id is based on the source file that actually owns the declaration node, instead of the file currently being traversed.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
