### PR TITLE
fix(bench): stamp Go binary spawn instead of execFileSync in CLI bench

### DIFF
--- a/tests/bench-cli/scripts/spawn-stamp-preload.cjs
+++ b/tests/bench-cli/scripts/spawn-stamp-preload.cjs
@@ -1,4 +1,5 @@
 const fs = require('node:fs');
+const path = require('node:path');
 const childProcess = require('node:child_process');
 const { syncBuiltinESMExports } = require('node:module');
 const { performance } = require('node:perf_hooks');
@@ -10,18 +11,29 @@ if (Number.isNaN(stampFd)) {
   return;
 }
 
-const originalExecFileSync = childProcess.execFileSync;
+// The CLI launches the Go binary through `spawn` (see runEngine in
+// packages/rslint/src/engine.ts), so that is the call to stamp. Match on the
+// binary name instead of stamping the first call so unrelated spawns the CLI
+// may grow later never shift the measurement.
+const GO_BINARY_NAME = process.platform === 'win32' ? 'rslint.exe' : 'rslint';
+
+const originalSpawn = childProcess.spawn;
 let stamped = false;
 
-childProcess.execFileSync = function patchedExecFileSync(file, args, options) {
-  if (!stamped) {
+childProcess.spawn = function patchedSpawn(...args) {
+  const file = args[0];
+  if (
+    !stamped &&
+    typeof file === 'string' &&
+    path.basename(file) === GO_BINARY_NAME
+  ) {
     stamped = true;
     try {
       fs.writeSync(
         stampFd,
         JSON.stringify({
           interceptedAtMs: performance.timeOrigin + performance.now(),
-          file: typeof file === 'string' ? file : null,
+          file,
         }) + '\n',
       );
     } catch {
@@ -30,7 +42,7 @@ childProcess.execFileSync = function patchedExecFileSync(file, args, options) {
     }
   }
 
-  return originalExecFileSync.call(this, file, args, options);
+  return originalSpawn.apply(this, args);
 };
 
 syncBuiltinESMExports();

--- a/tests/bench-cli/src/cli.bench.ts
+++ b/tests/bench-cli/src/cli.bench.ts
@@ -21,9 +21,9 @@ const cliEntrypoint = path.join(repoRoot, 'packages/rslint/bin/rslint.cjs');
 const vscodeRepoDir = path.join(os.tmpdir(), 'rslint-bench', 'vscode');
 const benchmarkTaskName = 'cli@vscode';
 const preBinaryBenchmarkName = 'cli@vscode_before_go_exec';
-const execFileSyncPreloadPath = path.resolve(
+const spawnStampPreloadPath = path.resolve(
   import.meta.dirname,
-  '../scripts/exec-file-sync-preload.cjs',
+  '../scripts/spawn-stamp-preload.cjs',
 );
 
 const cliArgs = ['--format', 'jsonline', '--quiet', '.'] as const;
@@ -38,7 +38,7 @@ const bench = createCodspeedCompatibleBench();
  * Timing model used here:
  * - `startedAtMs` is captured in the parent process right before `spawnSync`.
  * - `completedAtMs` is captured right after the CLI process finishes in parent.
- * - preload writes `interceptedAtMs` when child process first calls `execFileSync`.
+ * - preload writes `interceptedAtMs` when the child first spawns the Go binary.
  * - total latency ns: `(completedAtMs - startedAtMs) * 1e6`.
  * - before-go latency ns: `readPreBinaryLatencyNs()` => `(interceptedAtMs - startedAtMs) * 1e6`.
  *
@@ -51,7 +51,7 @@ async function runCLI(): Promise<{ totalNs: number; beforeGoNs: number }> {
   // lint execution instead of output buffering costs.
   const result = spawnSync(
     process.execPath,
-    ['--require', execFileSyncPreloadPath, cliEntrypoint, ...cliArgs],
+    ['--require', spawnStampPreloadPath, cliEntrypoint, ...cliArgs],
     {
       cwd: vscodeRepoDir,
       env: {
@@ -94,7 +94,7 @@ function toOverriddenDuration(ns: number): BenchTaskDurationOverride {
 await Promise.all([
   assertExists(cliEntrypoint),
   assertExists(vscodeRepoDir),
-  assertExists(execFileSyncPreloadPath),
+  assertExists(spawnStampPreloadPath),
 ]);
 
 addCodspeedCompatibleTask(bench, benchmarkTaskName, async () => {

--- a/tests/bench-cli/src/utils/pre-binary-stamp.ts
+++ b/tests/bench-cli/src/utils/pre-binary-stamp.ts
@@ -2,17 +2,17 @@ import path from 'node:path';
 
 export const STAMP_FD = 3;
 
-type ExecFileSyncStamp = {
+type SpawnStamp = {
   interceptedAtMs?: number;
   file?: string | null;
 };
 
-function parseExecFileSyncStamp(output: string | Buffer | null): {
-  payload: ExecFileSyncStamp;
+function parseSpawnStamp(output: string | Buffer | null): {
+  payload: SpawnStamp;
   rawOutput: string;
 } {
   if (output == null) {
-    throw new Error('Missing execFileSync stamp output');
+    throw new Error('Missing spawn stamp output');
   }
 
   const rawOutput =
@@ -23,11 +23,13 @@ function parseExecFileSyncStamp(output: string | Buffer | null): {
     .filter((line) => line.length > 0);
 
   if (lines.length === 0) {
-    throw new Error('Empty execFileSync stamp output');
+    throw new Error(
+      'Empty spawn stamp output: the CLI never spawned the Go rslint binary',
+    );
   }
 
   return {
-    payload: JSON.parse(lines[lines.length - 1]) as ExecFileSyncStamp,
+    payload: JSON.parse(lines[lines.length - 1]) as SpawnStamp,
     rawOutput,
   };
 }
@@ -37,11 +39,12 @@ export function readPreBinaryLatencyNs(
   output: string | Buffer | null,
 ): number {
   // "before_go_exec" latency is computed against the parent timestamp:
-  // startedAtMs (parent pre-spawn) -> interceptedAtMs (child first execFileSync).
-  const { payload, rawOutput } = parseExecFileSyncStamp(output);
+  // startedAtMs (parent pre-spawn) -> interceptedAtMs (child's first spawn of
+  // the Go binary).
+  const { payload, rawOutput } = parseSpawnStamp(output);
 
   if (typeof payload.interceptedAtMs !== 'number') {
-    throw new Error(`Invalid execFileSync stamp payload: ${rawOutput}`);
+    throw new Error(`Invalid spawn stamp payload: ${rawOutput}`);
   }
 
   const expectedBinaryName =
@@ -50,9 +53,7 @@ export function readPreBinaryLatencyNs(
     typeof payload.file !== 'string' ||
     path.basename(payload.file) !== expectedBinaryName
   ) {
-    throw new Error(
-      `Unexpected execFileSync target in stamp payload: ${rawOutput}`,
-    );
+    throw new Error(`Unexpected spawn target in stamp payload: ${rawOutput}`);
   }
 
   return Math.round((payload.interceptedAtMs - startedAtMs) * 1_000_000);


### PR DESCRIPTION
## Summary

`benchmark-cli` has been broken since #1037: the CLI now launches the Go binary via async `spawn` (`runEngine` in `packages/rslint/src/engine.ts`), so the bench preload that patched `execFileSync` never fired and every iteration crashed with `Error: Empty execFileSync stamp output`. The job only runs on `chore/release-*` branches, so it first surfaced on the 0.6.0 release PR (#1079, attempts 1/2; attempt 3 failed earlier on an unrelated runner disk-full).

Fix: patch `child_process.spawn` in the preload instead, matching on the binary basename (`rslint` / `rslint.exe`, same check the parent-side validation already enforces) so unrelated spawns never shift the `before_go_exec` stamp. Preload renamed to `spawn-stamp-preload.cjs`.

Verified locally: with the old preload the fd3 stamp pipe is empty (reproduces the CI failure); with this fix `pnpm run bench:cli` completes and both `cli@vscode` and `cli@vscode_before_go_exec` report samples.

## Related Links

- #1079 (failing release CI: https://github.com/web-infra-dev/rslint/actions/runs/27326811343)
- #1037 (CLI moved to the spawn-based IPC engine)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).