### PR TITLE
ci: ignore release artifacts in self-lint config

### DIFF
--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -6,6 +6,11 @@ export default defineConfig([
     '**/dist/**',
     'typescript-go/**',
 
+    // Release CI artifacts (downloaded binaries + tsgo lib files copied
+    // into the npm publish shells) — keep in sync with .prettierignore
+    'binaries/**',
+    'npm/**',
+
     // Test fixtures — not real source code
     '**/fixtures/**',
     'packages/rslint-test-tools/tests/**',


### PR DESCRIPTION
## Summary

The release workflow's Test job fails on every non-dry-run release at the **Lint code** step (e.g. [0.6.0 run](https://github.com/web-infra-dev/rslint/actions/runs/27326834229/job/80730691001), same for 0.5.x releases on 5/7 and 5/14).

Root cause: the Test job downloads build artifacts into `binaries/` and `move-artifacts` copies tsgo lib `.d.ts` files into `npm/tsgo/*/lib` before `pnpm lint` runs. Neither path is in `globalIgnores`, so self-lint picks up 12 artifact dirs × 108 TypeScript lib files and reports 16836 errors (`no-var`, `no-empty-object-type`, … on `lib.dom.d.ts` etc.) — all from artifacts, 0 from repo sources. `format:check` passes in the same job because `.prettierignore` already has `binaries/` and `npm/tsgo/**/lib/`.

Fix: add `binaries/**` and `npm/**` to `globalIgnores`, matching `.prettierignore`. `npm/` contains no lintable sources (publish shells + copied artifacts only).

Verified locally by reproducing the CI layout (copied 108 lib files into both `binaries/darwin-arm64-tsgo-built/local/` and `npm/tsgo/darwin-arm64/lib/`):

| state | result |
|---|---|
| clean tree | 0 errors / 144 files / exit 0 |
| artifacts present, before fix | 2806 errors / 360 files / exit 1 |
| artifacts present, after fix | 0 errors / 144 files / exit 0 |

## Related Links

https://github.com/web-infra-dev/rslint/actions/runs/27326834229/job/80730691001

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).