### PR TITLE
docs: fix dead link breaking website build and unify wording

### DIFF
--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.md
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.md
@@ -9,7 +9,7 @@ This rule triggers a warning if `toHaveLength` is used to assert the number of
 times a mock has been called.
 
 This rule is often used together with
-[`prefer-to-have-length`](./prefer_to_have_length.md).
+[`prefer-to-have-length`](./prefer-to-have-length.md).
 
 Examples of **incorrect** code for this rule:
 

--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -125,7 +125,7 @@ For rule severity levels, option format, and plugin configuration, see [Rules & 
 
 Plugins enabled for this entry, in one of two forms.
 
-**Array of names** — built-in (natively-ported) plugins. A name declares a rule namespace; its rules become available under the `<plugin>/<rule>` prefix inside `rules`.
+**Array of names** — built-in (native) plugins. A name declares a rule namespace; its rules become available under the `<plugin>/<rule>` prefix inside `rules`.
 
 Built-in plugin names: `@typescript-eslint`, `import`, `jest`, `jsx-a11y`, `promise`, `react`, `react-hooks`, `unicorn`.
 

--- a/website/docs/en/config/rules-and-presets.mdx
+++ b/website/docs/en/config/rules-and-presets.mdx
@@ -56,7 +56,7 @@ In **array form**, the names of the built-in (native) plugins to enable. Availab
 
 <PluginPrefixTable />
 
-In **object form** (`{ prefix: pluginObject }`), community ESLint plugins mounted by prefix — see [ESLint plugin compatibility](/guide/eslint-plugins). A single entry uses one form.
+In **object form** (`{ prefix: pluginObject }`), community ESLint plugins are mounted by prefix — see [ESLint plugin compatibility](/guide/eslint-plugins). A single entry uses one form.
 
 ESLint core rules (e.g. `no-unused-vars`, `prefer-const`, `no-var`) have no prefix and do not belong to any plugin — they can be enabled directly in `rules` without listing anything in `plugins`.
 

--- a/website/docs/en/guide/eslint-plugins.mdx
+++ b/website/docs/en/guide/eslint-plugins.mdx
@@ -1,4 +1,4 @@
-# ESLint plugin compatibility
+# ESLint Plugin Compatibility
 
 rslint can run community ESLint plugins' rules alongside its own native rules.
 Plugin diagnostics merge into the same report, and it works the same way in the


### PR DESCRIPTION
## Summary

- Fix a dead link in the `jest/prefer-to-have-been-called-times` rule doc: `./prefer_to_have_length.md` -> `./prefer-to-have-length.md`. The generated website pages use hyphenated file names, so the underscore link failed rspress's dead-link check and every website build has been failing since #1048 landed, leaving the live site stale (e.g. `/guide/eslint-plugins` from #1047 returns 404).
- Align the ESLint plugin compatibility page h1 with its sidebar label and the Title Case convention used by all other guide pages.
- Fix a verb-less sentence in `rules-and-presets.mdx` (`community ESLint plugins are mounted by prefix`).
- Unify `built-in (natively-ported) plugins` to `built-in (native) plugins` to match the other docs.

Verified locally: `pnpm --filter @rslint/website build` fails on `main` with the dead-link error and passes with this change (413 pages generated).

## Related Links

- https://github.com/web-infra-dev/rslint/pull/1048
- https://github.com/web-infra-dev/rslint/pull/1047

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).